### PR TITLE
Add Support for Zmmul

### DIFF
--- a/model/riscv_insts_mext.sail
+++ b/model/riscv_insts_mext.sail
@@ -85,7 +85,7 @@ mapping clause encdec = MUL(rs2, rs1, rd, high, signed1, signed2)
   <-> 0b0000001 @ rs2 @ rs1 @ encdec_mul_op(high, signed1, signed2) : bits(3) @ rd @ 0b0110011
 
 function clause execute (MUL(rs2, rs1, rd, high, signed1, signed2)) = {
-  if haveMulDiv() then {
+  if haveMulDiv() | haveZmmul() then {
     let rs1_val = X(rs1);
     let rs2_val = X(rs2);
     let rs1_int : int = if signed1 then signed(rs1_val) else unsigned(rs1_val);
@@ -177,7 +177,7 @@ mapping clause encdec = MULW(rs2, rs1, rd)
       if sizeof(xlen) == 64
 
 function clause execute (MULW(rs2, rs1, rd)) = {
-  if haveMulDiv() then {
+  if haveMulDiv() | haveZmmul() then {
     let rs1_val = X(rs1)[31..0];
     let rs2_val = X(rs2)[31..0];
     let rs1_int : int = signed(rs1_val);

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -190,6 +190,8 @@ function haveZknh()   -> bool = true
 function haveZkne()   -> bool = true
 function haveZknd()   -> bool = true
 
+function haveZmmul()  -> bool = true
+
 bitfield Mstatush : bits(32) = {
   MBE  : 5,
   SBE  : 4


### PR DESCRIPTION
RISC-V Zmmul extension includes following instructions:
 - mul
 - mulh
 - mulhsu
 - mulhu
 - mulw (RV64 only)
The opcode encodings and instruction semantics are identical to those in the M-extension.
The ISA string is Zmmul.
8.3 Zmmul Extension, Version 0.1 (riscv unpriv spec)