### PR TITLE
Scalar crypto - post code review improvments

### DIFF
--- a/model/riscv_insts_zkn.sail
+++ b/model/riscv_insts_zkn.sail
@@ -190,37 +190,37 @@ mapping clause assembly = SHA512SUM1R (rs2, rs1, rd)
 
 function clause execute (SHA512SIG0H(rs2, rs1, rd)) = {
   X(rd) = EXTS((X(rs1) >>  1) ^ (X(rs1) >>  7) ^ (X(rs1) >>  8) ^
-               (X(rs2) << 31)                  ^ (X(rs2) << 24) );
+               (X(rs2) << 31)                  ^ (X(rs2) << 24));
   RETIRE_SUCCESS
 }
 
 function clause execute (SHA512SIG0L(rs2, rs1, rd)) = {
   X(rd) = EXTS((X(rs1) >>  1) ^ (X(rs1) >>  7) ^ (X(rs1) >>  8) ^
-               (X(rs2) << 31) ^ (X(rs2) << 25) ^ (X(rs2) << 24) );
+               (X(rs2) << 31) ^ (X(rs2) << 25) ^ (X(rs2) << 24));
   RETIRE_SUCCESS
 }
 
 function clause execute (SHA512SIG1H(rs2, rs1, rd)) = {
   X(rd) = EXTS((X(rs1) <<  3) ^ (X(rs1) >>  6) ^ (X(rs1) >> 19) ^
-               (X(rs2) >> 29)                  ^ (X(rs2) << 13) );
+               (X(rs2) >> 29)                  ^ (X(rs2) << 13));
   RETIRE_SUCCESS
 }
 
 function clause execute (SHA512SIG1L(rs2, rs1, rd)) = {
   X(rd) = EXTS((X(rs1) <<  3) ^ (X(rs1) >>  6) ^ (X(rs1) >> 19) ^
-               (X(rs2) >> 29) ^ (X(rs2) << 26) ^ (X(rs2) << 13) );
+               (X(rs2) >> 29) ^ (X(rs2) << 26) ^ (X(rs2) << 13));
   RETIRE_SUCCESS
 }
 
 function clause execute (SHA512SUM0R(rs2, rs1, rd)) = {
   X(rd) = EXTS((X(rs1) << 25) ^ (X(rs1) << 30) ^ (X(rs1) >> 28) ^
-               (X(rs2) >>  7) ^ (X(rs2) >>  2) ^ (X(rs2) <<  4) );
+               (X(rs2) >>  7) ^ (X(rs2) >>  2) ^ (X(rs2) <<  4));
   RETIRE_SUCCESS
 }
 
 function clause execute (SHA512SUM1R(rs2, rs1, rd)) = {
   X(rd) = EXTS((X(rs1) << 23) ^ (X(rs1) >> 14) ^ (X(rs1) >> 18) ^
-               (X(rs2) >>  9) ^ (X(rs2) << 18) ^ (X(rs2) << 14) );
+               (X(rs2) >>  9) ^ (X(rs2) << 18) ^ (X(rs2) << 14));
   RETIRE_SUCCESS
 }
 

--- a/model/riscv_insts_zkn.sail
+++ b/model/riscv_insts_zkn.sail
@@ -152,22 +152,22 @@ union clause ast = SHA512SIG1H : (regidx, regidx, regidx)
 union clause ast = SHA512SUM0R : (regidx, regidx, regidx)
 union clause ast = SHA512SUM1R : (regidx, regidx, regidx)
 
-mapping clause encdec = SHA512SUM0R (rs2, rs1, rd) if haveZknh() & sizeof(xlen)==32
+mapping clause encdec = SHA512SUM0R (rs2, rs1, rd) if haveZknh() & sizeof(xlen) == 32
   <-> 0b01 @ 0b01000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011
 
-mapping clause encdec = SHA512SUM1R (rs2, rs1, rd) if haveZknh() & sizeof(xlen)==32
+mapping clause encdec = SHA512SUM1R (rs2, rs1, rd) if haveZknh() & sizeof(xlen) == 32
   <-> 0b01 @ 0b01001 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011
 
-mapping clause encdec = SHA512SIG0L (rs2, rs1, rd) if haveZknh() & sizeof(xlen)==32
+mapping clause encdec = SHA512SIG0L (rs2, rs1, rd) if haveZknh() & sizeof(xlen) == 32
   <-> 0b01 @ 0b01010 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011
 
-mapping clause encdec = SHA512SIG0H (rs2, rs1, rd) if haveZknh() & sizeof(xlen)==32
+mapping clause encdec = SHA512SIG0H (rs2, rs1, rd) if haveZknh() & sizeof(xlen) == 32
   <-> 0b01 @ 0b01110 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011
 
-mapping clause encdec = SHA512SIG1L (rs2, rs1, rd) if haveZknh() & sizeof(xlen)==32
+mapping clause encdec = SHA512SIG1L (rs2, rs1, rd) if haveZknh() & sizeof(xlen) == 32
   <-> 0b01 @ 0b01011 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011
 
-mapping clause encdec = SHA512SIG1H (rs2, rs1, rd) if haveZknh() & sizeof(xlen)==32
+mapping clause encdec = SHA512SIG1H (rs2, rs1, rd) if haveZknh() & sizeof(xlen) == 32
   <-> 0b01 @ 0b01111 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011
 
 mapping clause assembly = SHA512SIG0L (rs2, rs1, rd)
@@ -349,16 +349,16 @@ union clause ast = SHA512SIG1 : (regidx, regidx)
 union clause ast = SHA512SUM0 : (regidx, regidx)
 union clause ast = SHA512SUM1 : (regidx, regidx)
 
-mapping clause encdec = SHA512SUM0 (rs1, rd) if haveZknh() & sizeof(xlen)==64
+mapping clause encdec = SHA512SUM0 (rs1, rd) if haveZknh() & sizeof(xlen) == 64
   <-> 0b00 @ 0b01000 @ 0b00100 @ rs1 @ 0b001 @ rd @ 0b0010011
 
-mapping clause encdec = SHA512SUM1 (rs1, rd) if haveZknh() & sizeof(xlen)==64
+mapping clause encdec = SHA512SUM1 (rs1, rd) if haveZknh() & sizeof(xlen) == 64
   <-> 0b00 @ 0b01000 @ 0b00101 @ rs1 @ 0b001 @ rd @ 0b0010011
 
-mapping clause encdec = SHA512SIG0 (rs1, rd) if haveZknh() & sizeof(xlen)==64
+mapping clause encdec = SHA512SIG0 (rs1, rd) if haveZknh() & sizeof(xlen) == 64
   <-> 0b00 @ 0b01000 @ 0b00110 @ rs1 @ 0b001 @ rd @ 0b0010011
 
-mapping clause encdec = SHA512SIG1 (rs1, rd) if haveZknh() & sizeof(xlen)==64
+mapping clause encdec = SHA512SIG1 (rs1, rd) if haveZknh() & sizeof(xlen) == 64
   <-> 0b00 @ 0b01000 @ 0b00111 @ rs1 @ 0b001 @ rd @ 0b0010011
 
 mapping clause assembly = SHA512SIG0 (rs1, rd)

--- a/model/riscv_insts_zkn.sail
+++ b/model/riscv_insts_zkn.sail
@@ -237,8 +237,8 @@ union clause ast = AES64ES   : (regidx, regidx, regidx)
 union clause ast = AES64DSM  : (regidx, regidx, regidx)
 union clause ast = AES64DS   : (regidx, regidx, regidx)
 
-mapping clause encdec = AES64KS1I (rcon, rs1, rd) if (haveZkne() | haveZknd()) & (sizeof(xlen) == 64) & (rcon <_u 0xB)
-  <-> 0b00 @ 0b11000 @ 0b1 @ rcon @ rs1 @ 0b001 @ rd @ 0b0010011
+mapping clause encdec = AES64KS1I (rnum, rs1, rd) if (haveZkne() | haveZknd()) & (sizeof(xlen) == 64) & (rnum <_u 0xB)
+  <-> 0b00 @ 0b11000 @ 0b1 @ rnum @ rs1 @ 0b001 @ rd @ 0b0010011
 
 mapping clause encdec = AES64IM (rs1, rd) if haveZknd() & sizeof(xlen) == 64
   <-> 0b00 @ 0b11000 @ 0b00000 @ rs1 @ 0b001 @ rd @ 0b0010011
@@ -279,13 +279,16 @@ mapping clause assembly = AES64DSM (rs2, rs1, rd)
 mapping clause assembly = AES64DS (rs2, rs1, rd)
   <-> "aes64ds" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (AES64KS1I(rcon, rs1, rd)) = {
+/* Note: The decoding for this instruction ensures that `rnum` is always in
+   the range 0x0..0xA. See the encdec clause for AES64KS1I.
+   The rum == 0xA case is used specifically for the AES-256 KeySchedule */
+function clause execute (AES64KS1I(rnum, rs1, rd)) = {
   assert(sizeof(xlen) == 64);
-  let rs1_hi  : bits(32) = X(rs1)[63..32];
-  let rc      : bits(32) = aes_decode_rcon(rcon);
-  let rotated : bits(32) = if (rcon == 0xA) then rs1_hi else (rs1_hi >>> 8);
-  let post_sb : bits(32) = aes_subword_fwd(rotated);
-  X(rd) = (post_sb ^ rc) @ (post_sb ^ rc);
+  let prev     : bits(32) = X(rs1)[63..32];
+  let subwords : bits(32) = aes_subword_fwd(prev);
+  let result   : bits(32) = if (rnum == 0xA) then subwords
+                            else (subwords >>> 8) ^ aes_decode_rcon(rnum);
+  X(rd) = result @ result;
   RETIRE_SUCCESS
 }
 

--- a/model/riscv_types_kext.sail
+++ b/model/riscv_types_kext.sail
@@ -68,8 +68,15 @@ function aes_mixcolumn_inv(x) = {
   b3 @ b2 @ b1 @ b0 /* Return value */
 }
 
-val aes_decode_rcon : bits(4) -> bits(32)
+/* Turn a round number into a round constant for AES. Note that the
+   AES64KS1I instruction is defined such that the r argument is always
+   in the range 0x0..0xA. Values of rnum outside the range 0x0..0xA
+   do not decode to the AES64KS1I instruction. The 0xA case is used
+   specifically for the AES-256 KeySchedule, and this function is never
+   called in that case. */
+val aes_decode_rcon : bits(4) -> bits(32) effect {escape}
 function aes_decode_rcon(r) = {
+  assert(r <_u 0xA);
   match r {
     0x0 => 0x00000001,
     0x1 => 0x00000002,
@@ -80,13 +87,7 @@ function aes_decode_rcon(r) = {
     0x6 => 0x00000040,
     0x7 => 0x00000080,
     0x8 => 0x0000001b,
-    0x9 => 0x00000036,
-    0xA => 0x00000000,
-    0xB => 0x00000000,
-    0xC => 0x00000000,
-    0xD => 0x00000000,
-    0xE => 0x00000000,
-    0xF => 0x00000000
+    0x9 => 0x00000036
   }
 }
 


### PR DESCRIPTION
Hi there

This PR contains updates from @jrtc27's review [here](https://github.com/riscv/sail-riscv/pull/99#pullrequestreview-786873720) which were missing from the original merge of the scalar cryptography extension code.

- [Commit 1](https://github.com/riscv/sail-riscv/commit/a527ad769c9acba9cba70261c3bd73a1d5a0069c) addresses the [inconsistency of `==` whitespace](https://github.com/riscv/sail-riscv/pull/99#discussion_r734560390)
- [Commit 2](https://github.com/riscv/sail-riscv/commit/c4ad3c16a943de9996224a2439b5488ce4fac359) addresses the [inconsistency of ` );`](https://github.com/riscv/sail-riscv/pull/99#discussion_r734563951) whitespace in the `sha*` instructions.
- [Commit 3](https://github.com/riscv/sail-riscv/commit/53611ff431bac23b438f30bbd214cff3c55c6bb6) tries to address [comments](https://github.com/riscv/sail-riscv/pull/99#discussion_r734584700) about the clarity of `aesks1i` by adding code comments, and ensuring that the `aes_decode_rcon` function only accepts valid inputs. It also renames some arguments to the `aesks1i` execute and encdec clauses to match the specification.

About [this question](https://github.com/riscv/sail-riscv/pull/99#discussion_r734562267) asking "please confirm every single change in [commit](https://github.com/riscv/sail-riscv/compare/33aaaa04eaeaa9d2ed69023735ad6ebb93f71775..b83f68b3ade2d5444fd7dfe952e441824bb19dd8) is what you intended?" - Yes, these functional changes were intended and should have been part of the initial PR. Specifically, the changes to when `aesks1i` and `aesks2` are enabled were deliberate, as they should be present for both the `Zkne` and `Zknd` extensions.

About the `aesks1i` comments [here](https://github.com/riscv/sail-riscv/pull/99#discussion_r734584700) - It's been interesting watching people react to these instructions. The more cryptography minded people have reacted quite positively to how they're specified because they map onto some common implementation patterns for the AES KeySchedule _fairly_ well. But, that's only apparent if you're very familiar with those patterns in the first place, which is precious few people. Others have initially been quite perplexed about them for exactly the reasons highlighted. If there's anything _more_ to be done about explaining these instructions better then I'm all ears. Whether this is best going into the Sail code or the specification document, I'm not sure - maybe both. In terms of being future-proof to changes in FIPS-197 parameters, I think we are fairly safe. AES is very stable at this point, and I don't think NIST or anyone in the cryptography community is expecting to see AES parameter changes.

I've deliberately kept the commits separate in the hope it makes the PR easier to map back onto the original review. If you'd like me to squash them down before merging, please let me know. Likewise if there's anything else which could be made clearer.

Cheers,
Ben