### PR TITLE
Added missing effects for RVFI builds

### DIFF
--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -154,7 +154,7 @@ function pmp_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext_
 /* Atomic accesses can be done to MMIO regions, e.g. in kernel access to device registers. */
 
 $ifdef RVFI_DII
-val rvfi_read : forall 'n, 'n > 0. (xlenbits, atom('n), MemoryOpResult((bits(8 * 'n), mem_meta))) -> unit effect {wreg}
+val rvfi_read : forall 'n, 'n > 0. (xlenbits, atom('n), MemoryOpResult((bits(8 * 'n), mem_meta))) -> unit effect {escape, wreg}
 function rvfi_read (addr, width, result) = {
   rvfi_mem_data->rvfi_mem_addr() = EXTZ(addr);
   rvfi_mem_data_present = true;
@@ -228,7 +228,7 @@ function mem_write_ea (addr, width, aq, rl, con) = {
 }
 
 $ifdef RVFI_DII
-val rvfi_write : forall 'n, 0 < 'n <= max_mem_access . (xlenbits, atom('n), bits(8 * 'n), mem_meta) -> unit effect {wreg}
+val rvfi_write : forall 'n, 0 < 'n <= max_mem_access . (xlenbits, atom('n), bits(8 * 'n), mem_meta) -> unit effect {escape, wreg}
 function rvfi_write (addr, width, value, meta) = {
   rvfi_mem_data->rvfi_mem_addr() = EXTZ(addr);
   rvfi_mem_data_present = true;

--- a/model/riscv_step_rvfi.sail
+++ b/model/riscv_step_rvfi.sail
@@ -77,7 +77,7 @@ function ext_post_step_hook() -> unit = {
   rvfi_pc_data->rvfi_pc_wdata() = EXTZ(get_arch_pc())
 }
 
-val ext_init : unit -> unit effect {wreg}
+val ext_init : unit -> unit effect {rreg, wreg}
 function ext_init() = {
   init_base_regs();
   init_fdext_regs();

--- a/model/riscv_vmem_sv32.sail
+++ b/model/riscv_vmem_sv32.sail
@@ -74,7 +74,11 @@
 
 function to_phys_addr(a : paddr32) -> xlenbits = a[31..0]
 
+$ifdef RVFI_DII
+val walk32 : (vaddr32, AccessType(ext_access_type), Privilege, bool, bool, paddr32, nat, bool, ext_ptw) -> PTW_Result(paddr32, SV32_PTE) effect {rmem, rmemt, rreg, wreg, escape}
+$else
 val walk32 : (vaddr32, AccessType(ext_access_type), Privilege, bool, bool, paddr32, nat, bool, ext_ptw) -> PTW_Result(paddr32, SV32_PTE) effect {rmem, rmemt, rreg, escape}
+$endif
 function walk32(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
   let va = Mk_SV32_Vaddr(vaddr);
   let pt_ofs : paddr32 = shiftl(EXTZ(shiftr(va.VPNi(), (level * SV32_LEVEL_BITS))[(SV32_LEVEL_BITS - 1) .. 0]),

--- a/model/riscv_vmem_sv39.sail
+++ b/model/riscv_vmem_sv39.sail
@@ -68,7 +68,11 @@
 
 /* Sv39 address translation for RV64. */
 
+$ifdef RVFI_DII
+val walk39 : (vaddr39, AccessType(ext_access_type), Privilege, bool, bool, paddr64, nat, bool, ext_ptw) -> PTW_Result(paddr64, SV39_PTE) effect {rmem, rmemt, rreg, wreg, escape}
+$else
 val walk39 : (vaddr39, AccessType(ext_access_type), Privilege, bool, bool, paddr64, nat, bool, ext_ptw) -> PTW_Result(paddr64, SV39_PTE) effect {rmem, rmemt, rreg, escape}
+$endif
 function walk39(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
   let va = Mk_SV39_Vaddr(vaddr);
   let pt_ofs : paddr64 = shiftl(EXTZ(shiftr(va.VPNi(), (level * SV39_LEVEL_BITS))[(SV39_LEVEL_BITS - 1) .. 0]),

--- a/model/riscv_vmem_sv48.sail
+++ b/model/riscv_vmem_sv48.sail
@@ -68,7 +68,11 @@
 
 /* Sv48 address translation for RV64. */
 
+$ifdef RVFI_DII
+val walk48 : (vaddr48, AccessType(ext_access_type), Privilege, bool, bool, paddr64, nat, bool, ext_ptw) -> PTW_Result(paddr64, SV48_PTE) effect {rmem, rmemt, rreg, wreg, escape}
+$else
 val walk48 : (vaddr48, AccessType(ext_access_type), Privilege, bool, bool, paddr64, nat, bool, ext_ptw) -> PTW_Result(paddr64, SV48_PTE) effect {rmem, rmemt, rreg, escape}
+$endif
 function walk48(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
   let va = Mk_SV48_Vaddr(vaddr);
   let pt_ofs : paddr64 = shiftl(EXTZ(shiftr(va.VPNi(), (level * SV48_LEVEL_BITS))[(SV48_LEVEL_BITS - 1) .. 0]),

--- a/model/rvfi_dii.sail
+++ b/model/rvfi_dii.sail
@@ -259,7 +259,7 @@ register rvfi_mem_data : RVFI_DII_Execution_Packet_Ext_MemAccess
 register rvfi_mem_data_present : bool
 
 // Reset the trace
-val rvfi_zero_exec_packet : unit -> unit effect {wreg}
+val rvfi_zero_exec_packet : unit -> unit effect {rreg, wreg}
 
 function rvfi_zero_exec_packet () = {
   rvfi_inst_data = Mk_RVFI_DII_Execution_Packet_InstMetaData(EXTZ(0b0));
@@ -346,13 +346,13 @@ function rvfi_get_exec_packet_v2 () = {
   return packet.bits();
 }
 
-val rvfi_get_int_data : unit -> bits(320) effect {rreg}
+val rvfi_get_int_data : unit -> bits(320) effect {escape, rreg}
 function rvfi_get_int_data () = {
   assert(rvfi_int_data_present, "reading uninitialized data");
   return rvfi_int_data.bits();
 }
 
-val rvfi_get_mem_data : unit -> bits(704) effect {rreg}
+val rvfi_get_mem_data : unit -> bits(704) effect {escape, rreg}
 function rvfi_get_mem_data () = {
   assert(rvfi_mem_data_present, "reading uninitialized data");
   return rvfi_mem_data.bits();


### PR DESCRIPTION
This is required for building sail-riscv with RVFI using the current version of the sail compiler after this commit: https://github.com/rems-project/sail/commit/adcd56e8baa4f6424f4115af2c8f88036b7d400f
The reason is that -O is only used for the C emulator in sail-riscv's Makefile and this flag no longer implies no effects.

This is an example TypeError that I got when compiling without these changes:
```
Type error:
[model/rvfi_dii.sail]:264:0-275:1
264 |function rvfi_zero_exec_packet () = {
    |^------------------------------------
275 |}
    |^
    | Effects do not match: {wreg} declared and {rreg, wreg} found
    |
```

You can replicate the error using the following command:
`ARCH=RV32 make c_emulator/riscv_rvfi_RV32`