### PR TITLE
Add support for Zfh extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ SAIL_DEFAULT_INST += riscv_insts_zba.sail
 SAIL_DEFAULT_INST += riscv_insts_zbb.sail
 SAIL_DEFAULT_INST += riscv_insts_zbc.sail
 SAIL_DEFAULT_INST += riscv_insts_zbs.sail
+
+SAIL_DEFAULT_INST += riscv_insts_zfh.sail
+
 SAIL_DEFAULT_INST += riscv_insts_zkn.sail
 SAIL_DEFAULT_INST += riscv_insts_zks.sail
 

--- a/c_emulator/riscv_softfloat.c
+++ b/c_emulator/riscv_softfloat.c
@@ -17,6 +17,58 @@ static uint_fast8_t uint8_of_rm(mach_bits rm) {
   zfloat_result = res.v;                                    \
   zfloat_fflags |= (mach_bits) softfloat_exceptionFlags     \
 
+unit softfloat_f16add(mach_bits rm, mach_bits v1, mach_bits v2) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a, b, res;
+  a.v = v1;
+  b.v = v2;
+  res = f16_add(a, b);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f16sub(mach_bits rm, mach_bits v1, mach_bits v2) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a, b, res;
+  a.v = v1;
+  b.v = v2;
+  res = f16_sub(a, b);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f16mul(mach_bits rm, mach_bits v1, mach_bits v2) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a, b, res;
+  a.v = v1;
+  b.v = v2;
+  res = f16_mul(a, b);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f16div(mach_bits rm, mach_bits v1, mach_bits v2) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a, b, res;
+  a.v = v1;
+  b.v = v2;
+  res = f16_div(a, b);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
 unit softfloat_f32add(mach_bits rm, mach_bits v1, mach_bits v2) {
   SOFTFLOAT_PRELUDE(rm);
 
@@ -121,6 +173,20 @@ unit softfloat_f64div(mach_bits rm, mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
+unit softfloat_f16muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a, b, c, res;
+  a.v = v1;
+  b.v = v2;
+  c.v = v3;
+  res = f16_mulAdd(a, b, c);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
 unit softfloat_f32muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3) {
   SOFTFLOAT_PRELUDE(rm);
 
@@ -143,6 +209,18 @@ unit softfloat_f64muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3)
   b.v = v2;
   c.v = v3;
   res = f64_mulAdd(a, b, c);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f16sqrt(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a, res;
+  a.v = v;
+  res = f16_sqrt(a);
 
   SOFTFLOAT_POSTLUDE(res);
 
@@ -176,6 +254,62 @@ unit softfloat_f64sqrt(mach_bits rm, mach_bits v) {
 // The boolean 'true' argument in the conversion calls below selects
 // 'exact' conversion, which sets the Inexact exception flag if
 // needed.
+unit softfloat_f16toi32(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a;
+  float32_t res;
+  uint_fast8_t rm8 = uint8_of_rm(rm);
+  a.v = v;
+  res.v = f16_to_i32(a, rm8, true);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f16toui32(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a;
+  float32_t res;
+  uint_fast8_t rm8 = uint8_of_rm(rm);
+  a.v = v;
+  res.v = f16_to_ui32(a, rm8, true);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f16toi64(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a;
+  float64_t res;
+  uint_fast8_t rm8 = uint8_of_rm(rm);
+  a.v = v;
+  res.v = f16_to_i64(a, rm8, true);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f16toui64(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a;
+  float64_t res;
+  uint_fast8_t rm8 = uint8_of_rm(rm);
+  a.v = v;
+  res.v = f16_to_ui64(a, rm8, true);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
 unit softfloat_f32toi32(mach_bits rm, mach_bits v) {
   SOFTFLOAT_PRELUDE(rm);
 
@@ -284,6 +418,50 @@ unit softfloat_f64toui64(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
+unit softfloat_i32tof16(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t res;
+  res = i32_to_f16((int32_t)v);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_ui32tof16(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t res;
+  res = ui32_to_f16((uint32_t)v);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_i64tof16(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t res;
+  res = i64_to_f16(v);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_ui64tof16(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t res;
+  res = ui64_to_f16(v);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
 unit softfloat_i32tof32(mach_bits rm, mach_bits v) {
   SOFTFLOAT_PRELUDE(rm);
 
@@ -372,6 +550,32 @@ unit softfloat_ui64tof64(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
+unit softfloat_f16tof32(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a;
+  float32_t res;
+  a.v = v;
+  res = f16_to_f32(a);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f16tof64(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a;
+  float64_t res;
+  a.v = v;
+  res = f16_to_f64(a);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
 unit softfloat_f32tof64(mach_bits rm, mach_bits v) {
   SOFTFLOAT_PRELUDE(rm);
 
@@ -385,6 +589,32 @@ unit softfloat_f32tof64(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
+unit softfloat_f32tof16(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float32_t a;
+  float16_t res;
+  a.v = v;
+  res = f32_to_f16(a);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f64tof16(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float64_t a;
+  float16_t res;
+  a.v = v;
+  res = f64_to_f16(a);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
 unit softfloat_f64tof32(mach_bits rm, mach_bits v) {
   SOFTFLOAT_PRELUDE(rm);
 
@@ -392,6 +622,45 @@ unit softfloat_f64tof32(mach_bits rm, mach_bits v) {
   float32_t res;
   a.v = v;
   res = f64_to_f32(a);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f16lt(mach_bits v1, mach_bits v2) {
+  SOFTFLOAT_PRELUDE(0);
+
+  float16_t a, b, res;
+  a.v = v1;
+  b.v = v2;
+  res.v = f16_lt(a, b);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f16le(mach_bits v1, mach_bits v2) {
+  SOFTFLOAT_PRELUDE(0);
+
+  float16_t a, b, res;
+  a.v = v1;
+  b.v = v2;
+  res.v = f16_le(a, b);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f16eq(mach_bits v1, mach_bits v2) {
+  SOFTFLOAT_PRELUDE(0);
+
+  float16_t a, b, res;
+  a.v = v1;
+  b.v = v2;
+  res.v = f16_eq(a, b);
 
   SOFTFLOAT_POSTLUDE(res);
 

--- a/c_emulator/riscv_softfloat.h
+++ b/c_emulator/riscv_softfloat.h
@@ -1,5 +1,10 @@
 #pragma once
 
+unit softfloat_f16add(mach_bits rm, mach_bits v1, mach_bits v2);
+unit softfloat_f16sub(mach_bits rm, mach_bits v1, mach_bits v2);
+unit softfloat_f16mul(mach_bits rm, mach_bits v1, mach_bits v2);
+unit softfloat_f16div(mach_bits rm, mach_bits v1, mach_bits v2);
+
 unit softfloat_f32add(mach_bits rm, mach_bits v1, mach_bits v2);
 unit softfloat_f32sub(mach_bits rm, mach_bits v1, mach_bits v2);
 unit softfloat_f32mul(mach_bits rm, mach_bits v1, mach_bits v2);
@@ -10,11 +15,18 @@ unit softfloat_f64sub(mach_bits rm, mach_bits v1, mach_bits v2);
 unit softfloat_f64mul(mach_bits rm, mach_bits v1, mach_bits v2);
 unit softfloat_f64div(mach_bits rm, mach_bits v1, mach_bits v2);
 
+unit softfloat_f16muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3);
 unit softfloat_f32muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3);
 unit softfloat_f64muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3);
 
+unit softfloat_f16sqrt(mach_bits rm, mach_bits v);
 unit softfloat_f32sqrt(mach_bits rm, mach_bits v);
 unit softfloat_f64sqrt(mach_bits rm, mach_bits v);
+
+unit softfloat_f16toi32(mach_bits rm, mach_bits v);
+unit softfloat_f16toui32(mach_bits rm, mach_bits v);
+unit softfloat_f16toi64(mach_bits rm, mach_bits v);
+unit softfloat_f16toui64(mach_bits rm, mach_bits v);
 
 unit softfloat_f32toi32(mach_bits rm, mach_bits v);
 unit softfloat_f32toui32(mach_bits rm, mach_bits v);
@@ -26,6 +38,11 @@ unit softfloat_f64toui32(mach_bits rm, mach_bits v);
 unit softfloat_f64toi64(mach_bits rm, mach_bits v);
 unit softfloat_f64toui64(mach_bits rm, mach_bits v);
 
+unit softfloat_i32tof16(mach_bits rm, mach_bits v);
+unit softfloat_ui32tof16(mach_bits rm, mach_bits v);
+unit softfloat_i64tof16(mach_bits rm, mach_bits v);
+unit softfloat_ui64tof16(mach_bits rm, mach_bits v);
+
 unit softfloat_i32tof32(mach_bits rm, mach_bits v);
 unit softfloat_ui32tof32(mach_bits rm, mach_bits v);
 unit softfloat_i64tof32(mach_bits rm, mach_bits v);
@@ -36,9 +53,17 @@ unit softfloat_ui32tof64(mach_bits rm, mach_bits v);
 unit softfloat_i64tof64(mach_bits rm, mach_bits v);
 unit softfloat_ui64tof64(mach_bits rm, mach_bits v);
 
+unit softfloat_f16tof32(mach_bits rm, mach_bits v);
+unit softfloat_f16tof64(mach_bits rm, mach_bits v);
 unit softfloat_f32tof64(mach_bits rm, mach_bits v);
+
+unit softfloat_f32tof16(mach_bits rm, mach_bits v);
+unit softfloat_f64tof16(mach_bits rm, mach_bits v);
 unit softfloat_f64tof32(mach_bits rm, mach_bits v);
 
+unit softfloat_f16lt(mach_bits v1, mach_bits v2);
+unit softfloat_f16le(mach_bits v1, mach_bits v2);
+unit softfloat_f16eq(mach_bits v1, mach_bits v2);
 unit softfloat_f32lt(mach_bits v1, mach_bits v2);
 unit softfloat_f32le(mach_bits v1, mach_bits v2);
 unit softfloat_f32eq(mach_bits v1, mach_bits v2);

--- a/handwritten_support/0.11/riscv_extras_fdext.lem
+++ b/handwritten_support/0.11/riscv_extras_fdext.lem
@@ -10,6 +10,18 @@ type bitvector 'a = mword 'a
 
 (* stub functions emulating the C softfloat interface *)
 
+val softfloat_f16_add : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit
+let softfloat_f16_add _ _ _ = ()
+
+val softfloat_f16_sub : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit
+let softfloat_f16_sub _ _ _ = ()
+
+val softfloat_f16_mul : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit
+let softfloat_f16_mul _ _ _ = ()
+
+val softfloat_f16_div : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit
+let softfloat_f16_div _ _ _ = ()
+
 val softfloat_f32_add : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit
 let softfloat_f32_add _ _ _ = ()
 
@@ -35,6 +47,9 @@ val softfloat_f64_div : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bit
 let softfloat_f64_div _ _ _ = ()
 
 
+val softfloat_f16_muladd : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> bitvector 's -> unit
+let softfloat_f16_muladd _ _ _ _ = ()
+
 val softfloat_f32_muladd : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> bitvector 's -> unit
 let softfloat_f32_muladd _ _ _ _ = ()
 
@@ -42,11 +57,39 @@ val softfloat_f64_muladd : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> 
 let softfloat_f64_muladd _ _ _ _ = ()
 
 
+val softfloat_f16_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_sqrt _ _ = ()
+
 val softfloat_f32_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_f32_sqrt _ _ = ()
 
 val softfloat_f64_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_f64_sqrt _ _ = ()
+
+
+val softfloat_f16_to_i32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_i32 _ _ = ()
+
+val softfloat_f16_to_ui32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_ui32 _ _ = ()
+
+val softfloat_i32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_i32_to_f16 _ _ = ()
+
+val softfloat_ui32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_ui32_to_f16 _ _ = ()
+
+val softfloat_f16_to_i64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_i64 _ _ = ()
+
+val softfloat_f16_to_ui64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_ui64 _ _ = ()
+
+val softfloat_i64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_i64_to_f16 _ _ = ()
+
+val softfloat_ui64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_ui64_to_f16 _ _ = ()
 
 
 val softfloat_f32_to_i32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
@@ -99,12 +142,33 @@ val softfloat_ui64_to_f64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> 
 let softfloat_ui64_to_f64 _ _ = ()
 
 
+val softfloat_f16_to_f32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_f32 _ _ = ()
+
+val softfloat_f16_to_f64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_f64 _ _ = ()
+
 val softfloat_f32_to_f64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_f32_to_f64 _ _ = ()
+
+val softfloat_f32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f32_to_f16 _ _ = ()
+
+val softfloat_f64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f64_to_f16 _ _ = ()
 
 val softfloat_f64_to_f32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_f64_to_f32 _ _ = ()
 
+
+val softfloat_f16_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
+let softfloat_f16_lt _ _ = ()
+
+val softfloat_f16_le : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
+let softfloat_f16_le _ _ = ()
+
+val softfloat_f16_eq : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
+let softfloat_f16_eq _ _ = ()
 
 val softfloat_f32_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
 let softfloat_f32_lt _ _ = ()

--- a/handwritten_support/riscv_extras_fdext.lem
+++ b/handwritten_support/riscv_extras_fdext.lem
@@ -78,6 +78,18 @@ type bitvector 'a = mword 'a
 
 (* stub functions emulating the C softfloat interface *)
 
+val softfloat_f16_add : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit
+let softfloat_f16_add _ _ _ = ()
+
+val softfloat_f16_sub : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit
+let softfloat_f16_sub _ _ _ = ()
+
+val softfloat_f16_mul : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit
+let softfloat_f16_mul _ _ _ = ()
+
+val softfloat_f16_div : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit
+let softfloat_f16_div _ _ _ = ()
+
 val softfloat_f32_add : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit
 let softfloat_f32_add _ _ _ = ()
 
@@ -103,6 +115,9 @@ val softfloat_f64_div : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bit
 let softfloat_f64_div _ _ _ = ()
 
 
+val softfloat_f16_muladd : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> bitvector 's -> unit
+let softfloat_f16_muladd _ _ _ _ = ()
+
 val softfloat_f32_muladd : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> bitvector 's -> unit
 let softfloat_f32_muladd _ _ _ _ = ()
 
@@ -110,11 +125,39 @@ val softfloat_f64_muladd : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> 
 let softfloat_f64_muladd _ _ _ _ = ()
 
 
+val softfloat_f16_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_sqrt _ _ = ()
+
 val softfloat_f32_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_f32_sqrt _ _ = ()
 
 val softfloat_f64_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_f64_sqrt _ _ = ()
+
+
+val softfloat_f16_to_i32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_i32 _ _ = ()
+
+val softfloat_f16_to_ui32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_ui32 _ _ = ()
+
+val softfloat_i32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_i32_to_f16 _ _ = ()
+
+val softfloat_ui32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_ui32_to_f16 _ _ = ()
+
+val softfloat_f16_to_i64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_i64 _ _ = ()
+
+val softfloat_f16_to_ui64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_ui64 _ _ = ()
+
+val softfloat_i64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_i64_to_f16 _ _ = ()
+
+val softfloat_ui64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_ui64_to_f16 _ _ = ()
 
 
 val softfloat_f32_to_i32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
@@ -167,12 +210,33 @@ val softfloat_ui64_to_f64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> 
 let softfloat_ui64_to_f64 _ _ = ()
 
 
+val softfloat_f16_to_f32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_f32 _ _ = ()
+
+val softfloat_f16_to_f64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_f64 _ _ = ()
+
 val softfloat_f32_to_f64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_f32_to_f64 _ _ = ()
+
+val softfloat_f32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f32_to_f16 _ _ = ()
+
+val softfloat_f64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f64_to_f16 _ _ = ()
 
 val softfloat_f64_to_f32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_f64_to_f32 _ _ = ()
 
+
+val softfloat_f16_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
+let softfloat_f16_lt _ _ = ()
+
+val softfloat_f16_le : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
+let softfloat_f16_le _ _ = ()
+
+val softfloat_f16_eq : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
+let softfloat_f16_eq _ _ = ()
 
 val softfloat_f32_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
 let softfloat_f32_lt _ _ = ()

--- a/model/riscv_fdext_regs.sail
+++ b/model/riscv_fdext_regs.sail
@@ -75,24 +75,45 @@
 
 /* **************************************************************** */
 /* NaN boxing/unboxing.                                             */
+/* When 16-bit floats (half-precision) are stored in 32/64-bit regs  */
+/* they must be 'NaN boxed'.                                         */
+/* When 16-bit floats (half-precision) are read from 32/64-bit regs  */
+/* they must be 'NaN unboxed'.                                       */
 /* When 32-bit floats (single-precision) are stored in 64-bit regs  */
 /* they must be 'NaN boxed' (upper 32b all ones).                   */
 /* When 32-bit floats (single-precision) are read from 64-bit regs  */
 /* they must be 'NaN unboxed'.                                      */
 
+function canonical_NaN_H() -> bits(16) = 0x_7e00
 function canonical_NaN_S() -> bits(32) = 0x_7fc0_0000
 function canonical_NaN_D() -> bits(64) = 0x_7ff8_0000_0000_0000
 
-val nan_box : bits(32) -> flenbits effect {escape}
-function nan_box val_32b = {
+val      nan_box_H : bits(16) -> flenbits
+function nan_box_H   val_16b =
+  if (sizeof(flen) == 32)
+  then 0x_FFFF @ val_16b
+  else 0x_FFFF_FFFF_FFFF @ val_16b
+
+val      nan_unbox_H : flenbits -> bits(16)
+function nan_unbox_H   regval =
+  if (sizeof(flen) == 32)
+  then if regval [32..16] == 0x_FFFF
+       then regval [15..0]
+       else canonical_NaN_H()
+  else if regval [63..16] == 0x_FFFF_FFFF_FFFF
+       then regval [15..0]
+       else canonical_NaN_H()
+
+val nan_box_S : bits(32) -> flenbits effect {escape}
+function nan_box_S val_32b = {
   assert(sys_enable_fdext());
   if (sizeof(flen) == 32)
   then val_32b
   else 0x_FFFF_FFFF @ val_32b
 }
 
-val nan_unbox : flenbits -> bits(32) effect {escape}
-function nan_unbox regval = {
+val nan_unbox_S : flenbits -> bits(32) effect {escape}
+function nan_unbox_S regval = {
   assert(sys_enable_fdext());
   if (sizeof(flen) == 32)
   then regval
@@ -100,6 +121,9 @@ function nan_unbox regval = {
        then regval [31..0]
        else canonical_NaN_S()
 }
+
+overload nan_box = { nan_box_H, nan_box_S }
+overload nan_unbox = { nan_unbox_H, nan_unbox_S }
 
 /* **************************************************************** */
 /* Floating point register file                                     */

--- a/model/riscv_freg_type.sail
+++ b/model/riscv_freg_type.sail
@@ -93,6 +93,18 @@ function fregval_into_freg(v) = v
     RISC-V uses the following IEEE-defined rounding modes.
 */
 
+enum f_madd_op_H = {FMADD_H, FMSUB_H, FNMSUB_H, FNMADD_H}
+
+enum f_bin_rm_op_H = {FADD_H, FSUB_H, FMUL_H, FDIV_H}
+
+enum f_un_rm_op_H = {FSQRT_H, FCVT_W_H, FCVT_WU_H, FCVT_H_W, FCVT_H_WU,    // RV32 and RV64
+                     FCVT_H_S, FCVT_H_D, FCVT_S_H, FCVT_D_H,
+                     FCVT_L_H, FCVT_LU_H, FCVT_H_L, FCVT_H_LU}             // RV64 only
+
+enum f_un_op_H = {FCLASS_H, FMV_X_H, FMV_H_X}    /* RV32 and RV64 */
+
+enum f_bin_op_H = {FSGNJ_H, FSGNJN_H, FSGNJX_H, FMIN_H, FMAX_H, FEQ_H, FLT_H, FLE_H}
+
 enum rounding_mode = {RM_RNE, RM_RTZ, RM_RDN, RM_RUP, RM_RMM, RM_DYN}
 
 enum f_madd_op_S = {FMADD_S, FMSUB_S, FNMSUB_S, FNMADD_S}

--- a/model/riscv_insts_dext.sail
+++ b/model/riscv_insts_dext.sail
@@ -76,8 +76,9 @@
 
 /* **************************************************************** */
 /* IMPORTANT!                                                       */
-/* The files 'riscv_insts_fext.sail' and 'riscv_insts_dext.sail'    */
-/* define the F and D extensions, respectively.                     */
+/* The files 'riscv_insts_fext.sail', 'riscv_insts_dext.sail' and   */
+/* 'riscv_insts_zfh.sail' define the F, D and Zfh extensions,       */
+/* respectively.                                                    */
 /* The texts follow each other very closely; please try to maintain */
 /* this correspondence as the files are maintained for bug-fixes,   */
 /* improvements, and version updates.                               */

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -76,8 +76,9 @@
 
 /* **************************************************************** */
 /* IMPORTANT!                                                       */
-/* The files 'riscv_insts_fext.sail' and 'riscv_insts_dext.sail'    */
-/* define the F and D extensions, respectively.                     */
+/* The files 'riscv_insts_fext.sail', 'riscv_insts_dext.sail' and   */
+/* 'riscv_insts_zfh.sail' define the F, D and Zfh extensions,       */
+/* respectively.                                                    */
 /* The texts follow each other very closely; please try to maintain */
 /* this correspondence as the files are maintained for bug-fixes,   */
 /* improvements, and version updates.                               */
@@ -324,11 +325,14 @@ function haveSingleFPU() -> bool = haveFExt() | haveZfinx()
 /* Floating-point loads                                               */
 
 /* AST */
-/* FLW and FLD; W/D is encoded in 'word_width' */
+/* FLH, FLW and FLD; H/W/D is encoded in 'word_width' */
 
 union clause ast = LOAD_FP : (bits(12), regidx, regidx, word_width)
 
 /* AST <-> Binary encoding ================================ */
+
+mapping clause encdec = LOAD_FP(imm, rs1, rd, HALF)          if haveZfh()
+                    <-> imm @ rs1 @ 0b001 @ rd @ 0b000_0111  if haveZfh()
 
 mapping clause encdec = LOAD_FP(imm, rs1, rd, WORD)          if haveFExt()
                     <-> imm @ rs1 @ 0b010 @ rd @ 0b000_0111  if haveFExt()
@@ -359,6 +363,13 @@ function process_fload32(rd, addr, value) =
     MemException(e)  => { handle_mem_exception(addr, e); RETIRE_FAIL }
   }
 
+val process_fload16 : (regidx, xlenbits, MemoryOpResult(bits(16)))
+                      -> Retired effect {escape, rreg, wreg}
+function process_fload16(rd, addr, value) =
+  match value {
+    MemValue(result) => { F(rd) = nan_box(result); RETIRE_SUCCESS },
+    MemException(e)  => { handle_mem_exception(addr, e); RETIRE_FAIL }
+  }
 
 function clause execute(LOAD_FP(imm, rs1, rd, width)) = {
   let offset : xlenbits = EXTS(imm);
@@ -375,7 +386,8 @@ function clause execute(LOAD_FP(imm, rs1, rd, width)) = {
           let (aq, rl, res) = (false, false, false);
           match (width, sizeof(flen)) {
             (BYTE, _)   => { handle_illegal(); RETIRE_FAIL },
-            (HALF, _)   => { handle_illegal(); RETIRE_FAIL },
+            (HALF, _)   => 
+               process_fload16(rd, vaddr, mem_read(Read(Data), addr, 2, aq, rl, res)),
             (WORD, _)   =>
                process_fload32(rd, vaddr, mem_read(Read(Data), addr, 4, aq, rl, res)),
             (DOUBLE, 64) =>
@@ -398,11 +410,14 @@ mapping clause assembly = LOAD_FP(imm, rs1, rd, width)
 /* Floating-point stores                                              */
 
 /* AST */
-/* FLW and FLD; W/D is encoded in 'width' */
+/* FSH, FSW and FSD; H/W/D is encoded in 'word_width' */
 
 union clause ast = STORE_FP : (bits(12), regidx, regidx, word_width)
 
 /* AST <-> Binary encoding ================================ */
+
+mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, HALF)                             if haveZfh()
+                    <-> imm7 : bits(7) @ rs2 @ rs1 @ 0b001 @ imm5 : bits(5) @ 0b010_0111  if haveZfh()
 
 mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, WORD)                             if haveFExt()
                     <-> imm7 : bits(7) @ rs2 @ rs1 @ 0b010 @ imm5 : bits(5) @ 0b010_0111  if haveFExt()
@@ -435,7 +450,7 @@ function clause execute (STORE_FP(imm, rs2, rs1, width)) = {
         TR_Address(addr, _) => {
           let eares : MemoryOpResult(unit) = match width {
             BYTE   => MemValue () /* bogus placeholder for illegal size */,
-            HALF   => MemValue () /* bogus placeholder for illegal size */,
+            HALF   => mem_write_ea(addr, 2, aq, rl, false),
             WORD   => mem_write_ea(addr, 4, aq, rl, false),
             DOUBLE => mem_write_ea(addr, 8, aq, rl, false)
           };
@@ -445,7 +460,7 @@ function clause execute (STORE_FP(imm, rs2, rs1, width)) = {
               let rs2_val = F(rs2);
               match (width, sizeof(flen)) {
                 (BYTE, _)    => { handle_illegal(); RETIRE_FAIL },
-                (HALF, _)    => { handle_illegal(); RETIRE_FAIL },
+                (HALF, _)    => process_fstore (vaddr, mem_write_value(addr, 2, rs2_val[15..0], aq, rl, con)),
                 (WORD, _)    => process_fstore (vaddr, mem_write_value(addr, 4, rs2_val[31..0], aq, rl, con)),
                 (DOUBLE, 64) => process_fstore (vaddr, mem_write_value(addr, 8, rs2_val,        aq, rl, con))
               };

--- a/model/riscv_insts_zfh.sail
+++ b/model/riscv_insts_zfh.sail
@@ -1,0 +1,934 @@
+/* **************************************************************** */
+/* This file specifies the instructions in the Zfh extension        */
+/* (half precision floating point).                                 */
+
+/* RISC-V follows IEEE 754-2008 floating point arithmetic standard. */
+
+/* Original version written by Rishiyur S. Nikhil, Sept-Oct 2019    */
+
+/* **************************************************************** */
+/* IMPORTANT!                                                       */
+/* The files 'riscv_insts_fext.sail', 'riscv_insts_dext.sail' and   */
+/* 'riscv_insts_zfh.sail' define the F, D and Zfh extensions,       */
+/* respectively.                                                    */
+/* The texts follow each other very closely; please try to maintain */
+/* this correspondence as the files are maintained for bug-fixes,   */
+/* improvements, and version updates.                               */
+
+/* **************************************************************** */
+
+val      fsplit_H : bits(16) -> (bits(1), bits(5), bits(10))
+function fsplit_H   (xf16) = (xf16[15..15], xf16[14..10], xf16[9..0])
+
+val      fmake_H  : (bits(1), bits(5), bits(10)) -> bits(16)
+function fmake_H (sign, exp, mant) = sign @ exp @ mant
+
+val      negate_H : bits(16) -> bits(16)
+function negate_H (xf16) = {
+  let (sign, exp, mant) = fsplit_H (xf16);
+  let new_sign = if (sign == 0b0) then 0b1 else 0b0;
+  fmake_H (new_sign, exp, mant)
+}
+
+val      f_is_neg_inf_H : bits(16) -> bool
+function f_is_neg_inf_H   xf16 = {
+  let (sign, exp, mant) = fsplit_H (xf16);
+  (  (sign == 0b1)
+   & (exp  == ones())
+   & (mant == zeros()))
+}
+
+val      f_is_neg_norm_H : bits(16) -> bool
+function f_is_neg_norm_H   xf16 = {
+  let (sign, exp, mant) = fsplit_H (xf16);
+  (  (sign == 0b1)
+   & (exp  != zeros())
+   & (exp  != ones()))
+}
+
+val      f_is_neg_subnorm_H : bits(16) -> bool
+function f_is_neg_subnorm_H   xf16 = {
+  let (sign, exp, mant) = fsplit_H (xf16);
+  (  (sign == 0b1)
+   & (exp  == zeros())
+   & (mant != zeros()))
+}
+
+val      f_is_pos_subnorm_H : bits(16) -> bool
+function f_is_pos_subnorm_H   xf16 = {
+  let (sign, exp, mant) = fsplit_H (xf16);
+  (  (sign == zeros())
+   & (exp  == zeros())
+   & (mant != zeros()))
+}
+
+val      f_is_pos_norm_H : bits(16) -> bool
+function f_is_pos_norm_H   xf16 = {
+  let (sign, exp, mant) = fsplit_H (xf16);
+  (  (sign == zeros())
+   & (exp  != zeros())
+   & (exp  != ones()))
+}
+
+val      f_is_pos_inf_H : bits(16) -> bool
+function f_is_pos_inf_H   xf16 = {
+  let (sign, exp, mant) = fsplit_H (xf16);
+  (  (sign == zeros())
+   & (exp  == ones())
+   & (mant == zeros()))
+}
+
+val      f_is_neg_zero_H : bits(16) -> bool
+function f_is_neg_zero_H   xf16 = {
+  let (sign, exp, mant) = fsplit_H (xf16);
+  (  (sign == ones())
+   & (exp  == zeros())
+   & (mant == zeros()))
+}
+
+val      f_is_pos_zero_H : bits(16) -> bool
+function f_is_pos_zero_H   xf16 = {
+  let (sign, exp, mant) = fsplit_H (xf16);
+  (  (sign == zeros())
+   & (exp  == zeros())
+   & (mant == zeros()))
+}
+
+val      f_is_SNaN_H : bits(16) -> bool
+function f_is_SNaN_H   xf16 = {
+  let (sign, exp, mant) = fsplit_H (xf16);
+  (  (exp == ones())
+   & (mant [9] == bitzero)
+   & (mant != zeros()))
+}
+
+val      f_is_QNaN_H : bits(16) -> bool
+function f_is_QNaN_H   xf16 = {
+  let (sign, exp, mant) = fsplit_H (xf16);
+  (  (exp == ones())
+   & (mant [9] == bitone))
+}
+
+/* Either QNaN or SNan */
+val      f_is_NaN_H : bits(16) -> bool
+function f_is_NaN_H   xf16 = {
+  let (sign, exp, mant) = fsplit_H (xf16);
+  (  (exp == ones())
+   & (mant != zeros()))
+}
+
+val      fle_H : (bits(16), bits (16), bool) -> (bool, bits(5))
+function fle_H   (v1,       v2,        is_quiet) = {
+  let (s1, e1, m1) = fsplit_H (v1);
+  let (s2, e2, m2) = fsplit_H (v2);
+
+  let v1Is0    = f_is_neg_zero_H(v1) | f_is_pos_zero_H(v1);
+  let v2Is0    = f_is_neg_zero_H(v2) | f_is_pos_zero_H(v2);
+
+  let result : bool =
+    if (s1 == 0b0) & (s2 == 0b0) then
+      if   (e1 == e2)
+      then unsigned (m1) <=  unsigned (m2)
+      else unsigned (e1)  <  unsigned (e2)
+    else if (s1 == 0b0) & (s2 == 0b1)
+    then (v1Is0 & v2Is0)                         /* Equal in this case (+0=-0) */
+    else if (s1 == 0b1) & (s2 == 0b0)
+    then true
+    else
+      if   (e1 == e2)
+      then unsigned (m1) >=  unsigned (m2)
+      else unsigned (e1)  >  unsigned (e2);
+
+  let fflags = if is_quiet then
+                 if   (f_is_SNaN_H(v1) | f_is_SNaN_H(v2))
+                 then nvFlag()
+                 else zeros()
+               else
+                 if   (f_is_NaN_H(v1) | f_is_NaN_H(v2))
+                 then nvFlag()
+                 else zeros();
+
+  (result, fflags)
+}
+
+/* ****************************************************************** */
+/* Floating-point loads                                               */
+/* These are defined in: riscv_insts_fext.sail                        */
+
+/* ****************************************************************** */
+/* Floating-point stores                                              */
+/* These are defined in: riscv_insts_fext.sail                        */
+
+/* Binary ops with rounding mode */
+
+/* AST */
+
+union clause ast = F_BIN_RM_TYPE_H : (regidx, regidx, rounding_mode, regidx, f_bin_rm_op_H)
+
+/* AST <-> Binary encoding ================================ */
+
+mapping clause encdec =
+    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FADD_H)                             if haveZfh()
+<-> 0b000_0010 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec =
+    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FSUB_H)                             if haveZfh()
+<-> 0b000_0110 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec =
+    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FMUL_H)                             if haveZfh()
+<-> 0b000_1010 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec =
+    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FDIV_H)                             if haveZfh()
+<-> 0b000_1110 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh()
+
+/* Execution semantics ================================ */
+
+function clause execute (F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, op)) = {
+  let rs1_val_16b = nan_unbox_H (F(rs1));
+  let rs2_val_16b = nan_unbox_H (F(rs2));
+  match (select_instr_or_fcsr_rm (rm)) {
+    None() => { handle_illegal(); RETIRE_FAIL },
+    Some(rm') => {
+      let rm_3b = encdec_rounding_mode(rm');
+      let (fflags, rd_val_16b) : (bits(5), bits(16)) = match op {
+        FADD_H  => riscv_f16Add (rm_3b, rs1_val_16b, rs2_val_16b),
+        FSUB_H  => riscv_f16Sub (rm_3b, rs1_val_16b, rs2_val_16b),
+        FMUL_H  => riscv_f16Mul (rm_3b, rs1_val_16b, rs2_val_16b),
+        FDIV_H  => riscv_f16Div (rm_3b, rs1_val_16b, rs2_val_16b)
+      };
+      write_fflags(fflags);
+      F(rd) = nan_box (rd_val_16b);
+      RETIRE_SUCCESS
+    }
+  }
+}
+
+/* AST -> Assembly notation ================================ */
+
+mapping f_bin_rm_type_mnemonic_H : f_bin_rm_op_H <-> string = {
+  FADD_H  <-> "fadd.h",
+  FSUB_H  <-> "fsub.h",
+  FMUL_H  <-> "fmul.h",
+  FDIV_H  <-> "fdiv.h"
+}
+
+mapping clause assembly = F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, op)
+                      <-> f_bin_rm_type_mnemonic_H(op)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ freg_name(rs2)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+/* ****************************************************************** */
+/* Fused multiply-add */
+
+/* AST */
+
+union clause ast = F_MADD_TYPE_H : (regidx, regidx, regidx, rounding_mode, regidx, f_madd_op_H)
+
+/* AST <-> Binary encoding ================================ */
+
+mapping clause encdec =
+    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FMADD_H)                         if haveZfh()
+<-> rs3 @ 0b10 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b100_0011  if haveZfh()
+
+mapping clause encdec =
+    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FMSUB_H)                         if haveZfh()
+<-> rs3 @ 0b10 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b100_0111  if haveZfh()
+
+mapping clause encdec =
+    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FNMSUB_H)                        if haveZfh()
+<-> rs3 @ 0b10 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b100_1011  if haveZfh()
+
+mapping clause encdec =
+    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FNMADD_H)                        if haveZfh()
+<-> rs3 @ 0b10 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b100_1111  if haveZfh()
+
+/* Execution semantics ================================ */
+
+function clause execute (F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, op)) = {
+  let rs1_val_16b = nan_unbox_H (F(rs1));
+  let rs2_val_16b = nan_unbox_H (F(rs2));
+  let rs3_val_16b = nan_unbox_H (F(rs3));
+  match (select_instr_or_fcsr_rm (rm)) {
+    None() => { handle_illegal(); RETIRE_FAIL },
+    Some(rm') => {
+      let rm_3b = encdec_rounding_mode(rm');
+      let (fflags, rd_val_16b) : (bits(5), bits(16)) =
+        match op {
+          FMADD_H  => riscv_f16MulAdd (rm_3b, rs1_val_16b, rs2_val_16b, rs3_val_16b),
+          FMSUB_H  => riscv_f16MulAdd (rm_3b, rs1_val_16b, rs2_val_16b, negate_H (rs3_val_16b)),
+          FNMSUB_H => riscv_f16MulAdd (rm_3b, negate_H (rs1_val_16b), rs2_val_16b, rs3_val_16b),
+          FNMADD_H => riscv_f16MulAdd (rm_3b, negate_H (rs1_val_16b), rs2_val_16b, negate_H (rs3_val_16b))
+        };
+      write_fflags(fflags);
+      F(rd) = nan_box (rd_val_16b);
+      RETIRE_SUCCESS
+    }
+  }
+}
+
+/* AST -> Assembly notation ================================ */
+
+mapping f_madd_type_mnemonic_H : f_madd_op_H <-> string = {
+    FMADD_H  <-> "fmadd.h",
+    FMSUB_H  <-> "fmsub.h",
+    FNMSUB_H <-> "fnmsub.h",
+    FNMADD_H <-> "fnmadd.h"
+}
+
+mapping clause assembly = F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, op)
+                      <-> f_madd_type_mnemonic_H(op)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ freg_name(rs2)
+                          ^ sep() ^ freg_name(rs3)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+/* ****************************************************************** */
+/* Binary, no rounding mode */
+
+/* AST */
+
+union clause ast = F_BIN_TYPE_H : (regidx, regidx, regidx, f_bin_op_H)
+
+/* AST <-> Binary encoding ================================ */
+
+mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJ_H)               if haveZfh()
+                    <-> 0b001_0010 @ rs2 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJN_H)              if haveZfh()
+                    <-> 0b001_0010 @ rs2 @ rs1 @ 0b001 @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJX_H)              if haveZfh()
+                    <-> 0b001_0010 @ rs2 @ rs1 @ 0b010 @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FMIN_H)                if haveZfh()
+                    <-> 0b001_0110 @ rs2 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FMAX_H)                if haveZfh()
+                    <-> 0b001_0110 @ rs2 @ rs1 @ 0b001 @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FEQ_H)                 if haveZfh()
+                    <-> 0b101_0010 @ rs2 @ rs1 @ 0b010 @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FLT_H)                 if haveZfh()
+                    <-> 0b101_0010 @ rs2 @ rs1 @ 0b001 @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FLE_H)                 if haveZfh()
+                    <-> 0b101_0010 @ rs2 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveZfh()
+
+/* Execution semantics ================================ */
+
+function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FSGNJ_H)) = {
+  let rs1_val_H    = nan_unbox_H (F(rs1));
+  let rs2_val_H    = nan_unbox_H (F(rs2));
+  let (s1, e1, m1) = fsplit_H (rs1_val_H);
+  let (s2, e2, m2) = fsplit_H (rs2_val_H);
+  let rd_val_H     = fmake_H (s2, e1, m1);
+
+  F(rd) = nan_box (rd_val_H);
+  RETIRE_SUCCESS
+}
+
+function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FSGNJN_H)) = {
+  let rs1_val_H    = nan_unbox_H (F(rs1));
+  let rs2_val_H    = nan_unbox_H (F(rs2));
+  let (s1, e1, m1) = fsplit_H (rs1_val_H);
+  let (s2, e2, m2) = fsplit_H (rs2_val_H);
+  let rd_val_H     = fmake_H (0b1 ^ s2, e1, m1);
+
+  F(rd) = nan_box (rd_val_H);
+  RETIRE_SUCCESS
+}
+
+function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FSGNJX_H)) = {
+  let rs1_val_H    = nan_unbox_H (F(rs1));
+  let rs2_val_H    = nan_unbox_H (F(rs2));
+  let (s1, e1, m1) = fsplit_H (rs1_val_H);
+  let (s2, e2, m2) = fsplit_H (rs2_val_H);
+  let rd_val_H     = fmake_H (s1 ^ s2, e1, m1);
+
+  F(rd) = nan_box (rd_val_H);
+  RETIRE_SUCCESS
+}
+
+function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FMIN_H)) = {
+  let rs1_val_H = nan_unbox_H (F(rs1));
+  let rs2_val_H = nan_unbox_H (F(rs2));
+
+  let is_quiet  = true;
+  let (rs1_lt_rs2, fflags) = fle_H (rs1_val_H, rs2_val_H, is_quiet);
+
+  let rd_val_H  = if      (f_is_NaN_H(rs1_val_H) & f_is_NaN_H(rs2_val_H))           then canonical_NaN_H()
+                  else if f_is_NaN_H(rs1_val_H)                                     then rs2_val_H
+                  else if f_is_NaN_H(rs2_val_H)                                     then rs1_val_H
+                  else if (f_is_neg_zero_H(rs1_val_H) & f_is_pos_zero_H(rs2_val_H)) then rs1_val_H
+                  else if (f_is_neg_zero_H(rs2_val_H) & f_is_pos_zero_H(rs1_val_H)) then rs2_val_H
+                  else if rs1_lt_rs2                                                then rs1_val_H
+                  else /* (not rs1_lt_rs2) */                                            rs2_val_H;
+
+  accrue_fflags(fflags);
+  F(rd) = nan_box (rd_val_H);
+  RETIRE_SUCCESS
+}
+
+function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FMAX_H)) = {
+  let rs1_val_H = nan_unbox_H (F(rs1));
+  let rs2_val_H = nan_unbox_H (F(rs2));
+
+  let is_quiet  = true;
+  let (rs2_lt_rs1, fflags) = fle_H (rs2_val_H, rs1_val_H, is_quiet);
+
+  let rd_val_H  = if      (f_is_NaN_H(rs1_val_H) & f_is_NaN_H(rs2_val_H))           then canonical_NaN_H()
+                  else if f_is_NaN_H(rs1_val_H)                                     then rs2_val_H
+                  else if f_is_NaN_H(rs2_val_H)                                     then rs1_val_H
+                  else if (f_is_neg_zero_H(rs1_val_H) & f_is_pos_zero_H(rs2_val_H)) then rs2_val_H
+                  else if (f_is_neg_zero_H(rs2_val_H) & f_is_pos_zero_H(rs1_val_H)) then rs1_val_H
+                  else if rs2_lt_rs1                                                then rs1_val_H
+                  else /* (not rs2_lt_rs1) */                                            rs2_val_H;
+
+  accrue_fflags(fflags);
+  F(rd) = nan_box (rd_val_H);
+  RETIRE_SUCCESS
+}
+
+function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FEQ_H)) = {
+  let rs1_val_H = nan_unbox_H (F(rs1));
+  let rs2_val_H = nan_unbox_H (F(rs2));
+
+  let (fflags, rd_val) : (bits_fflags, bool) =
+      riscv_f16Eq (rs1_val_H, rs2_val_H);
+
+  write_fflags(fflags);
+  X(rd) = EXTZ(bool_to_bits(rd_val));
+  RETIRE_SUCCESS
+}
+
+function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FLT_H)) = {
+  let rs1_val_H = nan_unbox_H (F(rs1));
+  let rs2_val_H = nan_unbox_H (F(rs2));
+
+  let (fflags, rd_val) : (bits_fflags, bool) =
+      riscv_f16Lt (rs1_val_H, rs2_val_H);
+
+  write_fflags(fflags);
+  X(rd) = EXTZ(bool_to_bits(rd_val));
+  RETIRE_SUCCESS
+}
+
+function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FLE_H)) = {
+  let rs1_val_H = nan_unbox_H (F(rs1));
+  let rs2_val_H = nan_unbox_H (F(rs2));
+
+  let (fflags, rd_val) : (bits_fflags, bool) =
+      riscv_f16Le (rs1_val_H, rs2_val_H);
+
+  write_fflags(fflags);
+  X(rd) = EXTZ(bool_to_bits(rd_val));
+  RETIRE_SUCCESS
+}
+
+/* AST -> Assembly notation ================================ */
+
+mapping f_bin_type_mnemonic_H : f_bin_op_H <-> string = {
+    FSGNJ_H  <-> "fsgnj.h",
+    FSGNJN_H <-> "fsgnjn.h",
+    FSGNJX_H <-> "fsgnjx.h",
+    FMIN_H   <-> "fmin.h",
+    FMAX_H   <-> "fmax.h",
+    FEQ_H    <-> "feq.h",
+    FLT_H    <-> "flt.h",
+    FLE_H    <-> "fle.h"
+}
+
+mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJ_H)
+                      <-> f_bin_type_mnemonic_H(FSGNJ_H)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ freg_name(rs2)
+
+mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJN_H)
+                      <-> f_bin_type_mnemonic_H(FSGNJN_H)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ freg_name(rs2)
+
+mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJX_H)
+                      <-> f_bin_type_mnemonic_H(FSGNJX_H)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ freg_name(rs2)
+
+mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FMIN_H)
+                      <-> f_bin_type_mnemonic_H(FMIN_H)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ freg_name(rs2)
+
+mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FMAX_H)
+                      <-> f_bin_type_mnemonic_H(FMAX_H)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ freg_name(rs2)
+
+mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FEQ_H)
+                      <-> f_bin_type_mnemonic_H(FEQ_H)
+                          ^ spc() ^ reg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ freg_name(rs2)
+
+mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FLT_H)
+                      <-> f_bin_type_mnemonic_H(FLT_H)
+                          ^ spc() ^ reg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ freg_name(rs2)
+
+mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FLE_H)
+                      <-> f_bin_type_mnemonic_H(FLE_H)
+                          ^ spc() ^ reg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ freg_name(rs2)
+
+/* ****************************************************************** */
+/* Unary with rounding mode */
+
+/* AST */
+
+union clause ast = F_UN_RM_TYPE_H : (regidx, rounding_mode, regidx, f_un_rm_op_H)
+
+/* AST <-> Binary encoding ================================ */
+
+mapping clause encdec =
+    F_UN_RM_TYPE_H(rs1, rm, rd, FSQRT_H)                                      if haveZfh()
+<-> 0b010_1110 @ 0b00000 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec =
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_W_H)                                     if haveZfh()
+<-> 0b110_0010 @ 0b00000 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec =
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_WU_H)                                    if haveZfh()
+<-> 0b110_0010 @ 0b00001 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec =
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_W)                                     if haveZfh()
+<-> 0b110_1010 @ 0b00000 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec =
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_WU)                                    if haveZfh()
+<-> 0b110_1010 @ 0b00001 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec =
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_S)                                     if haveZfh()
+<-> 0b010_0010 @ 0b00000 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec =
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_D)                                     if haveZfh()
+<-> 0b010_0010 @ 0b00001 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec =
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_S_H)                                     if haveZfh()
+<-> 0b010_0000 @ 0b00010 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec =
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_D_H)                                     if haveZfh()
+<-> 0b010_0001 @ 0b00010 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh()
+
+// TODO:
+/* FCVT_H_Q, FCVT_Q_H : Will be added with Q Extension */
+
+/* F instructions, RV64 only */
+
+mapping clause encdec =
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_L_H)                                     if haveZfh() & sizeof(xlen) >= 64
+<-> 0b110_0010 @ 0b00010 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh() & sizeof(xlen) >= 64
+
+mapping clause encdec =
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_LU_H)                                    if haveZfh() & sizeof(xlen) >= 64
+<-> 0b110_0010 @ 0b00011 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh() & sizeof(xlen) >= 64
+
+mapping clause encdec =
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_L)                                     if haveZfh() & sizeof(xlen) >= 64
+<-> 0b110_1010 @ 0b00010 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh() & sizeof(xlen) >= 64
+
+mapping clause encdec =
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_LU)                                    if haveZfh() & sizeof(xlen) >= 64
+<-> 0b110_1010 @ 0b00011 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveZfh() & sizeof(xlen) >= 64
+
+/* Execution semantics ================================ */
+
+function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FSQRT_H)) = {
+  let rs1_val_H = nan_unbox_H (F(rs1));
+  match (select_instr_or_fcsr_rm (rm)) {
+    None() => { handle_illegal(); RETIRE_FAIL },
+    Some(rm') => {
+      let rm_3b = encdec_rounding_mode(rm');
+      let (fflags, rd_val_H) = riscv_f16Sqrt   (rm_3b, rs1_val_H);
+
+      write_fflags(fflags);
+      F(rd) = nan_box (rd_val_H);
+      RETIRE_SUCCESS
+    }
+  }
+}
+
+function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_W_H)) = {
+  let rs1_val_H = nan_unbox_H (F(rs1));
+  match (select_instr_or_fcsr_rm (rm)) {
+    None() => { handle_illegal(); RETIRE_FAIL },
+    Some(rm') => {
+      let rm_3b = encdec_rounding_mode(rm');
+      let (fflags, rd_val_W) = riscv_f16ToI32 (rm_3b, rs1_val_H);
+
+      write_fflags(fflags);
+      X(rd) = EXTS (rd_val_W);
+      RETIRE_SUCCESS
+    }
+  }
+}
+
+function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_WU_H)) = {
+  let rs1_val_H = nan_unbox_H (F(rs1));
+  match (select_instr_or_fcsr_rm (rm)) {
+    None() => { handle_illegal(); RETIRE_FAIL },
+    Some(rm') => {
+      let rm_3b = encdec_rounding_mode(rm');
+      let (fflags, rd_val_WU) = riscv_f16ToUi32 (rm_3b, rs1_val_H);
+
+      write_fflags(fflags);
+      X(rd) = EXTS (rd_val_WU);
+      RETIRE_SUCCESS
+    }
+  }
+}
+
+function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_W)) = {
+  let rs1_val_W = X(rs1) [31..0];
+  match (select_instr_or_fcsr_rm (rm)) {
+    None() => { handle_illegal(); RETIRE_FAIL },
+    Some(rm') => {
+      let rm_3b = encdec_rounding_mode(rm');
+      let (fflags, rd_val_H) = riscv_i32ToF16 (rm_3b, rs1_val_W);
+
+      write_fflags(fflags);
+      F(rd) = nan_box (rd_val_H);
+      RETIRE_SUCCESS
+    }
+  }
+}
+
+function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_WU)) = {
+  let rs1_val_WU = X(rs1) [31..0];
+  match (select_instr_or_fcsr_rm (rm)) {
+    None() => { handle_illegal(); RETIRE_FAIL },
+    Some(rm') => {
+      let rm_3b = encdec_rounding_mode(rm');
+      let (fflags, rd_val_H) = riscv_ui32ToF16 (rm_3b, rs1_val_WU);
+
+      write_fflags(fflags);
+      F(rd) = nan_box (rd_val_H);
+      RETIRE_SUCCESS
+    }
+  }
+}
+
+function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_S)) = {
+  let rs1_val_S = nan_unbox_S (F(rs1));
+  match (select_instr_or_fcsr_rm (rm)) {
+    None() => { handle_illegal(); RETIRE_FAIL },
+    Some(rm') => {
+      let rm_3b = encdec_rounding_mode(rm');
+      let (fflags, rd_val_H) = riscv_f32ToF16 (rm_3b, rs1_val_S);
+
+      write_fflags(fflags);
+      F(rd) = nan_box (rd_val_H);
+      RETIRE_SUCCESS
+    }
+  }
+}
+
+function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_D)) = {
+  let rs1_val_D = F(rs1);
+  match (select_instr_or_fcsr_rm (rm)) {
+    None() => { handle_illegal(); RETIRE_FAIL },
+    Some(rm') => {
+      let rm_3b = encdec_rounding_mode(rm');
+      let (fflags, rd_val_H) = riscv_f64ToF16 (rm_3b, rs1_val_D);
+
+      write_fflags(fflags);
+      F(rd) = nan_box (rd_val_H);
+      RETIRE_SUCCESS
+    }
+  }
+}
+
+function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_S_H)) = {
+  let rs1_val_H = nan_unbox_H (F(rs1));
+  match (select_instr_or_fcsr_rm (rm)) {
+    None() => { handle_illegal(); RETIRE_FAIL },
+    Some(rm') => {
+      let rm_3b = encdec_rounding_mode(rm');
+      let (fflags, rd_val_S) = riscv_f16ToF32 (rm_3b, rs1_val_H);
+
+      write_fflags(fflags);
+      F(rd) = nan_box (rd_val_S);
+      RETIRE_SUCCESS
+    }
+  }
+}
+
+
+function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_D_H)) = {
+  let rs1_val_H = nan_unbox_H (F(rs1));
+  match (select_instr_or_fcsr_rm (rm)) {
+    None() => { handle_illegal(); RETIRE_FAIL },
+    Some(rm') => {
+      let rm_3b = encdec_rounding_mode(rm');
+      let (fflags, rd_val_D) = riscv_f16ToF64 (rm_3b, rs1_val_H);
+
+      write_fflags(fflags);
+      F(rd) = rd_val_D;
+      RETIRE_SUCCESS
+    }
+  }
+}
+
+function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_L_H)) = {
+  assert(sizeof(xlen) >= 64);
+  let rs1_val_H = nan_unbox_H (F(rs1));
+  match (select_instr_or_fcsr_rm (rm)) {
+    None() => { handle_illegal(); RETIRE_FAIL },
+    Some(rm') => {
+      let rm_3b = encdec_rounding_mode(rm');
+      let (fflags, rd_val_L) = riscv_f16ToI64 (rm_3b, rs1_val_H);
+
+      write_fflags(fflags);
+      X(rd) = EXTS(rd_val_L);
+      RETIRE_SUCCESS
+    }
+  }
+}
+
+function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_LU_H)) = {
+  assert(sizeof(xlen) >= 64);
+  let rs1_val_H = nan_unbox_H (F(rs1));
+  match (select_instr_or_fcsr_rm (rm)) {
+    None() => { handle_illegal(); RETIRE_FAIL },
+    Some(rm') => {
+      let rm_3b = encdec_rounding_mode(rm');
+      let (fflags, rd_val_LU) = riscv_f16ToUi64 (rm_3b, rs1_val_H);
+
+      write_fflags(fflags);
+      X(rd) = EXTS(rd_val_LU);
+      RETIRE_SUCCESS
+    }
+  }
+}
+
+function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_L)) = {
+  assert(sizeof(xlen) >= 64);
+  let rs1_val_L = X(rs1)[63..0];
+  match (select_instr_or_fcsr_rm (rm)) {
+    None() => { handle_illegal(); RETIRE_FAIL },
+    Some(rm') => {
+      let rm_3b = encdec_rounding_mode(rm');
+      let (fflags, rd_val_H) = riscv_i64ToF16 (rm_3b, rs1_val_L);
+
+      write_fflags(fflags);
+      F(rd) = nan_box (rd_val_H);
+      RETIRE_SUCCESS
+    }
+  }
+}
+
+function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_LU)) = {
+  assert(sizeof(xlen) >= 64);
+  let rs1_val_LU = X(rs1)[63..0];
+  match (select_instr_or_fcsr_rm (rm)) {
+    None() => { handle_illegal(); RETIRE_FAIL },
+    Some(rm') => {
+      let rm_3b = encdec_rounding_mode(rm');
+      let (fflags, rd_val_H) = riscv_ui64ToF16 (rm_3b, rs1_val_LU);
+
+      write_fflags(fflags);
+      F(rd) = nan_box (rd_val_H);
+      RETIRE_SUCCESS
+    }
+  }
+}
+
+/* AST -> Assembly notation ================================ */
+
+mapping f_un_rm_type_mnemonic_H : f_un_rm_op_H <-> string = {
+    FSQRT_H   <-> "fsqrt.h",
+    FCVT_W_H  <-> "fcvt.w.h",
+    FCVT_WU_H <-> "fcvt.wu.h",
+    FCVT_H_W  <-> "fcvt.h.w",
+    FCVT_H_WU <-> "fcvt.h.wu",
+    
+    FCVT_H_S  <-> "fcvt.h.s",
+    FCVT_H_D  <-> "fcvt.h.d",
+    FCVT_S_H  <-> "fcvt.s.h",
+    FCVT_D_H  <-> "fcvt.d.h",
+
+    FCVT_L_H  <-> "fcvt.l.h",
+    FCVT_LU_H <-> "fcvt.lu.h",
+    FCVT_H_L  <-> "fcvt.h.l",
+    FCVT_H_LU <-> "fcvt.h.lu"
+}
+
+mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FSQRT_H)
+                      <-> f_un_rm_type_mnemonic_H(FSQRT_H)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_W_H)
+                      <-> f_un_rm_type_mnemonic_H(FCVT_W_H)
+                          ^ spc() ^ reg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_WU_H)
+                      <-> f_un_rm_type_mnemonic_H(FCVT_WU_H)
+                          ^ spc() ^ reg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_W)
+                      <-> f_un_rm_type_mnemonic_H(FCVT_H_W)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ reg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_WU)
+                      <-> f_un_rm_type_mnemonic_H(FCVT_H_WU)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ reg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_L_H)
+                      <-> f_un_rm_type_mnemonic_H(FCVT_L_H)
+                          ^ spc() ^ reg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_LU_H)
+                      <-> f_un_rm_type_mnemonic_H(FCVT_LU_H)
+                          ^ spc() ^ reg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_L)
+                      <-> f_un_rm_type_mnemonic_H(FCVT_H_L)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ reg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_LU)
+                      <-> f_un_rm_type_mnemonic_H(FCVT_H_LU)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ reg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_S)
+                      <-> f_un_rm_type_mnemonic_H(FCVT_H_S)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_D)
+                      <-> f_un_rm_type_mnemonic_H(FCVT_H_D)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_S_H)
+                      <-> f_un_rm_type_mnemonic_H(FCVT_S_H)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_D_H)
+                      <-> f_un_rm_type_mnemonic_H(FCVT_D_H)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+/* ****************************************************************** */
+/* Unary, no rounding mode */
+
+union clause ast = F_UN_TYPE_H : (regidx, regidx, f_un_op_H)
+
+/* AST <-> Binary encoding ================================ */
+
+mapping clause encdec = F_UN_TYPE_H(rs1, rd, FCLASS_H)                        if haveZfh()
+                    <-> 0b111_0010 @ 0b00000 @ rs1 @ 0b001 @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec = F_UN_TYPE_H(rs1, rd, FMV_X_H)                         if haveZfh()
+                    <-> 0b111_0010 @ 0b00000 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveZfh()
+
+mapping clause encdec = F_UN_TYPE_H(rs1, rd, FMV_H_X)                         if haveZfh()
+                    <-> 0b111_1010 @ 0b00000 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveZfh()
+
+/* Execution semantics ================================ */
+
+function clause execute (F_UN_TYPE_H(rs1, rd, FCLASS_H)) = {
+  let rs1_val_H = nan_unbox_H (F(rs1));
+
+  let rd_val_10b : bits (10) =
+    if      f_is_neg_inf_H     (rs1_val_H) then 0b_00_0000_0001
+    else if f_is_neg_norm_H    (rs1_val_H) then 0b_00_0000_0010
+    else if f_is_neg_subnorm_H (rs1_val_H) then 0b_00_0000_0100
+    else if f_is_neg_zero_H    (rs1_val_H) then 0b_00_0000_1000
+    else if f_is_pos_zero_H    (rs1_val_H) then 0b_00_0001_0000
+    else if f_is_pos_subnorm_H (rs1_val_H) then 0b_00_0010_0000
+    else if f_is_pos_norm_H    (rs1_val_H) then 0b_00_0100_0000
+    else if f_is_pos_inf_H     (rs1_val_H) then 0b_00_1000_0000
+    else if f_is_SNaN_H        (rs1_val_H) then 0b_01_0000_0000
+    else if f_is_QNaN_H        (rs1_val_H) then 0b_10_0000_0000
+    else zeros();
+
+  X(rd) = EXTZ (rd_val_10b);
+  RETIRE_SUCCESS
+}
+
+function clause execute (F_UN_TYPE_H(rs1, rd, FMV_X_H)) = {
+  let rs1_val_H            = F(rs1)[15..0];
+  let rd_val_X  : xlenbits = EXTS(rs1_val_H);
+  X(rd) = rd_val_X;
+  RETIRE_SUCCESS
+}
+
+function clause execute (F_UN_TYPE_H(rs1, rd, FMV_H_X)) = {
+  let rs1_val_X            = X(rs1);
+  let rd_val_H             = rs1_val_X [15..0];
+  F(rd) = nan_box (rd_val_H);
+  RETIRE_SUCCESS
+}
+
+/* AST -> Assembly notation ================================ */
+
+mapping f_un_type_mnemonic_H : f_un_op_H <-> string = {
+    FMV_X_H  <-> "fmv.x.h",
+    FCLASS_H <-> "fclass.h",
+    FMV_H_X  <-> "fmv.h.x"
+}
+
+mapping clause assembly = F_UN_TYPE_H(rs1, rd, FMV_X_H)
+                      <-> f_un_type_mnemonic_H(FMV_X_H)
+                          ^ spc() ^ reg_name(rd)
+                          ^ sep() ^ freg_name(rs1)
+
+mapping clause assembly = F_UN_TYPE_H(rs1, rd, FMV_H_X)
+                      <-> f_un_type_mnemonic_H(FMV_H_X)
+                          ^ spc() ^ freg_name(rd)
+                          ^ sep() ^ reg_name(rs1)
+
+mapping clause assembly = F_UN_TYPE_H(rs1, rd, FCLASS_H)
+                      <-> f_un_type_mnemonic_H(FCLASS_H)
+                          ^ spc() ^ reg_name(rd)
+                          ^ sep() ^ freg_name(rs1)

--- a/model/riscv_softfloat_interface.sail
+++ b/model/riscv_softfloat_interface.sail
@@ -87,6 +87,7 @@
 
 type bits_rm     = bits(3)    /* Rounding mode */
 type bits_fflags = bits(5)    /* Accrued exceptions: NV,DZ,OF,UF,NX */
+type bits_H      = bits(16)   /* Half-precision float value */      
 type bits_S      = bits(32)   /* Single-precision float value */
 type bits_D      = bits(64)   /* Double-precision float value */
 
@@ -111,6 +112,34 @@ function update_softfloat_fflags(flags) = {
 
 /* **************************************************************** */
 /* ADD/SUB/MUL/DIV                                                  */
+
+val     extern_f16Add = {c: "softfloat_f16add", ocaml: "Softfloat.f16_add", lem: "softfloat_f16_add"} : (bits_rm, bits_H, bits_H) -> unit
+val      riscv_f16Add : (bits_rm, bits_H, bits_H) -> (bits_fflags, bits_H) effect {rreg}
+function riscv_f16Add (rm, v1, v2) = {
+  extern_f16Add(rm, v1, v2);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
+
+val     extern_f16Sub = {c: "softfloat_f16sub", ocaml: "Softfloat.f16_sub", lem: "softfloat_f16_sub"} : (bits_rm, bits_H, bits_H) -> unit
+val      riscv_f16Sub : (bits_rm, bits_H, bits_H) -> (bits_fflags, bits_H) effect {rreg}
+function riscv_f16Sub (rm, v1, v2) = {
+  extern_f16Sub(rm, v1, v2);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
+
+val     extern_f16Mul = {c: "softfloat_f16mul", ocaml: "Softfloat.f16_mul", lem: "softfloat_f16_mul"} : (bits_rm, bits_H, bits_H) -> unit
+val      riscv_f16Mul : (bits_rm, bits_H, bits_H) -> (bits_fflags, bits_H) effect {rreg}
+function riscv_f16Mul (rm, v1, v2) = {
+  extern_f16Mul(rm, v1, v2);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
+
+val     extern_f16Div = {c: "softfloat_f16div", ocaml: "Softfloat.f16_div", lem: "softfloat_f16_div"} : (bits_rm, bits_H, bits_H) -> unit
+val      riscv_f16Div : (bits_rm, bits_H, bits_H) -> (bits_fflags, bits_H) effect {rreg}
+function riscv_f16Div (rm, v1, v2) = {
+  extern_f16Div(rm, v1, v2);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
 
 val     extern_f32Add = {c: "softfloat_f32add", ocaml: "Softfloat.f32_add", lem: "softfloat_f32_add"} : (bits_rm, bits_S, bits_S) -> unit
 val      riscv_f32Add : (bits_rm, bits_S, bits_S) -> (bits_fflags, bits_S) effect {rreg}
@@ -171,6 +200,13 @@ function riscv_f64Div (rm, v1, v2) = {
 /* **************************************************************** */
 /* MULTIPLY-ADD                                                     */
 
+val     extern_f16MulAdd = {c: "softfloat_f16muladd", ocaml: "Softfloat.f16_muladd", lem: "softfloat_f16_muladd"} : (bits_rm, bits_H, bits_H, bits_H) -> unit
+val      riscv_f16MulAdd : (bits_rm, bits_H, bits_H, bits_H) -> (bits_fflags, bits_H) effect {rreg}
+function riscv_f16MulAdd (rm, v1, v2, v3) = {
+  extern_f16MulAdd(rm, v1, v2, v3);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
+
 val     extern_f32MulAdd = {c: "softfloat_f32muladd", ocaml: "Softfloat.f32_muladd", lem: "softfloat_f32_muladd"} : (bits_rm, bits_S, bits_S, bits_S) -> unit
 val      riscv_f32MulAdd : (bits_rm, bits_S, bits_S, bits_S) -> (bits_fflags, bits_S) effect {rreg}
 function riscv_f32MulAdd (rm, v1, v2, v3) = {
@@ -188,6 +224,13 @@ function riscv_f64MulAdd (rm, v1, v2, v3) = {
 /* **************************************************************** */
 /* SQUARE ROOT                                                      */
 
+val     extern_f16Sqrt = {c: "softfloat_f16sqrt", ocaml: "Softfloat.f16_sqrt", lem: "softfloat_f16_sqrt"} : (bits_rm, bits_H) -> unit
+val      riscv_f16Sqrt : (bits_rm, bits_H) -> (bits_fflags, bits_H) effect {rreg}
+function riscv_f16Sqrt (rm, v) = {
+  extern_f16Sqrt(rm, v);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
+
 val     extern_f32Sqrt = {c: "softfloat_f32sqrt", ocaml: "Softfloat.f32_sqrt", lem: "softfloat_f32_sqrt"} : (bits_rm, bits_S) -> unit
 val      riscv_f32Sqrt : (bits_rm, bits_S) -> (bits_fflags, bits_S) effect {rreg}
 function riscv_f32Sqrt (rm, v) = {
@@ -204,6 +247,62 @@ function riscv_f64Sqrt (rm, v) = {
 
 /* **************************************************************** */
 /* CONVERSIONS                                                      */
+
+val     extern_f16ToI32 = {c: "softfloat_f16toi32", ocaml: "Softfloat.f16_to_i32", lem: "softfloat_f16_to_i32"} : (bits_rm, bits_H) -> unit
+val      riscv_f16ToI32 : (bits_rm, bits_H) -> (bits_fflags, bits_W) effect {rreg}
+function riscv_f16ToI32 (rm, v) = {
+  extern_f16ToI32(rm, v);
+  (float_fflags[4 .. 0], float_result[31 .. 0])
+}
+
+val     extern_f16ToUi32 = {c: "softfloat_f16toui32", ocaml: "Softfloat.f16_to_ui32", lem: "softfloat_f16_to_ui32"} : (bits_rm, bits_H) -> unit
+val      riscv_f16ToUi32 : (bits_rm, bits_H) -> (bits_fflags, bits_WU) effect {rreg}
+function riscv_f16ToUi32 (rm, v) = {
+  extern_f16ToUi32(rm, v);
+  (float_fflags[4 .. 0], float_result[31 .. 0])
+}
+
+val     extern_i32ToF16 = {c: "softfloat_i32tof16", ocaml: "Softfloat.i32_to_f16", lem: "softfloat_i32_to_f16"} : (bits_rm, bits_W) -> unit
+val      riscv_i32ToF16 : (bits_rm, bits_W) -> (bits_fflags, bits_H) effect {rreg}
+function riscv_i32ToF16 (rm, v) = {
+  extern_i32ToF16(rm, v);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
+
+val     extern_ui32ToF16 = {c: "softfloat_ui32tof16", ocaml: "Softfloat.ui32_to_f16", lem: "softfloat_ui32_to_f16"} : (bits_rm, bits_WU) -> unit
+val      riscv_ui32ToF16 : (bits_rm, bits_WU) -> (bits_fflags, bits_H) effect {rreg}
+function riscv_ui32ToF16 (rm, v) = {
+  extern_ui32ToF16(rm, v);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
+
+val     extern_f16ToI64 = {c: "softfloat_f16toi64", ocaml: "Softfloat.f16_to_i64", lem: "softfloat_f16_to_i64"} : (bits_rm, bits_H) -> unit
+val      riscv_f16ToI64 : (bits_rm, bits_H) -> (bits_fflags, bits_L) effect {rreg}
+function riscv_f16ToI64 (rm, v) = {
+  extern_f16ToI64(rm, v);
+  (float_fflags[4 .. 0], float_result)
+}
+
+val     extern_f16ToUi64 = {c: "softfloat_f16toui64", ocaml: "Softfloat.f16_to_ui64", lem: "softfloat_f16_to_ui64"} : (bits_rm, bits_H) -> unit
+val      riscv_f16ToUi64 : (bits_rm, bits_H) -> (bits_fflags, bits_LU) effect {rreg}
+function riscv_f16ToUi64 (rm, v) = {
+  extern_f16ToUi64(rm, v);
+  (float_fflags[4 .. 0], float_result)
+}
+
+val     extern_i64ToF16 = {c: "softfloat_i64tof16", ocaml: "Softfloat.i64_to_f16", lem: "softfloat_i64_to_f16"} : (bits_rm, bits_L) -> unit
+val      riscv_i64ToF16 : (bits_rm, bits_L) -> (bits_fflags, bits_H) effect {rreg}
+function riscv_i64ToF16 (rm, v) = {
+  extern_i64ToF16(rm, v);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
+
+val     extern_ui64ToF16 = {c: "softfloat_ui64tof16", ocaml: "Softfloat.ui64_to_f16", lem: "softfloat_ui64_to_f16"} : (bits_rm, bits_L) -> unit
+val      riscv_ui64ToF16 : (bits_rm, bits_LU) -> (bits_fflags, bits_H) effect {rreg}
+function riscv_ui64ToF16 (rm, v) = {
+  extern_ui64ToF16(rm, v);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
 
 val     extern_f32ToI32 = {c: "softfloat_f32toi32", ocaml: "Softfloat.f32_to_i32", lem: "softfloat_f32_to_i32"} : (bits_rm, bits_S) -> unit
 val      riscv_f32ToI32 : (bits_rm, bits_S) -> (bits_fflags, bits_W) effect {rreg}
@@ -317,11 +416,39 @@ function riscv_ui64ToF64 (rm, v) = {
   (float_fflags[4 .. 0], float_result)
 }
 
+val     extern_f16ToF32 = {c: "softfloat_f16tof32", ocaml: "Softfloat.f16_to_f32", lem: "softfloat_f16_to_f32"} : (bits_rm, bits_H) -> unit
+val      riscv_f16ToF32 : (bits_rm, bits_H) -> (bits_fflags, bits_S) effect {rreg}
+function riscv_f16ToF32 (rm, v) = {
+  extern_f16ToF32(rm, v);
+  (float_fflags[4 .. 0], float_result[31 .. 0])
+}
+
+val     extern_f16ToF64 = {c: "softfloat_f16tof64", ocaml: "Softfloat.f16_to_f64", lem: "softfloat_f16_to_f64"} : (bits_rm, bits_H) -> unit
+val      riscv_f16ToF64 : (bits_rm, bits_H) -> (bits_fflags, bits_D) effect {rreg}
+function riscv_f16ToF64 (rm, v) = {
+  extern_f16ToF64(rm, v);
+  (float_fflags[4 .. 0], float_result)
+}
+
 val     extern_f32ToF64 = {c: "softfloat_f32tof64", ocaml: "Softfloat.f32_to_f64", lem: "softfloat_f32_to_f64"} : (bits_rm, bits_S) -> unit
 val      riscv_f32ToF64 : (bits_rm, bits_S) -> (bits_fflags, bits_D) effect {rreg}
 function riscv_f32ToF64 (rm, v) = {
   extern_f32ToF64(rm, v);
   (float_fflags[4 .. 0], float_result)
+}
+
+val     extern_f32ToF16 = {c: "softfloat_f32tof16", ocaml: "Softfloat.f32_to_f16", lem: "softfloat_f32_to_f16"} : (bits_rm, bits_S) -> unit
+val      riscv_f32ToF16 : (bits_rm, bits_S) -> (bits_fflags, bits_H) effect {rreg}
+function riscv_f32ToF16 (rm, v) = {
+  extern_f32ToF16(rm, v);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
+
+val     extern_f64ToF16 = {c: "softfloat_f64tof16", ocaml: "Softfloat.f64_to_f16", lem: "softfloat_f64_to_f16"} : (bits_rm, bits_D) -> unit
+val      riscv_f64ToF16 : (bits_rm, bits_D) -> (bits_fflags, bits_H) effect {rreg}
+function riscv_f64ToF16 (rm, v) = {
+  extern_f64ToF16(rm, v);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
 }
 
 val     extern_f64ToF32 = {c: "softfloat_f64tof32", ocaml: "Softfloat.f64_to_f32", lem: "softfloat_f64_to_f32"} : (bits_rm, bits_D) -> unit
@@ -333,6 +460,27 @@ function riscv_f64ToF32 (rm, v) = {
 
 /* **************************************************************** */
 /* COMPARISONS                                                      */
+
+val     extern_f16Lt = {c: "softfloat_f16lt", ocaml: "Softfloat.f16_lt", lem: "softfloat_f16_lt"} : (bits_H, bits_H) -> unit
+val      riscv_f16Lt : (bits_H, bits_H) -> (bits_fflags, bool) effect {rreg}
+function riscv_f16Lt (v1, v2) = {
+  extern_f16Lt(v1, v2);
+  (float_fflags[4 .. 0], bit_to_bool(float_result[0]))
+}
+
+val     extern_f16Le = {c: "softfloat_f16le", ocaml: "Softfloat.f16_le", lem: "softfloat_f16_le"} : (bits_H, bits_H) -> unit
+val      riscv_f16Le : (bits_H, bits_H) -> (bits_fflags, bool) effect {rreg}
+function riscv_f16Le (v1, v2) = {
+  extern_f16Le(v1, v2);
+  (float_fflags[4 .. 0], bit_to_bool(float_result[0]))
+}
+
+val     extern_f16Eq = {c: "softfloat_f16eq", ocaml: "Softfloat.f16_eq", lem: "softfloat_f16_eq"} : (bits_H, bits_H) -> unit
+val      riscv_f16Eq : (bits_H, bits_H) -> (bits_fflags, bool) effect {rreg}
+function riscv_f16Eq (v1, v2) = {
+  extern_f16Eq(v1, v2);
+  (float_fflags[4 .. 0], bit_to_bool(float_result[0]))
+}
 
 val     extern_f32Lt = {c: "softfloat_f32lt", ocaml: "Softfloat.f32_lt", lem: "softfloat_f32_lt"} : (bits_S, bits_S) -> unit
 val      riscv_f32Lt : (bits_S, bits_S) -> (bits_fflags, bool) effect {rreg}

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -188,6 +188,9 @@ function haveZbb()  -> bool = true
 function haveZbc()  -> bool = true
 function haveZbs()  -> bool = true
 
+/* Zfh (half-precision) extension */
+function haveZfh()    -> bool = true
+
 /* Cryptography extension support. Note these will need updating once */
 /* Sail can be dynamically configured with different extension support */
 /* and have dynamic changes of XLEN via S/UXL */

--- a/ocaml_emulator/softfloat.ml
+++ b/ocaml_emulator/softfloat.ml
@@ -1,4 +1,16 @@
 
+let f16_add rm v1 v2 =
+  ()
+
+let f16_sub rm v1 v2 =
+  ()
+
+let f16_mul rm v1 v2 =
+  ()
+
+let f16_div rm v1 v2 =
+  ()
+
 let f32_add rm v1 v2 =
   ()
 
@@ -23,16 +35,46 @@ let f64_mul rm v1 v2 =
 let f64_div rm v1 v2 =
   ()
 
+let f16_muladd rm v1 v2 v3 =
+  ()
+
 let f32_muladd rm v1 v2 v3 =
   ()
 
 let f64_muladd rm v1 v2 v3 =
   ()
 
+let f16_sqrt rm v =
+  ()
+
 let f32_sqrt rm v =
   ()
 
 let f64_sqrt rm v =
+  ()
+
+let f16_to_i32 rm v =
+  ()
+
+let f16_to_ui32 rm v =
+  ()
+
+let i32_to_f16 rm v =
+  ()
+
+let ui32_to_f16 rm v =
+  ()
+
+let f16_to_i64 rm v =
+  ()
+
+let f16_to_ui64 rm v =
+  ()
+
+let i64_to_f16 rm v =
+  ()
+
+let ui64_to_f16 rm v =
   ()
 
 let f32_to_i32 rm v =
@@ -83,10 +125,31 @@ let i64_to_f64 rm v =
 let ui64_to_f64 rm v =
   ()
 
+let f16_to_f32 rm v =
+  ()
+
+let f16_to_f64 rm v =
+  ()
+
 let f32_to_f64 rm v =
   ()
 
+let f32_to_f16 rm v =
+  ()
+
+let f64_to_f16 rm v =
+  ()
+
 let f64_to_f32 rm v =
+  ()
+
+let f16_lt v1 v2 =
+  ()
+
+let f16_le v1 v2 =
+  ()
+
+let f16_eq v1 v2 =
   ()
 
 let f32_lt v1 v2 =

--- a/prover_snapshots/hol4/RV32/riscvScript.sml
+++ b/prover_snapshots/hol4/RV32/riscvScript.sml
@@ -10325,6 +10325,50 @@ val _ = Define `
     (sail2_state_monad$write_regS float_fflags_ref ((zero_extend flags (( 64 : int):ii)  :  64 words$word))))`;
 
 
+(*val riscv_f16Add : mword ty3 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16Add:(3)words$word ->(16)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v1 v2=
+    (let (_ : unit) = (softfloat_f16_add rm v1 v2) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_f16Sub : mword ty3 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16Sub:(3)words$word ->(16)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v1 v2=
+    (let (_ : unit) = (softfloat_f16_sub rm v1 v2) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_f16Mul : mword ty3 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16Mul:(3)words$word ->(16)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v1 v2=
+    (let (_ : unit) = (softfloat_f16_mul rm v1 v2) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_f16Div : mword ty3 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16Div:(3)words$word ->(16)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v1 v2=
+    (let (_ : unit) = (softfloat_f16_div rm v1 v2) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
 (*val riscv_f32Add : mword ty3 -> mword ty32 -> mword ty32 -> M (mword ty5 * mword ty32)*)
 
 val _ = Define `
@@ -10409,6 +10453,17 @@ val _ = Define `
    sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word), w__1)))))`;
 
 
+(*val riscv_f16MulAdd : mword ty3 -> mword ty16 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16MulAdd:(3)words$word ->(16)words$word ->(16)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v1 v2 v3=
+    (let (_ : unit) = (softfloat_f16_muladd rm v1 v2 v3) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
 (*val riscv_f32MulAdd : mword ty3 -> mword ty32 -> mword ty32 -> mword ty32 -> M (mword ty5 * mword ty32)*)
 
 val _ = Define `
@@ -10430,6 +10485,17 @@ val _ = Define `
    sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word), w__1)))))`;
 
 
+(*val riscv_f16Sqrt : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16Sqrt:(3)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f16_sqrt rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
 (*val riscv_f32Sqrt : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty32)*)
 
 val _ = Define `
@@ -10449,6 +10515,92 @@ val _ = Define `
    (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
    (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
    sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word), w__1)))))`;
+
+
+(*val riscv_f16ToI32 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty32)*)
+
+val _ = Define `
+ ((riscv_f16ToI32:(3)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(32)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f16_to_i32 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 31 : int):ii) (( 0 : int):ii)  :  32 words$word))))))`;
+
+
+(*val riscv_f16ToUi32 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty32)*)
+
+val _ = Define `
+ ((riscv_f16ToUi32:(3)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(32)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f16_to_ui32 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 31 : int):ii) (( 0 : int):ii)  :  32 words$word))))))`;
+
+
+(*val riscv_i32ToF16 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_i32ToF16:(3)words$word ->(32)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(32)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_i32_to_f16 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_ui32ToF16 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_ui32ToF16:(3)words$word ->(32)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(32)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_ui32_to_f16 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_f16ToI64 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty64)*)
+
+val _ = Define `
+ ((riscv_f16ToI64:(3)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(64)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f16_to_i64 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word), w__1)))))`;
+
+
+(*val riscv_f16ToUi64 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty64)*)
+
+val _ = Define `
+ ((riscv_f16ToUi64:(3)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(64)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f16_to_ui64 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word), w__1)))))`;
+
+
+(*val riscv_i64ToF16 : mword ty3 -> mword ty64 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_i64ToF16:(3)words$word ->(64)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(32)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_i64_to_f16 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_ui64ToF16 : mword ty3 -> mword ty64 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_ui64ToF16:(3)words$word ->(64)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(32)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_ui64_to_f16 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
 
 
 (*val riscv_f32ToI32 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty32)*)
@@ -10619,6 +10771,27 @@ val _ = Define `
    sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word), w__1)))))`;
 
 
+(*val riscv_f16ToF32 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty32)*)
+
+val _ = Define `
+ ((riscv_f16ToF32:(3)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(32)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f16_to_f32 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 31 : int):ii) (( 0 : int):ii)  :  32 words$word))))))`;
+
+
+(*val riscv_f16ToF64 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty64)*)
+
+val _ = Define `
+ ((riscv_f16ToF64:(3)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(64)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f16_to_f64 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word), w__1)))))`;
+
+
 (*val riscv_f32ToF64 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty64)*)
 
 val _ = Define `
@@ -10627,6 +10800,28 @@ val _ = Define `
    (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
    (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
    sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word), w__1)))))`;
+
+
+(*val riscv_f32ToF16 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f32ToF16:(3)words$word ->(32)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f32_to_f16 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_f64ToF16 : mword ty3 -> mword ty64 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f64ToF16:(3)words$word ->(64)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f64_to_f16 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
 
 
 (*val riscv_f64ToF32 : mword ty3 -> mword ty64 -> M (mword ty5 * mword ty32)*)
@@ -10638,6 +10833,39 @@ val _ = Define `
    (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
    sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
            (subrange_vec_dec w__1 (( 31 : int):ii) (( 0 : int):ii)  :  32 words$word))))))`;
+
+
+(*val riscv_f16Lt : mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16Lt:(16)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) v1 v2=
+    (let (_ : unit) = (softfloat_f16_lt v1 v2) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_f16Le : mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16Le:(16)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) v1 v2=
+    (let (_ : unit) = (softfloat_f16_le v1 v2) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_f16Eq : mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16Eq:(16)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) v1 v2=
+    (let (_ : unit) = (softfloat_f16_eq v1 v2) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
 
 
 (*val riscv_f32Lt : mword ty32 -> mword ty32 -> M (mword ty5 * mword ty32)*)

--- a/prover_snapshots/hol4/RV32/riscv_extras_fdextScript.sml
+++ b/prover_snapshots/hol4/RV32/riscv_extras_fdextScript.sml
@@ -20,6 +20,25 @@ val _ = type_abbrev((*  'a *) "bitvector0" , ``:  'a words$word``);
 
 (* stub functions emulating the C softfloat interface *)
 
+(*val softfloat_f16_add : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_add:'rm words$word -> 's words$word -> 's words$word -> unit) _ _ _=  () )`;
+
+
+(*val softfloat_f16_sub : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_sub:'rm words$word -> 's words$word -> 's words$word -> unit) _ _ _=  () )`;
+
+
+(*val softfloat_f16_mul : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_mul:'rm words$word -> 's words$word -> 's words$word -> unit) _ _ _=  () )`;
+
+
+(*val softfloat_f16_div : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_div:'rm words$word -> 's words$word -> 's words$word -> unit) _ _ _=  () )`;
+
 (*val softfloat_f32_add : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit*)
 val _ = Define `
  ((softfloat_f32_add:'rm words$word -> 's words$word -> 's words$word -> unit) _ _ _=  () )`;
@@ -61,6 +80,11 @@ val _ = Define `
 
 
 
+(*val softfloat_f16_muladd : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_muladd:'rm words$word -> 's words$word -> 's words$word -> 's words$word -> unit) _ _ _ _=  () )`;
+
+
 (*val softfloat_f32_muladd : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> bitvector 's -> unit*)
 val _ = Define `
  ((softfloat_f32_muladd:'rm words$word -> 's words$word -> 's words$word -> 's words$word -> unit) _ _ _ _=  () )`;
@@ -72,6 +96,11 @@ val _ = Define `
 
 
 
+(*val softfloat_f16_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_sqrt:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
 (*val softfloat_f32_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
 val _ = Define `
  ((softfloat_f32_sqrt:'rm words$word -> 's words$word -> unit) _ _=  () )`;
@@ -80,6 +109,47 @@ val _ = Define `
 (*val softfloat_f64_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
 val _ = Define `
  ((softfloat_f64_sqrt:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+
+(*val softfloat_f16_to_i32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_to_i32:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_f16_to_ui32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_to_ui32:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_i32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_i32_to_f16:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_ui32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_ui32_to_f16:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_f16_to_i64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_to_i64:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_f16_to_ui64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_to_ui64:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_i64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_i64_to_f16:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_ui64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_ui64_to_f16:'rm words$word -> 's words$word -> unit) _ _=  () )`;
 
 
 
@@ -165,15 +235,50 @@ val _ = Define `
 
 
 
+(*val softfloat_f16_to_f32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_to_f32:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_f16_to_f64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_to_f64:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
 (*val softfloat_f32_to_f64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
 val _ = Define `
  ((softfloat_f32_to_f64:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_f32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f32_to_f16:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_f64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f64_to_f16:'rm words$word -> 's words$word -> unit) _ _=  () )`;
 
 
 (*val softfloat_f64_to_f32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
 val _ = Define `
  ((softfloat_f64_to_f32:'rm words$word -> 's words$word -> unit) _ _=  () )`;
 
+
+
+(*val softfloat_f16_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_lt:'s words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_f16_le : forall 's. Size 's => bitvector 's -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_le:'s words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_f16_eq : forall 's. Size 's => bitvector 's -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_eq:'s words$word -> 's words$word -> unit) _ _=  () )`;
 
 
 (*val softfloat_f32_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit*)

--- a/prover_snapshots/hol4/RV64/riscvScript.sml
+++ b/prover_snapshots/hol4/RV64/riscvScript.sml
@@ -10339,6 +10339,50 @@ val _ = Define `
     (sail2_state_monad$write_regS float_fflags_ref ((zero_extend flags (( 64 : int):ii)  :  64 words$word))))`;
 
 
+(*val riscv_f16Add : mword ty3 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16Add:(3)words$word ->(16)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v1 v2=
+    (let (_ : unit) = (softfloat_f16_add rm v1 v2) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_f16Sub : mword ty3 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16Sub:(3)words$word ->(16)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v1 v2=
+    (let (_ : unit) = (softfloat_f16_sub rm v1 v2) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_f16Mul : mword ty3 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16Mul:(3)words$word ->(16)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v1 v2=
+    (let (_ : unit) = (softfloat_f16_mul rm v1 v2) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_f16Div : mword ty3 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16Div:(3)words$word ->(16)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v1 v2=
+    (let (_ : unit) = (softfloat_f16_div rm v1 v2) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
 (*val riscv_f32Add : mword ty3 -> mword ty32 -> mword ty32 -> M (mword ty5 * mword ty32)*)
 
 val _ = Define `
@@ -10423,6 +10467,17 @@ val _ = Define `
    sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word), w__1)))))`;
 
 
+(*val riscv_f16MulAdd : mword ty3 -> mword ty16 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16MulAdd:(3)words$word ->(16)words$word ->(16)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v1 v2 v3=
+    (let (_ : unit) = (softfloat_f16_muladd rm v1 v2 v3) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
 (*val riscv_f32MulAdd : mword ty3 -> mword ty32 -> mword ty32 -> mword ty32 -> M (mword ty5 * mword ty32)*)
 
 val _ = Define `
@@ -10444,6 +10499,17 @@ val _ = Define `
    sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word), w__1)))))`;
 
 
+(*val riscv_f16Sqrt : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16Sqrt:(3)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f16_sqrt rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
 (*val riscv_f32Sqrt : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty32)*)
 
 val _ = Define `
@@ -10463,6 +10529,92 @@ val _ = Define `
    (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
    (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
    sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word), w__1)))))`;
+
+
+(*val riscv_f16ToI32 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty32)*)
+
+val _ = Define `
+ ((riscv_f16ToI32:(3)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(32)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f16_to_i32 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 31 : int):ii) (( 0 : int):ii)  :  32 words$word))))))`;
+
+
+(*val riscv_f16ToUi32 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty32)*)
+
+val _ = Define `
+ ((riscv_f16ToUi32:(3)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(32)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f16_to_ui32 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 31 : int):ii) (( 0 : int):ii)  :  32 words$word))))))`;
+
+
+(*val riscv_i32ToF16 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_i32ToF16:(3)words$word ->(32)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(32)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_i32_to_f16 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_ui32ToF16 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_ui32ToF16:(3)words$word ->(32)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(32)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_ui32_to_f16 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_f16ToI64 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty64)*)
+
+val _ = Define `
+ ((riscv_f16ToI64:(3)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(64)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f16_to_i64 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word), w__1)))))`;
+
+
+(*val riscv_f16ToUi64 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty64)*)
+
+val _ = Define `
+ ((riscv_f16ToUi64:(3)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(64)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f16_to_ui64 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word), w__1)))))`;
+
+
+(*val riscv_i64ToF16 : mword ty3 -> mword ty64 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_i64ToF15:(3)words$word ->(64)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(32)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_i64_to_f16 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_ui64ToF16 : mword ty3 -> mword ty64 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_ui64ToF16:(3)words$word ->(64)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(32)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_ui64_to_f16 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
 
 
 (*val riscv_f32ToI32 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty32)*)
@@ -10633,6 +10785,27 @@ val _ = Define `
    sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word), w__1)))))`;
 
 
+(*val riscv_f16ToF32 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty32)*)
+
+val _ = Define `
+ ((riscv_f16ToF32:(3)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(32)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f16_to_f32 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 31 : int):ii) (( 0 : int):ii)  :  32 words$word))))))`;
+
+
+(*val riscv_f16ToF64 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty64)*)
+
+val _ = Define `
+ ((riscv_f16ToF64:(3)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(64)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f16_to_f64 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word), w__1)))))`;
+
+
 (*val riscv_f32ToF64 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty64)*)
 
 val _ = Define `
@@ -10641,6 +10814,28 @@ val _ = Define `
    (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
    (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
    sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word), w__1)))))`;
+
+
+(*val riscv_f32ToF16 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f32ToF16:(3)words$word ->(32)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f32_to_f16 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_f64ToF16 : mword ty3 -> mword ty64 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f64ToF16:(3)words$word ->(64)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) rm v=
+    (let (_ : unit) = (softfloat_f64_to_f16 rm v) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
 
 
 (*val riscv_f64ToF32 : mword ty3 -> mword ty64 -> M (mword ty5 * mword ty32)*)
@@ -10652,6 +10847,39 @@ val _ = Define `
    (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
    sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
            (subrange_vec_dec w__1 (( 31 : int):ii) (( 0 : int):ii)  :  32 words$word))))))`;
+
+
+(*val riscv_f16Lt : mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16Lt:(16)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) v1 v2=
+    (let (_ : unit) = (softfloat_f16_lt v1 v2) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_f16Le : mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16Le:(16)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) v1 v2=
+    (let (_ : unit) = (softfloat_f16_le v1 v2) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
+
+
+(*val riscv_f16Eq : mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)*)
+
+val _ = Define `
+ ((riscv_f16Eq:(16)words$word ->(16)words$word ->(regstate)sail2_state_monad$sequential_state ->((((5)words$word#(16)words$word),(exception))sail2_state_monad$result#(regstate)sail2_state_monad$sequential_state)set) v1 v2=
+    (let (_ : unit) = (softfloat_f16_eq v1 v2) in sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_fflags_ref  : ( 64 words$word) M) (\ (w__0 :  64 words$word) .  sail2_state_monad$bindS
+   (sail2_state_monad$read_regS float_result_ref  : ( 64 words$word) M) (\ (w__1 :  64 words$word) . 
+   sail2_state_monad$returnS ((subrange_vec_dec w__0 (( 4 : int):ii) (( 0 : int):ii)  :  5 words$word),
+           (subrange_vec_dec w__1 (( 15 : int):ii) (( 0 : int):ii)  :  16 words$word))))))`;
 
 
 (*val riscv_f32Lt : mword ty32 -> mword ty32 -> M (mword ty5 * mword ty32)*)

--- a/prover_snapshots/hol4/RV64/riscv_extras_fdextScript.sml
+++ b/prover_snapshots/hol4/RV64/riscv_extras_fdextScript.sml
@@ -20,6 +20,25 @@ val _ = type_abbrev((*  'a *) "bitvector0" , ``:  'a words$word``);
 
 (* stub functions emulating the C softfloat interface *)
 
+(*val softfloat_f16_add : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_add:'rm words$word -> 's words$word -> 's words$word -> unit) _ _ _=  () )`;
+
+
+(*val softfloat_f16_sub : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_sub:'rm words$word -> 's words$word -> 's words$word -> unit) _ _ _=  () )`;
+
+
+(*val softfloat_f16_mul : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_mul:'rm words$word -> 's words$word -> 's words$word -> unit) _ _ _=  () )`;
+
+
+(*val softfloat_f16_div : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_div:'rm words$word -> 's words$word -> 's words$word -> unit) _ _ _=  () )`;
+
 (*val softfloat_f32_add : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit*)
 val _ = Define `
  ((softfloat_f32_add:'rm words$word -> 's words$word -> 's words$word -> unit) _ _ _=  () )`;
@@ -61,6 +80,11 @@ val _ = Define `
 
 
 
+(*val softfloat_f16_muladd : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_muladd:'rm words$word -> 's words$word -> 's words$word -> 's words$word -> unit) _ _ _ _=  () )`;
+
+
 (*val softfloat_f32_muladd : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> bitvector 's -> unit*)
 val _ = Define `
  ((softfloat_f32_muladd:'rm words$word -> 's words$word -> 's words$word -> 's words$word -> unit) _ _ _ _=  () )`;
@@ -72,6 +96,11 @@ val _ = Define `
 
 
 
+(*val softfloat_f16_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_sqrt:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
 (*val softfloat_f32_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
 val _ = Define `
  ((softfloat_f32_sqrt:'rm words$word -> 's words$word -> unit) _ _=  () )`;
@@ -80,6 +109,47 @@ val _ = Define `
 (*val softfloat_f64_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
 val _ = Define `
  ((softfloat_f64_sqrt:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+
+(*val softfloat_f16_to_i32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_to_i32:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_f16_to_ui32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_to_ui32:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_i32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_i32_to_f16:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_ui32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_ui32_to_f16:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_f16_to_i64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_to_i64:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_f16_to_ui64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_to_ui64:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_i64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_i64_to_f16:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_ui64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_ui64_to_f16:'rm words$word -> 's words$word -> unit) _ _=  () )`;
 
 
 
@@ -165,15 +235,49 @@ val _ = Define `
 
 
 
+(*val softfloat_f16_to_f32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_to_f32:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_f16_to_f64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_to_f64:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
 (*val softfloat_f32_to_f64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
 val _ = Define `
  ((softfloat_f32_to_f64:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_f32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f32_to_f16:'rm words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_f64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f64_to_f16:'rm words$word -> 's words$word -> unit) _ _=  () )`;
 
 
 (*val softfloat_f64_to_f32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit*)
 val _ = Define `
  ((softfloat_f64_to_f32:'rm words$word -> 's words$word -> unit) _ _=  () )`;
 
+
+(*val softfloat_f16_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_lt:'s words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_f16_le : forall 's. Size 's => bitvector 's -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_le:'s words$word -> 's words$word -> unit) _ _=  () )`;
+
+
+(*val softfloat_f16_eq : forall 's. Size 's => bitvector 's -> bitvector 's -> unit*)
+val _ = Define `
+ ((softfloat_f16_eq:'s words$word -> 's words$word -> unit) _ _=  () )`;
 
 
 (*val softfloat_f32_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit*)

--- a/prover_snapshots/isabelle/RV32/Riscv.thy
+++ b/prover_snapshots/isabelle/RV32/Riscv.thy
@@ -10514,6 +10514,62 @@ definition update_softfloat_fflags  :: \<open>(5)Word.word \<Rightarrow>((regist
   for  flags  :: "(5)Word.word "
 
 
+\<comment> \<open>\<open>val riscv_f16Add : mword ty3 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16Add  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16Add rm v1 v2 = (
+   (let (_ :: unit) = (softfloat_f16_add rm v1 v2) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v1  :: "(16)Word.word " 
+  and  v2  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16Sub : mword ty3 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16Sub  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16Sub rm v1 v2 = (
+   (let (_ :: unit) = (softfloat_f16_sub rm v1 v2) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v1  :: "(16)Word.word " 
+  and  v2  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16Mul : mword ty3 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16Mul  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16Mul rm v1 v2 = (
+   (let (_ :: unit) = (softfloat_f16_mul rm v1 v2) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v1  :: "(16)Word.word " 
+  and  v2  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16Div : mword ty3 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16Div  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16Div rm v1 v2 = (
+   (let (_ :: unit) = (softfloat_f16_div rm v1 v2) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v1  :: "(16)Word.word " 
+  and  v2  :: "(16)Word.word "
+
+
 \<comment> \<open>\<open>val riscv_f32Add : mword ty3 -> mword ty32 -> mword ty32 -> M (mword ty5 * mword ty32)\<close>\<close>
 
 definition riscv_f32Add  :: \<open>(3)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>((register_value),((5)Word.word*(32)Word.word),(exception))monad \<close>  where 
@@ -10622,6 +10678,21 @@ definition riscv_f64Div  :: \<open>(3)Word.word \<Rightarrow>(64)Word.word \<Rig
   and  v2  :: "(64)Word.word "
 
 
+\<comment> \<open>\<open>val riscv_f16MulAdd : mword ty3 -> mword ty16 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16MulAdd  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16MulAdd rm v1 v2 v3 = (
+   (let (_ :: unit) = (softfloat_f16_muladd rm v1 v2 v3) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v1  :: "(16)Word.word " 
+  and  v2  :: "(16)Word.word " 
+  and  v3  :: "(16)Word.word "
+
+
 \<comment> \<open>\<open>val riscv_f32MulAdd : mword ty3 -> mword ty32 -> mword ty32 -> mword ty32 -> M (mword ty5 * mword ty32)\<close>\<close>
 
 definition riscv_f32MulAdd  :: \<open>(3)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>((register_value),((5)Word.word*(32)Word.word),(exception))monad \<close>  where 
@@ -10651,6 +10722,19 @@ definition riscv_f64MulAdd  :: \<open>(3)Word.word \<Rightarrow>(64)Word.word \<
   and  v3  :: "(64)Word.word "
 
 
+\<comment> \<open>\<open>val riscv_f16Sqrt : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16Sqrt  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16Sqrt rm v = (
+   (let (_ :: unit) = (softfloat_f16_sqrt rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(16)Word.word "
+
+
 \<comment> \<open>\<open>val riscv_f32Sqrt : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty32)\<close>\<close>
 
 definition riscv_f32Sqrt  :: \<open>(3)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>((register_value),((5)Word.word*(32)Word.word),(exception))monad \<close>  where 
@@ -10672,6 +10756,108 @@ definition riscv_f64Sqrt  :: \<open>(3)Word.word \<Rightarrow>(64)Word.word \<Ri
    (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
    (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
    return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word), w__1)))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(64)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16ToI32 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty32)\<close>\<close>
+
+definition riscv_f16ToI32  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(32)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16ToI32 rm v = (
+   (let (_ :: unit) = (softfloat_f16_to_i32 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 31 :: int)::ii) (( 0 :: int)::ii)  ::  32 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16ToUi32 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty32)\<close>\<close>
+
+definition riscv_f16ToUi32  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(32)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16ToUi32 rm v = (
+   (let (_ :: unit) = (softfloat_f16_to_ui32 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 31 :: int)::ii) (( 0 :: int)::ii)  ::  32 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_i32ToF16 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_i32ToF16  :: \<open>(3)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_i32ToF16 rm v = (
+   (let (_ :: unit) = (softfloat_i32_to_f16 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(32)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_ui32ToF16 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_ui32ToF16  :: \<open>(3)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_ui32ToF16 rm v = (
+   (let (_ :: unit) = (softfloat_ui32_to_f16 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(32)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16ToI64 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty64)\<close>\<close>
+
+definition riscv_f16ToI64  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(64)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16ToI64 rm v = (
+   (let (_ :: unit) = (softfloat_f16_to_i64 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word), w__1)))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16ToUi64 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty64)\<close>\<close>
+
+definition riscv_f16ToUi64  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(64)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16ToUi64 rm v = (
+   (let (_ :: unit) = (softfloat_f16_to_ui64 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word), w__1)))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_i64ToF16 : mword ty3 -> mword ty64 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_i64ToF16  :: \<open>(3)Word.word \<Rightarrow>(64)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_i64ToF16 rm v = (
+   (let (_ :: unit) = (softfloat_i64_to_f16 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(64)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_ui64ToF16 : mword ty3 -> mword ty64 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_ui64ToF16  :: \<open>(3)Word.word \<Rightarrow>(64)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_ui64ToF16 rm v = (
+   (let (_ :: unit) = (softfloat_ui64_to_f16 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
   for  rm  :: "(3)Word.word " 
   and  v  :: "(64)Word.word "
 
@@ -10876,6 +11062,31 @@ definition riscv_ui64ToF64  :: \<open>(3)Word.word \<Rightarrow>(64)Word.word \<
   and  v  :: "(64)Word.word "
 
 
+\<comment> \<open>\<open>val riscv_f16ToF32 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty32)\<close>\<close>
+
+definition riscv_f16ToF32  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(32)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16ToF32 rm v = (
+   (let (_ :: unit) = (softfloat_f16_to_f32 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 31 :: int)::ii) (( 0 :: int)::ii)  ::  32 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16ToF64 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty64)\<close>\<close>
+
+definition riscv_f16ToF64  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(64)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16ToF64 rm v = (
+   (let (_ :: unit) = (softfloat_f16_to_f64 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word), w__1)))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(16)Word.word "
+
+
 \<comment> \<open>\<open>val riscv_f32ToF64 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty64)\<close>\<close>
 
 definition riscv_f32ToF64  :: \<open>(3)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>((register_value),((5)Word.word*(64)Word.word),(exception))monad \<close>  where 
@@ -10886,6 +11097,32 @@ definition riscv_f32ToF64  :: \<open>(3)Word.word \<Rightarrow>(32)Word.word \<R
    return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word), w__1)))))))\<close> 
   for  rm  :: "(3)Word.word " 
   and  v  :: "(32)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f32ToF16 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f32ToF16  :: \<open>(3)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f32ToF16 rm v = (
+   (let (_ :: unit) = (softfloat_f32_to_f16 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(32)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f64ToF16 : mword ty3 -> mword ty64 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f64ToF16  :: \<open>(3)Word.word \<Rightarrow>(64)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f64ToF16 rm v = (
+   (let (_ :: unit) = (softfloat_f64_to_f16 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(64)Word.word "
 
 
 \<comment> \<open>\<open>val riscv_f64ToF32 : mword ty3 -> mword ty64 -> M (mword ty5 * mword ty32)\<close>\<close>
@@ -10899,6 +11136,45 @@ definition riscv_f64ToF32  :: \<open>(3)Word.word \<Rightarrow>(64)Word.word \<R
            (subrange_vec_dec w__1 (( 31 :: int)::ii) (( 0 :: int)::ii)  ::  32 Word.word))))))))\<close> 
   for  rm  :: "(3)Word.word " 
   and  v  :: "(64)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16Lt : mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16Lt  :: \<open>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16Lt v1 v2 = (
+   (let (_ :: unit) = (softfloat_f16_lt v1 v2) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  v1  :: "(16)Word.word " 
+  and  v2  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16Le : mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16Le  :: \<open>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16Le v1 v2 = (
+   (let (_ :: unit) = (softfloat_f16_le v1 v2) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  v1  :: "(16)Word.word " 
+  and  v2  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16Eq : mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16Eq  :: \<open>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16Eq v1 v2 = (
+   (let (_ :: unit) = (softfloat_f16_eq v1 v2) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  v1  :: "(16)Word.word " 
+  and  v2  :: "(16)Word.word "
 
 
 \<comment> \<open>\<open>val riscv_f32Lt : mword ty32 -> mword ty32 -> M (mword ty5 * mword ty32)\<close>\<close>

--- a/prover_snapshots/isabelle/RV32/Riscv_extras_fdext.thy
+++ b/prover_snapshots/isabelle/RV32/Riscv_extras_fdext.thy
@@ -26,6 +26,26 @@ type_synonym 'a bitvector0 =" ( 'a::len)Word.word "
 
 \<comment> \<open>\<open> stub functions emulating the C softfloat interface \<close>\<close>
 
+\<comment> \<open>\<open>val softfloat_f16_add : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_add  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_add _ _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_sub : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_sub  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_sub _ _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_mul : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_mul  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_mul _ _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_div : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_div  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_div _ _ _ = ( ()  )\<close>
+
+
 \<comment> \<open>\<open>val softfloat_f32_add : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit\<close>\<close>
 definition softfloat_f32_add  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
      \<open> softfloat_f32_add _ _ _ = ( ()  )\<close>
@@ -67,6 +87,11 @@ definition softfloat_f64_div  :: \<open>('rm::len)Word.word \<Rightarrow>('s::le
 
 
 
+\<comment> \<open>\<open>val softfloat_f16_muladd : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_muladd  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_muladd _ _ _ _ = ( ()  )\<close>
+ 
+
 \<comment> \<open>\<open>val softfloat_f32_muladd : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> bitvector 's -> unit\<close>\<close>
 definition softfloat_f32_muladd  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
      \<open> softfloat_f32_muladd _ _ _ _ = ( ()  )\<close>
@@ -78,6 +103,11 @@ definition softfloat_f64_muladd  :: \<open>('rm::len)Word.word \<Rightarrow>('s:
 
 
 
+\<comment> \<open>\<open>val softfloat_f16_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_sqrt  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_sqrt _ _ = ( ()  )\<close>
+
+
 \<comment> \<open>\<open>val softfloat_f32_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
 definition softfloat_f32_sqrt  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
      \<open> softfloat_f32_sqrt _ _ = ( ()  )\<close>
@@ -86,6 +116,47 @@ definition softfloat_f32_sqrt  :: \<open>('rm::len)Word.word \<Rightarrow>('s::l
 \<comment> \<open>\<open>val softfloat_f64_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
 definition softfloat_f64_sqrt  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
      \<open> softfloat_f64_sqrt _ _ = ( ()  )\<close>
+
+
+
+\<comment> \<open>\<open>val softfloat_f16_to_i32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_to_i32  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_to_i32 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_to_ui32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_to_ui32  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_to_ui32 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_i32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_i32_to_f16  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_i32_to_f16 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_ui32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_ui32_to_f16  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_ui32_to_f16 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_to_i64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_to_i64  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_to_i64 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_to_ui64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_to_ui64  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_to_ui64 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_i64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_i64_to_f16  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_i64_to_f16 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_ui64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_ui64_to_f16  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_ui64_to_f16 _ _ = ( ()  )\<close>
 
 
 
@@ -171,15 +242,50 @@ definition softfloat_ui64_to_f64  :: \<open>('rm::len)Word.word \<Rightarrow>('s
 
 
 
+\<comment> \<open>\<open>val softfloat_f16_to_f32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_to_f32  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_to_f32 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_to_f64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_to_f64  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_to_f64 _ _ = ( ()  )\<close>
+
+
 \<comment> \<open>\<open>val softfloat_f32_to_f64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
 definition softfloat_f32_to_f64  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
      \<open> softfloat_f32_to_f64 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f32_to_f16  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f32_to_f16 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f64_to_f16  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f64_to_f16 _ _ = ( ()  )\<close>
 
 
 \<comment> \<open>\<open>val softfloat_f64_to_f32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
 definition softfloat_f64_to_f32  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
      \<open> softfloat_f64_to_f32 _ _ = ( ()  )\<close>
 
+
+
+\<comment> \<open>\<open>val softfloat_f16_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_lt  :: \<open>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_lt _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_le : forall 's. Size 's => bitvector 's -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_le  :: \<open>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_le _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_eq : forall 's. Size 's => bitvector 's -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_eq  :: \<open>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_eq _ _ = ( ()  )\<close>
 
 
 \<comment> \<open>\<open>val softfloat_f32_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit\<close>\<close>

--- a/prover_snapshots/isabelle/RV64/Riscv.thy
+++ b/prover_snapshots/isabelle/RV64/Riscv.thy
@@ -10528,6 +10528,62 @@ definition update_softfloat_fflags  :: \<open>(5)Word.word \<Rightarrow>((regist
   for  flags  :: "(5)Word.word "
 
 
+\<comment> \<open>\<open>val riscv_f16Add : mword ty3 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16Add  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16Add rm v1 v2 = (
+   (let (_ :: unit) = (softfloat_f16_add rm v1 v2) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v1  :: "(16)Word.word " 
+  and  v2  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16Sub : mword ty3 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16Sub  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16Sub rm v1 v2 = (
+   (let (_ :: unit) = (softfloat_f16_sub rm v1 v2) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v1  :: "(16)Word.word " 
+  and  v2  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16Mul : mword ty3 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16Mul  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16Mul rm v1 v2 = (
+   (let (_ :: unit) = (softfloat_f16_mul rm v1 v2) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v1  :: "(16)Word.word " 
+  and  v2  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16Div : mword ty3 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16Div  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16Div rm v1 v2 = (
+   (let (_ :: unit) = (softfloat_f16_div rm v1 v2) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v1  :: "(16)Word.word " 
+  and  v2  :: "(16)Word.word "
+
+
 \<comment> \<open>\<open>val riscv_f32Add : mword ty3 -> mword ty32 -> mword ty32 -> M (mword ty5 * mword ty32)\<close>\<close>
 
 definition riscv_f32Add  :: \<open>(3)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>((register_value),((5)Word.word*(32)Word.word),(exception))monad \<close>  where 
@@ -10636,6 +10692,21 @@ definition riscv_f64Div  :: \<open>(3)Word.word \<Rightarrow>(64)Word.word \<Rig
   and  v2  :: "(64)Word.word "
 
 
+\<comment> \<open>\<open>val riscv_f16MulAdd : mword ty3 -> mword ty16 -> mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16MulAdd  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16MulAdd rm v1 v2 v3 = (
+   (let (_ :: unit) = (softfloat_f16_muladd rm v1 v2 v3) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v1  :: "(16)Word.word " 
+  and  v2  :: "(16)Word.word " 
+  and  v3  :: "(16)Word.word "
+
+
 \<comment> \<open>\<open>val riscv_f32MulAdd : mword ty3 -> mword ty32 -> mword ty32 -> mword ty32 -> M (mword ty5 * mword ty32)\<close>\<close>
 
 definition riscv_f32MulAdd  :: \<open>(3)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>((register_value),((5)Word.word*(32)Word.word),(exception))monad \<close>  where 
@@ -10665,6 +10736,19 @@ definition riscv_f64MulAdd  :: \<open>(3)Word.word \<Rightarrow>(64)Word.word \<
   and  v3  :: "(64)Word.word "
 
 
+\<comment> \<open>\<open>val riscv_f16Sqrt : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16Sqrt  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16Sqrt rm v = (
+   (let (_ :: unit) = (softfloat_f16_sqrt rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(16)Word.word "
+
+
 \<comment> \<open>\<open>val riscv_f32Sqrt : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty32)\<close>\<close>
 
 definition riscv_f32Sqrt  :: \<open>(3)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>((register_value),((5)Word.word*(32)Word.word),(exception))monad \<close>  where 
@@ -10686,6 +10770,108 @@ definition riscv_f64Sqrt  :: \<open>(3)Word.word \<Rightarrow>(64)Word.word \<Ri
    (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
    (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
    return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word), w__1)))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(64)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16ToI32 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty32)\<close>\<close>
+
+definition riscv_f16ToI32  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(32)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16ToI32 rm v = (
+   (let (_ :: unit) = (softfloat_f16_to_i32 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 31 :: int)::ii) (( 0 :: int)::ii)  ::  32 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16ToUi32 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty32)\<close>\<close>
+
+definition riscv_f16ToUi32  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(32)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16ToUi32 rm v = (
+   (let (_ :: unit) = (softfloat_f16_to_ui32 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 31 :: int)::ii) (( 0 :: int)::ii)  ::  32 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_i32ToF16 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_i32ToF16  :: \<open>(3)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_i32ToF16 rm v = (
+   (let (_ :: unit) = (softfloat_i32_to_f16 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(32)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_ui32ToF16 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_ui32ToF16  :: \<open>(3)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_ui32ToF16 rm v = (
+   (let (_ :: unit) = (softfloat_ui32_to_f16 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(32)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16ToI64 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty64)\<close>\<close>
+
+definition riscv_f16ToI64  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(64)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16ToI64 rm v = (
+   (let (_ :: unit) = (softfloat_f16_to_i64 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word), w__1)))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16ToUi64 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty64)\<close>\<close>
+
+definition riscv_f16ToUi64  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(64)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16ToUi64 rm v = (
+   (let (_ :: unit) = (softfloat_f16_to_ui64 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word), w__1)))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_i64ToF16 : mword ty3 -> mword ty64 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_i64ToF16  :: \<open>(3)Word.word \<Rightarrow>(64)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_i64ToF16 rm v = (
+   (let (_ :: unit) = (softfloat_i64_to_f16 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(64)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_ui64ToF16 : mword ty3 -> mword ty64 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_ui64ToF16  :: \<open>(3)Word.word \<Rightarrow>(64)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_ui64ToF16 rm v = (
+   (let (_ :: unit) = (softfloat_ui64_to_f16 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
   for  rm  :: "(3)Word.word " 
   and  v  :: "(64)Word.word "
 
@@ -10890,6 +11076,31 @@ definition riscv_ui64ToF64  :: \<open>(3)Word.word \<Rightarrow>(64)Word.word \<
   and  v  :: "(64)Word.word "
 
 
+\<comment> \<open>\<open>val riscv_f16ToF32 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty32)\<close>\<close>
+
+definition riscv_f16ToF32  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(32)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16ToF32 rm v = (
+   (let (_ :: unit) = (softfloat_f16_to_f32 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 31 :: int)::ii) (( 0 :: int)::ii)  ::  32 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16ToF64 : mword ty3 -> mword ty16 -> M (mword ty5 * mword ty64)\<close>\<close>
+
+definition riscv_f16ToF64  :: \<open>(3)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(64)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16ToF64 rm v = (
+   (let (_ :: unit) = (softfloat_f16_to_f64 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word), w__1)))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(16)Word.word "
+
+
 \<comment> \<open>\<open>val riscv_f32ToF64 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty64)\<close>\<close>
 
 definition riscv_f32ToF64  :: \<open>(3)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>((register_value),((5)Word.word*(64)Word.word),(exception))monad \<close>  where 
@@ -10900,6 +11111,32 @@ definition riscv_f32ToF64  :: \<open>(3)Word.word \<Rightarrow>(32)Word.word \<R
    return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word), w__1)))))))\<close> 
   for  rm  :: "(3)Word.word " 
   and  v  :: "(32)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f32ToF16 : mword ty3 -> mword ty32 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f32ToF16  :: \<open>(3)Word.word \<Rightarrow>(32)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f32ToF16 rm v = (
+   (let (_ :: unit) = (softfloat_f32_to_f16 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(32)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f64ToF16 : mword ty3 -> mword ty64 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f64ToF16  :: \<open>(3)Word.word \<Rightarrow>(64)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f64ToF16 rm v = (
+   (let (_ :: unit) = (softfloat_f64_to_f16 rm v) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  rm  :: "(3)Word.word " 
+  and  v  :: "(64)Word.word "
 
 
 \<comment> \<open>\<open>val riscv_f64ToF32 : mword ty3 -> mword ty64 -> M (mword ty5 * mword ty32)\<close>\<close>
@@ -10913,6 +11150,45 @@ definition riscv_f64ToF32  :: \<open>(3)Word.word \<Rightarrow>(64)Word.word \<R
            (subrange_vec_dec w__1 (( 31 :: int)::ii) (( 0 :: int)::ii)  ::  32 Word.word))))))))\<close> 
   for  rm  :: "(3)Word.word " 
   and  v  :: "(64)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16Lt : mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16Lt  :: \<open>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16Lt v1 v2 = (
+   (let (_ :: unit) = (softfloat_f16_lt v1 v2) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  v1  :: "(16)Word.word " 
+  and  v2  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16Le : mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16Le  :: \<open>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16Le v1 v2 = (
+   (let (_ :: unit) = (softfloat_f16_le v1 v2) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  v1  :: "(16)Word.word " 
+  and  v2  :: "(16)Word.word "
+
+
+\<comment> \<open>\<open>val riscv_f16Eq : mword ty16 -> mword ty16 -> M (mword ty5 * mword ty16)\<close>\<close>
+
+definition riscv_f16Eq  :: \<open>(16)Word.word \<Rightarrow>(16)Word.word \<Rightarrow>((register_value),((5)Word.word*(16)Word.word),(exception))monad \<close>  where 
+     \<open> riscv_f16Eq v1 v2 = (
+   (let (_ :: unit) = (softfloat_f16_eq v1 v2) in
+   (read_reg float_fflags_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__0 ::  64 Word.word) . 
+   (read_reg float_result_ref  :: ( 64 Word.word) M) \<bind> ((\<lambda> (w__1 ::  64 Word.word) . 
+   return ((subrange_vec_dec w__0 (( 4 :: int)::ii) (( 0 :: int)::ii)  ::  5 Word.word),
+           (subrange_vec_dec w__1 (( 15 :: int)::ii) (( 0 :: int)::ii)  ::  16 Word.word))))))))\<close> 
+  for  v1  :: "(16)Word.word " 
+  and  v2  :: "(16)Word.word "
 
 
 \<comment> \<open>\<open>val riscv_f32Lt : mword ty32 -> mword ty32 -> M (mword ty5 * mword ty32)\<close>\<close>

--- a/prover_snapshots/isabelle/RV64/Riscv_extras_fdext.thy
+++ b/prover_snapshots/isabelle/RV64/Riscv_extras_fdext.thy
@@ -26,6 +26,26 @@ type_synonym 'a bitvector0 =" ( 'a::len)Word.word "
 
 \<comment> \<open>\<open> stub functions emulating the C softfloat interface \<close>\<close>
 
+\<comment> \<open>\<open>val softfloat_f16_add : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_add  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_add _ _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_sub : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_sub  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_sub _ _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_mul : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_mul  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_mul _ _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_div : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_div  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_div _ _ _ = ( ()  )\<close>
+
+
 \<comment> \<open>\<open>val softfloat_f32_add : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> unit\<close>\<close>
 definition softfloat_f32_add  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
      \<open> softfloat_f32_add _ _ _ = ( ()  )\<close>
@@ -67,6 +87,11 @@ definition softfloat_f64_div  :: \<open>('rm::len)Word.word \<Rightarrow>('s::le
 
 
 
+\<comment> \<open>\<open>val softfloat_f16_muladd : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_muladd  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_muladd _ _ _ _ = ( ()  )\<close>
+
+
 \<comment> \<open>\<open>val softfloat_f32_muladd : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> bitvector 's -> bitvector 's -> unit\<close>\<close>
 definition softfloat_f32_muladd  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
      \<open> softfloat_f32_muladd _ _ _ _ = ( ()  )\<close>
@@ -78,6 +103,11 @@ definition softfloat_f64_muladd  :: \<open>('rm::len)Word.word \<Rightarrow>('s:
 
 
 
+\<comment> \<open>\<open>val softfloat_f16_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_sqrt  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_sqrt _ _ = ( ()  )\<close>
+
+
 \<comment> \<open>\<open>val softfloat_f32_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
 definition softfloat_f32_sqrt  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
      \<open> softfloat_f32_sqrt _ _ = ( ()  )\<close>
@@ -86,6 +116,47 @@ definition softfloat_f32_sqrt  :: \<open>('rm::len)Word.word \<Rightarrow>('s::l
 \<comment> \<open>\<open>val softfloat_f64_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
 definition softfloat_f64_sqrt  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
      \<open> softfloat_f64_sqrt _ _ = ( ()  )\<close>
+
+
+
+\<comment> \<open>\<open>val softfloat_f16_to_i32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_to_i32  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_to_i32 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_to_ui32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_to_ui32  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_to_ui32 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_i32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_i32_to_f16  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_i32_to_f16 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_ui32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_ui32_to_f16  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_ui32_to_f16 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_to_i64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_to_i64  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_to_i64 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_to_ui64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_to_ui64  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_to_ui64 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_i64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_i64_to_f16  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_i64_to_f16 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_ui64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_ui64_to_f16  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_ui64_to_f16 _ _ = ( ()  )\<close>
 
 
 
@@ -171,15 +242,50 @@ definition softfloat_ui64_to_f64  :: \<open>('rm::len)Word.word \<Rightarrow>('s
 
 
 
+\<comment> \<open>\<open>val softfloat_f16_to_f32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_to_f32  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_to_f32 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_to_f64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_to_f64  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_to_f64 _ _ = ( ()  )\<close>
+
+
 \<comment> \<open>\<open>val softfloat_f32_to_f64: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
 definition softfloat_f32_to_f64  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
      \<open> softfloat_f32_to_f64 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f32_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f32_to_f16  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f32_to_f16 _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f64_to_f16  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f64_to_f16 _ _ = ( ()  )\<close>
 
 
 \<comment> \<open>\<open>val softfloat_f64_to_f32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit\<close>\<close>
 definition softfloat_f64_to_f32  :: \<open>('rm::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
      \<open> softfloat_f64_to_f32 _ _ = ( ()  )\<close>
 
+
+
+\<comment> \<open>\<open>val softfloat_f16_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_lt  :: \<open>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_lt _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_le : forall 's. Size 's => bitvector 's -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_le  :: \<open>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_le _ _ = ( ()  )\<close>
+
+
+\<comment> \<open>\<open>val softfloat_f16_eq : forall 's. Size 's => bitvector 's -> bitvector 's -> unit\<close>\<close>
+definition softfloat_f16_eq  :: \<open>('s::len)Word.word \<Rightarrow>('s::len)Word.word \<Rightarrow> unit \<close>  where 
+     \<open> softfloat_f16_eq _ _ = ( ()  )\<close>
 
 
 \<comment> \<open>\<open>val softfloat_f32_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit\<close>\<close>


### PR DESCRIPTION
“Zfh” Standard Extensions for Half-Precision Floating-Point, Version 0.1

Chapter 15 in the [draft](https://github.com/riscv/riscv-isa-manual/releases/tag/draft-20211118-d42b61f) spec.

FCVT.Q.H and FCVT.H.Q are not implemented. (Quad-Precision is not supported by sail yet)