### PR TITLE
Move ILLEGAL/C_ILLEGAL ast declaration to riscv_insts_begin.sail

### DIFF
--- a/model/riscv_insts_begin.sail
+++ b/model/riscv_insts_begin.sail
@@ -85,3 +85,12 @@ scattered mapping encdec
 
 val encdec_compressed : ast <-> bits(16) effect {rreg}
 scattered mapping encdec_compressed
+
+/*
+ * We declare the ILLEGAL/C_ILLEGAL ast clauses here instead of in
+ * riscv_insts_end, so that model extensions can make use of them.
+ * However, the encdec mapping must come last to ensure that all
+ * unmatched encodings decode to an illegal instruction.
+ */
+union clause ast = ILLEGAL : word
+union clause ast = C_ILLEGAL : half

--- a/model/riscv_insts_end.sail
+++ b/model/riscv_insts_end.sail
@@ -70,8 +70,6 @@
 
 /* ****************************************************************** */
 
-union clause ast = ILLEGAL : word
-
 mapping clause encdec = ILLEGAL(s) <-> s
 
 function clause execute (ILLEGAL(s)) = { handle_illegal(); RETIRE_FAIL }
@@ -79,8 +77,6 @@ function clause execute (ILLEGAL(s)) = { handle_illegal(); RETIRE_FAIL }
 mapping clause assembly = ILLEGAL(s) <-> "illegal" ^ spc() ^ hex_bits_32(s)
 
 /* ****************************************************************** */
-
-union clause ast = C_ILLEGAL : half
 
 mapping clause encdec_compressed = C_ILLEGAL(s) <-> s
 


### PR DESCRIPTION
This is useful for the sail-cheri-riscv model, where we would like to reuse C_ILLEGAL, but can't right now since it is current defined too late.

It is needed for https://github.com/CTSRD-CHERI/sail-cheri-riscv/pull/69