### PR TITLE
added 3 new command line switches (plus functionality):  -X/--enable-experimental-extensions, --enable-smepmp, --enable-zicond

### DIFF
--- a/c_emulator/riscv_platform.c
+++ b/c_emulator/riscv_platform.c
@@ -21,6 +21,15 @@ bool sys_enable_fdext(unit u)
 bool sys_enable_zfinx(unit u)
 { return rv_enable_zfinx; }
 
+bool sys_enable_smepmp(unit u)
+{ return rv_enable_Smepmp; }
+
+bool sys_enable_zicond(unit u)
+{ return rv_enable_Zicond; }
+
+bool sys_enable_experimental_extensions(unit u)
+{ return rv_enable_experimental_extensions; }
+
 bool sys_enable_writable_misa(unit u)
 { return rv_enable_writable_misa; }
 

--- a/c_emulator/riscv_platform.c
+++ b/c_emulator/riscv_platform.c
@@ -22,10 +22,10 @@ bool sys_enable_zfinx(unit u)
 { return rv_enable_zfinx; }
 
 bool sys_enable_smepmp(unit u)
-{ return rv_enable_Smepmp; }
+{ return ( (rv_enable_Smepmp == 0) ? false : true); }
 
 bool sys_enable_zicond(unit u)
-{ return rv_enable_Zicond; }
+{ return ( (rv_enable_Zicond == 0) ? false : true); }
 
 bool sys_enable_experimental_extensions(unit u)
 { return rv_enable_experimental_extensions; }

--- a/c_emulator/riscv_platform_impl.c
+++ b/c_emulator/riscv_platform_impl.c
@@ -14,8 +14,8 @@ bool rv_enable_dirty_update         = false;
 bool rv_enable_misaligned           = false;
 bool rv_mtval_has_illegal_inst_bits = false;
 
-bool rv_enable_Smepmp               = false;
-bool rv_enable_Zicond               = false;
+int  rv_enable_Smepmp               = 0;
+int  rv_enable_Zicond               = 0;
 
 bool rv_enable_experimental_extensions = false;
 

--- a/c_emulator/riscv_platform_impl.c
+++ b/c_emulator/riscv_platform_impl.c
@@ -14,6 +14,11 @@ bool rv_enable_dirty_update         = false;
 bool rv_enable_misaligned           = false;
 bool rv_mtval_has_illegal_inst_bits = false;
 
+bool rv_enable_Smepmp               = false;
+bool rv_enable_Zicond               = false;
+
+bool rv_enable_experimental_extensions = false;
+
 uint64_t rv_ram_base = UINT64_C(0x80000000);
 uint64_t rv_ram_size = UINT64_C(0x4000000);
 

--- a/c_emulator/riscv_platform_impl.h
+++ b/c_emulator/riscv_platform_impl.h
@@ -17,8 +17,8 @@ extern bool rv_enable_dirty_update;
 extern bool rv_enable_misaligned;
 extern bool rv_mtval_has_illegal_inst_bits;
 
-extern bool rv_enable_Smepmp;
-extern bool rv_enable_Zicond;
+extern int  rv_enable_Smepmp;
+extern int  rv_enable_Zicond;
 
 extern bool rv_enable_experimental_extensions;
 

--- a/c_emulator/riscv_platform_impl.h
+++ b/c_emulator/riscv_platform_impl.h
@@ -17,6 +17,11 @@ extern bool rv_enable_dirty_update;
 extern bool rv_enable_misaligned;
 extern bool rv_mtval_has_illegal_inst_bits;
 
+extern bool rv_enable_Smepmp;
+extern bool rv_enable_Zicond;
+
+extern bool rv_enable_experimental_extensions;
+
 extern uint64_t rv_ram_base;
 extern uint64_t rv_ram_size;
 
@@ -34,3 +39,11 @@ extern uint64_t rv_insns_per_tick;
 
 extern int term_fd;
 void plat_term_write_impl(char c);
+
+// for command line options and getopt()
+extern char *optarg;
+extern int optind, opterr, optopt;
+
+
+
+

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -123,6 +123,10 @@ static struct option options[] = {
   {"report-arch",                 no_argument,       0, 'a'},
   {"test-signature",              required_argument, 0, 'T'},
   {"signature-granularity",       required_argument, 0, 'g'},
+  {"enable-experimental-extensions", no_argument,    0, 'X'}, // follows naming convention of LLVM
+  {"enable-Smepmp",               no_argument,       &rv_enable_Smepmp, 0 },
+  {"enable-Zicond",               no_argument,       &rv_enable_Zicond, 0 },
+
 #ifdef RVFI_DII
   {"rvfi-dii",                    required_argument, 0, 'r'},
 #endif
@@ -217,6 +221,9 @@ char *process_args(int argc, char **argv)
   int c;
   uint64_t ram_size = 0;
   while(true) {
+    int this_option_optind = optind ? optind : 1;
+    int option_index = 0;
+
     c = getopt_long(argc, argv,
                     "a"
                     "d"
@@ -242,12 +249,21 @@ char *process_args(int argc, char **argv)
                     "v::"
                     "l:"
                     "x"
+                    "X"
 #ifdef SAILCOV
                     "c:"
 #endif
-                         , options, NULL);
+                         , options, &option_index);
     if (c == -1) break;
     switch (c) {
+    case 0:     // Not the character '0', but the NULL value.
+      printf ("option %s", options[option_index].name);
+      if (optarg) {
+        printf (" with arg %s", optarg);
+      }
+      printf ("\n");
+      break;
+
     case 'a':
       report_arch();
       break;
@@ -339,6 +355,10 @@ char *process_args(int argc, char **argv)
       fprintf(stderr, "enabling Zfinx support.\n");
       rv_enable_zfinx = true;
       rv_enable_fdext = false;
+      break;
+    case 'X':
+      fprintf(stderr, "enabling experimental support.\n");
+      rv_enable_experimental = true;
       break;
 #ifdef SAILCOV
     case 'c':

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -263,7 +263,6 @@ char *process_args(int argc, char **argv)
       }
       printf ("\n");
       break;
-
     case 'a':
       report_arch();
       break;
@@ -358,7 +357,7 @@ char *process_args(int argc, char **argv)
       break;
     case 'X':
       fprintf(stderr, "enabling experimental support.\n");
-      rv_enable_experimental = true;
+      rv_enable_experimental_extensions = true;
       break;
 #ifdef SAILCOV
     case 'c':

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -116,15 +116,22 @@ val plat_mtval_has_illegal_inst_bits = {ocaml: "Platform.mtval_has_illegal_inst_
                                         c: "plat_mtval_has_illegal_inst_bits",
                                         lem: "plat_mtval_has_illegal_inst_bits"} : unit -> bool
 
+/* whether the Smepmp extension is supported */
+val plat_enable_smepmp = {
+                            c: "plat_enable_smepmp"
+                         } : unit -> bool
+
+/* whether the Smepmp extension is supported */
+val plat_enable_zicond = {
+                            c: "plat_enable_zicond"
+                         } : unit -> bool
+
 /* whether the model supports extensions/CSRs/functionality that is considered "experimental"   */
 /*      this is meant to support testing of extensions that are in development but have not     */
 /*      been ratified. */
-val plat_enable_experimental_extensions = {
-                                    /* ocaml: "Platform.mtval_has_illegal_inst_bits", */
-                                    /* interpreter: "Platform.mtval_has_illegal_inst_bits", */
-                                    /* lem: "plat_mtval_has_illegal_inst_bits",  */
-                                    c: "plat_enable_expermimental_extensions"
-                                } : unit -> bool
+val plat_enable_experimental_extensions =   {
+                                                c: "plat_enable_expermimental_extensions"
+                                            } : unit -> bool
 
 /* ROM holding reset vector and device-tree DTB */
 val plat_rom_base   = {ocaml: "Platform.rom_base", interpreter: "Platform.rom_base", c: "plat_rom_base", lem: "plat_rom_base"} : unit -> xlenbits

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -116,6 +116,16 @@ val plat_mtval_has_illegal_inst_bits = {ocaml: "Platform.mtval_has_illegal_inst_
                                         c: "plat_mtval_has_illegal_inst_bits",
                                         lem: "plat_mtval_has_illegal_inst_bits"} : unit -> bool
 
+/* whether the model supports extensions/CSRs/functionality that is considered "experimental"   */
+/*      this is meant to support testing of extensions that are in development but have not     */
+/*      been ratified. */
+val plat_enable_experimental_extensions = {
+                                    /* ocaml: "Platform.mtval_has_illegal_inst_bits", */
+                                    /* interpreter: "Platform.mtval_has_illegal_inst_bits", */
+                                    /* lem: "plat_mtval_has_illegal_inst_bits",  */
+                                    c: "plat_enable_expermimental_extensions"
+                                } : unit -> bool
+
 /* ROM holding reset vector and device-tree DTB */
 val plat_rom_base   = {ocaml: "Platform.rom_base", interpreter: "Platform.rom_base", c: "plat_rom_base", lem: "plat_rom_base"} : unit -> xlenbits
 val plat_rom_size   = {ocaml: "Platform.rom_size", interpreter: "Platform.rom_size", c: "plat_rom_size", lem: "plat_rom_size"} : unit -> xlenbits

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -148,6 +148,10 @@ val sys_enable_fdext = {c: "sys_enable_fdext", ocaml: "Platform.enable_fdext", _
 val sys_enable_zfinx = {c: "sys_enable_zfinx", ocaml: "Platform.enable_zfinx", _: "sys_enable_zfinx"} : unit -> bool
 /* whether the N extension was enabled at boot */
 val sys_enable_next = {c: "sys_enable_next", ocaml: "Platform.enable_next", _: "sys_enable_next"} : unit -> bool
+/* whether the Smepmp extension was enabled at boot */
+val sys_enable_smepmp = {c: "sys_enable_smepmp"} : unit -> bool
+/* whether the Zicond extension was enabled at boot */
+val sys_enable_zicond = {c: "sys_enable_zicond"} : unit -> bool
 
 /* This function allows an extension to veto a write to Misa
    if it would violate an alignment restriction on

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -149,6 +149,8 @@ val sys_enable_zfinx = {c: "sys_enable_zfinx", ocaml: "Platform.enable_zfinx", _
 /* whether the N extension was enabled at boot */
 val sys_enable_next = {c: "sys_enable_next", ocaml: "Platform.enable_next", _: "sys_enable_next"} : unit -> bool
 /* whether the Smepmp extension was enabled at boot */
+val sys_enable_experimental_extensions = {c: "sys_enable_experimental_extensions"} : unit -> bool
+/* whether the Smepmp extension was enabled at boot */
 val sys_enable_smepmp = {c: "sys_enable_smepmp"} : unit -> bool
 /* whether the Zicond extension was enabled at boot */
 val sys_enable_zicond = {c: "sys_enable_zicond"} : unit -> bool


### PR DESCRIPTION
This pull request is intended to satisfy issue #209.

The -X switch (plus its long version) causes the Sail function, plat_enable_experimental_extensions(), to return true.
Functionality that is in the experimental stage (such as extensions that have been implemented but have not been
formally ratified) can be conditionally checked with this function.

Two other switches were also added.

The --enable-Smepmp switch can be used to enable the Smepmp functionality.  The Sail function,  plat_enable_smepmp(),
returns the value of the switch (true if the switch exists;  false otherwise).

The --enable-Zicond can be used to enable the Zicond extension.  The Sail function, plat_enable_zicond(), returns
the value of the switch (true if the switch exists; false otherwise).

Note:  the implementations of Smepmp and Zicond will need to make use of these functions.
