### PR TITLE
Add missing MPRV clearing on MRET/SRET

### DIFF
--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -456,6 +456,8 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
       mstatus->MIE()  = mstatus.MPIE();
       mstatus->MPIE() = 0b1;
       cur_privilege   = privLevel_of_bits(mstatus.MPP());
+      if cur_privilege != Machine
+      then mstatus->MPRV() = 0b0;
       mstatus->MPP()  = privLevel_to_bits(if haveUsrMode() then User else Machine);
       if   cur_privilege != Machine
       then mstatus->MPRV() = 0b0;
@@ -473,6 +475,7 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
       mstatus->SIE()  = mstatus.SPIE();
       mstatus->SPIE() = 0b1;
       cur_privilege   = if mstatus.SPP() == 0b1 then Supervisor else User;
+      mstatus->MPRV() = 0b0;
       mstatus->SPP()  = 0b0;
       if   cur_privilege != Machine
       then mstatus->MPRV() = 0b0;


### PR DESCRIPTION
The 1.12 privileged spec [requires](https://github.com/riscv/riscv-isa-manual/blob/d29cb13885d7dfaae9aaa27b45e44733254ead37/src/machine.tex#L689-L690):

> An MRET or SRET instruction that changes the privilege mode to a mode less privileged than M also sets MPRV=0.

In this PR, SRET is implemented a little differently than MRET, because SRET always returns to a mode less privileged than M; whereas MRET might stay in M-mode.
