### PR TITLE
Run ISA tests in CI

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -6,10 +6,10 @@ jobs:
   build:
     runs-on: [ubuntu-18.04]
     steps:
-    - name: Install opam2
-      run: |
-        sudo add-apt-repository -y ppa:avsm/ppa
-        sudo apt install -y opam zlib1g-dev pkg-config libgmp-dev z3
+    - name: Add opam2 PPA
+      run: sudo add-apt-repository -y ppa:avsm/ppa
+    - name: Install packages
+      run: sudo apt install -y opam zlib1g-dev pkg-config libgmp-dev z3 device-tree-compiler
     - name: Init opam
       run: opam init --disable-sandboxing -y
     - name: Install sail
@@ -18,7 +18,17 @@ jobs:
       uses: actions/checkout@HEAD
       with:
         submodules: true
-    - name: Build RV32 simulators
-      run: eval $(opam env) && make ARCH=RV32 -j2 csim rvfi osim
-    - name: Build RV64 simulators
-      run: eval $(opam env) && make ARCH=RV64 -j2 csim rvfi osim
+    - name: Build and test simulators
+      run: eval $(opam env) && test/run_tests.sh
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: tests.xml
+        path: test/tests.xml
+    - name: Upload event payload
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: event.json
+        path: ${{ github.event_path }}

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,0 +1,51 @@
+name: Publish test results
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+    - completed
+
+jobs:
+  publish-test-results:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+    steps:
+    - name: Download artifacts
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+          var fs = require('fs');
+          var artifacts = await github.actions.listWorkflowRunArtifacts({
+             owner: context.repo.owner,
+             repo: context.repo.repo,
+             run_id: ${{github.event.workflow_run.id }},
+          });
+          var matchArtifacts = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == 'tests.xml' || artifact.name == 'event.json'
+          });
+          var count = matchArtifacts.length;
+          for (var i = 0; i < count; i++) {
+            var matchArtifact = matchArtifacts[i];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var name = matchArtifact.name;
+            var dest = name + '.zip'
+            fs.writeFileSync('${{github.workspace}}/' + dest, Buffer.from(download.data));
+            console.log("Downloaded", name, "as", dest);
+          }
+    - name: Extract test results
+      run: unzip tests.xml.zip
+    - name: Extract event payload
+      run: unzip event.json.zip
+    - name: Publish test results
+      uses: EnricoMi/publish-unit-test-result-action@v1
+      with:
+        commit: ${{ github.event.workflow_run.head_sha }}
+        event_file: event.json
+        event_name: ${{ github.event.workflow_run.event }}
+        files: tests.xml

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,1 @@
+/tests.xml

--- a/test/run_fp_tests.sh
+++ b/test/run_fp_tests.sh
@@ -16,31 +16,31 @@ pass=0
 fail=0
 all_pass=0
 all_fail=0
-XML=""
+SUITE_XML=""
+SUITES_XML=""
 
 function green {
     (( pass += 1 ))
     printf "$1: ${GREEN}$2${NC}\n"
-    XML+="    <testcase name=\"$1\"/>\n"
+    SUITE_XML+="    <testcase name=\"$1\"/>\n"
 }
 
 function yellow {
     (( fail += 1 ))
     printf "$1: ${YELLOW}$2${NC}\n"
-    XML+="    <testcase name=\"$1\">\n      <error message=\"$2\">$2</error>\n    </testcase>\n"
+    SUITE_XML+="    <testcase name=\"$1\">\n      <error message=\"$2\">$2</error>\n    </testcase>\n"
 }
 
 function red {
     (( fail += 1 ))
     printf "$1: ${RED}$2${NC}\n"
-    XML+="    <testcase name=\"$1\">\n      <error message=\"$2\">$2</error>\n    </testcase>\n"
+    SUITE_XML+="    <testcase name=\"$1\">\n      <error message=\"$2\">$2</error>\n    </testcase>\n"
 }
 
 function finish_suite {
     printf "$1: Passed ${pass} out of $(( pass + fail ))\n\n"
-    XML="  <testsuite name=\"$1\" tests=\"$(( pass + fail ))\" failures=\"${fail}\" timestamp=\"$(date)\">\n$XML  </testsuite>\n"
-    printf "$XML" >> $DIR/tests.xml
-    XML=""
+    SUITES_XML+="  <testsuite name=\"$1\" tests=\"$(( pass + fail ))\" failures=\"${fail}\" timestamp=\"$(date)\">\n$SUITE_XML  </testsuite>\n"
+    SUITE_XML=""
     (( all_pass += pass )) || :
     (( all_fail += fail )) || :
     pass=0
@@ -48,8 +48,6 @@ function finish_suite {
 }
 
 SAILLIBDIR="$DIR/../../lib/"
-
-printf "<testsuites>\n" >> $DIR/tests.xml
 
 cd $RISCVDIR
 
@@ -89,9 +87,9 @@ for test in $DIR/riscv-tests/rv32u{f,d}*.elf $DIR/riscv-tests/rv32mi-p-csr.elf; 
 done
 finish_suite "32-bit RISCV C tests"
 
-printf "</testsuites>\n" >> $DIR/tests.xml
-
 printf "Passed ${all_pass} out of $(( all_pass + all_fail ))\n\n"
+XML="<testsuites tests=\"$(( all_pass + all_fail ))\" failures=\"${all_fail}\">\n$SUITES_XML</testsuites>\n"
+printf "$XML" > $DIR/tests.xml
 
 if [ $all_fail -gt 0 ]
 then

--- a/test/run_fp_tests.sh
+++ b/test/run_fp_tests.sh
@@ -14,6 +14,8 @@ rm -f $DIR/tests.xml
 
 pass=0
 fail=0
+all_pass=0
+all_fail=0
 XML=""
 
 function green {
@@ -39,6 +41,8 @@ function finish_suite {
     XML="  <testsuite name=\"$1\" tests=\"$(( pass + fail ))\" failures=\"${fail}\" timestamp=\"$(date)\">\n$XML  </testsuite>\n"
     printf "$XML" >> $DIR/tests.xml
     XML=""
+    (( all_pass += pass )) || :
+    (( all_fail += fail )) || :
     pass=0
     fail=0
 }
@@ -86,3 +90,10 @@ done
 finish_suite "32-bit RISCV C tests"
 
 printf "</testsuites>\n" >> $DIR/tests.xml
+
+printf "Passed ${all_pass} out of $(( all_pass + all_fail ))\n\n"
+
+if [ $all_fail -gt 0 ]
+then
+    exit 1
+fi

--- a/test/run_fp_tests.sh
+++ b/test/run_fp_tests.sh
@@ -28,13 +28,13 @@ function green {
 function yellow {
     (( fail += 1 ))
     printf "$1: ${YELLOW}$2${NC}\n"
-    SUITE_XML+="    <testcase name=\"$1\">\n      <error message=\"$2\">$2</error>\n    </testcase>\n"
+    SUITE_XML+="    <testcase name=\"$1\">\n      <failure message=\"$2\">$2</failure>\n    </testcase>\n"
 }
 
 function red {
     (( fail += 1 ))
     printf "$1: ${RED}$2${NC}\n"
-    SUITE_XML+="    <testcase name=\"$1\">\n      <error message=\"$2\">$2</error>\n    </testcase>\n"
+    SUITE_XML+="    <testcase name=\"$1\">\n      <failure message=\"$2\">$2</failure>\n    </testcase>\n"
 }
 
 function finish_suite {

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -16,31 +16,31 @@ pass=0
 fail=0
 all_pass=0
 all_fail=0
-XML=""
+SUITE_XML=""
+SUITES_XML=""
 
 function green {
     (( pass += 1 ))
     printf "$1: ${GREEN}$2${NC}\n"
-    XML+="    <testcase name=\"$1\"/>\n"
+    SUITE_XML+="    <testcase name=\"$1\"/>\n"
 }
 
 function yellow {
     (( fail += 1 ))
     printf "$1: ${YELLOW}$2${NC}\n"
-    XML+="    <testcase name=\"$1\">\n      <error message=\"$2\">$2</error>\n    </testcase>\n"
+    SUITE_XML+="    <testcase name=\"$1\">\n      <error message=\"$2\">$2</error>\n    </testcase>\n"
 }
 
 function red {
     (( fail += 1 ))
     printf "$1: ${RED}$2${NC}\n"
-    XML+="    <testcase name=\"$1\">\n      <error message=\"$2\">$2</error>\n    </testcase>\n"
+    SUITE_XML+="    <testcase name=\"$1\">\n      <error message=\"$2\">$2</error>\n    </testcase>\n"
 }
 
 function finish_suite {
     printf "$1: Passed ${pass} out of $(( pass + fail ))\n\n"
-    XML="  <testsuite name=\"$1\" tests=\"$(( pass + fail ))\" failures=\"${fail}\" timestamp=\"$(date)\">\n$XML  </testsuite>\n"
-    printf "$XML" >> $DIR/tests.xml
-    XML=""
+    SUITES_XML+="  <testsuite name=\"$1\" tests=\"$(( pass + fail ))\" failures=\"${fail}\" timestamp=\"$(date)\">\n$SUITE_XML  </testsuite>\n"
+    SUITE_XML=""
     (( all_pass += pass )) || :
     (( all_fail += fail )) || :
     pass=0
@@ -48,8 +48,6 @@ function finish_suite {
 }
 
 SAILLIBDIR="$DIR/../../lib/"
-
-printf "<testsuites>\n" >> $DIR/tests.xml
 
 cd $RISCVDIR
 
@@ -167,9 +165,9 @@ else
 fi
 finish_suite "64-bit RISCV RVFI C tests"
 
-printf "</testsuites>\n" >> $DIR/tests.xml
-
 printf "Passed ${all_pass} out of $(( all_pass + all_fail ))\n\n"
+XML="<testsuites tests=\"$(( all_pass + all_fail ))\" failures=\"${all_fail}\">\n$SUITES_XML</testsuites>\n"
+printf "$XML" > $DIR/tests.xml
 
 if [ $all_fail -gt 0 ]
 then

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -141,4 +141,26 @@ for test in $DIR/riscv-tests/rv64*.elf; do
 done
 finish_suite "64-bit RISCV C tests"
 
+# Do 'make clean' to avoid cross-arch pollution.
+make clean
+
+if ARCH=RV32 make c_emulator/riscv_rvfi_RV32;
+then
+    green "Building 32-bit RISCV RVFI C emulator" "ok"
+else
+    red "Building 32-bit RISCV RVFI C emulator" "fail"
+fi
+finish_suite "32-bit RISCV RVFI C tests"
+
+# Do 'make clean' to avoid cross-arch pollution.
+make clean
+
+if ARCH=RV64 make c_emulator/riscv_rvfi_RV64;
+then
+    green "Building 64-bit RISCV RVFI C emulator" "ok"
+else
+    red "Building 64-bit RISCV RVFI C emulator" "fail"
+fi
+finish_suite "64-bit RISCV RVFI C tests"
+
 printf "</testsuites>\n" >> $DIR/tests.xml

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -14,6 +14,8 @@ rm -f $DIR/tests.xml
 
 pass=0
 fail=0
+all_pass=0
+all_fail=0
 XML=""
 
 function green {
@@ -39,6 +41,8 @@ function finish_suite {
     XML="  <testsuite name=\"$1\" tests=\"$(( pass + fail ))\" failures=\"${fail}\" timestamp=\"$(date)\">\n$XML  </testsuite>\n"
     printf "$XML" >> $DIR/tests.xml
     XML=""
+    (( all_pass += pass )) || :
+    (( all_fail += fail )) || :
     pass=0
     fail=0
 }
@@ -164,3 +168,10 @@ fi
 finish_suite "64-bit RISCV RVFI C tests"
 
 printf "</testsuites>\n" >> $DIR/tests.xml
+
+printf "Passed ${all_pass} out of $(( all_pass + all_fail ))\n\n"
+
+if [ $all_fail -gt 0 ]
+then
+    exit 1
+fi

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -28,13 +28,13 @@ function green {
 function yellow {
     (( fail += 1 ))
     printf "$1: ${YELLOW}$2${NC}\n"
-    SUITE_XML+="    <testcase name=\"$1\">\n      <error message=\"$2\">$2</error>\n    </testcase>\n"
+    SUITE_XML+="    <testcase name=\"$1\">\n      <failure message=\"$2\">$2</failure>\n    </testcase>\n"
 }
 
 function red {
     (( fail += 1 ))
     printf "$1: ${RED}$2${NC}\n"
-    SUITE_XML+="    <testcase name=\"$1\">\n      <error message=\"$2\">$2</error>\n    </testcase>\n"
+    SUITE_XML+="    <testcase name=\"$1\">\n      <failure message=\"$2\">$2</failure>\n    </testcase>\n"
 }
 
 function finish_suite {


### PR DESCRIPTION
Includes various improvements to the test scripts to make them work in an automated setting and produce better JUnit output.

The separate workflow is needed in order to support pull requests from forks of the repository, since the `on: pull_request` job runs with only limited access to the upstream repository for security reasons. This means the workflow that actually parses and uploads the test results is defined in the default branch (currently master), not in the pull request contents, and so won't actually run until this pull request is merged. I've pushed this series of commits to my own fork, set that branch as the default there and submitted a pull request against that that introduces a regression in order to demonstrate how this will look once merged at https://github.com/jrtc27/sail-riscv/pull/1.