### PR TITLE
add support for cmo extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ SAIL_DEFAULT_INST += riscv_insts_zbkx.sail
 
 SAIL_DEFAULT_INST += riscv_insts_zicond.sail
 
+SAIL_DEFAULT_INST += riscv_insts_zicbom.sail
+SAIL_DEFAULT_INST += riscv_insts_zicboz.sail
+
 SAIL_SEQ_INST  = $(SAIL_DEFAULT_INST) riscv_jalr_seq.sail
 SAIL_RMEM_INST = $(SAIL_DEFAULT_INST) riscv_jalr_rmem.sail riscv_insts_rmem.sail
 

--- a/c_emulator/riscv_platform.c
+++ b/c_emulator/riscv_platform.c
@@ -82,6 +82,11 @@ mach_bits plat_rom_size(unit u)
   return rv_rom_size;
 }
 
+mach_bits plat_cache_block_size()
+{
+  return rv_cache_block_size;
+}
+
 // Provides entropy for the scalar cryptography extension.
 mach_bits plat_get_16_random_bits()
 {

--- a/c_emulator/riscv_platform.h
+++ b/c_emulator/riscv_platform.h
@@ -19,6 +19,8 @@ bool within_phys_mem(mach_bits, sail_int);
 mach_bits plat_rom_base(unit);
 mach_bits plat_rom_size(unit);
 
+mach_bits plat_cache_block_size(unit);
+
 // Provides entropy for the scalar cryptography extension.
 mach_bits plat_get_16_random_bits();
 

--- a/c_emulator/riscv_platform_impl.c
+++ b/c_emulator/riscv_platform_impl.c
@@ -20,6 +20,8 @@ uint64_t rv_ram_size = UINT64_C(0x4000000);
 uint64_t rv_rom_base = UINT64_C(0x1000);
 uint64_t rv_rom_size = UINT64_C(0x100);
 
+uint64_t rv_cache_block_size = UINT64_C(0x40);
+
 // Provides entropy for the scalar cryptography extension.
 uint64_t rv_16_random_bits(void)
 {

--- a/c_emulator/riscv_platform_impl.h
+++ b/c_emulator/riscv_platform_impl.h
@@ -23,6 +23,8 @@ extern uint64_t rv_ram_size;
 extern uint64_t rv_rom_base;
 extern uint64_t rv_rom_size;
 
+extern uint64_t rv_cache_block_size;
+
 // Provides entropy for the scalar cryptography extension.
 extern uint64_t rv_16_random_bits(void);
 

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -137,6 +137,7 @@ static struct option options[] = {
 #ifdef SAILCOV
     {"sailcov-file",                required_argument, 0, 'c'},
 #endif
+    {"cache-block-size",            required_argument, 0, 'B'},
     {0,                             0,                 0, 0  }
 };
 
@@ -221,6 +222,7 @@ char *process_args(int argc, char **argv)
 {
   int c;
   uint64_t ram_size = 0;
+  uint64_t block_size = 0;
   while (true) {
     c = getopt_long(argc, argv,
                     "a"
@@ -249,6 +251,7 @@ char *process_args(int argc, char **argv)
                     "V::"
                     "v::"
                     "l:"
+                    "B:"
                     "x",
                     options, NULL);
     if (c == -1)
@@ -352,6 +355,17 @@ char *process_args(int argc, char **argv)
       sailcov_file = strdup(optarg);
       break;
 #endif
+    case 'B':
+      block_size = atol(optarg);
+      if ((block_size & (block_size - 1)) == 0) {
+        fprintf(stderr, "setting cache-block-size to %" PRIu64 " B\n",
+                block_size);
+        rv_cache_block_size = block_size;
+      } else {
+        fprintf(stderr, "invalid cache-block-size '%s' provided.\n", optarg);
+        exit(1);
+      }
+      break;
     case '?':
       print_usage(argv[0], 1);
       break;

--- a/handwritten_support/0.11/riscv_extras.lem
+++ b/handwritten_support/0.11/riscv_extras.lem
@@ -107,6 +107,10 @@ val plat_rom_size : forall 'a. Size 'a => unit -> bitvector 'a
 let plat_rom_size () = wordFromInteger 0
 declare ocaml target_rep function plat_rom_size = `Platform.rom_size`
 
+val plat_cache_block_size : forall 'a. Size 'a => unit -> bitvector 'a
+let plat_cache_block_size () = wordFromInteger 0
+declare ocaml target_rep function plat_cache_block_size = `Platform.cache_block_size`
+
 val plat_clint_base : forall 'a. Size 'a => unit -> bitvector 'a
 let plat_clint_base () = wordFromInteger 0
 declare ocaml target_rep function plat_clint_base = `Platform.clint_base`

--- a/handwritten_support/0.11/riscv_extras_sequential.lem
+++ b/handwritten_support/0.11/riscv_extras_sequential.lem
@@ -99,6 +99,10 @@ val plat_rom_size : forall 'a. Size 'a => unit -> bitvector 'a
 let plat_rom_size () = wordFromInteger 0
 declare ocaml target_rep function plat_rom_size = `Platform.rom_size`
 
+val plat_cache_block_size : forall 'a. Size 'a => unit -> bitvector 'a
+let plat_cache_block_size () = wordFromInteger 0
+declare ocaml target_rep function plat_cache_block_size = `Platform.cache_block_size`
+
 val plat_clint_base : forall 'a. Size 'a => unit -> bitvector 'a
 let plat_clint_base () = wordFromInteger 0
 declare ocaml target_rep function plat_clint_base = `Platform.clint_base`

--- a/handwritten_support/riscv_extras.lem
+++ b/handwritten_support/riscv_extras.lem
@@ -177,6 +177,10 @@ val plat_rom_size : forall 'a. Size 'a => unit -> bitvector 'a
 let plat_rom_size () = wordFromInteger 0
 declare ocaml target_rep function plat_rom_size = `Platform.rom_size`
 
+val plat_cache_block_size : forall 'a. Size 'a => unit -> bitvector 'a
+let plat_cache_block_size () = wordFromInteger 0
+declare ocaml target_rep function plat_cache_block_size = `Platform.cache_block_size`
+
 val plat_clint_base : forall 'a. Size 'a => unit -> bitvector 'a
 let plat_clint_base () = wordFromInteger 0
 declare ocaml target_rep function plat_clint_base = `Platform.clint_base`

--- a/handwritten_support/riscv_extras_sequential.lem
+++ b/handwritten_support/riscv_extras_sequential.lem
@@ -169,6 +169,10 @@ val plat_rom_size : forall 'a. Size 'a => unit -> bitvector 'a
 let plat_rom_size () = wordFromInteger 0
 declare ocaml target_rep function plat_rom_size = `Platform.rom_size`
 
+val plat_cache_block_size : forall 'a. Size 'a => unit -> bitvector 'a
+let plat_cache_block_size () = wordFromInteger 0
+declare ocaml target_rep function plat_cache_block_size = `Platform.cache_block_size`
+
 val plat_clint_base : forall 'a. Size 'a => unit -> bitvector 'a
 let plat_clint_base () = wordFromInteger 0
 declare ocaml target_rep function plat_clint_base = `Platform.clint_base`

--- a/model/riscv_addr_checks.sail
+++ b/model/riscv_addr_checks.sail
@@ -116,7 +116,7 @@ type ext_data_addr_error = unit
 
 /* Default data addr is just base register + immediate offset (may be zero).
    Extensions might override and add additional checks. */
-function ext_data_get_addr(base : regidx, offset : xlenbits, acc : AccessType(ext_access_type), width : word_width)
+function ext_data_get_addr(base : regidx, offset : xlenbits, acc : AccessType(ext_access_type), width : xlenbits)
          -> Ext_DataAddr_Check(ext_data_addr_error) =
   let addr = X(base) + offset in
   Ext_DataAddr_OK(addr)

--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -127,7 +127,7 @@ function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
     /* Get the address, X(rs1) (no offset).
      * Extensions might perform additional checks on address validity.
      */
-    match ext_data_get_addr(rs1, zeros(), Read(Data), width) {
+    match ext_data_get_addr(rs1, zeros(), Read(Data), EXTZ(size_bits(width))) {
       Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
       Ext_DataAddr_OK(vaddr) => {
         let aligned : bool =
@@ -188,7 +188,7 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
       /* Get the address, X(rs1) (no offset).
        * Extensions might perform additional checks on address validity.
        */
-      match ext_data_get_addr(rs1, zeros(), Write(Data), width) {
+      match ext_data_get_addr(rs1, zeros(), Write(Data), EXTZ(size_bits(width))) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
         Ext_DataAddr_OK(vaddr) => {
           let aligned : bool =
@@ -278,7 +278,7 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
     /* Get the address, X(rs1) (no offset).
      * Some extensions perform additional checks on address validity.
      */
-    match ext_data_get_addr(rs1, zeros(), ReadWrite(Data, Data), width) {
+    match ext_data_get_addr(rs1, zeros(), ReadWrite(Data, Data), EXTZ(size_bits(width))) {
       Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
       Ext_DataAddr_OK(vaddr) => {
         match translateAddr(vaddr, ReadWrite(Data, Data)) {

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -388,7 +388,7 @@ function clause execute(LOAD(imm, rs1, rd, is_unsigned, width, aq, rl)) = {
   let offset : xlenbits = EXTS(imm);
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
-  match ext_data_get_addr(rs1, offset, Read(Data), width) {
+  match ext_data_get_addr(rs1, offset, Read(Data), EXTZ(size_bits(width))) {
     Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
     Ext_DataAddr_OK(vaddr) =>
       if   check_misaligned(vaddr, width)
@@ -444,7 +444,7 @@ function clause execute (STORE(imm, rs2, rs1, width, aq, rl)) = {
   let offset : xlenbits = EXTS(imm);
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
-  match ext_data_get_addr(rs1, offset, Write(Data), width) {
+  match ext_data_get_addr(rs1, offset, Write(Data), EXTZ(size_bits(width))) {
     Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
     Ext_DataAddr_OK(vaddr) =>
       if   check_misaligned(vaddr, width)

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -377,7 +377,7 @@ function clause execute(LOAD_FP(imm, rs1, rd, width)) = {
   let offset : xlenbits = EXTS(imm);
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
-  match ext_data_get_addr(rs1, offset, Read(Data), width) {
+  match ext_data_get_addr(rs1, offset, Read(Data), EXTZ(size_bits(width))) {
     Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
     Ext_DataAddr_OK(vaddr) =>
       if   check_misaligned(vaddr, width)
@@ -443,7 +443,7 @@ function clause execute (STORE_FP(imm, rs2, rs1, width)) = {
   let (aq, rl, con) = (false, false, false);
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
-  match ext_data_get_addr(rs1, offset, Write(Data), width) {
+  match ext_data_get_addr(rs1, offset, Write(Data), EXTZ(size_bits(width))) {
     Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
     Ext_DataAddr_OK(vaddr) =>
       if   check_misaligned(vaddr, width)

--- a/model/riscv_insts_zicbom.sail
+++ b/model/riscv_insts_zicbom.sail
@@ -25,6 +25,7 @@
 /*    Aril Computer Corp., for contributions by Scott Johnson                            */
 /*    Philipp Tomsich                                                                    */
 /*    VRULL GmbH, for contributions by its employees                                     */
+/*    PLCT, for contributions by its employees                                           */
 /*                                                                                       */
 /*  All rights reserved.                                                                 */
 /*                                                                                       */
@@ -68,129 +69,82 @@
 /*  SUCH DAMAGE.                                                                         */
 /*=======================================================================================*/
 
-/* Mapping of csr addresses to their names. */
+/* ****************************************************************** */
+union clause ast = RISCV_ZICBOM : (cbop_zicbom, regidx)
 
-val csr_name_map : csreg <-> string
+mapping encdec_cbop : cbop_zicbom <-> bits(12) = {
+  CBO_CLEAN <-> 0b000000000001,
+  CBO_FLUSH <-> 0b000000000010,
+  CBO_INVAL <-> 0b000000000000
+}
 
-scattered mapping csr_name_map
+mapping clause encdec = RISCV_ZICBOM(cbop, rs1) if haveZicbom()
+  <-> encdec_cbop(cbop) @ rs1 @ 0b010 @ 0b00000 @ 0b0001111 if haveZicbom()
 
-/* user trap setup */
-mapping clause csr_name_map = 0x000  <-> "ustatus"
-mapping clause csr_name_map = 0x004  <-> "uie"
-mapping clause csr_name_map = 0x005  <-> "utvec"
-/* user trap handling */
-mapping clause csr_name_map = 0x040  <-> "uscratch"
-mapping clause csr_name_map = 0x041  <-> "uepc"
-mapping clause csr_name_map = 0x042  <-> "ucause"
-mapping clause csr_name_map = 0x043  <-> "utval"
-mapping clause csr_name_map = 0x044  <-> "uip"
-/* user floating-point context */
-mapping clause csr_name_map = 0x001  <-> "fflags"
-mapping clause csr_name_map = 0x002  <-> "frm"
-mapping clause csr_name_map = 0x003  <-> "fcsr"
-/* user entropy source */
-mapping clause csr_name_map = 0x015  <-> "seed"
-/* counter/timers */
-mapping clause csr_name_map = 0xC00  <-> "cycle"
-mapping clause csr_name_map = 0xC01  <-> "time"
-mapping clause csr_name_map = 0xC02  <-> "instret"
-mapping clause csr_name_map = 0xC80  <-> "cycleh"
-mapping clause csr_name_map = 0xC81  <-> "timeh"
-mapping clause csr_name_map = 0xC82  <-> "instreth"
-/* TODO: other hpm counters */
-/* supervisor trap setup */
-mapping clause csr_name_map = 0x100  <-> "sstatus"
-mapping clause csr_name_map = 0x102  <-> "sedeleg"
-mapping clause csr_name_map = 0x103  <-> "sideleg"
-mapping clause csr_name_map = 0x104  <-> "sie"
-mapping clause csr_name_map = 0x105  <-> "stvec"
-mapping clause csr_name_map = 0x106  <-> "scounteren"
-/* supervisor trap handling */
-mapping clause csr_name_map = 0x140  <-> "sscratch"
-mapping clause csr_name_map = 0x141  <-> "sepc"
-mapping clause csr_name_map = 0x142  <-> "scause"
-mapping clause csr_name_map = 0x143  <-> "stval"
-mapping clause csr_name_map = 0x144  <-> "sip"
-/* supervisor protection and translation */
-mapping clause csr_name_map = 0x180  <-> "satp"
-/* supervisor envcfg */
-mapping clause csr_name_map = 0x10A  <-> "senvcfg"
-/* machine information registers */
-mapping clause csr_name_map = 0xF11  <-> "mvendorid"
-mapping clause csr_name_map = 0xF12  <-> "marchid"
-mapping clause csr_name_map = 0xF13  <-> "mimpid"
-mapping clause csr_name_map = 0xF14  <-> "mhartid"
-/* machine trap setup */
-mapping clause csr_name_map = 0x300  <-> "mstatus"
-mapping clause csr_name_map = 0x301  <-> "misa"
-mapping clause csr_name_map = 0x302  <-> "medeleg"
-mapping clause csr_name_map = 0x303  <-> "mideleg"
-mapping clause csr_name_map = 0x304  <-> "mie"
-mapping clause csr_name_map = 0x305  <-> "mtvec"
-mapping clause csr_name_map = 0x306  <-> "mcounteren"
-mapping clause csr_name_map = 0x320  <-> "mcountinhibit"
-/* machine trap handling */
-mapping clause csr_name_map = 0x340  <-> "mscratch"
-mapping clause csr_name_map = 0x341  <-> "mepc"
-mapping clause csr_name_map = 0x342  <-> "mcause"
-mapping clause csr_name_map = 0x343  <-> "mtval"
-mapping clause csr_name_map = 0x344  <-> "mip"
-/* machine protection and translation */
-mapping clause csr_name_map = 0x3A0  <-> "pmpcfg0"
-mapping clause csr_name_map = 0x3A1  <-> "pmpcfg1"
-mapping clause csr_name_map = 0x3A2  <-> "pmpcfg2"
-mapping clause csr_name_map = 0x3A3  <-> "pmpcfg3"
-mapping clause csr_name_map = 0x3B0  <-> "pmpaddr0"
-mapping clause csr_name_map = 0x3B1  <-> "pmpaddr1"
-mapping clause csr_name_map = 0x3B2  <-> "pmpaddr2"
-mapping clause csr_name_map = 0x3B3  <-> "pmpaddr3"
-mapping clause csr_name_map = 0x3B4  <-> "pmpaddr4"
-mapping clause csr_name_map = 0x3B5  <-> "pmpaddr5"
-mapping clause csr_name_map = 0x3B6  <-> "pmpaddr6"
-mapping clause csr_name_map = 0x3B7  <-> "pmpaddr7"
-mapping clause csr_name_map = 0x3B8  <-> "pmpaddr8"
-mapping clause csr_name_map = 0x3B9  <-> "pmpaddr9"
-mapping clause csr_name_map = 0x3BA  <-> "pmpaddr10"
-mapping clause csr_name_map = 0x3BB  <-> "pmpaddr11"
-mapping clause csr_name_map = 0x3BC  <-> "pmpaddr12"
-mapping clause csr_name_map = 0x3BD  <-> "pmpaddr13"
-mapping clause csr_name_map = 0x3BE  <-> "pmpaddr14"
-mapping clause csr_name_map = 0x3BF  <-> "pmpaddr15"
-/* machine counters/timers */
-mapping clause csr_name_map = 0xB00  <-> "mcycle"
-mapping clause csr_name_map = 0xB02  <-> "minstret"
-mapping clause csr_name_map = 0xB80  <-> "mcycleh"
-mapping clause csr_name_map = 0xB82  <-> "minstreth"
-/* machine envcfg */
-mapping clause csr_name_map = 0x30A  <-> "menvcfg"
-/* TODO: other hpm counters and events */
-/* trigger/debug */
-mapping clause csr_name_map = 0x7a0  <-> "tselect"
-mapping clause csr_name_map = 0x7a1  <-> "tdata1"
-mapping clause csr_name_map = 0x7a2  <-> "tdata2"
-mapping clause csr_name_map = 0x7a3  <-> "tdata3"
+mapping cbop_mnemonic : cbop_zicbom <-> string = {
+  CBO_CLEAN <-> "cbo.clean",
+  CBO_FLUSH <-> "cbo.flush",
+  CBO_INVAL <-> "cbo.inval"
+}
 
-val csr_name : csreg -> string
-overload to_str = {csr_name}
+mapping clause assembly = RISCV_ZICBOM(cbop, rs1)
+  <-> cbop_mnemonic(cbop) ^ spc() ^ "(" ^ reg_name(rs1) ^ ")"
 
-/* Extensions may want to add additional CSR registers to the CSR address map.
- * These scattered functions support access to such registers.
- *
- * The default implementation provides access to the CSRs added by the 'N'
- * extension.
- */
+val process_clean_inval : (regidx, cbop_zicbom) -> Retired effect {escape, rmem, rmemt, rreg, wmv, wmvt, wreg}
+function process_clean_inval(rs1, cbop) = {
+  let rs1_val = X(rs1);
+  let cache_block_size = plat_cache_block_size();
+  let begin_addr = rs1_val & ~(cache_block_size - EXTZ(0b1));
+  let offset = begin_addr - rs1_val;
+  match ext_data_get_addr(rs1, offset, Read(Data), cache_block_size) {
+    Ext_DataAddr_Error(e) => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_OK(vaddr) => {
+      let res: option(ExceptionType) = match translateAddr(vaddr, Read(Data)) {
+        TR_Address(paddr, _) => {
+          match mem_read(Read(Data), paddr, 1, false, false, false) {
+            MemValue(_) => None(),
+            MemException(e)  => Some(e)
+          }
+        },
+        TR_Failure(e, _) => Some(e)
+      };
+      match res {
+        None() => RETIRE_SUCCESS,  // do nothing for cbop currently
+        Some(e) => {
+          match (e) {
+            E_Load_Access_Fault() => { handle_mem_exception(vaddr, E_SAMO_Access_Fault()); RETIRE_FAIL },
+            E_Load_Page_Fault() => { handle_mem_exception(vaddr, E_SAMO_Page_Fault()); RETIRE_FAIL }
+          }
+        }
+      }
+    }
+  }
+}
 
+function cbo_clean_flush_enable(p : Privilege) -> bool =
+   ~((p != Machine & menvcfg.CBCFE() == 0b0) | (p == User & senvcfg.CBCFE() == 0b0))
 
-/* returns whether a CSR is defined and accessible at a given address
- * and privilege
- */
-val ext_is_CSR_defined : (csreg, Privilege) -> bool effect {rreg}
-scattered function ext_is_CSR_defined
+function cbop_for_cbo_inval(p : Privilege) -> option(cbop_zicbom) = {
+  let illegal = ((p != Machine) & (menvcfg.CBIE() == 0b00)) |
+                ((p == User) & (senvcfg.CBIE() == 0b00));
+  let flush = ((p != Machine) & (menvcfg.CBIE() == 0b01)) |
+              ((p == User) & (senvcfg.CBIE() == 0b01));
+  if illegal then None()
+  else if flush then Some(CBO_FLUSH)
+  else Some(CBO_INVAL)
+}
 
-/* returns the value of the CSR if it is defined */
-val ext_read_CSR : csreg -> option(xlenbits) effect {rreg}
-scattered function ext_read_CSR
-
-/* returns new value (after legalisation) if the CSR is defined */
-val ext_write_CSR : (csreg, xlenbits) -> option(xlenbits) effect {rreg, wreg, escape}
-scattered function ext_write_CSR
+function clause execute(RISCV_ZICBOM(cbop, rs1)) = {
+  let cbcfe = cbo_clean_flush_enable(cur_privilege);
+  let final_op : option(cbop_zicbom) = match (cbop, cbcfe) {
+    (CBO_CLEAN, true) => Some(CBO_CLEAN),
+    (CBO_CLEAN, false) => None(),
+    (CBO_FLUSH, true) => Some(CBO_FLUSH),
+    (CBO_FLUSH, false) => None(),
+    (CBO_INVAL, _) => cbop_for_cbo_inval(cur_privilege)
+  };
+  match final_op {
+    None() => { handle_illegal(); RETIRE_FAIL },
+    Some(cbop) => process_clean_inval(rs1, cbop)
+  }
+}

--- a/model/riscv_insts_zicboz.sail
+++ b/model/riscv_insts_zicboz.sail
@@ -25,6 +25,7 @@
 /*    Aril Computer Corp., for contributions by Scott Johnson                            */
 /*    Philipp Tomsich                                                                    */
 /*    VRULL GmbH, for contributions by its employees                                     */
+/*    PLCT, for contributions by its employees                                           */
 /*                                                                                       */
 /*  All rights reserved.                                                                 */
 /*                                                                                       */
@@ -68,129 +69,59 @@
 /*  SUCH DAMAGE.                                                                         */
 /*=======================================================================================*/
 
-/* Mapping of csr addresses to their names. */
+/* ****************************************************************** */
+union clause ast = RISCV_ZICBOZ : (regidx)
 
-val csr_name_map : csreg <-> string
+mapping clause encdec = RISCV_ZICBOZ(rs1) if haveZicboz()
+  <-> 0b000000000100 @ rs1 @ 0b010 @ 0b00000 @ 0b0001111 if haveZicboz()
 
-scattered mapping csr_name_map
+mapping clause assembly = RISCV_ZICBOZ(rs1)
+  <-> "cbo.zero" ^ spc()  ^ "(" ^ reg_name(rs1) ^ ")"
 
-/* user trap setup */
-mapping clause csr_name_map = 0x000  <-> "ustatus"
-mapping clause csr_name_map = 0x004  <-> "uie"
-mapping clause csr_name_map = 0x005  <-> "utvec"
-/* user trap handling */
-mapping clause csr_name_map = 0x040  <-> "uscratch"
-mapping clause csr_name_map = 0x041  <-> "uepc"
-mapping clause csr_name_map = 0x042  <-> "ucause"
-mapping clause csr_name_map = 0x043  <-> "utval"
-mapping clause csr_name_map = 0x044  <-> "uip"
-/* user floating-point context */
-mapping clause csr_name_map = 0x001  <-> "fflags"
-mapping clause csr_name_map = 0x002  <-> "frm"
-mapping clause csr_name_map = 0x003  <-> "fcsr"
-/* user entropy source */
-mapping clause csr_name_map = 0x015  <-> "seed"
-/* counter/timers */
-mapping clause csr_name_map = 0xC00  <-> "cycle"
-mapping clause csr_name_map = 0xC01  <-> "time"
-mapping clause csr_name_map = 0xC02  <-> "instret"
-mapping clause csr_name_map = 0xC80  <-> "cycleh"
-mapping clause csr_name_map = 0xC81  <-> "timeh"
-mapping clause csr_name_map = 0xC82  <-> "instreth"
-/* TODO: other hpm counters */
-/* supervisor trap setup */
-mapping clause csr_name_map = 0x100  <-> "sstatus"
-mapping clause csr_name_map = 0x102  <-> "sedeleg"
-mapping clause csr_name_map = 0x103  <-> "sideleg"
-mapping clause csr_name_map = 0x104  <-> "sie"
-mapping clause csr_name_map = 0x105  <-> "stvec"
-mapping clause csr_name_map = 0x106  <-> "scounteren"
-/* supervisor trap handling */
-mapping clause csr_name_map = 0x140  <-> "sscratch"
-mapping clause csr_name_map = 0x141  <-> "sepc"
-mapping clause csr_name_map = 0x142  <-> "scause"
-mapping clause csr_name_map = 0x143  <-> "stval"
-mapping clause csr_name_map = 0x144  <-> "sip"
-/* supervisor protection and translation */
-mapping clause csr_name_map = 0x180  <-> "satp"
-/* supervisor envcfg */
-mapping clause csr_name_map = 0x10A  <-> "senvcfg"
-/* machine information registers */
-mapping clause csr_name_map = 0xF11  <-> "mvendorid"
-mapping clause csr_name_map = 0xF12  <-> "marchid"
-mapping clause csr_name_map = 0xF13  <-> "mimpid"
-mapping clause csr_name_map = 0xF14  <-> "mhartid"
-/* machine trap setup */
-mapping clause csr_name_map = 0x300  <-> "mstatus"
-mapping clause csr_name_map = 0x301  <-> "misa"
-mapping clause csr_name_map = 0x302  <-> "medeleg"
-mapping clause csr_name_map = 0x303  <-> "mideleg"
-mapping clause csr_name_map = 0x304  <-> "mie"
-mapping clause csr_name_map = 0x305  <-> "mtvec"
-mapping clause csr_name_map = 0x306  <-> "mcounteren"
-mapping clause csr_name_map = 0x320  <-> "mcountinhibit"
-/* machine trap handling */
-mapping clause csr_name_map = 0x340  <-> "mscratch"
-mapping clause csr_name_map = 0x341  <-> "mepc"
-mapping clause csr_name_map = 0x342  <-> "mcause"
-mapping clause csr_name_map = 0x343  <-> "mtval"
-mapping clause csr_name_map = 0x344  <-> "mip"
-/* machine protection and translation */
-mapping clause csr_name_map = 0x3A0  <-> "pmpcfg0"
-mapping clause csr_name_map = 0x3A1  <-> "pmpcfg1"
-mapping clause csr_name_map = 0x3A2  <-> "pmpcfg2"
-mapping clause csr_name_map = 0x3A3  <-> "pmpcfg3"
-mapping clause csr_name_map = 0x3B0  <-> "pmpaddr0"
-mapping clause csr_name_map = 0x3B1  <-> "pmpaddr1"
-mapping clause csr_name_map = 0x3B2  <-> "pmpaddr2"
-mapping clause csr_name_map = 0x3B3  <-> "pmpaddr3"
-mapping clause csr_name_map = 0x3B4  <-> "pmpaddr4"
-mapping clause csr_name_map = 0x3B5  <-> "pmpaddr5"
-mapping clause csr_name_map = 0x3B6  <-> "pmpaddr6"
-mapping clause csr_name_map = 0x3B7  <-> "pmpaddr7"
-mapping clause csr_name_map = 0x3B8  <-> "pmpaddr8"
-mapping clause csr_name_map = 0x3B9  <-> "pmpaddr9"
-mapping clause csr_name_map = 0x3BA  <-> "pmpaddr10"
-mapping clause csr_name_map = 0x3BB  <-> "pmpaddr11"
-mapping clause csr_name_map = 0x3BC  <-> "pmpaddr12"
-mapping clause csr_name_map = 0x3BD  <-> "pmpaddr13"
-mapping clause csr_name_map = 0x3BE  <-> "pmpaddr14"
-mapping clause csr_name_map = 0x3BF  <-> "pmpaddr15"
-/* machine counters/timers */
-mapping clause csr_name_map = 0xB00  <-> "mcycle"
-mapping clause csr_name_map = 0xB02  <-> "minstret"
-mapping clause csr_name_map = 0xB80  <-> "mcycleh"
-mapping clause csr_name_map = 0xB82  <-> "minstreth"
-/* machine envcfg */
-mapping clause csr_name_map = 0x30A  <-> "menvcfg"
-/* TODO: other hpm counters and events */
-/* trigger/debug */
-mapping clause csr_name_map = 0x7a0  <-> "tselect"
-mapping clause csr_name_map = 0x7a1  <-> "tdata1"
-mapping clause csr_name_map = 0x7a2  <-> "tdata2"
-mapping clause csr_name_map = 0x7a3  <-> "tdata3"
+function get_envcfg_cbze(p : Privilege) -> bool =
+  ~((p != Machine & menvcfg.CBZE() == 0b0) | (p == User & senvcfg.CBZE() == 0b0))
 
-val csr_name : csreg -> string
-overload to_str = {csr_name}
+val process_cbo_zero : (regidx) -> Retired effect {eamem, escape, rmem, rmemt, rreg, wmv, wmvt, wreg}
+function process_cbo_zero(rs1) = {
+  let rs1_val = X(rs1);
+  let cache_block_size = plat_cache_block_size();
+  let begin_addr = rs1_val & ~(cache_block_size - EXTZ(0b1));
+  let offset = begin_addr - rs1_val;
+  index : xlenbits = zeros();
+  failed : bool = false;
+  match ext_data_get_addr(rs1, offset, Write(Data), cache_block_size) {
+    Ext_DataAddr_Error(e) => { ext_handle_data_check_error(e); failed = true },
+    Ext_DataAddr_OK(vaddr) =>
+      while (index <_u cache_block_size) & (failed == false) do {
+        let addr = vaddr + index;
+        match translateAddr(addr, Write(Data)) {
+          TR_Failure(e, _) => { handle_mem_exception(vaddr, e); failed = true },
+          TR_Address(paddr, _) => {
+            let eares : MemoryOpResult(unit) = mem_write_ea(paddr, 1, false, false, false);
+            match (eares) {
+              MemException(e) => { handle_mem_exception(vaddr, e); failed = true },
+              MemValue(_) => {
+                let res : MemoryOpResult(bool) = mem_write_value(paddr, 1, zeros(), false, false, false);
+                match (res) {
+                  MemValue(true) => index = index + EXTZ(0b1),
+                  MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
+                  MemException(e) => { handle_mem_exception(vaddr, e); failed = true }
+                }
+              }
+            }
+          }
+        }
+    }
+  };
+  if failed then RETIRE_FAIL
+  else RETIRE_SUCCESS
+}
 
-/* Extensions may want to add additional CSR registers to the CSR address map.
- * These scattered functions support access to such registers.
- *
- * The default implementation provides access to the CSRs added by the 'N'
- * extension.
- */
-
-
-/* returns whether a CSR is defined and accessible at a given address
- * and privilege
- */
-val ext_is_CSR_defined : (csreg, Privilege) -> bool effect {rreg}
-scattered function ext_is_CSR_defined
-
-/* returns the value of the CSR if it is defined */
-val ext_read_CSR : csreg -> option(xlenbits) effect {rreg}
-scattered function ext_read_CSR
-
-/* returns new value (after legalisation) if the CSR is defined */
-val ext_write_CSR : (csreg, xlenbits) -> option(xlenbits) effect {rreg, wreg, escape}
-scattered function ext_write_CSR
+function clause execute(RISCV_ZICBOZ(rs1)) = {
+  if get_envcfg_cbze(cur_privilege) then
+    process_cbo_zero(rs1)
+  else {
+    handle_illegal();
+    RETIRE_FAIL
+  }
+}

--- a/model/riscv_insts_zicsr.sail
+++ b/model/riscv_insts_zicsr.sail
@@ -98,6 +98,7 @@ function readCSR csr : csreg -> xlenbits = {
     (0x304,  _) => mie.bits(),
     (0x305,  _) => get_mtvec(),
     (0x306,  _) => EXTZ(mcounteren.bits()),
+    (0x30A,  _) => menvcfg.bits(),
     (0x310, 32) => mstatush.bits(),
     (0x320,  _) => EXTZ(mcountinhibit.bits()),
 
@@ -145,6 +146,7 @@ function readCSR csr : csreg -> xlenbits = {
     (0x104,  _) => lower_mie(mie, mideleg).bits(),
     (0x105,  _) => get_stvec(),
     (0x106,  _) => EXTZ(scounteren.bits()),
+    (0x10A,  _) => senvcfg.bits(),
     (0x140,  _) => sscratch,
     (0x141,  _) => get_xret_target(Supervisor) & pc_alignment_mask(),
     (0x142,  _) => scause.bits(),
@@ -186,6 +188,7 @@ function writeCSR (csr : csreg, value : xlenbits) -> unit = {
     (0x304,  _) => { mie = legalize_mie(mie, value); Some(mie.bits()) },
     (0x305,  _) => { Some(set_mtvec(value)) },
     (0x306,  _) => { mcounteren = legalize_mcounteren(mcounteren, value); Some(EXTZ(mcounteren.bits())) },
+    (0x30A,  _) => { menvcfg = legalize_envcfg(menvcfg, value); Some(menvcfg.bits()) },
     (0x310, 32) => { Some(mstatush.bits()) }, // ignore writes for now
     (0x320,  _) => { mcountinhibit = legalize_mcountinhibit(mcountinhibit, value); Some(EXTZ(mcountinhibit.bits())) },
     (0x340,  _) => { mscratch = value; Some(mscratch) },
@@ -233,6 +236,7 @@ function writeCSR (csr : csreg, value : xlenbits) -> unit = {
     (0x104,  _) => { mie = legalize_sie(mie, mideleg, value); Some(mie.bits()) },
     (0x105,  _) => { Some(set_stvec(value)) },
     (0x106,  _) => { scounteren = legalize_scounteren(scounteren, value); Some(EXTZ(scounteren.bits())) },
+    (0x10A,  _) => { senvcfg = legalize_envcfg(senvcfg, value); Some(senvcfg.bits()) },
     (0x140,  _) => { sscratch = value; Some(sscratch) },
     (0x141,  _) => { Some(set_xret_target(Supervisor, value)) },
     (0x142,  _) => { scause->bits() = value; Some(scause.bits()) },

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -88,6 +88,8 @@ val elf_entry = {
   c: "elf_entry"
 } : unit -> int
 
+val plat_cache_block_size = {c: "plat_cache_block_size", ocaml: "Platform.cache_block_size", interpreter: "Platform.cache_block_size", lem: "plat_cache_block_size"} : unit -> xlenbits
+
 /* Main memory */
 val plat_ram_base = {c: "plat_ram_base", ocaml: "Platform.dram_base", interpreter: "Platform.dram_base", lem: "plat_ram_base"} : unit -> xlenbits
 val plat_ram_size = {c: "plat_ram_size", ocaml: "Platform.dram_size", interpreter: "Platform.dram_size", lem: "plat_ram_size"} : unit -> xlenbits

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -91,6 +91,7 @@ function is_CSR_defined (csr : csreg, p : Privilege) -> bool =
     0x304 => p == Machine, // mie
     0x305 => p == Machine, // mtvec
     0x306 => p == Machine & haveUsrMode(), // mcounteren
+    0x30a => p == Machine, // menvcfg
     0x310 => p == Machine & (sizeof(xlen) == 32), // mstatush
     0x320 => p == Machine, // mcountinhibit
     /* machine mode: trap handling */
@@ -139,6 +140,8 @@ function is_CSR_defined (csr : csreg, p : Privilege) -> bool =
     0x104 => haveSupMode() & (p == Machine | p == Supervisor), // sie
     0x105 => haveSupMode() & (p == Machine | p == Supervisor), // stvec
     0x106 => haveSupMode() & (p == Machine | p == Supervisor), // scounteren
+
+    0x10a => haveSupMode() & (p == Machine | p == Supervisor), // senvcfg
 
     /* supervisor mode: trap handling */
     0x140 => haveSupMode() & (p == Machine | p == Supervisor), // sscratch
@@ -597,6 +600,8 @@ function init_sys() -> unit = {
 
   minstret           = EXTZ(0b0);
   minstret_increment = true;
+
+  menvcfg->bits() = EXTZ(0b0);
 
   init_pmp();
 

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -213,6 +213,10 @@ function haveZmmul()  -> bool = true
 /* Zicond extension support */
 function haveZicond() -> bool = true
 
+/* Cache Management Operations extension support. */
+function haveZicbom() -> bool = true
+function haveZicboz() -> bool = true
+
 bitfield Mstatush : bits(32) = {
   MBE  : 5,
   SBE  : 4
@@ -830,3 +834,27 @@ function read_seed_csr() -> xlenbits = {
 
 /* Writes to the seed CSR are ignored */
 function write_seed_csr () -> option(xlenbits) = None()
+
+bitfield Envcfg : xlenbits = {
+  CBZE  : 7,
+  CBCFE : 6,
+  CBIE  : 5 .. 4
+}
+register senvcfg : Envcfg
+register menvcfg : Envcfg
+
+/* treat 0b10 as 0b00: Partially, the encoding was set up so that bit [4] was an
+ * "enable" bit, and bit [5] was an "operation" bit. So if bit [4] was zero,
+ *  bit [5] is a don't care.
+ */
+function legalize_envcfg_cbie(o : bits(2), v : bits(2)) -> bits(2) = match (v) {
+  0b10 => 0b00,
+  _ => v
+}
+
+function legalize_envcfg(o : Envcfg, v : xlenbits) -> Envcfg = {
+  let c = update_CBZE(o, [v[7]]);
+  let c = update_CBCFE(c, [v[6]]);
+  let c = update_CBIE(c, legalize_envcfg_cbie(o.CBIE(), v[5 .. 4]));
+  c
+}

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -398,6 +398,8 @@ enum amoop = {AMOSWAP, AMOADD, AMOXOR, AMOAND, AMOOR,
               AMOMIN, AMOMAX, AMOMINU, AMOMAXU}   /* AMO ops */
 enum csrop = {CSRRW, CSRRS, CSRRC}                /* CSR ops */
 
+enum cbop_zicbom = {CBO_CLEAN, CBO_FLUSH, CBO_INVAL}  /* Zicbom ops */
+
 enum brop_zba = {RISCV_SH1ADD, RISCV_SH2ADD, RISCV_SH3ADD}
 
 enum brop_zbb = {RISCV_ANDN, RISCV_ORN, RISCV_XNOR, RISCV_MAX,

--- a/ocaml_emulator/platform.ml
+++ b/ocaml_emulator/platform.ml
@@ -90,6 +90,8 @@ let rom_size ()   = arch_bits_of_int   !rom_size_ref
 let dram_base ()  = arch_bits_of_int64 P.dram_base
 let dram_size ()  = arch_bits_of_int64 !P.dram_size_ref
 
+let cache_block_size ()  = arch_bits_of_int64 !P.cache_block_size_ref
+
 let clint_base () = arch_bits_of_int64 P.clint_base
 let clint_size () = arch_bits_of_int64 P.clint_size
 

--- a/ocaml_emulator/platform_impl.ml
+++ b/ocaml_emulator/platform_impl.ml
@@ -57,6 +57,8 @@ let rom_base   = 0x00001000L;;  (* Spike::DEFAULT_RSTVEC *)
 
 let dram_size_ref = ref (Int64.(shift_left 64L 20))
 
+let cache_block_size_ref = ref (Int64.(64L))
+
 type mem_region = {
     addr : Int64.t;
     size : Int64.t
@@ -143,6 +145,9 @@ let set_dtc path =
 
 let set_dram_size mb =
   dram_size_ref := Int64.(shift_left (Int64.of_int mb) 20)
+
+let set_cache_block_size b =
+  cache_block_size_ref := Int64.(Int64.of_int b)
 
 let make_dtb dts = (* Call the dtc compiler, assumed to be at /usr/bin/dtc *)
   try

--- a/ocaml_emulator/riscv_ocaml_sim.ml
+++ b/ocaml_emulator/riscv_ocaml_sim.ml
@@ -59,6 +59,9 @@ let options = Arg.align ([("-dump-dts",
                           ("-ram-size",
                            Arg.Int PI.set_dram_size,
                            " size of physical ram memory to use (in MB)");
+                          ("-cache-block-size",
+                           Arg.Int PI.set_cache_block_size,
+                           " size of cache block size to use (in bytes)");
                           ("-report-arch",
                            Arg.Unit report_arch,
                            " report model architecture (RV32 or RV64)");


### PR DESCRIPTION
add support for cmo extension:
- add parameter for cache block size
- add cbo.zero to zero the cache block
- add cbo.inval/flush/clean to do envcfg csr and memory access check
- add prefetch* to only do the address-translation









