### PR TITLE
Fix packw sign-extension

### DIFF
--- a/model/riscv_insts_zbkb.sail
+++ b/model/riscv_insts_zbkb.sail
@@ -40,7 +40,7 @@ function clause execute (ZBKB_PACKW(rs2, rs1, rd)) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
   let result : bits(32) = rs2_val[15..0] @ rs1_val[15..0];
-  X(rd) = EXTZ(result);
+  X(rd) = EXTS(result);
   RETIRE_SUCCESS
 }
 


### PR DESCRIPTION
Currently, the result of packw is zero-extended, but according to spec, packw should sign-extend its result to 64bit.

This sign-extension is also in accordance with the other simulators:
Spike: https://github.com/riscv-software-src/riscv-isa-sim/blob/86d9fe49eda1fff863a43e682015216a25cc72f3/riscv/insns/packw.h#L10
QEMU: https://gitlab.com/qemu-project/qemu/-/blob/master/target/riscv/insn_trans/trans_rvb.c.inc#L540

Signed-off-by: Jan Henrik Weinstock <jan@mwa.re>