### PR TITLE
Fix build without -fcommon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ GMP_LIBS = $(shell pkg-config --libs gmp || echo -lgmp)
 ZLIB_FLAGS = $(shell pkg-config --cflags zlib)
 ZLIB_LIBS = $(shell pkg-config --libs zlib)
 
-C_FLAGS = -I $(SAIL_LIB_DIR) -I c_emulator $(GMP_FLAGS) $(ZLIB_FLAGS) $(SOFTFLOAT_FLAGS) -fcommon
+C_FLAGS = -I $(SAIL_LIB_DIR) -I c_emulator $(GMP_FLAGS) $(ZLIB_FLAGS) $(SOFTFLOAT_FLAGS)
 C_LIBS  = $(GMP_LIBS) $(ZLIB_LIBS) $(SOFTFLOAT_LIBS)
 
 # The C simulator can be built to be linked against Spike for tandem-verification.

--- a/c_emulator/riscv_sail.h
+++ b/c_emulator/riscv_sail.h
@@ -7,7 +7,7 @@ typedef int unit;
 typedef uint64_t mach_bits;
 
 struct zMisa {mach_bits zMisa_chunk_0;};
-struct zMisa zmisa;
+extern struct zMisa zmisa;
 
 void model_init(void);
 void model_fini(void);
@@ -67,6 +67,6 @@ extern mach_bits zsepc, zstval;
 extern mach_bits zfloat_result, zfloat_fflags;
 
 struct zMcause {mach_bits zMcause_chunk_0;};
-struct zMcause zmcause, zscause;
+extern struct zMcause zmcause, zscause;
 
 extern mach_bits zminstret;


### PR DESCRIPTION
The sail C code generator will emit definions for these structs. The
duplicate definition linker error were worked around by adding -fcommon
in https://github.com/riscv/sail-riscv/commit/ffea7a39c32a210a446379aeda0eabcec4918ed6. This commit fixes the
underlying issue by declaring the variables as `extern`.