### PR TITLE
Vector load / store instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ SAIL_DEFAULT_INST += riscv_insts_zbkx.sail
 
 SAIL_DEFAULT_INST += riscv_insts_vext_utils.sail
 SAIL_DEFAULT_INST += riscv_insts_vext_vset.sail
+SAIL_DEFAULT_INST += riscv_insts_vext_arith.sail
+SAIL_DEFAULT_INST += riscv_insts_vext_mem.sail
+
 SAIL_SEQ_INST  = $(SAIL_DEFAULT_INST) riscv_jalr_seq.sail
 SAIL_RMEM_INST = $(SAIL_DEFAULT_INST) riscv_jalr_rmem.sail riscv_insts_rmem.sail
 

--- a/model/prelude.sail
+++ b/model/prelude.sail
@@ -74,7 +74,6 @@ $include <arith.sail>
 $include <string.sail>
 $include <vector_dec.sail>
 $include <regfp.sail>
-$include <real.sail>
 
 val string_startswith = "string_startswith" : (string, string) -> bool
 val string_drop = "string_drop" : (string, nat) -> string
@@ -343,21 +342,21 @@ function def_spc_backwards s = ()
 val def_spc_matches_prefix : string -> option((unit, nat))
 function def_spc_matches_prefix s = opt_spc_matches_prefix(s)
 
-val div_int : (int, int) -> int
-function div_int(x, y) = {
-  floor(div_real(to_real(x), to_real(y)))
-}
-
-val "print_real" : (string, real) -> unit
 val "print_int" : (string, int) -> unit
 
-overload operator / = {div_int, div_real}
-overload operator * = {mult_atom, mult_int, mult_real}
+overload operator / = {quot_round_zero}
+overload operator * = {mult_atom, mult_int}
 
-/* helper for vector extension where the element width is between 8 and 64 */
-val log2 : forall 'n, 'n in {8, 16, 32, 64}. int('n) -> int
+/* helper for vector extension 
+ * 1. EEW between 8 and 64
+ * 2. EMUL in vmv<nr>r.v instructions between 1 and 8
+ */
+val log2 : forall 'n, 'n in {1, 2, 4, 8, 16, 32, 64}. int('n) -> int
 function log2(n) = {
   let result : int = match n {
+    1    => 0,
+    2    => 1,
+    4    => 2,
     8    => 3,
     16   => 4,
     32   => 5,

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -1,0 +1,553 @@
+/* ******************************************************************************* */
+/* This file implements part of the vector extension.                              */
+/* Chapter 11: vector integer arithmetic instructions                              */
+/* Chapter 12: vector fixed-point arithmetic instructions                          */
+/* Chapter 16: vector permutation instructions                                     */
+
+/* ******************************************************************************* */
+
+/* **************************OPIVV(VVTYPE)**************************************** */
+
+union clause ast = VVTYPE : (vvfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_vvfunct6 : vvfunct6 <-> bits(6) = {
+  VV_VADD          <-> 0b000000,
+  VV_VSUB          <-> 0b000010,
+  VV_VMINU         <-> 0b000100,
+  VV_VMIN          <-> 0b000101,
+  VV_VMAXU         <-> 0b000110,
+  VV_VMAX          <-> 0b000111,
+  VV_VAND          <-> 0b001001,
+  VV_VOR           <-> 0b001010,
+  VV_VXOR          <-> 0b001011,
+  VV_VRGATHER      <-> 0b001100,
+  VV_VRGATHEREI16  <-> 0b001110,
+  VV_VSADDU        <-> 0b100000,
+  VV_VSADD         <-> 0b100001,
+  VV_VSSUBU        <-> 0b100010,
+  VV_VSSUB         <-> 0b100011,  
+  VV_VSLL          <-> 0b100101,
+  VV_VSMUL         <-> 0b100111,
+  VV_VSRL          <-> 0b101000,
+  VV_VSRA          <-> 0b101001,
+  VV_VSSRL         <-> 0b101010,
+  VV_VSSRA         <-> 0b101011
+}
+
+mapping clause encdec = VVTYPE(funct6, vm, vs2, vs1, vd)
+  <-> encdec_vvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111
+
+function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
+  let vsew_bits : int  = get_vtype_vsew();
+  let lmul      : real = get_vtype_LMUL();
+  let num_elem  : int  = get_num_elem(lmul, vsew_bits);
+
+  assert(vsew_bits == 8 | vsew_bits == 16 | vsew_bits == 32 | vsew_bits == 64);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+  let 'n = num_elem;
+  let 'm = vsew_bits;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask_helper : vector('n, dec, bool)     = undefined;
+
+  (result, mask_helper) = init_masked_result(num_elem, vsew_bits, lmul, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask_helper[i] == true then {
+      result[i] = match funct6 {
+        VV_VADD          => vs2_val[i] + vs1_val[i],
+        VV_VSUB          => vs2_val[i] - vs1_val[i],
+        VV_VAND          => vs2_val[i] & vs1_val[i],
+        VV_VOR           => vs2_val[i] | vs1_val[i],
+        VV_VXOR          => vs2_val[i] ^ vs1_val[i],
+        VV_VSADDU        => unsigned_saturation('m, EXTZ('m + 1, vs2_val[i]) + EXTZ('m + 1, vs1_val[i]) ),
+        VV_VSADD         => signed_saturation('m, EXTS('m + 1, vs2_val[i]) + EXTS('m + 1, vs1_val[i]) ),
+        VV_VSSUBU        => {
+                              if unsigned(vs2_val[i]) < unsigned(vs1_val[i]) then zeros()
+                              else unsigned_saturation('m, EXTZ('m + 1, vs2_val[i]) - EXTZ('m + 1, vs1_val[i]) )
+                            },
+        VV_VSSUB         => signed_saturation('m, EXTS('m + 1, vs2_val[i]) - EXTS('m + 1, vs1_val[i]) ),
+        VV_VSMUL         => {
+                              result_mul = to_bits('m * 2, signed(vs2_val[i]) * signed(vs1_val[i]));
+                              rounding_incr = get_fixed_rounding_incr(result_mul, 'm - 1);
+                              result_wide = (result_mul >> ('m - 1)) + EXTZ('m * 2, rounding_incr);
+                              signed_saturation('m, result_wide['m..0])
+                            },
+        VV_VSLL          => {
+                              let shift_amount = get_shift_amount(vs1_val[i], vsew_bits);
+                              assert(shift_amount >= 0);
+                              vs2_val[i] << shift_amount
+                            },
+        VV_VSRL          => {
+                              let shift_amount = get_shift_amount(vs1_val[i], vsew_bits);
+                              assert(shift_amount >= 0);
+                              vs2_val[i] >> shift_amount
+                            },
+        VV_VSRA          => {
+                              let shift_amount = get_shift_amount(vs1_val[i], vsew_bits);
+                              assert(shift_amount >= 0);
+                              let v_double : bits('m * 2) = EXTS(vs2_val[i]);
+                              slice(v_double >> shift_amount, 0, vsew_bits)
+                            },
+        VV_VSSRL         => {
+                              let shift_amount = get_shift_amount(vs1_val[i], vsew_bits);
+                              assert(shift_amount >= 0);
+                              let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
+                              (vs2_val[i] >> shift_amount) + EXTZ('m, rounding_incr)
+                            },
+        VV_VSSRA         => {
+                              let shift_amount = get_shift_amount(vs1_val[i], vsew_bits);
+                              assert(shift_amount >= 0);
+                              let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
+                              let v_double : bits('m * 2) = EXTS(vs2_val[i]);
+                              slice(v_double >> shift_amount, 0, vsew_bits) + EXTZ('m, rounding_incr)
+                            },
+        VV_VMINU         => to_bits(vsew_bits, min(unsigned(vs2_val[i]), unsigned(vs1_val[i]))),
+        VV_VMIN          => to_bits(vsew_bits, min(signed(vs2_val[i]), signed(vs1_val[i]))),
+        VV_VMAXU         => to_bits(vsew_bits, max(unsigned(vs2_val[i]), unsigned(vs1_val[i]))),
+        VV_VMAX          => to_bits(vsew_bits, max(signed(vs2_val[i]), signed(vs1_val[i]))),
+        VV_VRGATHER      => {
+                              assert(vs1 != vd & vs2 != vd);
+                              let idx = unsigned(vs1_val[i]);
+                              vlmax = floor(lmul * (to_real(get_vlen()) / to_real(vsew_bits)));
+                              if idx < vlmax then {
+                                assert(idx < 'n); 
+                                vs2_val[idx]
+                              } else zeros() 
+                            },
+        VV_VRGATHEREI16  => {
+                              assert(vs1 != vd & vs2 != vd);
+                              /* vrgatherei16.vv uses SEW/LMUL for the data in vs2 but EEW=16 and EMUL = (16/SEW)*LMUL for the indices in vs1 */
+                              let vs1_new : vector('n, dec, bits(16)) = read_vreg(num_elem, 16, (lmul * 16.0 / to_real(vsew_bits)), vs1);
+                              let idx = unsigned(vs1_new[i]);
+                              vlmax = floor(lmul * (to_real(get_vlen()) / to_real(vsew_bits)));
+                              if idx < vlmax then {
+                                assert(idx < 'n); 
+                                vs2_val[idx]
+                              } else zeros()                   
+                            }
+      }
+    }
+  };
+
+  write_vreg(num_elem, vsew_bits, lmul, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vvtype_mnemonic : vvfunct6 <-> string = {
+  VV_VADD          <-> "vadd.vv",
+  VV_VSUB          <-> "vsub.vv",
+  VV_VAND          <-> "vand.vv",
+  VV_VOR           <-> "vor.vv",
+  VV_VXOR          <-> "vxor.vv",
+  VV_VRGATHER      <-> "vrgather.vv",
+  VV_VRGATHEREI16  <-> "vrgatherei16.vv",
+  VV_VSADDU        <-> "vsaddu.vv",
+  VV_VSADD         <-> "vsadd.vv",
+  VV_VSSUBU        <-> "vssubu.vv",
+  VV_VSSUB         <-> "vssub.vv",
+  VV_VSLL          <-> "vsll.vv",
+  VV_VSMUL         <-> "vsmul.vv",
+  VV_VSRL          <-> "vsrl.vv",
+  VV_VSRA          <-> "vsra.vv",
+  VV_VSSRL         <-> "vssrl.vv",
+  VV_VSSRA         <-> "vssra.vv",
+  VV_VMINU         <-> "vminu.vv",
+  VV_VMIN          <-> "vmin.vv",
+  VV_VMAXU         <-> "vmaxu.vv",
+  VV_VMAX          <-> "vmax.vv"
+}
+
+mapping clause assembly = VVTYPE(funct6, vm, vs2, vs1, vd)
+  <-> vvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+
+/* *******************************OPIVX(Vector Slide & Gather Instructions)******************************** */
+/* Slide and gather instructions extend rs1 / imm to XLEN bits (not SEW bits as others do) */
+
+union clause ast = VXSG : (vxsgfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_vxsgfunct6 : vxsgfunct6 <-> bits(6) = {
+  VX_VSLIDEUP     <-> 0b001110,
+  VX_VSLIDEDOWN   <-> 0b001111,
+  VX_VRGATHER     <-> 0b001100
+}
+
+mapping clause encdec = VXSG(funct6, vm, vs2, rs1, vd)
+  <-> encdec_vxsgfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111
+
+function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
+  let vsew_bits : int  = get_vtype_vsew();
+  let lmul      : real = get_vtype_LMUL();
+  let num_elem  : int  = get_num_elem(lmul, vsew_bits);
+
+  assert(8 <= vsew_bits & vsew_bits <= 64);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+  let 'n = num_elem;
+  let 'm = vsew_bits;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let rs1_val : int                       = unsigned(X(rs1));
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask_helper : vector('n, dec, bool)     = undefined;
+
+  (result, mask_helper) = init_masked_result(num_elem, vsew_bits, lmul, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask_helper[i] == true then {
+      result[i] = match funct6 {
+        VX_VSLIDEUP    => {
+                            assert(vs2 != vd);
+                            assert(i - rs1_val < 'n);
+                            if i >= rs1_val then vs2_val[i - rs1_val] else vd_val[i]
+                          },
+        VX_VSLIDEDOWN  => {
+                            assert(i + rs1_val >= 0);
+                            vlmax = floor(lmul * to_real(get_vlen()) / to_real(vsew_bits));
+                            if i + rs1_val < vlmax then {
+                              assert(i + rs1_val < 'n); 
+                              vs2_val[i + rs1_val]
+                            } else zeros()
+                          },
+        VX_VRGATHER    => {
+                            assert(vs2 != vd);
+                            assert(rs1_val >= 0);
+                            vlmax = floor(lmul * to_real(get_vlen()) / to_real(vsew_bits));
+                            if rs1_val < vlmax then {
+                              assert(rs1_val < 'n); 
+                              vs2_val[rs1_val]
+                            } else zeros() 
+                          }
+      }
+    }
+  };
+
+  write_vreg(num_elem, vsew_bits, lmul, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+} 
+
+mapping vxsg_mnemonic : vxsgfunct6 <-> string = {
+  VX_VSLIDEUP     <-> "vslideup.vx",
+  VX_VSLIDEDOWN   <-> "vslidedown.vx",
+  VX_VRGATHER     <-> "vrgather.vx"
+}
+
+mapping clause assembly = VXSG(funct6, vm, vs2, rs1, vd)
+  <-> vxsg_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+
+
+/* *******************************OPIVI(Vector Slide & Gather Instructions)******************************** */
+/* Slide and gather instructions extend rs1 / imm to XLEN bits (not SEW bits as others do) */
+
+union clause ast = VISG : (visgfunct6, bits(1), regidx, bits(5), regidx)
+
+mapping encdec_visgfunct6 : visgfunct6 <-> bits(6) = {
+  VI_VSLIDEUP     <-> 0b001110,
+  VI_VSLIDEDOWN   <-> 0b001111,
+  VI_VRGATHER     <-> 0b001100
+}
+
+mapping clause encdec = VISG(funct6, vm, vs2, simm, vd)
+  <-> encdec_visgfunct6(funct6) @ vm @ vs2 @ simm @ 0b011 @ vd @ 0b1010111
+
+function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
+  let vsew_bits : int  = get_vtype_vsew();
+  let lmul      : real = get_vtype_LMUL();
+  let num_elem  : int  = get_num_elem(lmul, vsew_bits);
+
+  assert(8 <= vsew_bits & vsew_bits <= 64);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+  let 'n = num_elem;
+  let 'm = vsew_bits;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let imm_val : int                       = unsigned(EXTZ(sizeof(xlen), simm));
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask_helper : vector('n, dec, bool)     = undefined;
+
+  (result, mask_helper) = init_masked_result(num_elem, vsew_bits, lmul, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask_helper[i] == true then {
+      result[i] = match funct6 {
+        VI_VSLIDEUP    => {
+                            assert(vs2 != vd);
+                            assert(i - imm_val < 'n);
+                            if i >= imm_val then vs2_val[i - imm_val] else vd_val[i]
+                          },
+        VI_VSLIDEDOWN  => {
+                            assert(i + imm_val >= 0);
+                            vlmax = floor(lmul * to_real(get_vlen()) / to_real(vsew_bits));
+                            if i + imm_val < vlmax then {
+                              assert(i + imm_val < 'n); 
+                              vs2_val[i + imm_val]
+                            } else zeros()
+                          },
+        VI_VRGATHER    => {
+                            assert(vs2 != vd);
+                            assert(imm_val >= 0);
+                            vlmax = floor(lmul * to_real(get_vlen()) / to_real(vsew_bits));
+                            if imm_val < vlmax then {
+                              assert(imm_val < 'n); 
+                              vs2_val[imm_val]
+                            } else zeros() 
+                          }
+      }
+    }
+  };
+
+  write_vreg(num_elem, vsew_bits, lmul, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+} 
+
+mapping visg_mnemonic : visgfunct6 <-> string = {
+  VI_VSLIDEUP     <-> "vslideup.vi",
+  VI_VSLIDEDOWN   <-> "vslidedown.vi",
+  VI_VRGATHER     <-> "vrgather.vi"
+}
+
+mapping clause assembly = VISG(funct6, vm, vs2, simm, vd)
+  <-> visg_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(simm) ^ maybe_vmask(vm)
+
+
+/* ******************************Whole Vector Register Move(OPIVI)******************************** */
+
+union clause ast = VMVRTYPE : (regidx, bits(5), regidx)
+
+mapping clause encdec = VMVRTYPE(vs2, simm, vd)
+  <-> 0b100111 @ 0b1 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111
+
+function clause execute(VMVRTYPE(vs2, simm, vd)) = {
+  let vsew_bits : int = get_vtype_vsew();
+  let imm_val   : int = unsigned(EXTZ(sizeof(xlen), simm));
+  let lmul      : int = imm_val + 1;
+
+  assert(8 <= vsew_bits & vsew_bits <= 64);
+  assert(lmul == 1 | lmul == 2 | lmul == 4 | lmul == 8);
+  let num_elem  : int = get_num_elem(to_real(lmul), vsew_bits);
+  let 'n = num_elem;
+  let 'm = vsew_bits;
+
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, to_real(lmul), vs2);
+  write_vreg(num_elem, vsew_bits, to_real(lmul), vd, vs2_val);
+  vstart = EXTZ(0b0);
+
+  RETIRE_SUCCESS
+} 
+
+mapping simm_string : bits(5) <-> string = {
+  0b00000 <-> "1",
+  0b00001 <-> "2",
+  0b00011 <-> "4",
+  0b00111 <-> "8"
+}
+
+mapping clause assembly = VMVRTYPE(vs2, simm, vd)
+  <-> "vmv" ^ simm_string(simm) ^ "r.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)
+
+
+/* *******************************OPMVV(VWXUNARY0)******************************** */
+
+union clause ast = VMVXS : (regidx, regidx)
+
+mapping clause encdec = VMVXS(vs2, rd)
+  <-> 0b010000 @ 0b1 @ vs2 @ 0b00000 @ 0b010 @ rd @ 0b1010111
+
+function clause execute(VMVXS(vs2, rd)) = {
+  let vsew_bits : int = get_vtype_vsew();
+  let num_elem  : int = get_num_elem(1.0, vsew_bits);
+
+  assert(8 <= vsew_bits & vsew_bits <= 64);
+  assert(0 < num_elem & num_elem <= get_vlen());
+  let 'n = num_elem;
+  let 'm = vsew_bits;
+
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, 1.0, vs2);
+  if sizeof(xlen) < vsew_bits then X(rd) = slice(vs2_val[0], 0, sizeof(xlen))
+  else if sizeof(xlen) > vsew_bits then X(rd) = sail_sign_extend(vs2_val[0], sizeof(xlen))
+  else X(rd) = vs2_val[0];
+  vstart = EXTZ(0b0);
+
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = VMVXS(vs2, rd)
+  <-> "vmv.x.s" ^ spc() ^ reg_name(rd) ^ sep() ^ vreg_name(vs2)
+
+
+/* *******************************OPMVX(VRXUNARY0)******************************** */
+
+union clause ast = VMVSX : (regidx, regidx)
+
+mapping clause encdec = VMVSX(rs1, vd)
+  <-> 0b010000 @ 0b1 @ 0b00000 @ rs1 @ 0b110 @ vd @ 0b1010111
+
+function clause execute(VMVSX(rs1, vd)) = {
+  let vsew_bits : int  = get_vtype_vsew();
+  let num_elem  : int  = get_num_elem(1.0, vsew_bits);
+
+  assert(8 <= vsew_bits & vsew_bits <= 64);
+  assert(0 < num_elem & num_elem <= get_vlen());
+  let 'n = num_elem;
+  let 'm = vsew_bits;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
+  let rs1_val = get_scalar(rs1, 'm);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, 1.0, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask_helper : vector('n, dec, bool)     = undefined;
+
+  (result, mask_helper) = init_masked_result(num_elem, vsew_bits, 1.0, vd_val, vm_val);
+
+  /* one body element */
+  if mask_helper[0] == true then result[0] = rs1_val;
+
+  /* others treated as tail elements */
+  let tail_ag : agtype = get_vtype_vta();
+  if tail_ag == UNDISTURBED then {
+    foreach (i from 1 to (num_elem - 1)) result[i] = vd_val[i]
+  }
+  else if tail_ag == AGNOSTIC then {
+    foreach (i from 1 to (num_elem - 1)) result[i] = vd_val[i]
+  };
+
+  write_vreg(num_elem, vsew_bits, 1.0, vd, result);
+  vstart = EXTZ(0b0);
+
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = VMVSX(rs1, vd)
+  <-> "vmv.s.x" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)
+
+
+/* **************************Integer move instruction(OPIVV)*************************************** */
+
+union clause ast = MOVETYPEV : (regidx, regidx)
+
+mapping clause encdec = MOVETYPEV (vs1, vd)
+  <-> 0b010111 @ 0b1 @ 0b00000 @ vs1 @ 0b000 @ vd @ 0b1010111
+
+function clause execute(MOVETYPEV(vs1, vd)) = {
+  let vsew_bits : int  = get_vtype_vsew();
+  let lmul      : real = get_vtype_LMUL();
+  let num_elem  : int  = get_num_elem(lmul, vsew_bits);
+
+  assert(8 <= vsew_bits & vsew_bits <= 64);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+  let 'n = num_elem;
+  let 'm = vsew_bits;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vs1);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask_helper : vector('n, dec, bool)     = undefined;
+
+  (result, mask_helper) = init_masked_result(num_elem, vsew_bits, lmul, vd_val, vm_val);
+  foreach (i from 0 to (num_elem - 1)){
+    if mask_helper[i] == true then{
+      result[i] = vs1_val[i]
+    }
+  };
+
+  write_vreg(num_elem, vsew_bits, lmul, vd, result);
+  vstart = EXTZ(0b0);
+
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = MOVETYPEV(vs1, vd)
+<-> "vmv.v.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1)
+
+
+/* **************************Integer move instruction(OPIVX)*************************************** */
+
+union clause ast = MOVETYPEX : (regidx, regidx)
+
+mapping clause encdec = MOVETYPEX (rs1, vd)
+  <-> 0b010111 @ 0b1 @ 0b00000 @ rs1 @ 0b100 @ vd @ 0b1010111
+
+function clause execute(MOVETYPEX(rs1, vd)) = {
+  let vsew_bits : int  = get_vtype_vsew();
+  let lmul      : real = get_vtype_LMUL();
+  let num_elem  : int  = get_num_elem(lmul, vsew_bits);
+
+  assert(8 <= vsew_bits & vsew_bits <= 64);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+  let 'n = num_elem;
+  let 'm = vsew_bits;
+
+  let rs1_val = get_scalar(rs1, vsew_bits);
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask_helper : vector('n, dec, bool)     = undefined;
+
+  (result, mask_helper) = init_masked_result(num_elem, vsew_bits, lmul, vd_val, vm_val);
+  foreach (i from 0 to (num_elem - 1)){
+    if mask_helper[i] == true then{
+      result[i] = rs1_val
+    }
+  };
+
+  write_vreg(num_elem, vsew_bits, lmul, vd, result);
+  vstart = EXTZ(0b0);
+
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = MOVETYPEX(rs1, vd)
+<-> "vmv.v.x" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)   
+
+
+/* **************************Integer move instruction(OPIVI)*************************************** */
+
+union clause ast = MOVETYPEI : (regidx, bits(5))
+
+mapping clause encdec = MOVETYPEI (vd, simm)
+  <-> 0b010111 @ 0b1 @ 0b00000 @ simm @ 0b011 @ vd @ 0b1010111
+
+function clause execute(MOVETYPEI(vd, simm)) = {
+  let vsew_bits : int = get_vtype_vsew();
+  let lmul      : real = get_vtype_LMUL();
+  let num_elem  : int = get_num_elem(lmul, vsew_bits);
+
+  assert(8 <= vsew_bits & vsew_bits <= 64);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+  let 'n = num_elem;
+  let 'm = vsew_bits;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
+  let imm_val = sail_sign_extend(simm, vsew_bits);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask_helper : vector('n, dec, bool)     = undefined;
+
+  (result, mask_helper) = init_masked_result(num_elem, vsew_bits, lmul, vd_val, vm_val);
+  foreach (i from 0 to (num_elem - 1)){
+    if mask_helper[i] == true then{
+      result[i] = imm_val
+    }
+  };
+
+  write_vreg(num_elem, vsew_bits, lmul, vd, result);
+  vstart = EXTZ(0b0);
+
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = MOVETYPEI(vd, simm)
+<-> "vmv.v.i" ^ spc() ^ vreg_name(vd) ^ sep() ^ hex_bits_5(simm)
+

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -38,23 +38,24 @@ mapping clause encdec = VVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_vvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111
 
 function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
-  let vsew_bits : int  = get_vtype_vsew();
-  let lmul      : real = get_vtype_LMUL();
-  let num_elem  : int  = get_num_elem(lmul, vsew_bits);
+  let SEW_pow  : int = get_sew_pow();
+  let SEW      : int = int_power(2, SEW_pow);
+  let LMUL_pow : int = get_lmul_pow();
+  let VLEN_pow : int = get_vlen_pow();
+  let num_elem : int = get_num_elem(LMUL_pow, SEW);
 
-  assert(vsew_bits == 8 | vsew_bits == 16 | vsew_bits == 32 | vsew_bits == 64);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(SEW == 8 | SEW == 16 | SEW == 32 | SEW == 64);
   let 'n = num_elem;
-  let 'm = vsew_bits;
+  let 'm = SEW;
 
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vs1);
-  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vs2);
-  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vd);
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   result      : vector('n, dec, bits('m)) = undefined;
   mask_helper : vector('n, dec, bool)     = undefined;
 
-  (result, mask_helper) = init_masked_result(num_elem, vsew_bits, lmul, vd_val, vm_val);
+  (result, mask_helper) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask_helper[i] == true then {
@@ -64,13 +65,13 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
         VV_VAND          => vs2_val[i] & vs1_val[i],
         VV_VOR           => vs2_val[i] | vs1_val[i],
         VV_VXOR          => vs2_val[i] ^ vs1_val[i],
-        VV_VSADDU        => unsigned_saturation('m, EXTZ('m + 1, vs2_val[i]) + EXTZ('m + 1, vs1_val[i]) ),
-        VV_VSADD         => signed_saturation('m, EXTS('m + 1, vs2_val[i]) + EXTS('m + 1, vs1_val[i]) ),
+        VV_VSADDU        => unsigned_saturation('m, EXTZ('m + 1, vs2_val[i]) + EXTZ('m + 1, vs1_val[i])),
+        VV_VSADD         => signed_saturation('m, EXTS('m + 1, vs2_val[i]) + EXTS('m + 1, vs1_val[i])),
         VV_VSSUBU        => {
                               if unsigned(vs2_val[i]) < unsigned(vs1_val[i]) then zeros()
-                              else unsigned_saturation('m, EXTZ('m + 1, vs2_val[i]) - EXTZ('m + 1, vs1_val[i]) )
+                              else unsigned_saturation('m, EXTZ('m + 1, vs2_val[i]) - EXTZ('m + 1, vs1_val[i]))
                             },
-        VV_VSSUB         => signed_saturation('m, EXTS('m + 1, vs2_val[i]) - EXTS('m + 1, vs1_val[i]) ),
+        VV_VSSUB         => signed_saturation('m, EXTS('m + 1, vs2_val[i]) - EXTS('m + 1, vs1_val[i])),
         VV_VSMUL         => {
                               result_mul = to_bits('m * 2, signed(vs2_val[i]) * signed(vs1_val[i]));
                               rounding_incr = get_fixed_rounding_incr(result_mul, 'm - 1);
@@ -78,43 +79,43 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
                               signed_saturation('m, result_wide['m..0])
                             },
         VV_VSLL          => {
-                              let shift_amount = get_shift_amount(vs1_val[i], vsew_bits);
+                              let shift_amount = get_shift_amount(vs1_val[i], SEW);
                               assert(shift_amount >= 0);
                               vs2_val[i] << shift_amount
                             },
         VV_VSRL          => {
-                              let shift_amount = get_shift_amount(vs1_val[i], vsew_bits);
+                              let shift_amount = get_shift_amount(vs1_val[i], SEW);
                               assert(shift_amount >= 0);
                               vs2_val[i] >> shift_amount
                             },
         VV_VSRA          => {
-                              let shift_amount = get_shift_amount(vs1_val[i], vsew_bits);
+                              let shift_amount = get_shift_amount(vs1_val[i], SEW);
                               assert(shift_amount >= 0);
                               let v_double : bits('m * 2) = EXTS(vs2_val[i]);
-                              slice(v_double >> shift_amount, 0, vsew_bits)
+                              slice(v_double >> shift_amount, 0, SEW)
                             },
         VV_VSSRL         => {
-                              let shift_amount = get_shift_amount(vs1_val[i], vsew_bits);
+                              let shift_amount = get_shift_amount(vs1_val[i], SEW);
                               assert(shift_amount >= 0);
                               let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
                               (vs2_val[i] >> shift_amount) + EXTZ('m, rounding_incr)
                             },
         VV_VSSRA         => {
-                              let shift_amount = get_shift_amount(vs1_val[i], vsew_bits);
+                              let shift_amount = get_shift_amount(vs1_val[i], SEW);
                               assert(shift_amount >= 0);
                               let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
                               let v_double : bits('m * 2) = EXTS(vs2_val[i]);
-                              slice(v_double >> shift_amount, 0, vsew_bits) + EXTZ('m, rounding_incr)
+                              slice(v_double >> shift_amount, 0, SEW) + EXTZ('m, rounding_incr)
                             },
-        VV_VMINU         => to_bits(vsew_bits, min(unsigned(vs2_val[i]), unsigned(vs1_val[i]))),
-        VV_VMIN          => to_bits(vsew_bits, min(signed(vs2_val[i]), signed(vs1_val[i]))),
-        VV_VMAXU         => to_bits(vsew_bits, max(unsigned(vs2_val[i]), unsigned(vs1_val[i]))),
-        VV_VMAX          => to_bits(vsew_bits, max(signed(vs2_val[i]), signed(vs1_val[i]))),
+        VV_VMINU         => to_bits(SEW, min(unsigned(vs2_val[i]), unsigned(vs1_val[i]))),
+        VV_VMIN          => to_bits(SEW, min(signed(vs2_val[i]), signed(vs1_val[i]))),
+        VV_VMAXU         => to_bits(SEW, max(unsigned(vs2_val[i]), unsigned(vs1_val[i]))),
+        VV_VMAX          => to_bits(SEW, max(signed(vs2_val[i]), signed(vs1_val[i]))),
         VV_VRGATHER      => {
                               assert(vs1 != vd & vs2 != vd);
                               let idx = unsigned(vs1_val[i]);
-                              vlmax = floor(lmul * (to_real(get_vlen()) / to_real(vsew_bits)));
-                              if idx < vlmax then {
+                              VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
+                              if idx < VLMAX then {
                                 assert(idx < 'n); 
                                 vs2_val[idx]
                               } else zeros() 
@@ -122,10 +123,10 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
         VV_VRGATHEREI16  => {
                               assert(vs1 != vd & vs2 != vd);
                               /* vrgatherei16.vv uses SEW/LMUL for the data in vs2 but EEW=16 and EMUL = (16/SEW)*LMUL for the indices in vs1 */
-                              let vs1_new : vector('n, dec, bits(16)) = read_vreg(num_elem, 16, (lmul * 16.0 / to_real(vsew_bits)), vs1);
+                              let vs1_new : vector('n, dec, bits(16)) = read_vreg(num_elem, 16, 4 + LMUL_pow - SEW_pow, vs1);
                               let idx = unsigned(vs1_new[i]);
-                              vlmax = floor(lmul * (to_real(get_vlen()) / to_real(vsew_bits)));
-                              if idx < vlmax then {
+                              VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
+                              if idx < VLMAX then {
                                 assert(idx < 'n); 
                                 vs2_val[idx]
                               } else zeros()                   
@@ -134,7 +135,7 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
     }
   };
 
-  write_vreg(num_elem, vsew_bits, lmul, vd, result);
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   vstart = EXTZ(0b0);
   RETIRE_SUCCESS
 }
@@ -182,23 +183,24 @@ mapping clause encdec = VXSG(funct6, vm, vs2, rs1, vd)
   <-> encdec_vxsgfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111
 
 function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
-  let vsew_bits : int  = get_vtype_vsew();
-  let lmul      : real = get_vtype_LMUL();
-  let num_elem  : int  = get_num_elem(lmul, vsew_bits);
+  let SEW_pow  : int = get_sew_pow();
+  let SEW      : int = int_power(2, SEW_pow);
+  let LMUL_pow : int = get_lmul_pow();
+  let VLEN_pow : int = get_vlen_pow();
+  let num_elem : int = get_num_elem(LMUL_pow, SEW);
 
-  assert(8 <= vsew_bits & vsew_bits <= 64);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(8 <= SEW & SEW <= 64);
   let 'n = num_elem;
-  let 'm = vsew_bits;
+  let 'm = SEW;
 
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
   let rs1_val : int                       = unsigned(X(rs1));
-  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vs2);
-  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vd);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   result      : vector('n, dec, bits('m)) = undefined;
   mask_helper : vector('n, dec, bool)     = undefined;
 
-  (result, mask_helper) = init_masked_result(num_elem, vsew_bits, lmul, vd_val, vm_val);
+  (result, mask_helper) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask_helper[i] == true then {
@@ -210,8 +212,8 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
                           },
         VX_VSLIDEDOWN  => {
                             assert(i + rs1_val >= 0);
-                            vlmax = floor(lmul * to_real(get_vlen()) / to_real(vsew_bits));
-                            if i + rs1_val < vlmax then {
+                            VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
+                            if i + rs1_val < VLMAX then {
                               assert(i + rs1_val < 'n); 
                               vs2_val[i + rs1_val]
                             } else zeros()
@@ -219,8 +221,8 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
         VX_VRGATHER    => {
                             assert(vs2 != vd);
                             assert(rs1_val >= 0);
-                            vlmax = floor(lmul * to_real(get_vlen()) / to_real(vsew_bits));
-                            if rs1_val < vlmax then {
+                            VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
+                            if rs1_val < VLMAX then {
                               assert(rs1_val < 'n); 
                               vs2_val[rs1_val]
                             } else zeros() 
@@ -229,7 +231,7 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
     }
   };
 
-  write_vreg(num_elem, vsew_bits, lmul, vd, result);
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   vstart = EXTZ(0b0);
   RETIRE_SUCCESS
 } 
@@ -259,23 +261,24 @@ mapping clause encdec = VISG(funct6, vm, vs2, simm, vd)
   <-> encdec_visgfunct6(funct6) @ vm @ vs2 @ simm @ 0b011 @ vd @ 0b1010111
 
 function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
-  let vsew_bits : int  = get_vtype_vsew();
-  let lmul      : real = get_vtype_LMUL();
-  let num_elem  : int  = get_num_elem(lmul, vsew_bits);
+  let SEW_pow  : int = get_sew_pow();
+  let SEW      : int = int_power(2, SEW_pow);
+  let LMUL_pow : int = get_lmul_pow();
+  let VLEN_pow : int = get_vlen_pow();
+  let num_elem : int = get_num_elem(LMUL_pow, SEW);
 
-  assert(8 <= vsew_bits & vsew_bits <= 64);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(8 <= SEW & SEW <= 64);
   let 'n = num_elem;
-  let 'm = vsew_bits;
+  let 'm = SEW;
 
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
   let imm_val : int                       = unsigned(EXTZ(sizeof(xlen), simm));
-  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vs2);
-  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vd);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   result      : vector('n, dec, bits('m)) = undefined;
   mask_helper : vector('n, dec, bool)     = undefined;
 
-  (result, mask_helper) = init_masked_result(num_elem, vsew_bits, lmul, vd_val, vm_val);
+  (result, mask_helper) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask_helper[i] == true then {
@@ -287,8 +290,8 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
                           },
         VI_VSLIDEDOWN  => {
                             assert(i + imm_val >= 0);
-                            vlmax = floor(lmul * to_real(get_vlen()) / to_real(vsew_bits));
-                            if i + imm_val < vlmax then {
+                            VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
+                            if i + imm_val < VLMAX then {
                               assert(i + imm_val < 'n); 
                               vs2_val[i + imm_val]
                             } else zeros()
@@ -296,8 +299,8 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
         VI_VRGATHER    => {
                             assert(vs2 != vd);
                             assert(imm_val >= 0);
-                            vlmax = floor(lmul * to_real(get_vlen()) / to_real(vsew_bits));
-                            if imm_val < vlmax then {
+                            VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
+                            if imm_val < VLMAX then {
                               assert(imm_val < 'n); 
                               vs2_val[imm_val]
                             } else zeros() 
@@ -306,7 +309,7 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
     }
   };
 
-  write_vreg(num_elem, vsew_bits, lmul, vd, result);
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   vstart = EXTZ(0b0);
   RETIRE_SUCCESS
 } 
@@ -329,18 +332,19 @@ mapping clause encdec = VMVRTYPE(vs2, simm, vd)
   <-> 0b100111 @ 0b1 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111
 
 function clause execute(VMVRTYPE(vs2, simm, vd)) = {
-  let vsew_bits : int = get_vtype_vsew();
-  let imm_val   : int = unsigned(EXTZ(sizeof(xlen), simm));
-  let lmul      : int = imm_val + 1;
+  let SEW     : int = int_power(2, get_sew_pow());
+  let imm_val : int = unsigned(EXTZ(sizeof(xlen), simm));
+  let EMUL    : int = imm_val + 1;
 
-  assert(8 <= vsew_bits & vsew_bits <= 64);
-  assert(lmul == 1 | lmul == 2 | lmul == 4 | lmul == 8);
-  let num_elem  : int = get_num_elem(to_real(lmul), vsew_bits);
+  assert(8 <= SEW & SEW <= 64);
+  assert(EMUL == 1 | EMUL == 2 | EMUL == 4 | EMUL == 8);
+  let EMUL_pow : int = log2(EMUL);
+  let num_elem : int = get_num_elem(EMUL_pow, SEW);
   let 'n = num_elem;
-  let 'm = vsew_bits;
+  let 'm = SEW;
 
-  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, to_real(lmul), vs2);
-  write_vreg(num_elem, vsew_bits, to_real(lmul), vd, vs2_val);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, EMUL_pow, vs2);
+  write_vreg(num_elem, SEW, EMUL_pow, vd, vs2_val);
   vstart = EXTZ(0b0);
 
   RETIRE_SUCCESS
@@ -365,17 +369,17 @@ mapping clause encdec = VMVXS(vs2, rd)
   <-> 0b010000 @ 0b1 @ vs2 @ 0b00000 @ 0b010 @ rd @ 0b1010111
 
 function clause execute(VMVXS(vs2, rd)) = {
-  let vsew_bits : int = get_vtype_vsew();
-  let num_elem  : int = get_num_elem(1.0, vsew_bits);
+  let SEW      : int = int_power(2, get_sew_pow());
+  let num_elem : int = get_num_elem(0, SEW);
 
-  assert(8 <= vsew_bits & vsew_bits <= 64);
-  assert(0 < num_elem & num_elem <= get_vlen());
+  assert(8 <= SEW & SEW <= 64);
+  assert(num_elem > 0);
   let 'n = num_elem;
-  let 'm = vsew_bits;
+  let 'm = SEW;
 
-  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, 1.0, vs2);
-  if sizeof(xlen) < vsew_bits then X(rd) = slice(vs2_val[0], 0, sizeof(xlen))
-  else if sizeof(xlen) > vsew_bits then X(rd) = sail_sign_extend(vs2_val[0], sizeof(xlen))
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, 0, vs2);
+  if sizeof(xlen) < SEW then X(rd) = slice(vs2_val[0], 0, sizeof(xlen))
+  else if sizeof(xlen) > SEW then X(rd) = EXTS(vs2_val[0])
   else X(rd) = vs2_val[0];
   vstart = EXTZ(0b0);
 
@@ -394,21 +398,21 @@ mapping clause encdec = VMVSX(rs1, vd)
   <-> 0b010000 @ 0b1 @ 0b00000 @ rs1 @ 0b110 @ vd @ 0b1010111
 
 function clause execute(VMVSX(rs1, vd)) = {
-  let vsew_bits : int  = get_vtype_vsew();
-  let num_elem  : int  = get_num_elem(1.0, vsew_bits);
+  let SEW      : int = int_power(2, get_sew_pow());
+  let num_elem : int = get_num_elem(0, SEW);
 
-  assert(8 <= vsew_bits & vsew_bits <= 64);
-  assert(0 < num_elem & num_elem <= get_vlen());
+  assert(8 <= SEW & SEW <= 64);
+  assert(num_elem > 0);
   let 'n = num_elem;
-  let 'm = vsew_bits;
+  let 'm = SEW;
 
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
   let rs1_val = get_scalar(rs1, 'm);
-  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, 1.0, vd);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
   result      : vector('n, dec, bits('m)) = undefined;
   mask_helper : vector('n, dec, bool)     = undefined;
 
-  (result, mask_helper) = init_masked_result(num_elem, vsew_bits, 1.0, vd_val, vm_val);
+  (result, mask_helper) = init_masked_result(num_elem, SEW, 0, vd_val, vm_val);
 
   /* one body element */
   if mask_helper[0] == true then result[0] = rs1_val;
@@ -422,7 +426,7 @@ function clause execute(VMVSX(rs1, vd)) = {
     foreach (i from 1 to (num_elem - 1)) result[i] = vd_val[i]
   };
 
-  write_vreg(num_elem, vsew_bits, 1.0, vd, result);
+  write_vreg(num_elem, SEW, 0, vd, result);
   vstart = EXTZ(0b0);
 
   RETIRE_SUCCESS
@@ -440,29 +444,28 @@ mapping clause encdec = MOVETYPEV (vs1, vd)
   <-> 0b010111 @ 0b1 @ 0b00000 @ vs1 @ 0b000 @ vd @ 0b1010111
 
 function clause execute(MOVETYPEV(vs1, vd)) = {
-  let vsew_bits : int  = get_vtype_vsew();
-  let lmul      : real = get_vtype_LMUL();
-  let num_elem  : int  = get_num_elem(lmul, vsew_bits);
+  let SEW      : int = int_power(2, get_sew_pow());
+  let LMUL_pow : int = get_lmul_pow();
+  let num_elem : int = get_num_elem(LMUL_pow, SEW);
 
-  assert(8 <= vsew_bits & vsew_bits <= 64);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(8 <= SEW & SEW <= 64);
   let 'n = num_elem;
-  let 'm = vsew_bits;
+  let 'm = SEW;
 
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
-  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vs1);
-  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vd);
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   result      : vector('n, dec, bits('m)) = undefined;
   mask_helper : vector('n, dec, bool)     = undefined;
 
-  (result, mask_helper) = init_masked_result(num_elem, vsew_bits, lmul, vd_val, vm_val);
+  (result, mask_helper) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   foreach (i from 0 to (num_elem - 1)){
     if mask_helper[i] == true then{
       result[i] = vs1_val[i]
     }
   };
 
-  write_vreg(num_elem, vsew_bits, lmul, vd, result);
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   vstart = EXTZ(0b0);
 
   RETIRE_SUCCESS
@@ -480,29 +483,28 @@ mapping clause encdec = MOVETYPEX (rs1, vd)
   <-> 0b010111 @ 0b1 @ 0b00000 @ rs1 @ 0b100 @ vd @ 0b1010111
 
 function clause execute(MOVETYPEX(rs1, vd)) = {
-  let vsew_bits : int  = get_vtype_vsew();
-  let lmul      : real = get_vtype_LMUL();
-  let num_elem  : int  = get_num_elem(lmul, vsew_bits);
+  let SEW      : int = int_power(2, get_sew_pow());
+  let LMUL_pow : int = get_lmul_pow();
+  let num_elem : int = get_num_elem(LMUL_pow, SEW);
 
-  assert(8 <= vsew_bits & vsew_bits <= 64);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(8 <= SEW & SEW <= 64);
   let 'n = num_elem;
-  let 'm = vsew_bits;
+  let 'm = SEW;
 
-  let rs1_val = get_scalar(rs1, vsew_bits);
+  let rs1_val = get_scalar(rs1, 'm);
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
-  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vd);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   result      : vector('n, dec, bits('m)) = undefined;
   mask_helper : vector('n, dec, bool)     = undefined;
 
-  (result, mask_helper) = init_masked_result(num_elem, vsew_bits, lmul, vd_val, vm_val);
+  (result, mask_helper) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   foreach (i from 0 to (num_elem - 1)){
     if mask_helper[i] == true then{
       result[i] = rs1_val
     }
   };
 
-  write_vreg(num_elem, vsew_bits, lmul, vd, result);
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   vstart = EXTZ(0b0);
 
   RETIRE_SUCCESS
@@ -520,29 +522,28 @@ mapping clause encdec = MOVETYPEI (vd, simm)
   <-> 0b010111 @ 0b1 @ 0b00000 @ simm @ 0b011 @ vd @ 0b1010111
 
 function clause execute(MOVETYPEI(vd, simm)) = {
-  let vsew_bits : int = get_vtype_vsew();
-  let lmul      : real = get_vtype_LMUL();
-  let num_elem  : int = get_num_elem(lmul, vsew_bits);
+  let SEW      : int = int_power(2, get_sew_pow());
+  let LMUL_pow : int = get_lmul_pow();
+  let num_elem : int = get_num_elem(LMUL_pow, SEW);
 
-  assert(8 <= vsew_bits & vsew_bits <= 64);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(8 <= SEW & SEW <= 64);
   let 'n = num_elem;
-  let 'm = vsew_bits;
+  let 'm = SEW;
 
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
-  let imm_val = sail_sign_extend(simm, vsew_bits);
-  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, vsew_bits, lmul, vd);
+  let imm_val = sail_sign_extend(simm, SEW);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   result      : vector('n, dec, bits('m)) = undefined;
   mask_helper : vector('n, dec, bool)     = undefined;
 
-  (result, mask_helper) = init_masked_result(num_elem, vsew_bits, lmul, vd_val, vm_val);
+  (result, mask_helper) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   foreach (i from 0 to (num_elem - 1)){
     if mask_helper[i] == true then{
       result[i] = imm_val
     }
   };
 
-  write_vreg(num_elem, vsew_bits, lmul, vd, result);
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   vstart = EXTZ(0b0);
 
   RETIRE_SUCCESS

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -32,8 +32,8 @@ mapping encdec_vvfunct6 : vvfunct6 <-> bits(6) = {
   VV_VSSRA         <-> 0b101011
 }
 
-mapping clause encdec = VVTYPE(funct6, vm, vs2, vs1, vd)
-  <-> encdec_vvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111
+mapping clause encdec = VVTYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_vvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if haveRVV()
 
 function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW_pow  = get_sew_pow();
@@ -165,8 +165,8 @@ mapping encdec_vxsgfunct6 : vxsgfunct6 <-> bits(6) = {
   VX_VRGATHER     <-> 0b001100
 }
 
-mapping clause encdec = VXSG(funct6, vm, vs2, rs1, vd)
-  <-> encdec_vxsgfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111
+mapping clause encdec = VXSG(funct6, vm, vs2, rs1, vd) if haveRVV()
+  <-> encdec_vxsgfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if haveRVV()
 
 function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let SEW_pow  = get_sew_pow();
@@ -233,8 +233,8 @@ mapping encdec_visgfunct6 : visgfunct6 <-> bits(6) = {
   VI_VRGATHER     <-> 0b001100
 }
 
-mapping clause encdec = VISG(funct6, vm, vs2, simm, vd)
-  <-> encdec_visgfunct6(funct6) @ vm @ vs2 @ simm @ 0b011 @ vd @ 0b1010111
+mapping clause encdec = VISG(funct6, vm, vs2, simm, vd) if haveRVV()
+  <-> encdec_visgfunct6(funct6) @ vm @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if haveRVV()
 
 function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let SEW_pow  = get_sew_pow();
@@ -294,8 +294,8 @@ mapping clause assembly = VISG(funct6, vm, vs2, simm, vd)
 /* ********************* Whole Vector Register Move (OPIVI) ********************** */
 union clause ast = VMVRTYPE : (regidx, bits(5), regidx)
 
-mapping clause encdec = VMVRTYPE(vs2, simm, vd)
-  <-> 0b100111 @ 0b1 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111
+mapping clause encdec = VMVRTYPE(vs2, simm, vd) if haveRVV()
+  <-> 0b100111 @ 0b1 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if haveRVV()
 
 function clause execute(VMVRTYPE(vs2, simm, vd)) = {
   let SEW     = get_sew();
@@ -328,8 +328,8 @@ mapping clause assembly = VMVRTYPE(vs2, simm, vd)
 /* ****************************** OPMVV (VWXUNARY0) ****************************** */
 union clause ast = VMVXS : (regidx, regidx)
 
-mapping clause encdec = VMVXS(vs2, rd)
-  <-> 0b010000 @ 0b1 @ vs2 @ 0b00000 @ 0b010 @ rd @ 0b1010111
+mapping clause encdec = VMVXS(vs2, rd) if haveRVV()
+  <-> 0b010000 @ 0b1 @ vs2 @ 0b00000 @ 0b010 @ rd @ 0b1010111 if haveRVV()
 
 function clause execute(VMVXS(vs2, rd)) = {
   let SEW      = get_sew();
@@ -340,9 +340,9 @@ function clause execute(VMVXS(vs2, rd)) = {
   let 'm = SEW;
 
   let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, 0, vs2);
-  if sizeof(xlen) < SEW then X(rd) = slice(vs2_val[0], 0, sizeof(xlen))
-  else if sizeof(xlen) > SEW then X(rd) = EXTS(vs2_val[0])
-  else X(rd) = vs2_val[0];
+  X(rd) = if sizeof(xlen) < SEW then slice(vs2_val[0], 0, sizeof(xlen))
+          else if sizeof(xlen) > SEW then EXTS(vs2_val[0])
+          else vs2_val[0];
   vstart = EXTZ(0b0);
 
   RETIRE_SUCCESS
@@ -354,8 +354,8 @@ mapping clause assembly = VMVXS(vs2, rd)
 /* ****************************** OPMVX (VRXUNARY0) ****************************** */
 union clause ast = VMVSX : (regidx, regidx)
 
-mapping clause encdec = VMVSX(rs1, vd)
-  <-> 0b010000 @ 0b1 @ 0b00000 @ rs1 @ 0b110 @ vd @ 0b1010111
+mapping clause encdec = VMVSX(rs1, vd) if haveRVV()
+  <-> 0b010000 @ 0b1 @ 0b00000 @ rs1 @ 0b110 @ vd @ 0b1010111 if haveRVV()
 
 function clause execute(VMVSX(rs1, vd)) = {
   let SEW      = get_sew();
@@ -381,7 +381,7 @@ function clause execute(VMVSX(rs1, vd)) = {
   if tail_ag == UNDISTURBED then {
     foreach (i from 1 to (num_elem - 1)) result[i] = vd_val[i]
   } else if tail_ag == AGNOSTIC then {
-    foreach (i from 1 to (num_elem - 1)) result[i] = vd_val[i]
+    foreach (i from 1 to (num_elem - 1)) result[i] = vd_val[i] /* TODO: configuration support */
   };
 
   write_vreg(num_elem, SEW, 0, vd, result);
@@ -396,8 +396,8 @@ mapping clause assembly = VMVSX(rs1, vd)
 /* ********************** Integer Move Instruction (OPIVV) *********************** */
 union clause ast = MOVETYPEV : (regidx, regidx)
 
-mapping clause encdec = MOVETYPEV (vs1, vd)
-  <-> 0b010111 @ 0b1 @ 0b00000 @ vs1 @ 0b000 @ vd @ 0b1010111
+mapping clause encdec = MOVETYPEV (vs1, vd) if haveRVV()
+  <-> 0b010111 @ 0b1 @ 0b00000 @ vs1 @ 0b000 @ vd @ 0b1010111 if haveRVV()
 
 function clause execute(MOVETYPEV(vs1, vd)) = {
   let SEW      = get_sew();
@@ -430,8 +430,8 @@ mapping clause assembly = MOVETYPEV(vs1, vd)
 /* ********************** Integer Move Instruction (OPIVX) *********************** */
 union clause ast = MOVETYPEX : (regidx, regidx)
 
-mapping clause encdec = MOVETYPEX (rs1, vd)
-  <-> 0b010111 @ 0b1 @ 0b00000 @ rs1 @ 0b100 @ vd @ 0b1010111
+mapping clause encdec = MOVETYPEX (rs1, vd) if haveRVV()
+  <-> 0b010111 @ 0b1 @ 0b00000 @ rs1 @ 0b100 @ vd @ 0b1010111 if haveRVV()
 
 function clause execute(MOVETYPEX(rs1, vd)) = {
   let SEW      = get_sew();
@@ -464,8 +464,8 @@ mapping clause assembly = MOVETYPEX(rs1, vd)
 /* ********************** Integer Move Instruction (OPIVI) *********************** */
 union clause ast = MOVETYPEI : (regidx, bits(5))
 
-mapping clause encdec = MOVETYPEI (vd, simm)
-  <-> 0b010111 @ 0b1 @ 0b00000 @ simm @ 0b011 @ vd @ 0b1010111
+mapping clause encdec = MOVETYPEI (vd, simm) if haveRVV()
+  <-> 0b010111 @ 0b1 @ 0b00000 @ simm @ 0b011 @ vd @ 0b1010111 if haveRVV()
 
 function clause execute(MOVETYPEI(vd, simm)) = {
   let SEW      = get_sew();

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -1,13 +1,11 @@
 /* ******************************************************************************* */
 /* This file implements part of the vector extension.                              */
-/* Chapter 11: vector integer arithmetic instructions                              */
-/* Chapter 12: vector fixed-point arithmetic instructions                          */
-/* Chapter 16: vector permutation instructions                                     */
-
+/* Chapter 11: Vector Integer Arithmetic Instructions                              */
+/* Chapter 12: Vector Fixed-Point Arithmetic Instructions                          */
+/* Chapter 16: Vector Permutation Instructions                                     */
 /* ******************************************************************************* */
 
-/* **************************OPIVV(VVTYPE)**************************************** */
-
+/* ******************************* OPIVV (VVTYPE) ******************************** */
 union clause ast = VVTYPE : (vvfunct6, bits(1), regidx, regidx, regidx)
 
 mapping encdec_vvfunct6 : vvfunct6 <-> bits(6) = {
@@ -38,13 +36,12 @@ mapping clause encdec = VVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_vvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111
 
 function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
-  let SEW_pow  : int = get_sew_pow();
-  let SEW      : int = int_power(2, SEW_pow);
-  let LMUL_pow : int = get_lmul_pow();
-  let VLEN_pow : int = get_vlen_pow();
-  let num_elem : int = get_num_elem(LMUL_pow, SEW);
+  let SEW_pow  = get_sew_pow();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let VLEN_pow = get_vlen_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  assert(SEW == 8 | SEW == 16 | SEW == 32 | SEW == 64);
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -53,12 +50,12 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   result      : vector('n, dec, bits('m)) = undefined;
-  mask_helper : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
 
-  (result, mask_helper) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
-    if mask_helper[i] == true then {
+    if mask[i] then {
       result[i] = match funct6 {
         VV_VADD          => vs2_val[i] + vs1_val[i],
         VV_VSUB          => vs2_val[i] - vs1_val[i],
@@ -158,10 +155,8 @@ mapping vvtype_mnemonic : vvfunct6 <-> string = {
 mapping clause assembly = VVTYPE(funct6, vm, vs2, vs1, vd)
   <-> vvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
-
-/* *******************************OPIVX(Vector Slide & Gather Instructions)******************************** */
-/* Slide and gather instructions extend rs1 / imm to XLEN bits (not SEW bits as others do) */
-
+/* ***************** OPIVX (Vector Slide & Gather Instructions) ****************** */
+/* Slide and gather instructions extend rs1/imm to XLEN intead of SEW bits */
 union clause ast = VXSG : (vxsgfunct6, bits(1), regidx, regidx, regidx)
 
 mapping encdec_vxsgfunct6 : vxsgfunct6 <-> bits(6) = {
@@ -174,13 +169,12 @@ mapping clause encdec = VXSG(funct6, vm, vs2, rs1, vd)
   <-> encdec_vxsgfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111
 
 function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
-  let SEW_pow  : int = get_sew_pow();
-  let SEW      : int = int_power(2, SEW_pow);
-  let LMUL_pow : int = get_lmul_pow();
-  let VLEN_pow : int = get_vlen_pow();
-  let num_elem : int = get_num_elem(LMUL_pow, SEW);
+  let SEW_pow  = get_sew_pow();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let VLEN_pow = get_vlen_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  assert(8 <= SEW & SEW <= 64);
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -189,12 +183,12 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   result      : vector('n, dec, bits('m)) = undefined;
-  mask_helper : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
 
-  (result, mask_helper) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
-    if mask_helper[i] == true then {
+    if mask[i] then {
       result[i] = match funct6 {
         VX_VSLIDEUP    => {
                             assert(vs2 != vd);
@@ -229,10 +223,8 @@ mapping vxsg_mnemonic : vxsgfunct6 <-> string = {
 mapping clause assembly = VXSG(funct6, vm, vs2, rs1, vd)
   <-> vxsg_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
 
-
-/* *******************************OPIVI(Vector Slide & Gather Instructions)******************************** */
-/* Slide and gather instructions extend rs1 / imm to XLEN bits (not SEW bits as others do) */
-
+/* ***************** OPIVI (Vector Slide & Gather Instructions) ****************** */
+/* Slide and gather instructions extend rs1/imm to XLEN intead of SEW bits */
 union clause ast = VISG : (visgfunct6, bits(1), regidx, bits(5), regidx)
 
 mapping encdec_visgfunct6 : visgfunct6 <-> bits(6) = {
@@ -245,13 +237,12 @@ mapping clause encdec = VISG(funct6, vm, vs2, simm, vd)
   <-> encdec_visgfunct6(funct6) @ vm @ vs2 @ simm @ 0b011 @ vd @ 0b1010111
 
 function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
-  let SEW_pow  : int = get_sew_pow();
-  let SEW      : int = int_power(2, SEW_pow);
-  let LMUL_pow : int = get_lmul_pow();
-  let VLEN_pow : int = get_vlen_pow();
-  let num_elem : int = get_num_elem(LMUL_pow, SEW);
+  let SEW_pow  = get_sew_pow();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let VLEN_pow = get_vlen_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  assert(8 <= SEW & SEW <= 64);
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -260,12 +251,12 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   result      : vector('n, dec, bits('m)) = undefined;
-  mask_helper : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
 
-  (result, mask_helper) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
-    if mask_helper[i] == true then {
+    if mask[i] then {
       result[i] = match funct6 {
         VI_VSLIDEUP    => {
                             assert(vs2 != vd);
@@ -300,23 +291,20 @@ mapping visg_mnemonic : visgfunct6 <-> string = {
 mapping clause assembly = VISG(funct6, vm, vs2, simm, vd)
   <-> visg_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(simm) ^ maybe_vmask(vm)
 
-
-/* ******************************Whole Vector Register Move(OPIVI)******************************** */
-
+/* ********************* Whole Vector Register Move (OPIVI) ********************** */
 union clause ast = VMVRTYPE : (regidx, bits(5), regidx)
 
 mapping clause encdec = VMVRTYPE(vs2, simm, vd)
   <-> 0b100111 @ 0b1 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111
 
 function clause execute(VMVRTYPE(vs2, simm, vd)) = {
-  let SEW     : int = int_power(2, get_sew_pow());
-  let imm_val : int = unsigned(EXTZ(sizeof(xlen), simm));
-  let EMUL    : int = imm_val + 1;
+  let SEW     = get_sew();
+  let imm_val = unsigned(EXTZ(sizeof(xlen), simm));
+  let EMUL    = imm_val + 1;
 
-  assert(8 <= SEW & SEW <= 64);
   assert(EMUL == 1 | EMUL == 2 | EMUL == 4 | EMUL == 8);
-  let EMUL_pow : int = log2(EMUL);
-  let num_elem : int = get_num_elem(EMUL_pow, SEW);
+  let EMUL_pow = log2(EMUL);
+  let num_elem = get_num_elem(EMUL_pow, SEW);
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -337,19 +325,16 @@ mapping simm_string : bits(5) <-> string = {
 mapping clause assembly = VMVRTYPE(vs2, simm, vd)
   <-> "vmv" ^ simm_string(simm) ^ "r.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)
 
-
-/* *******************************OPMVV(VWXUNARY0)******************************** */
-
+/* ****************************** OPMVV (VWXUNARY0) ****************************** */
 union clause ast = VMVXS : (regidx, regidx)
 
 mapping clause encdec = VMVXS(vs2, rd)
   <-> 0b010000 @ 0b1 @ vs2 @ 0b00000 @ 0b010 @ rd @ 0b1010111
 
 function clause execute(VMVXS(vs2, rd)) = {
-  let SEW      : int = int_power(2, get_sew_pow());
-  let num_elem : int = get_num_elem(0, SEW);
+  let SEW      = get_sew();
+  let num_elem = get_num_elem(0, SEW);
 
-  assert(8 <= SEW & SEW <= 64);
   assert(num_elem > 0);
   let 'n = num_elem;
   let 'm = SEW;
@@ -366,40 +351,36 @@ function clause execute(VMVXS(vs2, rd)) = {
 mapping clause assembly = VMVXS(vs2, rd)
   <-> "vmv.x.s" ^ spc() ^ reg_name(rd) ^ sep() ^ vreg_name(vs2)
 
-
-/* *******************************OPMVX(VRXUNARY0)******************************** */
-
+/* ****************************** OPMVX (VRXUNARY0) ****************************** */
 union clause ast = VMVSX : (regidx, regidx)
 
 mapping clause encdec = VMVSX(rs1, vd)
   <-> 0b010000 @ 0b1 @ 0b00000 @ rs1 @ 0b110 @ vd @ 0b1010111
 
 function clause execute(VMVSX(rs1, vd)) = {
-  let SEW      : int = int_power(2, get_sew_pow());
-  let num_elem : int = get_num_elem(0, SEW);
+  let SEW      = get_sew();
+  let num_elem = get_num_elem(0, SEW);
 
-  assert(8 <= SEW & SEW <= 64);
   assert(num_elem > 0);
   let 'n = num_elem;
   let 'm = SEW;
 
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
-  let rs1_val = get_scalar(rs1, 'm);
+  let rs1_val : bits('m)                  = get_scalar(rs1, 'm);
   let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
   result      : vector('n, dec, bits('m)) = undefined;
-  mask_helper : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
 
-  (result, mask_helper) = init_masked_result(num_elem, SEW, 0, vd_val, vm_val);
+  (result, mask) = init_masked_result(num_elem, SEW, 0, vd_val, vm_val);
 
   /* one body element */
-  if mask_helper[0] == true then result[0] = rs1_val;
+  if mask[0] == true then result[0] = rs1_val;
 
   /* others treated as tail elements */
   let tail_ag : agtype = get_vtype_vta();
   if tail_ag == UNDISTURBED then {
     foreach (i from 1 to (num_elem - 1)) result[i] = vd_val[i]
-  }
-  else if tail_ag == AGNOSTIC then {
+  } else if tail_ag == AGNOSTIC then {
     foreach (i from 1 to (num_elem - 1)) result[i] = vd_val[i]
   };
 
@@ -412,20 +393,17 @@ function clause execute(VMVSX(rs1, vd)) = {
 mapping clause assembly = VMVSX(rs1, vd)
   <-> "vmv.s.x" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)
 
-
-/* **************************Integer move instruction(OPIVV)*************************************** */
-
+/* ********************** Integer Move Instruction (OPIVV) *********************** */
 union clause ast = MOVETYPEV : (regidx, regidx)
 
 mapping clause encdec = MOVETYPEV (vs1, vd)
   <-> 0b010111 @ 0b1 @ 0b00000 @ vs1 @ 0b000 @ vd @ 0b1010111
 
 function clause execute(MOVETYPEV(vs1, vd)) = {
-  let SEW      : int = int_power(2, get_sew_pow());
-  let LMUL_pow : int = get_lmul_pow();
-  let num_elem : int = get_num_elem(LMUL_pow, SEW);
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  assert(8 <= SEW & SEW <= 64);
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -433,13 +411,11 @@ function clause execute(MOVETYPEV(vs1, vd)) = {
   let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   result      : vector('n, dec, bits('m)) = undefined;
-  mask_helper : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
 
-  (result, mask_helper) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
-  foreach (i from 0 to (num_elem - 1)){
-    if mask_helper[i] == true then{
-      result[i] = vs1_val[i]
-    }
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then result[i] = vs1_val[i]
   };
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
@@ -449,36 +425,31 @@ function clause execute(MOVETYPEV(vs1, vd)) = {
 }
 
 mapping clause assembly = MOVETYPEV(vs1, vd)
-<-> "vmv.v.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1)
+  <-> "vmv.v.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1)
 
-
-/* **************************Integer move instruction(OPIVX)*************************************** */
-
+/* ********************** Integer Move Instruction (OPIVX) *********************** */
 union clause ast = MOVETYPEX : (regidx, regidx)
 
 mapping clause encdec = MOVETYPEX (rs1, vd)
   <-> 0b010111 @ 0b1 @ 0b00000 @ rs1 @ 0b100 @ vd @ 0b1010111
 
 function clause execute(MOVETYPEX(rs1, vd)) = {
-  let SEW      : int = int_power(2, get_sew_pow());
-  let LMUL_pow : int = get_lmul_pow();
-  let num_elem : int = get_num_elem(LMUL_pow, SEW);
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  assert(8 <= SEW & SEW <= 64);
   let 'n = num_elem;
   let 'm = SEW;
 
-  let rs1_val = get_scalar(rs1, 'm);
+  let rs1_val : bits('m)                  = get_scalar(rs1, 'm);
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
   let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   result      : vector('n, dec, bits('m)) = undefined;
-  mask_helper : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
 
-  (result, mask_helper) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
-  foreach (i from 0 to (num_elem - 1)){
-    if mask_helper[i] == true then{
-      result[i] = rs1_val
-    }
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then result[i] = rs1_val
   };
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
@@ -488,36 +459,31 @@ function clause execute(MOVETYPEX(rs1, vd)) = {
 }
 
 mapping clause assembly = MOVETYPEX(rs1, vd)
-<-> "vmv.v.x" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)   
+  <-> "vmv.v.x" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)
 
-
-/* **************************Integer move instruction(OPIVI)*************************************** */
-
+/* ********************** Integer Move Instruction (OPIVI) *********************** */
 union clause ast = MOVETYPEI : (regidx, bits(5))
 
 mapping clause encdec = MOVETYPEI (vd, simm)
   <-> 0b010111 @ 0b1 @ 0b00000 @ simm @ 0b011 @ vd @ 0b1010111
 
 function clause execute(MOVETYPEI(vd, simm)) = {
-  let SEW      : int = int_power(2, get_sew_pow());
-  let LMUL_pow : int = get_lmul_pow();
-  let num_elem : int = get_num_elem(LMUL_pow, SEW);
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  assert(8 <= SEW & SEW <= 64);
   let 'n = num_elem;
   let 'm = SEW;
 
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
-  let imm_val = sail_sign_extend(simm, SEW);
+  let imm_val : bits('m)                  = EXTS(simm);
   let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   result      : vector('n, dec, bits('m)) = undefined;
-  mask_helper : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
 
-  (result, mask_helper) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
-  foreach (i from 0 to (num_elem - 1)){
-    if mask_helper[i] == true then{
-      result[i] = imm_val
-    }
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then result[i] = imm_val
   };
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
@@ -527,5 +493,4 @@ function clause execute(MOVETYPEI(vd, simm)) = {
 }
 
 mapping clause assembly = MOVETYPEI(vd, simm)
-<-> "vmv.v.i" ^ spc() ^ vreg_name(vd) ^ sep() ^ hex_bits_5(simm)
-
+  <-> "vmv.v.i" ^ spc() ^ vreg_name(vd) ^ sep() ^ hex_bits_5(simm)

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -73,36 +73,31 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
                             },
         VV_VSSUB         => signed_saturation('m, EXTS('m + 1, vs2_val[i]) - EXTS('m + 1, vs1_val[i])),
         VV_VSMUL         => {
-                              result_mul = to_bits('m * 2, signed(vs2_val[i]) * signed(vs1_val[i]));
-                              rounding_incr = get_fixed_rounding_incr(result_mul, 'm - 1);
-                              result_wide = (result_mul >> ('m - 1)) + EXTZ('m * 2, rounding_incr);
+                              let result_mul = to_bits('m * 2, signed(vs2_val[i]) * signed(vs1_val[i]));
+                              let rounding_incr = get_fixed_rounding_incr(result_mul, 'm - 1);
+                              let result_wide = (result_mul >> ('m - 1)) + EXTZ('m * 2, rounding_incr);
                               signed_saturation('m, result_wide['m..0])
                             },
         VV_VSLL          => {
                               let shift_amount = get_shift_amount(vs1_val[i], SEW);
-                              assert(shift_amount >= 0);
                               vs2_val[i] << shift_amount
                             },
         VV_VSRL          => {
                               let shift_amount = get_shift_amount(vs1_val[i], SEW);
-                              assert(shift_amount >= 0);
                               vs2_val[i] >> shift_amount
                             },
         VV_VSRA          => {
                               let shift_amount = get_shift_amount(vs1_val[i], SEW);
-                              assert(shift_amount >= 0);
                               let v_double : bits('m * 2) = EXTS(vs2_val[i]);
                               slice(v_double >> shift_amount, 0, SEW)
                             },
         VV_VSSRL         => {
                               let shift_amount = get_shift_amount(vs1_val[i], SEW);
-                              assert(shift_amount >= 0);
                               let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
                               (vs2_val[i] >> shift_amount) + EXTZ('m, rounding_incr)
                             },
         VV_VSSRA         => {
                               let shift_amount = get_shift_amount(vs1_val[i], SEW);
-                              assert(shift_amount >= 0);
                               let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
                               let v_double : bits('m * 2) = EXTS(vs2_val[i]);
                               slice(v_double >> shift_amount, 0, SEW) + EXTZ('m, rounding_incr)
@@ -114,22 +109,18 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
         VV_VRGATHER      => {
                               assert(vs1 != vd & vs2 != vd);
                               let idx = unsigned(vs1_val[i]);
-                              VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
-                              if idx < VLMAX then {
-                                assert(idx < 'n); 
-                                vs2_val[idx]
-                              } else zeros() 
+                              let VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
+                              assert(VLMAX <= 'n);
+                              if idx < VLMAX then vs2_val[idx] else zeros() 
                             },
         VV_VRGATHEREI16  => {
                               assert(vs1 != vd & vs2 != vd);
                               /* vrgatherei16.vv uses SEW/LMUL for the data in vs2 but EEW=16 and EMUL = (16/SEW)*LMUL for the indices in vs1 */
                               let vs1_new : vector('n, dec, bits(16)) = read_vreg(num_elem, 16, 4 + LMUL_pow - SEW_pow, vs1);
                               let idx = unsigned(vs1_new[i]);
-                              VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
-                              if idx < VLMAX then {
-                                assert(idx < 'n); 
-                                vs2_val[idx]
-                              } else zeros()                   
+                              let VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
+                              assert(VLMAX <= 'n);
+                              if idx < VLMAX then vs2_val[idx] else zeros()                   
                             }
       }
     }
@@ -194,7 +185,7 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let 'm = SEW;
 
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
-  let rs1_val : int                       = unsigned(X(rs1));
+  let rs1_val : nat                       = unsigned(X(rs1));
   let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   result      : vector('n, dec, bits('m)) = undefined;
@@ -207,25 +198,18 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
       result[i] = match funct6 {
         VX_VSLIDEUP    => {
                             assert(vs2 != vd);
-                            assert(i - rs1_val < 'n);
                             if i >= rs1_val then vs2_val[i - rs1_val] else vd_val[i]
                           },
         VX_VSLIDEDOWN  => {
-                            assert(i + rs1_val >= 0);
-                            VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
-                            if i + rs1_val < VLMAX then {
-                              assert(i + rs1_val < 'n); 
-                              vs2_val[i + rs1_val]
-                            } else zeros()
+                            let VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
+                            assert(VLMAX > 0 & VLMAX <= 'n);
+                            if i + rs1_val < VLMAX then vs2_val[i + rs1_val] else zeros()
                           },
         VX_VRGATHER    => {
                             assert(vs2 != vd);
-                            assert(rs1_val >= 0);
-                            VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
-                            if rs1_val < VLMAX then {
-                              assert(rs1_val < 'n); 
-                              vs2_val[rs1_val]
-                            } else zeros() 
+                            let VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
+                            assert(VLMAX > 0 & VLMAX <= 'n);
+                            if rs1_val < VLMAX then vs2_val[rs1_val] else zeros() 
                           }
       }
     }
@@ -272,7 +256,7 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let 'm = SEW;
 
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
-  let imm_val : int                       = unsigned(EXTZ(sizeof(xlen), simm));
+  let imm_val : nat                       = unsigned(EXTZ(sizeof(xlen), simm));
   let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   result      : vector('n, dec, bits('m)) = undefined;
@@ -285,25 +269,18 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
       result[i] = match funct6 {
         VI_VSLIDEUP    => {
                             assert(vs2 != vd);
-                            assert(i - imm_val < 'n);
                             if i >= imm_val then vs2_val[i - imm_val] else vd_val[i]
                           },
         VI_VSLIDEDOWN  => {
-                            assert(i + imm_val >= 0);
-                            VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
-                            if i + imm_val < VLMAX then {
-                              assert(i + imm_val < 'n); 
-                              vs2_val[i + imm_val]
-                            } else zeros()
+                            let VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
+                            assert(VLMAX > 0 & VLMAX <= 'n);
+                            if i + imm_val < VLMAX then vs2_val[i + imm_val] else zeros()
                           },
         VI_VRGATHER    => {
                             assert(vs2 != vd);
-                            assert(imm_val >= 0);
-                            VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
-                            if imm_val < VLMAX then {
-                              assert(imm_val < 'n); 
-                              vs2_val[imm_val]
-                            } else zeros() 
+                            let VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
+                            assert(VLMAX > 0 & VLMAX <= 'n);
+                            if imm_val < VLMAX then vs2_val[imm_val] else zeros() 
                           }
       }
     }

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -1,10 +1,9 @@
 /* ************************************************************************ */
 /* This file implements part of the vector extension.                       */
 /* Chapter 7: vector loads and stores                                       */
-
 /* ************************************************************************ */
 
-mapping nfields_int : bits(3) <-> int = {
+mapping nfields_int : bits(3) <-> {|1, 2, 3, 4, 5, 6, 7, 8|} = {
   0b000     <-> 1,
   0b001     <-> 2,
   0b010     <-> 3,
@@ -40,64 +39,52 @@ mapping encdec_vlewidth : vlewidth <-> bits(3) = {
   VLE64     <-> 0b111
 }
 
-mapping vlewidth_bytesnumber : vlewidth <-> int = {
+mapping vlewidth_bytesnumber : vlewidth <-> {|1, 2, 4, 8|} = {
   VLE8      <-> 1,
   VLE16     <-> 2,
   VLE32     <-> 4,
   VLE64     <-> 8
 }
 
-mapping vlewidth_pow : vlewidth <-> int = {
+mapping vlewidth_pow : vlewidth <-> {|3, 4, 5, 6|} = {
   VLE8      <-> 3,
   VLE16     <-> 4,
   VLE32     <-> 5,
   VLE64     <-> 6
 }
 
-mapping bytes_wordwidth : int <-> word_width = {
+mapping bytes_wordwidth : {|1, 2, 4, 8|} <-> word_width = {
   1 <-> BYTE,
   2 <-> HALF,
   4 <-> WORD,
   8 <-> DOUBLE
 }
 
-/* Vector misaligned checking (used in vload) */
-val vcheck_misaligned : (xlenbits, word_width) -> bool effect {undef}
-function vcheck_misaligned(vaddr : xlenbits, width : word_width) -> bool = {
-  if   plat_enable_misaligned_access() then false
-  else match width {
-    BYTE     => false,
-    HALF     => vaddr[0] == bitone,
-    WORD     => vaddr[0] == bitone | vaddr[1] == bitone,
-    DOUBLE   => vaddr[0] == bitone | vaddr[1] == bitone | vaddr[2] == bitone
-  };
-}
-
-/* *****VLOAD**************VLETYPE(Vector Load Unit-Strided Normal, nf=0, mop=0, lumop=0)*************************** */
+/* ******************** Vector Load Unit-Stride Normal (nf=0, mop=0, lumop=0) ******************** */
 union clause ast = VLETYPE : (bits(1), regidx, vlewidth, regidx)
 
 mapping clause encdec = VLETYPE(vm, rs1, width, vd)
   <-> 0b000 @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vle : forall 'b 'n 'p, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+val process_vle : forall 'b 'n 'p, ('b in {1, 2, 4, 8}) & ('n >= 0). (bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vle (vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vd_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd);
   total : vector('n, dec, bits('b * 8)) = undefined;
-  mask_helper : vector('n, dec, bool) = undefined;
+  mask : vector('n, dec, bool) = undefined;
   status : Retired = RETIRE_SUCCESS;
 
-  (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_val, vm_val);
+  (total, mask) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
-    if mask_helper[i] == true then{
+    if mask[i] then {
       vstart = to_bits(16, i);
       let elem_offset = i * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
         Ext_DataAddr_OK(vaddr) => 
-          if vcheck_misaligned(vaddr, width_type)
+          if check_misaligned(vaddr, width_type)
           then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
           else match translateAddr(vaddr, Read(Data)) {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -118,16 +105,13 @@ function process_vle (vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
 }
 
 function clause execute(VLETYPE(vm, rs1, width, vd)) = {
-  let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let EEW : int = load_width_bytes * 8;
-  let EEW_pow : int = vlewidth_pow(width);
-  let SEW_pow : int = get_sew_pow();
-  let LMUL_pow : int = get_lmul_pow();
-  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
-  let num_elem : int = get_num_elem(EMUL_pow, EEW);
-
-  assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(num_elem >= 0);
+  let load_width_bytes = vlewidth_bytesnumber(width);
+  let EEW = load_width_bytes * 8;
+  let EEW_pow = vlewidth_pow(width);
+  let SEW_pow = get_sew_pow();
+  let LMUL_pow = get_lmul_pow();
+  let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem = get_num_elem(EMUL_pow, EEW);
 
   process_vle(vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -142,33 +126,31 @@ mapping vletype_mnemonic : vlewidth <-> string = {
 mapping clause assembly = VLETYPE(vm, rs1, width, vd)
   <-> vletype_mnemonic(width) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
 
-
-/* *****VSTORE**************VSETYPE(Vector Store Unit-Strided Normal, nf=0, mop=0, sumop=0)*************************** */
-
+/* ******************** Vector Store Unit-Stride Normal (nf=0, mop=0, sumop=0) ******************* */
 union clause ast = VSETYPE : (bits(1), regidx, vlewidth, regidx)
 
 mapping clause encdec = VSETYPE(vm, rs1, width, vs3)
   <-> 0b000 @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
 
-val process_vse : forall 'b 'n 'p, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+val process_vse : forall 'b 'n 'p, ('b in {1, 2, 4, 8}) & ('n >= 0). (bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vse (vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vs3_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vs3);
   total : vector('n, dec, bits('b * 8)) = undefined;
-  mask_helper : vector('n, dec, bool) = undefined;
+  mask : vector('n, dec, bool) = undefined;
   status : Retired = RETIRE_SUCCESS;
 
-  (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vs3_val, vm_val);
+  (total, mask) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vs3_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
     let elem_offset = i * load_width_bytes;
-    if mask_helper[i] == true then {
+    if mask[i] then {
       vstart = to_bits(16, i);
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
         Ext_DataAddr_OK(vaddr) =>
-          if vcheck_misaligned(vaddr, width_type)
+          if check_misaligned(vaddr, width_type)
           then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
           else match translateAddr(vaddr, Write(Data)) {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -196,16 +178,13 @@ function process_vse (vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
 }
 
 function clause execute(VSETYPE(vm, rs1, width, vs3)) = {
-  let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let EEW : int = load_width_bytes * 8;
-  let EEW_pow : int = vlewidth_pow(width);
-  let SEW_pow : int = get_sew_pow();
-  let LMUL_pow : int = get_lmul_pow();
-  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
-  let num_elem : int = get_num_elem(EMUL_pow, EEW);
-
-  assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(num_elem >= 0);
+  let load_width_bytes = vlewidth_bytesnumber(width);
+  let EEW = load_width_bytes * 8;
+  let EEW_pow = vlewidth_pow(width);
+  let SEW_pow = get_sew_pow();
+  let LMUL_pow = get_lmul_pow();
+  let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem = get_num_elem(EMUL_pow, EEW);
 
   process_vse(vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -220,34 +199,32 @@ mapping vsetype_mnemonic : vlewidth <-> string = {
 mapping clause assembly = VSETYPE(vm, rs1, width, vs3)
   <-> vsetype_mnemonic(width) ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
 
-
-/* ****VLOAD************VLSETYPE(Vector Load Strided Normal, nf=0, mop=10)*************************** */
-
+/* ************************** Vector Load Strided Normal (nf=0, mop=10) ************************** */
 union clause ast = VLSETYPE : (bits(1), regidx, regidx, vlewidth, regidx)
 
 mapping clause encdec = VLSETYPE(vm, rs2, rs1, width, vd)
   <-> 0b000 @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vlse : forall 'b 'n 'p, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+val process_vlse : forall 'b 'n 'p, ('b in {1, 2, 4, 8}) & ('n >= 0). (bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vlse (vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vd_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd);
   let rs2_val : int = signed(get_scalar(rs2, sizeof(xlen)));
   total : vector('n, dec, bits('b * 8)) = undefined;
-  mask_helper : vector('n, dec, bool) = undefined;
+  mask : vector('n, dec, bool) = undefined;
   status : Retired = RETIRE_SUCCESS;
 
-  (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_val, vm_val);
+  (total, mask) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
     let elem_offset = i * rs2_val;
-    if mask_helper[i] == true then {
+    if mask[i] then {
       vstart = to_bits(16, i);
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
         Ext_DataAddr_OK(vaddr) => 
-          if vcheck_misaligned(vaddr, width_type)
+          if check_misaligned(vaddr, width_type)
           then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
           else match translateAddr(vaddr, Read(Data)) {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -262,22 +239,19 @@ function process_vlse (vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) =
     }
   };
 
-  if status== RETIRE_SUCCESS then write_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd, total);
+  if status == RETIRE_SUCCESS then write_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd, total);
   vstart = EXTZ(0b0);
   status
 }
 
 function clause execute(VLSETYPE(vm, rs2, rs1, width, vd)) = {
-  let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let EEW : int = load_width_bytes * 8;
-  let EEW_pow : int = vlewidth_pow(width);
-  let SEW_pow : int = get_sew_pow();
-  let LMUL_pow : int = get_lmul_pow();
-  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
-  let num_elem : int = get_num_elem(EMUL_pow, EEW);
-
-  assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(num_elem >= 0);
+  let load_width_bytes = vlewidth_bytesnumber(width);
+  let EEW = load_width_bytes * 8;
+  let EEW_pow = vlewidth_pow(width);
+  let SEW_pow = get_sew_pow();
+  let LMUL_pow = get_lmul_pow();
+  let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem = get_num_elem(EMUL_pow, EEW);
 
   process_vlse(vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
@@ -292,34 +266,32 @@ mapping vlsetype_mnemonic : vlewidth <-> string = {
 mapping clause assembly = VLSETYPE(vm, rs2, rs1, width, vd)
   <-> vlsetype_mnemonic(width) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)^ sep() ^ maybe_vmask(vm)
 
-
-/* *****VSTORE**************VSSETYPE(Vector Store Strided Normal, nf=0, mop=10)*************************** */
-
+/* ************************** Vector Store Strided Normal (nf=0, mop=10) ************************* */
 union clause ast = VSSETYPE : (bits(1), regidx, regidx, vlewidth, regidx)
 
 mapping clause encdec = VSSETYPE(vm, rs2, rs1, width, vs3)
   <-> 0b000 @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
 
-val process_vsse : forall 'b 'n 'p, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+val process_vsse : forall 'b 'n 'p, ('b in {1, 2, 4, 8}) & ('n >= 0). (bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vsse (vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vs3_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vs3);
   let rs2_val : int = signed(get_scalar(rs2, sizeof(xlen)));
   total : vector('n, dec, bits('b * 8)) = undefined;
-  mask_helper : vector('n, dec, bool) = undefined;
+  mask : vector('n, dec, bool) = undefined;
   status : Retired = RETIRE_SUCCESS;
 
-  (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vs3_val, vm_val);
+  (total, mask) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vs3_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
     let elem_offset = i * rs2_val;
-    if mask_helper[i] == true then {
+    if mask[i] then {
       vstart = to_bits(16, i);
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
         Ext_DataAddr_OK(vaddr) =>
-          if vcheck_misaligned(vaddr, width_type)
+          if check_misaligned(vaddr, width_type)
           then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
           else match translateAddr(vaddr, Write(Data)) {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -347,16 +319,13 @@ function process_vsse (vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) 
 }
 
 function clause execute(VSSETYPE(vm, rs2, rs1, width, vs3)) = {
-  let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let EEW : int = load_width_bytes * 8;
-  let EEW_pow : int = vlewidth_pow(width);
-  let SEW_pow : int = get_sew_pow();
-  let LMUL_pow : int = get_lmul_pow();
-  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
-  let num_elem : int = get_num_elem(EMUL_pow, EEW);
-
-  assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(num_elem >= 0);
+  let load_width_bytes = vlewidth_bytesnumber(width);
+  let EEW = load_width_bytes * 8;
+  let EEW_pow = vlewidth_pow(width);
+  let SEW_pow = get_sew_pow();
+  let LMUL_pow = get_lmul_pow();
+  let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem = get_num_elem(EMUL_pow, EEW);
 
   process_vsse(vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
@@ -371,34 +340,32 @@ mapping vssetype_mnemonic : vlewidth <-> string = {
 mapping clause assembly = VSSETYPE(vm, rs2, rs1, width, vs3)
   <-> vssetype_mnemonic(width) ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)^ sep() ^ maybe_vmask(vm)
 
-
-/* *****VLOAD**************VLUXEITYPE(Vector Load Indexed Unordered, nf=0, mop=01)*************************** */
-
+/* ************************ Vector Load Indexed Unordered (nf=0, mop=01) ************************* */
 union clause ast = VLUXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
 
 mapping clause encdec = VLUXEITYPE(vm, vs2, rs1, width, vd)
   <-> 0b000 @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vlxei : forall 'ib 'db 'ip 'dp 'n, (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+val process_vlxei : forall 'ib 'db 'ip 'dp 'n, ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n >= 0). (bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vlxei (vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let width_type : word_width = bytes_wordwidth(EEW_data_bytes);
   let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vd_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd);
   let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
   total : vector('n, dec, bits('db * 8)) = undefined;
-  mask_helper : vector('n, dec, bool) = undefined;
-  (total, mask_helper) = init_masked_result(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd_val, vm_val);
+  mask : vector('n, dec, bool) = undefined;
+  (total, mask) = init_masked_result(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd_val, vm_val);
   status : Retired = RETIRE_SUCCESS;
 
   /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
-    if mask_helper[i] == true then {
+    if mask[i] then {
       vstart = to_bits(16, i);
       let elem_offset = signed(vs2_val[i]);
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
         Ext_DataAddr_OK(vaddr) => 
-          if vcheck_misaligned(vaddr, width_type) then
+          if check_misaligned(vaddr, width_type) then
             { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
           else match translateAddr(vaddr, Read(Data)) {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -419,17 +386,13 @@ function process_vlxei (vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow,
 }
 
 function clause execute(VLUXEITYPE(vm, vs2, rs1, width, vd)) = {
-  let EEW_index_pow : int = vlewidth_pow(width);
-  let EEW_index_bytes : int = vlewidth_bytesnumber(width);
-  let EEW_data_pow : int = get_sew_pow();
-  let EEW_data_bytes : int = int_power(2, EEW_data_pow - 3);
-  let EMUL_data_pow : int = get_lmul_pow();
-  let EMUL_index_pow : int = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
-  let num_elem : int = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
-
-  assert(0 < EEW_index_bytes & EEW_index_bytes <= 8);
-  assert(0 < EEW_data_bytes & EEW_data_bytes <= 8);
-  assert(num_elem >= 0);
+  let EEW_index_pow = vlewidth_pow(width);
+  let EEW_index_bytes = vlewidth_bytesnumber(width);
+  let EEW_data_pow = get_sew_pow();
+  let EEW_data_bytes = get_sew_bytes();
+  let EMUL_data_pow = get_lmul_pow();
+  let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
 
   process_vlxei(vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
@@ -437,26 +400,20 @@ function clause execute(VLUXEITYPE(vm, vs2, rs1, width, vd)) = {
 mapping clause assembly = VLUXEITYPE(vm, vs2, rs1, width, vd)
   <-> "vluxei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
 
-
-/* *****VLOAD**************VLOXEITYPE(Vector Load Indexed Ordered, nf=0, mop=11)*************************** */
-
+/* ************************* Vector Load Indexed Ordered (nf=0, mop=11) ************************** */
 union clause ast = VLOXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
 
 mapping clause encdec = VLOXEITYPE(vm, vs2, rs1, width, vd)
   <-> 0b000 @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
 function clause execute(VLOXEITYPE(vm, vs2, rs1, width, vd)) = {
-  let EEW_index_pow : int = vlewidth_pow(width);
-  let EEW_index_bytes : int = vlewidth_bytesnumber(width);
-  let EEW_data_pow : int = get_sew_pow();
-  let EEW_data_bytes : int = int_power(2, EEW_data_pow - 3);
-  let EMUL_data_pow : int = get_lmul_pow();
-  let EMUL_index_pow : int = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
-  let num_elem : int = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
-
-  assert(0 < EEW_index_bytes & EEW_index_bytes <= 8);
-  assert(0 < EEW_data_bytes & EEW_data_bytes <= 8);
-  assert(num_elem >= 0);
+  let EEW_index_pow = vlewidth_pow(width);
+  let EEW_index_bytes = vlewidth_bytesnumber(width);
+  let EEW_data_pow = get_sew_pow();
+  let EEW_data_bytes = get_sew_bytes();
+  let EMUL_data_pow = get_lmul_pow();
+  let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
 
   process_vlxei(vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
@@ -464,34 +421,32 @@ function clause execute(VLOXEITYPE(vm, vs2, rs1, width, vd)) = {
 mapping clause assembly = VLOXEITYPE(vm, vs2, rs1, width, vd)
   <-> "vloxei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
 
-
-/* *****VSTORE**************VSUXEITYPE(Vector Store Indexed Unordered, nf=0, mop=01)*************************** */
-
+/* ************************ Vector Store Indexed Unordered (nf=0, mop=01) ************************ */
 union clause ast = VSUXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
 
 mapping clause encdec = VSUXEITYPE(vm, vs2, rs1, width, vs3)
   <-> 0b000 @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
 
-val process_vsxei : forall 'ib 'db 'ip 'dp 'n, (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+val process_vsxei : forall 'ib 'db 'ip 'dp 'n, ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n >= 0). (bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vsxei (vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let width_type : word_width = bytes_wordwidth(EEW_data_bytes);
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vs3_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vs3);
   let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
-  total : vector('n, dec, bits('db * 8)) = undefined; /* just used to generate mask_helper */
-  mask_helper : vector('n, dec, bool) = undefined;
-  (total, mask_helper) = init_masked_result(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vs3_val, vm_val);
+  total : vector('n, dec, bits('db * 8)) = undefined; /* just used to generate mask */
+  mask : vector('n, dec, bool) = undefined;
+  (total, mask) = init_masked_result(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vs3_val, vm_val);
   status : Retired = RETIRE_SUCCESS;
 
   /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
-    if mask_helper[i] == true then {
+    if mask[i] then {
       vstart = to_bits(16, i);
       let elem_offset = signed(vs2_val[i]);
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) =>
-            if vcheck_misaligned(vaddr, width_type)
+            if check_misaligned(vaddr, width_type)
             then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
             else match translateAddr(vaddr, Write(Data)) {
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -519,17 +474,13 @@ function process_vsxei (vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow
 }
 
 function clause execute(VSUXEITYPE(vm, vs2, rs1, width, vs3)) = {
-  let EEW_index_pow : int = vlewidth_pow(width);
-  let EEW_index_bytes : int = vlewidth_bytesnumber(width);
-  let EEW_data_pow : int = get_sew_pow();
-  let EEW_data_bytes : int = int_power(2, EEW_data_pow - 3);
-  let EMUL_data_pow : int = get_lmul_pow();
-  let EMUL_index_pow : int = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
-  let num_elem : int = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
-
-  assert(0 < EEW_index_bytes & EEW_index_bytes <= 8);
-  assert(0 < EEW_data_bytes & EEW_data_bytes <= 8);
-  assert(num_elem >= 0);
+  let EEW_index_pow = vlewidth_pow(width);
+  let EEW_index_bytes = vlewidth_bytesnumber(width);
+  let EEW_data_pow = get_sew_pow();
+  let EEW_data_bytes = get_sew_bytes();
+  let EMUL_data_pow = get_lmul_pow();
+  let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
 
   process_vsxei(vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
@@ -537,26 +488,20 @@ function clause execute(VSUXEITYPE(vm, vs2, rs1, width, vs3)) = {
 mapping clause assembly = VSUXEITYPE(vm, vs2, rs1, width, vs3)
   <-> "vsuxei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
 
-
-/* *****VSTORE**************VSOXEITYPE(Vector Store Indexed Ordered, nf=0, mop=11)*************************** */
-
+/* ************************* Vector Store Indexed Ordered (nf=0, mop=11) ************************* */
 union clause ast = VSOXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
 
 mapping clause encdec = VSOXEITYPE(vm, vs2, rs1, width, vs3)
   <-> 0b000 @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
 
 function clause execute(VSOXEITYPE(vm, vs2, rs1, width, vs3)) = {
-  let EEW_index_pow : int = vlewidth_pow(width);
-  let EEW_index_bytes : int = vlewidth_bytesnumber(width);
-  let EEW_data_pow : int = get_sew_pow();
-  let EEW_data_bytes : int = int_power(2, EEW_data_pow - 3);
-  let EMUL_data_pow : int = get_lmul_pow();
-  let EMUL_index_pow : int = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
-  let num_elem : int = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
-
-  assert(0 < EEW_index_bytes & EEW_index_bytes <= 8);
-  assert(0 < EEW_data_bytes & EEW_data_bytes <= 8);
-  assert(num_elem >= 0);
+  let EEW_index_pow = vlewidth_pow(width);
+  let EEW_index_bytes = vlewidth_bytesnumber(width);
+  let EEW_data_pow = get_sew_pow();
+  let EEW_data_bytes = get_sew_bytes();
+  let EMUL_data_pow = get_lmul_pow();
+  let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
 
   process_vsxei(vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
@@ -564,60 +509,52 @@ function clause execute(VSOXEITYPE(vm, vs2, rs1, width, vs3)) = {
 mapping clause assembly = VSOXEITYPE(vm, vs2, rs1, width, vs3)
   <-> "vsoxei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
 
-
-/* *****VLOAD**************VLEFFTYPE(Vector Load Unit-Strided Fault-Only-First, nf=0, mop=0, lumop=10000)*************************** */
-
+/* ************* Vector Load Unit-Stride Fault-Only-First (nf=0, mop=0, lumop=10000) ************* */
 union clause ast = VLEFFTYPE : (bits(1), regidx, vlewidth, regidx)
 
 mapping clause encdec = VLEFFTYPE(vm, rs1, width, vd)
   <-> 0b000 @ 0b0 @ 0b00 @ vm @ 0b10000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vleff : forall 'b 'n 'p, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+val process_vleff : forall 'b 'n 'p, ('b in {1, 2, 4, 8}) & ('n >= 0). (bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vleff (vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vd_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd);
   total : vector('n, dec, bits('b * 8)) = undefined;
-  mask_helper : vector('n, dec, bool) = undefined;
+  mask : vector('n, dec, bool) = undefined;
+  (total, mask) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_val, vm_val);
   status : Retired = RETIRE_SUCCESS;
 
   foreach (i from 0 to (num_elem - 1)) {
-    (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_val, vm_val);
-    if mask_helper[i] == true then {
+    if mask[i] then {
       let elem_offset = i * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
         Ext_DataAddr_Error(e) => {
           if i == 0 then {
             ext_handle_data_check_error(e);
-            status = RETIRE_SUCCESS
+            status = RETIRE_FAIL
           } else {
             vl = to_bits(sizeof(xlen), i);
-            print_reg("CSR vl <- " ^ BitStr(vl));
-            ext_handle_data_check_error(e);
-            status = RETIRE_SUCCESS
+            print_reg("CSR vl <- " ^ BitStr(vl))
           }
         },
         Ext_DataAddr_OK(vaddr) => {
-          if vcheck_misaligned(vaddr, width_type) then {
+          if check_misaligned(vaddr, width_type) then {
             if i == 0 then {
               handle_mem_exception(vaddr, E_Load_Addr_Align());
-              status = RETIRE_SUCCESS
+              status = RETIRE_FAIL
             } else {
               vl = to_bits(sizeof(xlen), i);
-              print_reg("CSR vl <- " ^ BitStr(vl));
-              handle_mem_exception(vaddr, E_Load_Addr_Align());
-              status = RETIRE_SUCCESS
+              print_reg("CSR vl <- " ^ BitStr(vl))
             }
           } else match translateAddr(vaddr, Read(Data)) {
             TR_Failure(e, _) => { 
               if i == 0 then {
                 handle_mem_exception(vaddr, e);
-                status = RETIRE_SUCCESS
+                status = RETIRE_FAIL
               } else {
                 vl = to_bits(sizeof(xlen), i);
-                print_reg("CSR vl <- " ^ BitStr(vl));
-                handle_mem_exception(vaddr, e);
-                status = RETIRE_SUCCESS
+                print_reg("CSR vl <- " ^ BitStr(vl))
               }
             },
             TR_Address(paddr, _) => {
@@ -626,12 +563,10 @@ function process_vleff (vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
                 MemException(e)  => {
                   if i == 0 then {
                     handle_mem_exception(vaddr, e);
-                    status = RETIRE_SUCCESS
+                    status = RETIRE_FAIL
                   } else {
                     vl = to_bits(sizeof(xlen), i);
-                    print_reg("CSR vl <- " ^ BitStr(vl));
-                    handle_mem_exception(vaddr, e);
-                    status = RETIRE_SUCCESS
+                    print_reg("CSR vl <- " ^ BitStr(vl))
                   }
                 }
               }
@@ -648,18 +583,15 @@ function process_vleff (vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
 }
 
 function clause execute(VLEFFTYPE(vm, rs1, width, vd)) = {
-  let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let EEW : int = load_width_bytes * 8;
-  let EEW_pow : int = vlewidth_pow(width);
-  let SEW_pow : int = get_sew_pow();
-  let LMUL_pow : int = get_lmul_pow();
-  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
-  let num_elem : int = get_num_elem(EMUL_pow, EEW);
+  let load_width_bytes = vlewidth_bytesnumber(width);
+  let EEW = load_width_bytes * 8;
+  let EEW_pow = vlewidth_pow(width);
+  let SEW_pow = get_sew_pow();
+  let LMUL_pow = get_lmul_pow();
+  let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem = get_num_elem(EMUL_pow, EEW);
 
-  assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(num_elem >= 0);
-
-  process_vle(vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
+  process_vleff(vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
 
 mapping vlefftype_mnemonic : vlewidth <-> string = {
@@ -672,15 +604,13 @@ mapping vlefftype_mnemonic : vlewidth <-> string = {
 mapping clause assembly = VLEFFTYPE(vm, rs1, width, vd)
   <-> vlefftype_mnemonic(width) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
 
-
-/* ****VLOAD***********VLSEGTYPE(Vector Load Unit-Strided Segments, mop=0, lumop=00000)*************************** */
-
+/* ******************** Vector Load Unit-Stride Segment (mop=0, lumop=00000) ********************* */
 union clause ast = VLSEGTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
 
 mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vlseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+val process_vlseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else int_power(2, EMUL_pow);
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
@@ -693,17 +623,17 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
     if vd_t == vd_a & a != 0 then vd_t = vd_t + 1; /* EMUL < 1 */
     let vd_t_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd_t);
     total : vector('n, dec, bits('b * 8)) = undefined;
-    mask_helper : vector('n, dec, bool) = undefined;
-    (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_t_val, vm_val);
+    mask : vector('n, dec, bool) = undefined;
+    (total, mask) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_t_val, vm_val);
 
     foreach (i from 0 to (num_elem - 1)) {
-      if (mask_helper[i] == true) then {
+      if mask[i] then {
         vstart = to_bits(16, i);
         let elem_offset = load_width_bytes * (a + i * nf);
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) => 
-              if vcheck_misaligned(vaddr, width_type)
+              if check_misaligned(vaddr, width_type)
               then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
               else match translateAddr(vaddr, Read(Data)) {
                 TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -728,18 +658,14 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
 }
 
 function clause execute(VLSEGTYPE(nf, vm, rs1, width, vd)) = {
-  let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let EEW : int = load_width_bytes * 8;
-  let EEW_pow : int = vlewidth_pow(width);
-  let SEW_pow : int = get_sew_pow();
-  let LMUL_pow : int = get_lmul_pow();
-  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
-  let num_elem : int = get_num_elem(EMUL_pow, EEW); /* # of element of each register group */
+  let load_width_bytes = vlewidth_bytesnumber(width);
+  let EEW = load_width_bytes * 8;
+  let EEW_pow = vlewidth_pow(width);
+  let SEW_pow = get_sew_pow();
+  let LMUL_pow = get_lmul_pow();
+  let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem = get_num_elem(EMUL_pow, EEW); /* # of element of each register group */
   let nf_int = nfields_int(nf);
-
-  assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 < '_nf_int & '_nf_int <= 8);
-  assert(num_elem >= 0);
 
   process_vlseg(nf_int, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -747,33 +673,31 @@ function clause execute(VLSEGTYPE(nf, vm, rs1, width, vd)) = {
 mapping clause assembly = VLSEGTYPE(nf, vm, rs1, width, vd)
   <-> "vlseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ maybe_vmask(vm)
 
-
-/* ****VLOAD*****VLSEGFFTYPE(Vector Load Unit-Strided Segments Fault-Only-First, mop=0, lumop=00000)******** */
-
+/* ************ Vector Load Unit-Stride Segment Fault-Only-First (mop=0, lumop=10000) ************ */
 union clause ast = VLSEGFFTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
 
 mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd)
-  <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+  <-> nf @ 0b0 @ 0b00 @ vm @ 0b10000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vlsegff : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+val process_vlsegff : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else int_power(2, EMUL_pow);
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
-  let start_element : int = get_start_element();
+  let start_element = get_start_element();
   let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   status : Retired = RETIRE_SUCCESS;
   if start_element >= num_elem then return status;
 
-  loop_times : int = num_elem - 1;
-  foreach (i from start_element to loop_times) {
-    assert(i >= 0 & i < num_elem);
+  end_element : int = num_elem - 1;
+  foreach (i from start_element to end_element) {
+    assert(i < num_elem);
     if (vm_val[i] == true) then {
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = (i * nf + j) * load_width_bytes;
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
           Ext_DataAddr_Error(e)  => { if i == 0 then ext_handle_data_check_error(e); status = RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) => 
-            if vcheck_misaligned(vaddr, width_type)
+            if check_misaligned(vaddr, width_type)
             then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
             else match translateAddr(vaddr, Read(Data)) {
               TR_Failure(e, _)     => { if i == 0 then handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -786,7 +710,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
             }
         }
       };
-      if status == RETIRE_FAIL then loop_times = i;
+      if status == RETIRE_FAIL then end_element = i;
     }
   };
 
@@ -795,18 +719,14 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
 
 function clause execute(VLSEGFFTYPE(nf, vm, rs1, width, vd)) = {
-  let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let EEW : int = load_width_bytes * 8;
-  let EEW_pow : int = vlewidth_pow(width);
-  let SEW_pow : int = get_sew_pow();
-  let LMUL_pow : int = get_lmul_pow();
-  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
-  let num_elem : int = get_num_elem(EMUL_pow, EEW);
+  let load_width_bytes = vlewidth_bytesnumber(width);
+  let EEW = load_width_bytes * 8;
+  let EEW_pow = vlewidth_pow(width);
+  let SEW_pow = get_sew_pow();
+  let LMUL_pow = get_lmul_pow();
+  let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem = get_num_elem(EMUL_pow, EEW);
   let nf_int = nfields_int(nf);
-
-  assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 < '_nf_int & '_nf_int <= 8);
-  assert(num_elem >= 0);
 
   process_vlsegff(nf_int, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -814,23 +734,20 @@ function clause execute(VLSEGFFTYPE(nf, vm, rs1, width, vd)) = {
 mapping clause assembly = VLSEGTYPE(nf, vm, rs1, width, vd)
   <-> "vlseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ "ff.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
 
-
-/* ****VSTORE***********VSSEGTYPE(Vector Store Unit-Strided Segments, mop=0, sumop=00000)*************************** */
-
+/* ******************** Vector Store Unit-Stride Segment (mop=0, sumop=00000) ******************** */
 union clause ast = VSSEGTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
 
 mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
 
-val process_vsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+val process_vsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else int_power(2, EMUL_pow);
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
-  let start_element : int = get_start_element();
+  let start_element = get_start_element();
   let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   status : Retired = RETIRE_SUCCESS;
   if start_element >= num_elem then return status;
-  assert(start_element >= 0);
 
   foreach (i from start_element to (num_elem - 1)) {
     if vm_val[i] == true then {
@@ -840,7 +757,7 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) =>
-            if vcheck_misaligned(vaddr, width_type)
+            if check_misaligned(vaddr, width_type)
             then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
             else match translateAddr(vaddr, Write(Data)) {
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -870,18 +787,14 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
 }
 
 function clause execute(VSSEGTYPE(nf, vm, rs1, width, vs3)) = {
-  let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let EEW : int = load_width_bytes * 8;
-  let EEW_pow : int = vlewidth_pow(width);
-  let SEW_pow : int = get_sew_pow();
-  let LMUL_pow : int = get_lmul_pow();
-  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
-  let num_elem : int = get_num_elem(EMUL_pow, EEW);
+  let load_width_bytes = vlewidth_bytesnumber(width);
+  let EEW = load_width_bytes * 8;
+  let EEW_pow = vlewidth_pow(width);
+  let SEW_pow = get_sew_pow();
+  let LMUL_pow = get_lmul_pow();
+  let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem = get_num_elem(EMUL_pow, EEW);
   let nf_int = nfields_int(nf);
-
-  assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 < '_nf_int & '_nf_int <= 8);
-  assert(num_elem >= 0);
 
   process_vsseg(nf_int, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -889,35 +802,33 @@ function clause execute(VSSEGTYPE(nf, vm, rs1, width, vs3)) = {
 mapping clause assembly = VSSEGTYPE(nf, vm, rs1, width, vs3)
   <-> "vsseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
 
-
-/* ****VLOAD***********VLSSEGTYPE(Vector Load Strided Segments, mop=10)*************************** */
-
+/* **************************** Vector Load Strided Segment (mop=10) ***************************** */
 union clause ast = VLSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
 mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
   <-> nf @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vlsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+val process_vlsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else int_power(2, EMUL_pow);
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vd_val  : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd); /* only to generate mask_helper */
+  let vd_val  : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd); /* only to generate mask */
   result      : vector('n, dec, bits('b * 8)) = undefined;
-  mask_helper : vector('n, dec, bool)     = undefined;
-  (result, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_val, vm_val);
+  mask : vector('n, dec, bool)     = undefined;
+  (result, mask) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_val, vm_val);
 
   let rs2_val : int = signed(get_scalar(rs2, sizeof(xlen)));
   status : Retired = RETIRE_SUCCESS;
   foreach (i from 0 to (num_elem - 1)) {
-    if mask_helper[i] == true then {
+    if mask[i] then {
       vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = i * rs2_val + j * load_width_bytes;
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) => 
-            if vcheck_misaligned(vaddr, width_type)
+            if check_misaligned(vaddr, width_type)
             then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
             else match translateAddr(vaddr, Read(Data)) {
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -938,18 +849,14 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
 }
 
 function clause execute(VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)) = {
-  let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let EEW : int = load_width_bytes * 8;
-  let EEW_pow : int = vlewidth_pow(width);
-  let SEW_pow : int = get_sew_pow();
-  let LMUL_pow : int = get_lmul_pow();
-  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
-  let num_elem : int = get_num_elem(EMUL_pow, EEW);
+  let load_width_bytes = vlewidth_bytesnumber(width);
+  let EEW = load_width_bytes * 8;
+  let EEW_pow = vlewidth_pow(width);
+  let SEW_pow = get_sew_pow();
+  let LMUL_pow = get_lmul_pow();
+  let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem = get_num_elem(EMUL_pow, EEW);
   let nf_int = nfields_int(nf);
-
-  assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 < '_nf_int & '_nf_int <= 8);
-  assert(num_elem >= 0);
 
   process_vlsseg(nf_int, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
@@ -957,35 +864,33 @@ function clause execute(VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)) = {
 mapping clause assembly = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
   <-> "vlsseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ maybe_vmask(vm)
 
-
-/* ****VSTORE***********VSSSEGTYPE(Vector Store Strided Segments, mop=0, sumop=00000)*************************** */
-
+/* **************************** Vector Store Strided Segment (mop=10) **************************** */
 union clause ast = VSSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
 mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
 
-val process_vssseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+val process_vssseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else int_power(2, EMUL_pow);
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vs3_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vs3); /* only to generate mask_helper */
+  let vs3_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vs3); /* only to generate mask */
   result      : vector('n, dec, bits('b * 8)) = undefined;
-  mask_helper : vector('n, dec, bool)     = undefined;
-  (result, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vs3_val, vm_val);
+  mask : vector('n, dec, bool)     = undefined;
+  (result, mask) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vs3_val, vm_val);
 
   let rs2_val : int = signed(get_scalar(rs2, sizeof(xlen)));
   status : Retired = RETIRE_SUCCESS;
   foreach (i from 0 to (num_elem - 1)) {
-    if mask_helper[i] == true then {
+    if mask[i] then {
       vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = i * rs2_val + j * load_width_bytes;
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) =>
-            if vcheck_misaligned(vaddr, width_type)
+            if check_misaligned(vaddr, width_type)
             then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
             else match translateAddr(vaddr, Write(Data)) {
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -1015,18 +920,14 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
 }
 
 function clause execute(VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)) = {
-  let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let EEW : int = load_width_bytes * 8;
-  let EEW_pow : int = vlewidth_pow(width);
-  let SEW_pow : int = get_sew_pow();
-  let LMUL_pow : int = get_lmul_pow();
-  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
-  let num_elem : int = get_num_elem(EMUL_pow, EEW);
+  let load_width_bytes = vlewidth_bytesnumber(width);
+  let EEW = load_width_bytes * 8;
+  let EEW_pow = vlewidth_pow(width);
+  let SEW_pow = get_sew_pow();
+  let LMUL_pow = get_lmul_pow();
+  let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem = get_num_elem(EMUL_pow, EEW);
   let nf_int = nfields_int(nf);
-
-  assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 < '_nf_int & '_nf_int <= 8);
-  assert(num_elem >= 0);
 
   process_vssseg(nf_int, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
@@ -1034,15 +935,13 @@ function clause execute(VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)) = {
 mapping clause assembly = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
   <-> "vssseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ maybe_vmask(vm)
 
-
-/* ****VLOAD***********VLUXSEGTYPE(Vector Load Indexed Unordered Segments, mop=01)*************************** */
-
+/* *********************** Vector Load Indexed Unordered Segment (mop=01) ************************ */
 union clause ast = VLUXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
 mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   <-> nf @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vlxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+val process_vlxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n >= 0). (int('f), bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else int_power(2, EMUL_data_pow);
   let width_type : word_width = bytes_wordwidth(EEW_data_bytes);
@@ -1050,20 +949,20 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
   let vd_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd);
   let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
   total : vector('n, dec, bits('db * 8)) = undefined;
-  mask_helper : vector('n, dec, bool) = undefined;
-  (total, mask_helper) = init_masked_result(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd_val, vm_val);
+  mask : vector('n, dec, bool) = undefined;
+  (total, mask) = init_masked_result(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd_val, vm_val);
   status : Retired = RETIRE_SUCCESS;
 
   /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
-    if mask_helper[i] == true then {
+    if mask[i] then {
       vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
         let elem_offset : int = signed(vs2_val[i]) + j * EEW_data_bytes;
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) => 
-            if vcheck_misaligned(vaddr, width_type)
+            if check_misaligned(vaddr, width_type)
             then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
             else match translateAddr(vaddr, Read(Data)) {
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -1084,19 +983,14 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
 }
 
 function clause execute(VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
-  let EEW_index_pow : int = vlewidth_pow(width);
-  let EEW_index_bytes : int = vlewidth_bytesnumber(width);
-  let EEW_data_pow : int = get_sew_pow();
-  let EEW_data_bytes : int = int_power(2, EEW_data_pow - 3);
-  let EMUL_data_pow : int = get_lmul_pow();
-  let EMUL_index_pow : int = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
-  let num_elem : int = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
+  let EEW_index_pow = vlewidth_pow(width);
+  let EEW_index_bytes = vlewidth_bytesnumber(width);
+  let EEW_data_pow = get_sew_pow();
+  let EEW_data_bytes = get_sew_bytes();
+  let EMUL_data_pow = get_lmul_pow();
+  let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
   let nf_int = nfields_int(nf);
-
-  assert(0 < EEW_index_bytes & EEW_index_bytes <= 8);
-  assert(0 < EEW_data_bytes & EEW_data_bytes <= 8);
-  assert(0 < '_nf_int & '_nf_int <= 8);
-  assert(num_elem >= 0);
 
   process_vlxseg(nf_int, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
@@ -1104,28 +998,21 @@ function clause execute(VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
 mapping clause assembly = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   <-> "vluxseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
 
-
-/* ****VLOAD***********VLOXSEGTYPE(Vector Load Indexed Unordered Segments, mop=11)*************************** */
-
+/* ************************ Vector Load Indexed Ordered Segment (mop=11) ************************* */
 union clause ast = VLOXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
 mapping clause encdec = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   <-> nf @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
 function clause execute(VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
-  let EEW_index_pow : int = vlewidth_pow(width);
-  let EEW_index_bytes : int = vlewidth_bytesnumber(width);
-  let EEW_data_pow : int = get_sew_pow();
-  let EEW_data_bytes : int = int_power(2, EEW_data_pow - 3);
-  let EMUL_data_pow : int = get_lmul_pow();
-  let EMUL_index_pow : int = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
-  let num_elem : int = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
+  let EEW_index_pow = vlewidth_pow(width);
+  let EEW_index_bytes = vlewidth_bytesnumber(width);
+  let EEW_data_pow = get_sew_pow();
+  let EEW_data_bytes = get_sew_bytes();
+  let EMUL_data_pow = get_lmul_pow();
+  let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
   let nf_int = nfields_int(nf);
-
-  assert(0 < EEW_index_bytes & EEW_index_bytes <= 8);
-  assert(0 < EEW_data_bytes & EEW_data_bytes <= 8);
-  assert(0 < '_nf_int & '_nf_int <= 8);
-  assert(num_elem >= 0);
 
   process_vlxseg(nf_int, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
@@ -1133,15 +1020,13 @@ function clause execute(VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
 mapping clause assembly = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   <-> "vloxseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
 
-
-/* ****VSTORE***********VSUXSEGTYPE(Vector Store Indexed Unordered Segments, mop=01)*************************** */
-
+/* *********************** Vector Store Indexed Unordered Segment (mop=01) *********************** */
 union clause ast = VSUXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
 mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
 
-val process_vsxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+val process_vsxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n >= 0). (int('f), bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else int_power(2, EMUL_data_pow);
   let width_type : word_width = bytes_wordwidth(EEW_data_bytes);
@@ -1149,20 +1034,20 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
   let vs3_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vs3);
   let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
   total : vector('n, dec, bits('db * 8)) = undefined;
-  mask_helper : vector('n, dec, bool) = undefined;
-  (total, mask_helper) = init_masked_result(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vs3_val, vm_val);
+  mask : vector('n, dec, bool) = undefined;
+  (total, mask) = init_masked_result(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vs3_val, vm_val);
   status : Retired = RETIRE_SUCCESS;
 
   /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
-    if mask_helper[i] == true then {
+    if mask[i] then {
       vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
         let elem_offset : int = signed(vs2_val[i]) + j * EEW_data_bytes;
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) =>
-            if vcheck_misaligned(vaddr, width_type)
+            if check_misaligned(vaddr, width_type)
             then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
             else match translateAddr(vaddr, Write(Data)) {
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -1192,19 +1077,14 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
 }
 
 function clause execute(VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
-  let EEW_index_pow : int = vlewidth_pow(width);
-  let EEW_index_bytes : int = vlewidth_bytesnumber(width);
-  let EEW_data_pow : int = get_sew_pow();
-  let EEW_data_bytes : int = int_power(2, EEW_data_pow - 3);
-  let EMUL_data_pow : int = get_lmul_pow();
-  let EMUL_index_pow : int = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
-  let num_elem : int = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
+  let EEW_index_pow = vlewidth_pow(width);
+  let EEW_index_bytes = vlewidth_bytesnumber(width);
+  let EEW_data_pow = get_sew_pow();
+  let EEW_data_bytes = get_sew_bytes();
+  let EMUL_data_pow = get_lmul_pow();
+  let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
   let nf_int = nfields_int(nf);
-
-  assert(0 < EEW_index_bytes & EEW_index_bytes <= 8);
-  assert(0 < EEW_data_bytes & EEW_data_bytes <= 8);
-  assert(0 < '_nf_int & '_nf_int <= 8);
-  assert(num_elem >= 0);
 
   process_vsxseg(nf_int, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
@@ -1212,28 +1092,21 @@ function clause execute(VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
 mapping clause assembly = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   <-> "vsuxseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
 
-
-/* ****VSTORE***********VSOXSEGTYPE(Vector Store Indexed Ordered Segments, mop=11)*************************** */
-
+/* ************************ Vector Store Indexed Ordered Segment (mop=11) ************************ */
 union clause ast = VSOXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
 mapping clause encdec = VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
 
 function clause execute(VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
-  let EEW_index_pow : int = vlewidth_pow(width);
-  let EEW_index_bytes : int = vlewidth_bytesnumber(width);
-  let EEW_data_pow : int = get_sew_pow();
-  let EEW_data_bytes : int = int_power(2, EEW_data_pow - 3);
-  let EMUL_data_pow : int = get_lmul_pow();
-  let EMUL_index_pow : int = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
-  let num_elem : int = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
+  let EEW_index_pow = vlewidth_pow(width);
+  let EEW_index_bytes = vlewidth_bytesnumber(width);
+  let EEW_data_pow = get_sew_pow();
+  let EEW_data_bytes = get_sew_bytes();
+  let EMUL_data_pow = get_lmul_pow();
+  let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
   let nf_int = nfields_int(nf);
-
-  assert(0 < EEW_index_bytes & EEW_index_bytes <= 8);
-  assert(0 < EEW_data_bytes & EEW_data_bytes <= 8);
-  assert(0 < '_nf_int & '_nf_int <= 8);
-  assert(num_elem >= 0);
 
   process_vsxseg(nf_int, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
@@ -1241,23 +1114,18 @@ function clause execute(VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
 mapping clause assembly = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   <-> "vsoxseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
 
-
-/* ****VLOAD***************VLRETYPE(Vector Load Unit-Strided Whole Register, vm=1, mop=0, lumop=01000)*************************** */
-
+/* ************** Vector Load Unit-Stride Whole Register (vm=1, mop=0, lumop=01000) ************** */
 union clause ast = VLRETYPE : (bits(3), regidx, vlewidth, regidx)
 
 mapping clause encdec = VLRETYPE(nf, rs1, width, vd)
   <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vlre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), regidx, int('b), regidx, int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+val process_vlre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), regidx, int('b), regidx, int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   status : Retired = RETIRE_SUCCESS;
-  start_element : int = get_start_element();
-  if start_element >= nf * elem_per_reg then {
-    /* no elements are written */
-    return status
-  };
+  start_element = get_start_element();
+  if start_element >= nf * elem_per_reg then return status; /* no elements are written */
   cur_field : int = start_element / elem_per_reg;
   elem_to_align : int = start_element % elem_per_reg;
 
@@ -1268,7 +1136,7 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
         Ext_DataAddr_OK(vaddr) => 
-          if vcheck_misaligned(vaddr, width_type)
+          if check_misaligned(vaddr, width_type)
           then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
           else match translateAddr(vaddr, Read(Data)) {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -1294,7 +1162,7 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
         Ext_DataAddr_OK(vaddr) => 
-          if vcheck_misaligned(vaddr, width_type)
+          if check_misaligned(vaddr, width_type)
           then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
           else match translateAddr(vaddr, Read(Data)) {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -1316,13 +1184,12 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
 }
 
 function clause execute(VLRETYPE(nf, rs1, width, vd)) = {
-  let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let EEW : int = load_width_bytes * 8;
-  let VLEN : int = int_power(2, get_vlen_pow());
+  let load_width_bytes = vlewidth_bytesnumber(width);
+  let EEW = load_width_bytes * 8;
+  let VLEN = int_power(2, get_vlen_pow());
   let elem_per_reg : int = VLEN / EEW;
   let nf_int = nfields_int(nf);
 
-  assert(0 < load_width_bytes & load_width_bytes <= 8);
   assert(elem_per_reg >= 0);
   assert(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8);
 
@@ -1332,23 +1199,18 @@ function clause execute(VLRETYPE(nf, rs1, width, vd)) = {
 mapping clause assembly = VLRETYPE(nf, rs1, width, vd)
   <-> "vl" ^ nfields_string(nf) ^ "re" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)
 
-
-/* ****VSTORE***************VSRETYPE(Vector Store Unit-Strided Whole Register, vm=1, mop=0, lumop=01000)*************************** */
-
+/* ************* Vector Store Unit-Stride Whole Register (vm=1, mop=0, lumop=01000) ************** */
 union clause ast = VSRETYPE : (bits(3), regidx, regidx)
 
 mapping clause encdec = VSRETYPE(nf, rs1, vs3)
   <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ rs1 @ 0b000 @ vs3 @ 0b0100111
 
-val process_vsre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), int('b), regidx, regidx, int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+val process_vsre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), int('b), regidx, regidx, int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
   let width_type : word_width = BYTE;
-  start_element : int = get_start_element();
+  start_element = get_start_element();
   status : Retired = RETIRE_SUCCESS;
-  if start_element >= nf * elem_per_reg then {
-    /* no elements are written */
-    return status
-  };
+  if start_element >= nf * elem_per_reg then return status; /* no elements are written */
   cur_field : int = start_element / elem_per_reg;
   elem_to_align : int = start_element % elem_per_reg;
 
@@ -1359,7 +1221,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
         Ext_DataAddr_OK(vaddr) =>
-          if vcheck_misaligned(vaddr, width_type)
+          if check_misaligned(vaddr, width_type)
           then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
           else match translateAddr(vaddr, Write(Data)) {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -1393,7 +1255,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
         Ext_DataAddr_OK(vaddr) =>
-          if vcheck_misaligned(vaddr, width_type)
+          if check_misaligned(vaddr, width_type)
           then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
           else match translateAddr(vaddr, Write(Data)) {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -1422,13 +1284,12 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
 }
 
 function clause execute(VSRETYPE(nf, rs1, vs3)) = {
-  let load_width_bytes : int = 1;
-  let EEW : int = 8;
-  let VLEN : int = int_power(2, get_vlen_pow());
+  let load_width_bytes = 1;
+  let EEW = 8;
+  let VLEN = int_power(2, get_vlen_pow());
   let elem_per_reg : int = VLEN / EEW;
   let nf_int = nfields_int(nf);
 
-  assert(0 < load_width_bytes & load_width_bytes <= 8);
   assert(elem_per_reg >= 0);
   assert(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8);
 
@@ -1438,9 +1299,7 @@ function clause execute(VSRETYPE(nf, rs1, vs3)) = {
 mapping clause assembly = VSRETYPE(nf, rs1, vs3)
   <-> "vs" ^ nfields_string(nf) ^ "r.v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1)
 
-
-/* *****VLOAD&VSTORE**************VMTYPE(Vector MASK Load&STORE Unit-Strided Normal, nf=0, mop=0, lumop=0)*************************** */
-
+/* *********** Vector Mask Load/Store Unit-Stride (nf=0, mop=0, lumop or sumop=01011) ************ */
 union clause ast = VMTYPE : (regidx, regidx, vmlsop)
 
 mapping encdec_lsop : vmlsop <-> bits(7) = {
@@ -1454,7 +1313,7 @@ mapping clause encdec = VMTYPE(rs1, vd_or_vs3, op)
 val process_vm : forall 'n 'p, ('n >= 0). (regidx, regidx, int('p), int('n), vmlsop) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vm(vd_or_vs3, rs1, EMUL_pow, num_elem, op) = {
   let width_type : word_width = BYTE;
-  let start_element : int = get_start_element();
+  let start_element = get_start_element();
   let vd_or_vs3_val : vector('n, dec, bits(8)) = read_vreg(num_elem, 8, EMUL_pow, vd_or_vs3);
   total : vector('n, dec, bits(8)) = undefined;
   elem_offset : int = undefined;
@@ -1470,7 +1329,7 @@ function process_vm(vd_or_vs3, rs1, EMUL_pow, num_elem, op) = {
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) => 
-            if vcheck_misaligned(vaddr, width_type)
+            if check_misaligned(vaddr, width_type)
             then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
             else match translateAddr(vaddr, Read(Data)) {
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -1490,7 +1349,7 @@ function process_vm(vd_or_vs3, rs1, EMUL_pow, num_elem, op) = {
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) =>
-            if vcheck_misaligned(vaddr, width_type)
+            if check_misaligned(vaddr, width_type)
             then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
             else match translateAddr(vaddr, Write(Data)) {
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
@@ -1519,14 +1378,13 @@ function process_vm(vd_or_vs3, rs1, EMUL_pow, num_elem, op) = {
 }
 
 function clause execute(VMTYPE(rs1, vd_or_vs3, op)) = {
-  let EEW : int = 8;
-  let EMUL_pow : int = 0;
-  let tmp : int = unsigned(vl);
+  let EEW = 8;
+  let EMUL_pow = 0;
+  let tmp = unsigned(vl);
   let num_elem : int = if tmp % 8 == 0 then tmp / 8 else tmp / 8 + 1;
 
-  assert(num_elem >= 0);
-
   /* unmask vle8 except that the effective vector length is evl=ceil(vl/8) */
+  assert(num_elem >= 0);
   process_vm(vd_or_vs3, rs1, EMUL_pow, num_elem, op)
 }
 

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -1,6 +1,6 @@
 /* ************************************************************************ */
 /* This file implements part of the vector extension.                       */
-/* Chapter 7: vector loads and stores                                       */
+/* Chapter 7: Vector Loads and Stores                                       */
 /* ************************************************************************ */
 
 mapping nfields_int : bits(3) <-> {|1, 2, 3, 4, 5, 6, 7, 8|} = {
@@ -63,8 +63,8 @@ mapping bytes_wordwidth : {|1, 2, 4, 8|} <-> word_width = {
 /* ******************** Vector Load Unit-Stride Normal (nf=0, mop=0, lumop=0) ******************** */
 union clause ast = VLETYPE : (bits(1), regidx, vlewidth, regidx)
 
-mapping clause encdec = VLETYPE(vm, rs1, width, vd)
-  <-> 0b000 @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+mapping clause encdec = VLETYPE(vm, rs1, width, vd) if haveRVV()
+  <-> 0b000 @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if haveRVV()
 
 val process_vle : forall 'b 'n 'p, ('b in {1, 2, 4, 8}) & ('n >= 0). (bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vle (vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
@@ -72,29 +72,31 @@ function process_vle (vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vd_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd);
   total : vector('n, dec, bits('b * 8)) = undefined;
-  mask : vector('n, dec, bool) = undefined;
+  mask  : vector('n, dec, bool) = undefined;
   status : Retired = RETIRE_SUCCESS;
 
   (total, mask) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] then {
-      vstart = to_bits(16, i);
-      let elem_offset = i * load_width_bytes;
-      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-        Ext_DataAddr_OK(vaddr) => 
-          if check_misaligned(vaddr, width_type)
-          then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
-          else match translateAddr(vaddr, Read(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-            TR_Address(paddr, _) => {
-              match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                MemValue(result) => total[i] = result,
-                MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+    if status != RETIRE_FAIL then {
+      if mask[i] then {
+        vstart = to_bits(16, i);
+        let elem_offset = i * load_width_bytes;
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) => 
+            if check_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Read(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
+                  MemValue(result) => total[i] = result,
+                  MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                }
               }
             }
-          }
+        }
       }
     }
   };
@@ -129,8 +131,8 @@ mapping clause assembly = VLETYPE(vm, rs1, width, vd)
 /* ******************** Vector Store Unit-Stride Normal (nf=0, mop=0, sumop=0) ******************* */
 union clause ast = VSETYPE : (bits(1), regidx, vlewidth, regidx)
 
-mapping clause encdec = VSETYPE(vm, rs1, width, vs3)
-  <-> 0b000 @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
+mapping clause encdec = VSETYPE(vm, rs1, width, vs3) if haveRVV()
+  <-> 0b000 @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111 if haveRVV()
 
 val process_vse : forall 'b 'n 'p, ('b in {1, 2, 4, 8}) & ('n >= 0). (bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vse (vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
@@ -138,37 +140,39 @@ function process_vse (vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vs3_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vs3);
   total : vector('n, dec, bits('b * 8)) = undefined;
-  mask : vector('n, dec, bool) = undefined;
+  mask  : vector('n, dec, bool) = undefined;
   status : Retired = RETIRE_SUCCESS;
 
   (total, mask) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vs3_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
-    let elem_offset = i * load_width_bytes;
-    if mask[i] then {
-      vstart = to_bits(16, i);
-      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-        Ext_DataAddr_OK(vaddr) =>
-          if check_misaligned(vaddr, width_type)
-          then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
-          else match translateAddr(vaddr, Write(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-            TR_Address(paddr, _) => {
-              let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
-              match (eares) {
-                MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-                MemValue(_) => {
-                  let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, vs3_val[i], false, false, false);
-                  match (res) {
-                    MemValue(true)  => status = RETIRE_SUCCESS,
-                    MemValue(false) => internal_error("store got false from mem_write_value"),
-                    MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+    if status != RETIRE_FAIL then {
+      if mask[i] then {
+        vstart = to_bits(16, i);
+        let elem_offset = i * load_width_bytes;
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) =>
+            if check_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Write(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
+                match (eares) {
+                  MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                  MemValue(_) => {
+                    let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, vs3_val[i], false, false, false);
+                    match (res) {
+                      MemValue(true)  => status = RETIRE_SUCCESS,
+                      MemValue(false) => internal_error("store got false from mem_write_value"),
+                      MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                    }
                   }
                 }
               }
             }
-          }
+        }
       }
     }
   };
@@ -202,39 +206,41 @@ mapping clause assembly = VSETYPE(vm, rs1, width, vs3)
 /* ************************** Vector Load Strided Normal (nf=0, mop=10) ************************** */
 union clause ast = VLSETYPE : (bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VLSETYPE(vm, rs2, rs1, width, vd)
-  <-> 0b000 @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+mapping clause encdec = VLSETYPE(vm, rs2, rs1, width, vd) if haveRVV()
+  <-> 0b000 @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if haveRVV()
 
 val process_vlse : forall 'b 'n 'p, ('b in {1, 2, 4, 8}) & ('n >= 0). (bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vlse (vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vd_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd);
+  let vd_val  : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd);
   let rs2_val : int = signed(get_scalar(rs2, sizeof(xlen)));
   total : vector('n, dec, bits('b * 8)) = undefined;
-  mask : vector('n, dec, bool) = undefined;
+  mask  : vector('n, dec, bool) = undefined;
   status : Retired = RETIRE_SUCCESS;
 
   (total, mask) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
-    let elem_offset = i * rs2_val;
-    if mask[i] then {
-      vstart = to_bits(16, i);
-      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-        Ext_DataAddr_OK(vaddr) => 
-          if check_misaligned(vaddr, width_type)
-          then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
-          else match translateAddr(vaddr, Read(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-            TR_Address(paddr, _) => {
-              match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                MemValue(result) => total[i] = result,
-                MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+    if status != RETIRE_FAIL then {
+      if mask[i] then {
+        vstart = to_bits(16, i);
+        let elem_offset = i * rs2_val;
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) => 
+            if check_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Read(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
+                  MemValue(result) => total[i] = result,
+                  MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                }
               }
             }
-          }
+        }
       }
     }
   };
@@ -269,8 +275,8 @@ mapping clause assembly = VLSETYPE(vm, rs2, rs1, width, vd)
 /* ************************** Vector Store Strided Normal (nf=0, mop=10) ************************* */
 union clause ast = VSSETYPE : (bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VSSETYPE(vm, rs2, rs1, width, vs3)
-  <-> 0b000 @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
+mapping clause encdec = VSSETYPE(vm, rs2, rs1, width, vs3) if haveRVV()
+  <-> 0b000 @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111 if haveRVV()
 
 val process_vsse : forall 'b 'n 'p, ('b in {1, 2, 4, 8}) & ('n >= 0). (bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vsse (vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
@@ -279,37 +285,39 @@ function process_vsse (vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) 
   let vs3_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vs3);
   let rs2_val : int = signed(get_scalar(rs2, sizeof(xlen)));
   total : vector('n, dec, bits('b * 8)) = undefined;
-  mask : vector('n, dec, bool) = undefined;
+  mask  : vector('n, dec, bool) = undefined;
   status : Retired = RETIRE_SUCCESS;
 
   (total, mask) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vs3_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
-    let elem_offset = i * rs2_val;
-    if mask[i] then {
-      vstart = to_bits(16, i);
-      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-        Ext_DataAddr_OK(vaddr) =>
-          if check_misaligned(vaddr, width_type)
-          then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
-          else match translateAddr(vaddr, Write(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-            TR_Address(paddr, _) => {
-              let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
-              match (eares) {
-                MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-                MemValue(_) => {
-                  let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, vs3_val[i], false, false, false);
-                  match (res) {
-                    MemValue(true)  => status = RETIRE_SUCCESS,
-                    MemValue(false) => internal_error("store got false from mem_write_value"),
-                    MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+    if status != RETIRE_FAIL then {
+      if mask[i] then {
+        vstart = to_bits(16, i);
+        let elem_offset = i * rs2_val;
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) =>
+            if check_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Write(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
+                match (eares) {
+                  MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                  MemValue(_) => {
+                    let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, vs3_val[i], false, false, false);
+                    match (res) {
+                      MemValue(true)  => status = RETIRE_SUCCESS,
+                      MemValue(false) => internal_error("store got false from mem_write_value"),
+                      MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                    }
                   }
                 }
               }
             }
-          }
+        }
       }
     }
   };
@@ -343,43 +351,45 @@ mapping clause assembly = VSSETYPE(vm, rs2, rs1, width, vs3)
 /* ************************ Vector Load Indexed Unordered (nf=0, mop=01) ************************* */
 union clause ast = VLUXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VLUXEITYPE(vm, vs2, rs1, width, vd)
-  <-> 0b000 @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+mapping clause encdec = VLUXEITYPE(vm, vs2, rs1, width, vd) if haveRVV()
+  <-> 0b000 @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if haveRVV()
 
 val process_vlxei : forall 'ib 'db 'ip 'dp 'n, ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n >= 0). (bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vlxei (vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let width_type : word_width = bytes_wordwidth(EEW_data_bytes);
-  let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vd_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd);
+  let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd);
   let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
   total : vector('n, dec, bits('db * 8)) = undefined;
-  mask : vector('n, dec, bool) = undefined;
+  mask  : vector('n, dec, bool) = undefined;
   (total, mask) = init_masked_result(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd_val, vm_val);
   status : Retired = RETIRE_SUCCESS;
 
   /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] then {
-      vstart = to_bits(16, i);
-      let elem_offset = signed(vs2_val[i]);
-      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-        Ext_DataAddr_OK(vaddr) => 
-          if check_misaligned(vaddr, width_type) then
-            { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
-          else match translateAddr(vaddr, Read(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-            TR_Address(paddr, _) => {
-              match mem_read(Read(Data), paddr, EEW_data_bytes, false, false, false) {
-                MemValue(result) => total[i] = result,
-                MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+    if status != RETIRE_FAIL then {
+      if mask[i] then {
+        vstart = to_bits(16, i);
+        let elem_offset = signed(vs2_val[i]);
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) => 
+            if check_misaligned(vaddr, width_type) then
+              { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Read(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                match mem_read(Read(Data), paddr, EEW_data_bytes, false, false, false) {
+                  MemValue(result) => total[i] = result,
+                  MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                }
               }
             }
-          }
+        }
       }
     }
   };
-  
+
   if status == RETIRE_SUCCESS then write_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd, total);
   vstart = EXTZ(0b0);
   status
@@ -403,8 +413,8 @@ mapping clause assembly = VLUXEITYPE(vm, vs2, rs1, width, vd)
 /* ************************* Vector Load Indexed Ordered (nf=0, mop=11) ************************** */
 union clause ast = VLOXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VLOXEITYPE(vm, vs2, rs1, width, vd)
-  <-> 0b000 @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+mapping clause encdec = VLOXEITYPE(vm, vs2, rs1, width, vd) if haveRVV()
+  <-> 0b000 @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if haveRVV()
 
 function clause execute(VLOXEITYPE(vm, vs2, rs1, width, vd)) = {
   let EEW_index_pow = vlewidth_pow(width);
@@ -424,8 +434,8 @@ mapping clause assembly = VLOXEITYPE(vm, vs2, rs1, width, vd)
 /* ************************ Vector Store Indexed Unordered (nf=0, mop=01) ************************ */
 union clause ast = VSUXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VSUXEITYPE(vm, vs2, rs1, width, vs3)
-  <-> 0b000 @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
+mapping clause encdec = VSUXEITYPE(vm, vs2, rs1, width, vs3) if haveRVV()
+  <-> 0b000 @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111 if haveRVV()
 
 val process_vsxei : forall 'ib 'db 'ip 'dp 'n, ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n >= 0). (bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vsxei (vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
@@ -434,38 +444,40 @@ function process_vsxei (vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow
   let vs3_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vs3);
   let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
   total : vector('n, dec, bits('db * 8)) = undefined; /* just used to generate mask */
-  mask : vector('n, dec, bool) = undefined;
+  mask  : vector('n, dec, bool) = undefined;
   (total, mask) = init_masked_result(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vs3_val, vm_val);
   status : Retired = RETIRE_SUCCESS;
 
   /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] then {
-      vstart = to_bits(16, i);
-      let elem_offset = signed(vs2_val[i]);
-      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-          Ext_DataAddr_OK(vaddr) =>
-            if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
-            else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-              TR_Address(paddr, _) => {
-                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, EEW_data_bytes, false, false, false);
-                match (eares) {
-                  MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-                  MemValue(_) => {
-                    let res : MemoryOpResult(bool) = mem_write_value(paddr, EEW_data_bytes, vs3_val[i], false, false, false);
-                    match (res) {
-                      MemValue(true)  => status = RETIRE_SUCCESS,
-                      MemValue(false) => internal_error("store got false from mem_write_value"),
-                      MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+    if status != RETIRE_FAIL then {
+      if mask[i] then {
+        vstart = to_bits(16, i);
+        let elem_offset = signed(vs2_val[i]);
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+            Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+            Ext_DataAddr_OK(vaddr) =>
+              if check_misaligned(vaddr, width_type)
+              then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+              else match translateAddr(vaddr, Write(Data)) {
+                TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                TR_Address(paddr, _) => {
+                  let eares : MemoryOpResult(unit) = mem_write_ea(paddr, EEW_data_bytes, false, false, false);
+                  match (eares) {
+                    MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                    MemValue(_) => {
+                      let res : MemoryOpResult(bool) = mem_write_value(paddr, EEW_data_bytes, vs3_val[i], false, false, false);
+                      match (res) {
+                        MemValue(true)  => status = RETIRE_SUCCESS,
+                        MemValue(false) => internal_error("store got false from mem_write_value"),
+                        MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                      }
                     }
                   }
                 }
               }
-            }
         }
+      }
     }
   };
 
@@ -491,8 +503,8 @@ mapping clause assembly = VSUXEITYPE(vm, vs2, rs1, width, vs3)
 /* ************************* Vector Store Indexed Ordered (nf=0, mop=11) ************************* */
 union clause ast = VSOXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VSOXEITYPE(vm, vs2, rs1, width, vs3)
-  <-> 0b000 @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
+mapping clause encdec = VSOXEITYPE(vm, vs2, rs1, width, vs3) if haveRVV()
+  <-> 0b000 @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111 if haveRVV()
 
 function clause execute(VSOXEITYPE(vm, vs2, rs1, width, vs3)) = {
   let EEW_index_pow = vlewidth_pow(width);
@@ -512,8 +524,8 @@ mapping clause assembly = VSOXEITYPE(vm, vs2, rs1, width, vs3)
 /* ************* Vector Load Unit-Stride Fault-Only-First (nf=0, mop=0, lumop=10000) ************* */
 union clause ast = VLEFFTYPE : (bits(1), regidx, vlewidth, regidx)
 
-mapping clause encdec = VLEFFTYPE(vm, rs1, width, vd)
-  <-> 0b000 @ 0b0 @ 0b00 @ vm @ 0b10000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+mapping clause encdec = VLEFFTYPE(vm, rs1, width, vd) if haveRVV()
+  <-> 0b000 @ 0b0 @ 0b00 @ vm @ 0b10000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if haveRVV()
 
 val process_vleff : forall 'b 'n 'p, ('b in {1, 2, 4, 8}) & ('n >= 0). (bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vleff (vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
@@ -521,52 +533,54 @@ function process_vleff (vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vd_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd);
   total : vector('n, dec, bits('b * 8)) = undefined;
-  mask : vector('n, dec, bool) = undefined;
+  mask  : vector('n, dec, bool) = undefined;
   (total, mask) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_val, vm_val);
   status : Retired = RETIRE_SUCCESS;
 
   foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] then {
-      let elem_offset = i * load_width_bytes;
-      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
-        Ext_DataAddr_Error(e) => {
-          if i == 0 then {
-            ext_handle_data_check_error(e);
-            status = RETIRE_FAIL
-          } else {
-            vl = to_bits(sizeof(xlen), i);
-            print_reg("CSR vl <- " ^ BitStr(vl))
-          }
-        },
-        Ext_DataAddr_OK(vaddr) => {
-          if check_misaligned(vaddr, width_type) then {
+    if status != RETIRE_FAIL then {
+      if mask[i] then {
+        let elem_offset = i * load_width_bytes;
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+          Ext_DataAddr_Error(e) => {
             if i == 0 then {
-              handle_mem_exception(vaddr, E_Load_Addr_Align());
+              ext_handle_data_check_error(e);
               status = RETIRE_FAIL
             } else {
               vl = to_bits(sizeof(xlen), i);
               print_reg("CSR vl <- " ^ BitStr(vl))
             }
-          } else match translateAddr(vaddr, Read(Data)) {
-            TR_Failure(e, _) => { 
+          },
+          Ext_DataAddr_OK(vaddr) => {
+            if check_misaligned(vaddr, width_type) then {
               if i == 0 then {
-                handle_mem_exception(vaddr, e);
+                handle_mem_exception(vaddr, E_Load_Addr_Align());
                 status = RETIRE_FAIL
               } else {
                 vl = to_bits(sizeof(xlen), i);
                 print_reg("CSR vl <- " ^ BitStr(vl))
               }
-            },
-            TR_Address(paddr, _) => {
-              match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                MemValue(result) => total[i] = result,
-                MemException(e)  => {
-                  if i == 0 then {
-                    handle_mem_exception(vaddr, e);
-                    status = RETIRE_FAIL
-                  } else {
-                    vl = to_bits(sizeof(xlen), i);
-                    print_reg("CSR vl <- " ^ BitStr(vl))
+            } else match translateAddr(vaddr, Read(Data)) {
+              TR_Failure(e, _) => { 
+                if i == 0 then {
+                  handle_mem_exception(vaddr, e);
+                  status = RETIRE_FAIL
+                } else {
+                  vl = to_bits(sizeof(xlen), i);
+                  print_reg("CSR vl <- " ^ BitStr(vl))
+                }
+              },
+              TR_Address(paddr, _) => {
+                match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
+                  MemValue(result) => total[i] = result,
+                  MemException(e)  => {
+                    if i == 0 then {
+                      handle_mem_exception(vaddr, e);
+                      status = RETIRE_FAIL
+                    } else {
+                      vl = to_bits(sizeof(xlen), i);
+                      print_reg("CSR vl <- " ^ BitStr(vl))
+                    }
                   }
                 }
               }
@@ -607,8 +621,8 @@ mapping clause assembly = VLEFFTYPE(vm, rs1, width, vd)
 /* ******************** Vector Load Unit-Stride Segment (mop=0, lumop=00000) ********************* */
 union clause ast = VLSEGTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
 
-mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd)
-  <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd) if haveRVV()
+  <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if haveRVV()
 
 val process_vlseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
@@ -623,27 +637,29 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
     if vd_t == vd_a & a != 0 then vd_t = vd_t + 1; /* EMUL < 1 */
     let vd_t_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd_t);
     total : vector('n, dec, bits('b * 8)) = undefined;
-    mask : vector('n, dec, bool) = undefined;
+    mask  : vector('n, dec, bool) = undefined;
     (total, mask) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_t_val, vm_val);
 
     foreach (i from 0 to (num_elem - 1)) {
-      if mask[i] then {
-        vstart = to_bits(16, i);
-        let elem_offset = load_width_bytes * (a + i * nf);
-        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-          Ext_DataAddr_OK(vaddr) => 
-              if check_misaligned(vaddr, width_type)
-              then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
-              else match translateAddr(vaddr, Read(Data)) {
-                TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-                TR_Address(paddr, _) => {
-                  match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                    MemValue(result) => total[i] = result,
-                    MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+      if status != RETIRE_FAIL then {
+        if mask[i] then {
+          vstart = to_bits(16, i);
+          let elem_offset = load_width_bytes * (a + i * nf);
+          match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+            Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+            Ext_DataAddr_OK(vaddr) => 
+                if check_misaligned(vaddr, width_type)
+                then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+                else match translateAddr(vaddr, Read(Data)) {
+                  TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                  TR_Address(paddr, _) => {
+                    match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
+                      MemValue(result) => total[i] = result,
+                      MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                    }
                   }
                 }
-              }
+          }
         }
       }
     };
@@ -676,8 +692,8 @@ mapping clause assembly = VLSEGTYPE(nf, vm, rs1, width, vd)
 /* ************ Vector Load Unit-Stride Segment Fault-Only-First (mop=0, lumop=10000) ************ */
 union clause ast = VLSEGFFTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
 
-mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd)
-  <-> nf @ 0b0 @ 0b00 @ vm @ 0b10000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd) if haveRVV()
+  <-> nf @ 0b0 @ 0b00 @ vm @ 0b10000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if haveRVV()
 
 val process_vlsegff : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
@@ -688,29 +704,59 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
   status : Retired = RETIRE_SUCCESS;
   if start_element >= num_elem then return status;
 
-  end_element : int = num_elem - 1;
-  foreach (i from start_element to end_element) {
-    assert(i < num_elem);
-    if (vm_val[i] == true) then {
-      foreach (j from 0 to (nf - 1)) {
-        let elem_offset = (i * nf + j) * load_width_bytes;
-        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
-          Ext_DataAddr_Error(e)  => { if i == 0 then ext_handle_data_check_error(e); status = RETIRE_FAIL },
-          Ext_DataAddr_OK(vaddr) => 
-            if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
-            else match translateAddr(vaddr, Read(Data)) {
-              TR_Failure(e, _)     => { if i == 0 then handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-              TR_Address(paddr, _) => {
-                match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                  MemValue(result) => write_single_element(load_width_bytes * 8, i, EMUL_pow, vd + to_bits(5, j * EMUL_reg), result),
-                  MemException(e)  => { if i == 0 then handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+  foreach (i from start_element to (num_elem - 1)) {
+    if status != RETIRE_FAIL then {
+      if vm_val[i] then {
+        foreach (j from 0 to (nf - 1)) {
+          let elem_offset = (i * nf + j) * load_width_bytes;
+          match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+            Ext_DataAddr_Error(e)  => { 
+              if i == 0 then {
+                ext_handle_data_check_error(e); 
+                status = RETIRE_FAIL
+              } else {
+                vl = to_bits(sizeof(xlen), i);
+                print_reg("CSR vl <- " ^ BitStr(vl))
+              }
+            },
+            Ext_DataAddr_OK(vaddr) => {
+              if check_misaligned(vaddr, width_type) then {
+                if i == 0 then {
+                  handle_mem_exception(vaddr, E_Load_Addr_Align()); 
+                  status = RETIRE_FAIL
+                } else {
+                  vl = to_bits(sizeof(xlen), i);
+                  print_reg("CSR vl <- " ^ BitStr(vl))
+                }
+              } else match translateAddr(vaddr, Read(Data)) {
+                TR_Failure(e, _)     => { 
+                  if i == 0 then {
+                    handle_mem_exception(vaddr, e);
+                    status = RETIRE_FAIL
+                  } else {
+                    vl = to_bits(sizeof(xlen), i);
+                    print_reg("CSR vl <- " ^ BitStr(vl))
+                  }
+                },
+                TR_Address(paddr, _) => {
+                  match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
+                    MemValue(result) => write_single_element(load_width_bytes * 8, i, EMUL_pow, vd + to_bits(5, j * EMUL_reg), result),
+                    MemException(e)  => { 
+                      if i == 0 then {
+                        handle_mem_exception(vaddr, e);
+                        status = RETIRE_FAIL
+                      } else {
+                        vl = to_bits(sizeof(xlen), i);
+                        print_reg("CSR vl <- " ^ BitStr(vl))
+                      }
+                    }
+                  }
                 }
               }
             }
+          }
         }
-      };
-      if status == RETIRE_FAIL then end_element = i;
+      }
     }
   };
 
@@ -737,8 +783,8 @@ mapping clause assembly = VLSEGTYPE(nf, vm, rs1, width, vd)
 /* ******************** Vector Store Unit-Stride Segment (mop=0, sumop=00000) ******************** */
 union clause ast = VSSEGTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
 
-mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3)
-  <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
+mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3) if haveRVV()
+  <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111 if haveRVV()
 
 val process_vsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
@@ -750,33 +796,35 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
   if start_element >= num_elem then return status;
 
   foreach (i from start_element to (num_elem - 1)) {
-    if vm_val[i] == true then {
+    if vm_val[i] then {
       vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
-        let elem_offset = (i * nf + j) * load_width_bytes;
-        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-          Ext_DataAddr_OK(vaddr) =>
-            if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
-            else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-              TR_Address(paddr, _) => {
-                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
-                match (eares) {
-                  MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-                  MemValue(_) => {
-                    let one_elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, EMUL_pow, vs3 + to_bits(5, j * EMUL_reg));
-                    let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, one_elem_val, false, false, false);
-                    match (res) {
-                      MemValue(true)  => status = RETIRE_SUCCESS,
-                      MemValue(false) => internal_error("store got false from mem_write_value"),
-                      MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+        if status != RETIRE_FAIL then {
+          let elem_offset = (i * nf + j) * load_width_bytes;
+          match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+            Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+            Ext_DataAddr_OK(vaddr) =>
+              if check_misaligned(vaddr, width_type)
+              then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+              else match translateAddr(vaddr, Write(Data)) {
+                TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                TR_Address(paddr, _) => {
+                  let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
+                  match (eares) {
+                    MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                    MemValue(_) => {
+                      let one_elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, EMUL_pow, vs3 + to_bits(5, j * EMUL_reg));
+                      let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, one_elem_val, false, false, false);
+                      match (res) {
+                        MemValue(true)  => status = RETIRE_SUCCESS,
+                        MemValue(false) => internal_error("store got false from mem_write_value"),
+                        MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                      }
                     }
                   }
                 }
               }
-            }
+          }
         }
       }
     }
@@ -805,17 +853,17 @@ mapping clause assembly = VSSEGTYPE(nf, vm, rs1, width, vs3)
 /* **************************** Vector Load Strided Segment (mop=10) ***************************** */
 union clause ast = VLSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
-  <-> nf @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd) if haveRVV()
+  <-> nf @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if haveRVV()
 
 val process_vlsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else int_power(2, EMUL_pow);
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
-  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vd_val  : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd); /* only to generate mask */
-  result      : vector('n, dec, bits('b * 8)) = undefined;
-  mask : vector('n, dec, bool)     = undefined;
+  let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd); /* only to generate mask */
+  result : vector('n, dec, bits('b * 8)) = undefined;
+  mask   : vector('n, dec, bool) = undefined;
   (result, mask) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_val, vm_val);
 
   let rs2_val : int = signed(get_scalar(rs2, sizeof(xlen)));
@@ -824,21 +872,23 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
     if mask[i] then {
       vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
-        let elem_offset = i * rs2_val + j * load_width_bytes;
-        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-          Ext_DataAddr_OK(vaddr) => 
-            if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
-            else match translateAddr(vaddr, Read(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-              TR_Address(paddr, _) => {
-                match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                  MemValue(result) => write_single_element(load_width_bytes * 8, i, EMUL_pow, vd + to_bits(5, j * EMUL_reg) , result),
-                  MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+        if status != RETIRE_FAIL then {
+          let elem_offset = i * rs2_val + j * load_width_bytes;
+          match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+            Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+            Ext_DataAddr_OK(vaddr) => 
+              if check_misaligned(vaddr, width_type)
+              then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+              else match translateAddr(vaddr, Read(Data)) {
+                TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                TR_Address(paddr, _) => {
+                  match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
+                    MemValue(result) => write_single_element(load_width_bytes * 8, i, EMUL_pow, vd + to_bits(5, j * EMUL_reg) , result),
+                    MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                  }
                 }
               }
-            }
+          }
         }
       }
     }
@@ -867,17 +917,17 @@ mapping clause assembly = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
 /* **************************** Vector Store Strided Segment (mop=10) **************************** */
 union clause ast = VSSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
-  <-> nf @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
+mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3) if haveRVV()
+  <-> nf @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111 if haveRVV()
 
 val process_vssseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else int_power(2, EMUL_pow);
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
-  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vs3_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vs3); /* only to generate mask */
-  result      : vector('n, dec, bits('b * 8)) = undefined;
-  mask : vector('n, dec, bool)     = undefined;
+  result : vector('n, dec, bits('b * 8)) = undefined;
+  mask   : vector('n, dec, bool) = undefined;
   (result, mask) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vs3_val, vm_val);
 
   let rs2_val : int = signed(get_scalar(rs2, sizeof(xlen)));
@@ -886,32 +936,34 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
     if mask[i] then {
       vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
-        let elem_offset = i * rs2_val + j * load_width_bytes;
-        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-          Ext_DataAddr_OK(vaddr) =>
-            if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
-            else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-              TR_Address(paddr, _) => {
-                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
-                match (eares) {
-                  MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-                  MemValue(_) => {
-                    let one_elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, EMUL_pow, vs3 + to_bits(5, j * EMUL_reg));
-                    let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, one_elem_val, false, false, false);
-                    match (res) {
-                      MemValue(true)  => status = RETIRE_SUCCESS,
-                      MemValue(false) => internal_error("store got false from mem_write_value"),
-                      MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+        if status != RETIRE_FAIL then {
+          let elem_offset = i * rs2_val + j * load_width_bytes;
+          match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+            Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+            Ext_DataAddr_OK(vaddr) =>
+              if check_misaligned(vaddr, width_type)
+              then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+              else match translateAddr(vaddr, Write(Data)) {
+                TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                TR_Address(paddr, _) => {
+                  let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
+                  match (eares) {
+                    MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                    MemValue(_) => {
+                      let one_elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, EMUL_pow, vs3 + to_bits(5, j * EMUL_reg));
+                      let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, one_elem_val, false, false, false);
+                      match (res) {
+                        MemValue(true)  => status = RETIRE_SUCCESS,
+                        MemValue(false) => internal_error("store got false from mem_write_value"),
+                        MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                      }
                     }
                   }
                 }
               }
-            }
+          }
         }
-      };
+      }
     }
   };
 
@@ -938,18 +990,18 @@ mapping clause assembly = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
 /* *********************** Vector Load Indexed Unordered Segment (mop=01) ************************ */
 union clause ast = VLUXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
-  <-> nf @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd) if haveRVV()
+  <-> nf @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if haveRVV()
 
 val process_vlxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n >= 0). (int('f), bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else int_power(2, EMUL_data_pow);
   let width_type : word_width = bytes_wordwidth(EEW_data_bytes);
-  let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vd_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd);
+  let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd);
   let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
   total : vector('n, dec, bits('db * 8)) = undefined;
-  mask : vector('n, dec, bool) = undefined;
+  mask  : vector('n, dec, bool) = undefined;
   (total, mask) = init_masked_result(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd_val, vm_val);
   status : Retired = RETIRE_SUCCESS;
 
@@ -958,21 +1010,23 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
     if mask[i] then {
       vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
-        let elem_offset : int = signed(vs2_val[i]) + j * EEW_data_bytes;
-        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-          Ext_DataAddr_OK(vaddr) => 
-            if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
-            else match translateAddr(vaddr, Read(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-              TR_Address(paddr, _) => {
-                match mem_read(Read(Data), paddr, EEW_data_bytes, false, false, false) {
-                  MemValue(result) => write_single_element(EEW_data_bytes * 8, i, EMUL_data_pow, vd + to_bits(5, j * EMUL_data_reg) , result),
-                  MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+        if status != RETIRE_FAIL then {
+          let elem_offset : int = signed(vs2_val[i]) + j * EEW_data_bytes;
+          match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+            Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+            Ext_DataAddr_OK(vaddr) => 
+              if check_misaligned(vaddr, width_type)
+              then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+              else match translateAddr(vaddr, Read(Data)) {
+                TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                TR_Address(paddr, _) => {
+                  match mem_read(Read(Data), paddr, EEW_data_bytes, false, false, false) {
+                    MemValue(result) => write_single_element(EEW_data_bytes * 8, i, EMUL_data_pow, vd + to_bits(5, j * EMUL_data_reg) , result),
+                    MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                  }
                 }
               }
-            }
+          }
         }
       }
     }
@@ -1001,8 +1055,8 @@ mapping clause assembly = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
 /* ************************ Vector Load Indexed Ordered Segment (mop=11) ************************* */
 union clause ast = VLOXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)
-  <-> nf @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+mapping clause encdec = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd) if haveRVV()
+  <-> nf @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if haveRVV()
 
 function clause execute(VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
   let EEW_index_pow = vlewidth_pow(width);
@@ -1023,8 +1077,8 @@ mapping clause assembly = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)
 /* *********************** Vector Store Indexed Unordered Segment (mop=01) *********************** */
 union clause ast = VSUXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
-  <-> nf @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
+mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3) if haveRVV()
+  <-> nf @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111 if haveRVV()
 
 val process_vsxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n >= 0). (int('f), bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
@@ -1034,7 +1088,7 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
   let vs3_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vs3);
   let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
   total : vector('n, dec, bits('db * 8)) = undefined;
-  mask : vector('n, dec, bool) = undefined;
+  mask  : vector('n, dec, bool) = undefined;
   (total, mask) = init_masked_result(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vs3_val, vm_val);
   status : Retired = RETIRE_SUCCESS;
 
@@ -1043,30 +1097,32 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
     if mask[i] then {
       vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
-        let elem_offset : int = signed(vs2_val[i]) + j * EEW_data_bytes;
-        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-          Ext_DataAddr_OK(vaddr) =>
-            if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
-            else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-              TR_Address(paddr, _) => {
-                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, EEW_data_bytes, false, false, false);
-                match (eares) {
-                  MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-                  MemValue(_) => {
-                    let one_elem_val : bits('db * 8) = read_single_element(EEW_data_bytes * 8, i, EMUL_data_pow, vs3 + to_bits(5, j * EMUL_data_reg));
-                    let res : MemoryOpResult(bool) = mem_write_value(paddr, EEW_data_bytes, one_elem_val, false, false, false);
-                    match (res) {
-                      MemValue(true)  => status = RETIRE_SUCCESS,
-                      MemValue(false) => internal_error("store got false from mem_write_value"),
-                      MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+        if status != RETIRE_FAIL then {
+          let elem_offset : int = signed(vs2_val[i]) + j * EEW_data_bytes;
+          match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+            Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+            Ext_DataAddr_OK(vaddr) =>
+              if check_misaligned(vaddr, width_type)
+              then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+              else match translateAddr(vaddr, Write(Data)) {
+                TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                TR_Address(paddr, _) => {
+                  let eares : MemoryOpResult(unit) = mem_write_ea(paddr, EEW_data_bytes, false, false, false);
+                  match (eares) {
+                    MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                    MemValue(_) => {
+                      let one_elem_val : bits('db * 8) = read_single_element(EEW_data_bytes * 8, i, EMUL_data_pow, vs3 + to_bits(5, j * EMUL_data_reg));
+                      let res : MemoryOpResult(bool) = mem_write_value(paddr, EEW_data_bytes, one_elem_val, false, false, false);
+                      match (res) {
+                        MemValue(true)  => status = RETIRE_SUCCESS,
+                        MemValue(false) => internal_error("store got false from mem_write_value"),
+                        MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                      }
                     }
                   }
                 }
               }
-            }
+          }
         }
       }
     }
@@ -1095,8 +1151,8 @@ mapping clause assembly = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
 /* ************************ Vector Store Indexed Ordered Segment (mop=11) ************************ */
 union clause ast = VSOXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
-  <-> nf @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
+mapping clause encdec = VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3) if haveRVV()
+  <-> nf @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111 if haveRVV()
 
 function clause execute(VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
   let EEW_index_pow = vlewidth_pow(width);
@@ -1117,8 +1173,8 @@ mapping clause assembly = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
 /* ************** Vector Load Unit-Stride Whole Register (vm=1, mop=0, lumop=01000) ************** */
 union clause ast = VLRETYPE : (bits(3), regidx, vlewidth, regidx)
 
-mapping clause encdec = VLRETYPE(nf, rs1, width, vd)
-  <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+mapping clause encdec = VLRETYPE(nf, rs1, width, vd) if haveRVV()
+  <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if haveRVV()
 
 val process_vlre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), regidx, int('b), regidx, int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
@@ -1131,52 +1187,53 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
 
   if elem_to_align > 0 then {
     foreach (i from elem_to_align to (elem_per_reg - 1)) {
-      vstart = to_bits(16, start_element);
-      let elem_offset : int = start_element * load_width_bytes;
-      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-        Ext_DataAddr_OK(vaddr) => 
-          if check_misaligned(vaddr, width_type)
-          then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
-          else match translateAddr(vaddr, Read(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-            TR_Address(paddr, _) => {
-              match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                MemValue(result) => write_single_element(load_width_bytes * 8, i, 0, vd + to_bits(5, cur_field) , result),
-                MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+      if status != RETIRE_FAIL then {
+        vstart = to_bits(16, start_element);
+        let elem_offset : int = start_element * load_width_bytes;
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) => 
+            if check_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Read(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
+                  MemValue(result) => write_single_element(load_width_bytes * 8, i, 0, vd + to_bits(5, cur_field) , result),
+                  MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                }
               }
             }
-          }
-      };
-      start_element = start_element + 1
+        };
+        start_element = start_element + 1
+      }
     };
     cur_field = cur_field + 1
   };
 
-  total : vector('n, dec, bits('b * 8)) = undefined;
   foreach (j from cur_field to (nf - 1)) {
-    total = undefined;
     foreach (i from 0 to (elem_per_reg - 1)) {
-      vstart = to_bits(16, start_element);
-      let elem_offset = start_element * load_width_bytes;
-      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-        Ext_DataAddr_OK(vaddr) => 
-          if check_misaligned(vaddr, width_type)
-          then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
-          else match translateAddr(vaddr, Read(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-            TR_Address(paddr, _) => {
-              match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                MemValue(result) => total[i] = result,
-                MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+      if status != RETIRE_FAIL then {
+        vstart = to_bits(16, start_element);
+        let elem_offset = start_element * load_width_bytes;
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) => 
+            if check_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Read(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
+                  MemValue(result) => write_single_element(load_width_bytes * 8, i, 0, vd + to_bits(5, j) , result),
+                  MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                }
               }
             }
-          }
-      };
-      start_element = start_element + 1
+        };
+        start_element = start_element + 1
+      }
     };
-    if status == RETIRE_SUCCESS then write_vreg(elem_per_reg, load_width_bytes * 8, 0, vd + to_bits(5, j), total) /* EMUL=1 */
   };
 
   vstart = EXTZ(0b0);
@@ -1202,8 +1259,8 @@ mapping clause assembly = VLRETYPE(nf, rs1, width, vd)
 /* ************* Vector Store Unit-Stride Whole Register (vm=1, mop=0, lumop=01000) ************** */
 union clause ast = VSRETYPE : (bits(3), regidx, regidx)
 
-mapping clause encdec = VSRETYPE(nf, rs1, vs3)
-  <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ rs1 @ 0b000 @ vs3 @ 0b0100111
+mapping clause encdec = VSRETYPE(nf, rs1, vs3) if haveRVV()
+  <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ rs1 @ 0b000 @ vs3 @ 0b0100111 if haveRVV()
 
 val process_vsre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), int('b), regidx, regidx, int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
@@ -1216,33 +1273,35 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
 
   if elem_to_align > 0 then {
     foreach (i from elem_to_align to (elem_per_reg - 1)) {
-      vstart = to_bits(16, start_element);
-      let elem_offset : int = start_element * load_width_bytes;
-      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-        Ext_DataAddr_OK(vaddr) =>
-          if check_misaligned(vaddr, width_type)
-          then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
-          else match translateAddr(vaddr, Write(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-            TR_Address(paddr, _) => {
-              let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
-              match (eares) {
-                MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-                MemValue(_) => {
-                  let one_elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, 0, vs3 + to_bits(5, cur_field));
-                  let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, one_elem_val, false, false, false);
-                  match (res) {
-                    MemValue(true)  => status = RETIRE_SUCCESS,
-                    MemValue(false) => internal_error("store got false from mem_write_value"),
-                    MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+      if status != RETIRE_FAIL then {
+        vstart = to_bits(16, start_element);
+        let elem_offset : int = start_element * load_width_bytes;
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) =>
+            if check_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Write(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
+                match (eares) {
+                  MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                  MemValue(_) => {
+                    let one_elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, 0, vs3 + to_bits(5, cur_field));
+                    let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, one_elem_val, false, false, false);
+                    match (res) {
+                      MemValue(true)  => status = RETIRE_SUCCESS,
+                      MemValue(false) => internal_error("store got false from mem_write_value"),
+                      MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                    }
                   }
                 }
               }
             }
-          }
-      };
-      start_element = start_element + 1
+        };
+        start_element = start_element + 1
+      }
     };
     cur_field = cur_field + 1
   };
@@ -1250,33 +1309,35 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
   foreach (j from cur_field to (nf - 1)) {
     let vs_val : vector('n, dec, bits('b * 8)) = read_vreg(elem_per_reg, load_width_bytes * 8, 0, vs3 + to_bits(5, j));
     foreach (i from 0 to (elem_per_reg - 1)) {
-      vstart = to_bits(16, start_element);
-      let elem_offset = start_element * load_width_bytes;
-      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-        Ext_DataAddr_OK(vaddr) =>
-          if check_misaligned(vaddr, width_type)
-          then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
-          else match translateAddr(vaddr, Write(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-            TR_Address(paddr, _) => {
-              let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
-              match (eares) {
-                MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-                MemValue(_) => {
-                  let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, vs_val[i], false, false, false);
-                  match (res) {
-                    MemValue(true)  => status = RETIRE_SUCCESS,
-                    MemValue(false) => internal_error("store got false from mem_write_value"),
-                    MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+      if status != RETIRE_FAIL then {
+        vstart = to_bits(16, start_element);
+        let elem_offset = start_element * load_width_bytes;
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) =>
+            if check_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Write(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
+                match (eares) {
+                  MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                  MemValue(_) => {
+                    let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, vs_val[i], false, false, false);
+                    match (res) {
+                      MemValue(true)  => status = RETIRE_SUCCESS,
+                      MemValue(false) => internal_error("store got false from mem_write_value"),
+                      MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                    }
                   }
                 }
               }
             }
-          }
-      };
-      start_element = start_element + 1
-    };
+        };
+        start_element = start_element + 1
+      }
+    }
   };
 
   vstart = EXTZ(0b0);
@@ -1307,8 +1368,8 @@ mapping encdec_lsop : vmlsop <-> bits(7) = {
   VSM      <-> 0b0100111
 }
 
-mapping clause encdec = VMTYPE(rs1, vd_or_vs3, op)
-  <-> 0b000 @ 0b0 @ 0b00 @ 0b1 @ 0b01011 @ rs1 @ 0b000 @ vd_or_vs3 @ encdec_lsop(op)
+mapping clause encdec = VMTYPE(rs1, vd_or_vs3, op) if haveRVV()
+  <-> 0b000 @ 0b0 @ 0b00 @ 0b1 @ 0b01011 @ rs1 @ 0b000 @ vd_or_vs3 @ encdec_lsop(op) if haveRVV()
 
 val process_vm : forall 'n 'p, ('n >= 0). (regidx, regidx, int('p), int('n), vmlsop) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vm(vd_or_vs3, rs1, EMUL_pow, num_elem, op) = {
@@ -1320,59 +1381,61 @@ function process_vm(vd_or_vs3, rs1, EMUL_pow, num_elem, op) = {
   status : Retired = RETIRE_SUCCESS;
   
   foreach (i from 0 to (num_elem - 1)) {
-    let elem_offset = i;                     
-    if op == VLM then { /* load */
-      if i < start_element then {
-        total[i] = vd_or_vs3_val[i]
-      } else {
-        vstart = to_bits(16, i);
-        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-          Ext_DataAddr_OK(vaddr) => 
-            if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
-            else match translateAddr(vaddr, Read(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-              TR_Address(paddr, _) => {
-                match mem_read(Read(Data), paddr, 1, false, false, false) {
-                  MemValue(result) => if i < num_elem then total[i] = result,
-                  MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+    if status != RETIRE_FAIL then {
+      let elem_offset = i;
+      if op == VLM then { /* load */
+        if i < start_element then {
+          total[i] = vd_or_vs3_val[i]
+        } else {
+          vstart = to_bits(16, i);
+          match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+            Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+            Ext_DataAddr_OK(vaddr) => 
+              if check_misaligned(vaddr, width_type)
+              then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+              else match translateAddr(vaddr, Read(Data)) {
+                TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                TR_Address(paddr, _) => {
+                  match mem_read(Read(Data), paddr, 1, false, false, false) {
+                    MemValue(result) => if i < num_elem then total[i] = result,
+                    MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                  }
                 }
               }
-            }
-        }
-      };
-      if status == RETIRE_SUCCESS then write_vreg(num_elem, 8, EMUL_pow, vd_or_vs3, total)
-    } else if op == VSM then { /* store */
-      if i > start_element then {
-        vstart = to_bits(16, i);
-        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
-          Ext_DataAddr_OK(vaddr) =>
-            if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
-            else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-              TR_Address(paddr, _) => {
-                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, 1, false, false, false);
-                match (eares) {
-                  MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
-                  MemValue(_) => {
-                    let res : MemoryOpResult(bool) = mem_write_value(paddr, 1, vd_or_vs3_val[i], false, false, false);
-                    match (res) {
-                      MemValue(true)  => status = RETIRE_SUCCESS,
-                      MemValue(false) => internal_error("store got false from mem_write_value"),
-                      MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+          }
+        };
+      } else if op == VSM then { /* store */
+        if i >= start_element then {
+          vstart = to_bits(16, i);
+          match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+            Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+            Ext_DataAddr_OK(vaddr) =>
+              if check_misaligned(vaddr, width_type)
+              then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+              else match translateAddr(vaddr, Write(Data)) {
+                TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                TR_Address(paddr, _) => {
+                  let eares : MemoryOpResult(unit) = mem_write_ea(paddr, 1, false, false, false);
+                  match (eares) {
+                    MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                    MemValue(_) => {
+                      let res : MemoryOpResult(bool) = mem_write_value(paddr, 1, vd_or_vs3_val[i], false, false, false);
+                      match (res) {
+                        MemValue(true)  => status = RETIRE_SUCCESS,
+                        MemValue(false) => internal_error("store got false from mem_write_value"),
+                        MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                      }
                     }
                   }
                 }
               }
-            }
+          }
         }
       }
     }
   };
 
+  if op == VLM & status == RETIRE_SUCCESS then write_vreg(num_elem, 8, EMUL_pow, vd_or_vs3, total);
   vstart = EXTZ(0b0);
   status
 }

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -92,6 +92,7 @@ function process_vle (vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask_helper[i] == true then{
+      vstart = to_bits(16, i);
       let elem_offset = i * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
@@ -163,6 +164,7 @@ function process_vse (vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   foreach (i from 0 to (num_elem - 1)) {
     let elem_offset = i * load_width_bytes;
     if mask_helper[i] == true then {
+      vstart = to_bits(16, i);
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
         Ext_DataAddr_OK(vaddr) =>
@@ -241,6 +243,7 @@ function process_vlse (vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) =
   foreach (i from 0 to (num_elem - 1)) {
     let elem_offset = i * rs2_val;
     if mask_helper[i] == true then {
+      vstart = to_bits(16, i);
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
         Ext_DataAddr_OK(vaddr) => 
@@ -312,6 +315,7 @@ function process_vsse (vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) 
   foreach (i from 0 to (num_elem - 1)) {
     let elem_offset = i * rs2_val;
     if mask_helper[i] == true then {
+      vstart = to_bits(16, i);
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
         Ext_DataAddr_OK(vaddr) =>
@@ -378,7 +382,6 @@ mapping clause encdec = VLUXEITYPE(vm, vs2, rs1, width, vd)
 val process_vlxei : forall 'ib 'db 'ip 'dp 'n, (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vlxei (vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let width_type : word_width = bytes_wordwidth(EEW_data_bytes);
-  let start_element : int = get_start_element();
   let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vd_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd);
   let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
@@ -390,6 +393,7 @@ function process_vlxei (vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow,
   /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
     if mask_helper[i] == true then {
+      vstart = to_bits(16, i);
       let elem_offset = signed(vs2_val[i]);
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
@@ -471,7 +475,6 @@ mapping clause encdec = VSUXEITYPE(vm, vs2, rs1, width, vs3)
 val process_vsxei : forall 'ib 'db 'ip 'dp 'n, (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
 function process_vsxei (vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let width_type : word_width = bytes_wordwidth(EEW_data_bytes);
-  let start_element : int = get_start_element();
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vs3_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vs3);
   let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
@@ -483,6 +486,7 @@ function process_vsxei (vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow
   /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
     if mask_helper[i] == true then {
+      vstart = to_bits(16, i);
       let elem_offset = signed(vs2_val[i]);
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
@@ -694,6 +698,7 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
 
     foreach (i from 0 to (num_elem - 1)) {
       if (mask_helper[i] == true) then {
+        vstart = to_bits(16, i);
         let elem_offset = load_width_bytes * (a + i * nf);
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
@@ -829,6 +834,7 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
 
   foreach (i from start_element to (num_elem - 1)) {
     if vm_val[i] == true then {
+      vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = (i * nf + j) * load_width_bytes;
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
@@ -855,7 +861,7 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
               }
             }
         }
-      };
+      }
     }
   };
 
@@ -905,6 +911,7 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
   status : Retired = RETIRE_SUCCESS;
   foreach (i from 0 to (num_elem - 1)) {
     if mask_helper[i] == true then {
+      vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = i * rs2_val + j * load_width_bytes;
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
@@ -972,6 +979,7 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
   status : Retired = RETIRE_SUCCESS;
   foreach (i from 0 to (num_elem - 1)) {
     if mask_helper[i] == true then {
+      vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = i * rs2_val + j * load_width_bytes;
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
@@ -1038,7 +1046,6 @@ val process_vlxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & (0 < 'ib
 function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else int_power(2, EMUL_data_pow);
   let width_type : word_width = bytes_wordwidth(EEW_data_bytes);
-  let start_element : int = get_start_element();
   let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vd_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd);
   let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
@@ -1050,6 +1057,7 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
   /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
     if mask_helper[i] == true then {
+      vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
         let elem_offset : int = signed(vs2_val[i]) + j * EEW_data_bytes;
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
@@ -1137,7 +1145,6 @@ val process_vsxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & (0 < 'ib
 function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else int_power(2, EMUL_data_pow);
   let width_type : word_width = bytes_wordwidth(EEW_data_bytes);
-  let start_element : int = get_start_element();
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vs3_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vs3);
   let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
@@ -1149,6 +1156,7 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
   /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
     if mask_helper[i] == true then {
+      vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
         let elem_offset : int = signed(vs2_val[i]) + j * EEW_data_bytes;
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
@@ -1231,10 +1239,10 @@ function clause execute(VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
 }
 
 mapping clause assembly = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
-  <-> "vsuoseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+  <-> "vsoxseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
 
 
-/* ****VLOAD***************VLRETYPE(Vector Load Unit-Steided Whole Register, vm=1, mop=0, lumop=01000)*************************** */
+/* ****VLOAD***************VLRETYPE(Vector Load Unit-Strided Whole Register, vm=1, mop=0, lumop=01000)*************************** */
 
 union clause ast = VLRETYPE : (bits(3), regidx, vlewidth, regidx)
 
@@ -1255,6 +1263,7 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
 
   if elem_to_align > 0 then {
     foreach (i from elem_to_align to (elem_per_reg - 1)) {
+      vstart = to_bits(16, start_element);
       let elem_offset : int = start_element * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
@@ -1280,6 +1289,7 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
   foreach (j from cur_field to (nf - 1)) {
     total = undefined;
     foreach (i from 0 to (elem_per_reg - 1)) {
+      vstart = to_bits(16, start_element);
       let elem_offset = start_element * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
@@ -1344,6 +1354,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
 
   if elem_to_align > 0 then {
     foreach (i from elem_to_align to (elem_per_reg - 1)) {
+      vstart = to_bits(16, start_element);
       let elem_offset : int = start_element * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
@@ -1377,6 +1388,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
   foreach (j from cur_field to (nf - 1)) {
     let vs_val : vector('n, dec, bits('b * 8)) = read_vreg(elem_per_reg, load_width_bytes * 8, 0, vs3 + to_bits(5, j));
     foreach (i from 0 to (elem_per_reg - 1)) {
+      vstart = to_bits(16, start_element);
       let elem_offset = start_element * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
@@ -1454,6 +1466,7 @@ function process_vm(vd_or_vs3, rs1, EMUL_pow, num_elem, op) = {
       if i < start_element then {
         total[i] = vd_or_vs3_val[i]
       } else {
+        vstart = to_bits(16, i);
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) => 
@@ -1473,6 +1486,7 @@ function process_vm(vd_or_vs3, rs1, EMUL_pow, num_elem, op) = {
       if status == RETIRE_SUCCESS then write_vreg(num_elem, 8, EMUL_pow, vd_or_vs3, total)
     } else if op == VSM then { /* store */
       if i > start_element then {
+        vstart = to_bits(16, i);
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) =>

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -1,0 +1,1508 @@
+/* ************************************************************************ */
+/* This file implements part of the vector extension.                       */
+/* Chapter 7: vector loads and stores                                       */
+
+/* ************************************************************************ */
+
+mapping nfields_int : bits(3) <-> int = {
+  0b000     <-> 1,
+  0b001     <-> 2,
+  0b010     <-> 3,
+  0b011     <-> 4,
+  0b100     <-> 5,
+  0b101     <-> 6,
+  0b110     <-> 7,
+  0b111     <-> 8
+}
+
+mapping nfields_string : bits(3) <-> string = {
+  0b000     <-> "1",
+  0b001     <-> "2",
+  0b010     <-> "3",
+  0b011     <-> "4",
+  0b100     <-> "5",
+  0b101     <-> "6",
+  0b110     <-> "7",
+  0b111     <-> "8"
+}
+
+mapping vlewidth_bitsnumberstr : vlewidth <-> string = {
+  VLE8      <-> "8",
+  VLE16     <-> "16",
+  VLE32     <-> "32",
+  VLE64     <-> "64"
+}
+
+mapping encdec_vlewidth : vlewidth <-> bits(3) = {
+  VLE8      <-> 0b000,
+  VLE16     <-> 0b101,
+  VLE32     <-> 0b110,
+  VLE64     <-> 0b111
+}
+
+mapping vlewidth_bytesnumber : vlewidth <-> int = {
+  VLE8      <-> 1,
+  VLE16     <-> 2,
+  VLE32     <-> 4,
+  VLE64     <-> 8
+}
+
+mapping bytes_wordwidth : int <-> word_width = {
+  1 <-> BYTE,
+  2 <-> HALF,
+  4 <-> WORD,
+  8 <-> DOUBLE
+}
+
+/* Vector misaligned checking (used in vload) */
+val vcheck_misaligned : (xlenbits, word_width) -> bool effect {undef}
+function vcheck_misaligned(vaddr : xlenbits, width : word_width) -> bool = {
+  if   plat_enable_misaligned_access() then false
+  else match width {
+    BYTE     => false,
+    HALF     => vaddr[0] == bitone,
+    WORD     => vaddr[0] == bitone | vaddr[1] == bitone,
+    DOUBLE   => vaddr[0] == bitone | vaddr[1] == bitone | vaddr[2] == bitone
+  };
+}
+
+/* *****VLOAD**************VLETYPE(Vector Load Unit-Strided Normal, nf=0, mop=0, lumop=0)*************************** */
+union clause ast = VLETYPE : (bits(1), regidx, vlewidth, regidx)
+
+mapping clause encdec = VLETYPE(vm, rs1, width, vd)
+  <-> 0b000 @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+
+val process_vle : forall 'b 'n, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, real, int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vle (vm, vd, load_width_bytes, rs1, emul, num_elem) = {
+  let width_type : word_width = bytes_wordwidth(load_width_bytes);
+  let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, emul, vd);
+  total : vector('n, dec, bits('b * 8)) = undefined;
+  mask_helper : vector('n, dec, bool) = undefined;
+  status : Retired = RETIRE_SUCCESS;
+
+  (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, emul, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask_helper[i] == true then{
+      let elem_offset = i * load_width_bytes;
+      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+        Ext_DataAddr_OK(vaddr) => 
+          if vcheck_misaligned(vaddr, width_type)
+          then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+          else match translateAddr(vaddr, Read(Data)) {
+            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+            TR_Address(paddr, _) => {
+              match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
+                MemValue(result) => total[i] = result,
+                MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+              }
+            }
+          }
+      }
+    }
+  };
+
+  if status == RETIRE_SUCCESS then write_vreg(num_elem, load_width_bytes * 8, emul, vd, total);
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VLETYPE(vm, rs1, width, vd)) = {
+  let load_width_bytes : int = vlewidth_bytesnumber(width);
+  let veew_bits : int = load_width_bytes * 8;
+  let vsew_bits : int = get_vtype_vsew();
+  let lmul : real = get_vtype_LMUL();
+  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
+  let num_elem : int = get_num_elem(emul, veew_bits);
+
+  assert(0 < load_width_bytes & load_width_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+
+  process_vle(vm, vd, load_width_bytes, rs1,  emul, num_elem)
+}
+
+mapping vletype_mnemonic : vlewidth <-> string = {
+  VLE8        <-> "vle8.v",
+  VLE16       <-> "vle16.v",
+  VLE32       <-> "vle32.v",
+  VLE64       <-> "vle64.v"
+}
+
+mapping clause assembly = VLETYPE(vm, rs1, width, vd)
+  <-> vletype_mnemonic(width) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
+
+
+/* *****VSTORE**************VSETYPE(Vector Store Unit-Strided Normal, nf=0, mop=0, sumop=0)*************************** */
+
+union clause ast = VSETYPE : (bits(1), regidx, vlewidth, regidx)
+
+mapping clause encdec = VSETYPE(vm, rs1, width, vs3)
+  <-> 0b000 @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
+
+val process_vse : forall 'b 'n, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, real, int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vse (vm, vs3, load_width_bytes, rs1, emul, num_elem) = {
+  let width_type : word_width = bytes_wordwidth(load_width_bytes);
+  let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs3_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, emul, vs3);
+  total : vector('n, dec, bits('b * 8)) = undefined;
+  mask_helper : vector('n, dec, bool) = undefined;
+  status : Retired = RETIRE_SUCCESS;
+
+  (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, emul, vs3_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    let elem_offset = i * load_width_bytes;
+    if mask_helper[i] == true then {
+      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+        Ext_DataAddr_OK(vaddr) =>
+          if vcheck_misaligned(vaddr, width_type)
+          then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+          else match translateAddr(vaddr, Write(Data)) {
+            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+            TR_Address(paddr, _) => {
+              let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
+              match (eares) {
+                MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                MemValue(_) => {
+                  let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, vs3_val[i], false, false, false);
+                  match (res) {
+                    MemValue(true)  => status = RETIRE_SUCCESS,
+                    MemValue(false) => internal_error("store got false from mem_write_value"),
+                    MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                  }
+                }
+              }
+            }
+          }
+      }
+    }
+  };
+
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VSETYPE(vm, rs1, width, vs3)) = {
+  let load_width_bytes : int = vlewidth_bytesnumber(width);
+  let veew_bits : int = load_width_bytes * 8;
+  let vsew_bits : int = get_vtype_vsew();
+  let lmul : real = get_vtype_LMUL();
+  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
+  let num_elem : int = get_num_elem(emul, veew_bits);
+
+  assert(0 < load_width_bytes & load_width_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+
+  process_vse(vm, vs3, load_width_bytes, rs1, emul, num_elem)
+}
+
+mapping vsetype_mnemonic : vlewidth <-> string = {
+  VLE8        <-> "vse8.v",
+  VLE16       <-> "vse16.v",
+  VLE32       <-> "vse32.v",
+  VLE64       <-> "vse64.v"
+}
+
+mapping clause assembly = VSETYPE(vm, rs1, width, vs3)
+  <-> vsetype_mnemonic(width) ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
+
+
+/* ****VLOAD************VLSETYPE(Vector Load Strided Normal, nf=0, mop=10)*************************** */
+
+union clause ast = VLSETYPE : (bits(1), regidx, regidx, vlewidth, regidx)
+
+mapping clause encdec = VLSETYPE(vm, rs2, rs1, width, vd)
+  <-> 0b000 @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+
+val process_vlse : forall 'b 'n, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, regidx, real, int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vlse (vm, vd, load_width_bytes, rs1, rs2, emul, num_elem) = {
+  let width_type : word_width = bytes_wordwidth(load_width_bytes);
+  let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, emul, vd);
+  let rs2_val : int = signed(get_scalar(rs2, sizeof(xlen)));
+  total : vector('n, dec, bits('b * 8)) = undefined;
+  mask_helper : vector('n, dec, bool) = undefined;
+  status : Retired = RETIRE_SUCCESS;
+
+  (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, emul, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    let elem_offset = i * rs2_val;
+    if mask_helper[i] == true then {
+      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+        Ext_DataAddr_OK(vaddr) => 
+          if vcheck_misaligned(vaddr, width_type)
+          then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+          else match translateAddr(vaddr, Read(Data)) {
+            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+            TR_Address(paddr, _) => {
+              match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
+                MemValue(result) => total[i] = result,
+                MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+              }
+            }
+          }
+      }
+    }
+  };
+
+  if status== RETIRE_SUCCESS then write_vreg(num_elem, load_width_bytes * 8, emul, vd, total);
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VLSETYPE(vm, rs2, rs1, width, vd)) = {
+  let load_width_bytes : int = vlewidth_bytesnumber(width);
+  let veew_bits : int = load_width_bytes * 8;
+  let vsew_bits : int = get_vtype_vsew();
+  let lmul : real = get_vtype_LMUL();
+  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
+  let num_elem : int = get_num_elem(emul, veew_bits);
+
+  assert(0 < load_width_bytes & load_width_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+
+  process_vlse(vm, vd, load_width_bytes, rs1, rs2, emul, num_elem)
+}
+
+mapping vlsetype_mnemonic : vlewidth <-> string = {
+  VLE8        <-> "vlse8.v",
+  VLE16       <-> "vlse16.v",
+  VLE32       <-> "vlse32.v",
+  VLE64       <-> "vlse64.v"
+}
+
+mapping clause assembly = VLSETYPE(vm, rs2, rs1, width, vd)
+  <-> vlsetype_mnemonic(width) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)^ sep() ^ maybe_vmask(vm)
+
+
+/* *****VSTORE**************VSSETYPE(Vector Store Strided Normal, nf=0, mop=10)*************************** */
+
+union clause ast = VSSETYPE : (bits(1), regidx, regidx, vlewidth, regidx)
+
+mapping clause encdec = VSSETYPE(vm, rs2, rs1, width, vs3)
+  <-> 0b000 @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
+
+val process_vsse : forall 'b 'n, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, regidx, real, int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vsse (vm, vs3, load_width_bytes, rs1, rs2, emul, num_elem) = {
+  let width_type : word_width = bytes_wordwidth(load_width_bytes);
+  let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs3_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, emul, vs3);
+  let rs2_val : int = signed(get_scalar(rs2, sizeof(xlen)));
+  total : vector('n, dec, bits('b * 8)) = undefined;
+  mask_helper : vector('n, dec, bool) = undefined;
+  status : Retired = RETIRE_SUCCESS;
+
+  (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, emul, vs3_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    let elem_offset = i * rs2_val;
+    if mask_helper[i] == true then {
+      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+        Ext_DataAddr_OK(vaddr) =>
+          if vcheck_misaligned(vaddr, width_type)
+          then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+          else match translateAddr(vaddr, Write(Data)) {
+            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+            TR_Address(paddr, _) => {
+              let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
+              match (eares) {
+                MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                MemValue(_) => {
+                  let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, vs3_val[i], false, false, false);
+                  match (res) {
+                    MemValue(true)  => status = RETIRE_SUCCESS,
+                    MemValue(false) => internal_error("store got false from mem_write_value"),
+                    MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                  }
+                }
+              }
+            }
+          }
+      }
+    }
+  };
+
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VSSETYPE(vm, rs2, rs1, width, vs3)) = {
+  let load_width_bytes : int = vlewidth_bytesnumber(width);
+  let veew_bits : int = load_width_bytes * 8;
+  let vsew_bits : int = get_vtype_vsew();
+  let lmul : real = get_vtype_LMUL();
+  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
+  let num_elem : int = get_num_elem(emul, veew_bits);
+
+  assert(0 < load_width_bytes & load_width_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+
+  process_vsse(vm, vs3, load_width_bytes, rs1, rs2, emul, num_elem)
+}
+
+mapping vssetype_mnemonic : vlewidth <-> string = {
+  VLE8        <-> "vsse8.v",
+  VLE16       <-> "vsse16.v",
+  VLE32       <-> "vsse32.v",
+  VLE64       <-> "vsse64.v"
+}
+
+mapping clause assembly = VSSETYPE(vm, rs2, rs1, width, vs3)
+  <-> vssetype_mnemonic(width) ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)^ sep() ^ maybe_vmask(vm)
+
+
+/* *****VLOAD**************VLUXEITYPE(Vector Load Indexed Unordered, nf=0, mop=01)*************************** */
+
+union clause ast = VLUXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
+
+mapping clause encdec = VLUXEITYPE(vm, vs2, rs1, width, vd)
+  <-> 0b000 @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+
+val process_vlxei : forall 'ib 'db 'n, (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (bits(1), regidx, int('ib), int('db), regidx, regidx, int('n), int) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vlxei (vm, vd, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, mop) = {
+  let index_eew_bits : int = index_eew_bytes * 8;
+  let data_eew_bits = data_eew_bytes * 8;
+  let data_emul : real = get_vtype_LMUL();
+  let index_emul : real = (to_real( index_eew_bits / data_eew_bits )) * data_emul;
+  assert(8 <= data_eew_bits & data_eew_bits <= 64);
+
+  let width_type : word_width = bytes_wordwidth(data_eew_bytes);
+  let start_element : int = get_start_element();
+  let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, data_eew_bytes * 8, data_emul, vd);
+  let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, index_eew_bytes * 8, index_emul, vs2);
+  total : vector('n, dec, bits('db * 8)) = undefined;
+  mask_helper : vector('n, dec, bool) = undefined;
+  (total, mask_helper) = init_masked_result(num_elem, data_eew_bytes * 8, data_emul, vd_val, vm_val);
+  status : Retired = RETIRE_SUCCESS;
+
+  /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask_helper[i] == true then {
+      let elem_offset = signed(vs2_val[i]);
+      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+        Ext_DataAddr_OK(vaddr) => 
+          if vcheck_misaligned(vaddr, width_type) then
+            { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+          else match translateAddr(vaddr, Read(Data)) {
+            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+            TR_Address(paddr, _) => {
+              match mem_read(Read(Data), paddr, data_eew_bytes, false, false, false) {
+                MemValue(result) => total[i] = result,
+                MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+              }
+            }
+          }
+      }
+    }
+  };
+  
+  if status == RETIRE_SUCCESS then write_vreg(num_elem, data_eew_bits, data_emul, vd, total);
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VLUXEITYPE(vm, vs2, rs1, width, vd)) = {
+  let index_eew_bytes : int = vlewidth_bytesnumber(width);
+  let data_eew_bits : int = get_vtype_vsew();
+  let data_eew_bytes : int = data_eew_bits / 8;
+  let data_emul : real = get_vtype_LMUL();
+  let num_elem : int = get_num_elem(data_emul, data_eew_bits); /* number of data and indices are the same */
+
+  assert(0 < index_eew_bytes & index_eew_bytes <= 8);
+  assert(0 < data_eew_bytes & data_eew_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+
+  process_vlxei(vm, vd, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, 1)
+}
+
+mapping clause assembly = VLUXEITYPE(vm, vs2, rs1, width, vd)
+  <-> "vluxei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+
+
+/* *****VLOAD**************VLOXEITYPE(Vector Load Indexed Ordered, nf=0, mop=11)*************************** */
+
+union clause ast = VLOXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
+
+mapping clause encdec = VLOXEITYPE(vm, vs2, rs1, width, vd)
+  <-> 0b000 @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+
+function clause execute(VLOXEITYPE(vm, vs2, rs1, width, vd)) = {
+  let index_eew_bytes : int = vlewidth_bytesnumber(width);
+  let data_eew_bits : int = get_vtype_vsew();
+  let data_eew_bytes : int = data_eew_bits / 8;
+  let data_emul : real = get_vtype_LMUL();
+  let num_elem : int = get_num_elem(data_emul, data_eew_bits); /* number of data and indeces are the same */
+
+  assert(0 < index_eew_bytes & index_eew_bytes <= 8);
+  assert(0 < data_eew_bytes & data_eew_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+
+  process_vlxei(vm, vd, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, 3)
+}
+
+mapping clause assembly = VLOXEITYPE(vm, vs2, rs1, width, vd)
+  <-> "vloxei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+
+
+/* *****VSTORE**************VSUXEITYPE(Vector Store Indexed Unordered, nf=0, mop=01)*************************** */
+
+union clause ast = VSUXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
+
+mapping clause encdec = VSUXEITYPE(vm, vs2, rs1, width, vs3)
+  <-> 0b000 @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
+
+val process_vsxei : forall 'ib 'db 'n, (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (bits(1), regidx, int('ib), int('db), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vsxei (vm, vs3, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, mop) = {
+  let index_eew_bits : int = index_eew_bytes * 8;
+  let data_eew_bits = data_eew_bytes * 8;
+  let data_emul : real = get_vtype_LMUL();
+  let index_emul : real = (to_real( index_eew_bits / data_eew_bits )) * data_emul;
+  assert(8 <= data_eew_bits & data_eew_bits <= 64);
+
+  let width_type : word_width = bytes_wordwidth(data_eew_bytes);
+  let start_element : int = get_start_element();
+  let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs3_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, data_eew_bytes * 8, data_emul, vs3);
+  let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, index_eew_bytes * 8, index_emul, vs2);
+  total : vector('n, dec, bits('db * 8)) = undefined; /* just used to generate mask_helper */
+  mask_helper : vector('n, dec, bool) = undefined;
+  (total, mask_helper) = init_masked_result(num_elem, data_eew_bytes * 8, data_emul, vs3_val, vm_val);
+  status : Retired = RETIRE_SUCCESS;
+
+  /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask_helper[i] == true then {
+      let elem_offset = signed(vs2_val[i]);
+      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) =>
+            if vcheck_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Write(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, data_eew_bytes, false, false, false);
+                match (eares) {
+                  MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                  MemValue(_) => {
+                    let res : MemoryOpResult(bool) = mem_write_value(paddr, data_eew_bytes, vs3_val[i], false, false, false);
+                    match (res) {
+                      MemValue(true)  => status = RETIRE_SUCCESS,
+                      MemValue(false) => internal_error("store got false from mem_write_value"),
+                      MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                    }
+                  }
+                }
+              }
+            }
+        }
+    }
+  };
+
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VSUXEITYPE(vm, vs2, rs1, width, vs3)) = {
+  let index_eew_bytes : int = vlewidth_bytesnumber(width);
+  let data_eew_bits : int = get_vtype_vsew();
+  let data_eew_bytes : int = data_eew_bits / 8;
+  let data_emul : real = get_vtype_LMUL();
+  let num_elem : int = get_num_elem(data_emul, data_eew_bits); /* number of data and indeces are the same */
+
+  assert(0 < index_eew_bytes & index_eew_bytes <= 8);
+  assert(0 < data_eew_bytes & data_eew_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+
+  process_vsxei(vm, vs3, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, 1)
+}
+
+mapping clause assembly = VSUXEITYPE(vm, vs2, rs1, width, vs3)
+  <-> "vsuxei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+
+
+/* *****VSTORE**************VSOXEITYPE(Vector Store Indexed Ordered, nf=0, mop=11)*************************** */
+
+union clause ast = VSOXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
+
+mapping clause encdec = VSOXEITYPE(vm, vs2, rs1, width, vs3)
+  <-> 0b000 @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
+
+function clause execute(VSOXEITYPE(vm, vs2, rs1, width, vs3)) = {
+  let index_eew_bytes : int = vlewidth_bytesnumber(width);
+  let data_eew_bits : int = get_vtype_vsew();
+  let data_eew_bytes : int = data_eew_bits / 8;
+  let data_emul : real = get_vtype_LMUL();
+  let num_elem : int = get_num_elem(data_emul, data_eew_bits); /* number of data and indeces are the same */
+
+  assert(0 < index_eew_bytes & index_eew_bytes <= 8);
+  assert(0 < data_eew_bytes & data_eew_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+
+  process_vsxei(vm, vs3, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, 3)
+}
+
+mapping clause assembly = VSOXEITYPE(vm, vs2, rs1, width, vs3)
+  <-> "vsoxei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+
+
+/* *****VLOAD**************VLEFFTYPE(Vector Load Unit-Strided Fault-Only-First, nf=0, mop=0, lumop=10000)*************************** */
+
+union clause ast = VLEFFTYPE : (bits(1), regidx, vlewidth, regidx)
+
+mapping clause encdec = VLEFFTYPE(vm, rs1, width, vd)
+  <-> 0b000 @ 0b0 @ 0b00 @ vm @ 0b10000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+
+val process_vleff : forall 'b 'n, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, real, int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vleff (vm, vd, load_width_bytes, rs1, emul, num_elem) = {
+  let width_type : word_width = bytes_wordwidth(load_width_bytes);
+  let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, emul, vd);
+  total : vector('n, dec, bits('b * 8)) = undefined;
+  mask_helper : vector('n, dec, bool) = undefined;
+  status : Retired = RETIRE_SUCCESS;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, emul, vd_val, vm_val);
+    if mask_helper[i] == true then {
+      let elem_offset = i * load_width_bytes;
+      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+        Ext_DataAddr_Error(e) => {
+          if i == 0 then {
+            ext_handle_data_check_error(e);
+            status = RETIRE_SUCCESS
+          } else {
+            vl = to_bits(sizeof(xlen), i);
+            print_reg("CSR vl <- " ^ BitStr(vl));
+            ext_handle_data_check_error(e);
+            status = RETIRE_SUCCESS
+          }
+        },
+        Ext_DataAddr_OK(vaddr) => {
+          if vcheck_misaligned(vaddr, width_type) then {
+            if i == 0 then {
+              handle_mem_exception(vaddr, E_Load_Addr_Align());
+              status = RETIRE_SUCCESS
+            } else {
+              vl = to_bits(sizeof(xlen), i);
+              print_reg("CSR vl <- " ^ BitStr(vl));
+              handle_mem_exception(vaddr, E_Load_Addr_Align());
+              status = RETIRE_SUCCESS
+            }
+          } else match translateAddr(vaddr, Read(Data)) {
+            TR_Failure(e, _) => { 
+              if i == 0 then {
+                handle_mem_exception(vaddr, e);
+                status = RETIRE_SUCCESS
+              } else {
+                vl = to_bits(sizeof(xlen), i);
+                print_reg("CSR vl <- " ^ BitStr(vl));
+                handle_mem_exception(vaddr, e);
+                status = RETIRE_SUCCESS
+              }
+            },
+            TR_Address(paddr, _) => {
+              match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
+                MemValue(result) => total[i] = result,
+                MemException(e)  => {
+                  if i == 0 then {
+                    handle_mem_exception(vaddr, e);
+                    status = RETIRE_SUCCESS
+                  } else {
+                    vl = to_bits(sizeof(xlen), i);
+                    print_reg("CSR vl <- " ^ BitStr(vl));
+                    handle_mem_exception(vaddr, e);
+                    status = RETIRE_SUCCESS
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  };
+
+  if status == RETIRE_SUCCESS then write_vreg(num_elem, load_width_bytes * 8, emul, vd, total);
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VLEFFTYPE(vm, rs1, width, vd)) = {
+  let load_width_bytes : int = vlewidth_bytesnumber(width);
+  let veew_bits : int = load_width_bytes * 8;
+  let vsew_bits : int = get_vtype_vsew();
+  let lmul : real = get_vtype_LMUL();
+  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
+  let num_elem : int = get_num_elem(emul, veew_bits);
+
+  assert(0 < load_width_bytes & load_width_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+
+  process_vle(vm, vd, load_width_bytes, rs1,  emul, num_elem)
+}
+
+mapping vlefftype_mnemonic : vlewidth <-> string = {
+  VLE8        <-> "vle8ff.v",
+  VLE16       <-> "vle16ff.v",
+  VLE32       <-> "vle32ff.v",
+  VLE64       <-> "vle64ff.v"
+}
+
+mapping clause assembly = VLEFFTYPE(vm, rs1, width, vd)
+  <-> vlefftype_mnemonic(width) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
+
+
+/* ****VLOAD***********VLSEGTYPE(Vector Load Unit-Strided Segments, mop=0, lumop=00000)*************************** */
+
+union clause ast = VLSEGTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
+
+mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd)
+  <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+
+val process_vlseg : forall 'f 'b 'n, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, real, int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vlseg (nf, vm, vd, load_width_bytes, rs1, emul, num_elem) = {
+  let width_type : word_width = bytes_wordwidth(load_width_bytes);
+  let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  status : Retired = RETIRE_SUCCESS;
+  vd_a = vd;
+  vd_t = vd;
+
+  foreach(a from 0 to (nf - 1)) {
+    if vd_t == vd_a & a != 0 then vd_t = vd_t + 1; /* emul < 1 */
+    let vd_t_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, emul, vd_t);
+    total : vector('n, dec, bits('b * 8)) = undefined;
+    mask_helper : vector('n, dec, bool) = undefined;
+    (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, emul, vd_t_val, vm_val);
+
+    foreach (i from 0 to (num_elem - 1)) {
+      if (mask_helper[i] == true) then {
+        let elem_offset = load_width_bytes * (a + i * nf);
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) => 
+              if vcheck_misaligned(vaddr, width_type)
+              then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+              else match translateAddr(vaddr, Read(Data)) {
+                TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                TR_Address(paddr, _) => {
+                  match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
+                    MemValue(result) => total[i] = result,
+                    MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                  }
+                }
+              }
+        }
+      }
+    };
+
+    if status == RETIRE_SUCCESS then write_vreg(num_elem, load_width_bytes * 8, emul, vd_t, total);
+    vd_a = vd_t;
+    vd_t = vd_t + to_bits(5, ceil(emul))
+  };
+
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VLSEGTYPE(nf, vm, rs1, width, vd)) = {
+  let load_width_bytes : int = vlewidth_bytesnumber(width);
+  let veew_bits : int = load_width_bytes * 8;
+  let vsew_bits : int = get_vtype_vsew();
+  let lmul : real = get_vtype_LMUL();
+  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
+  let num_elem : int = get_num_elem(emul, veew_bits); /* # of element of each register group */
+  let nf_int = nfields_int(nf);
+
+  assert(0 < load_width_bytes & load_width_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < '_nf_int & '_nf_int <= 8);
+
+  process_vlseg(nf_int, vm, vd, load_width_bytes, rs1, emul, num_elem)
+}
+
+mapping clause assembly = VLSEGTYPE(nf, vm, rs1, width, vd)
+  <-> "vlseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ maybe_vmask(vm)
+
+
+/* ****VLOAD*****VLSEGFFTYPE(Vector Load Unit-Strided Segments Fault-Only-First, mop=0, lumop=00000)******** */
+
+union clause ast = VLSEGFFTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
+
+mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd)
+  <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+
+val process_vlsegff : forall 'f 'b 'n, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, real, int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, emul, num_elem) = {
+  let width_type : word_width = bytes_wordwidth(load_width_bytes);
+  let start_element : int = get_start_element();
+  let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  status : Retired = RETIRE_SUCCESS;
+  if start_element >= num_elem then return status;
+
+  loop_times : int = num_elem - 1;
+  foreach (i from start_element to loop_times) {
+    assert(i >= 0 & i < num_elem);
+    if (vm_val[i] == true) then {
+      foreach (j from 0 to (nf - 1)) {
+        let elem_offset = (i * nf + j) * load_width_bytes;
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { if i == 0 then ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) => 
+            if vcheck_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Read(Data)) {
+              TR_Failure(e, _)     => { if i == 0 then handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
+                  MemValue(result) => write_single_element(load_width_bytes * 8, i, emul, vd + to_bits(5, j * ceil(emul)), result),
+                  MemException(e)  => { if i == 0 then handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                }
+              }
+            }
+        }
+      };
+      if status == RETIRE_FAIL then loop_times = i;
+    }
+  };
+
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VLSEGFFTYPE(nf, vm, rs1, width, vd)) = {
+  let load_width_bytes : int = vlewidth_bytesnumber(width);
+  let veew_bits : int = load_width_bytes * 8;
+  let vsew_bits : int = get_vtype_vsew();
+  let lmul : real = get_vtype_LMUL();
+  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
+  let num_elem : int = get_num_elem(emul, veew_bits);
+  let nf_int = nfields_int(nf);
+
+  assert(0 < load_width_bytes & load_width_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < '_nf_int & '_nf_int <= 8);
+
+  process_vlsegff(nf_int, vm, vd, load_width_bytes, rs1, emul, num_elem)
+}
+
+mapping clause assembly = VLSEGTYPE(nf, vm, rs1, width, vd)
+  <-> "vlseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ "ff.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
+
+
+/* ****VSTORE***********VSSEGTYPE(Vector Store Unit-Strided Segments, mop=0, sumop=00000)*************************** */
+
+union clause ast = VSSEGTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
+
+mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3)
+  <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
+
+val process_vsseg : forall 'f 'b 'n, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, real, int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, emul, num_elem) = {
+  let width_type : word_width = bytes_wordwidth(load_width_bytes);
+  let start_element : int = get_start_element();
+  let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  status : Retired = RETIRE_SUCCESS;
+  if start_element >= num_elem then return status;
+  assert(start_element >= 0);
+
+  foreach (i from start_element to (num_elem - 1)) {
+    if vm_val[i] == true then {
+      foreach (j from 0 to (nf - 1)) {
+        let elem_offset = (i * nf + j) * load_width_bytes;
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) =>
+            if vcheck_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Write(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
+                match (eares) {
+                  MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                  MemValue(_) => {
+                    let one_elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, emul, vs3 + to_bits(5, j * ceil(emul)));
+                    let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, one_elem_val, false, false, false);
+                    match (res) {
+                      MemValue(true)  => status = RETIRE_SUCCESS,
+                      MemValue(false) => internal_error("store got false from mem_write_value"),
+                      MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                    }
+                  }
+                }
+              }
+            }
+        }
+      };
+    }
+  };
+
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VSSEGTYPE(nf, vm, rs1, width, vs3)) = {
+  let load_width_bytes : int = vlewidth_bytesnumber(width);
+  let veew_bits : int = load_width_bytes * 8;
+  let vsew_bits : int = get_vtype_vsew();
+  let lmul : real = get_vtype_LMUL();
+  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
+  let num_elem : int = get_num_elem(emul, veew_bits);
+  let nf_int = nfields_int(nf);
+
+  assert(0 < load_width_bytes & load_width_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < '_nf_int & '_nf_int <= 8);
+
+  process_vsseg(nf_int, vm, vs3, load_width_bytes, rs1, emul, num_elem)
+}
+
+mapping clause assembly = VSSEGTYPE(nf, vm, rs1, width, vs3)
+  <-> "vsseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
+
+
+/* ****VLOAD***********VLSSEGTYPE(Vector Load Strided Segments, mop=10)*************************** */
+
+union clause ast = VLSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
+
+mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
+  <-> nf @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+
+val process_vlsseg : forall 'f 'b 'n, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, regidx, real, int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, emul, num_elem) = {
+  let width_type : word_width = bytes_wordwidth(load_width_bytes);
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, emul, vd); /* only to generate mask_helper */
+  result      : vector('n, dec, bits('b * 8)) = undefined;
+  mask_helper : vector('n, dec, bool)     = undefined;
+  (result, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, emul, vd_val, vm_val);
+
+  let rs2_val : int = signed(get_scalar(rs2, sizeof(xlen)));
+  status : Retired = RETIRE_SUCCESS;
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask_helper[i] == true then {
+      foreach (j from 0 to (nf - 1)) {
+        let elem_offset = i * rs2_val + j * load_width_bytes;
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) => 
+            if vcheck_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Read(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
+                  MemValue(result) => write_single_element(load_width_bytes * 8, i, emul, vd + to_bits(5, j * ceil(emul)) , result),
+                  MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                }
+              }
+            }
+        }
+      }
+    }
+  };
+
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)) = {
+  let load_width_bytes : int = vlewidth_bytesnumber(width);
+  let veew_bits : int = load_width_bytes * 8;
+  let vsew_bits : int = get_vtype_vsew();
+  let lmul : real = get_vtype_LMUL();
+  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
+  let num_elem : int = get_num_elem(emul, veew_bits);
+  let nf_int = nfields_int(nf);
+
+  assert(0 < load_width_bytes & load_width_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < '_nf_int & '_nf_int <= 8);
+
+  process_vlsseg(nf_int, vm, vd, load_width_bytes, rs1, rs2, emul, num_elem)
+}
+
+mapping clause assembly = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
+  <-> "vlsseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ maybe_vmask(vm)
+
+
+/* ****VSTORE***********VSSSEGTYPE(Vector Store Strided Segments, mop=0, sumop=00000)*************************** */
+
+union clause ast = VSSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
+
+mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
+  <-> nf @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
+
+val process_vssseg : forall 'f 'b 'n, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, regidx, real, int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, emul, num_elem) = {
+  let width_type : word_width = bytes_wordwidth(load_width_bytes);
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs3_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, emul, vs3); /* only to generate mask_helper */
+  result      : vector('n, dec, bits('b * 8)) = undefined;
+  mask_helper : vector('n, dec, bool)     = undefined;
+  (result, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, emul, vs3_val, vm_val);
+
+  let rs2_val : int = signed(get_scalar(rs2, sizeof(xlen)));
+  status : Retired = RETIRE_SUCCESS;
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask_helper[i] == true then {
+      foreach (j from 0 to (nf - 1)) {
+        let elem_offset = i * rs2_val + j * load_width_bytes;
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) =>
+            if vcheck_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Write(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
+                match (eares) {
+                  MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                  MemValue(_) => {
+                    let one_elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, emul, vs3 + to_bits(5, j * ceil(emul)));
+                    let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, one_elem_val, false, false, false);
+                    match (res) {
+                      MemValue(true)  => status = RETIRE_SUCCESS,
+                      MemValue(false) => internal_error("store got false from mem_write_value"),
+                      MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                    }
+                  }
+                }
+              }
+            }
+        }
+      };
+    }
+  };
+
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)) = {
+  let load_width_bytes : int = vlewidth_bytesnumber(width);
+  let veew_bits : int = load_width_bytes * 8;
+  let vsew_bits : int = get_vtype_vsew();
+  let lmul : real = get_vtype_LMUL();
+  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
+  let num_elem : int = get_num_elem(emul, veew_bits);
+  let nf_int = nfields_int(nf);
+
+  assert(0 < load_width_bytes & load_width_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < '_nf_int & '_nf_int <= 8);
+
+  process_vssseg(nf_int, vm, vs3, load_width_bytes, rs1, rs2, emul, num_elem)
+}
+
+mapping clause assembly = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
+  <-> "vssseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ maybe_vmask(vm)
+
+
+/* ****VLOAD***********VLUXSEGTYPE(Vector Load Indexed Unordered Segments, mop=01)*************************** */
+
+union clause ast = VLUXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
+
+mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
+  <-> nf @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+
+val process_vlxseg : forall 'f 'ib 'db 'n, (0 < 'f & 'f <= 8) & (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('ib), int('db), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vlxseg (nf, vm, vd, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, mop) = {
+  let index_eew_bits : int = index_eew_bytes * 8;
+  let data_eew_bits = data_eew_bytes * 8;
+  let data_emul : real = get_vtype_LMUL();
+  let index_emul : real = (to_real( index_eew_bits / data_eew_bits )) * data_emul;
+  assert(8 <= data_eew_bits & data_eew_bits <= 64);
+
+  let width_type : word_width = bytes_wordwidth(data_eew_bytes);
+  let start_element : int = get_start_element();
+  let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, data_eew_bytes * 8, data_emul, vd);
+  let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, index_eew_bytes * 8, index_emul, vs2);
+  total : vector('n, dec, bits('db * 8)) = undefined;
+  mask_helper : vector('n, dec, bool) = undefined;
+  (total, mask_helper) = init_masked_result(num_elem, data_eew_bytes * 8, data_emul, vd_val, vm_val);
+  status : Retired = RETIRE_SUCCESS;
+
+  /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask_helper[i] == true then {
+      foreach (j from 0 to (nf - 1)) {
+        let elem_offset : int = signed(vs2_val[i]) + j * data_eew_bytes;
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) => 
+            if vcheck_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Read(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                match mem_read(Read(Data), paddr, data_eew_bytes, false, false, false) {
+                  MemValue(result) => write_single_element(data_eew_bits, i, data_emul, vd + to_bits(5, j * ceil(data_emul)) , result),
+                  MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                }
+              }
+            }
+        }
+      }
+    }
+  };
+
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
+  let index_eew_bytes : int = vlewidth_bytesnumber(width);
+  let data_eew_bits : int = get_vtype_vsew();
+  let data_eew_bytes : int = data_eew_bits / 8;
+  let data_emul : real = get_vtype_LMUL();
+  let num_elem : int = get_num_elem(data_emul, data_eew_bits); /* number of data and indeces are the same */
+  let nf_int = nfields_int(nf);
+
+  assert(0 < index_eew_bytes & index_eew_bytes <= 8);
+  assert(0 < data_eew_bytes & data_eew_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < '_nf_int & '_nf_int <= 8);
+
+  process_vlxseg(nf_int, vm, vd, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, 1)
+}
+
+mapping clause assembly = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
+  <-> "vluxseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+
+
+/* ****VLOAD***********VLOXSEGTYPE(Vector Load Indexed Unordered Segments, mop=11)*************************** */
+
+union clause ast = VLOXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
+
+mapping clause encdec = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)
+  <-> nf @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+
+function clause execute(VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
+  let index_eew_bytes : int = vlewidth_bytesnumber(width);
+  let data_eew_bits : int = get_vtype_vsew();
+  let data_eew_bytes : int = data_eew_bits / 8;
+  let data_emul : real = get_vtype_LMUL();
+  let num_elem : int = get_num_elem(data_emul, data_eew_bits); /* number of data and indeces are the same */
+  let nf_int = nfields_int(nf);
+
+  assert(0 < index_eew_bytes & index_eew_bytes <= 8);
+  assert(0 < data_eew_bytes & data_eew_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < '_nf_int & '_nf_int <= 8);
+
+  process_vlxseg(nf_int, vm, vd, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, 3)
+}
+
+mapping clause assembly = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)
+  <-> "vloxseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+
+
+/* ****VSTORE***********VSUXSEGTYPE(Vector Store Indexed Unordered Segments, mop=01)*************************** */
+
+union clause ast = VSUXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
+
+mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
+  <-> nf @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
+
+val process_vsxseg : forall 'f 'ib 'db 'n, (0 < 'f & 'f <= 8) & (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('ib), int('db), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vsxseg (nf, vm, vs3, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, mop) = {
+  let index_eew_bits : int = index_eew_bytes * 8;
+  let data_eew_bits = data_eew_bytes * 8;
+  let data_emul : real = get_vtype_LMUL();
+  let index_emul : real = (to_real( index_eew_bits / data_eew_bits )) * data_emul;
+  assert (8 <= data_eew_bits & data_eew_bits <= 64);
+
+  let width_type : word_width = bytes_wordwidth(data_eew_bytes);
+  let start_element : int = get_start_element();
+  let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs3_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, data_eew_bytes * 8, data_emul, vs3);
+  let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, index_eew_bytes * 8, index_emul, vs2);
+  total : vector('n, dec, bits('db * 8)) = undefined;
+  mask_helper : vector('n, dec, bool) = undefined;
+  (total, mask_helper) = init_masked_result(num_elem, data_eew_bytes * 8, data_emul, vs3_val, vm_val);
+  status : Retired = RETIRE_SUCCESS;
+
+  /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask_helper[i] == true then {
+      foreach (j from 0 to (nf - 1)) {
+        let elem_offset : int = signed(vs2_val[i]) + j * data_eew_bytes;
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) =>
+            if vcheck_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Write(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, data_eew_bytes, false, false, false);
+                match (eares) {
+                  MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                  MemValue(_) => {
+                    let one_elem_val : bits('db * 8) = read_single_element(data_eew_bits, i, data_emul, vs3 + to_bits(5, j * ceil(data_emul)));
+                    let res : MemoryOpResult(bool) = mem_write_value(paddr, data_eew_bytes, one_elem_val, false, false, false);
+                    match (res) {
+                      MemValue(true)  => status = RETIRE_SUCCESS,
+                      MemValue(false) => internal_error("store got false from mem_write_value"),
+                      MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                    }
+                  }
+                }
+              }
+            }
+        }
+      }
+    }
+  };
+
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
+  let index_eew_bytes : int = vlewidth_bytesnumber(width);
+  let data_eew_bits : int = get_vtype_vsew();
+  let data_eew_bytes : int = data_eew_bits / 8;
+  let data_emul : real = get_vtype_LMUL();
+  let num_elem : int = get_num_elem(data_emul, data_eew_bits); /* number of data and indeces are the same */
+  let nf_int = nfields_int(nf);
+
+  assert(0 < index_eew_bytes & index_eew_bytes <= 8);
+  assert(0 < data_eew_bytes & data_eew_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < '_nf_int & '_nf_int <= 8);
+
+  process_vsxseg(nf_int, vm, vs3, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, 1)
+}
+
+mapping clause assembly = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
+  <-> "vsuxseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+
+
+/* ****VSTORE***********VSOXSEGTYPE(Vector Store Indexed Ordered Segments, mop=11)*************************** */
+
+union clause ast = VSOXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
+
+mapping clause encdec = VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
+  <-> nf @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
+
+function clause execute(VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
+  let index_eew_bytes : int = vlewidth_bytesnumber(width);
+  let data_eew_bits : int = get_vtype_vsew();
+  let data_eew_bytes : int = data_eew_bits / 8;
+  let data_emul : real = get_vtype_LMUL();
+  let num_elem : int = get_num_elem(data_emul, data_eew_bits); /* number of data and indeces are the same */
+  let nf_int = nfields_int(nf);
+
+  assert(0 < index_eew_bytes & index_eew_bytes <= 8);
+  assert(0 < data_eew_bytes & data_eew_bytes <= 8);
+  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < '_nf_int & '_nf_int <= 8);
+
+  process_vsxseg(nf_int, vm, vs3, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, 3)
+}
+
+mapping clause assembly = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
+  <-> "vsuoseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+
+
+/* ****VLOAD***************VLRETYPE(Vector Load Unit-Steided Whole Register, vm=1, mop=0, lumop=01000)*************************** */
+
+union clause ast = VLRETYPE : (bits(3), regidx, vlewidth, regidx)
+
+mapping clause encdec = VLRETYPE(nf, rs1, width, vd)
+  <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
+
+val process_vlre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), regidx, int('b), regidx, int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
+  let width_type : word_width = bytes_wordwidth(load_width_bytes);
+  status : Retired = RETIRE_SUCCESS;
+  start_element : int = get_start_element();
+  if start_element >= nf * elem_per_reg then {
+    /* no elements are written */
+    return status
+  };
+  cur_field : int = start_element / elem_per_reg;
+  elem_to_align : int = start_element % elem_per_reg;
+
+  if elem_to_align > 0 then {
+    foreach (i from elem_to_align to (elem_per_reg - 1)) {
+      let elem_offset : int = start_element * load_width_bytes;
+      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+        Ext_DataAddr_OK(vaddr) => 
+          if vcheck_misaligned(vaddr, width_type)
+          then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+          else match translateAddr(vaddr, Read(Data)) {
+            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+            TR_Address(paddr, _) => {
+              match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
+                MemValue(result) => write_single_element(load_width_bytes * 8, i, to_real(1), vd + to_bits(5, cur_field) , result),
+                MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+              }
+            }
+          }
+      };
+      start_element = start_element + 1
+    };
+    cur_field = cur_field + 1
+  };
+
+  total : vector('n, dec, bits('b * 8)) = undefined;
+  foreach (j from cur_field to (nf - 1)) {
+    total = undefined;
+    foreach (i from 0 to (elem_per_reg - 1)) {
+      let elem_offset = start_element * load_width_bytes;
+      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+        Ext_DataAddr_OK(vaddr) => 
+          if vcheck_misaligned(vaddr, width_type)
+          then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+          else match translateAddr(vaddr, Read(Data)) {
+            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+            TR_Address(paddr, _) => {
+              match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
+                MemValue(result) => total[i] = result,
+                MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+              }
+            }
+          }
+      };
+      start_element = start_element + 1
+    };
+    if status == RETIRE_SUCCESS then write_vreg(elem_per_reg, load_width_bytes * 8, to_real(1), vd + to_bits(5, j), total) /* emul=1 */
+  };
+
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VLRETYPE(nf, rs1, width, vd)) = {
+  let load_width_bytes : int = vlewidth_bytesnumber(width);
+  let veew_bits : int = load_width_bytes * 8;
+  let elem_per_reg : int = get_vlen() / veew_bits;
+  let nf_int = nfields_int(nf);
+
+  assert(0 < load_width_bytes & load_width_bytes <= 8);
+  assert(0 <= elem_per_reg & elem_per_reg <= get_vlen());
+  assert((nf_int == 1) | (nf_int == 2) | (nf_int == 4) | (nf_int == 8));
+
+  process_vlre(nf_int, vd, load_width_bytes, rs1, elem_per_reg)
+}
+
+mapping clause assembly = VLRETYPE(nf, rs1, width, vd)
+  <-> "vl" ^ nfields_string(nf) ^ "re" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)
+
+
+/* ****VSTORE***************VSRETYPE(Vector Store Unit-Strided Whole Register, vm=1, mop=0, lumop=01000)*************************** */
+
+union clause ast = VSRETYPE : (bits(3), regidx, regidx)
+
+mapping clause encdec = VSRETYPE(nf, rs1, vs3)
+  <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ rs1 @ 0b000 @ vs3 @ 0b0100111
+
+val process_vsre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), int('b), regidx, regidx, int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
+  let width_type : word_width = BYTE;
+  start_element : int = get_start_element();
+  status : Retired = RETIRE_SUCCESS;
+  if start_element >= nf * elem_per_reg then {
+    /* no elements are written */
+    return status
+  };
+  cur_field : int = start_element / elem_per_reg;
+  elem_to_align : int = start_element % elem_per_reg;
+
+  if elem_to_align > 0 then {
+    foreach (i from elem_to_align to (elem_per_reg - 1)) {
+      let elem_offset : int = start_element * load_width_bytes;
+      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+        Ext_DataAddr_OK(vaddr) =>
+          if vcheck_misaligned(vaddr, width_type)
+          then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+          else match translateAddr(vaddr, Write(Data)) {
+            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+            TR_Address(paddr, _) => {
+              let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
+              match (eares) {
+                MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                MemValue(_) => {
+                  let one_elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, to_real(1), vs3 + to_bits(5, cur_field));
+                  let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, one_elem_val, false, false, false);
+                  match (res) {
+                    MemValue(true)  => status = RETIRE_SUCCESS,
+                    MemValue(false) => internal_error("store got false from mem_write_value"),
+                    MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                  }
+                }
+              }
+            }
+          }
+      };
+      start_element = start_element + 1
+    };
+    cur_field = cur_field + 1
+  };
+
+  foreach (j from cur_field to (nf - 1)) {
+    let vs_val : vector('n, dec, bits('b * 8)) = read_vreg(elem_per_reg, load_width_bytes * 8, to_real(1), vs3 + to_bits(5, j));
+    foreach (i from 0 to (elem_per_reg - 1)) {
+      let elem_offset = start_element * load_width_bytes;
+      match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+        Ext_DataAddr_OK(vaddr) =>
+          if vcheck_misaligned(vaddr, width_type)
+          then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+          else match translateAddr(vaddr, Write(Data)) {
+            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+            TR_Address(paddr, _) => {
+              let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
+              match (eares) {
+                MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                MemValue(_) => {
+                  let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, vs_val[i], false, false, false);
+                  match (res) {
+                    MemValue(true)  => status = RETIRE_SUCCESS,
+                    MemValue(false) => internal_error("store got false from mem_write_value"),
+                    MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                  }
+                }
+              }
+            }
+          }
+      };
+      start_element = start_element + 1
+    };
+  };
+
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VSRETYPE(nf, rs1, vs3)) = {
+  let load_width_bytes : int = 1;
+  let veew_bits : int = 8;
+  let elem_per_reg : int = get_vlen() / veew_bits;
+  let nf_int = nfields_int(nf);
+
+  assert(0 < load_width_bytes & load_width_bytes <= 8);
+  assert(0 <= elem_per_reg & elem_per_reg <= get_vlen());
+  assert((nf_int == 1) | (nf_int == 2) | (nf_int == 4) | (nf_int == 8));
+
+  process_vsre(nf_int, load_width_bytes, rs1, vs3, elem_per_reg)
+}
+
+mapping clause assembly = VSRETYPE(nf, rs1, vs3)
+  <-> "vs" ^ nfields_string(nf) ^ "r.v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1)
+
+
+/* *****VLOAD&VSTORE**************VMTYPE(Vector MASK Load&STORE Unit-Strided Normal, nf=0, mop=0, lumop=0)*************************** */
+
+union clause ast = VMTYPE : (regidx, regidx, vmlsop)
+
+mapping encdec_lsop : vmlsop <-> bits(7) = {
+  VLM      <-> 0b0000111,
+  VSM      <-> 0b0100111
+}
+
+mapping clause encdec = VMTYPE(rs1, vd_or_vs3, op)
+  <-> 0b000 @ 0b0 @ 0b00 @ 0b1 @ 0b01011 @ rs1 @ 0b000 @ vd_or_vs3 @ encdec_lsop(op)
+
+val process_vm : forall 'n, ('n >= 0). (regidx, regidx, real, int('n), vmlsop) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vm(vd_or_vs3, rs1, emul, num_elem, op) = {
+  let width_type : word_width = BYTE;
+  let start_element : int = get_start_element();
+  let vd_or_vs3_val : vector('n, dec, bits(8)) = read_vreg(num_elem, 8, emul, vd_or_vs3);
+  total : vector('n, dec, bits(8)) = undefined;
+  elem_offset : int = undefined;
+  status : Retired = RETIRE_SUCCESS;
+  
+  foreach (i from 0 to (num_elem - 1)) {
+    let elem_offset = i;                     
+    if op == VLM then { /* load */
+      if i < start_element then {
+        total[i] = vd_or_vs3_val[i]
+      } else {
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) => 
+            if vcheck_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Read(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                match mem_read(Read(Data), paddr, 1, false, false, false) {
+                  MemValue(result) => if i < num_elem then total[i] = result,
+                  MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                }
+              }
+            }
+        }
+      };
+      if status == RETIRE_SUCCESS then write_vreg(num_elem, 8, emul, vd_or_vs3, total)
+    } else if op == VSM then { /* store */
+      if i > start_element then {
+        match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
+          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
+          Ext_DataAddr_OK(vaddr) =>
+            if vcheck_misaligned(vaddr, width_type)
+            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); status = RETIRE_FAIL }
+            else match translateAddr(vaddr, Write(Data)) {
+              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+              TR_Address(paddr, _) => {
+                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, 1, false, false, false);
+                match (eares) {
+                  MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
+                  MemValue(_) => {
+                    let res : MemoryOpResult(bool) = mem_write_value(paddr, 1, vd_or_vs3_val[i], false, false, false);
+                    match (res) {
+                      MemValue(true)  => status = RETIRE_SUCCESS,
+                      MemValue(false) => internal_error("store got false from mem_write_value"),
+                      MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
+                    }
+                  }
+                }
+              }
+            }
+        }
+      }
+    }
+  };
+
+  vstart = EXTZ(0b0);
+  status
+}
+
+function clause execute(VMTYPE(rs1, vd_or_vs3, op)) = {
+  let veew_bits : int = 8;
+  let vsew_bits : int = get_vtype_vsew();
+  let emul : real = 1.0;
+  let tmp : int = unsigned(vl);
+  let num_elem : int = ceil( to_real(tmp) / 8.0);
+
+  assert(0 <= num_elem & num_elem <= get_vlen());
+
+  /* unmask vle8 except that the effective vector length is evl=ceil(vl/8) */
+  process_vm(vd_or_vs3, rs1, emul, num_elem, op)
+}
+
+mapping vmtype_mnemonic : vmlsop <-> string = {
+  VLM      <-> "vlm.v",
+  VSM      <-> "vsm.v"
+}
+
+mapping clause assembly = VMTYPE(rs1, vd_or_vs3, op)
+  <-> vmtype_mnemonic(op) ^ spc() ^ vreg_name(vd_or_vs3) ^ sep() ^ reg_name(rs1)

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -47,6 +47,13 @@ mapping vlewidth_bytesnumber : vlewidth <-> int = {
   VLE64     <-> 8
 }
 
+mapping vlewidth_pow : vlewidth <-> int = {
+  VLE8      <-> 3,
+  VLE16     <-> 4,
+  VLE32     <-> 5,
+  VLE64     <-> 6
+}
+
 mapping bytes_wordwidth : int <-> word_width = {
   1 <-> BYTE,
   2 <-> HALF,
@@ -72,16 +79,16 @@ union clause ast = VLETYPE : (bits(1), regidx, vlewidth, regidx)
 mapping clause encdec = VLETYPE(vm, rs1, width, vd)
   <-> 0b000 @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vle : forall 'b 'n, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, real, int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
-function process_vle (vm, vd, load_width_bytes, rs1, emul, num_elem) = {
+val process_vle : forall 'b 'n 'p, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vle (vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vd_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, emul, vd);
+  let vd_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd);
   total : vector('n, dec, bits('b * 8)) = undefined;
   mask_helper : vector('n, dec, bool) = undefined;
   status : Retired = RETIRE_SUCCESS;
 
-  (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, emul, vd_val, vm_val);
+  (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask_helper[i] == true then{
@@ -104,23 +111,24 @@ function process_vle (vm, vd, load_width_bytes, rs1, emul, num_elem) = {
     }
   };
 
-  if status == RETIRE_SUCCESS then write_vreg(num_elem, load_width_bytes * 8, emul, vd, total);
+  if status == RETIRE_SUCCESS then write_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd, total);
   vstart = EXTZ(0b0);
   status
 }
 
 function clause execute(VLETYPE(vm, rs1, width, vd)) = {
   let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let veew_bits : int = load_width_bytes * 8;
-  let vsew_bits : int = get_vtype_vsew();
-  let lmul : real = get_vtype_LMUL();
-  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
-  let num_elem : int = get_num_elem(emul, veew_bits);
+  let EEW : int = load_width_bytes * 8;
+  let EEW_pow : int = vlewidth_pow(width);
+  let SEW_pow : int = get_sew_pow();
+  let LMUL_pow : int = get_lmul_pow();
+  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem : int = get_num_elem(EMUL_pow, EEW);
 
   assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(num_elem >= 0);
 
-  process_vle(vm, vd, load_width_bytes, rs1,  emul, num_elem)
+  process_vle(vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
 
 mapping vletype_mnemonic : vlewidth <-> string = {
@@ -141,16 +149,16 @@ union clause ast = VSETYPE : (bits(1), regidx, vlewidth, regidx)
 mapping clause encdec = VSETYPE(vm, rs1, width, vs3)
   <-> 0b000 @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
 
-val process_vse : forall 'b 'n, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, real, int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
-function process_vse (vm, vs3, load_width_bytes, rs1, emul, num_elem) = {
+val process_vse : forall 'b 'n 'p, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vse (vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vs3_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, emul, vs3);
+  let vs3_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vs3);
   total : vector('n, dec, bits('b * 8)) = undefined;
   mask_helper : vector('n, dec, bool) = undefined;
   status : Retired = RETIRE_SUCCESS;
 
-  (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, emul, vs3_val, vm_val);
+  (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vs3_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
     let elem_offset = i * load_width_bytes;
@@ -187,16 +195,17 @@ function process_vse (vm, vs3, load_width_bytes, rs1, emul, num_elem) = {
 
 function clause execute(VSETYPE(vm, rs1, width, vs3)) = {
   let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let veew_bits : int = load_width_bytes * 8;
-  let vsew_bits : int = get_vtype_vsew();
-  let lmul : real = get_vtype_LMUL();
-  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
-  let num_elem : int = get_num_elem(emul, veew_bits);
+  let EEW : int = load_width_bytes * 8;
+  let EEW_pow : int = vlewidth_pow(width);
+  let SEW_pow : int = get_sew_pow();
+  let LMUL_pow : int = get_lmul_pow();
+  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem : int = get_num_elem(EMUL_pow, EEW);
 
   assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(num_elem >= 0);
 
-  process_vse(vm, vs3, load_width_bytes, rs1, emul, num_elem)
+  process_vse(vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
 
 mapping vsetype_mnemonic : vlewidth <-> string = {
@@ -217,17 +226,17 @@ union clause ast = VLSETYPE : (bits(1), regidx, regidx, vlewidth, regidx)
 mapping clause encdec = VLSETYPE(vm, rs2, rs1, width, vd)
   <-> 0b000 @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vlse : forall 'b 'n, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, regidx, real, int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
-function process_vlse (vm, vd, load_width_bytes, rs1, rs2, emul, num_elem) = {
+val process_vlse : forall 'b 'n 'p, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vlse (vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vd_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, emul, vd);
+  let vd_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd);
   let rs2_val : int = signed(get_scalar(rs2, sizeof(xlen)));
   total : vector('n, dec, bits('b * 8)) = undefined;
   mask_helper : vector('n, dec, bool) = undefined;
   status : Retired = RETIRE_SUCCESS;
 
-  (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, emul, vd_val, vm_val);
+  (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
     let elem_offset = i * rs2_val;
@@ -250,23 +259,24 @@ function process_vlse (vm, vd, load_width_bytes, rs1, rs2, emul, num_elem) = {
     }
   };
 
-  if status== RETIRE_SUCCESS then write_vreg(num_elem, load_width_bytes * 8, emul, vd, total);
+  if status== RETIRE_SUCCESS then write_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd, total);
   vstart = EXTZ(0b0);
   status
 }
 
 function clause execute(VLSETYPE(vm, rs2, rs1, width, vd)) = {
   let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let veew_bits : int = load_width_bytes * 8;
-  let vsew_bits : int = get_vtype_vsew();
-  let lmul : real = get_vtype_LMUL();
-  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
-  let num_elem : int = get_num_elem(emul, veew_bits);
+  let EEW : int = load_width_bytes * 8;
+  let EEW_pow : int = vlewidth_pow(width);
+  let SEW_pow : int = get_sew_pow();
+  let LMUL_pow : int = get_lmul_pow();
+  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem : int = get_num_elem(EMUL_pow, EEW);
 
   assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(num_elem >= 0);
 
-  process_vlse(vm, vd, load_width_bytes, rs1, rs2, emul, num_elem)
+  process_vlse(vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
 
 mapping vlsetype_mnemonic : vlewidth <-> string = {
@@ -287,17 +297,17 @@ union clause ast = VSSETYPE : (bits(1), regidx, regidx, vlewidth, regidx)
 mapping clause encdec = VSSETYPE(vm, rs2, rs1, width, vs3)
   <-> 0b000 @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
 
-val process_vsse : forall 'b 'n, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, regidx, real, int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
-function process_vsse (vm, vs3, load_width_bytes, rs1, rs2, emul, num_elem) = {
+val process_vsse : forall 'b 'n 'p, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vsse (vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vs3_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, emul, vs3);
+  let vs3_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vs3);
   let rs2_val : int = signed(get_scalar(rs2, sizeof(xlen)));
   total : vector('n, dec, bits('b * 8)) = undefined;
   mask_helper : vector('n, dec, bool) = undefined;
   status : Retired = RETIRE_SUCCESS;
 
-  (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, emul, vs3_val, vm_val);
+  (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vs3_val, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
     let elem_offset = i * rs2_val;
@@ -334,16 +344,17 @@ function process_vsse (vm, vs3, load_width_bytes, rs1, rs2, emul, num_elem) = {
 
 function clause execute(VSSETYPE(vm, rs2, rs1, width, vs3)) = {
   let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let veew_bits : int = load_width_bytes * 8;
-  let vsew_bits : int = get_vtype_vsew();
-  let lmul : real = get_vtype_LMUL();
-  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
-  let num_elem : int = get_num_elem(emul, veew_bits);
+  let EEW : int = load_width_bytes * 8;
+  let EEW_pow : int = vlewidth_pow(width);
+  let SEW_pow : int = get_sew_pow();
+  let LMUL_pow : int = get_lmul_pow();
+  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem : int = get_num_elem(EMUL_pow, EEW);
 
   assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(num_elem >= 0);
 
-  process_vsse(vm, vs3, load_width_bytes, rs1, rs2, emul, num_elem)
+  process_vsse(vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
 
 mapping vssetype_mnemonic : vlewidth <-> string = {
@@ -364,22 +375,16 @@ union clause ast = VLUXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
 mapping clause encdec = VLUXEITYPE(vm, vs2, rs1, width, vd)
   <-> 0b000 @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vlxei : forall 'ib 'db 'n, (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (bits(1), regidx, int('ib), int('db), regidx, regidx, int('n), int) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
-function process_vlxei (vm, vd, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, mop) = {
-  let index_eew_bits : int = index_eew_bytes * 8;
-  let data_eew_bits = data_eew_bytes * 8;
-  let data_emul : real = get_vtype_LMUL();
-  let index_emul : real = (to_real( index_eew_bits / data_eew_bits )) * data_emul;
-  assert(8 <= data_eew_bits & data_eew_bits <= 64);
-
-  let width_type : word_width = bytes_wordwidth(data_eew_bytes);
+val process_vlxei : forall 'ib 'db 'ip 'dp 'n, (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vlxei (vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
+  let width_type : word_width = bytes_wordwidth(EEW_data_bytes);
   let start_element : int = get_start_element();
-  let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vd_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, data_eew_bytes * 8, data_emul, vd);
-  let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, index_eew_bytes * 8, index_emul, vs2);
+  let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd);
+  let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
   total : vector('n, dec, bits('db * 8)) = undefined;
   mask_helper : vector('n, dec, bool) = undefined;
-  (total, mask_helper) = init_masked_result(num_elem, data_eew_bytes * 8, data_emul, vd_val, vm_val);
+  (total, mask_helper) = init_masked_result(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd_val, vm_val);
   status : Retired = RETIRE_SUCCESS;
 
   /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
@@ -394,7 +399,7 @@ function process_vlxei (vm, vd, index_eew_bytes, data_eew_bytes, rs1, vs2, num_e
           else match translateAddr(vaddr, Read(Data)) {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
             TR_Address(paddr, _) => {
-              match mem_read(Read(Data), paddr, data_eew_bytes, false, false, false) {
+              match mem_read(Read(Data), paddr, EEW_data_bytes, false, false, false) {
                 MemValue(result) => total[i] = result,
                 MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
               }
@@ -404,23 +409,25 @@ function process_vlxei (vm, vd, index_eew_bytes, data_eew_bytes, rs1, vs2, num_e
     }
   };
   
-  if status == RETIRE_SUCCESS then write_vreg(num_elem, data_eew_bits, data_emul, vd, total);
+  if status == RETIRE_SUCCESS then write_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd, total);
   vstart = EXTZ(0b0);
   status
 }
 
 function clause execute(VLUXEITYPE(vm, vs2, rs1, width, vd)) = {
-  let index_eew_bytes : int = vlewidth_bytesnumber(width);
-  let data_eew_bits : int = get_vtype_vsew();
-  let data_eew_bytes : int = data_eew_bits / 8;
-  let data_emul : real = get_vtype_LMUL();
-  let num_elem : int = get_num_elem(data_emul, data_eew_bits); /* number of data and indices are the same */
+  let EEW_index_pow : int = vlewidth_pow(width);
+  let EEW_index_bytes : int = vlewidth_bytesnumber(width);
+  let EEW_data_pow : int = get_sew_pow();
+  let EEW_data_bytes : int = int_power(2, EEW_data_pow - 3);
+  let EMUL_data_pow : int = get_lmul_pow();
+  let EMUL_index_pow : int = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem : int = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
 
-  assert(0 < index_eew_bytes & index_eew_bytes <= 8);
-  assert(0 < data_eew_bytes & data_eew_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < EEW_index_bytes & EEW_index_bytes <= 8);
+  assert(0 < EEW_data_bytes & EEW_data_bytes <= 8);
+  assert(num_elem >= 0);
 
-  process_vlxei(vm, vd, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, 1)
+  process_vlxei(vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
 
 mapping clause assembly = VLUXEITYPE(vm, vs2, rs1, width, vd)
@@ -435,17 +442,19 @@ mapping clause encdec = VLOXEITYPE(vm, vs2, rs1, width, vd)
   <-> 0b000 @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
 function clause execute(VLOXEITYPE(vm, vs2, rs1, width, vd)) = {
-  let index_eew_bytes : int = vlewidth_bytesnumber(width);
-  let data_eew_bits : int = get_vtype_vsew();
-  let data_eew_bytes : int = data_eew_bits / 8;
-  let data_emul : real = get_vtype_LMUL();
-  let num_elem : int = get_num_elem(data_emul, data_eew_bits); /* number of data and indeces are the same */
+  let EEW_index_pow : int = vlewidth_pow(width);
+  let EEW_index_bytes : int = vlewidth_bytesnumber(width);
+  let EEW_data_pow : int = get_sew_pow();
+  let EEW_data_bytes : int = int_power(2, EEW_data_pow - 3);
+  let EMUL_data_pow : int = get_lmul_pow();
+  let EMUL_index_pow : int = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem : int = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
 
-  assert(0 < index_eew_bytes & index_eew_bytes <= 8);
-  assert(0 < data_eew_bytes & data_eew_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < EEW_index_bytes & EEW_index_bytes <= 8);
+  assert(0 < EEW_data_bytes & EEW_data_bytes <= 8);
+  assert(num_elem >= 0);
 
-  process_vlxei(vm, vd, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, 3)
+  process_vlxei(vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
 
 mapping clause assembly = VLOXEITYPE(vm, vs2, rs1, width, vd)
@@ -459,22 +468,16 @@ union clause ast = VSUXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
 mapping clause encdec = VSUXEITYPE(vm, vs2, rs1, width, vs3)
   <-> 0b000 @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
 
-val process_vsxei : forall 'ib 'db 'n, (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (bits(1), regidx, int('ib), int('db), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
-function process_vsxei (vm, vs3, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, mop) = {
-  let index_eew_bits : int = index_eew_bytes * 8;
-  let data_eew_bits = data_eew_bytes * 8;
-  let data_emul : real = get_vtype_LMUL();
-  let index_emul : real = (to_real( index_eew_bits / data_eew_bits )) * data_emul;
-  assert(8 <= data_eew_bits & data_eew_bits <= 64);
-
-  let width_type : word_width = bytes_wordwidth(data_eew_bytes);
+val process_vsxei : forall 'ib 'db 'ip 'dp 'n, (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vsxei (vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
+  let width_type : word_width = bytes_wordwidth(EEW_data_bytes);
   let start_element : int = get_start_element();
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vs3_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, data_eew_bytes * 8, data_emul, vs3);
-  let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, index_eew_bytes * 8, index_emul, vs2);
+  let vs3_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vs3);
+  let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
   total : vector('n, dec, bits('db * 8)) = undefined; /* just used to generate mask_helper */
   mask_helper : vector('n, dec, bool) = undefined;
-  (total, mask_helper) = init_masked_result(num_elem, data_eew_bytes * 8, data_emul, vs3_val, vm_val);
+  (total, mask_helper) = init_masked_result(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vs3_val, vm_val);
   status : Retired = RETIRE_SUCCESS;
 
   /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
@@ -489,11 +492,11 @@ function process_vsxei (vm, vs3, index_eew_bytes, data_eew_bytes, rs1, vs2, num_
             else match translateAddr(vaddr, Write(Data)) {
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
               TR_Address(paddr, _) => {
-                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, data_eew_bytes, false, false, false);
+                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, EEW_data_bytes, false, false, false);
                 match (eares) {
                   MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
                   MemValue(_) => {
-                    let res : MemoryOpResult(bool) = mem_write_value(paddr, data_eew_bytes, vs3_val[i], false, false, false);
+                    let res : MemoryOpResult(bool) = mem_write_value(paddr, EEW_data_bytes, vs3_val[i], false, false, false);
                     match (res) {
                       MemValue(true)  => status = RETIRE_SUCCESS,
                       MemValue(false) => internal_error("store got false from mem_write_value"),
@@ -512,17 +515,19 @@ function process_vsxei (vm, vs3, index_eew_bytes, data_eew_bytes, rs1, vs2, num_
 }
 
 function clause execute(VSUXEITYPE(vm, vs2, rs1, width, vs3)) = {
-  let index_eew_bytes : int = vlewidth_bytesnumber(width);
-  let data_eew_bits : int = get_vtype_vsew();
-  let data_eew_bytes : int = data_eew_bits / 8;
-  let data_emul : real = get_vtype_LMUL();
-  let num_elem : int = get_num_elem(data_emul, data_eew_bits); /* number of data and indeces are the same */
+  let EEW_index_pow : int = vlewidth_pow(width);
+  let EEW_index_bytes : int = vlewidth_bytesnumber(width);
+  let EEW_data_pow : int = get_sew_pow();
+  let EEW_data_bytes : int = int_power(2, EEW_data_pow - 3);
+  let EMUL_data_pow : int = get_lmul_pow();
+  let EMUL_index_pow : int = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem : int = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
 
-  assert(0 < index_eew_bytes & index_eew_bytes <= 8);
-  assert(0 < data_eew_bytes & data_eew_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < EEW_index_bytes & EEW_index_bytes <= 8);
+  assert(0 < EEW_data_bytes & EEW_data_bytes <= 8);
+  assert(num_elem >= 0);
 
-  process_vsxei(vm, vs3, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, 1)
+  process_vsxei(vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
 
 mapping clause assembly = VSUXEITYPE(vm, vs2, rs1, width, vs3)
@@ -537,17 +542,19 @@ mapping clause encdec = VSOXEITYPE(vm, vs2, rs1, width, vs3)
   <-> 0b000 @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
 
 function clause execute(VSOXEITYPE(vm, vs2, rs1, width, vs3)) = {
-  let index_eew_bytes : int = vlewidth_bytesnumber(width);
-  let data_eew_bits : int = get_vtype_vsew();
-  let data_eew_bytes : int = data_eew_bits / 8;
-  let data_emul : real = get_vtype_LMUL();
-  let num_elem : int = get_num_elem(data_emul, data_eew_bits); /* number of data and indeces are the same */
+  let EEW_index_pow : int = vlewidth_pow(width);
+  let EEW_index_bytes : int = vlewidth_bytesnumber(width);
+  let EEW_data_pow : int = get_sew_pow();
+  let EEW_data_bytes : int = int_power(2, EEW_data_pow - 3);
+  let EMUL_data_pow : int = get_lmul_pow();
+  let EMUL_index_pow : int = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem : int = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
 
-  assert(0 < index_eew_bytes & index_eew_bytes <= 8);
-  assert(0 < data_eew_bytes & data_eew_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < EEW_index_bytes & EEW_index_bytes <= 8);
+  assert(0 < EEW_data_bytes & EEW_data_bytes <= 8);
+  assert(num_elem >= 0);
 
-  process_vsxei(vm, vs3, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, 3)
+  process_vsxei(vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
 
 mapping clause assembly = VSOXEITYPE(vm, vs2, rs1, width, vs3)
@@ -561,17 +568,17 @@ union clause ast = VLEFFTYPE : (bits(1), regidx, vlewidth, regidx)
 mapping clause encdec = VLEFFTYPE(vm, rs1, width, vd)
   <-> 0b000 @ 0b0 @ 0b00 @ vm @ 0b10000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vleff : forall 'b 'n, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, real, int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
-function process_vleff (vm, vd, load_width_bytes, rs1, emul, num_elem) = {
+val process_vleff : forall 'b 'n 'p, (0 < 'b & 'b <= 8) & ('n >= 0). (bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vleff (vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vd_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, emul, vd);
+  let vd_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd);
   total : vector('n, dec, bits('b * 8)) = undefined;
   mask_helper : vector('n, dec, bool) = undefined;
   status : Retired = RETIRE_SUCCESS;
 
   foreach (i from 0 to (num_elem - 1)) {
-    (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, emul, vd_val, vm_val);
+    (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_val, vm_val);
     if mask_helper[i] == true then {
       let elem_offset = i * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
@@ -631,23 +638,24 @@ function process_vleff (vm, vd, load_width_bytes, rs1, emul, num_elem) = {
     }
   };
 
-  if status == RETIRE_SUCCESS then write_vreg(num_elem, load_width_bytes * 8, emul, vd, total);
+  if status == RETIRE_SUCCESS then write_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd, total);
   vstart = EXTZ(0b0);
   status
 }
 
 function clause execute(VLEFFTYPE(vm, rs1, width, vd)) = {
   let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let veew_bits : int = load_width_bytes * 8;
-  let vsew_bits : int = get_vtype_vsew();
-  let lmul : real = get_vtype_LMUL();
-  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
-  let num_elem : int = get_num_elem(emul, veew_bits);
+  let EEW : int = load_width_bytes * 8;
+  let EEW_pow : int = vlewidth_pow(width);
+  let SEW_pow : int = get_sew_pow();
+  let LMUL_pow : int = get_lmul_pow();
+  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem : int = get_num_elem(EMUL_pow, EEW);
 
   assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(num_elem >= 0);
 
-  process_vle(vm, vd, load_width_bytes, rs1,  emul, num_elem)
+  process_vle(vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
 
 mapping vlefftype_mnemonic : vlewidth <-> string = {
@@ -668,8 +676,9 @@ union clause ast = VLSEGTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
 mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vlseg : forall 'f 'b 'n, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, real, int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
-function process_vlseg (nf, vm, vd, load_width_bytes, rs1, emul, num_elem) = {
+val process_vlseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
+  let EMUL_reg : int = if EMUL_pow <= 0 then 1 else int_power(2, EMUL_pow);
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   status : Retired = RETIRE_SUCCESS;
@@ -677,11 +686,11 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, emul, num_elem) = {
   vd_t = vd;
 
   foreach(a from 0 to (nf - 1)) {
-    if vd_t == vd_a & a != 0 then vd_t = vd_t + 1; /* emul < 1 */
-    let vd_t_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, emul, vd_t);
+    if vd_t == vd_a & a != 0 then vd_t = vd_t + 1; /* EMUL < 1 */
+    let vd_t_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd_t);
     total : vector('n, dec, bits('b * 8)) = undefined;
     mask_helper : vector('n, dec, bool) = undefined;
-    (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, emul, vd_t_val, vm_val);
+    (total, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_t_val, vm_val);
 
     foreach (i from 0 to (num_elem - 1)) {
       if (mask_helper[i] == true) then {
@@ -704,9 +713,9 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, emul, num_elem) = {
       }
     };
 
-    if status == RETIRE_SUCCESS then write_vreg(num_elem, load_width_bytes * 8, emul, vd_t, total);
+    if status == RETIRE_SUCCESS then write_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd_t, total);
     vd_a = vd_t;
-    vd_t = vd_t + to_bits(5, ceil(emul))
+    vd_t = vd_t + to_bits(5, EMUL_reg)
   };
 
   vstart = EXTZ(0b0);
@@ -715,18 +724,19 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, emul, num_elem) = {
 
 function clause execute(VLSEGTYPE(nf, vm, rs1, width, vd)) = {
   let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let veew_bits : int = load_width_bytes * 8;
-  let vsew_bits : int = get_vtype_vsew();
-  let lmul : real = get_vtype_LMUL();
-  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
-  let num_elem : int = get_num_elem(emul, veew_bits); /* # of element of each register group */
+  let EEW : int = load_width_bytes * 8;
+  let EEW_pow : int = vlewidth_pow(width);
+  let SEW_pow : int = get_sew_pow();
+  let LMUL_pow : int = get_lmul_pow();
+  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem : int = get_num_elem(EMUL_pow, EEW); /* # of element of each register group */
   let nf_int = nfields_int(nf);
 
   assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
   assert(0 < '_nf_int & '_nf_int <= 8);
+  assert(num_elem >= 0);
 
-  process_vlseg(nf_int, vm, vd, load_width_bytes, rs1, emul, num_elem)
+  process_vlseg(nf_int, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
 
 mapping clause assembly = VLSEGTYPE(nf, vm, rs1, width, vd)
@@ -740,8 +750,9 @@ union clause ast = VLSEGFFTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
 mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vlsegff : forall 'f 'b 'n, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, real, int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
-function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, emul, num_elem) = {
+val process_vlsegff : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
+  let EMUL_reg : int = if EMUL_pow <= 0 then 1 else int_power(2, EMUL_pow);
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let start_element : int = get_start_element();
   let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
@@ -763,7 +774,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, emul, num_elem) = {
               TR_Failure(e, _)     => { if i == 0 then handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                  MemValue(result) => write_single_element(load_width_bytes * 8, i, emul, vd + to_bits(5, j * ceil(emul)), result),
+                  MemValue(result) => write_single_element(load_width_bytes * 8, i, EMUL_pow, vd + to_bits(5, j * EMUL_reg), result),
                   MemException(e)  => { if i == 0 then handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
                 }
               }
@@ -780,18 +791,19 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, emul, num_elem) = {
 
 function clause execute(VLSEGFFTYPE(nf, vm, rs1, width, vd)) = {
   let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let veew_bits : int = load_width_bytes * 8;
-  let vsew_bits : int = get_vtype_vsew();
-  let lmul : real = get_vtype_LMUL();
-  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
-  let num_elem : int = get_num_elem(emul, veew_bits);
+  let EEW : int = load_width_bytes * 8;
+  let EEW_pow : int = vlewidth_pow(width);
+  let SEW_pow : int = get_sew_pow();
+  let LMUL_pow : int = get_lmul_pow();
+  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem : int = get_num_elem(EMUL_pow, EEW);
   let nf_int = nfields_int(nf);
 
   assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
   assert(0 < '_nf_int & '_nf_int <= 8);
+  assert(num_elem >= 0);
 
-  process_vlsegff(nf_int, vm, vd, load_width_bytes, rs1, emul, num_elem)
+  process_vlsegff(nf_int, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
 
 mapping clause assembly = VLSEGTYPE(nf, vm, rs1, width, vd)
@@ -805,8 +817,9 @@ union clause ast = VSSEGTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
 mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
 
-val process_vsseg : forall 'f 'b 'n, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, real, int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
-function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, emul, num_elem) = {
+val process_vsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
+  let EMUL_reg : int = if EMUL_pow <= 0 then 1 else int_power(2, EMUL_pow);
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let start_element : int = get_start_element();
   let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
@@ -830,7 +843,7 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, emul, num_elem) = {
                 match (eares) {
                   MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
                   MemValue(_) => {
-                    let one_elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, emul, vs3 + to_bits(5, j * ceil(emul)));
+                    let one_elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, EMUL_pow, vs3 + to_bits(5, j * EMUL_reg));
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, one_elem_val, false, false, false);
                     match (res) {
                       MemValue(true)  => status = RETIRE_SUCCESS,
@@ -852,18 +865,19 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, emul, num_elem) = {
 
 function clause execute(VSSEGTYPE(nf, vm, rs1, width, vs3)) = {
   let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let veew_bits : int = load_width_bytes * 8;
-  let vsew_bits : int = get_vtype_vsew();
-  let lmul : real = get_vtype_LMUL();
-  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
-  let num_elem : int = get_num_elem(emul, veew_bits);
+  let EEW : int = load_width_bytes * 8;
+  let EEW_pow : int = vlewidth_pow(width);
+  let SEW_pow : int = get_sew_pow();
+  let LMUL_pow : int = get_lmul_pow();
+  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem : int = get_num_elem(EMUL_pow, EEW);
   let nf_int = nfields_int(nf);
 
   assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
   assert(0 < '_nf_int & '_nf_int <= 8);
+  assert(num_elem >= 0);
 
-  process_vsseg(nf_int, vm, vs3, load_width_bytes, rs1, emul, num_elem)
+  process_vsseg(nf_int, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
 
 mapping clause assembly = VSSEGTYPE(nf, vm, rs1, width, vs3)
@@ -877,14 +891,15 @@ union clause ast = VLSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, reg
 mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
   <-> nf @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vlsseg : forall 'f 'b 'n, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, regidx, real, int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
-function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, emul, num_elem) = {
+val process_vlsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired effect {escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
+  let EMUL_reg : int = if EMUL_pow <= 0 then 1 else int_power(2, EMUL_pow);
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vd_val  : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, emul, vd); /* only to generate mask_helper */
+  let vd_val  : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vd); /* only to generate mask_helper */
   result      : vector('n, dec, bits('b * 8)) = undefined;
   mask_helper : vector('n, dec, bool)     = undefined;
-  (result, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, emul, vd_val, vm_val);
+  (result, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vd_val, vm_val);
 
   let rs2_val : int = signed(get_scalar(rs2, sizeof(xlen)));
   status : Retired = RETIRE_SUCCESS;
@@ -901,7 +916,7 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, emul, num_elem)
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                  MemValue(result) => write_single_element(load_width_bytes * 8, i, emul, vd + to_bits(5, j * ceil(emul)) , result),
+                  MemValue(result) => write_single_element(load_width_bytes * 8, i, EMUL_pow, vd + to_bits(5, j * EMUL_reg) , result),
                   MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
                 }
               }
@@ -917,18 +932,19 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, emul, num_elem)
 
 function clause execute(VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)) = {
   let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let veew_bits : int = load_width_bytes * 8;
-  let vsew_bits : int = get_vtype_vsew();
-  let lmul : real = get_vtype_LMUL();
-  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
-  let num_elem : int = get_num_elem(emul, veew_bits);
+  let EEW : int = load_width_bytes * 8;
+  let EEW_pow : int = vlewidth_pow(width);
+  let SEW_pow : int = get_sew_pow();
+  let LMUL_pow : int = get_lmul_pow();
+  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem : int = get_num_elem(EMUL_pow, EEW);
   let nf_int = nfields_int(nf);
 
   assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
   assert(0 < '_nf_int & '_nf_int <= 8);
+  assert(num_elem >= 0);
 
-  process_vlsseg(nf_int, vm, vd, load_width_bytes, rs1, rs2, emul, num_elem)
+  process_vlsseg(nf_int, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
 
 mapping clause assembly = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
@@ -942,14 +958,15 @@ union clause ast = VSSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, reg
 mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
 
-val process_vssseg : forall 'f 'b 'n, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, regidx, real, int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
-function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, emul, num_elem) = {
+val process_vssseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & (0 < 'b & 'b <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
+  let EMUL_reg : int = if EMUL_pow <= 0 then 1 else int_power(2, EMUL_pow);
   let width_type : word_width = bytes_wordwidth(load_width_bytes);
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vs3_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, emul, vs3); /* only to generate mask_helper */
+  let vs3_val : vector('n, dec, bits('b * 8)) = read_vreg(num_elem, load_width_bytes * 8, EMUL_pow, vs3); /* only to generate mask_helper */
   result      : vector('n, dec, bits('b * 8)) = undefined;
   mask_helper : vector('n, dec, bool)     = undefined;
-  (result, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, emul, vs3_val, vm_val);
+  (result, mask_helper) = init_masked_result(num_elem, load_width_bytes * 8, EMUL_pow, vs3_val, vm_val);
 
   let rs2_val : int = signed(get_scalar(rs2, sizeof(xlen)));
   status : Retired = RETIRE_SUCCESS;
@@ -969,7 +986,7 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, emul, num_elem
                 match (eares) {
                   MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
                   MemValue(_) => {
-                    let one_elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, emul, vs3 + to_bits(5, j * ceil(emul)));
+                    let one_elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, EMUL_pow, vs3 + to_bits(5, j * EMUL_reg));
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, one_elem_val, false, false, false);
                     match (res) {
                       MemValue(true)  => status = RETIRE_SUCCESS,
@@ -991,18 +1008,19 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, emul, num_elem
 
 function clause execute(VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)) = {
   let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let veew_bits : int = load_width_bytes * 8;
-  let vsew_bits : int = get_vtype_vsew();
-  let lmul : real = get_vtype_LMUL();
-  let emul : real = (to_real(veew_bits) / to_real(vsew_bits)) * lmul;
-  let num_elem : int = get_num_elem(emul, veew_bits);
+  let EEW : int = load_width_bytes * 8;
+  let EEW_pow : int = vlewidth_pow(width);
+  let SEW_pow : int = get_sew_pow();
+  let LMUL_pow : int = get_lmul_pow();
+  let EMUL_pow : int = EEW_pow - SEW_pow + LMUL_pow;
+  let num_elem : int = get_num_elem(EMUL_pow, EEW);
   let nf_int = nfields_int(nf);
 
   assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
   assert(0 < '_nf_int & '_nf_int <= 8);
+  assert(num_elem >= 0);
 
-  process_vssseg(nf_int, vm, vs3, load_width_bytes, rs1, rs2, emul, num_elem)
+  process_vssseg(nf_int, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
 
 mapping clause assembly = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
@@ -1016,29 +1034,24 @@ union clause ast = VLUXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, re
 mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   <-> nf @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
-val process_vlxseg : forall 'f 'ib 'db 'n, (0 < 'f & 'f <= 8) & (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('ib), int('db), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
-function process_vlxseg (nf, vm, vd, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, mop) = {
-  let index_eew_bits : int = index_eew_bytes * 8;
-  let data_eew_bits = data_eew_bytes * 8;
-  let data_emul : real = get_vtype_LMUL();
-  let index_emul : real = (to_real( index_eew_bits / data_eew_bits )) * data_emul;
-  assert(8 <= data_eew_bits & data_eew_bits <= 64);
-
-  let width_type : word_width = bytes_wordwidth(data_eew_bytes);
+val process_vlxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
+  let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else int_power(2, EMUL_data_pow);
+  let width_type : word_width = bytes_wordwidth(EEW_data_bytes);
   let start_element : int = get_start_element();
   let vm_val : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vd_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, data_eew_bytes * 8, data_emul, vd);
-  let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, index_eew_bytes * 8, index_emul, vs2);
+  let vd_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd);
+  let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
   total : vector('n, dec, bits('db * 8)) = undefined;
   mask_helper : vector('n, dec, bool) = undefined;
-  (total, mask_helper) = init_masked_result(num_elem, data_eew_bytes * 8, data_emul, vd_val, vm_val);
+  (total, mask_helper) = init_masked_result(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vd_val, vm_val);
   status : Retired = RETIRE_SUCCESS;
 
   /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
     if mask_helper[i] == true then {
       foreach (j from 0 to (nf - 1)) {
-        let elem_offset : int = signed(vs2_val[i]) + j * data_eew_bytes;
+        let elem_offset : int = signed(vs2_val[i]) + j * EEW_data_bytes;
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Read(Data), width_type) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) => 
@@ -1047,8 +1060,8 @@ function process_vlxseg (nf, vm, vd, index_eew_bytes, data_eew_bytes, rs1, vs2, 
             else match translateAddr(vaddr, Read(Data)) {
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
               TR_Address(paddr, _) => {
-                match mem_read(Read(Data), paddr, data_eew_bytes, false, false, false) {
-                  MemValue(result) => write_single_element(data_eew_bits, i, data_emul, vd + to_bits(5, j * ceil(data_emul)) , result),
+                match mem_read(Read(Data), paddr, EEW_data_bytes, false, false, false) {
+                  MemValue(result) => write_single_element(EEW_data_bytes * 8, i, EMUL_data_pow, vd + to_bits(5, j * EMUL_data_reg) , result),
                   MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
                 }
               }
@@ -1063,19 +1076,21 @@ function process_vlxseg (nf, vm, vd, index_eew_bytes, data_eew_bytes, rs1, vs2, 
 }
 
 function clause execute(VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
-  let index_eew_bytes : int = vlewidth_bytesnumber(width);
-  let data_eew_bits : int = get_vtype_vsew();
-  let data_eew_bytes : int = data_eew_bits / 8;
-  let data_emul : real = get_vtype_LMUL();
-  let num_elem : int = get_num_elem(data_emul, data_eew_bits); /* number of data and indeces are the same */
+  let EEW_index_pow : int = vlewidth_pow(width);
+  let EEW_index_bytes : int = vlewidth_bytesnumber(width);
+  let EEW_data_pow : int = get_sew_pow();
+  let EEW_data_bytes : int = int_power(2, EEW_data_pow - 3);
+  let EMUL_data_pow : int = get_lmul_pow();
+  let EMUL_index_pow : int = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem : int = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
   let nf_int = nfields_int(nf);
 
-  assert(0 < index_eew_bytes & index_eew_bytes <= 8);
-  assert(0 < data_eew_bytes & data_eew_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < EEW_index_bytes & EEW_index_bytes <= 8);
+  assert(0 < EEW_data_bytes & EEW_data_bytes <= 8);
   assert(0 < '_nf_int & '_nf_int <= 8);
+  assert(num_elem >= 0);
 
-  process_vlxseg(nf_int, vm, vd, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, 1)
+  process_vlxseg(nf_int, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
 
 mapping clause assembly = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
@@ -1090,19 +1105,21 @@ mapping clause encdec = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   <-> nf @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111
 
 function clause execute(VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
-  let index_eew_bytes : int = vlewidth_bytesnumber(width);
-  let data_eew_bits : int = get_vtype_vsew();
-  let data_eew_bytes : int = data_eew_bits / 8;
-  let data_emul : real = get_vtype_LMUL();
-  let num_elem : int = get_num_elem(data_emul, data_eew_bits); /* number of data and indeces are the same */
+  let EEW_index_pow : int = vlewidth_pow(width);
+  let EEW_index_bytes : int = vlewidth_bytesnumber(width);
+  let EEW_data_pow : int = get_sew_pow();
+  let EEW_data_bytes : int = int_power(2, EEW_data_pow - 3);
+  let EMUL_data_pow : int = get_lmul_pow();
+  let EMUL_index_pow : int = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem : int = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
   let nf_int = nfields_int(nf);
 
-  assert(0 < index_eew_bytes & index_eew_bytes <= 8);
-  assert(0 < data_eew_bytes & data_eew_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < EEW_index_bytes & EEW_index_bytes <= 8);
+  assert(0 < EEW_data_bytes & EEW_data_bytes <= 8);
   assert(0 < '_nf_int & '_nf_int <= 8);
+  assert(num_elem >= 0);
 
-  process_vlxseg(nf_int, vm, vd, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, 3)
+  process_vlxseg(nf_int, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
 
 mapping clause assembly = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)
@@ -1116,29 +1133,24 @@ union clause ast = VSUXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, re
 mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
 
-val process_vsxseg : forall 'f 'ib 'db 'n, (0 < 'f & 'f <= 8) & (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('ib), int('db), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
-function process_vsxseg (nf, vm, vs3, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, mop) = {
-  let index_eew_bits : int = index_eew_bytes * 8;
-  let data_eew_bits = data_eew_bytes * 8;
-  let data_emul : real = get_vtype_LMUL();
-  let index_emul : real = (to_real( index_eew_bits / data_eew_bits )) * data_emul;
-  assert (8 <= data_eew_bits & data_eew_bits <= 64);
-
-  let width_type : word_width = bytes_wordwidth(data_eew_bytes);
+val process_vsxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & (0 < 'ib & 'ib <= 8) & (0 < 'db & 'db <= 8) & ('n >= 0). (int('f), bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
+  let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else int_power(2, EMUL_data_pow);
+  let width_type : word_width = bytes_wordwidth(EEW_data_bytes);
   let start_element : int = get_start_element();
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vs3_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, data_eew_bytes * 8, data_emul, vs3);
-  let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, index_eew_bytes * 8, index_emul, vs2);
+  let vs3_val : vector('n, dec, bits('db * 8)) = read_vreg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vs3);
+  let vs2_val : vector('n, dec, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
   total : vector('n, dec, bits('db * 8)) = undefined;
   mask_helper : vector('n, dec, bool) = undefined;
-  (total, mask_helper) = init_masked_result(num_elem, data_eew_bytes * 8, data_emul, vs3_val, vm_val);
+  (total, mask_helper) = init_masked_result(num_elem, EEW_data_bytes * 8, EMUL_data_pow, vs3_val, vm_val);
   status : Retired = RETIRE_SUCCESS;
 
   /* Currently mop = 1(unordered) or 3(ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
     if mask_helper[i] == true then {
       foreach (j from 0 to (nf - 1)) {
-        let elem_offset : int = signed(vs2_val[i]) + j * data_eew_bytes;
+        let elem_offset : int = signed(vs2_val[i]) + j * EEW_data_bytes;
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); status = RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) =>
@@ -1147,12 +1159,12 @@ function process_vsxseg (nf, vm, vs3, index_eew_bytes, data_eew_bytes, rs1, vs2,
             else match translateAddr(vaddr, Write(Data)) {
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
               TR_Address(paddr, _) => {
-                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, data_eew_bytes, false, false, false);
+                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, EEW_data_bytes, false, false, false);
                 match (eares) {
                   MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
                   MemValue(_) => {
-                    let one_elem_val : bits('db * 8) = read_single_element(data_eew_bits, i, data_emul, vs3 + to_bits(5, j * ceil(data_emul)));
-                    let res : MemoryOpResult(bool) = mem_write_value(paddr, data_eew_bytes, one_elem_val, false, false, false);
+                    let one_elem_val : bits('db * 8) = read_single_element(EEW_data_bytes * 8, i, EMUL_data_pow, vs3 + to_bits(5, j * EMUL_data_reg));
+                    let res : MemoryOpResult(bool) = mem_write_value(paddr, EEW_data_bytes, one_elem_val, false, false, false);
                     match (res) {
                       MemValue(true)  => status = RETIRE_SUCCESS,
                       MemValue(false) => internal_error("store got false from mem_write_value"),
@@ -1172,19 +1184,21 @@ function process_vsxseg (nf, vm, vs3, index_eew_bytes, data_eew_bytes, rs1, vs2,
 }
 
 function clause execute(VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
-  let index_eew_bytes : int = vlewidth_bytesnumber(width);
-  let data_eew_bits : int = get_vtype_vsew();
-  let data_eew_bytes : int = data_eew_bits / 8;
-  let data_emul : real = get_vtype_LMUL();
-  let num_elem : int = get_num_elem(data_emul, data_eew_bits); /* number of data and indeces are the same */
+  let EEW_index_pow : int = vlewidth_pow(width);
+  let EEW_index_bytes : int = vlewidth_bytesnumber(width);
+  let EEW_data_pow : int = get_sew_pow();
+  let EEW_data_bytes : int = int_power(2, EEW_data_pow - 3);
+  let EMUL_data_pow : int = get_lmul_pow();
+  let EMUL_index_pow : int = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem : int = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
   let nf_int = nfields_int(nf);
 
-  assert(0 < index_eew_bytes & index_eew_bytes <= 8);
-  assert(0 < data_eew_bytes & data_eew_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < EEW_index_bytes & EEW_index_bytes <= 8);
+  assert(0 < EEW_data_bytes & EEW_data_bytes <= 8);
   assert(0 < '_nf_int & '_nf_int <= 8);
+  assert(num_elem >= 0);
 
-  process_vsxseg(nf_int, vm, vs3, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, 1)
+  process_vsxseg(nf_int, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
 
 mapping clause assembly = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
@@ -1199,19 +1213,21 @@ mapping clause encdec = VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111
 
 function clause execute(VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
-  let index_eew_bytes : int = vlewidth_bytesnumber(width);
-  let data_eew_bits : int = get_vtype_vsew();
-  let data_eew_bytes : int = data_eew_bits / 8;
-  let data_emul : real = get_vtype_LMUL();
-  let num_elem : int = get_num_elem(data_emul, data_eew_bits); /* number of data and indeces are the same */
+  let EEW_index_pow : int = vlewidth_pow(width);
+  let EEW_index_bytes : int = vlewidth_bytesnumber(width);
+  let EEW_data_pow : int = get_sew_pow();
+  let EEW_data_bytes : int = int_power(2, EEW_data_pow - 3);
+  let EMUL_data_pow : int = get_lmul_pow();
+  let EMUL_index_pow : int = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem : int = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
   let nf_int = nfields_int(nf);
 
-  assert(0 < index_eew_bytes & index_eew_bytes <= 8);
-  assert(0 < data_eew_bytes & data_eew_bytes <= 8);
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(0 < EEW_index_bytes & EEW_index_bytes <= 8);
+  assert(0 < EEW_data_bytes & EEW_data_bytes <= 8);
   assert(0 < '_nf_int & '_nf_int <= 8);
+  assert(num_elem >= 0);
 
-  process_vsxseg(nf_int, vm, vs3, index_eew_bytes, data_eew_bytes, rs1, vs2, num_elem, 3)
+  process_vsxseg(nf_int, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
 
 mapping clause assembly = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
@@ -1249,7 +1265,7 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
             TR_Address(paddr, _) => {
               match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                MemValue(result) => write_single_element(load_width_bytes * 8, i, to_real(1), vd + to_bits(5, cur_field) , result),
+                MemValue(result) => write_single_element(load_width_bytes * 8, i, 0, vd + to_bits(5, cur_field) , result),
                 MemException(e)  => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
               }
             }
@@ -1282,7 +1298,7 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
       };
       start_element = start_element + 1
     };
-    if status == RETIRE_SUCCESS then write_vreg(elem_per_reg, load_width_bytes * 8, to_real(1), vd + to_bits(5, j), total) /* emul=1 */
+    if status == RETIRE_SUCCESS then write_vreg(elem_per_reg, load_width_bytes * 8, 0, vd + to_bits(5, j), total) /* EMUL=1 */
   };
 
   vstart = EXTZ(0b0);
@@ -1291,13 +1307,14 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
 
 function clause execute(VLRETYPE(nf, rs1, width, vd)) = {
   let load_width_bytes : int = vlewidth_bytesnumber(width);
-  let veew_bits : int = load_width_bytes * 8;
-  let elem_per_reg : int = get_vlen() / veew_bits;
+  let EEW : int = load_width_bytes * 8;
+  let VLEN : int = int_power(2, get_vlen_pow());
+  let elem_per_reg : int = VLEN / EEW;
   let nf_int = nfields_int(nf);
 
   assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 <= elem_per_reg & elem_per_reg <= get_vlen());
-  assert((nf_int == 1) | (nf_int == 2) | (nf_int == 4) | (nf_int == 8));
+  assert(elem_per_reg >= 0);
+  assert(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8);
 
   process_vlre(nf_int, vd, load_width_bytes, rs1, elem_per_reg)
 }
@@ -1340,7 +1357,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
               match (eares) {
                 MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL },
                 MemValue(_) => {
-                  let one_elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, to_real(1), vs3 + to_bits(5, cur_field));
+                  let one_elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, 0, vs3 + to_bits(5, cur_field));
                   let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, one_elem_val, false, false, false);
                   match (res) {
                     MemValue(true)  => status = RETIRE_SUCCESS,
@@ -1358,7 +1375,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
   };
 
   foreach (j from cur_field to (nf - 1)) {
-    let vs_val : vector('n, dec, bits('b * 8)) = read_vreg(elem_per_reg, load_width_bytes * 8, to_real(1), vs3 + to_bits(5, j));
+    let vs_val : vector('n, dec, bits('b * 8)) = read_vreg(elem_per_reg, load_width_bytes * 8, 0, vs3 + to_bits(5, j));
     foreach (i from 0 to (elem_per_reg - 1)) {
       let elem_offset = start_element * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
@@ -1394,13 +1411,14 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
 
 function clause execute(VSRETYPE(nf, rs1, vs3)) = {
   let load_width_bytes : int = 1;
-  let veew_bits : int = 8;
-  let elem_per_reg : int = get_vlen() / veew_bits;
+  let EEW : int = 8;
+  let VLEN : int = int_power(2, get_vlen_pow());
+  let elem_per_reg : int = VLEN / EEW;
   let nf_int = nfields_int(nf);
 
   assert(0 < load_width_bytes & load_width_bytes <= 8);
-  assert(0 <= elem_per_reg & elem_per_reg <= get_vlen());
-  assert((nf_int == 1) | (nf_int == 2) | (nf_int == 4) | (nf_int == 8));
+  assert(elem_per_reg >= 0);
+  assert(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8);
 
   process_vsre(nf_int, load_width_bytes, rs1, vs3, elem_per_reg)
 }
@@ -1421,11 +1439,11 @@ mapping encdec_lsop : vmlsop <-> bits(7) = {
 mapping clause encdec = VMTYPE(rs1, vd_or_vs3, op)
   <-> 0b000 @ 0b0 @ 0b00 @ 0b1 @ 0b01011 @ rs1 @ 0b000 @ vd_or_vs3 @ encdec_lsop(op)
 
-val process_vm : forall 'n, ('n >= 0). (regidx, regidx, real, int('n), vmlsop) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
-function process_vm(vd_or_vs3, rs1, emul, num_elem, op) = {
+val process_vm : forall 'n 'p, ('n >= 0). (regidx, regidx, int('p), int('n), vmlsop) -> Retired effect {eamem, escape, rmem, rmemt, rreg, undef, wmv, wmvt, wreg}
+function process_vm(vd_or_vs3, rs1, EMUL_pow, num_elem, op) = {
   let width_type : word_width = BYTE;
   let start_element : int = get_start_element();
-  let vd_or_vs3_val : vector('n, dec, bits(8)) = read_vreg(num_elem, 8, emul, vd_or_vs3);
+  let vd_or_vs3_val : vector('n, dec, bits(8)) = read_vreg(num_elem, 8, EMUL_pow, vd_or_vs3);
   total : vector('n, dec, bits(8)) = undefined;
   elem_offset : int = undefined;
   status : Retired = RETIRE_SUCCESS;
@@ -1452,7 +1470,7 @@ function process_vm(vd_or_vs3, rs1, emul, num_elem, op) = {
             }
         }
       };
-      if status == RETIRE_SUCCESS then write_vreg(num_elem, 8, emul, vd_or_vs3, total)
+      if status == RETIRE_SUCCESS then write_vreg(num_elem, 8, EMUL_pow, vd_or_vs3, total)
     } else if op == VSM then { /* store */
       if i > start_element then {
         match ext_data_get_addr(rs1, to_bits(sizeof(xlen), elem_offset), Write(Data), width_type) {
@@ -1487,16 +1505,15 @@ function process_vm(vd_or_vs3, rs1, emul, num_elem, op) = {
 }
 
 function clause execute(VMTYPE(rs1, vd_or_vs3, op)) = {
-  let veew_bits : int = 8;
-  let vsew_bits : int = get_vtype_vsew();
-  let emul : real = 1.0;
+  let EEW : int = 8;
+  let EMUL_pow : int = 0;
   let tmp : int = unsigned(vl);
-  let num_elem : int = ceil( to_real(tmp) / 8.0);
+  let num_elem : int = if tmp % 8 == 0 then tmp / 8 else tmp / 8 + 1;
 
-  assert(0 <= num_elem & num_elem <= get_vlen());
+  assert(num_elem >= 0);
 
   /* unmask vle8 except that the effective vector length is evl=ceil(vl/8) */
-  process_vm(vd_or_vs3, rs1, emul, num_elem, op)
+  process_vm(vd_or_vs3, rs1, EMUL_pow, num_elem, op)
 }
 
 mapping vmtype_mnemonic : vmlsop <-> string = {

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -1,15 +1,12 @@
 /* ************************************************************************** */
 /* This file implements functions used by vector instructions.                */
-
 /* ************************************************************************** */
-
 
 /* Vector mask mapping */
 mapping maybe_vmask : string <-> bits(1) = {
   ""              <-> 0b1, /* unmasked by default */
   sep() ^ "v0.t"  <-> 0b0
 }
-
 
 /* Check for vstart value */
 val assert_vstart : int -> bool effect {rreg}
@@ -32,24 +29,24 @@ function get_scalar(rs1, vsew_bits) = {
 }
 
 /* Get the starting element index from csr vtype */
-val get_start_element : unit -> int effect {escape, rreg, wreg}
+val get_start_element : unit -> nat effect {escape, rreg, wreg}
 function get_start_element() = {
-  let start_element  = unsigned(vstart);
-  let VLEN_pow : int = get_vlen_pow();
-  let SEW_pow  : int = get_sew_pow();
+  let start_element = unsigned(vstart);
+  let VLEN_pow = get_vlen_pow();
+  let SEW_pow = get_sew_pow();
   /* The use of vstart values greater than the largest element
     index for the current SEW setting is reserved.
     It is recommended that implementations trap if vstart is out of bounds.
     It is not required to trap, as a possible future use of upper vstart bits
     is to store imprecise trap information. */
-  if start_element > (2 ^ (3 + VLEN_pow - SEW_pow) - 1) then -1
-  else start_element
+  if start_element > (2 ^ (3 + VLEN_pow - SEW_pow) - 1) then handle_illegal();
+  start_element
 }
 
 /* Get the ending element index from csr vl */
 val get_end_element : unit -> int effect {escape, rreg, wreg}
 function get_end_element() = {
-  let end_element : int = unsigned(vl) - 1;
+  let end_element = unsigned(vl) - 1;
   end_element
 }
 
@@ -63,69 +60,63 @@ function get_end_element() = {
  */
 val init_masked_result : forall 'n 'm 'p, 8 <= 'm <= 64. (int('n), int('m), int('p), vector('n, dec, bits('m)), vector('n, dec, bool)) -> (vector('n, dec, bits('m)), vector('n, dec, bool)) effect {escape, rreg, undef, wreg}
 function init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
-  let start_element : int                       = get_start_element();
-  let end_element   : int                       = get_end_element();
-  let tail_ag       : agtype                    = get_vtype_vta();
-  let mask_ag       : agtype                    = get_vtype_vma();
-  mask_helper       : vector('n, dec, bool)     = undefined;
-  result            : vector('n, dec, bits('m)) = undefined;
+  let start_element = get_start_element();
+  let end_element   = get_end_element();
+  let tail_ag : agtype = get_vtype_vta();
+  let mask_ag : agtype = get_vtype_vma();
+  mask : vector('n, dec, bool) = undefined;
+  result : vector('n, dec, bits('m)) = undefined;
 
-  if start_element < 0 then {
-    /* start element is not valid */
-    result      = undefined;
-    mask_helper = undefined;
-  } else {
-    /* Determine the actual number of elements when lmul < 1 */
-    let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow);
-    assert(num_elem >= real_num_elem);
+  /* Determine the actual number of elements when lmul < 1 */
+  let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow);
+  assert(num_elem >= real_num_elem);
 
-    foreach (i from 0 to (num_elem - 1)) {
-      if i < start_element then {
-        /* Prestart elements defined by vstart */
+  foreach (i from 0 to (num_elem - 1)) {
+    if i < start_element then {
+      /* Prestart elements defined by vstart */
+      result[i] = vd_val[i];
+      mask[i] = false
+    } else if i > end_element then {
+      /* Tail elements defined by vl */
+      if tail_ag == UNDISTURBED then {
         result[i] = vd_val[i];
-        mask_helper[i] = false
-      } else if i > end_element then {
-        /* Tail elements defined by vl */
-        if tail_ag == UNDISTURBED then {
-          result[i] = vd_val[i];
-        } else if tail_ag == AGNOSTIC then {
-          result[i] = vd_val[i];
-        };
-        mask_helper[i] = false
-      } else if i >= real_num_elem then {
-        /* Tail elements defined by lmul < 1 */
-        if tail_ag == UNDISTURBED then {
-          result[i] = vd_val[i];
-        } else if tail_ag == AGNOSTIC then {
-          result[i] = vd_val[i];
-        };
-        mask_helper[i] = false
-      } else if vm_val[i] == false then {
-        /* Inactive body elements defined by vm */
-        if mask_ag == UNDISTURBED then {
-          result[i] = vd_val[i]
-        } else if mask_ag == AGNOSTIC then {
-          result[i] = vd_val[i]
-        };
-        mask_helper[i] = false
-      } else {
-        /* Active body elements */
-        mask_helper[i] = true;
-      }
-    };    
+      } else if tail_ag == AGNOSTIC then {
+        result[i] = vd_val[i];
+      };
+      mask[i] = false
+    } else if i >= real_num_elem then {
+      /* Tail elements defined by lmul < 1 */
+      if tail_ag == UNDISTURBED then {
+        result[i] = vd_val[i];
+      } else if tail_ag == AGNOSTIC then {
+        result[i] = vd_val[i];
+      };
+      mask[i] = false
+    } else if vm_val[i] == false then {
+      /* Inactive body elements defined by vm */
+      if mask_ag == UNDISTURBED then {
+        result[i] = vd_val[i]
+      } else if mask_ag == AGNOSTIC then {
+        result[i] = vd_val[i]
+      };
+      mask[i] = false
+    } else {
+      /* Active body elements */
+      mask[i] = true;
+    }
   };
 
-  (result, mask_helper)
+  (result, mask)
 }
 
 /* Mask handling for carry functions that use masks as input/output */
 /* Only prestart and tail elements are masked in a mask value */
 val init_masked_result_carry : forall 'n 'm 'p, 8 <= 'm <= 64. (int('n), int('m), int('p), vector('n, dec, bool)) -> (vector('n, dec, bool), vector('n, dec, bool)) effect {escape, rreg, undef, wreg}
 function init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) = {
-  let start_element : int                   = get_start_element();
-  let end_element   : int                   = get_end_element();
-  mask_helper       : vector('n, dec, bool) = undefined;
-  result            : vector('n, dec, bool) = undefined;
+  let start_element = get_start_element();
+  let end_element   = get_end_element();
+  mask : vector('n, dec, bool) = undefined;
+  result : vector('n, dec, bool) = undefined;
 
   /* Determine the actual number of elements when lmul < 1 */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow);
@@ -135,34 +126,34 @@ function init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) = {
     if i < start_element then {
       /* Prestart elements defined by vstart */
       result[i] = vd_val[i];
-      mask_helper[i] = false
+      mask[i] = false
     } else if i > end_element then {
       /* Tail elements defined by vl */
       /* Mask tail is always agnostic */
       result[i] = vd_val[i];
-      mask_helper[i] = false
+      mask[i] = false
     } else if i >= real_num_elem then {
       /* Tail elements defined by lmul < 1 */
       /* Mask tail is always agnostic */
       result[i] = vd_val[i];
-      mask_helper[i] = false
+      mask[i] = false
     } else {
       /* Active body elements */
-      mask_helper[i] = true
+      mask[i] = true
     }
   };
 
-  (result, mask_helper)
+  (result, mask)
 }
 
 /* Mask handling for cmp functions that use masks as output */
 val init_masked_result_cmp : forall 'n 'm 'p, 8 <= 'm <= 64. (int('n), int('m), int('p), vector('n, dec, bool), vector('n, dec, bool)) -> (vector('n, dec, bool), vector('n, dec, bool)) effect {escape, rreg, undef, wreg}
 function init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
-  let start_element : int                       = get_start_element();
-  let end_element   : int                       = get_end_element();
-  let mask_ag       : agtype                    = get_vtype_vma();
-  mask_helper       : vector('n, dec, bool)     = undefined;
-  result            : vector('n, dec, bool)     = undefined;
+  let start_element = get_start_element();
+  let end_element   = get_end_element();
+  let mask_ag : agtype = get_vtype_vma();
+  mask : vector('n, dec, bool) = undefined;
+  result : vector('n, dec, bool) = undefined;
 
   /* Determine the actual number of elements when lmul < 1 */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow);
@@ -172,17 +163,17 @@ function init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
     if i < start_element then {
       /* Prestart elements defined by vstart */
       result[i] = vd_val[i];
-      mask_helper[i] = false
+      mask[i] = false
     } else if i > end_element then {
       /* Tail elements defined by vl */
       /* Mask tail is always agnostic */
       result[i] = vd_val[i];
-      mask_helper[i] = false
+      mask[i] = false
     } else if i >= real_num_elem then {
       /* Tail elements defined by lmul < 1 */
       /* Mask tail is always agnostic */
       result[i] = vd_val[i];
-      mask_helper[i] = false
+      mask[i] = false
     } else if vm_val[i] == false then {
       /* Inactive body elements defined by vm */
       if mask_ag == UNDISTURBED then {
@@ -190,14 +181,14 @@ function init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
       } else if mask_ag == AGNOSTIC then {
 	      result[i] = vd_val[i]
       };
-      mask_helper[i] = false
+      mask[i] = false
     } else {
       /* Active body elements */
-      mask_helper[i] = true
+      mask[i] = true
     }
   };
 
-  (result, mask_helper)
+  (result, mask)
 }
 
 /* Floating point canonical NaN for 16-bit, 32-bit, 64-bit and 128-bit types */
@@ -281,7 +272,7 @@ function get_scalar_fp(rs1, vsew_bits) = {
 /* Shift amounts */
 val get_shift_amount : forall 'n 'm, 0 <= 'n & 'm in {8, 16, 32, 64}. (bits('n), int('m)) -> nat effect {escape}
 function get_shift_amount(bit_val, vsew_bits) = {
-  let lowlog2bits : int = log2(vsew_bits);
+  let lowlog2bits = log2(vsew_bits);
   assert(0 < lowlog2bits & lowlog2bits < 'n);
   unsigned(bit_val[lowlog2bits - 1 .. 0]);
 }
@@ -355,7 +346,6 @@ function negate_fp (xf) = {
   let new_sign = if (sign == 0b0) then 0b1 else 0b0;
   fmakesign (new_sign, remain)
 }
-
 
 /* Floating point functions */
 val fp_add: forall 'n, 'n in {16, 32, 64}. (bits(3), bits('n), bits('n)) -> bits('n) effect {escape, rreg, undef, wreg}

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -81,7 +81,7 @@ function init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
       if tail_ag == UNDISTURBED then {
         result[i] = vd_val[i];
       } else if tail_ag == AGNOSTIC then {
-        result[i] = vd_val[i];
+        result[i] = vd_val[i]; /* TODO: configuration support */
       };
       mask[i] = false
     } else if i >= real_num_elem then {
@@ -89,7 +89,7 @@ function init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
       if tail_ag == UNDISTURBED then {
         result[i] = vd_val[i];
       } else if tail_ag == AGNOSTIC then {
-        result[i] = vd_val[i];
+        result[i] = vd_val[i]; /* TODO: configuration support */
       };
       mask[i] = false
     } else if vm_val[i] == false then {
@@ -97,7 +97,7 @@ function init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
       if mask_ag == UNDISTURBED then {
         result[i] = vd_val[i]
       } else if mask_ag == AGNOSTIC then {
-        result[i] = vd_val[i]
+        result[i] = vd_val[i] /* TODO: configuration support */
       };
       mask[i] = false
     } else {
@@ -130,12 +130,12 @@ function init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) = {
     } else if i > end_element then {
       /* Tail elements defined by vl */
       /* Mask tail is always agnostic */
-      result[i] = vd_val[i];
+      result[i] = vd_val[i]; /* TODO: configuration support */
       mask[i] = false
     } else if i >= real_num_elem then {
       /* Tail elements defined by lmul < 1 */
       /* Mask tail is always agnostic */
-      result[i] = vd_val[i];
+      result[i] = vd_val[i]; /* TODO: configuration support */
       mask[i] = false
     } else {
       /* Active body elements */
@@ -167,19 +167,19 @@ function init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
     } else if i > end_element then {
       /* Tail elements defined by vl */
       /* Mask tail is always agnostic */
-      result[i] = vd_val[i];
+      result[i] = vd_val[i]; /* TODO: configuration support */
       mask[i] = false
     } else if i >= real_num_elem then {
       /* Tail elements defined by lmul < 1 */
       /* Mask tail is always agnostic */
-      result[i] = vd_val[i];
+      result[i] = vd_val[i]; /* TODO: configuration support */
       mask[i] = false
     } else if vm_val[i] == false then {
       /* Inactive body elements defined by vm */
       if mask_ag == UNDISTURBED then {
         result[i] = vd_val[i]
       } else if mask_ag == AGNOSTIC then {
-	      result[i] = vd_val[i]
+	      result[i] = vd_val[i] /* TODO: configuration support */
       };
       mask[i] = false
     } else {

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -10,12 +10,6 @@ mapping maybe_vmask : string <-> bits(1) = {
   sep() ^ "v0.t"  <-> 0b0
 }
 
-/* Check for valid vsew and lmul values */
-val vcheck_vsew_lmul : (int, real) -> bool
-function vcheck_vsew_lmul(vsew_bits, lmul) = {
-  vsew_bits >= 8     & vsew_bits <= 64 &
-  lmul      >= 0.125 & lmul      <= 8.0;
-}
 
 /* Check for vstart value */
 val assert_vstart : int -> bool effect {rreg}
@@ -40,14 +34,15 @@ function get_scalar(rs1, vsew_bits) = {
 /* Get the starting element index from csr vtype */
 val get_start_element : unit -> int effect {escape, rreg, wreg}
 function get_start_element() = {
-  let start_element = unsigned(vstart);
-  let vsew_bits     = get_vtype_vsew();
+  let start_element  = unsigned(vstart);
+  let VLEN_pow : int = get_vlen_pow();
+  let SEW_pow  : int = get_sew_pow();
   /* The use of vstart values greater than the largest element
     index for the current SEW setting is reserved.
     It is recommended that implementations trap if vstart is out of bounds.
     It is not required to trap, as a possible future use of upper vstart bits
     is to store imprecise trap information. */
-  if start_element > ((8 * get_vlen() / vsew_bits) - 1) then -1
+  if start_element > (2 ^ (3 + VLEN_pow - SEW_pow) - 1) then -1
   else start_element
 }
 
@@ -66,8 +61,8 @@ function get_end_element() = {
  *   vector2 is a "mask" vector that is true for an element if the corresponding element
  *     in the result vector should be updated by the calling instruction
  */
-val init_masked_result : forall 'n 'm, 8 <= 'm <= 128. (int('n), int('m), real, vector('n, dec, bits('m)), vector('n, dec, bool)) -> (vector('n, dec, bits('m)), vector('n, dec, bool)) effect {escape, rreg, undef, wreg}
-function init_masked_result(num_elem, vsew_bits, lmul, vd_val, vm_val) = {
+val init_masked_result : forall 'n 'm 'p, 8 <= 'm <= 64. (int('n), int('m), int('p), vector('n, dec, bits('m)), vector('n, dec, bool)) -> (vector('n, dec, bits('m)), vector('n, dec, bool)) effect {escape, rreg, undef, wreg}
+function init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
   let start_element : int                       = get_start_element();
   let end_element   : int                       = get_end_element();
   let tail_ag       : agtype                    = get_vtype_vta();
@@ -81,7 +76,7 @@ function init_masked_result(num_elem, vsew_bits, lmul, vd_val, vm_val) = {
     mask_helper = undefined;
   } else {
     /* Determine the actual number of elements when lmul < 1 */
-    let real_num_elem = if lmul >= 1.0 then num_elem else floor(lmul * to_real(num_elem));
+    let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow);
     assert(num_elem >= real_num_elem);
 
     foreach (i from 0 to (num_elem - 1)) {
@@ -125,15 +120,15 @@ function init_masked_result(num_elem, vsew_bits, lmul, vd_val, vm_val) = {
 
 /* Mask handling for carry functions that use masks as input/output */
 /* Only prestart and tail elements are masked in a mask value */
-val init_masked_result_carry : forall 'n 'm, 8 <= 'm <= 128. (int('n), int('m), real, vector('n, dec, bool)) -> (vector('n, dec, bool), vector('n, dec, bool)) effect {escape, rreg, undef, wreg}
-function init_masked_result_carry(num_elem, vsew_bits, lmul, vd_val) = {
+val init_masked_result_carry : forall 'n 'm 'p, 8 <= 'm <= 64. (int('n), int('m), int('p), vector('n, dec, bool)) -> (vector('n, dec, bool), vector('n, dec, bool)) effect {escape, rreg, undef, wreg}
+function init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) = {
   let start_element : int                   = get_start_element();
   let end_element   : int                   = get_end_element();
   mask_helper       : vector('n, dec, bool) = undefined;
   result            : vector('n, dec, bool) = undefined;
 
   /* Determine the actual number of elements when lmul < 1 */
-  let real_num_elem = if lmul >= 1.0 then num_elem else floor(lmul * to_real(num_elem));
+  let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow);
   assert(num_elem >= real_num_elem);
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -161,8 +156,8 @@ function init_masked_result_carry(num_elem, vsew_bits, lmul, vd_val) = {
 }
 
 /* Mask handling for cmp functions that use masks as output */
-val init_masked_result_cmp : forall 'n 'm, 8 <= 'm <= 128. (int('n), int('m), real, vector('n, dec, bool), vector('n, dec, bool)) -> (vector('n, dec, bool), vector('n, dec, bool)) effect {escape, rreg, undef, wreg}
-function init_masked_result_cmp(num_elem, vsew_bits, lmul, vd_val, vm_val) = {
+val init_masked_result_cmp : forall 'n 'm 'p, 8 <= 'm <= 64. (int('n), int('m), int('p), vector('n, dec, bool), vector('n, dec, bool)) -> (vector('n, dec, bool), vector('n, dec, bool)) effect {escape, rreg, undef, wreg}
+function init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
   let start_element : int                       = get_start_element();
   let end_element   : int                       = get_end_element();
   let mask_ag       : agtype                    = get_vtype_vma();
@@ -170,7 +165,7 @@ function init_masked_result_cmp(num_elem, vsew_bits, lmul, vd_val, vm_val) = {
   result            : vector('n, dec, bool)     = undefined;
 
   /* Determine the actual number of elements when lmul < 1 */
-  let real_num_elem = if lmul >= 1.0 then num_elem else floor(lmul * to_real(num_elem));
+  let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow);
   assert(num_elem >= real_num_elem);
 
   foreach (i from 0 to (num_elem - 1)) {

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -279,7 +279,7 @@ function get_scalar_fp(rs1, vsew_bits) = {
 }
 
 /* Shift amounts */
-val get_shift_amount : forall 'n 'm, 0 <= 'n & 'm in {8, 16, 32, 64}. (bits('n), int('m)) -> int effect {escape}
+val get_shift_amount : forall 'n 'm, 0 <= 'n & 'm in {8, 16, 32, 64}. (bits('n), int('m)) -> nat effect {escape}
 function get_shift_amount(bit_val, vsew_bits) = {
   let lowlog2bits : int = log2(vsew_bits);
   assert(0 < lowlog2bits & lowlog2bits < 'n);

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -68,7 +68,7 @@ function clause execute VSET_TYPE(op, ma, ta, sew, lmul, rs1, rd) = {
   print_reg("CSR vtype <- " ^ BitStr(vtype.bits()));
   let LMUL_new : real = get_vtype_LMUL();
   let SEW_new  : int  = get_vtype_vsew();
-  let VLMAX = floor(LMUL_new) * vlen / SEW_new;
+  let VLMAX = floor(LMUL_new * to_real(vlen) / to_real(SEW_new));
 
   /* set vl according to VLMAX and AVL */
   if (rs1 != 0b00000) then { /* normal stripmining */
@@ -127,7 +127,7 @@ function clause execute VSETI_TYPE(ma, ta, sew, lmul, uimm, rd) = {
 
   let LMUL_new : real = get_vtype_LMUL();
   let SEW_new  : int = get_vtype_vsew();
-  let VLMAX    : int = floor(LMUL_new) * vlen / SEW_new;
+  let VLMAX    : int = floor(LMUL_new * to_real(vlen) / to_real(SEW_new));
   let AVL      : int = unsigned(uimm); /* AVL is encoded as 5-bit zero-extended imm in the rs1 field */
 
   /* set vl according to VLMAX and AVL */

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -1,6 +1,6 @@
 /* ************************************************************************ */
 /* This file implements part of the vector extension.                       */
-/* Chapter 6: configuration setting instructions                            */
+/* Chapter 6: Configuration-Setting Instructions                            */
 /* ************************************************************************ */
 
 mapping sew_flag : string <-> bits(3) = {
@@ -45,8 +45,8 @@ mapping encdec_vsetop : vsetop <-> bits(4) ={
   VSETVL  <-> 0b1000
 }
 
-mapping clause encdec = VSET_TYPE(op, ma, ta, sew, lmul, rs1, rd)  
-  <-> encdec_vsetop(op) @ ma @ ta @ sew @ lmul @ rs1 @ 0b111 @ rd @ 0b1010111
+mapping clause encdec = VSET_TYPE(op, ma, ta, sew, lmul, rs1, rd) if haveRVV() 
+  <-> encdec_vsetop(op) @ ma @ ta @ sew @ lmul @ rs1 @ 0b111 @ rd @ 0b1010111 if haveRVV()
 
 function clause execute VSET_TYPE(op, ma, ta, sew, lmul, rs1, rd) = {
   let VLEN_pow      = get_vlen_pow();
@@ -111,8 +111,8 @@ mapping clause assembly = VSET_TYPE(op, ma, ta, sew, lmul, rs1, rd)
 /* ******************** vsetivli *********************** */
 union clause ast = VSETI_TYPE : ( bits(1), bits(1), bits(3), bits(3), regidx, regidx)
 
-mapping clause encdec = VSETI_TYPE(ma, ta, sew, lmul, uimm, rd)  
-  <-> 0b1100 @ ma @ ta @ sew @ lmul @ uimm @ 0b111 @ rd @ 0b1010111
+mapping clause encdec = VSETI_TYPE(ma, ta, sew, lmul, uimm, rd) if haveRVV() 
+  <-> 0b1100 @ ma @ ta @ sew @ lmul @ uimm @ 0b111 @ rd @ 0b1010111 if haveRVV()
 
 function clause execute VSETI_TYPE(ma, ta, sew, lmul, uimm, rd) = {
   let VLEN_pow      = get_vlen_pow();

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -50,10 +50,10 @@ mapping clause encdec = VSET_TYPE(op, ma, ta, sew, lmul, rs1, rd)
   <-> encdec_vsetop(op) @ ma @ ta @ sew @ lmul @ rs1 @ 0b111 @ rd @ 0b1010111
 
 function clause execute VSET_TYPE(op, ma, ta, sew, lmul, rs1, rd) = {
-  let vlen      : int  = get_vlen();
-  let LMUL_ori  : real = get_vtype_LMUL();
-  let SEW_ori   : int  = get_vtype_vsew();
-  let ratio_ori : real = to_real(SEW_ori) / LMUL_ori;
+  let VLEN_pow      : int  = get_vlen_pow();
+  let LMUL_pow_ori  : int  = get_lmul_pow();
+  let SEW_pow_ori   : int  = get_sew_pow(); 
+  let ratio_pow_ori : int  = SEW_pow_ori - LMUL_pow_ori;
 
   /* set vtype and calculate VLMAX */
   match op {
@@ -66,9 +66,9 @@ function clause execute VSET_TYPE(op, ma, ta, sew, lmul, rs1, rd) = {
     }
   };
   print_reg("CSR vtype <- " ^ BitStr(vtype.bits()));
-  let LMUL_new : real = get_vtype_LMUL();
-  let SEW_new  : int  = get_vtype_vsew();
-  let VLMAX = floor(LMUL_new * to_real(vlen) / to_real(SEW_new));
+  let LMUL_pow_new : int = get_lmul_pow();
+  let SEW_pow_new  : int = get_sew_pow();
+  let VLMAX        : int = int_power(2, VLEN_pow + LMUL_pow_new - SEW_pow_new);
 
   /* set vl according to VLMAX and AVL */
   if (rs1 != 0b00000) then { /* normal stripmining */
@@ -86,8 +86,8 @@ function clause execute VSET_TYPE(op, ma, ta, sew, lmul, rs1, rd) = {
     print_reg("CSR vl <- " ^ BitStr(vl))
   } else { /* keep existing vl */
     let AVL = unsigned(vl);
-    let ratio_new : real = to_real(SEW_new) / LMUL_new; 
-    if (ratio_new != ratio_ori) then { 
+    let ratio_pow_new : int = SEW_pow_new - LMUL_pow_new;
+    if (ratio_pow_new != ratio_pow_ori) then { 
       vtype->bits() = 0b1 @ zeros(sizeof(xlen) - 1); /* set vtype.vill */
       print_reg("CSR vtype <- " ^ BitStr(vtype.bits()));
     }
@@ -116,19 +116,19 @@ mapping clause encdec = VSETI_TYPE(ma, ta, sew, lmul, uimm, rd)
   <-> 0b1100 @ ma @ ta @ sew @ lmul @ uimm @ 0b111 @ rd @ 0b1010111
 
 function clause execute VSETI_TYPE(ma, ta, sew, lmul, uimm, rd) = {
-  let vlen      : int  = get_vlen();
-  let LMUL_ori  : real = get_vtype_LMUL();
-  let SEW_ori   : int  = get_vtype_vsew();
-  let ratio_ori : real = to_real(SEW_ori) / LMUL_ori;
+  let VLEN_pow      : int  = get_vlen_pow();
+  let LMUL_pow_ori  : int  = get_lmul_pow();
+  let SEW_pow_ori   : int  = get_sew_pow(); 
+  let ratio_pow_ori : int  = SEW_pow_ori - LMUL_pow_ori;
 
   /* set vtype and calculate VLMAX */
   vtype->bits() = 0b0 @ zeros(sizeof(xlen) - 9) @ ma @ ta @ sew @ lmul;
   print_reg("CSR vtype <- " ^ BitStr(vtype.bits()));
 
-  let LMUL_new : real = get_vtype_LMUL();
-  let SEW_new  : int = get_vtype_vsew();
-  let VLMAX    : int = floor(LMUL_new * to_real(vlen) / to_real(SEW_new));
-  let AVL      : int = unsigned(uimm); /* AVL is encoded as 5-bit zero-extended imm in the rs1 field */
+  let LMUL_pow_new : int = get_lmul_pow();
+  let SEW_pow_new  : int = get_sew_pow();
+  let VLMAX        : int = int_power(2, VLEN_pow + LMUL_pow_new - SEW_pow_new);
+  let AVL          : int = unsigned(uimm); /* AVL is encoded as 5-bit zero-extended imm in the rs1 field */
 
   /* set vl according to VLMAX and AVL */
   vl = if AVL <= VLMAX then to_bits(sizeof(xlen), AVL)

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -1,7 +1,6 @@
 /* ************************************************************************ */
 /* This file implements part of the vector extension.                       */
 /* Chapter 6: configuration setting instructions                            */
-
 /* ************************************************************************ */
 
 mapping sew_flag : string <-> bits(3) = {
@@ -50,10 +49,10 @@ mapping clause encdec = VSET_TYPE(op, ma, ta, sew, lmul, rs1, rd)
   <-> encdec_vsetop(op) @ ma @ ta @ sew @ lmul @ rs1 @ 0b111 @ rd @ 0b1010111
 
 function clause execute VSET_TYPE(op, ma, ta, sew, lmul, rs1, rd) = {
-  let VLEN_pow      : int  = get_vlen_pow();
-  let LMUL_pow_ori  : int  = get_lmul_pow();
-  let SEW_pow_ori   : int  = get_sew_pow(); 
-  let ratio_pow_ori : int  = SEW_pow_ori - LMUL_pow_ori;
+  let VLEN_pow      = get_vlen_pow();
+  let LMUL_pow_ori  = get_lmul_pow();
+  let SEW_pow_ori   = get_sew_pow(); 
+  let ratio_pow_ori = SEW_pow_ori - LMUL_pow_ori;
 
   /* set vtype and calculate VLMAX */
   match op {
@@ -66,9 +65,9 @@ function clause execute VSET_TYPE(op, ma, ta, sew, lmul, rs1, rd) = {
     }
   };
   print_reg("CSR vtype <- " ^ BitStr(vtype.bits()));
-  let LMUL_pow_new : int = get_lmul_pow();
-  let SEW_pow_new  : int = get_sew_pow();
-  let VLMAX        : int = int_power(2, VLEN_pow + LMUL_pow_new - SEW_pow_new);
+  let LMUL_pow_new = get_lmul_pow();
+  let SEW_pow_new  = get_sew_pow();
+  let VLMAX        = int_power(2, VLEN_pow + LMUL_pow_new - SEW_pow_new);
 
   /* set vl according to VLMAX and AVL */
   if (rs1 != 0b00000) then { /* normal stripmining */
@@ -86,7 +85,7 @@ function clause execute VSET_TYPE(op, ma, ta, sew, lmul, rs1, rd) = {
     print_reg("CSR vl <- " ^ BitStr(vl))
   } else { /* keep existing vl */
     let AVL = unsigned(vl);
-    let ratio_pow_new : int = SEW_pow_new - LMUL_pow_new;
+    let ratio_pow_new = SEW_pow_new - LMUL_pow_new;
     if (ratio_pow_new != ratio_pow_ori) then { 
       vtype->bits() = 0b1 @ zeros(sizeof(xlen) - 1); /* set vtype.vill */
       print_reg("CSR vtype <- " ^ BitStr(vtype.bits()));
@@ -116,19 +115,19 @@ mapping clause encdec = VSETI_TYPE(ma, ta, sew, lmul, uimm, rd)
   <-> 0b1100 @ ma @ ta @ sew @ lmul @ uimm @ 0b111 @ rd @ 0b1010111
 
 function clause execute VSETI_TYPE(ma, ta, sew, lmul, uimm, rd) = {
-  let VLEN_pow      : int  = get_vlen_pow();
-  let LMUL_pow_ori  : int  = get_lmul_pow();
-  let SEW_pow_ori   : int  = get_sew_pow(); 
-  let ratio_pow_ori : int  = SEW_pow_ori - LMUL_pow_ori;
+  let VLEN_pow      = get_vlen_pow();
+  let LMUL_pow_ori  = get_lmul_pow();
+  let SEW_pow_ori   = get_sew_pow(); 
+  let ratio_pow_ori = SEW_pow_ori - LMUL_pow_ori;
 
   /* set vtype and calculate VLMAX */
   vtype->bits() = 0b0 @ zeros(sizeof(xlen) - 9) @ ma @ ta @ sew @ lmul;
   print_reg("CSR vtype <- " ^ BitStr(vtype.bits()));
 
-  let LMUL_pow_new : int = get_lmul_pow();
-  let SEW_pow_new  : int = get_sew_pow();
-  let VLMAX        : int = int_power(2, VLEN_pow + LMUL_pow_new - SEW_pow_new);
-  let AVL          : int = unsigned(uimm); /* AVL is encoded as 5-bit zero-extended imm in the rs1 field */
+  let LMUL_pow_new = get_lmul_pow();
+  let SEW_pow_new  = get_sew_pow();
+  let VLMAX        = int_power(2, VLEN_pow + LMUL_pow_new - SEW_pow_new);
+  let AVL          = unsigned(uimm); /* AVL is encoded as 5-bit zero-extended imm in the rs1 field */
 
   /* set vl according to VLMAX and AVL */
   vl = if AVL <= VLMAX then to_bits(sizeof(xlen), AVL)

--- a/model/riscv_insts_zicsr.sail
+++ b/model/riscv_insts_zicsr.sail
@@ -251,7 +251,7 @@ function writeCSR (csr : csreg, value : xlenbits) -> unit = {
     (0x015,  _) => write_seed_csr(),
 
     /* vector csr */
-    (0x008, _) => { let vstart_length = get_vstart_length(); vstart = EXTZ(16, value[(vstart_length - 1) .. 0]); Some(EXTZ(vstart)) },
+    (0x008, _) => { let vstart_length = get_vlen_pow(); vstart = EXTZ(16, value[(vstart_length - 1) .. 0]); Some(EXTZ(vstart)) },
     (0x009, _) => { vxsat = value[0 .. 0]; Some(EXTZ(vxsat)) },
     (0x00A, _) => { vxrm = value[1 .. 0]; Some(EXTZ(vxrm)) },
     (0x00F, _) => { vcsr->bits() = value[2 ..0];  Some(EXTZ(vcsr.bits())) },

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -846,8 +846,8 @@ bitfield Vtype  : xlenbits = {
 register vtype : Vtype
 
 /* the dynamic selected element width (SEW) */
-/* the return value is the power of 2 */
-val get_sew_pow : unit -> int effect {rreg}
+/* this returns the power of 2 for SEW */
+val get_sew_pow : unit -> {|3, 4, 5, 6|} effect {escape, rreg}
 function get_sew_pow() = {
   match vtype.vsew() {
     0b000 => 3,
@@ -857,10 +857,30 @@ function get_sew_pow() = {
     _     => {assert(false, "invalid vsew field in vtype"); 0}
   }
 }
+/* this returns the actual value of SEW */
+val get_sew : unit -> {|8, 16, 32, 64|} effect {escape, rreg}
+function get_sew() = {
+  match get_sew_pow() {
+    3 => 8,
+    4 => 16,
+    5 => 32,
+    6 => 64
+  }
+}
+/* this returns the value of SEW in bytes */
+val get_sew_bytes : unit -> {|1, 2, 4, 8|} effect {escape, rreg}
+function get_sew_bytes() = {
+  match get_sew_pow() {
+    3 => 1,
+    4 => 2,
+    5 => 4,
+    6 => 8
+  }
+}
 
 /* the vector register group multiplier (LMUL) */
-/* the return value is the power of 2 */
-val get_lmul_pow : unit -> int effect {rreg}
+/* this returns the power of 2 for LMUL */
+val get_lmul_pow : unit -> {|-3, -2, -1, 0, 1, 2, 3|} effect {escape, rreg}
 function get_lmul_pow() = {
   match vtype.vlmul() {
     0b101 => -3,

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -846,29 +846,31 @@ bitfield Vtype  : xlenbits = {
 register vtype : Vtype
 
 /* the dynamic selected element width (SEW) */
-val get_vtype_vsew : unit -> int effect {escape, rreg}
-function get_vtype_vsew() = {
+/* the return value is the power of 2 */
+val get_sew_pow : unit -> int effect {rreg}
+function get_sew_pow() = {
   match vtype.vsew() {
-    0b000 => 8,
-    0b001 => 16,
-    0b010 => 32,
-    0b011 => 64,
+    0b000 => 3,
+    0b001 => 4,
+    0b010 => 5,
+    0b011 => 6,
     _     => {assert(false, "invalid vsew field in vtype"); 0}
   }
 }
 
 /* the vector register group multiplier (LMUL) */
-val get_vtype_LMUL : unit -> real effect {escape, rreg}
-function get_vtype_LMUL() = {
+/* the return value is the power of 2 */
+val get_lmul_pow : unit -> int effect {rreg}
+function get_lmul_pow() = {
   match vtype.vlmul() {
-    0b101 => 0.125, /* 1/8 */
-    0b110 => 0.25, /* 1/4 */
-    0b111 => 0.5, /* 1/2 */
-    0b000 => 1.0,
-    0b001 => 2.0,
-    0b010 => 4.0,
-    0b011 => 8.0,
-    _     => {assert(false, "invalid vlmul field in vtype"); 0.0}
+    0b101 => -3,
+    0b110 => -2,
+    0b111 => -1,
+    0b000 => 0,
+    0b001 => 1,
+    0b010 => 2,
+    0b011 => 3,
+    _     => {assert(false, "invalid vlmul field in vtype"); 0}
   }
 }
 

--- a/model/riscv_vext_regs.sail
+++ b/model/riscv_vext_regs.sail
@@ -451,7 +451,7 @@ function write_vmask(num_elem, vrid, v) = {
   };
   foreach (i from num_elem to (VLEN - 1)) {
     /* Mask tail is always agnostic */
-    result[i] = vreg_val[i]
+    result[i] = vreg_val[i] /* TODO: configuration support */
   };
 
   V(vrid) = result

--- a/model/riscv_vext_regs.sail
+++ b/model/riscv_vext_regs.sail
@@ -152,9 +152,7 @@ function wV (r, in_v) = {
   let VLEN = int_power(2, get_vlen_pow());
   assert(0 < VLEN & VLEN <= sizeof(vlenmax));
   if   get_config_print_reg()
-  then {
-    print_reg("v" ^ string_of_int(r) ^ " <- " ^ BitStr(v[VLEN - 1 .. 0]));
-  }
+  then print_reg("v" ^ string_of_int(r) ^ " <- " ^ BitStr(v[VLEN - 1 .. 0]));
 }
 
 function rV_bits(i: bits(5)) -> vregtype = rV(unsigned(i))
@@ -204,25 +202,27 @@ function init_vregs () = {
 
 /* Vector CSR */   
 bitfield Vcsr : bits(3) = {
-  vxrm    : 2 .. 1,
-  vxsat   : 0
+  vxrm  : 2 .. 1,
+  vxsat : 0
 }
 register vcsr : Vcsr
 
 val ext_write_vcsr : (bits(2), bits(1)) -> unit effect {rreg, wreg}
 function ext_write_vcsr (vxrm_val, vxsat_val) = {
-  vcsr->vxrm()    = vxrm_val;      /* Note: frm can be an illegal value, 101, 110, 111 */
-  vcsr->vxsat()   = vxsat_val;
+  vcsr->vxrm()  = vxrm_val; /* Note: frm can be an illegal value, 101, 110, 111 */
+  vcsr->vxsat() = vxsat_val;
 }
 
 /* num_elem means max(VLMAX,VLEN/SEW)) according to Section 5.4 of RVV spec */
-val get_num_elem : (int, int) -> int effect {rreg, undef}
+val get_num_elem : (int, int) -> nat effect {escape, rreg}
 function get_num_elem(LMUL_pow, SEW) = {
-  let VLEN         : int = int_power(2, get_vlen_pow());
-  let LMUL_pow_reg : int = if LMUL_pow < 0 then 0 else LMUL_pow;
+  let VLEN = int_power(2, get_vlen_pow());
+  let LMUL_pow_reg = if LMUL_pow < 0 then 0 else LMUL_pow;
   /* Ignore lmul < 1 so that the entire vreg is read, allowing all masking to
    * be handled in init_masked_result */
-  int_power(2, LMUL_pow_reg) * VLEN / SEW
+  let num_elem = int_power(2, LMUL_pow_reg) * VLEN / SEW;
+  assert(num_elem > 0);
+  num_elem
 }
 
 /* Reads a single vreg into multiple elements */
@@ -233,7 +233,7 @@ function read_single_vreg(num_elem, SEW, vrid) = {
 
   assert(8 <= SEW & SEW <= 64);
   foreach (i from 0 to (num_elem - 1)) {
-    let start_index : int = i * SEW;
+    let start_index = i * SEW;
     result[i] = slice(bv, start_index, SEW);
   };
 
@@ -289,9 +289,9 @@ function write_mult_vreg(num_vreg, SEW, vrid, bv) = {
 /* The general vreg reading operation with num_elem as max(VLMAX,VLEN/SEW)) */
 val read_vreg : forall 'n 'm 'p. (int('n), int('m), int('p), regidx) -> vector('n, dec, bits('m)) effect {escape, rreg, undef}
 function read_vreg(num_elem, SEW, LMUL_pow, vrid) = {
-  var result       : vector('n, dec, bits('m)) = undefined;
-  let VLEN         : int = int_power(2, get_vlen_pow());
-  let LMUL_pow_reg : int = if LMUL_pow < 0 then 0 else LMUL_pow;
+  var result : vector('n, dec, bits('m)) = undefined;
+  let VLEN = int_power(2, get_vlen_pow());
+  let LMUL_pow_reg = if LMUL_pow < 0 then 0 else LMUL_pow;
 
   /* Check for valid vrid */
   if unsigned(vrid) + 2 ^ LMUL_pow_reg > 32 then {
@@ -336,7 +336,7 @@ function read_vreg(num_elem, SEW, LMUL_pow, vrid) = {
 /* Single element reading operation */
 val read_single_element : forall 'm 'x 'p, 8 <= 'm <= 128. (int('m), int('x), int('p), regidx) -> bits('m) effect {escape, rreg, undef}
 function read_single_element(EEW, index, EMUL_pow, vrid) = {
-  let VLEN : int = int_power(2, get_vlen_pow());
+  let VLEN = int_power(2, get_vlen_pow());
   assert(VLEN >= EEW);
   let 'elem_per_reg : int = VLEN / EEW;
   let real_vrid  : regidx = if EMUL_pow > 0 then vrid + to_bits(5, index / 'elem_per_reg) else vrid;
@@ -349,8 +349,8 @@ function read_single_element(EEW, index, EMUL_pow, vrid) = {
 /* The general vreg writing operation with num_elem as max(VLMAX,VLEN/SEW)) */
 val write_vreg : forall 'n 'm 'p. (int('n), int('m), int('p), regidx, vector('n, dec, bits('m))) -> unit effect {escape, rreg, undef, wreg} 
 function write_vreg(num_elem, SEW, LMUL_pow, vrid, vec) = {
-  let VLEN         : int = int_power(2, get_vlen_pow());
-  let LMUL_pow_reg : int = if LMUL_pow < 0 then 0 else LMUL_pow;
+  let VLEN = int_power(2, get_vlen_pow());
+  let LMUL_pow_reg = if LMUL_pow < 0 then 0 else LMUL_pow;
 
   if SEW > VLEN then {
     /* Multiple vregs per element */
@@ -381,7 +381,7 @@ function write_vreg(num_elem, SEW, LMUL_pow, vrid, vec) = {
 /* Single element writing operation */
 val write_single_element : forall 'm 'x 'p, 8 <= 'm <= 128. (int('m), int('x), int('p), regidx, bits('m)) -> unit effect {escape, rreg, undef, wreg}
 function write_single_element(EEW, index, EMUL_pow, vrid, value) = {
-  let VLEN : int = int_power(2, get_vlen_pow());
+  let VLEN = int_power(2, get_vlen_pow());
   let 'elem_per_reg : int = VLEN / EEW;
   let real_vrid  : regidx = if EMUL_pow > 0 then vrid + to_bits(5, index / 'elem_per_reg) else vrid;
   let real_index : int    = if EMUL_pow > 0 then index % 'elem_per_reg else index;
@@ -402,8 +402,8 @@ function write_single_element(EEW, index, EMUL_pow, vrid, value) = {
 /* Mask register reading operation with num_elem as max(VLMAX,VLEN/SEW)) */
 val read_vmask : forall 'n. (int('n), bits(1), regidx) -> vector('n, dec, bool) effect {escape, rreg, undef}
 function read_vmask(num_elem, vm, vrid) = {
-  let VLEN : int = int_power(2, get_vlen_pow());
-  assert(0 < num_elem & num_elem <= sizeof(vlenmax));
+  let VLEN = int_power(2, get_vlen_pow());
+  assert(num_elem <= sizeof(vlenmax));
   let vreg_val : vregtype = V(vrid);
   var result   : vector('n, dec, bool) = undefined;
 
@@ -421,7 +421,7 @@ function read_vmask(num_elem, vm, vrid) = {
 /* This is a special version of read_vmask for carry/borrow instructions, where vm=1 means no carry */
 val read_vmask_carry : forall 'n. (int('n), bits(1), regidx) -> vector('n, dec, bool) effect {escape, rreg, undef}
 function read_vmask_carry(num_elem, vm, vrid) = {
-  let VLEN : int = int_power(2, get_vlen_pow());
+  let VLEN = int_power(2, get_vlen_pow());
   assert(0 < num_elem & num_elem <= sizeof(vlenmax));
   let vreg_val : vregtype = V(vrid);
   var result   : vector('n, dec, bool) = undefined;
@@ -440,7 +440,7 @@ function read_vmask_carry(num_elem, vm, vrid) = {
 /* Mask register writing operation with num_elem as max(VLMAX,VLEN/SEW)) */
 val write_vmask : forall 'n. (int('n), regidx, vector('n, dec, bool)) -> unit effect {escape, rreg, undef, wreg}
 function write_vmask(num_elem, vrid, v) = {
-  let VLEN : int = int_power(2, get_vlen_pow());
+  let VLEN = int_power(2, get_vlen_pow());
   assert(0 < VLEN & VLEN <= sizeof(vlenmax));
   assert(0 < num_elem & num_elem <= VLEN);
   let vreg_val : vregtype = V(vrid);

--- a/model/riscv_vext_regs.sail
+++ b/model/riscv_vext_regs.sail
@@ -227,7 +227,7 @@ function get_num_elem(lmul, vsew_bits) = {
      * be handled in init_masked_result */
     num_elem = vlen / vsew_bits;
   };
-  
+
   num_elem
 }
 
@@ -295,17 +295,13 @@ val read_vreg : forall 'n 'm, 8 <= 'm <= 64. (int('n), int('m), real, regidx) ->
 function read_vreg(num_elem, vsew_bits, lmul, vrid) = {
   var result   : vector('n, dec, bits('m)) = undefined;
   let vlen     : int = get_vlen();
-  let lmul_int : int = if lmul < 1.0 then 1 else floor(lmul);
 
   /* Check for valid vrid */
-  if lmul > 1.0 & (unsigned(vrid) + floor(lmul)) > 31 then {
+  if lmul > 1.0 & (unsigned(vrid) + floor(lmul)) > 32 then {
     /* vrid would read past largest vreg (v31) */
     result = undefined
   } else if lmul > 1.0 & (unsigned(vrid) % floor(lmul) != 0) then {
     /* vrid must be a multiple of lmul */
-    result = undefined
-  } else if (vsew_bits > vlen) & (vsew_bits % vlen != 0) then {
-    /* vsew_bits must be a multiple of vlen */
     result = undefined
   } else {
     if vsew_bits > vlen then {
@@ -317,17 +313,21 @@ function read_vreg(num_elem, vsew_bits, lmul, vrid) = {
         result[i] = read_mult_vreg('num_reg_per_elem, vsew_bits, vrid_lmul)
       }
     } else {
-      let 'num_elem_single  : int = vlen / vsew_bits;
-      foreach (i_lmul from 0 to (lmul_int - 1)) {
-        let r_start_i : int = i_lmul * 'num_elem_single;
-        let r_end_i   : int = r_start_i + 'num_elem_single - 1;
-        let vrid_lmul     : regidx = vrid + to_bits(5, i_lmul);
-        let single_result : vector('num_elem_single, dec, bits('m)) = read_single_vreg('num_elem_single, vsew_bits, vrid_lmul);
-        foreach (r_i from r_start_i to r_end_i) {
-          let s_i : int = r_i - r_start_i;
-          assert(0 <= r_i & r_i < num_elem);
-          assert(0 <= s_i & s_i < 'num_elem_single);
-          result[r_i] = single_result[s_i];
+      if lmul < 1.0 then { 
+        result = read_single_vreg('n, vsew_bits, vrid);
+      } else {
+        let 'num_elem_single  : int = vlen / vsew_bits;
+        foreach (i_lmul from 0 to (floor(lmul) - 1)) {
+          let r_start_i : int = i_lmul * 'num_elem_single;
+          let r_end_i   : int = r_start_i + 'num_elem_single - 1;
+          let vrid_lmul     : regidx = vrid + to_bits(5, i_lmul);
+          let single_result : vector('num_elem_single, dec, bits('m)) = read_single_vreg('num_elem_single, vsew_bits, vrid_lmul);
+          foreach (r_i from r_start_i to r_end_i) {
+            let s_i : int = r_i - r_start_i;
+            assert(0 <= r_i & r_i < num_elem);
+            assert(0 <= s_i & s_i < 'num_elem_single);
+            result[r_i] = single_result[s_i];
+          }
         }
       }
     }
@@ -371,10 +371,10 @@ function write_vreg(num_elem, vsew_bits, lmul, vrid, vec) = {
   } else {
     let 'num_elem_single  : int = vlen / vsew_bits;
     foreach (i_lmul from 0 to (lmul_int - 1)) {
-      var single_vec  : vector('num_elem_single, dec, bits('m)) = undefined;
-      let vrid_lmul   : regidx = vrid + to_bits(5, i_lmul);
-      let r_start_i   : int = i_lmul * 'num_elem_single;
-      let r_end_i     : int = r_start_i + 'num_elem_single - 1;
+      var single_vec : vector('num_elem_single, dec, bits('m)) = undefined;
+      let vrid_lmul  : regidx = vrid + to_bits(5, i_lmul);
+      let r_start_i  : int = i_lmul * 'num_elem_single;
+      let r_end_i    : int = r_start_i + 'num_elem_single - 1;
       foreach (r_i from r_start_i to r_end_i) {
         let s_i : int = r_i - r_start_i;
         assert(0 <= r_i & r_i < num_elem);

--- a/model/riscv_vext_regs.sail
+++ b/model/riscv_vext_regs.sail
@@ -149,11 +149,11 @@ function wV (r, in_v) = {
     _ => assert(false, "invalid vector register number")
   };
 
-  let  vlen : int = get_vlen();
-  assert(0 < vlen & vlen <= sizeof(vlenmax));
+  let VLEN = int_power(2, get_vlen_pow());
+  assert(0 < VLEN & VLEN <= sizeof(vlenmax));
   if   get_config_print_reg()
   then {
-    print_reg("v" ^ string_of_int(r) ^ " <- " ^ BitStr(v[vlen - 1 .. 0]));
+    print_reg("v" ^ string_of_int(r) ^ " <- " ^ BitStr(v[VLEN - 1 .. 0]));
   }
 }
 
@@ -216,42 +216,38 @@ function ext_write_vcsr (vxrm_val, vxsat_val) = {
 }
 
 /* num_elem means max(VLMAX,VLEN/SEW)) according to Section 5.4 of RVV spec */
-val get_num_elem : (real, int) -> int effect {rreg, undef}
-function get_num_elem(lmul, vsew_bits) = {
-  let vlen     : int = get_vlen();
-  var num_elem : int = undefined;
-  if lmul >= 1.0 then {
-    num_elem = floor(lmul) * vlen / vsew_bits;
-  } else {
-    /* Ignore lmul < 1 so that the entire vreg is read, allowing all masking to
-     * be handled in init_masked_result */
-    num_elem = vlen / vsew_bits;
-  };
-
-  num_elem
+val get_num_elem : (int, int) -> int effect {rreg, undef}
+function get_num_elem(LMUL_pow, SEW) = {
+  let VLEN         : int = int_power(2, get_vlen_pow());
+  let LMUL_pow_reg : int = if LMUL_pow < 0 then 0 else LMUL_pow;
+  /* Ignore lmul < 1 so that the entire vreg is read, allowing all masking to
+   * be handled in init_masked_result */
+  int_power(2, LMUL_pow_reg) * VLEN / SEW
 }
 
 /* Reads a single vreg into multiple elements */
-val read_single_vreg : forall 'n 'm, 8 <= 'm <= 128. (int('n), int('m), regidx) -> vector('n, dec, bits('m)) effect {escape, rreg, undef}
-function read_single_vreg(num_elem, sew, vrid) = {
+val read_single_vreg : forall 'n 'm. (int('n), int('m), regidx) -> vector('n, dec, bits('m)) effect {escape, rreg, undef}
+function read_single_vreg(num_elem, SEW, vrid) = {
   let bv     : vregtype                  = V(vrid);
   var result : vector('n, dec, bits('m)) = undefined;
 
+  assert(8 <= SEW & SEW <= 64);
   foreach (i from 0 to (num_elem - 1)) {
-    let start_index : int = i * sew;
-    result[i] = slice(bv, start_index, sew);
+    let start_index : int = i * SEW;
+    result[i] = slice(bv, start_index, SEW);
   };
 
   result
 }
 
 /* Writes multiple elements into a single vreg */
-val write_single_vreg : forall 'n 'm, 8 <= 'm <= 128. (int('n), int('m), regidx, vector('n, dec, bits('m))) -> unit effect {escape, rreg, wreg}
-function write_single_vreg(num_elem, sew, vrid, v) = {
+val write_single_vreg : forall 'n 'm. (int('n), int('m), regidx, vector('n, dec, bits('m))) -> unit effect {escape, rreg, wreg}
+function write_single_vreg(num_elem, SEW, vrid, v) = {
   r : vregtype = zeros();
 
+  assert(8 <= SEW & SEW <= 64);
   foreach (i from (num_elem - 1) downto 0) {
-    r = r << sew;
+    r = r << SEW;
     r = r | EXTZ(v[i]);
   };
 
@@ -260,18 +256,18 @@ function write_single_vreg(num_elem, sew, vrid, v) = {
 
 /* Reads multiple vregs into a single element */
 val read_mult_vreg : forall 'n 'm, 'n >= 0. (int('n), int('m), regidx) -> bits('m) effect {escape, rreg}
-function read_mult_vreg(num_vreg, num_bits, vrid) = {
-  let vlen : int = get_vlen();
-  assert(0 < vlen & vlen <= sizeof(vlenmax));
-  assert('m >= vlen);
-  var result : bits('m) = zeros(num_bits);
+function read_mult_vreg(num_vreg, SEW, vrid) = {
+  let VLEN = int_power(2, get_vlen_pow());
+  assert(0 < VLEN & VLEN <= sizeof(vlenmax));
+  assert('m >= VLEN);
+  var result : bits('m) = zeros();
 
   foreach (i from (num_vreg - 1) downto 0) {
     let vrid_lmul : regidx   = vrid + to_bits(5, i);
     let bv        : vregtype = V(vrid_lmul);
 
-    result = (result << vlen);
-    result = result | sail_zero_extend(bv[vlen - 1 .. 0], num_bits);
+    result = (result << VLEN);
+    result = result | sail_zero_extend(bv[VLEN - 1 .. 0], SEW);
   };
 
   result
@@ -279,49 +275,50 @@ function read_mult_vreg(num_vreg, num_bits, vrid) = {
 
 /* Writes a single element into multiple vregs */
 val write_mult_vreg : forall 'n 'm, 'n >= 0. (int('n), int('m), regidx, bits('m)) -> unit effect {escape, rreg, wreg}
-function write_mult_vreg(num_vreg, num_bits, vrid, bv) = {
-  let vlen : int = get_vlen();
-  assert(0 < vlen & vlen <= sizeof(vlenmax));
-  assert('m >= vlen);
+function write_mult_vreg(num_vreg, SEW, vrid, bv) = {
+  let VLEN = int_power(2, get_vlen_pow());
+  assert(0 < VLEN & VLEN <= sizeof(vlenmax));
+  assert('m >= VLEN);
   foreach (i from (num_vreg - 1) downto 0) {
     let vrid_lmul : regidx   = vrid + to_bits(5, i);
-    let single_bv : vregtype = sail_zero_extend(slice(bv >> (vlen * i), 0, vlen), sizeof(vlenmax));
+    let single_bv : vregtype = sail_zero_extend(slice(bv >> (VLEN * i), 0, VLEN), sizeof(vlenmax));
     V(vrid_lmul) = single_bv
   }
 }
 
 /* The general vreg reading operation with num_elem as max(VLMAX,VLEN/SEW)) */
-val read_vreg : forall 'n 'm, 8 <= 'm <= 64. (int('n), int('m), real, regidx) -> vector('n, dec, bits('m)) effect {escape, rreg, undef}
-function read_vreg(num_elem, vsew_bits, lmul, vrid) = {
-  var result   : vector('n, dec, bits('m)) = undefined;
-  let vlen     : int = get_vlen();
+val read_vreg : forall 'n 'm 'p. (int('n), int('m), int('p), regidx) -> vector('n, dec, bits('m)) effect {escape, rreg, undef}
+function read_vreg(num_elem, SEW, LMUL_pow, vrid) = {
+  var result       : vector('n, dec, bits('m)) = undefined;
+  let VLEN         : int = int_power(2, get_vlen_pow());
+  let LMUL_pow_reg : int = if LMUL_pow < 0 then 0 else LMUL_pow;
 
   /* Check for valid vrid */
-  if lmul > 1.0 & (unsigned(vrid) + floor(lmul)) > 32 then {
+  if unsigned(vrid) + 2 ^ LMUL_pow_reg > 32 then {
     /* vrid would read past largest vreg (v31) */
     result = undefined
-  } else if lmul > 1.0 & (unsigned(vrid) % floor(lmul) != 0) then {
+  } else if unsigned(vrid) % (2 ^ LMUL_pow_reg) != 0 then {
     /* vrid must be a multiple of lmul */
     result = undefined
   } else {
-    if vsew_bits > vlen then {
+    if SEW > VLEN then {
       /* Multiple vregs per element */
-      let 'num_reg_per_elem : int = vsew_bits / vlen;
+      let 'num_reg_per_elem : int = SEW / VLEN;
       assert('num_reg_per_elem >= 0);
       foreach (i from 0 to (num_elem - 1)) {
         let vrid_lmul : regidx = vrid + to_bits(5, i * 'num_reg_per_elem);
-        result[i] = read_mult_vreg('num_reg_per_elem, vsew_bits, vrid_lmul)
+        result[i] = read_mult_vreg('num_reg_per_elem, SEW, vrid_lmul)
       }
     } else {
-      if lmul < 1.0 then { 
-        result = read_single_vreg('n, vsew_bits, vrid);
+      if LMUL_pow < 0 then { 
+        result = read_single_vreg('n, SEW, vrid);
       } else {
-        let 'num_elem_single  : int = vlen / vsew_bits;
-        foreach (i_lmul from 0 to (floor(lmul) - 1)) {
+        let 'num_elem_single : int = VLEN / SEW;
+        foreach (i_lmul from 0 to (2 ^ LMUL_pow_reg - 1)) {
           let r_start_i : int = i_lmul * 'num_elem_single;
           let r_end_i   : int = r_start_i + 'num_elem_single - 1;
           let vrid_lmul     : regidx = vrid + to_bits(5, i_lmul);
-          let single_result : vector('num_elem_single, dec, bits('m)) = read_single_vreg('num_elem_single, vsew_bits, vrid_lmul);
+          let single_result : vector('num_elem_single, dec, bits('m)) = read_single_vreg('num_elem_single, SEW, vrid_lmul);
           foreach (r_i from r_start_i to r_end_i) {
             let s_i : int = r_i - r_start_i;
             assert(0 <= r_i & r_i < num_elem);
@@ -337,40 +334,35 @@ function read_vreg(num_elem, vsew_bits, lmul, vrid) = {
 }
 
 /* Single element reading operation */
-val read_single_element : forall 'm 'x, 8 <= 'm <= 128. (int('m), int('x), real, regidx) -> bits('m)  effect {escape, rreg, undef}
-function read_single_element(elem_width_bits, index, emul, vrid) = {
-  real_vrid  : regidx = vrid;
-  real_index : int = index;
-  let vlen   : int = get_vlen();
-  let 'elem_per_reg : int = vlen / elem_width_bits;
-  if emul > 1.0 then {
-    real_vrid = vrid + to_bits(5, index / 'elem_per_reg);
-    real_index = index % 'elem_per_reg;
-  };
-  let vrid_val : vector('elem_per_reg, dec, bits('m)) = read_single_vreg('elem_per_reg, elem_width_bits, real_vrid);
-
-  let 'real_index = real_index;
-  assert( 0 <= 'real_index & 'real_index < 'elem_per_reg );
-  vrid_val['real_index]
+val read_single_element : forall 'm 'x 'p, 8 <= 'm <= 128. (int('m), int('x), int('p), regidx) -> bits('m) effect {escape, rreg, undef}
+function read_single_element(EEW, index, EMUL_pow, vrid) = {
+  let VLEN : int = int_power(2, get_vlen_pow());
+  assert(VLEN >= EEW);
+  let 'elem_per_reg : int = VLEN / EEW;
+  let real_vrid  : regidx = if EMUL_pow > 0 then vrid + to_bits(5, index / 'elem_per_reg) else vrid;
+  let real_index : int    = if EMUL_pow > 0 then index % 'elem_per_reg else index;
+  let vrid_val : vector('elem_per_reg, dec, bits('m)) = read_single_vreg('elem_per_reg, EEW, real_vrid);
+  assert(0 <= real_index & real_index < 'elem_per_reg);
+  vrid_val[real_index]
 }
 
 /* The general vreg writing operation with num_elem as max(VLMAX,VLEN/SEW)) */
-val write_vreg : forall 'n 'm, 8 <= 'm <= 128. (int('n), int('m), real, regidx, vector('n, dec, bits('m))) -> unit effect {escape, rreg, undef, wreg} 
-function write_vreg(num_elem, vsew_bits, lmul, vrid, vec) = {
-  let vlen     : int = get_vlen();
-  let lmul_int : int = if lmul < 1.0 then 1 else floor(lmul);
+val write_vreg : forall 'n 'm 'p. (int('n), int('m), int('p), regidx, vector('n, dec, bits('m))) -> unit effect {escape, rreg, undef, wreg} 
+function write_vreg(num_elem, SEW, LMUL_pow, vrid, vec) = {
+  let VLEN         : int = int_power(2, get_vlen_pow());
+  let LMUL_pow_reg : int = if LMUL_pow < 0 then 0 else LMUL_pow;
 
-  if vsew_bits > vlen then {
+  if SEW > VLEN then {
     /* Multiple vregs per element */
-    let 'num_reg_per_elem : int = vsew_bits / vlen;
+    let 'num_reg_per_elem : int = SEW / VLEN;
     assert('num_reg_per_elem >= 0);
     foreach (i from 0 to (num_elem - 1)) {
       let vrid_lmul : regidx = vrid + to_bits(5, i * 'num_reg_per_elem);
-      write_mult_vreg('num_reg_per_elem, vsew_bits, vrid_lmul, vec[i])
+      write_mult_vreg('num_reg_per_elem, SEW, vrid_lmul, vec[i])
     }
   } else {
-    let 'num_elem_single  : int = vlen / vsew_bits;
-    foreach (i_lmul from 0 to (lmul_int - 1)) {
+    let 'num_elem_single  : int = VLEN / SEW;
+    foreach (i_lmul from 0 to (2 ^ LMUL_pow_reg - 1)) {
       var single_vec : vector('num_elem_single, dec, bits('m)) = undefined;
       let vrid_lmul  : regidx = vrid + to_bits(5, i_lmul);
       let r_start_i  : int = i_lmul * 'num_elem_single;
@@ -381,26 +373,23 @@ function write_vreg(num_elem, vsew_bits, lmul, vrid, vec) = {
         assert(0 <= s_i & s_i < 'num_elem_single);
         single_vec[s_i] = vec[r_i]
       };
-      write_single_vreg('num_elem_single, vsew_bits, vrid_lmul, single_vec)
+      write_single_vreg('num_elem_single, SEW, vrid_lmul, single_vec)
     }
   }
 }
 
 /* Single element writing operation */
-val write_single_element : forall 'm 'x, 8 <= 'm <= 128. (int('m), int('x), real, regidx, bits('m)) -> unit  effect {escape, rreg, undef, wreg}
-function write_single_element(elem_width_bits, index, emul, vrid, value) = {
-  real_vrid  : regidx = vrid;
-  real_index : int = index;
-  let vlen   : int = get_vlen();
-  let 'elem_per_reg : int = vlen / elem_width_bits;
-  if emul > 1.0 then {
-    real_vrid = vrid + to_bits(5, index / 'elem_per_reg);
-    real_index = index % 'elem_per_reg;
-  };
-  let vrid_val : vector('elem_per_reg, dec, bits('m)) = read_single_vreg('elem_per_reg, elem_width_bits, real_vrid);
+val write_single_element : forall 'm 'x 'p, 8 <= 'm <= 128. (int('m), int('x), int('p), regidx, bits('m)) -> unit effect {escape, rreg, undef, wreg}
+function write_single_element(EEW, index, EMUL_pow, vrid, value) = {
+  let VLEN : int = int_power(2, get_vlen_pow());
+  let 'elem_per_reg : int = VLEN / EEW;
+  let real_vrid  : regidx = if EMUL_pow > 0 then vrid + to_bits(5, index / 'elem_per_reg) else vrid;
+  let real_index : int    = if EMUL_pow > 0 then index % 'elem_per_reg else index;
+
+  let vrid_val : vector('elem_per_reg, dec, bits('m)) = read_single_vreg('elem_per_reg, EEW, real_vrid);
   r : vregtype = zeros();
   foreach (i from ('elem_per_reg - 1) downto 0) {
-    r = r << elem_width_bits;
+    r = r << EEW;
     if i == real_index then {
       r = r | EXTZ(value);
     } else {
@@ -411,10 +400,9 @@ function write_single_element(elem_width_bits, index, emul, vrid, value) = {
 }
 
 /* Mask register reading operation with num_elem as max(VLMAX,VLEN/SEW)) */
-val read_vmask : forall 'n, 'n >= 0. (int('n), bits(1), regidx) -> vector('n, dec, bool) effect {escape, rreg, undef}
+val read_vmask : forall 'n. (int('n), bits(1), regidx) -> vector('n, dec, bool) effect {escape, rreg, undef}
 function read_vmask(num_elem, vm, vrid) = {
-  let vlen : int = get_vlen();
-  assert('n <= vlen);
+  let VLEN : int = int_power(2, get_vlen_pow());
   assert(0 < num_elem & num_elem <= sizeof(vlenmax));
   let vreg_val : vregtype = V(vrid);
   var result   : vector('n, dec, bool) = undefined;
@@ -431,10 +419,9 @@ function read_vmask(num_elem, vm, vrid) = {
 }
 
 /* This is a special version of read_vmask for carry/borrow instructions, where vm=1 means no carry */
-val read_vmask_carry : forall 'n, 'n >= 0. (int('n), bits(1), regidx) -> vector('n, dec, bool) effect {escape, rreg, undef}
+val read_vmask_carry : forall 'n. (int('n), bits(1), regidx) -> vector('n, dec, bool) effect {escape, rreg, undef}
 function read_vmask_carry(num_elem, vm, vrid) = {
-  let vlen : int = get_vlen();
-  assert('n <= vlen);
+  let VLEN : int = int_power(2, get_vlen_pow());
   assert(0 < num_elem & num_elem <= sizeof(vlenmax));
   let vreg_val : vregtype = V(vrid);
   var result   : vector('n, dec, bool) = undefined;
@@ -451,19 +438,18 @@ function read_vmask_carry(num_elem, vm, vrid) = {
 }
 
 /* Mask register writing operation with num_elem as max(VLMAX,VLEN/SEW)) */
-val write_vmask : forall 'n, 'n >= 0. (int('n), regidx, vector('n, dec, bool)) -> unit effect {escape, rreg, undef, wreg}
+val write_vmask : forall 'n. (int('n), regidx, vector('n, dec, bool)) -> unit effect {escape, rreg, undef, wreg}
 function write_vmask(num_elem, vrid, v) = {
-  let vlen : int = get_vlen();
-  assert('n <= vlen);
-  assert(0 < vlen & vlen <= sizeof(vlenmax));
-  assert(0 < num_elem & num_elem <= sizeof(vlenmax));
+  let VLEN : int = int_power(2, get_vlen_pow());
+  assert(0 < VLEN & VLEN <= sizeof(vlenmax));
+  assert(0 < num_elem & num_elem <= VLEN);
   let vreg_val : vregtype = V(vrid);
   var result   : vregtype = undefined;
 
   foreach (i from 0 to (num_elem - 1)) {
     result[i] = bool_to_bit(v[i])
   };
-  foreach (i from num_elem to (vlen - 1)) {
+  foreach (i from num_elem to (VLEN - 1)) {
     /* Mask tail is always agnostic */
     result[i] = vreg_val[i]
   };

--- a/model/riscv_vlen.sail
+++ b/model/riscv_vlen.sail
@@ -1,52 +1,17 @@
-register ELEN : bits(1)
+register elen : bits(1)
 
 val get_elen : unit -> {|32, 64|} effect {rreg}
 
-function get_elen() = match ELEN {
+function get_elen() = match elen {
     0b0 => 32,
     0b1 => 64
 }
 
-register VLEN : bits(4)
+register vlen : bits(4)
 
-val get_vlen : unit -> {|32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536|} effect {rreg}
+val get_vlen_pow : unit -> {|5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16|} effect {rreg}
 
-function get_vlen() = match VLEN {
-    0b0000 => 32,
-    0b0001 => 64,
-    0b0010 => 128,
-    0b0011 => 256,
-    0b0100 => 512,
-    0b0101 => 1024,
-    0b0110 => 2048,
-    0b0111 => 4096,
-    0b1000 => 8192,
-    0b1001 => 16384,
-    0b1010 => 32768,
-    _      => 65536
-}
-
-val vlen_bytes : unit -> {|4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192|} effect {rreg}
-
-function vlen_bytes() = match VLEN {
-    0b0000 => 4,
-    0b0001 => 8,
-    0b0010 => 16,
-    0b0011 => 32,
-    0b0100 => 64,
-    0b0101 => 128,
-    0b0110 => 256,
-    0b0111 => 512,
-    0b1000 => 1024,
-    0b1001 => 2048,
-    0b1010 => 4096,
-    _      => 8192
-}
-
-/* to determine the length of vstart csr */
-val get_vstart_length : unit -> {|5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16|} effect {rreg}
-
-function get_vstart_length() = match VLEN {
+function get_vlen_pow() = match vlen {
     0b0000 => 5,
     0b0001 => 6,
     0b0010 => 7,


### PR DESCRIPTION
This PR contains all vector load / store instructions in the file `riscv_insts_vext_mem.sail`, and a small part of other vector instructions in the file `riscv_insts_vext_arith.sail` for the help of running the vector ISA tests. The model generated by this code can pass the vector load / store ISA tests generated by the [rvv-atg](https://github.com/hushenwei2000/rvv-atg) for different configurations. (I specified ELEN and VLEN manually in `riscv_sys_control.sail` when testing my code.) Please send me comments if there are issues in the new code. I'll do my best to get it right soon.