### PR TITLE
Add command line option to set dram base address

### DIFF
--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -111,6 +111,7 @@ static struct option options[] = {
   {"enable-misaligned",           no_argument,       0, 'm'},
   {"enable-pmp",                  no_argument,       0, 'P'},
   {"enable-next",                 no_argument,       0, 'N'},
+  {"ram-base",                    required_argument, 0, 'B'},
   {"ram-size",                    required_argument, 0, 'z'},
   {"disable-compressed",          no_argument,       0, 'C'},
   {"disable-writable-misa",       no_argument,       0, 'I'},
@@ -288,6 +289,10 @@ char *process_args(int argc, char **argv)
     case 'p':
       fprintf(stderr, "will show execution times on completion.\n");
       do_show_times = true;
+      break;
+    case 'B':
+      rv_ram_base = strtol(optarg, NULL, 16);
+      fprintf(stderr, "setting ram-base to 0x%0" PRIx64 "\n", rv_ram_base);
       break;
     case 'z':
       ram_size = atol(optarg);

--- a/ocaml_emulator/platform.ml
+++ b/ocaml_emulator/platform.ml
@@ -87,7 +87,7 @@ let enable_zfinx ()                  = false
 let rom_base ()   = arch_bits_of_int64 P.rom_base
 let rom_size ()   = arch_bits_of_int   !rom_size_ref
 
-let dram_base ()  = arch_bits_of_int64 P.dram_base
+let dram_base ()  = arch_bits_of_int64 !P.dram_base_ref
 let dram_size ()  = arch_bits_of_int64 !P.dram_size_ref
 
 let clint_base () = arch_bits_of_int64 P.clint_base

--- a/ocaml_emulator/platform_impl.ml
+++ b/ocaml_emulator/platform_impl.ml
@@ -50,11 +50,11 @@ let reset_vec_int arch start_pc = [
 
 (* address map *)
 
-let dram_base  = 0x80000000L;;  (* Spike::DRAM_BASE *)
 let clint_base = 0x02000000L;;  (* Spike::CLINT_BASE *)
 let clint_size = 0x000c0000L;;  (* Spike::CLINT_SIZE *)
 let rom_base   = 0x00001000L;;  (* Spike::DEFAULT_RSTVEC *)
 
+let dram_base_ref  = ref (Int64.of_int (int_of_string "0x80000000"))
 let dram_size_ref = ref (Int64.(shift_left 64L 20))
 
 type mem_region = {
@@ -117,7 +117,7 @@ let spike_dts isa_spec mmu_spec cpu_hz insns_per_rtc_tick mems =
 let cpu_hz = 1000000000;;
 let insns_per_tick = 100;;
 
-let make_mems () = [{ addr = dram_base;
+let make_mems () = [{ addr = !dram_base_ref;
                       size = !dram_size_ref }];;
 
 let make_dts arch =
@@ -140,6 +140,9 @@ let set_dtc path =
   with Unix.Unix_error (e, _, _) ->
     ( Printf.eprintf "Error accessing %s: %s\n%!" path (Unix.error_message e);
       exit 1)
+
+let set_dram_base mb =
+  dram_base_ref := Int64.of_int (int_of_string mb)
 
 let set_dram_size mb =
   dram_size_ref := Int64.(shift_left (Int64.of_int mb) 20)

--- a/ocaml_emulator/riscv_ocaml_sim.ml
+++ b/ocaml_emulator/riscv_ocaml_sim.ml
@@ -56,6 +56,9 @@ let options = Arg.align ([("-dump-dts",
                           ("-disable-writable-misa-c",
                            Arg.Clear P.config_enable_writable_misa,
                            " leave misa hardwired to its initial value");
+                          ("-ram-base",
+                           Arg.String PI.set_dram_base,
+                           " base of physical ram memory");
                           ("-ram-size",
                            Arg.Int PI.set_dram_size,
                            " size of physical ram memory to use (in MB)");


### PR DESCRIPTION
Fix for the issue #73 
Now by default ram_base is 0x80000000
ram-base=<ram-base-in-hex> cli is added.