### PR TITLE
riscv_step: Fix -i/--mtval-has-illegal-inst-bits option

### DIFF
--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -98,6 +98,7 @@ function step(step_no : int) -> bool = {
           },
           /* non-error cases: */
           F_RVC(h) => {
+            instbits = EXTZ(h);
             let ast = decodeCompressed(h);
             if   get_config_print_instr()
             then {
@@ -113,6 +114,7 @@ function step(step_no : int) -> bool = {
              }
           },
           F_Base(w) => {
+            instbits = EXTZ(w);
             let ast = decode(w);
             if   get_config_print_instr()
             then {


### PR DESCRIPTION
This option causes handle_illegal to pass instbits as the value to set
for xtval, but instbits is never set so it ends up being 0 just as if
the option was never enabled. Fix this by initialising instbits during
fetch; we could make this conditional on whether the option is enabled
but that seems unnecessary and introduces tighter coupling.

Note that this option appears to have always been broken; when it was
originally added, instbits was only written two in two cases which were
both dead code and later removed in eb176111887b.

Closes: #173
