### PR TITLE
Add preliminary support for Zsn extension

### DIFF
--- a/model/riscv_pte.sail
+++ b/model/riscv_pte.sail
@@ -29,6 +29,11 @@ bitfield PTE_Bits : pteAttribs = {
   V : 0
 }
 
+bitfield PTE_Ext : extPte = {
+  C : 9,
+  N : 8
+}
+
 function isPTEPtr(p : pteAttribs, ext : extPte) -> bool = {
   let a = Mk_PTE_Bits(p);
   a.R() == 0b0 & a.W() == 0b0 & a.X() == 0b0

--- a/model/riscv_vmem_common.sail
+++ b/model/riscv_vmem_common.sail
@@ -147,7 +147,7 @@ bitfield SV48_PTE : pte48 = {
 /* Result of a page-table walk.  */
 
 union PTW_Result('paddr : Type, 'pte : Type) = {
-  PTW_Success: ('paddr, 'pte, 'paddr, nat, bool, ext_ptw),
+  PTW_Success: ('paddr, 'pte, 'paddr, nat, bool, ext_ptw, nat),
   PTW_Failure: (PTW_Error, ext_ptw)
 }
 

--- a/model/riscv_vmem_sv32.sail
+++ b/model/riscv_vmem_sv32.sail
@@ -62,16 +62,17 @@ function walk32(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
                 } else {
                   /* add the appropriate bits of the VPN to the superpage PPN */
                   let ppn = pte.PPNi() | (EXTZ(va.VPNi()) & mask);
+                  let shift : nat = PAGESIZE_BITS + (level * SV32_LEVEL_BITS);
 /*                let res = append(ppn, va.PgOfs());
                   print("walk32: using superpage: pte.ppn=" ^ BitStr(pte.PPNi())
                         ^ " ppn=" ^ BitStr(ppn) ^ " res=" ^ BitStr(res)); */
-                  PTW_Success(append(ppn, va.PgOfs()), pte, pte_addr, level, is_global, ext_ptw)
+                  PTW_Success(append(ppn, va.PgOfs()), pte, pte_addr, level, is_global, ext_ptw, shift)
                 }
               } else {
                 /* normal leaf PTE */
 /*              let res = append(pte.PPNi(), va.PgOfs());
                 print("walk32: pte.ppn=" ^ BitStr(pte.PPNi()) ^ " ppn=" ^ BitStr(pte.PPNi()) ^ " res=" ^ BitStr(res)); */
-                PTW_Success(append(pte.PPNi(), va.PgOfs()), pte, pte_addr, level, is_global, ext_ptw)
+                PTW_Success(append(pte.PPNi(), va.PgOfs()), pte, pte_addr, level, is_global, ext_ptw, PAGESIZE_BITS)
               }
             }
           }
@@ -95,9 +96,9 @@ function lookup_TLB32(asid, vaddr) =
     Some(e) => if match_TLB_Entry(e, asid, vaddr) then Some((0, e)) else None()
   }
 
-val add_to_TLB32 : (asid32, vaddr32, paddr32, SV32_PTE, paddr32, nat, bool) -> unit effect {wreg, rreg}
-function add_to_TLB32(asid, vAddr, pAddr, pte, pteAddr, level, global) = {
-  let ent : TLB32_Entry = make_TLB_Entry(asid, global, vAddr, pAddr, pte.bits(), level, pteAddr, SV32_LEVEL_BITS);
+val add_to_TLB32 : (asid32, vaddr32, paddr32, SV32_PTE, paddr32, nat, bool, nat) -> unit effect {wreg, rreg}
+function add_to_TLB32(asid, vAddr, pAddr, pte, pteAddr, level, global, shift) = {
+  let ent : TLB32_Entry = make_TLB_Entry(asid, global, vAddr, pAddr, pte.bits(), level, pteAddr, shift);
   tlb32 = Some(ent)
 }
 
@@ -155,10 +156,10 @@ function translate32(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = 
     None() => {
       match walk32(vAddr, ac, priv, mxr, do_sum, ptb, level, false, ext_ptw) {
         PTW_Failure(f, ext_ptw) => TR_Failure(f, ext_ptw),
-        PTW_Success(pAddr, pte, pteAddr, level, global, ext_ptw) => {
+        PTW_Success(pAddr, pte, pteAddr, level, global, ext_ptw, shift) => {
           match update_PTE_Bits(Mk_PTE_Bits(pte.BITS()), ac, zeros()) {
             None() => {
-              add_to_TLB32(asid, vAddr, pAddr, pte, pteAddr, level, global);
+              add_to_TLB32(asid, vAddr, pAddr, pte, pteAddr, level, global, shift);
               TR_Address(pAddr, ext_ptw)
             },
             Some(pbits, ext) =>
@@ -171,7 +172,7 @@ function translate32(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = 
                 /* ext is unused since there are no reserved bits for extensions */
                 match mem_write_value(to_phys_addr(pteAddr), 4, w_pte.bits(), false, false, false) {
                   MemValue(_) => {
-                    add_to_TLB32(asid, vAddr, pAddr, w_pte, pteAddr, level, global);
+                    add_to_TLB32(asid, vAddr, pAddr, w_pte, pteAddr, level, global, shift);
                     TR_Address(pAddr, ext_ptw)
                   },
                   MemException(e) => {

--- a/model/riscv_vmem_sv39.sail
+++ b/model/riscv_vmem_sv39.sail
@@ -1,5 +1,18 @@
 /* Sv39 address translation for RV64. */
 
+val napot_bits39 : (bits(44), nat) -> nat
+function napot_bits39 (v, n) = {
+  let mask = shiftl(v ^ v ^ EXTZ(0b1), n + 1) - 1;
+  let pattern = shiftl(v ^ v ^ EXTZ(0b1), n);
+  if n > 8 then {
+    0
+  } else if (v & mask) == pattern then {
+    n + 1
+  } else {
+    napot_bits39(v, n + 1)
+  }
+}
+
 val walk39 : (vaddr39, AccessType(ext_access_type), Privilege, bool, bool, paddr64, nat, bool, ext_ptw) -> PTW_Result(paddr64, SV39_PTE) effect {rmem, rmemt, rreg, escape}
 function walk39(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
   let va = Mk_SV39_Vaddr(vaddr);
@@ -56,16 +69,30 @@ function walk39(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
                 } else {
                   /* add the appropriate bits of the VPN to the superpage PPN */
                   let ppn = pte.PPNi() | (EXTZ(va.VPNi()) & mask);
+                  let shift : nat = PAGESIZE_BITS + (level * SV39_LEVEL_BITS);
 /*                let res = append(ppn, va.PgOfs());
                   print("walk39: using superpage: pte.ppn=" ^ BitStr(pte.PPNi())
                         ^ " ppn=" ^ BitStr(ppn) ^ " res=" ^ BitStr(res)); */
-                  PTW_Success(append(ppn, va.PgOfs()), pte, pte_addr, level, is_global, ext_ptw)
+                  PTW_Success(append(ppn, va.PgOfs()), pte, pte_addr, level, is_global, ext_ptw, shift)
+                }
+              } else if Mk_PTE_Ext(ext_pte).N() == 0b1 then {
+                let shift = napot_bits39(pte.PPNi(), 0);
+                if shift == 4 then {
+                  let Zsn_ppn_part = (pte.PPNi() >> shift) << shift;
+                  let Zsn_mask_vpn_bits = shiftl(va.VPNi() ^ va.VPNi() ^ EXTZ(0b1), shift) - 1;
+                  let napot_vpn_part = Zsn_mask_vpn_bits & va.VPNi();
+                  let napot_ppn = Zsn_ppn_part | EXTZ(napot_vpn_part);
+/*                let res = append(napot_ppn, va.PgOfs());
+                  print("walk39: NAPOT: pte.ppn=" ^ BitStr(pte.PPNi()) ^ " ppn=" ^ BitStr(pte.PPNi()) ^ " res=" ^ BitStr(res)); */
+                  PTW_Success(append(pte.PPNi(), va.PgOfs()), pte, pte_addr, level, is_global, ext_ptw, PAGESIZE_BITS + shift)
+                } else {
+                  PTW_Failure(PTW_Invalid_PTE(), ext_ptw)
                 }
               } else {
                 /* normal leaf PTE */
 /*              let res = append(pte.PPNi(), va.PgOfs());
                 print("walk39: pte.ppn=" ^ BitStr(pte.PPNi()) ^ " ppn=" ^ BitStr(pte.PPNi()) ^ " res=" ^ BitStr(res)); */
-                PTW_Success(append(pte.PPNi(), va.PgOfs()), pte, pte_addr, level, is_global, ext_ptw)
+                PTW_Success(append(pte.PPNi(), va.PgOfs()), pte, pte_addr, level, is_global, ext_ptw, PAGESIZE_BITS)
               }
             }
           }
@@ -89,9 +116,9 @@ function lookup_TLB39(asid, vaddr) =
     Some(e) => if match_TLB_Entry(e, asid, vaddr) then Some((0, e)) else None()
   }
 
-val add_to_TLB39 : (asid64, vaddr39, paddr64, SV39_PTE, paddr64, nat, bool) -> unit effect {wreg, rreg}
-function add_to_TLB39(asid, vAddr, pAddr, pte, pteAddr, level, global) = {
-  let ent : TLB39_Entry = make_TLB_Entry(asid, global, vAddr, pAddr, pte.bits(), level, pteAddr, SV39_LEVEL_BITS);
+val add_to_TLB39 : (asid64, vaddr39, paddr64, SV39_PTE, paddr64, nat, bool, nat) -> unit effect {wreg, rreg}
+function add_to_TLB39(asid, vAddr, pAddr, pte, pteAddr, level, global, shift) = {
+  let ent : TLB39_Entry = make_TLB_Entry(asid, global, vAddr, pAddr, pte.bits(), level, pteAddr, shift);
   tlb39 = Some(ent)
 }
 
@@ -149,10 +176,10 @@ function translate39(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = 
     None() => {
       match walk39(vAddr, ac, priv, mxr, do_sum, ptb, level, false, ext_ptw) {
         PTW_Failure(f, ext_ptw) => TR_Failure(f, ext_ptw),
-        PTW_Success(pAddr, pte, pteAddr, level, global, ext_ptw) => {
+        PTW_Success(pAddr, pte, pteAddr, level, global, ext_ptw, shift) => {
           match update_PTE_Bits(Mk_PTE_Bits(pte.BITS()), ac, pte.Ext()) {
             None() => {
-              add_to_TLB39(asid, vAddr, pAddr, pte, pteAddr, level, global);
+              add_to_TLB39(asid, vAddr, pAddr, pte, pteAddr, level, global, shift);
               TR_Address(pAddr, ext_ptw)
             },
             Some(pbits, ext) =>
@@ -165,7 +192,7 @@ function translate39(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = 
 		w_pte : SV39_PTE = update_Ext(w_pte, ext);
                 match mem_write_value(EXTZ(pteAddr), 8, w_pte.bits(), false, false, false) {
                   MemValue(_) => {
-                    add_to_TLB39(asid, vAddr, pAddr, w_pte, pteAddr, level, global);
+                    add_to_TLB39(asid, vAddr, pAddr, w_pte, pteAddr, level, global, shift);
                     TR_Address(pAddr, ext_ptw)
                   },
                   MemException(e) => {

--- a/model/riscv_vmem_sv48.sail
+++ b/model/riscv_vmem_sv48.sail
@@ -1,5 +1,18 @@
 /* Sv48 address translation for RV64. */
 
+val napot_bits48 : (bits(44), nat) -> nat
+function napot_bits48 (v, n) = {
+  let mask = shiftl(v ^ v ^ EXTZ(0b1), n + 1) - 1;
+  let pattern = shiftl(v ^ v ^ EXTZ(0b1), n);
+  if n > 8 then {
+    0
+  } else if (v & mask) == pattern then {
+    n + 1
+  } else {
+    napot_bits39(v, n + 1)
+  }
+}
+
 val walk48 : (vaddr48, AccessType(ext_access_type), Privilege, bool, bool, paddr64, nat, bool, ext_ptw) -> PTW_Result(paddr64, SV48_PTE) effect {rmem, rmemt, rreg, escape}
 function walk48(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
   let va = Mk_SV48_Vaddr(vaddr);
@@ -56,16 +69,30 @@ function walk48(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
                 } else {
                   /* add the appropriate bits of the VPN to the superpage PPN */
                   let ppn = pte.PPNi() | (EXTZ(va.VPNi()) & mask);
+                  let shift : nat = PAGESIZE_BITS + (level * SV48_LEVEL_BITS);
 /*                let res = append(ppn, va.PgOfs());
                   print("walk48: using superpage: pte.ppn=" ^ BitStr(pte.PPNi())
                         ^ " ppn=" ^ BitStr(ppn) ^ " res=" ^ BitStr(res)); */
-                  PTW_Success(append(ppn, va.PgOfs()), pte, pte_addr, level, is_global, ext_ptw)
+                  PTW_Success(append(ppn, va.PgOfs()), pte, pte_addr, level, is_global, ext_ptw, shift)
+                }
+              } else if Mk_PTE_Ext(ext_pte).N() == 0b1 then {
+                let shift = napot_bits48(pte.PPNi(), 0);
+                if shift == 4 then {
+                  let Zsn_ppn_part = (pte.PPNi() >> shift) << shift;
+                  let Zsn_mask_vpn_bits = shiftl(va.VPNi() ^ va.VPNi() ^ EXTZ(0b1), shift) - 1;
+                  let napot_vpn_part = Zsn_mask_vpn_bits & va.VPNi();
+                  let napot_ppn = Zsn_ppn_part | EXTZ(napot_vpn_part);
+/*                let res = append(napot_ppn, va.PgOfs());
+                  print("walk48: NAPOT: pte.ppn=" ^ BitStr(pte.PPNi()) ^ " ppn=" ^ BitStr(pte.PPNi()) ^ " res=" ^ BitStr(res)); */
+                  PTW_Success(append(pte.PPNi(), va.PgOfs()), pte, pte_addr, level, is_global, ext_ptw, PAGESIZE_BITS + shift)
+                } else {
+                  PTW_Failure(PTW_Invalid_PTE(), ext_ptw)
                 }
               } else {
                 /* normal leaf PTE */
 /*              let res = append(pte.PPNi(), va.PgOfs());
                 print("walk48: pte.ppn=" ^ BitStr(pte.PPNi()) ^ " ppn=" ^ BitStr(pte.PPNi()) ^ " res=" ^ BitStr(res)); */
-                PTW_Success(append(pte.PPNi(), va.PgOfs()), pte, pte_addr, level, is_global, ext_ptw)
+                PTW_Success(append(pte.PPNi(), va.PgOfs()), pte, pte_addr, level, is_global, ext_ptw, PAGESIZE_BITS)
               }
             }
           }
@@ -89,9 +116,9 @@ function lookup_TLB48(asid, vaddr) =
     Some(e) => if match_TLB_Entry(e, asid, vaddr) then Some((0, e)) else None()
   }
 
-val add_to_TLB48 : (asid64, vaddr48, paddr64, SV48_PTE, paddr64, nat, bool) -> unit effect {wreg, rreg}
-function add_to_TLB48(asid, vAddr, pAddr, pte, pteAddr, level, global) = {
-  let ent : TLB48_Entry = make_TLB_Entry(asid, global, vAddr, pAddr, pte.bits(), level, pteAddr, SV48_LEVEL_BITS);
+val add_to_TLB48 : (asid64, vaddr48, paddr64, SV48_PTE, paddr64, nat, bool, nat) -> unit effect {wreg, rreg}
+function add_to_TLB48(asid, vAddr, pAddr, pte, pteAddr, level, global, shift) = {
+  let ent : TLB48_Entry = make_TLB_Entry(asid, global, vAddr, pAddr, pte.bits(), level, pteAddr, shift);
   tlb48 = Some(ent)
 }
 
@@ -113,10 +140,10 @@ val translate48 : (asid64, paddr64, vaddr48, AccessType(ext_access_type), Privil
 function translate48(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = {
   match walk48(vAddr, ac, priv, mxr, do_sum, ptb, level, false, ext_ptw) {
     PTW_Failure(f, ext_ptw) => TR_Failure(f, ext_ptw),
-    PTW_Success(pAddr, pte, pteAddr, level, global, ext_ptw) => {
+    PTW_Success(pAddr, pte, pteAddr, level, global, ext_ptw, shift) => {
       match update_PTE_Bits(Mk_PTE_Bits(pte.BITS()), ac, pte.Ext()) {
         None() => {
-          add_to_TLB48(asid, vAddr, pAddr, pte, pteAddr, level, global);
+          add_to_TLB48(asid, vAddr, pAddr, pte, pteAddr, level, global, shift);
           TR_Address(pAddr, ext_ptw)
         },
         Some(pbits, ext) =>
@@ -129,7 +156,7 @@ function translate48(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = 
 	    w_pte : SV48_PTE = update_Ext(w_pte, ext);
             match mem_write_value(EXTZ(pteAddr), 8, w_pte.bits(), false, false, false) {
               MemValue(_) => {
-                add_to_TLB48(asid, vAddr, pAddr, w_pte, pteAddr, level, global);
+                add_to_TLB48(asid, vAddr, pAddr, w_pte, pteAddr, level, global, shift);
                 TR_Address(pAddr, ext_ptw)
               },
               MemException(e) => {

--- a/model/riscv_vmem_tlb.sail
+++ b/model/riscv_vmem_tlb.sail
@@ -16,8 +16,7 @@ struct TLB_Entry('asidlen: Int, 'valen: Int, 'palen: Int, 'ptelen: Int) = {
 val make_TLB_Entry : forall 'asidlen 'valen 'palen 'ptelen, 'valen > 0.
   (bits('asidlen), bool, bits('valen), bits('palen), bits('ptelen), nat, bits('palen), nat)
   -> TLB_Entry('asidlen, 'valen, 'palen, 'ptelen) effect {rreg}
-function make_TLB_Entry(asid, global, vAddr, pAddr, pte, level, pteAddr, levelBitSize) = {
-  let shift : nat = PAGESIZE_BITS + (level * levelBitSize);
+function make_TLB_Entry(asid, global, vAddr, pAddr, pte, level, pteAddr, shift) = {
   /* fixme hack: use a better idiom for masks */
   let vAddrMask  : bits('valen) = shiftl(vAddr ^ vAddr ^ EXTZ(0b1), shift) - 1;
   let vMatchMask : bits('valen) = ~ (vAddrMask);


### PR DESCRIPTION
Zsn is a new supervisor mode extension being developed by the virtual memory task group.  The goal of Zsn is to support contiguous address translation ranges of naturally-aligned power-of-two (NAPOT) sizes between the existing page sizes (4KiB, 2MiB).  The specific region size we're aiming to support for now is 64KiB, but we may extend support to other power-of-two sizes in the future.  Zsn is currently in draft state, with a plan to go to public review hopefully by the end of the year.

See https://github.com/riscv/virtual-memory for more info on Zsn.  See https://github.com/riscv/virtual-memory/blob/main/presentations/2020-12-03-Zsn-Sail.adoc for some commentary on these Sail changes.

The Zsn part itself has not yet been tested.  The virtual memory group is working on creating a suite of tests, but we don't have them ready yet.  There's no urgency to merge this before we're sure it's ready, but I figured I'd still open a PR to allow for feedback on the code in the meantime.  This is my first attempt to write Sail, so feedback is welcome.