### PR TITLE
Vector integer/fixed-point arithmetic & mask instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ SAIL_DEFAULT_INST += riscv_insts_vext_utils.sail
 SAIL_DEFAULT_INST += riscv_insts_vext_vset.sail
 SAIL_DEFAULT_INST += riscv_insts_vext_arith.sail
 SAIL_DEFAULT_INST += riscv_insts_vext_mem.sail
+SAIL_DEFAULT_INST += riscv_insts_vext_mask.sail
+SAIL_DEFAULT_INST += riscv_insts_vext_vm.sail
 
 SAIL_SEQ_INST  = $(SAIL_DEFAULT_INST) riscv_jalr_seq.sail
 SAIL_RMEM_INST = $(SAIL_DEFAULT_INST) riscv_jalr_rmem.sail riscv_insts_rmem.sail

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -42,7 +42,7 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -106,14 +106,14 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
         VV_VMAXU         => to_bits(SEW, max(unsigned(vs2_val[i]), unsigned(vs1_val[i]))),
         VV_VMAX          => to_bits(SEW, max(signed(vs2_val[i]), signed(vs1_val[i]))),
         VV_VRGATHER      => {
-                              if (vs1 == vd | vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
+                              if (vs1 == vd | vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
                               let idx = unsigned(vs1_val[i]);
                               let VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
                               assert(VLMAX <= 'n);
                               if idx < VLMAX then vs2_val[idx] else zeros() 
                             },
         VV_VRGATHEREI16  => {
-                              if (vs1 == vd | vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
+                              if (vs1 == vd | vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
                               /* vrgatherei16.vv uses SEW/LMUL for the data in vs2 but EEW=16 and EMUL = (16/SEW)*LMUL for the indices in vs1 */
                               let vs1_new : vector('n, dec, bits(16)) = read_vreg(num_elem, 16, 4 + LMUL_pow - SEW_pow, vs1);
                               let idx = unsigned(vs1_new[i]);
@@ -178,7 +178,7 @@ function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
       ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
-  then {handle_illegal(); return RETIRE_FAIL};
+  then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -245,7 +245,7 @@ function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
       ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
-  then {handle_illegal(); return RETIRE_FAIL};
+  then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -305,7 +305,7 @@ function clause execute(MASKTYPEV(vs2, vs1, vd)) = {
   let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
 
-  if vd == vreg_name("v0") then {handle_illegal(); return RETIRE_FAIL};
+  if vd == vreg_name("v0") then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -408,7 +408,7 @@ function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -528,7 +528,7 @@ function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
       ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
-  then {handle_illegal(); return RETIRE_FAIL};
+  then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -595,7 +595,7 @@ function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
       ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
-  then {handle_illegal(); return RETIRE_FAIL};
+  then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -661,7 +661,7 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -679,7 +679,7 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
     if mask[i] then {
       result[i] = match funct6 {
         VX_VSLIDEUP    => {
-                            if (vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
+                            if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
                             if i >= rs1_val then vs2_val[i - rs1_val] else vd_val[i]
                           },
         VX_VSLIDEDOWN  => {
@@ -688,7 +688,7 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
                             if i + rs1_val < VLMAX then vs2_val[i + rs1_val] else zeros()
                           },
         VX_VRGATHER    => {
-                            if (vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
+                            if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
                             let VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
                             assert(VLMAX > 0 & VLMAX <= 'n);
                             if rs1_val < VLMAX then vs2_val[rs1_val] else zeros() 
@@ -725,7 +725,7 @@ function clause execute(MASKTYPEX(vs2, rs1, vd)) = {
   let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
 
-  if vd == vreg_name("v0") then {handle_illegal(); return RETIRE_FAIL};
+  if vd == vreg_name("v0") then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -820,7 +820,7 @@ function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -916,7 +916,7 @@ function clause execute(NISTYPE(funct6, vm, vs2, simm, vd)) = {
 
   if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
       ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
-  then {handle_illegal(); return RETIRE_FAIL};
+  then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -983,7 +983,7 @@ function clause execute(NITYPE(funct6, vm, vs2, simm, vd)) = {
 
   if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
       ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
-  then {handle_illegal(); return RETIRE_FAIL};
+  then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1049,7 +1049,7 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1067,7 +1067,7 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
     if mask[i] then {
       result[i] = match funct6 {
         VI_VSLIDEUP    => {
-                            if (vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
+                            if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
                             if i >= imm_val then vs2_val[i - imm_val] else vd_val[i]
                           },
         VI_VSLIDEDOWN  => {
@@ -1076,7 +1076,7 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
                             if i + imm_val < VLMAX then vs2_val[i + imm_val] else zeros()
                           },
         VI_VRGATHER    => {
-                            if (vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
+                            if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
                             let VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
                             assert(VLMAX > 0 & VLMAX <= 'n);
                             if imm_val < VLMAX then vs2_val[imm_val] else zeros() 
@@ -1113,7 +1113,7 @@ function clause execute(MASKTYPEI(vs2, simm, vd)) = {
   let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
 
-  if vd == vreg_name("v0") then {handle_illegal(); return RETIRE_FAIL};
+  if vd == vreg_name("v0") then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1194,7 +1194,7 @@ function clause execute(VMVRTYPE(vs2, simm, vd)) = {
   let imm_val = unsigned(EXTZ(sizeof(xlen), simm));
   let EMUL    = imm_val + 1;
 
-  if ~(EMUL == 1 | EMUL == 2 | EMUL == 4 | EMUL == 8) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(EMUL == 1 | EMUL == 2 | EMUL == 4 | EMUL == 8) then { handle_illegal(); return RETIRE_FAIL };
 
   let EMUL_pow = log2(EMUL);
   let num_elem = get_num_elem(EMUL_pow, SEW);
@@ -1251,7 +1251,7 @@ function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1361,7 +1361,7 @@ function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let VLEN     = int_power(2, get_vlen_pow());
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1426,7 +1426,7 @@ function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) | 
       ~(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
-  then {handle_illegal(); return RETIRE_FAIL};
+  then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1496,7 +1496,7 @@ function clause execute(WVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) | 
       ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
-  then {handle_illegal(); return RETIRE_FAIL};
+  then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1560,7 +1560,7 @@ function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) | 
       ~(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
-  then {handle_illegal(); return RETIRE_FAIL};
+  then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1621,7 +1621,7 @@ function clause execute(VEXT2TYPE(funct6, vm, vs2, vd)) = {
 
   if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_half, LMUL_pow)) | 
       ~(valid_eew_emul(SEW_half, LMUL_pow_half)) 
-  then {handle_illegal(); return RETIRE_FAIL};
+  then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1679,7 +1679,7 @@ function clause execute(VEXT4TYPE(funct6, vm, vs2, vd)) = {
 
   if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_quart, LMUL_pow)) | 
       ~(valid_eew_emul(SEW_quart, LMUL_pow_quart)) 
-  then {handle_illegal(); return RETIRE_FAIL};
+  then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1737,7 +1737,7 @@ function clause execute(VEXT8TYPE(funct6, vm, vs2, vd)) = {
 
   if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_eighth, LMUL_pow)) | 
       ~(valid_eew_emul(SEW_eighth, LMUL_pow_eighth)) 
-  then {handle_illegal(); return RETIRE_FAIL};
+  then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1811,7 +1811,7 @@ function clause execute(MVVCOMPRESS(vs2, vs1, vd)) = {
   let end_element = get_end_element();
 
   /* vcompress should always be executed with a vstart of 0 */
-  if (start_element != 0 | vs1 == vd | vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
+  if (start_element != 0 | vs1 == vd | vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
 
   let SEW = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -1884,7 +1884,7 @@ function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1922,11 +1922,11 @@ function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
                               slice(result_sub >> 1, 0, 'm) + EXTZ('m, rounding_incr)
                             },
         MVX_VSLIDE1UP    => {
-                              if (vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
+                              if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
                               if i == 0 then rs1_val else vs2_val[i - 1]
                             },
         MVX_VSLIDE1DOWN  => {
-                              if (vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
+                              if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
                               let last_elem = get_end_element();
                               assert(last_elem < num_elem);
                               if i < last_elem then vs2_val[i + 1] else rs1_val
@@ -2006,7 +2006,7 @@ function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let VLEN     = int_power(2, get_vlen_pow());
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -2072,7 +2072,7 @@ function clause execute(WVXTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | 
       ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
-  then {handle_illegal(); return RETIRE_FAIL};
+  then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -2141,7 +2141,7 @@ function clause execute(WXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if  ~(valid_rd_mask(vd, vm)) | ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
-  then {handle_illegal(); return RETIRE_FAIL};
+  then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -2206,7 +2206,7 @@ function clause execute(WMVXTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | 
       ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
-  then {handle_illegal(); return RETIRE_FAIL};
+  then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -42,6 +42,8 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -104,14 +106,14 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
         VV_VMAXU         => to_bits(SEW, max(unsigned(vs2_val[i]), unsigned(vs1_val[i]))),
         VV_VMAX          => to_bits(SEW, max(signed(vs2_val[i]), signed(vs1_val[i]))),
         VV_VRGATHER      => {
-                              assert(vs1 != vd & vs2 != vd);
+                              if (vs1 == vd | vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
                               let idx = unsigned(vs1_val[i]);
                               let VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
                               assert(VLMAX <= 'n);
                               if idx < VLMAX then vs2_val[idx] else zeros() 
                             },
         VV_VRGATHEREI16  => {
-                              assert(vs1 != vd & vs2 != vd);
+                              if (vs1 == vd | vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
                               /* vrgatherei16.vv uses SEW/LMUL for the data in vs2 but EEW=16 and EMUL = (16/SEW)*LMUL for the indices in vs1 */
                               let vs1_new : vector('n, dec, bits(16)) = read_vreg(num_elem, 16, 4 + LMUL_pow - SEW_pow, vs1);
                               let idx = unsigned(vs1_new[i]);
@@ -171,10 +173,13 @@ function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
-  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+
+  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
+      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
   let 'o = SEW_widen;
@@ -235,10 +240,13 @@ function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
-  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+
+  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
+      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
   let 'o = SEW_widen;
@@ -294,7 +302,10 @@ function clause execute(MASKTYPEV(vs2, vs1, vd)) = {
   let end_element   = get_end_element();
   let SEW           = get_sew();
   let LMUL_pow      = get_lmul_pow();
-  let num_elem      = get_num_elem(LMUL_pow, SEW);
+  let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
+  let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
+
+  if vd == vreg_name("v0") then {handle_illegal(); return RETIRE_FAIL};
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -309,13 +320,14 @@ function clause execute(MASKTYPEV(vs2, vs1, vd)) = {
   foreach (i from 0 to (num_elem - 1)) {
     if i < start_element then {
       result[i] = vd_val[i]
-    } else if i > end_element then {
+    } else if i > end_element | i >= real_num_elem then {
       if tail_ag == UNDISTURBED then {
         result[i] = vd_val[i]
       } else if tail_ag == AGNOSTIC then {
         result[i] = vd_val[i] /* TODO: configuration support */
       }
     } else {
+      /* the merge operates on all body elements */
       result[i] = if vm_val[i] then vs1_val[i] else vs2_val[i]
     }
   };
@@ -327,96 +339,6 @@ function clause execute(MASKTYPEV(vs2, vs1, vd)) = {
 
 mapping clause assembly = MASKTYPEV(vs2, vs1, vd)
 <-> "vmerge.vvm" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ sep() ^ "v0"
-
-/* ********************** OPIVX (Integer Merge Instruction) ********************** */
-union clause ast = MASKTYPEX : (regidx, regidx, regidx)
-
-mapping clause encdec = MASKTYPEX(vs2, rs1, vd) if haveRVV()
-  <-> 0b010111 @ 0b0 @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if haveRVV()
-
-function clause execute(MASKTYPEX(vs2, rs1, vd)) = {
-  let start_element = get_start_element();
-  let end_element   = get_end_element();
-  let SEW           = get_sew();
-  let LMUL_pow      = get_lmul_pow();
-  let num_elem      = get_num_elem(LMUL_pow, SEW);
-
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vreg_name("v0"));
-  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  result      : vector('n, dec, bits('m)) = undefined;
-
-  let tail_ag : agtype = get_vtype_vta();
-  foreach (i from 0 to (num_elem - 1)) {
-    if i < start_element then {
-      result[i] = vd_val[i]
-    } else if i > end_element then {
-      if tail_ag == UNDISTURBED then {
-        result[i] = vd_val[i]
-      } else if tail_ag == AGNOSTIC then {
-        result[i] = vd_val[i] /* TODO: configuration support */
-      }
-    } else {
-      result[i] = if vm_val[i] then rs1_val else vs2_val[i]
-    }
-  };
-
-  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
-  vstart = EXTZ(0b0);
-  RETIRE_SUCCESS
-}
-
-mapping clause assembly = MASKTYPEX(vs2, rs1, vd)
-  <-> "vmerge.vxm" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ sep() ^ "v0" 
-
-/* ********************** OPIVI (Integer Merge Instruction) ********************** */
-union clause ast = MASKTYPEI : (regidx, bits(5), regidx)
-
-mapping clause encdec = MASKTYPEI(vs2, simm, vd) if haveRVV()
-  <-> 0b010111 @ 0b0 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if haveRVV()
-
-function clause execute(MASKTYPEI(vs2, simm, vd)) = {
-  let start_element = get_start_element();
-  let end_element   = get_end_element();
-  let SEW           = get_sew();
-  let LMUL_pow      = get_lmul_pow();
-  let num_elem      = get_num_elem(LMUL_pow, SEW);
-
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vreg_name("v0"));
-  let imm_val : bits('m)                  = EXTS(simm);
-  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  result      : vector('n, dec, bits('m)) = undefined;
-
-  let tail_ag : agtype = get_vtype_vta();
-  foreach (i from 0 to (num_elem - 1)) {
-    if i < start_element then {
-      result[i] = vd_val[i]
-    } else if i > end_element then {
-      if tail_ag == UNDISTURBED then {
-        result[i] = vd_val[i]
-      } else if tail_ag == AGNOSTIC then {
-        result[i] = vd_val[i] /* TODO: configuration support */
-      }
-    } else {
-      result[i] = if vm_val[i] then imm_val else vs2_val[i]
-    }
-  };
-
-  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
-  vstart = EXTZ(0b0);
-  RETIRE_SUCCESS
-}
-
-mapping clause assembly = MASKTYPEI(vs2, simm, vd)
-  <-> "vmerge.vim" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ sep() ^ "v0"
 
 /* ********************** OPIVV (Integer Move Instruction) *********************** */
 union clause ast = MOVETYPEV : (regidx, regidx)
@@ -439,6 +361,7 @@ function clause execute(MOVETYPEV(vs1, vd)) = {
   mask        : vector('n, dec, bool)     = undefined;
 
   (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] then result[i] = vs1_val[i]
   };
@@ -484,6 +407,8 @@ function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -598,10 +523,13 @@ function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
-  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+
+  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
+      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
   let 'o = SEW_widen;
@@ -662,10 +590,13 @@ function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
-  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+
+  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
+      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
   let 'o = SEW_widen;
@@ -730,6 +661,8 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -746,7 +679,7 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
     if mask[i] then {
       result[i] = match funct6 {
         VX_VSLIDEUP    => {
-                            assert(vs2 != vd);
+                            if (vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
                             if i >= rs1_val then vs2_val[i - rs1_val] else vd_val[i]
                           },
         VX_VSLIDEDOWN  => {
@@ -755,7 +688,7 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
                             if i + rs1_val < VLMAX then vs2_val[i + rs1_val] else zeros()
                           },
         VX_VRGATHER    => {
-                            assert(vs2 != vd);
+                            if (vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
                             let VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
                             assert(VLMAX > 0 & VLMAX <= 'n);
                             if rs1_val < VLMAX then vs2_val[rs1_val] else zeros() 
@@ -778,6 +711,55 @@ mapping vxsg_mnemonic : vxsgfunct6 <-> string = {
 mapping clause assembly = VXSG(funct6, vm, vs2, rs1, vd)
   <-> vxsg_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
 
+/* ********************** OPIVX (Integer Merge Instruction) ********************** */
+union clause ast = MASKTYPEX : (regidx, regidx, regidx)
+
+mapping clause encdec = MASKTYPEX(vs2, rs1, vd) if haveRVV()
+  <-> 0b010111 @ 0b0 @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(MASKTYPEX(vs2, rs1, vd)) = {
+  let start_element = get_start_element();
+  let end_element   = get_end_element();
+  let SEW           = get_sew();
+  let LMUL_pow      = get_lmul_pow();
+  let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
+  let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
+
+  if vd == vreg_name("v0") then {handle_illegal(); return RETIRE_FAIL};
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vreg_name("v0"));
+  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+
+  let tail_ag : agtype = get_vtype_vta();
+  foreach (i from 0 to (num_elem - 1)) {
+    if i < start_element then {
+      result[i] = vd_val[i]
+    } else if i > end_element | i >= real_num_elem then {
+      if tail_ag == UNDISTURBED then {
+        result[i] = vd_val[i]
+      } else if tail_ag == AGNOSTIC then {
+        result[i] = vd_val[i] /* TODO: configuration support */
+      }
+    } else {
+      /* the merge operates on all body elements */
+      result[i] = if vm_val[i] then rs1_val else vs2_val[i]
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = MASKTYPEX(vs2, rs1, vd)
+  <-> "vmerge.vxm" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ sep() ^ "v0" 
+
 /* ********************** OPIVX (Integer Move Instruction) *********************** */
 union clause ast = MOVETYPEX : (regidx, regidx)
 
@@ -799,6 +781,7 @@ function clause execute(MOVETYPEX(rs1, vd)) = {
   mask        : vector('n, dec, bool)     = undefined;
 
   (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] then result[i] = rs1_val
   };
@@ -837,6 +820,8 @@ function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -848,7 +833,7 @@ function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
   mask        : vector('n, dec, bool)     = undefined;
 
   (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
-  
+
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] then {
       result[i] = match funct6 {
@@ -926,10 +911,13 @@ function clause execute(NISTYPE(funct6, vm, vs2, simm, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
-  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+
+  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
+      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
   let 'o = SEW_widen;
@@ -990,10 +978,13 @@ function clause execute(NITYPE(funct6, vm, vs2, simm, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
-  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+
+  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
+      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
   let 'o = SEW_widen;
@@ -1058,6 +1049,8 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -1074,7 +1067,7 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
     if mask[i] then {
       result[i] = match funct6 {
         VI_VSLIDEUP    => {
-                            assert(vs2 != vd);
+                            if (vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
                             if i >= imm_val then vs2_val[i - imm_val] else vd_val[i]
                           },
         VI_VSLIDEDOWN  => {
@@ -1083,7 +1076,7 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
                             if i + imm_val < VLMAX then vs2_val[i + imm_val] else zeros()
                           },
         VI_VRGATHER    => {
-                            assert(vs2 != vd);
+                            if (vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
                             let VLMAX = int_power(2, LMUL_pow + VLEN_pow - SEW_pow);
                             assert(VLMAX > 0 & VLMAX <= 'n);
                             if imm_val < VLMAX then vs2_val[imm_val] else zeros() 
@@ -1106,6 +1099,55 @@ mapping visg_mnemonic : visgfunct6 <-> string = {
 mapping clause assembly = VISG(funct6, vm, vs2, simm, vd)
   <-> visg_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(simm) ^ maybe_vmask(vm)
 
+/* ********************** OPIVI (Integer Merge Instruction) ********************** */
+union clause ast = MASKTYPEI : (regidx, bits(5), regidx)
+
+mapping clause encdec = MASKTYPEI(vs2, simm, vd) if haveRVV()
+  <-> 0b010111 @ 0b0 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(MASKTYPEI(vs2, simm, vd)) = {
+  let start_element = get_start_element();
+  let end_element   = get_end_element();
+  let SEW           = get_sew();
+  let LMUL_pow      = get_lmul_pow();
+  let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
+  let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
+
+  if vd == vreg_name("v0") then {handle_illegal(); return RETIRE_FAIL};
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vreg_name("v0"));
+  let imm_val : bits('m)                  = EXTS(simm);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+
+  let tail_ag : agtype = get_vtype_vta();
+  foreach (i from 0 to (num_elem - 1)) {
+    if i < start_element then {
+      result[i] = vd_val[i]
+    } else if i > end_element | i >= real_num_elem then {
+      if tail_ag == UNDISTURBED then {
+        result[i] = vd_val[i]
+      } else if tail_ag == AGNOSTIC then {
+        result[i] = vd_val[i] /* TODO: configuration support */
+      }
+    } else {
+      /* the merge operates on all body elements */
+      result[i] = if vm_val[i] then imm_val else vs2_val[i]
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = MASKTYPEI(vs2, simm, vd)
+  <-> "vmerge.vim" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ sep() ^ "v0"
+
 /* ********************** OPIVI (Integer Move Instruction) *********************** */
 union clause ast = MOVETYPEI : (regidx, bits(5))
 
@@ -1127,6 +1169,7 @@ function clause execute(MOVETYPEI(vd, simm)) = {
   mask        : vector('n, dec, bool)     = undefined;
 
   (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] then result[i] = imm_val
   };
@@ -1146,18 +1189,28 @@ mapping clause encdec = VMVRTYPE(vs2, simm, vd) if haveRVV()
   <-> 0b100111 @ 0b1 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if haveRVV()
 
 function clause execute(VMVRTYPE(vs2, simm, vd)) = {
+  let start_element = get_start_element();
   let SEW     = get_sew();
   let imm_val = unsigned(EXTZ(sizeof(xlen), simm));
   let EMUL    = imm_val + 1;
 
-  assert(EMUL == 1 | EMUL == 2 | EMUL == 4 | EMUL == 8);
+  if ~(EMUL == 1 | EMUL == 2 | EMUL == 4 | EMUL == 8) then {handle_illegal(); return RETIRE_FAIL};
+
   let EMUL_pow = log2(EMUL);
   let num_elem = get_num_elem(EMUL_pow, SEW);
   let 'n = num_elem;
   let 'm = SEW;
 
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
   let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, EMUL_pow, vs2);
-  write_vreg(num_elem, SEW, EMUL_pow, vd, vs2_val);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, EMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    result[i] = if i < start_element then vd_val[i] else vs2_val[i]
+  };
+
+  write_vreg(num_elem, SEW, EMUL_pow, vd, result);
   vstart = EXTZ(0b0);
   RETIRE_SUCCESS
 } 
@@ -1198,6 +1251,8 @@ function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -1233,10 +1288,10 @@ function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
                           let rounding_incr = get_fixed_rounding_incr(result_sub, 1);
                           slice(result_sub >> 1, 0, 'm) + EXTZ('m, rounding_incr)
                         },
-        MVV_VMUL     => slice(to_bits(SEW * 2, signed(vs2_val[i]) * signed(vs1_val[i])), 0, SEW),
-        MVV_VMULH    => slice(to_bits(SEW * 2, signed(vs2_val[i]) * signed(vs1_val[i])), SEW, SEW),
-        MVV_VMULHU   => slice(to_bits(SEW * 2, unsigned(vs2_val[i]) * unsigned(vs1_val[i])), SEW, SEW),  
-        MVV_VMULHSU  => slice(to_bits(SEW * 2, signed(vs2_val[i]) * unsigned(vs1_val[i])), SEW, SEW),
+        MVV_VMUL     => get_slice_int(SEW, signed(vs2_val[i]) * signed(vs1_val[i]), 0),
+        MVV_VMULH    => get_slice_int(SEW, signed(vs2_val[i]) * signed(vs1_val[i]), SEW),
+        MVV_VMULHU   => get_slice_int(SEW, unsigned(vs2_val[i]) * unsigned(vs1_val[i]), SEW),  
+        MVV_VMULHSU  => get_slice_int(SEW, signed(vs2_val[i]) * unsigned(vs1_val[i]), SEW),
         MVV_VDIVU    => {
                           let q : int = if unsigned(vs1_val[i]) == 0 then -1 else quot_round_zero(unsigned(vs2_val[i]), unsigned(vs1_val[i]));
                           to_bits(SEW, q)
@@ -1306,6 +1361,8 @@ function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let VLEN     = int_power(2, get_vlen_pow());
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -1322,10 +1379,10 @@ function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   foreach (i from 0 to (num_elem - 1)){
     if mask[i] then{
       result[i] = match funct6 {
-        MVV_VMACC  => slice(to_bits(VLEN, signed(vs1_val[i]) * signed(vs2_val[i])), 0, SEW) + vd_val[i],
-        MVV_VNMSAC => vd_val[i] - slice(to_bits(VLEN, signed(vs1_val[i]) * signed(vs2_val[i]) ), 0, SEW),
-        MVV_VMADD  => slice(to_bits(VLEN, signed(vs1_val[i]) * signed(vd_val[i])), 0, SEW) + vs2_val[i],
-        MVV_VNMSUB => vs2_val[i] - slice(to_bits(VLEN, signed(vs1_val[i]) * signed(vd_val[i]) ), 0, SEW)
+        MVV_VMACC  => get_slice_int(SEW, signed(vs1_val[i]) * signed(vs2_val[i]), 0) + vd_val[i],
+        MVV_VNMSAC => vd_val[i] - get_slice_int(SEW, signed(vs1_val[i]) * signed(vs2_val[i]), 0),
+        MVV_VMADD  => get_slice_int(SEW, signed(vs1_val[i]) * signed(vd_val[i]), 0) + vs2_val[i],
+        MVV_VNMSUB => vs2_val[i] - get_slice_int(SEW, signed(vs1_val[i]) * signed(vd_val[i]), 0)
       }
     }
   };
@@ -1364,10 +1421,13 @@ function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
-  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+
+  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) | 
+      ~(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
   let 'o = SEW_widen;
@@ -1381,7 +1441,7 @@ function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   assert(8 <= SEW_widen & SEW_widen <= 64);
   (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
-  
+
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] then {
       result[i] = match funct6 {
@@ -1431,10 +1491,13 @@ function clause execute(WVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
-  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+
+  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) | 
+      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
   let 'o = SEW_widen;
@@ -1492,10 +1555,13 @@ function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
-  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+
+  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) | 
+      ~(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
   let 'o = SEW_widen;
@@ -1550,10 +1616,13 @@ function clause execute(VEXT2TYPE(funct6, vm, vs2, vd)) = {
   let SEW = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-
   let SEW_half = SEW / 2;
   let LMUL_pow_half = LMUL_pow - 1;
-  if ~(check_eew_emul(SEW_half, LMUL_pow_half)) then {handle_illegal(); return RETIRE_FAIL};
+
+  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_half, LMUL_pow)) | 
+      ~(valid_eew_emul(SEW_half, LMUL_pow_half)) 
+  then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
   let 'o = SEW_half;
@@ -1605,10 +1674,13 @@ function clause execute(VEXT4TYPE(funct6, vm, vs2, vd)) = {
   let SEW = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-
   let SEW_quart = SEW / 4;
   let LMUL_pow_quart = LMUL_pow - 2;
-  if ~(check_eew_emul(SEW_quart, LMUL_pow_quart)) then {handle_illegal(); return RETIRE_FAIL};
+
+  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_quart, LMUL_pow)) | 
+      ~(valid_eew_emul(SEW_quart, LMUL_pow_quart)) 
+  then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
   let 'o = SEW_quart;
@@ -1660,10 +1732,13 @@ function clause execute(VEXT8TYPE(funct6, vm, vs2, vd)) = {
   let SEW = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-
   let SEW_eighth = SEW / 8;
   let LMUL_pow_eighth = LMUL_pow - 3;
-  if ~(check_eew_emul(SEW_eighth, LMUL_pow_eighth)) then {handle_illegal(); return RETIRE_FAIL};
+
+  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_eighth, LMUL_pow)) | 
+      ~(valid_eew_emul(SEW_eighth, LMUL_pow_eighth)) 
+  then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
   let 'o = SEW_eighth;
@@ -1734,14 +1809,14 @@ mapping clause encdec = MVVCOMPRESS(vs2, vs1, vd) if haveRVV()
 function clause execute(MVVCOMPRESS(vs2, vs1, vd)) = {
   let start_element = get_start_element();
   let end_element = get_end_element();
+
   /* vcompress should always be executed with a vstart of 0 */
-  if start_element != 0 then {handle_illegal(); return RETIRE_FAIL};
+  if (start_element != 0 | vs1 == vd | vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
 
   let SEW = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  assert(vd != vs1 & vd != vs2);
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -1809,6 +1884,8 @@ function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -1845,19 +1922,19 @@ function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
                               slice(result_sub >> 1, 0, 'm) + EXTZ('m, rounding_incr)
                             },
         MVX_VSLIDE1UP    => {
-                              assert(vs2 != vd);
+                              if (vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
                               if i == 0 then rs1_val else vs2_val[i - 1]
                             },
         MVX_VSLIDE1DOWN  => {
-                              assert(vs2 != vd);
+                              if (vs2 == vd) then {handle_illegal(); return RETIRE_FAIL};
                               let last_elem = get_end_element();
                               assert(last_elem < num_elem);
                               if i < last_elem then vs2_val[i + 1] else rs1_val
                             },
-        MVX_VMUL         => slice(to_bits(SEW * 2, signed(vs2_val[i]) * signed(rs1_val)), 0, SEW),
-        MVX_VMULH        => slice(to_bits(SEW * 2, signed(vs2_val[i]) * signed(rs1_val)), SEW, SEW),
-        MVX_VMULHU       => slice(to_bits(SEW * 2, unsigned(vs2_val[i]) * unsigned(rs1_val)), SEW, SEW),
-        MVX_VMULHSU      => slice(to_bits(SEW * 2, signed(vs2_val[i]) * unsigned(rs1_val)), SEW, SEW),
+        MVX_VMUL         => get_slice_int(SEW, signed(vs2_val[i]) * signed(rs1_val), 0),
+        MVX_VMULH        => get_slice_int(SEW, signed(vs2_val[i]) * signed(rs1_val), SEW),
+        MVX_VMULHU       => get_slice_int(SEW, unsigned(vs2_val[i]) * unsigned(rs1_val), SEW),
+        MVX_VMULHSU      => get_slice_int(SEW, signed(vs2_val[i]) * unsigned(rs1_val), SEW),
         MVX_VDIVU        => {
                               let q : int = if unsigned(rs1_val) == 0 then -1 else quot_round_zero(unsigned(vs2_val[i]), unsigned(rs1_val));
                               to_bits(SEW, q)
@@ -1929,6 +2006,8 @@ function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let VLEN     = int_power(2, get_vlen_pow());
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -1945,10 +2024,10 @@ function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
   foreach (i from 0 to (num_elem - 1)){
     if mask[i] then{
       result[i] = match funct6 {
-        MVX_VMACC  => slice(to_bits(VLEN, signed(rs1_val) * signed(vs2_val[i]) ), 0, SEW) + vd_val[i],
-        MVX_VNMSAC => vd_val[i] - slice(to_bits(VLEN, signed(rs1_val) * signed(vs2_val[i]) ), 0, SEW),
-        MVX_VMADD  => slice(to_bits(VLEN, signed(rs1_val) * signed(vd_val[i]) ), 0, SEW) + vs2_val[i],
-        MVX_VNMSUB => vs2_val[i] - slice(to_bits(VLEN, signed(rs1_val) * signed(vd_val[i]) ), 0, SEW)
+        MVX_VMACC  => get_slice_int(SEW, signed(rs1_val) * signed(vs2_val[i]), 0) + vd_val[i],
+        MVX_VNMSAC => vd_val[i] - get_slice_int(SEW, signed(rs1_val) * signed(vs2_val[i]), 0),
+        MVX_VMADD  => get_slice_int(SEW, signed(rs1_val) * signed(vd_val[i]), 0) + vs2_val[i],
+        MVX_VNMSUB => vs2_val[i] - get_slice_int(SEW, signed(rs1_val) * signed(vd_val[i]), 0)
       }
     }
   };
@@ -1988,10 +2067,13 @@ function clause execute(WVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
-  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+
+  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | 
+      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
   let 'o = SEW_widen;
@@ -2055,10 +2137,12 @@ function clause execute(WXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
-  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+
+  if  ~(valid_rd_mask(vd, vm)) | ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
   let 'o = SEW_widen;
@@ -2117,10 +2201,13 @@ function clause execute(WMVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
-  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+
+  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | 
+      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  then {handle_illegal(); return RETIRE_FAIL};
+
   let 'n = num_elem;
   let 'm = SEW;
   let 'o = SEW_widen;

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -155,6 +155,561 @@ mapping vvtype_mnemonic : vvfunct6 <-> string = {
 mapping clause assembly = VVTYPE(funct6, vm, vs2, vs1, vd)
   <-> vvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
+/* ************************** OPIVV (WVTYPE Narrowing) *************************** */
+/* ************** Vector Narrowing Integer Right Shift Instructions ************** */
+union clause ast = NVSTYPE : (nvsfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_nvsfunct6 : nvsfunct6 <-> bits(6) = {
+  NVS_VNSRL       <-> 0b101100,
+  NVS_VNSRA       <-> 0b101101
+}
+
+mapping clause encdec = NVSTYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_nvsfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  assert(SEW_widen <= 64);
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        NVS_VNSRL  => {
+                        let shift_amount = get_shift_amount(vs1_val[i], SEW_widen);
+                        slice(vs2_val[i] >> shift_amount, 0, SEW)
+                      },
+        NVS_VNSRA  => {
+                        let shift_amount = get_shift_amount(vs1_val[i], SEW_widen);
+                        let v_double : bits('o * 2) = EXTS(vs2_val[i]);
+                        let arith_shifted : bits('o) = slice(v_double >> shift_amount, 0, SEW_widen);
+                        slice(arith_shifted, 0, SEW)
+                      }
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping nvstype_mnemonic : nvsfunct6 <-> string = {
+  NVS_VNSRL       <-> "vnsrl.wv",
+  NVS_VNSRA       <-> "vnsra.wv"
+}
+
+mapping clause assembly = NVSTYPE(funct6, vm, vs2, vs1, vd)
+  <-> nvstype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+/* ************************** OPIVV (WVTYPE Narrowing) *************************** */
+/* *************** Vector Narrowing Fixed-Point Clip Instructions **************** */
+union clause ast = NVTYPE : (nvfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_nvfunct6 : nvfunct6 <-> bits(6) = {
+  NV_VNCLIPU     <-> 0b101110,
+  NV_VNCLIP      <-> 0b101111
+}
+
+mapping clause encdec = NVTYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_nvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      let shift_amount = get_shift_amount(vs1_val[i], SEW);
+      let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
+      result[i] = match funct6 {
+        NV_VNCLIPU => {
+                        let result_wide = (vs2_val[i] >> shift_amount) + EXTZ('o, rounding_incr);
+                        unsigned_saturation('m, result_wide);
+                      },
+        NV_VNCLIP  => {
+                        let v_double : bits('m * 4) = EXTS(vs2_val[i]);
+                        let result_wide = slice(v_double >> shift_amount, 0, 'o) + EXTZ('o, rounding_incr);
+                        signed_saturation('m, result_wide);
+                      }
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping nvtype_mnemonic : nvfunct6 <-> string = {
+  NV_VNCLIPU     <-> "vnclipu.wv",
+  NV_VNCLIP      <-> "vnclip.wv"
+}
+
+mapping clause assembly = NVTYPE(funct6, vm, vs2, vs1, vd)
+  <-> nvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+/* ********************** OPIVV (Integer Merge Instruction) ********************** */
+union clause ast = MASKTYPEV : (regidx, regidx, regidx)
+
+mapping clause encdec = MASKTYPEV (vs2, vs1,  vd) if haveRVV()
+  <-> 0b010111 @ 0b0 @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(MASKTYPEV(vs2, vs1, vd)) = {
+  let start_element = get_start_element();
+  let end_element   = get_end_element();
+  let SEW           = get_sew();
+  let LMUL_pow      = get_lmul_pow();
+  let num_elem      = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vreg_name("v0"));
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+
+  let tail_ag : agtype = get_vtype_vta();
+  foreach (i from 0 to (num_elem - 1)) {
+    if i < start_element then {
+      result[i] = vd_val[i]
+    } else if i > end_element then {
+      if tail_ag == UNDISTURBED then {
+        result[i] = vd_val[i]
+      } else if tail_ag == AGNOSTIC then {
+        result[i] = vd_val[i] /* TODO: configuration support */
+      }
+    } else {
+      result[i] = if vm_val[i] then vs1_val[i] else vs2_val[i]
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = MASKTYPEV(vs2, vs1, vd)
+<-> "vmerge.vvm" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ sep() ^ "v0"
+
+/* ********************** OPIVX (Integer Merge Instruction) ********************** */
+union clause ast = MASKTYPEX : (regidx, regidx, regidx)
+
+mapping clause encdec = MASKTYPEX(vs2, rs1, vd) if haveRVV()
+  <-> 0b010111 @ 0b0 @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(MASKTYPEX(vs2, rs1, vd)) = {
+  let start_element = get_start_element();
+  let end_element   = get_end_element();
+  let SEW           = get_sew();
+  let LMUL_pow      = get_lmul_pow();
+  let num_elem      = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vreg_name("v0"));
+  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+
+  let tail_ag : agtype = get_vtype_vta();
+  foreach (i from 0 to (num_elem - 1)) {
+    if i < start_element then {
+      result[i] = vd_val[i]
+    } else if i > end_element then {
+      if tail_ag == UNDISTURBED then {
+        result[i] = vd_val[i]
+      } else if tail_ag == AGNOSTIC then {
+        result[i] = vd_val[i] /* TODO: configuration support */
+      }
+    } else {
+      result[i] = if vm_val[i] then rs1_val else vs2_val[i]
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = MASKTYPEX(vs2, rs1, vd)
+  <-> "vmerge.vxm" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ sep() ^ "v0" 
+
+/* ********************** OPIVI (Integer Merge Instruction) ********************** */
+union clause ast = MASKTYPEI : (regidx, bits(5), regidx)
+
+mapping clause encdec = MASKTYPEI(vs2, simm, vd) if haveRVV()
+  <-> 0b010111 @ 0b0 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(MASKTYPEI(vs2, simm, vd)) = {
+  let start_element = get_start_element();
+  let end_element   = get_end_element();
+  let SEW           = get_sew();
+  let LMUL_pow      = get_lmul_pow();
+  let num_elem      = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vreg_name("v0"));
+  let imm_val : bits('m)                  = EXTS(simm);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+
+  let tail_ag : agtype = get_vtype_vta();
+  foreach (i from 0 to (num_elem - 1)) {
+    if i < start_element then {
+      result[i] = vd_val[i]
+    } else if i > end_element then {
+      if tail_ag == UNDISTURBED then {
+        result[i] = vd_val[i]
+      } else if tail_ag == AGNOSTIC then {
+        result[i] = vd_val[i] /* TODO: configuration support */
+      }
+    } else {
+      result[i] = if vm_val[i] then imm_val else vs2_val[i]
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = MASKTYPEI(vs2, simm, vd)
+  <-> "vmerge.vim" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ sep() ^ "v0"
+
+/* ********************** OPIVV (Integer Move Instruction) *********************** */
+union clause ast = MOVETYPEV : (regidx, regidx)
+
+mapping clause encdec = MOVETYPEV (vs1, vd) if haveRVV()
+  <-> 0b010111 @ 0b1 @ 0b00000 @ vs1 @ 0b000 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(MOVETYPEV(vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then result[i] = vs1_val[i]
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = MOVETYPEV(vs1, vd)
+  <-> "vmv.v.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1)
+
+/* ******************************* OPIVX (VXTYPE) ******************************** */
+union clause ast = VXTYPE : (vxfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_vxfunct6 : vxfunct6 <-> bits(6) = {
+  VX_VADD       <-> 0b000000,
+  VX_VSUB       <-> 0b000010,
+  VX_VRSUB      <-> 0b000011,
+  VX_VMINU      <-> 0b000100,
+  VX_VMIN       <-> 0b000101,
+  VX_VMAXU      <-> 0b000110,
+  VX_VMAX       <-> 0b000111,
+  VX_VAND       <-> 0b001001,
+  VX_VOR        <-> 0b001010,
+  VX_VXOR       <-> 0b001011,
+  VX_VSADDU     <-> 0b100000,
+  VX_VSADD      <-> 0b100001,
+  VX_VSSUBU     <-> 0b100010,
+  VX_VSSUB      <-> 0b100011,
+  VX_VSLL       <-> 0b100101,
+  VX_VSMUL      <-> 0b100111,
+  VX_VSRL       <-> 0b101000,
+  VX_VSRA       <-> 0b101001,
+  VX_VSSRL      <-> 0b101010,
+  VX_VSSRA      <-> 0b101011
+}
+
+mapping clause encdec = VXTYPE(funct6, vm, vs2, rs1, vd) if haveRVV()
+  <-> encdec_vxfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        VX_VADD    => vs2_val[i] + rs1_val,
+        VX_VSUB    => vs2_val[i] - rs1_val,
+        VX_VRSUB   => rs1_val - vs2_val[i],
+        VX_VAND    => vs2_val[i] & rs1_val,
+        VX_VOR     => vs2_val[i] | rs1_val,
+        VX_VXOR    => vs2_val[i] ^ rs1_val,
+        VX_VSADDU  => unsigned_saturation('m, EXTZ('m + 1, vs2_val[i]) + EXTZ('m + 1, rs1_val) ),
+        VX_VSADD   => signed_saturation('m, EXTS('m + 1, vs2_val[i]) + EXTS('m + 1, rs1_val) ),
+        VX_VSSUBU  => {
+                        if unsigned(vs2_val[i]) < unsigned(rs1_val) then zeros()
+                        else unsigned_saturation('m, EXTZ('m + 1, vs2_val[i]) - EXTZ('m + 1, rs1_val) )
+                      },
+        VX_VSSUB   => signed_saturation('m, EXTS('m + 1, vs2_val[i]) - EXTS('m + 1, rs1_val) ),
+        VX_VSMUL   => {
+                        let result_mul = to_bits('m * 2, signed(vs2_val[i]) * signed(rs1_val));
+                        let rounding_incr = get_fixed_rounding_incr(result_mul, 'm - 1);
+                        let result_wide = (result_mul >> ('m - 1)) + EXTZ('m * 2, rounding_incr);
+                        signed_saturation('m, result_wide['m..0])
+                      },
+        VX_VSLL    => {
+                        let shift_amount = get_shift_amount(rs1_val, SEW);
+                        vs2_val[i] << shift_amount
+                      },
+        VX_VSRL    => {
+                        let shift_amount = get_shift_amount(rs1_val, SEW);
+                        vs2_val[i] >> shift_amount
+                      },
+        VX_VSRA    => {
+                        let shift_amount = get_shift_amount(rs1_val, SEW);
+                        let v_double : bits('m * 2) = EXTS(vs2_val[i]);
+                        slice(v_double >> shift_amount, 0, SEW)
+                      },
+        VX_VSSRL   => {
+                        let shift_amount = get_shift_amount(rs1_val, SEW);
+                        let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
+                        (vs2_val[i] >> shift_amount) + EXTZ('m, rounding_incr)
+                      },
+        VX_VSSRA   => {
+                        let shift_amount = get_shift_amount(rs1_val, SEW);
+                        let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
+                        let v_double : bits('m * 2) = EXTS(vs2_val[i]);
+                        slice(v_double >> shift_amount, 0, SEW) + EXTZ('m, rounding_incr)
+                      },
+        VX_VMINU   => to_bits(SEW, min(unsigned(vs2_val[i]), unsigned(rs1_val))),
+        VX_VMIN    => to_bits(SEW, min(signed(vs2_val[i]), signed(rs1_val))),
+        VX_VMAXU   => to_bits(SEW, max(unsigned(vs2_val[i]), unsigned(rs1_val))),
+        VX_VMAX    => to_bits(SEW, max(signed(vs2_val[i]), signed(rs1_val)))
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vxtype_mnemonic : vxfunct6 <-> string = {
+  VX_VADD       <-> "vadd.vx",
+  VX_VSUB       <-> "vsub.vx",
+  VX_VRSUB      <-> "vrsub.vx",
+  VX_VAND       <-> "vand.vx",
+  VX_VOR        <-> "vor.vx",
+  VX_VXOR       <-> "vxor.vx",
+  VX_VSADDU     <-> "vsaddu.vx",
+  VX_VSADD      <-> "vsadd.vx",
+  VX_VSSUBU     <-> "vssubu.vx",
+  VX_VSSUB      <-> "vssub.vx",
+  VX_VSLL       <-> "vsll.vx",
+  VX_VSMUL      <-> "vsmul.vx",
+  VX_VSRL       <-> "vsrl.vx",
+  VX_VSRA       <-> "vsra.vx",
+  VX_VSSRL      <-> "vssrl.vx",
+  VX_VSSRA      <-> "vssra.vx",
+  VX_VMINU      <-> "vminu.vx",
+  VX_VMIN       <-> "vmin.vx",
+  VX_VMAXU      <-> "vmaxu.vx",
+  VX_VMAX       <-> "vmax.vx"
+}
+
+mapping clause assembly = VXTYPE(funct6, vm, vs2, rs1, vd)
+  <-> vxtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+
+/* ************************** OPIVX (WXTYPE Narrowing) *************************** */
+/* ************** Vector Narrowing Integer Right Shift Instructions ************** */
+union clause ast = NXSTYPE : (nxsfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_nxsfunct6 : nxsfunct6 <-> bits(6) = {
+  NXS_VNSRL       <-> 0b101100,
+  NXS_VNSRA       <-> 0b101101
+}
+
+mapping clause encdec = NXSTYPE(funct6, vm, vs2, rs1, vd) if haveRVV()
+  <-> encdec_nxsfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  assert(SEW_widen <= 64);
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        NXS_VNSRL  => {
+                        let shift_amount = get_shift_amount(rs1_val, SEW_widen);
+                        slice(vs2_val[i] >> shift_amount, 0, SEW)
+                      },
+        NXS_VNSRA  => {
+                        let shift_amount = get_shift_amount(rs1_val, SEW_widen);
+                        let v_double : bits('o * 2) = EXTS(vs2_val[i]);
+                        let arith_shifted : bits('o) = slice(v_double >> shift_amount, 0, SEW_widen);
+                        slice(arith_shifted, 0, SEW)
+                      }
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping nxstype_mnemonic : nxsfunct6 <-> string = {
+  NXS_VNSRL       <-> "vnsrl.wx",
+  NXS_VNSRA       <-> "vnsra.wx"
+}
+
+mapping clause assembly = NXSTYPE(funct6, vm, vs2, rs1, vd)
+  <-> nxstype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+
+/* ************************** OPIVX (WXTYPE Narrowing) *************************** */
+/* *************** Vector Narrowing Fixed-Point Clip Instructions **************** */
+union clause ast = NXTYPE : (nxfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_nxfunct6 : nxfunct6 <-> bits(6) = {
+  NX_VNCLIPU     <-> 0b101110,
+  NX_VNCLIP      <-> 0b101111
+}
+
+mapping clause encdec = NXTYPE(funct6, vm, vs2, rs1, vd) if haveRVV()
+  <-> encdec_nxfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      let shift_amount = get_shift_amount(rs1_val, SEW);
+      let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
+      result[i] = match funct6 {
+        NX_VNCLIPU => {                    
+                        let result_wide = (vs2_val[i] >> shift_amount) + EXTZ('o, rounding_incr);
+                        unsigned_saturation('m, result_wide)
+                      },
+        NX_VNCLIP  => {       
+                        let v_double : bits('m * 4) = EXTS(vs2_val[i]);
+                        let result_wide = slice(v_double >> shift_amount, 0, 'o) + EXTZ('o, rounding_incr);
+                        signed_saturation('m, result_wide)
+                      }
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping nxtype_mnemonic : nxfunct6 <-> string = {
+  NX_VNCLIPU     <-> "vnclipu.wx",
+  NX_VNCLIP      <-> "vnclip.wx"
+}
+
+mapping clause assembly = NXTYPE(funct6, vm, vs2, rs1, vd)
+  <-> nxtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+
 /* ***************** OPIVX (Vector Slide & Gather Instructions) ****************** */
 /* Slide and gather instructions extend rs1/imm to XLEN intead of SEW bits */
 union clause ast = VXSG : (vxsgfunct6, bits(1), regidx, regidx, regidx)
@@ -222,6 +777,266 @@ mapping vxsg_mnemonic : vxsgfunct6 <-> string = {
 
 mapping clause assembly = VXSG(funct6, vm, vs2, rs1, vd)
   <-> vxsg_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+
+/* ********************** OPIVX (Integer Move Instruction) *********************** */
+union clause ast = MOVETYPEX : (regidx, regidx)
+
+mapping clause encdec = MOVETYPEX (rs1, vd) if haveRVV()
+  <-> 0b010111 @ 0b1 @ 0b00000 @ rs1 @ 0b100 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(MOVETYPEX(rs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let rs1_val : bits('m)                  = get_scalar(rs1, 'm);
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then result[i] = rs1_val
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = MOVETYPEX(rs1, vd)
+  <-> "vmv.v.x" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)
+
+/* ******************************* OPIVI (VITYPE) ******************************** */
+union clause ast = VITYPE : (vifunct6, bits(1), regidx, bits(5), regidx)
+
+mapping encdec_vifunct6 : vifunct6 <-> bits(6) = {
+  VI_VADD       <-> 0b000000,
+  VI_VRSUB      <-> 0b000011,
+  VI_VAND       <-> 0b001001,
+  VI_VOR        <-> 0b001010,
+  VI_VXOR       <-> 0b001011,
+  VI_VSADDU     <-> 0b100000,
+  VI_VSADD      <-> 0b100001,
+  VI_VSLL       <-> 0b100101,
+  VI_VSRL       <-> 0b101000,
+  VI_VSRA       <-> 0b101001,
+  VI_VSSRL      <-> 0b101010,
+  VI_VSSRA      <-> 0b101011
+}
+
+mapping clause encdec = VITYPE(funct6, vm, vs2, simm, vd) if haveRVV()
+  <-> encdec_vifunct6(funct6) @ vm @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let imm_val : bits('m)                  = EXTS(simm);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        VI_VADD    => vs2_val[i] + imm_val,
+        VI_VRSUB   => imm_val - vs2_val[i],
+        VI_VAND    => vs2_val[i] & imm_val,
+        VI_VOR     => vs2_val[i] | imm_val,
+        VI_VXOR    => vs2_val[i] ^ imm_val,
+        VI_VSADDU  => unsigned_saturation('m, EXTZ('m + 1, vs2_val[i]) + EXTZ('m + 1, imm_val) ),
+        VI_VSADD   => signed_saturation('m, EXTS('m + 1, vs2_val[i]) + EXTS('m + 1, imm_val) ),
+        VI_VSLL    => {
+                        let shift_amount = get_shift_amount(sail_zero_extend(simm, SEW), SEW);
+                        vs2_val[i] << shift_amount
+                      },
+        VI_VSRL    => {
+                        let shift_amount = get_shift_amount(sail_zero_extend(simm, SEW), SEW);
+                        vs2_val[i] >> shift_amount
+                      },
+        VI_VSRA    => {
+                        let shift_amount = get_shift_amount(sail_zero_extend(simm, SEW), SEW);
+                        let v_double : bits('m * 2) = EXTS(vs2_val[i]);
+                        slice(v_double >> shift_amount, 0, SEW)
+                      },
+        VI_VSSRL   => {
+                        let shift_amount = get_shift_amount(sail_zero_extend(simm, SEW), SEW);
+                        let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
+                        (vs2_val[i] >> shift_amount) + EXTZ('m, rounding_incr)
+                      },
+        VI_VSSRA   => {
+                        let shift_amount = get_shift_amount(sail_zero_extend(simm, SEW), SEW);
+                        let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
+                        let v_double : bits('m * 2) = EXTS(vs2_val[i]);
+                        slice(v_double >> shift_amount, 0, SEW) + EXTZ('m, rounding_incr)
+                      }
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vitype_mnemonic : vifunct6 <-> string = {
+  VI_VADD   <-> "vadd.vi",
+  VI_VRSUB  <-> "vrsub.vi",
+  VI_VAND   <-> "vand.vi",
+  VI_VOR    <-> "vor.vi",
+  VI_VXOR   <-> "vxor.vi",
+  VI_VSADDU <-> "vsaddu.vi",
+  VI_VSADD  <-> "vsadd.vi",
+  VI_VSLL   <-> "vsll.vi",
+  VI_VSRL   <-> "vsrl.vi",
+  VI_VSRA   <-> "vsra.vi",
+  VI_VSSRL  <-> "vssrl.vi",
+  VI_VSSRA  <-> "vssra.vi"
+}
+
+mapping clause assembly = VITYPE(funct6, vm, vs2, simm, vd)
+  <-> vitype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ maybe_vmask(vm)
+
+/* ************************** OPIVI (WITYPE Narrowing) *************************** */
+/* ************** Vector Narrowing Integer Right Shift Instructions ************** */
+union clause ast = NISTYPE : (nisfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_nisfunct6 : nisfunct6 <-> bits(6) = {
+  NIS_VNSRL       <-> 0b101100,
+  NIS_VNSRA       <-> 0b101101
+}
+
+mapping clause encdec = NISTYPE(funct6, vm, vs2, simm, vd) if haveRVV()
+  <-> encdec_nisfunct6(funct6) @ vm @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(NISTYPE(funct6, vm, vs2, simm, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let imm_val : bits('m)                  = EXTS(simm);
+  let vs2_val : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  assert(SEW_widen <= 64);
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        NIS_VNSRL  => {
+                        let shift_amount = get_shift_amount(imm_val, SEW_widen);
+                        slice(vs2_val[i] >> shift_amount, 0, SEW)
+                      },
+        NIS_VNSRA  => {
+                        let shift_amount = get_shift_amount(imm_val, SEW_widen);
+                        let v_double : bits('o * 2) = EXTS(vs2_val[i]);
+                        let arith_shifted : bits('o) = slice(v_double >> shift_amount, 0, SEW_widen);
+                        slice(arith_shifted, 0, SEW)
+                      }
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping nistype_mnemonic : nisfunct6 <-> string = {
+  NIS_VNSRL       <-> "vnsrl.wi",
+  NIS_VNSRA       <-> "vnsra.wi"
+}
+
+mapping clause assembly = NISTYPE(funct6, vm, vs2, simm, vd)
+  <-> nistype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ maybe_vmask(vm) 
+
+/* ************************** OPIVI (WITYPE Narrowing) *************************** */
+/* *************** Vector Narrowing Fixed-Point Clip Instructions **************** */
+union clause ast = NITYPE : (nifunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_nifunct6 : nifunct6 <-> bits(6) = {
+  NI_VNCLIPU     <-> 0b101110,
+  NI_VNCLIP      <-> 0b101111
+}
+
+mapping clause encdec = NITYPE(funct6, vm, vs2, simm, vd) if haveRVV()
+  <-> encdec_nifunct6(funct6) @ vm @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(NITYPE(funct6, vm, vs2, simm, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let imm_val : bits('m)                  = EXTS(simm);
+  let vs2_val : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      let shift_amount = get_shift_amount(imm_val, SEW);
+      let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
+      result[i] = match funct6 {
+        NI_VNCLIPU => {                    
+                        let result_wide = (vs2_val[i] >> shift_amount) + EXTZ('o, rounding_incr);
+                        unsigned_saturation('m, result_wide)
+                      },
+        NI_VNCLIP  => {        
+                        let v_double : bits('m * 4) = EXTS(vs2_val[i]);
+                        let result_wide = slice(v_double >> shift_amount, 0, 'o) + EXTZ('o, rounding_incr);
+                        signed_saturation('m, result_wide)
+                      }
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping nitype_mnemonic : nifunct6 <-> string = {
+  NI_VNCLIPU     <-> "vnclipu.wi",
+  NI_VNCLIP      <-> "vnclip.wi"
+}
+
+mapping clause assembly = NITYPE(funct6, vm, vs2, simm, vd)
+  <-> nitype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ maybe_vmask(vm)
 
 /* ***************** OPIVI (Vector Slide & Gather Instructions) ****************** */
 /* Slide and gather instructions extend rs1/imm to XLEN intead of SEW bits */
@@ -291,177 +1106,7 @@ mapping visg_mnemonic : visgfunct6 <-> string = {
 mapping clause assembly = VISG(funct6, vm, vs2, simm, vd)
   <-> visg_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(simm) ^ maybe_vmask(vm)
 
-/* ********************* Whole Vector Register Move (OPIVI) ********************** */
-union clause ast = VMVRTYPE : (regidx, bits(5), regidx)
-
-mapping clause encdec = VMVRTYPE(vs2, simm, vd) if haveRVV()
-  <-> 0b100111 @ 0b1 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if haveRVV()
-
-function clause execute(VMVRTYPE(vs2, simm, vd)) = {
-  let SEW     = get_sew();
-  let imm_val = unsigned(EXTZ(sizeof(xlen), simm));
-  let EMUL    = imm_val + 1;
-
-  assert(EMUL == 1 | EMUL == 2 | EMUL == 4 | EMUL == 8);
-  let EMUL_pow = log2(EMUL);
-  let num_elem = get_num_elem(EMUL_pow, SEW);
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, EMUL_pow, vs2);
-  write_vreg(num_elem, SEW, EMUL_pow, vd, vs2_val);
-  vstart = EXTZ(0b0);
-
-  RETIRE_SUCCESS
-} 
-
-mapping simm_string : bits(5) <-> string = {
-  0b00000 <-> "1",
-  0b00001 <-> "2",
-  0b00011 <-> "4",
-  0b00111 <-> "8"
-}
-
-mapping clause assembly = VMVRTYPE(vs2, simm, vd)
-  <-> "vmv" ^ simm_string(simm) ^ "r.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)
-
-/* ****************************** OPMVV (VWXUNARY0) ****************************** */
-union clause ast = VMVXS : (regidx, regidx)
-
-mapping clause encdec = VMVXS(vs2, rd) if haveRVV()
-  <-> 0b010000 @ 0b1 @ vs2 @ 0b00000 @ 0b010 @ rd @ 0b1010111 if haveRVV()
-
-function clause execute(VMVXS(vs2, rd)) = {
-  let SEW      = get_sew();
-  let num_elem = get_num_elem(0, SEW);
-
-  assert(num_elem > 0);
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, 0, vs2);
-  X(rd) = if sizeof(xlen) < SEW then slice(vs2_val[0], 0, sizeof(xlen))
-          else if sizeof(xlen) > SEW then EXTS(vs2_val[0])
-          else vs2_val[0];
-  vstart = EXTZ(0b0);
-
-  RETIRE_SUCCESS
-}
-
-mapping clause assembly = VMVXS(vs2, rd)
-  <-> "vmv.x.s" ^ spc() ^ reg_name(rd) ^ sep() ^ vreg_name(vs2)
-
-/* ****************************** OPMVX (VRXUNARY0) ****************************** */
-union clause ast = VMVSX : (regidx, regidx)
-
-mapping clause encdec = VMVSX(rs1, vd) if haveRVV()
-  <-> 0b010000 @ 0b1 @ 0b00000 @ rs1 @ 0b110 @ vd @ 0b1010111 if haveRVV()
-
-function clause execute(VMVSX(rs1, vd)) = {
-  let SEW      = get_sew();
-  let num_elem = get_num_elem(0, SEW);
-
-  assert(num_elem > 0);
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
-  let rs1_val : bits('m)                  = get_scalar(rs1, 'm);
-  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
-  result      : vector('n, dec, bits('m)) = undefined;
-  mask        : vector('n, dec, bool)     = undefined;
-
-  (result, mask) = init_masked_result(num_elem, SEW, 0, vd_val, vm_val);
-
-  /* one body element */
-  if mask[0] == true then result[0] = rs1_val;
-
-  /* others treated as tail elements */
-  let tail_ag : agtype = get_vtype_vta();
-  if tail_ag == UNDISTURBED then {
-    foreach (i from 1 to (num_elem - 1)) result[i] = vd_val[i]
-  } else if tail_ag == AGNOSTIC then {
-    foreach (i from 1 to (num_elem - 1)) result[i] = vd_val[i] /* TODO: configuration support */
-  };
-
-  write_vreg(num_elem, SEW, 0, vd, result);
-  vstart = EXTZ(0b0);
-
-  RETIRE_SUCCESS
-}
-
-mapping clause assembly = VMVSX(rs1, vd)
-  <-> "vmv.s.x" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)
-
-/* ********************** Integer Move Instruction (OPIVV) *********************** */
-union clause ast = MOVETYPEV : (regidx, regidx)
-
-mapping clause encdec = MOVETYPEV (vs1, vd) if haveRVV()
-  <-> 0b010111 @ 0b1 @ 0b00000 @ vs1 @ 0b000 @ vd @ 0b1010111 if haveRVV()
-
-function clause execute(MOVETYPEV(vs1, vd)) = {
-  let SEW      = get_sew();
-  let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
-
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
-  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  result      : vector('n, dec, bits('m)) = undefined;
-  mask        : vector('n, dec, bool)     = undefined;
-
-  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
-  foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] then result[i] = vs1_val[i]
-  };
-
-  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
-  vstart = EXTZ(0b0);
-
-  RETIRE_SUCCESS
-}
-
-mapping clause assembly = MOVETYPEV(vs1, vd)
-  <-> "vmv.v.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1)
-
-/* ********************** Integer Move Instruction (OPIVX) *********************** */
-union clause ast = MOVETYPEX : (regidx, regidx)
-
-mapping clause encdec = MOVETYPEX (rs1, vd) if haveRVV()
-  <-> 0b010111 @ 0b1 @ 0b00000 @ rs1 @ 0b100 @ vd @ 0b1010111 if haveRVV()
-
-function clause execute(MOVETYPEX(rs1, vd)) = {
-  let SEW      = get_sew();
-  let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
-
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let rs1_val : bits('m)                  = get_scalar(rs1, 'm);
-  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
-  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  result      : vector('n, dec, bits('m)) = undefined;
-  mask        : vector('n, dec, bool)     = undefined;
-
-  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
-  foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] then result[i] = rs1_val
-  };
-
-  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
-  vstart = EXTZ(0b0);
-
-  RETIRE_SUCCESS
-}
-
-mapping clause assembly = MOVETYPEX(rs1, vd)
-  <-> "vmv.v.x" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)
-
-/* ********************** Integer Move Instruction (OPIVI) *********************** */
+/* ********************** OPIVI (Integer Move Instruction) *********************** */
 union clause ast = MOVETYPEI : (regidx, bits(5))
 
 mapping clause encdec = MOVETYPEI (vd, simm) if haveRVV()
@@ -488,9 +1133,1071 @@ function clause execute(MOVETYPEI(vd, simm)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   vstart = EXTZ(0b0);
-
   RETIRE_SUCCESS
 }
 
 mapping clause assembly = MOVETYPEI(vd, simm)
   <-> "vmv.v.i" ^ spc() ^ vreg_name(vd) ^ sep() ^ hex_bits_5(simm)
+
+/* ********************* OPIVI (Whole Vector Register Move) ********************** */
+union clause ast = VMVRTYPE : (regidx, bits(5), regidx)
+
+mapping clause encdec = VMVRTYPE(vs2, simm, vd) if haveRVV()
+  <-> 0b100111 @ 0b1 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VMVRTYPE(vs2, simm, vd)) = {
+  let SEW     = get_sew();
+  let imm_val = unsigned(EXTZ(sizeof(xlen), simm));
+  let EMUL    = imm_val + 1;
+
+  assert(EMUL == 1 | EMUL == 2 | EMUL == 4 | EMUL == 8);
+  let EMUL_pow = log2(EMUL);
+  let num_elem = get_num_elem(EMUL_pow, SEW);
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, EMUL_pow, vs2);
+  write_vreg(num_elem, SEW, EMUL_pow, vd, vs2_val);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+} 
+
+mapping simm_string : bits(5) <-> string = {
+  0b00000 <-> "1",
+  0b00001 <-> "2",
+  0b00011 <-> "4",
+  0b00111 <-> "8"
+}
+
+mapping clause assembly = VMVRTYPE(vs2, simm, vd)
+  <-> "vmv" ^ simm_string(simm) ^ "r.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)
+
+/* ******************************* OPMVV (MVVTYPE) ******************************* */
+union clause ast = MVVTYPE : (mvvfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_mvvfunct6 : mvvfunct6 <-> bits(6) = {
+  MVV_VAADDU      <-> 0b001000,
+  MVV_VAADD       <-> 0b001001,
+  MVV_VASUBU      <-> 0b001010,
+  MVV_VASUB       <-> 0b001011,
+  MVV_VMUL        <-> 0b100101,
+  MVV_VMULH       <-> 0b100111,
+  MVV_VMULHU      <-> 0b100100,
+  MVV_VMULHSU     <-> 0b100110,
+  MVV_VDIVU       <-> 0b100000,
+  MVV_VDIV        <-> 0b100001,
+  MVV_VREMU       <-> 0b100010,
+  MVV_VREM        <-> 0b100011
+}
+
+mapping clause encdec = MVVTYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_mvvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then{
+      result[i] = match funct6 {
+        MVV_VAADDU   => {
+                          let result_add = EXTZ('m + 1, vs2_val[i]) + EXTZ('m + 1, vs1_val[i]);
+                          let rounding_incr = get_fixed_rounding_incr(result_add, 1);
+                          slice(result_add >> 1, 0, 'm) + EXTZ('m, rounding_incr)                              
+                        },
+        MVV_VAADD    => {
+                          let result_add = EXTS('m + 1, vs2_val[i]) + EXTS('m + 1, vs1_val[i]);
+                          let rounding_incr = get_fixed_rounding_incr(result_add, 1);
+                          slice(result_add >> 1, 0, 'm) + EXTZ('m, rounding_incr)
+                        },
+        MVV_VASUBU   => {
+                          let result_sub = EXTZ('m + 1, vs2_val[i]) - EXTZ('m + 1, vs1_val[i]);
+                          let rounding_incr = get_fixed_rounding_incr(result_sub, 1);
+                          slice(result_sub >> 1, 0, 'm) + EXTZ('m, rounding_incr)                             
+                        },
+        MVV_VASUB    => {
+                          let result_sub = EXTS('m + 1, vs2_val[i]) - EXTS('m + 1, vs1_val[i]);
+                          let rounding_incr = get_fixed_rounding_incr(result_sub, 1);
+                          slice(result_sub >> 1, 0, 'm) + EXTZ('m, rounding_incr)
+                        },
+        MVV_VMUL     => slice(to_bits(SEW * 2, signed(vs2_val[i]) * signed(vs1_val[i])), 0, SEW),
+        MVV_VMULH    => slice(to_bits(SEW * 2, signed(vs2_val[i]) * signed(vs1_val[i])), SEW, SEW),
+        MVV_VMULHU   => slice(to_bits(SEW * 2, unsigned(vs2_val[i]) * unsigned(vs1_val[i])), SEW, SEW),  
+        MVV_VMULHSU  => slice(to_bits(SEW * 2, signed(vs2_val[i]) * unsigned(vs1_val[i])), SEW, SEW),
+        MVV_VDIVU    => {
+                          let q : int = if unsigned(vs1_val[i]) == 0 then -1 else quot_round_zero(unsigned(vs2_val[i]), unsigned(vs1_val[i]));
+                          to_bits(SEW, q)
+                        },
+        MVV_VDIV     => {
+                          let elem_max : int = 2 ^ (SEW - 1) - 1;
+                          let elem_min : int = 0 - 2 ^ (SEW - 1);
+                          let q : int = if signed(vs1_val[i]) == 0 then -1 else quot_round_zero(signed(vs2_val[i]), signed(vs1_val[i]));
+                          /* check for signed overflow */
+                          let q' : int = if q > elem_max then elem_min else q;
+                          to_bits(SEW, q')
+                        },
+        MVV_VREMU    => {
+                          let r : int = if unsigned(vs1_val[i]) == 0 then unsigned(vs2_val[i]) else rem_round_zero(unsigned(vs2_val[i]), unsigned(vs1_val[i]));
+                          /* signed overflow case returns zero naturally as required due to -1 divisor */
+                          to_bits(SEW, r)
+                        },
+        MVV_VREM     => {
+                          let r : int = if signed(vs1_val[i]) == 0 then signed(vs2_val[i]) else rem_round_zero(signed(vs2_val[i]), signed(vs1_val[i]));
+                          /* signed overflow case returns zero naturally as required due to -1 divisor */
+                          to_bits(SEW, r)
+                        }
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping mvvtype_mnemonic : mvvfunct6 <-> string = {
+  MVV_VAADDU   <-> "vaaddu.vv",
+  MVV_VAADD    <-> "vaadd.vv",
+  MVV_VASUBU   <-> "vasubu.vv",
+  MVV_VASUB    <-> "vasub.vv",
+  MVV_VMUL     <-> "vmul.vv",
+  MVV_VMULH    <-> "vmulh.vv",
+  MVV_VMULHU   <-> "vmulhu.vv",
+  MVV_VMULHSU  <-> "vmulhsu.vv",
+  MVV_VDIVU    <-> "vdivu.vv",
+  MVV_VDIV     <-> "vdiv.vv",
+  MVV_VREMU    <-> "vremu.vv",
+  MVV_VREM     <-> "vrem.vv"
+}
+
+mapping clause assembly = MVVTYPE(funct6, vm, vs2, vs1, vd)
+  <-> mvvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+/* ************************ OPMVV (MVVtype Multiply-Add) ************************* */
+/* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
+union clause ast = MVVMATYPE : (mvvmafunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_mvvmafunct6 : mvvmafunct6 <-> bits(6) = {
+  MVV_VMACC       <-> 0b101101,
+  MVV_VNMSAC      <-> 0b101111,
+  MVV_VMADD       <-> 0b101001,
+  MVV_VNMSUB      <-> 0b101011
+}
+
+mapping clause encdec = MVVMATYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_mvvmafunct6(funct6) @ vm @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let VLEN     = int_power(2, get_vlen_pow());
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  assert(VLEN >= 0);
+  foreach (i from 0 to (num_elem - 1)){
+    if mask[i] then{
+      result[i] = match funct6 {
+        MVV_VMACC  => slice(to_bits(VLEN, signed(vs1_val[i]) * signed(vs2_val[i])), 0, SEW) + vd_val[i],
+        MVV_VNMSAC => vd_val[i] - slice(to_bits(VLEN, signed(vs1_val[i]) * signed(vs2_val[i]) ), 0, SEW),
+        MVV_VMADD  => slice(to_bits(VLEN, signed(vs1_val[i]) * signed(vd_val[i])), 0, SEW) + vs2_val[i],
+        MVV_VNMSUB => vs2_val[i] - slice(to_bits(VLEN, signed(vs1_val[i]) * signed(vd_val[i]) ), 0, SEW)
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping mvvmatype_mnemonic : mvvmafunct6 <-> string = {
+  MVV_VMACC    <-> "vmacc.vv",
+  MVV_VNMSAC   <-> "vnmsac.vv",
+  MVV_VMADD    <-> "vmadd.vv",
+  MVV_VNMSUB   <-> "vnmsub.vv"
+}
+
+mapping clause assembly = MVVMATYPE(funct6, vm, vs2, vs1, vd)
+  <-> mvvmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* *************************** OPMVV (VVTYPE Widening) *************************** */
+union clause ast = WVVTYPE : (wvvfunct6, bits(1), regidx, regidx, regidx)
+mapping encdec_wvvfunct6 : wvvfunct6 <-> bits(6) = {
+  WVV_VADD       <-> 0b110001,
+  WVV_VSUB       <-> 0b110011,
+  WVV_VADDU      <-> 0b110000,
+  WVV_VSUBU      <-> 0b110010,
+  WVV_VWMUL      <-> 0b111011,
+  WVV_VWMULU     <-> 0b111000,
+  WVV_VWMULSU    <-> 0b111010
+}
+
+mapping clause encdec = WVVTYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_wvvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  result      : vector('n, dec, bits('o)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  assert(8 <= SEW_widen & SEW_widen <= 64);
+  (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        WVV_VADD    => to_bits(SEW_widen, signed(vs2_val[i]) + signed(vs1_val[i])),
+        WVV_VSUB    => to_bits(SEW_widen, signed(vs2_val[i]) - signed(vs1_val[i])),
+        WVV_VADDU   => to_bits(SEW_widen, unsigned(vs2_val[i]) + unsigned(vs1_val[i])),
+        WVV_VSUBU   => to_bits(SEW_widen, unsigned(vs2_val[i]) - unsigned(vs1_val[i])),
+        WVV_VWMUL   => to_bits(SEW_widen, signed(vs2_val[i]) * signed(vs1_val[i])),
+        WVV_VWMULU  => to_bits(SEW_widen, unsigned(vs2_val[i]) * unsigned(vs1_val[i])),
+        WVV_VWMULSU => to_bits(SEW_widen, signed(vs2_val[i]) * unsigned(vs1_val[i]))
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping wvvtype_mnemonic : wvvfunct6 <-> string = {
+  WVV_VADD       <-> "vwadd.vv",
+  WVV_VSUB       <-> "vwsub.vv",
+  WVV_VADDU      <-> "vwaddu.vv",
+  WVV_VSUBU      <-> "vwsubu.vv",
+  WVV_VWMUL      <-> "vwmul.vv",
+  WVV_VWMULU     <-> "vwmulu.vv",
+  WVV_VWMULSU    <-> "vwmulsu.vv"
+}
+
+mapping clause assembly = WVVTYPE(funct6, vm, vs2, vs1, vd)
+  <-> wvvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+/* ******************************* OPMVV (WVTYPE) ******************************** */
+union clause ast = WVTYPE : (wvfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_wvfunct6 : wvfunct6 <-> bits(6) = {
+  WV_VADD       <-> 0b110101,
+  WV_VSUB       <-> 0b110111,
+  WV_VADDU      <-> 0b110100,
+  WV_VSUBU      <-> 0b110110
+}
+
+mapping clause encdec = WVTYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_wvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(WVTYPE(funct6, vm, vs2, vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  result      : vector('n, dec, bits('o)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  assert(8 <= SEW_widen & SEW_widen <= 64);
+  (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        WV_VADD  => to_bits(SEW_widen, signed(vs2_val[i]) + signed(vs1_val[i])),
+        WV_VSUB  => to_bits(SEW_widen, signed(vs2_val[i]) - signed(vs1_val[i])),
+        WV_VADDU => to_bits(SEW_widen, unsigned(vs2_val[i]) + unsigned(vs1_val[i])),
+        WV_VSUBU => to_bits(SEW_widen, unsigned(vs2_val[i]) - unsigned(vs1_val[i]))
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping wvtype_mnemonic : wvfunct6 <-> string = {
+  WV_VADD       <-> "vwadd.wv",
+  WV_VSUB       <-> "vwsub.wv",
+  WV_VADDU      <-> "vwaddu.wv",
+  WV_VSUBU      <-> "vwsubu.wv"
+}
+
+mapping clause assembly = WVTYPE(funct6, vm, vs2, vs1, vd)
+  <-> wvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+/* ******************** OPMVV (MVVtype Widening Multiply-Add) ******************** */
+/* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
+union clause ast = WMVVTYPE : (wmvvfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_wmvvfunct6 : wmvvfunct6 <-> bits(6) = {
+  WMVV_VWMACCU   <-> 0b111100,
+  WMVV_VWMACC     <-> 0b111101,
+  WMVV_VWMACCSU  <-> 0b111111
+}
+
+mapping clause encdec =  WMVVTYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_wmvvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  result      : vector('n, dec, bits('o)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  assert(8 <= SEW_widen & SEW_widen <= 64);
+  (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        WMVV_VWMACC   => to_bits(SEW_widen, signed(vs1_val[i]) * signed(vs2_val[i])) + vd_val[i],
+        WMVV_VWMACCU  => to_bits(SEW_widen, unsigned(vs1_val[i]) * unsigned(vs2_val[i])) + vd_val[i], 
+        WMVV_VWMACCSU => to_bits(SEW_widen, signed(vs1_val[i]) * unsigned(vs2_val[i]))+ vd_val[i]
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping wmvvtype_mnemonic : wmvvfunct6 <-> string = {
+  WMVV_VWMACCU     <-> "vwmaccu.vv",
+  WMVV_VWMACC      <-> "vwmacc.vv",
+  WMVV_VWMACCSU    <-> "vwmaccsu.vv"
+}
+
+mapping clause assembly = WMVVTYPE(funct6, vm, vs2, vs1, vd)
+  <-> wmvvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* ****************************** OPMVV (VXUNARY0) ******************************* */
+/* ******************* Vector Integer Extension (SEW/2 source) ******************* */
+union clause ast = VEXT2TYPE : (vext2funct6, bits(1), regidx, regidx)
+
+mapping vext2_vs1 : vext2funct6 <-> bits(5) = {
+  VEXT2_ZVF2  <-> 0b00110,
+  VEXT2_SVF2  <-> 0b00111
+}
+
+mapping clause encdec = VEXT2TYPE(funct6, vm, vs2, vd) if haveRVV()
+  <-> 0b010010 @ vm @ vs2 @ vext2_vs1(funct6) @ 0b010 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VEXT2TYPE(funct6, vm, vs2, vd)) = {
+  let SEW = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let SEW_half = SEW / 2;
+  let LMUL_pow_half = LMUL_pow - 1;
+  if ~(check_eew_emul(SEW_half, LMUL_pow_half)) then {handle_illegal(); return RETIRE_FAIL};
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_half;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vs2_val : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_half, LMUL_pow_half, vs2);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  assert(SEW > SEW_half);
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        VEXT2_ZVF2 => EXTZ(vs2_val[i]),
+        VEXT2_SVF2 => EXTS(vs2_val[i])
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vext2type_mnemonic : vext2funct6 <-> string = {
+  VEXT2_ZVF2  <-> "vzext.vf2",
+  VEXT2_SVF2  <-> "vsext.vf2"
+}
+
+mapping clause assembly = VEXT2TYPE(funct6, vm, vs2, vd)
+  <-> vext2type_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* ****************************** OPMVV (VXUNARY0) ******************************* */
+/* ******************* Vector Integer Extension (SEW/4 source) ******************* */
+union clause ast = VEXT4TYPE : (vext4funct6, bits(1), regidx, regidx)
+
+mapping vext4_vs1 : vext4funct6 <-> bits(5) = {
+  VEXT4_ZVF4  <-> 0b00100,
+  VEXT4_SVF4  <-> 0b00101
+}
+
+mapping clause encdec = VEXT4TYPE(funct6, vm, vs2, vd) if haveRVV()
+  <-> 0b010010 @ vm @ vs2 @ vext4_vs1(funct6) @ 0b010 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VEXT4TYPE(funct6, vm, vs2, vd)) = {
+  let SEW = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let SEW_quart = SEW / 4;
+  let LMUL_pow_quart = LMUL_pow - 2;
+  if ~(check_eew_emul(SEW_quart, LMUL_pow_quart)) then {handle_illegal(); return RETIRE_FAIL};
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_quart;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vs2_val : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_quart, LMUL_pow_quart, vs2);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  assert(SEW > SEW_quart);
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        VEXT4_ZVF4 => EXTZ(vs2_val[i]),
+        VEXT4_SVF4 => EXTS(vs2_val[i])
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vext4type_mnemonic : vext4funct6 <-> string = {
+  VEXT4_ZVF4  <-> "vzext.vf4",
+  VEXT4_SVF4  <-> "vsext.vf4"
+}
+
+mapping clause assembly = VEXT4TYPE(funct6, vm, vs2, vd)
+  <-> vext4type_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* ****************************** OPMVV (VXUNARY0) ******************************* */
+/* ******************* Vector Integer Extension (SEW/8 source) ******************* */
+union clause ast = VEXT8TYPE : (vext8funct6, bits(1), regidx, regidx)
+
+mapping vext8_vs1 : vext8funct6 <-> bits(5) = {
+  VEXT8_ZVF8  <-> 0b00010,
+  VEXT8_SVF8  <-> 0b00011
+}
+
+mapping clause encdec = VEXT8TYPE(funct6, vm, vs2, vd) if haveRVV()
+  <-> 0b010010 @ vm @ vs2 @ vext8_vs1(funct6) @ 0b010 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VEXT8TYPE(funct6, vm, vs2, vd)) = {
+  let SEW = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let SEW_eighth = SEW / 8;
+  let LMUL_pow_eighth = LMUL_pow - 3;
+  if ~(check_eew_emul(SEW_eighth, LMUL_pow_eighth)) then {handle_illegal(); return RETIRE_FAIL};
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_eighth;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vs2_val : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_eighth, LMUL_pow_eighth, vs2);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  assert(SEW > SEW_eighth);
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        VEXT8_ZVF8 => EXTZ(vs2_val[i]),
+        VEXT8_SVF8 => EXTS(vs2_val[i])
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vext8type_mnemonic : vext8funct6 <-> string = {
+  VEXT8_ZVF8  <-> "vzext.vf8",
+  VEXT8_SVF8  <-> "vsext.vf8"
+}
+
+mapping clause assembly = VEXT8TYPE(funct6, vm, vs2, vd)
+  <-> vext8type_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* ************************ OPMVV (vmv.x.s in VWXUNARY0) ************************* */
+union clause ast = VMVXS : (regidx, regidx)
+
+mapping clause encdec = VMVXS(vs2, rd) if haveRVV()
+  <-> 0b010000 @ 0b1 @ vs2 @ 0b00000 @ 0b010 @ rd @ 0b1010111 if haveRVV()
+
+function clause execute(VMVXS(vs2, rd)) = {
+  let SEW      = get_sew();
+  let num_elem = get_num_elem(0, SEW);
+
+  assert(num_elem > 0);
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, 0, vs2);
+  X(rd) = if sizeof(xlen) < SEW then slice(vs2_val[0], 0, sizeof(xlen))
+          else if sizeof(xlen) > SEW then EXTS(vs2_val[0])
+          else vs2_val[0];
+  vstart = EXTZ(0b0);
+
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = VMVXS(vs2, rd)
+  <-> "vmv.x.s" ^ spc() ^ reg_name(rd) ^ sep() ^ vreg_name(vs2)
+
+/* ********************* OPMVV (Vector Compress Instruction) ********************* */
+union clause ast = MVVCOMPRESS : (regidx, regidx, regidx)
+
+mapping clause encdec = MVVCOMPRESS(vs2, vs1, vd) if haveRVV()
+  <-> 0b010111 @ 0b1 @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(MVVCOMPRESS(vs2, vs1, vd)) = {
+  let start_element = get_start_element();
+  let end_element = get_end_element();
+  /* vcompress should always be executed with a vstart of 0 */
+  if start_element != 0 then {handle_illegal(); return RETIRE_FAIL};
+
+  let SEW = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  assert(vd != vs1 & vd != vs2);
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vs1_val : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+
+  /* body elements */
+  vd_idx : nat = 0;
+  foreach (i from 0 to (num_elem - 1)) {
+    if i <= end_element then {
+      if vs1_val[i] then {
+        let 'p = vd_idx;
+        assert('p < 'n);
+        result['p] = vs2_val[i];
+        vd_idx = vd_idx + 1;
+      }
+    }
+  };
+  /* tail elements */
+  if vd_idx < num_elem then {
+    let tail_ag : agtype = get_vtype_vta();
+    let 'p = vd_idx;
+    if tail_ag == UNDISTURBED then {
+      foreach (i from 'p to (num_elem - 1)) result[i] = vd_val[i]
+    } else if tail_ag == AGNOSTIC then { /* TODO: configuration support */
+      foreach (i from 'p to (num_elem - 1)) result[i] = vd_val[i]
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = MVVCOMPRESS(vs2, vs1, vd)
+  <-> "vcompress.vm" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1)
+
+/* ******************************* OPMVX (MVXTYPE) ******************************* */
+union clause ast = MVXTYPE : (mvxfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_mvxfunct6 : mvxfunct6 <-> bits(6) = {
+  MVX_VAADDU        <-> 0b001000,
+  MVX_VAADD         <-> 0b001001,
+  MVX_VASUBU        <-> 0b001010,
+  MVX_VASUB         <-> 0b001011,
+  MVX_VSLIDE1UP     <-> 0b001110,
+  MVX_VSLIDE1DOWN   <-> 0b001111,
+  MVX_VMUL          <-> 0b100101,
+  MVX_VMULH         <-> 0b100111,
+  MVX_VMULHU        <-> 0b100100,
+  MVX_VMULHSU       <-> 0b100110,
+  MVX_VDIVU         <-> 0b100000,
+  MVX_VDIV          <-> 0b100001,
+  MVX_VREMU         <-> 0b100010,
+  MVX_VREM          <-> 0b100011
+}
+
+mapping clause encdec = MVXTYPE(funct6, vm, vs2, rs1, vd) if haveRVV()
+  <-> encdec_mvxfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b110 @ vd @ 0b1010111 if haveRVV() 
+
+function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        MVX_VAADDU       => {
+                              let result_add = EXTZ('m + 1, vs2_val[i]) + EXTZ('m + 1, rs1_val);
+                              let rounding_incr = get_fixed_rounding_incr(result_add, 1);
+                              slice(result_add >> 1, 0, 'm) + EXTZ('m, rounding_incr)                              
+                            },
+        MVX_VAADD        => {
+                              let result_add = EXTS('m + 1, vs2_val[i]) + EXTS('m + 1, rs1_val);
+                              let rounding_incr = get_fixed_rounding_incr(result_add, 1);
+                              slice(result_add >> 1, 0, 'm) + EXTZ('m, rounding_incr)
+                            },
+        MVX_VASUBU       => {
+                              let result_sub = EXTZ('m + 1, vs2_val[i]) - EXTZ('m + 1, rs1_val);
+                              let rounding_incr = get_fixed_rounding_incr(result_sub, 1);
+                              slice(result_sub >> 1, 0, 'm) + EXTZ('m, rounding_incr)                               
+                            },
+        MVX_VASUB        => {
+                              let result_sub = EXTS('m + 1, vs2_val[i]) - EXTS('m + 1, rs1_val);
+                              let rounding_incr = get_fixed_rounding_incr(result_sub, 1);
+                              slice(result_sub >> 1, 0, 'm) + EXTZ('m, rounding_incr)
+                            },
+        MVX_VSLIDE1UP    => {
+                              assert(vs2 != vd);
+                              if i == 0 then rs1_val else vs2_val[i - 1]
+                            },
+        MVX_VSLIDE1DOWN  => {
+                              assert(vs2 != vd);
+                              let last_elem = get_end_element();
+                              assert(last_elem < num_elem);
+                              if i < last_elem then vs2_val[i + 1] else rs1_val
+                            },
+        MVX_VMUL         => slice(to_bits(SEW * 2, signed(vs2_val[i]) * signed(rs1_val)), 0, SEW),
+        MVX_VMULH        => slice(to_bits(SEW * 2, signed(vs2_val[i]) * signed(rs1_val)), SEW, SEW),
+        MVX_VMULHU       => slice(to_bits(SEW * 2, unsigned(vs2_val[i]) * unsigned(rs1_val)), SEW, SEW),
+        MVX_VMULHSU      => slice(to_bits(SEW * 2, signed(vs2_val[i]) * unsigned(rs1_val)), SEW, SEW),
+        MVX_VDIVU        => {
+                              let q : int = if unsigned(rs1_val) == 0 then -1 else quot_round_zero(unsigned(vs2_val[i]), unsigned(rs1_val));
+                              to_bits(SEW, q)
+                            },
+        MVX_VDIV         => {
+                              let elem_max : int = 2 ^ (SEW - 1) - 1;
+                              let elem_min : int = 0 - 2 ^ (SEW - 1);
+                              let q : int = if signed(rs1_val) == 0 then -1 else quot_round_zero(signed(vs2_val[i]), signed(rs1_val));
+                              /* check for signed overflow */
+                              let q' : int = if q > elem_max then elem_min else q;
+                              to_bits(SEW, q')
+                            },
+        MVX_VREMU        => {
+                              let r : int = if unsigned(rs1_val) == 0 then unsigned(vs2_val[i]) else rem_round_zero(unsigned(vs2_val[i]), unsigned (rs1_val));
+                              /* signed overflow case returns zero naturally as required due to -1 divisor */
+                              to_bits(SEW, r)
+                            },
+        MVX_VREM         => {
+                              let r : int = if signed(rs1_val) == 0 then signed(vs2_val[i]) else rem_round_zero(signed(vs2_val[i]), signed(rs1_val));
+                              /* signed overflow case returns zero naturally as required due to -1 divisor */
+                              to_bits(SEW, r)
+                            }
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping mvxtype_mnemonic : mvxfunct6 <-> string = {
+  MVX_VAADDU        <-> "vaaddu.vx",
+  MVX_VAADD         <-> "vaadd.vx",
+  MVX_VASUBU        <-> "vasubu.vx",
+  MVX_VASUB         <-> "vasub.vx",
+  MVX_VSLIDE1UP     <-> "vslide1up.vx",
+  MVX_VSLIDE1DOWN   <-> "vslide1down.vx",
+  MVX_VMUL          <-> "vmul.vx",
+  MVX_VMULH         <-> "vmulh.vx",
+  MVX_VMULHU        <-> "vmulhu.vx",
+  MVX_VMULHSU       <-> "vmulhsu.vx",
+  MVX_VDIVU         <-> "vdivu.vx",
+  MVX_VDIV          <-> "vdiv.vx",
+  MVX_VREMU         <-> "vremu.vx",
+  MVX_VREM          <-> "vrem.vx"
+}
+
+mapping clause assembly = MVXTYPE(funct6, vm, vs2, rs1, vd)
+  <-> mvxtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm) 
+
+/* ************************ OPMVX (MVXtype Multiply-Add) ************************* */
+/* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
+union clause ast = MVXMATYPE : (mvxmafunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_mvxmafunct6 : mvxmafunct6 <-> bits(6) = {
+  MVX_VMACC         <-> 0b101101,
+  MVX_VNMSAC        <-> 0b101111,
+  MVX_VMADD         <-> 0b101001,
+  MVX_VNMSUB        <-> 0b101011
+}
+
+mapping clause encdec = MVXMATYPE(funct6, vm, vs2, rs1, vd) if haveRVV()
+  <-> encdec_mvxmafunct6(funct6) @ vm @ vs2 @ rs1 @ 0b110 @ vd @ 0b1010111 if haveRVV() 
+
+function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let VLEN     = int_power(2, get_vlen_pow());
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  assert(VLEN >= 0);
+  foreach (i from 0 to (num_elem - 1)){
+    if mask[i] then{
+      result[i] = match funct6 {
+        MVX_VMACC  => slice(to_bits(VLEN, signed(rs1_val) * signed(vs2_val[i]) ), 0, SEW) + vd_val[i],
+        MVX_VNMSAC => vd_val[i] - slice(to_bits(VLEN, signed(rs1_val) * signed(vs2_val[i]) ), 0, SEW),
+        MVX_VMADD  => slice(to_bits(VLEN, signed(rs1_val) * signed(vd_val[i]) ), 0, SEW) + vs2_val[i],
+        MVX_VNMSUB => vs2_val[i] - slice(to_bits(VLEN, signed(rs1_val) * signed(vd_val[i]) ), 0, SEW)
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping mvxmatype_mnemonic : mvxmafunct6 <-> string = {
+  MVX_VMACC         <-> "vmacc.vx",
+  MVX_VNMSAC        <-> "vnmsac.vx",
+  MVX_VMADD         <-> "vmadd.vx",
+  MVX_VNMSUB        <-> "vnmsub.vx"
+}
+
+mapping clause assembly = MVXMATYPE(funct6, vm, vs2, rs1, vd)
+  <-> mvxmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* *************************** OPMVX (VXTYPE Widening) *************************** */
+union clause ast = WVXTYPE : (wvxfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_wvxfunct6 : wvxfunct6 <-> bits(6) = {
+  WVX_VADD       <-> 0b110001,
+  WVX_VSUB       <-> 0b110011,
+  WVX_VADDU      <-> 0b110000,
+  WVX_VSUBU      <-> 0b110010,
+  WVX_VWMUL      <-> 0b111011,
+  WVX_VWMULU     <-> 0b111000,
+  WVX_VWMULSU    <-> 0b111010
+}
+
+mapping clause encdec = WVXTYPE(funct6, vm, vs2, rs1, vd) if haveRVV()
+  <-> encdec_wvxfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b110 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(WVXTYPE(funct6, vm, vs2, rs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  result      : vector('n, dec, bits('o)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  assert(8 <= SEW_widen & SEW_widen <= 64);
+  (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        WVX_VADD    => to_bits(SEW_widen, signed(vs2_val[i]) + signed(rs1_val)),
+        WVX_VSUB    => to_bits(SEW_widen, signed(vs2_val[i]) - signed(rs1_val)),
+        WVX_VADDU   => to_bits(SEW_widen, unsigned(vs2_val[i]) + unsigned(rs1_val)),
+        WVX_VSUBU   => to_bits(SEW_widen, unsigned(vs2_val[i]) - unsigned(rs1_val)),
+        WVX_VWMUL   => to_bits(SEW_widen, signed(vs2_val[i]) * signed(rs1_val)),
+        WVX_VWMULU  => to_bits(SEW_widen, unsigned(vs2_val[i]) * unsigned(rs1_val)),
+        WVX_VWMULSU => to_bits(SEW_widen, signed(vs2_val[i]) * unsigned(rs1_val))
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping wvxtype_mnemonic : wvxfunct6 <-> string = {
+  WVX_VADD       <-> "vwadd.vx",
+  WVX_VSUB       <-> "vwsub.vx",
+  WVX_VADDU      <-> "vwaddu.vx",
+  WVX_VSUBU      <-> "vwsubu.vx",
+  WVX_VWMUL      <-> "vwmul.vx",
+  WVX_VWMULU     <-> "vwmulu.vx",
+  WVX_VWMULSU    <-> "vwmulsu.vx"
+}
+
+mapping clause assembly = WVXTYPE(funct6, vm, vs2, rs1, vd)
+  <-> wvxtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+
+/* ******************************* OPMVX (WXTYPE) ******************************** */
+union clause ast = WXTYPE : (wxfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_wxfunct6 : wxfunct6 <-> bits(6) = {
+  WX_VADD       <-> 0b110101,
+  WX_VSUB       <-> 0b110111,
+  WX_VADDU      <-> 0b110100,
+  WX_VSUBU      <-> 0b110110
+}
+
+mapping clause encdec = WXTYPE(funct6, vm, vs2, rs1, vd) if haveRVV()
+  <-> encdec_wxfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b110 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(WXTYPE(funct6, vm, vs2, rs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  result      : vector('n, dec, bits('o)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  assert(8 <= SEW_widen & SEW_widen <= 64);
+  (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        WX_VADD  => to_bits(SEW_widen, signed(vs2_val[i]) + signed(rs1_val)),
+        WX_VSUB  => to_bits(SEW_widen, signed(vs2_val[i]) - signed(rs1_val)),
+        WX_VADDU => to_bits(SEW_widen, unsigned(vs2_val[i]) + unsigned(rs1_val)),
+        WX_VSUBU => to_bits(SEW_widen, unsigned(vs2_val[i]) - unsigned(rs1_val))
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping wxtype_mnemonic : wxfunct6 <-> string = {
+  WX_VADD       <-> "vwadd.wx",
+  WX_VSUB       <-> "vwsub.wx",
+  WX_VADDU      <-> "vwaddu.wx",
+  WX_VSUBU      <-> "vwsubu.wx"
+}
+
+mapping clause assembly = WXTYPE(funct6, vm, vs2, rs1, vd)
+  <-> wxtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+
+/* ******************** OPMVX (MVXtype Widening Multiply-Add) ******************** */
+/* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
+union clause ast =  WMVXTYPE : (wmvxfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_wmvxfunct6 : wmvxfunct6 <-> bits(6) = {
+  WMVX_VWMACCU    <-> 0b111100,
+  WMVX_VWMACC     <-> 0b111101,
+  WMVX_VWMACCUS   <-> 0b111110,
+  WMVX_VWMACCSU   <-> 0b111111
+}
+
+mapping clause encdec = WMVXTYPE(funct6, vm, vs2, rs1, vd) if haveRVV()
+  <-> encdec_wmvxfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b110 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(WMVXTYPE(funct6, vm, vs2, rs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+  if ~(check_eew_emul(SEW_widen, LMUL_pow_widen)) then {handle_illegal(); return RETIRE_FAIL};
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  result      : vector('n, dec, bits('o)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  assert(8 <= SEW_widen & SEW_widen <= 64);
+  (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        WMVX_VWMACCU  => (to_bits(SEW_widen, unsigned(rs1_val) * unsigned(vs2_val[i]) )) + vd_val[i],
+        WMVX_VWMACC   => (to_bits(SEW_widen, signed(rs1_val) * signed(vs2_val[i]) )) + vd_val[i],
+        WMVX_VWMACCUS => (to_bits(SEW_widen, unsigned(rs1_val) * signed(vs2_val[i]) ))+ vd_val[i],
+        WMVX_VWMACCSU => (to_bits(SEW_widen, signed(rs1_val) * unsigned(vs2_val[i]) ))+ vd_val[i]
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping wmvxtype_mnemonic : wmvxfunct6 <-> string = {
+  WMVX_VWMACCU     <-> "vwmaccu.vx",
+  WMVX_VWMACC      <-> "vwmacc.vx",
+  WMVX_VWMACCUS    <-> "vwmaccus.vx",
+  WMVX_VWMACCSU    <-> "vwmaccsu.vx"
+}
+
+mapping clause assembly = WMVXTYPE(funct6, vm, vs2, rs1, vd)
+  <-> wmvxtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* ****************************** OPMVX (VRXUNARY0) ****************************** */
+union clause ast = VMVSX : (regidx, regidx)
+
+mapping clause encdec = VMVSX(rs1, vd) if haveRVV()
+  <-> 0b010000 @ 0b1 @ 0b00000 @ rs1 @ 0b110 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VMVSX(rs1, vd)) = {
+  let SEW      = get_sew();
+  let num_elem = get_num_elem(0, SEW);
+
+  assert(num_elem > 0);
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
+  let rs1_val : bits('m)                  = get_scalar(rs1, 'm);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, 0, vd_val, vm_val);
+
+  /* one body element */
+  if mask[0] then result[0] = rs1_val;
+
+  /* others treated as tail elements */
+  let tail_ag : agtype = get_vtype_vta();
+  if tail_ag == UNDISTURBED then {
+    foreach (i from 1 to (num_elem - 1)) result[i] = vd_val[i]
+  } else if tail_ag == AGNOSTIC then {
+    foreach (i from 1 to (num_elem - 1)) result[i] = vd_val[i] /* TODO: configuration support */
+  };
+
+  write_vreg(num_elem, SEW, 0, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = VMVSX(rs1, vd)
+  <-> "vmv.s.x" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)

--- a/model/riscv_insts_vext_mask.sail
+++ b/model/riscv_insts_vext_mask.sail
@@ -1,0 +1,373 @@
+/* ******************************************************************************* */
+/* This file implements part of the vector extension.                              */
+/* Chapter 15: vector mask instructions                                            */
+/* ******************************************************************************* */
+
+/* ******************************* OPMVV (MMTYPE) ******************************** */
+union clause ast = MMTYPE : (mmfunct6, regidx, regidx, regidx)
+
+mapping encdec_mmfunct6 : mmfunct6 <-> bits(6) = {
+  MM_VMAND     <-> 0b011001,
+  MM_VMNAND    <-> 0b011101,
+  MM_VMANDNOT  <-> 0b011000,
+  MM_VMXOR     <-> 0b011011,
+  MM_VMOR      <-> 0b011010,
+  MM_VMNOR     <-> 0b011110,
+  MM_VMORNOT   <-> 0b011100,
+  MM_VMXNOR    <-> 0b011111
+}
+
+mapping clause encdec = MMTYPE(funct6, vs2, vs1, vd) if haveRVV()
+  <-> encdec_mmfunct6(funct6) @ 0b1 @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(MMTYPE(funct6, vs2, vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vs1_val : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vs1);
+  let vs2_val : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vs2);
+  let vd_val  : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vd);
+  result      : vector('n, dec, bool) = undefined;
+  mask        : vector('n, dec, bool) = undefined;
+
+  (result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      let res : bool = match funct6 {
+        MM_VMAND     => vs2_val[i] & vs1_val[i],
+        MM_VMNAND    => ~(vs2_val[i] & vs1_val[i]),
+        MM_VMANDNOT  => vs2_val[i] & ~(vs1_val[i]),
+        MM_VMXOR     => vs2_val[i] ^ vs1_val[i],
+        MM_VMOR      => vs2_val[i] | vs1_val[i],
+        MM_VMNOR     => ~(vs2_val[i] | vs1_val[i]),
+        MM_VMORNOT   => vs2_val[i] | ~(vs1_val[i]),
+        MM_VMXNOR    => ~(vs2_val[i] ^ vs1_val[i])
+      };
+      result[i] = res;
+    }
+  };
+
+  write_vmask(num_elem, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping mmtype_mnemonic : mmfunct6 <-> string = {
+  MM_VMAND     <-> "vmand.mm",
+  MM_VMNAND    <-> "vmnand.mm",
+  MM_VMANDNOT  <-> "vmandnot.mm",
+  MM_VMXOR     <-> "vmxor.mm",
+  MM_VMOR      <-> "vmor.mm",
+  MM_VMNOR     <-> "vmnor.mm",
+  MM_VMORNOT   <-> "vmornot.mm",
+  MM_VMXNOR    <-> "vmxnor.mm"
+}
+
+mapping clause assembly = MMTYPE(funct6, vs2, vs1, vd)
+  <-> mmtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1)
+
+/* ************************* OPMVV (vpopc in VWXUNARY0) ************************** */
+union clause ast = VCPOP_M : (bits(1), regidx, regidx)
+
+mapping clause encdec = VCPOP_M(vm, vs2, rd) if haveRVV()
+  <-> 0b010000 @ vm @ vs2 @ 0b10000 @ 0b010 @ rd @ 0b1010111 if haveRVV()
+
+function clause execute(VCPOP_M(vm, vs2, rd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  
+  let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs2_val : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vs2);
+  result      : vector('n, dec, bool) = undefined;
+  mask        : vector('n, dec, bool) = undefined;
+
+  /* Value of vstart must be 0 */
+  if ~(assert_vstart(0)) then {handle_illegal(); return RETIRE_FAIL};
+
+  (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vs2_val, vm_val);
+
+  count : nat = 0;
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] & vs2_val[i] then count = count + 1;
+  };
+  
+  X(rd) = to_bits(sizeof(xlen), count);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = VCPOP_M(vm, vs2, rd)
+  <-> "vpopc.m" ^ spc() ^ reg_name(rd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* ************************* OPMVV (vfirst in VWXUNARY0) ************************* */
+union clause ast = VFIRST_M : (bits(1), regidx, regidx)
+
+mapping clause encdec = VFIRST_M(vm, vs2, rd) if haveRVV()
+  <-> 0b010000 @ vm @ vs2 @ 0b10001 @ 0b010 @ rd @ 0b1010111 if haveRVV()
+
+function clause execute(VFIRST_M(vm, vs2, rd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  
+  let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs2_val : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vs2);
+  result      : vector('n, dec, bool) = undefined;
+  mask        : vector('n, dec, bool) = undefined;
+
+  /* Value of vstart must be 0 */
+  if ~(assert_vstart(0)) then {handle_illegal(); return RETIRE_FAIL};
+
+  (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vs2_val, vm_val);
+
+  index : int = -1;
+  foreach (i from 0 to (num_elem - 1)) {
+    if index == -1 then {
+      if mask[i] & vs2_val[i] then index = i;
+    };
+  };
+
+  X(rd) = to_bits(sizeof(xlen), index);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = VFIRST_M(vm, vs2, rd)
+  <-> "vfirst.m" ^ spc() ^ reg_name(rd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* ************************** OPMVV (vmsbf in VMUNARY0) ************************** */
+union clause ast = VMSBF_M : (bits(1), regidx, regidx)
+
+mapping clause encdec = VMSBF_M(vm, vs2, vd) if haveRVV()
+  <-> 0b010100 @ vm @ vs2 @ 0b00001 @ 0b010 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VMSBF_M(vm, vs2, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  
+  let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs2_val : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vs2);
+  let vd_val  : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vd);
+  result      : vector('n, dec, bool) = undefined;
+  mask        : vector('n, dec, bool) = undefined;
+
+  /* Value of vstart must be 0 */
+  if ~(assert_vstart(0)) then {handle_illegal(); return RETIRE_FAIL};
+
+  /* If masking is enabled, then dest reg cannot be v0 */
+  if vm == 0b0 & vd == vreg_name("v0") then {handle_illegal(); return RETIRE_FAIL};
+
+  /* Dest reg cannot be the same as source reg */
+  if vd == vs2 then {handle_illegal(); return RETIRE_FAIL};
+
+  (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  found_elem : bool = false;
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      if vs2_val[i] then found_elem = true;
+      result[i] = if found_elem then false else true
+    }
+  };
+  
+  write_vmask(num_elem, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = VMSBF_M(vm, vs2, vd)
+  <-> "vmsbf.m" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* ************************** OPMVV (vmsif in VMUNARY0) ************************** */
+union clause ast = VMSIF_M : (bits(1), regidx, regidx)
+
+mapping clause encdec = VMSIF_M(vm, vs2, vd) if haveRVV()
+  <-> 0b010100 @ vm @ vs2 @ 0b00011 @ 0b010 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VMSIF_M(vm, vs2, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  
+  let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs2_val : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vs2);
+  let vd_val  : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vd);
+  result      : vector('n, dec, bool) = undefined;
+  mask        : vector('n, dec, bool) = undefined;
+
+  /* Value of vstart must be 0 */
+  if ~(assert_vstart(0)) then {handle_illegal(); return RETIRE_FAIL};
+
+  /* If masking is enabled, then dest reg cannot be v0 */
+  if vm == 0b0 & vd == vreg_name("v0") then {handle_illegal(); return RETIRE_FAIL};
+
+  /* Dest reg cannot be the same as source reg */
+  if vd == vs2 then {handle_illegal(); return RETIRE_FAIL};
+
+  (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  found_elem : bool = false;
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = if found_elem then false else true;
+      if vs2_val[i] then found_elem = true
+    }
+  };
+
+  write_vmask(num_elem, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = VMSIF_M(vm, vs2, vd)
+  <-> "vmsif.m" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* ************************** OPMVV (vmsof in VMUNARY0) ************************** */
+union clause ast = VMSOF_M : (bits(1), regidx, regidx)
+
+mapping clause encdec = VMSOF_M(vm, vs2, vd) if haveRVV()
+  <-> 0b010100 @ vm @ vs2 @ 0b00010 @ 0b010 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VMSOF_M(vm, vs2, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  
+  let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs2_val : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vs2);
+  let vd_val  : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vd);
+  result      : vector('n, dec, bool) = undefined;
+  mask        : vector('n, dec, bool) = undefined;
+
+  /* Value of vstart must be 0 */
+  if ~(assert_vstart(0)) then {handle_illegal(); return RETIRE_FAIL};
+
+  /* If masking is enabled, then dest reg cannot be v0 */
+  if vm == 0b0 & vd == vreg_name("v0") then {handle_illegal(); return RETIRE_FAIL};
+
+  /* Dest reg cannot be the same as source reg */
+  if vd == vs2 then {handle_illegal(); return RETIRE_FAIL};
+
+  (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  found_elem : bool = false;
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      if vs2_val[i] & ~(found_elem) then {
+        result[i] = true;
+        found_elem = true
+      } else {
+        result[i] = false
+      }
+    }
+  };
+  
+  write_vmask(num_elem, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = VMSOF_M(vm, vs2, vd)
+  <-> "vmsof.m" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* ************************** OPMVV (viota in VMUNARY0) ************************** */
+union clause ast = VIOTA_M : (bits(1), regidx, regidx)
+
+mapping clause encdec = VIOTA_M(vm, vs2, vd) if haveRVV()
+  <-> 0b010100 @ vm @ vs2 @ 0b10000 @ 0b010 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VIOTA_M(vm, vs2, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs2_val : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  /* Value of vstart must be 0 */
+  if ~(assert_vstart(0)) then {handle_illegal(); return RETIRE_FAIL};
+
+  /* If masking is enabled, then dest reg cannot be v0 */
+  if vm == 0b0 & vd == vreg_name("v0") then {handle_illegal(); return RETIRE_FAIL};
+
+  /* Dest reg cannot be the same as source reg */
+  if vd == vs2 then {handle_illegal(); return RETIRE_FAIL};
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  sum : int = 0;
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = to_bits(SEW, sum);
+      if vs2_val[i] then sum = sum + 1
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = VIOTA_M(vm, vs2, vd)
+  <-> "viota.m" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* *************************** OPMVV (vid in VMUNARY0) *************************** */
+union clause ast = VID_V : (bits(1), regidx)
+
+mapping clause encdec = VID_V(vm, vd) if haveRVV()
+  <-> 0b010100 @ vm @ 0b00000 @ 0b10001 @ 0b010 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VID_V(vm, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then result[i] = to_bits(SEW, i)
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = VID_V(vm, vd)
+  <-> "vid.v" ^ spc() ^ vreg_name(vd) ^ maybe_vmask(vm)

--- a/model/riscv_insts_vext_mask.sail
+++ b/model/riscv_insts_vext_mask.sail
@@ -91,7 +91,7 @@ function clause execute(VCPOP_M(vm, vs2, rd)) = {
   mask        : vector('n, dec, bool) = undefined;
 
   /* Value of vstart must be 0 */
-  if ~(assert_vstart(0)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
 
   (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vs2_val, vm_val);
 
@@ -128,7 +128,7 @@ function clause execute(VFIRST_M(vm, vs2, rd)) = {
   mask        : vector('n, dec, bool) = undefined;
 
   /* Value of vstart must be 0 */
-  if ~(assert_vstart(0)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
 
   (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vs2_val, vm_val);
 
@@ -168,13 +168,13 @@ function clause execute(VMSBF_M(vm, vs2, vd)) = {
   mask        : vector('n, dec, bool) = undefined;
 
   /* Value of vstart must be 0 */
-  if ~(assert_vstart(0)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
 
   /* If masking is enabled, then dest reg cannot be v0 */
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   /* Dest reg cannot be the same as source reg */
-  if vd == vs2 then {handle_illegal(); return RETIRE_FAIL};
+  if vd == vs2 then { handle_illegal(); return RETIRE_FAIL };
 
   (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 
@@ -215,13 +215,13 @@ function clause execute(VMSIF_M(vm, vs2, vd)) = {
   mask        : vector('n, dec, bool) = undefined;
 
   /* Value of vstart must be 0 */
-  if ~(assert_vstart(0)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
 
   /* If masking is enabled, then dest reg cannot be v0 */
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   /* Dest reg cannot be the same as source reg */
-  if vd == vs2 then {handle_illegal(); return RETIRE_FAIL};
+  if vd == vs2 then { handle_illegal(); return RETIRE_FAIL };
 
   (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 
@@ -262,13 +262,13 @@ function clause execute(VMSOF_M(vm, vs2, vd)) = {
   mask        : vector('n, dec, bool) = undefined;
 
   /* Value of vstart must be 0 */
-  if ~(assert_vstart(0)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
 
   /* If masking is enabled, then dest reg cannot be v0 */
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   /* Dest reg cannot be the same as source reg */
-  if vd == vs2 then {handle_illegal(); return RETIRE_FAIL};
+  if vd == vs2 then { handle_illegal(); return RETIRE_FAIL };
 
   (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 
@@ -313,13 +313,13 @@ function clause execute(VIOTA_M(vm, vs2, vd)) = {
   mask        : vector('n, dec, bool)     = undefined;
 
   /* Value of vstart must be 0 */
-  if ~(assert_vstart(0)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
 
   /* If masking is enabled, then dest reg cannot be v0 */
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   /* Dest reg cannot be the same as source reg */
-  if vd == vs2 then {handle_illegal(); return RETIRE_FAIL};
+  if vd == vs2 then { handle_illegal(); return RETIRE_FAIL };
 
   (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 
@@ -350,7 +350,7 @@ function clause execute(VID_V(vm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;

--- a/model/riscv_insts_vext_mask.sail
+++ b/model/riscv_insts_vext_mask.sail
@@ -84,7 +84,7 @@ function clause execute(VCPOP_M(vm, vs2, rd)) = {
 
   let 'n = num_elem;
   let 'm = SEW;
-  
+
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vs2_val : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vs2);
   result      : vector('n, dec, bool) = undefined;
@@ -99,7 +99,7 @@ function clause execute(VCPOP_M(vm, vs2, rd)) = {
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] & vs2_val[i] then count = count + 1;
   };
-  
+
   X(rd) = to_bits(sizeof(xlen), count);
   vstart = EXTZ(0b0);
   RETIRE_SUCCESS
@@ -121,7 +121,7 @@ function clause execute(VFIRST_M(vm, vs2, rd)) = {
 
   let 'n = num_elem;
   let 'm = SEW;
-  
+
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vs2_val : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vs2);
   result      : vector('n, dec, bool) = undefined;
@@ -160,7 +160,7 @@ function clause execute(VMSBF_M(vm, vs2, vd)) = {
 
   let 'n = num_elem;
   let 'm = SEW;
-  
+
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vs2_val : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vd);
@@ -171,7 +171,7 @@ function clause execute(VMSBF_M(vm, vs2, vd)) = {
   if ~(assert_vstart(0)) then {handle_illegal(); return RETIRE_FAIL};
 
   /* If masking is enabled, then dest reg cannot be v0 */
-  if vm == 0b0 & vd == vreg_name("v0") then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
 
   /* Dest reg cannot be the same as source reg */
   if vd == vs2 then {handle_illegal(); return RETIRE_FAIL};
@@ -185,7 +185,7 @@ function clause execute(VMSBF_M(vm, vs2, vd)) = {
       result[i] = if found_elem then false else true
     }
   };
-  
+
   write_vmask(num_elem, vd, result);
   vstart = EXTZ(0b0);
   RETIRE_SUCCESS
@@ -207,7 +207,7 @@ function clause execute(VMSIF_M(vm, vs2, vd)) = {
 
   let 'n = num_elem;
   let 'm = SEW;
-  
+
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vs2_val : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vd);
@@ -218,7 +218,7 @@ function clause execute(VMSIF_M(vm, vs2, vd)) = {
   if ~(assert_vstart(0)) then {handle_illegal(); return RETIRE_FAIL};
 
   /* If masking is enabled, then dest reg cannot be v0 */
-  if vm == 0b0 & vd == vreg_name("v0") then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
 
   /* Dest reg cannot be the same as source reg */
   if vd == vs2 then {handle_illegal(); return RETIRE_FAIL};
@@ -254,7 +254,7 @@ function clause execute(VMSOF_M(vm, vs2, vd)) = {
 
   let 'n = num_elem;
   let 'm = SEW;
-  
+
   let vm_val  : vector('n, dec, bool) = read_vmask(num_elem, vm, vreg_name("v0"));
   let vs2_val : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : vector('n, dec, bool) = read_vmask(num_elem, 0b0, vd);
@@ -265,7 +265,7 @@ function clause execute(VMSOF_M(vm, vs2, vd)) = {
   if ~(assert_vstart(0)) then {handle_illegal(); return RETIRE_FAIL};
 
   /* If masking is enabled, then dest reg cannot be v0 */
-  if vm == 0b0 & vd == vreg_name("v0") then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
 
   /* Dest reg cannot be the same as source reg */
   if vd == vs2 then {handle_illegal(); return RETIRE_FAIL};
@@ -283,7 +283,7 @@ function clause execute(VMSOF_M(vm, vs2, vd)) = {
       }
     }
   };
-  
+
   write_vmask(num_elem, vd, result);
   vstart = EXTZ(0b0);
   RETIRE_SUCCESS
@@ -305,7 +305,7 @@ function clause execute(VIOTA_M(vm, vs2, vd)) = {
 
   let 'n = num_elem;
   let 'm = SEW;
-  
+
   let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
   let vs2_val : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -316,7 +316,7 @@ function clause execute(VIOTA_M(vm, vs2, vd)) = {
   if ~(assert_vstart(0)) then {handle_illegal(); return RETIRE_FAIL};
 
   /* If masking is enabled, then dest reg cannot be v0 */
-  if vm == 0b0 & vd == vreg_name("v0") then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
 
   /* Dest reg cannot be the same as source reg */
   if vd == vs2 then {handle_illegal(); return RETIRE_FAIL};
@@ -349,6 +349,8 @@ function clause execute(VID_V(vm, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
 
   let 'n = num_elem;
   let 'm = SEW;

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -115,7 +115,7 @@ function clause execute(VLETYPE(vm, rs1, width, vd)) = {
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vle(vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -261,7 +261,7 @@ function clause execute(VLSETYPE(vm, rs2, rs1, width, vd)) = {
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlse(vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
@@ -408,7 +408,7 @@ function clause execute(VLUXEITYPE(vm, vs2, rs1, width, vd)) = {
   let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
   let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlxei(vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
@@ -431,7 +431,7 @@ function clause execute(VLOXEITYPE(vm, vs2, rs1, width, vd)) = {
   let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
   let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlxei(vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
@@ -613,7 +613,7 @@ function clause execute(VLEFFTYPE(vm, rs1, width, vd)) = {
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vleff(vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -693,7 +693,7 @@ function clause execute(VLSEGTYPE(nf, vm, rs1, width, vd)) = {
   let num_elem = get_num_elem(EMUL_pow, EEW); /* # of element of each register group */
   let nf_int = nfields_int(nf);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlseg(nf_int, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -786,7 +786,7 @@ function clause execute(VLSEGFFTYPE(nf, vm, rs1, width, vd)) = {
   let num_elem = get_num_elem(EMUL_pow, EEW);
   let nf_int = nfields_int(nf);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlsegff(nf_int, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -922,7 +922,7 @@ function clause execute(VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)) = {
   let num_elem = get_num_elem(EMUL_pow, EEW);
   let nf_int = nfields_int(nf);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlsseg(nf_int, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
@@ -1062,7 +1062,7 @@ function clause execute(VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
   let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8);
   let nf_int = nfields_int(nf);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlxseg(nf_int, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
@@ -1086,7 +1086,7 @@ function clause execute(VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
   let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8);
   let nf_int = nfields_int(nf);
 
-  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlxseg(nf_int, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
@@ -1268,7 +1268,7 @@ function clause execute(VLRETYPE(nf, rs1, width, vd)) = {
   let nf_int = nfields_int(nf);
 
   assert(elem_per_reg >= 0);
-  if ~(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlre(nf_int, vd, load_width_bytes, rs1, elem_per_reg)
 }
@@ -1372,7 +1372,7 @@ function clause execute(VSRETYPE(nf, rs1, vs3)) = {
   let nf_int = nfields_int(nf);
 
   assert(elem_per_reg >= 0);
-  if ~(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then {handle_illegal(); return RETIRE_FAIL};
+  if ~(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vsre(nf_int, load_width_bytes, rs1, vs3, elem_per_reg)
 }

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -115,6 +115,8 @@ function clause execute(VLETYPE(vm, rs1, width, vd)) = {
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+
   process_vle(vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
 
@@ -259,6 +261,8 @@ function clause execute(VLSETYPE(vm, rs2, rs1, width, vd)) = {
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+
   process_vlse(vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
 
@@ -402,7 +406,9 @@ function clause execute(VLUXEITYPE(vm, vs2, rs1, width, vd)) = {
   let EEW_data_bytes = get_sew_bytes();
   let EMUL_data_pow = get_lmul_pow();
   let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
-  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
+  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8);
+
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
 
   process_vlxei(vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
@@ -423,7 +429,9 @@ function clause execute(VLOXEITYPE(vm, vs2, rs1, width, vd)) = {
   let EEW_data_bytes = get_sew_bytes();
   let EMUL_data_pow = get_lmul_pow();
   let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
-  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
+  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8);
+
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
 
   process_vlxei(vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
@@ -605,6 +613,8 @@ function clause execute(VLEFFTYPE(vm, rs1, width, vd)) = {
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
+
   process_vleff(vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
 
@@ -682,6 +692,8 @@ function clause execute(VLSEGTYPE(nf, vm, rs1, width, vd)) = {
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
   let num_elem = get_num_elem(EMUL_pow, EEW); /* # of element of each register group */
   let nf_int = nfields_int(nf);
+
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
 
   process_vlseg(nf_int, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -773,6 +785,8 @@ function clause execute(VLSEGFFTYPE(nf, vm, rs1, width, vd)) = {
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
   let num_elem = get_num_elem(EMUL_pow, EEW);
   let nf_int = nfields_int(nf);
+
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
 
   process_vlsegff(nf_int, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -907,6 +921,8 @@ function clause execute(VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)) = {
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
   let num_elem = get_num_elem(EMUL_pow, EEW);
   let nf_int = nfields_int(nf);
+
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
 
   process_vlsseg(nf_int, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
@@ -1043,8 +1059,10 @@ function clause execute(VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
   let EEW_data_bytes = get_sew_bytes();
   let EMUL_data_pow = get_lmul_pow();
   let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
-  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
+  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8);
   let nf_int = nfields_int(nf);
+
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
 
   process_vlxseg(nf_int, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
@@ -1065,8 +1083,10 @@ function clause execute(VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
   let EEW_data_bytes = get_sew_bytes();
   let EMUL_data_pow = get_lmul_pow();
   let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
-  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8); /* number of data and indices are the same */
+  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8);
   let nf_int = nfields_int(nf);
+
+  if ~(valid_rd_mask(vd, vm)) then {handle_illegal(); return RETIRE_FAIL};
 
   process_vlxseg(nf_int, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
@@ -1248,7 +1268,7 @@ function clause execute(VLRETYPE(nf, rs1, width, vd)) = {
   let nf_int = nfields_int(nf);
 
   assert(elem_per_reg >= 0);
-  assert(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8);
+  if ~(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then {handle_illegal(); return RETIRE_FAIL};
 
   process_vlre(nf_int, vd, load_width_bytes, rs1, elem_per_reg)
 }
@@ -1352,7 +1372,7 @@ function clause execute(VSRETYPE(nf, rs1, vs3)) = {
   let nf_int = nfields_int(nf);
 
   assert(elem_per_reg >= 0);
-  assert(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8);
+  if ~(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then {handle_illegal(); return RETIRE_FAIL};
 
   process_vsre(nf_int, load_width_bytes, rs1, vs3, elem_per_reg)
 }

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -12,8 +12,7 @@ mapping maybe_vmask : string <-> bits(1) = {
 val check_eew_emul : (int, int) -> bool effect {rreg}
 function check_eew_emul(EEW, EMUL_pow) = {
   let ELEN = int_power(2, get_elen_pow());
-  EEW      >= 8  & EEW      <= ELEN &
-  EMUL_pow >= -3 & EMUL_pow <= 3;
+  EEW >= 8 & EEW <= ELEN & EMUL_pow >= -3 & EMUL_pow <= 3;
 }
 
 /* Check for vstart value */

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -8,6 +8,14 @@ mapping maybe_vmask : string <-> bits(1) = {
   sep() ^ "v0.t"  <-> 0b0
 }
 
+/* Check for valid EEW and EMUL values in vector widening/narrowing instructions */
+val check_eew_emul : (int, int) -> bool effect {rreg}
+function check_eew_emul(EEW, EMUL_pow) = {
+  let ELEN = int_power(2, get_elen_pow());
+  EEW      >= 8  & EEW      <= ELEN &
+  EMUL_pow >= -3 & EMUL_pow <= 3;
+}
+
 /* Check for vstart value */
 val assert_vstart : int -> bool effect {rreg}
 function assert_vstart(i) = {

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -9,8 +9,8 @@ mapping maybe_vmask : string <-> bits(1) = {
 }
 
 /* Check for valid EEW and EMUL values in vector widening/narrowing instructions */
-val check_eew_emul : (int, int) -> bool effect {rreg}
-function check_eew_emul(EEW, EMUL_pow) = {
+val valid_eew_emul : (int, int) -> bool effect {rreg}
+function valid_eew_emul(EEW, EMUL_pow) = {
   let ELEN = int_power(2, get_elen_pow());
   EEW >= 8 & EEW <= ELEN & EMUL_pow >= -3 & EMUL_pow <= 3;
 }
@@ -19,6 +19,38 @@ function check_eew_emul(EEW, EMUL_pow) = {
 val assert_vstart : int -> bool effect {rreg}
 function assert_vstart(i) = {
   unsigned(vstart) == i;
+}
+
+/* Check for valid destination register when vector masking is enabled: 
+ *  The destination vector register group for a masked vector instruction 
+ *  cannot overlap the source mask register (v0), 
+ *  unless the destination vector register is being written with a mask value (e.g., compares)
+ *  or the scalar result of a reduction.
+ */
+val valid_rd_mask : (regidx, bits(1)) -> bool
+function valid_rd_mask(rd, vm) = {
+  vm != 0b0 | rd != vreg_name("v0")
+}
+
+/* Check for valid register overlap in vector widening/narrowing instructions:
+ *  In a widening instruction, the overlap is valid only in the highest-numbered part
+ *  of the destination register group, and the source EMUL is at least 1.
+ *  In a narrowing instruction, the overlap is valid only in the lowest-numbered part
+ *  of the source register group.
+ */
+val valid_reg_overlap : (regidx, regidx, int, int) -> bool
+function valid_reg_overlap(rs, rd, EMUL_pow_rs, EMUL_pow_rd) = {
+  let rs_group = if EMUL_pow_rs > 0 then int_power(2, EMUL_pow_rs) else 1;
+  let rd_group = if EMUL_pow_rd > 0 then int_power(2, EMUL_pow_rd) else 1;
+  let rs_int = unsigned(rs);
+  let rd_int = unsigned(rd);
+  let is_valid  = if EMUL_pow_rs < EMUL_pow_rd then {
+                    (rs_int + rs_group <= rd_int) | (rs_int >= rd_int + rd_group) |
+                    ((rs_int + rs_group == rd_int + rd_group) & (EMUL_pow_rs >= 0))
+                  } else if EMUL_pow_rs > EMUL_pow_rd then {
+                    (rd_int <= rs_int) | (rd_int >= rs_int + rs_group)
+                  } else true;
+  is_valid
 }
 
 /* Scalar register shaping */
@@ -99,7 +131,7 @@ function init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
         result[i] = vd_val[i]; /* TODO: configuration support */
       };
       mask[i] = false
-    } else if vm_val[i] == false then {
+    } else if ~(vm_val[i]) then {
       /* Inactive body elements defined by vm */
       if mask_ag == UNDISTURBED then {
         result[i] = vd_val[i]
@@ -181,7 +213,7 @@ function init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
       /* Mask tail is always agnostic */
       result[i] = vd_val[i]; /* TODO: configuration support */
       mask[i] = false
-    } else if vm_val[i] == false then {
+    } else if ~(vm_val[i]) then {
       /* Inactive body elements defined by vm */
       if mask_ag == UNDISTURBED then {
         result[i] = vd_val[i]

--- a/model/riscv_insts_vext_vm.sail
+++ b/model/riscv_insts_vext_vm.sail
@@ -1,0 +1,202 @@
+/* ******************************************************************************* */
+/* This file implements part of the vector extension.                              */
+/* Mask instructions from Chap 11 (integer arithmetic) and 13 (floating-point)     */
+/* ******************************************************************************* */
+
+/* ***************** OPIVV (Vector Integer Compare Instructions) ***************** */
+/* VVCMP instructions' destination is a mask register */
+union clause ast = VVCMPTYPE : (vvcmpfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_vvcmpfunct6 : vvcmpfunct6 <-> bits(6) = {
+  VVCMP_VMSEQ    <-> 0b011000,
+  VVCMP_VMSNE    <-> 0b011001,
+  VVCMP_VMSLTU   <-> 0b011010,
+  VVCMP_VMSLT    <-> 0b011011,
+  VVCMP_VMSLEU   <-> 0b011100,
+  VVCMP_VMSLE    <-> 0b011101
+}
+
+mapping clause encdec = VVCMPTYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_vvcmpfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VVCMPTYPE(funct6, vm, vs2, vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val   : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs1_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val   : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);
+  result       : vector('n, dec, bool)     = undefined;
+  mask         : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      let res : bool = match funct6 {
+        VVCMP_VMSEQ    => vs2_val[i] == vs1_val[i],
+        VVCMP_VMSNE    => vs2_val[i] != vs1_val[i],
+        VVCMP_VMSLTU   => unsigned(vs2_val[i]) < unsigned(vs1_val[i]),
+        VVCMP_VMSLT    => signed(vs2_val[i]) < signed(vs1_val[i]),
+        VVCMP_VMSLEU   => unsigned(vs2_val[i]) <= unsigned(vs1_val[i]),
+        VVCMP_VMSLE    => signed(vs2_val[i]) <= signed(vs1_val[i])
+      };
+      result[i] = res
+    }
+  };
+
+  write_vmask(num_elem, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vvcmptype_mnemonic : vvcmpfunct6 <-> string = {
+  VVCMP_VMSEQ    <-> "vmseq.vv",
+  VVCMP_VMSNE    <-> "vmsne.vv",
+  VVCMP_VMSLTU   <-> "vmsltu.vv",
+  VVCMP_VMSLT    <-> "vmslt.vv",
+  VVCMP_VMSLEU   <-> "vmsleu.vv",
+  VVCMP_VMSLE    <-> "vmsle.vv"
+}
+
+mapping clause assembly = VVCMPTYPE(funct6, vm, vs2, vs1, vd)
+  <-> vvcmptype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+/* ***************** OPIVX (Vector Integer Compare Instructions) ***************** */
+/* VXCMP instructions' destination is a mask register */
+union clause ast = VXCMPTYPE : (vxcmpfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_vxcmpfunct6 : vxcmpfunct6 <-> bits(6) = {
+  VXCMP_VMSEQ    <-> 0b011000,
+  VXCMP_VMSNE    <-> 0b011001,
+  VXCMP_VMSLTU   <-> 0b011010,
+  VXCMP_VMSLT    <-> 0b011011,
+  VXCMP_VMSLEU   <-> 0b011100,
+  VXCMP_VMSLE    <-> 0b011101,
+  VXCMP_VMSGTU   <-> 0b011110,
+  VXCMP_VMSGT    <-> 0b011111
+}
+
+mapping clause encdec = VXCMPTYPE(funct6, vm, vs2, rs1, vd) if haveRVV()
+  <-> encdec_vxcmpfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VXCMPTYPE(funct6, vm, vs2, rs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val   : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let rs1_val  : bits('m)                  = get_scalar(rs1, SEW);
+  let vs2_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val   : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);
+  result       : vector('n, dec, bool)     = undefined;
+  mask         : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      let res : bool = match funct6 {
+        VXCMP_VMSEQ    => vs2_val[i] == rs1_val,
+        VXCMP_VMSNE    => vs2_val[i] != rs1_val,
+        VXCMP_VMSLTU   => unsigned(vs2_val[i]) < unsigned(rs1_val),
+        VXCMP_VMSLT    => signed(vs2_val[i]) < signed(rs1_val),
+        VXCMP_VMSLEU   => unsigned(vs2_val[i]) <= unsigned(rs1_val),
+        VXCMP_VMSLE    => signed(vs2_val[i]) <= signed(rs1_val),
+        VXCMP_VMSGTU   => unsigned(vs2_val[i]) > unsigned(rs1_val),
+        VXCMP_VMSGT    => signed(vs2_val[i]) > signed(rs1_val)
+      };
+      result[i] = res
+    }
+  };
+
+  write_vmask(num_elem, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vxcmptype_mnemonic : vxcmpfunct6 <-> string = {
+  VXCMP_VMSEQ    <-> "vmseq.vx",
+  VXCMP_VMSNE    <-> "vmsne.vx",
+  VXCMP_VMSLTU   <-> "vmsltu.vx",
+  VXCMP_VMSLT    <-> "vmslt.vx",
+  VXCMP_VMSLEU   <-> "vmsleu.vx",
+  VXCMP_VMSLE    <-> "vmsle.vx",
+  VXCMP_VMSGTU   <-> "vmsgtu.vx",
+  VXCMP_VMSGT    <-> "vmsgt.vx"
+}
+
+mapping clause assembly = VXCMPTYPE(funct6, vm, vs2, rs1, vd)
+  <-> vxcmptype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+
+/* ***************** OPIVI (Vector Integer Compare Instructions) ***************** */
+/* VICMP instructions' destination is a mask register */
+union clause ast = VICMPTYPE : (vicmpfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_vicmpfunct6 : vicmpfunct6 <-> bits(6) = {
+  VICMP_VMSEQ    <-> 0b011000,
+  VICMP_VMSNE    <-> 0b011001,
+  VICMP_VMSLEU   <-> 0b011100,
+  VICMP_VMSLE    <-> 0b011101,
+  VICMP_VMSGTU   <-> 0b011110,
+  VICMP_VMSGT    <-> 0b011111
+}
+
+mapping clause encdec = VICMPTYPE(funct6, vm, vs2, simm, vd) if haveRVV()
+  <-> encdec_vicmpfunct6(funct6) @ vm @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VICMPTYPE(funct6, vm, vs2, simm, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val   : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let imm_val  : bits('m)                  = EXTS(simm);
+  let vs2_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val   : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);
+  result       : vector('n, dec, bool)     = undefined;
+  mask         : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      let res : bool = match funct6 {
+        VICMP_VMSEQ    => vs2_val[i] == imm_val,
+        VICMP_VMSNE    => vs2_val[i] != imm_val,
+        VICMP_VMSLEU   => unsigned(vs2_val[i]) <= unsigned(imm_val),
+        VICMP_VMSLE    => signed(vs2_val[i]) <= signed(imm_val),
+        VICMP_VMSGTU   => unsigned(vs2_val[i]) > unsigned(imm_val),
+        VICMP_VMSGT    => signed(vs2_val[i]) > signed(imm_val)
+      };
+      result[i] = res
+    }
+  };
+
+  write_vmask(num_elem, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vicmptype_mnemonic : vicmpfunct6 <-> string = {
+  VICMP_VMSEQ    <-> "vmseq.vi",
+  VICMP_VMSNE    <-> "vmsne.vi",
+  VICMP_VMSLEU   <-> "vmsleu.vi",
+  VICMP_VMSLE    <-> "vmsle.vi",
+  VICMP_VMSGTU   <-> "vmsgtu.vi",
+  VICMP_VMSGT    <-> "vmsgt.vi"
+}
+
+mapping clause assembly = VICMPTYPE(funct6, vm, vs2, simm, vd)
+  <-> vicmptype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ maybe_vmask(vm)

--- a/model/riscv_insts_vext_vm.sail
+++ b/model/riscv_insts_vext_vm.sail
@@ -101,7 +101,7 @@ function clause execute(VXCMPTYPE(funct6, vm, vs2, rs1, vd)) = {
   mask         : vector('n, dec, bool)     = undefined;
 
   (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
-  
+
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] then {
       let res : bool = match funct6 {

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -849,13 +849,16 @@ register vtype : Vtype
 /* this returns the power of 2 for SEW */
 val get_sew_pow : unit -> {|3, 4, 5, 6|} effect {escape, rreg}
 function get_sew_pow() = {
-  match vtype.vsew() {
+  let ELEN_pow = get_elen_pow();
+  let SEW_pow : {|3, 4, 5, 6|} = match vtype.vsew() {
     0b000 => 3,
     0b001 => 4,
     0b010 => 5,
     0b011 => 6,
     _     => {assert(false, "invalid vsew field in vtype"); 0}
-  }
+  };
+  assert(SEW_pow <= ELEN_pow);
+  SEW_pow
 }
 /* this returns the actual value of SEW */
 val get_sew : unit -> {|8, 16, 32, 64|} effect {escape, rreg}

--- a/model/riscv_vlen.sail
+++ b/model/riscv_vlen.sail
@@ -1,10 +1,10 @@
 register elen : bits(1)
 
-val get_elen : unit -> {|32, 64|} effect {rreg}
+val get_elen_pow : unit -> {|5, 6|} effect {rreg}
 
-function get_elen() = match elen {
-    0b0 => 32,
-    0b1 => 64
+function get_elen_pow() = match elen {
+    0b0 => 5,
+    0b1 => 6
 }
 
 register vlen : bits(4)


### PR DESCRIPTION
This PR mainly contains vector integer/fixed-point arithmetic instructions (Spec Chapter 11, 12) in `riscv_insts_vext_arith.sail` and vector mask instructions (Spec Chapter 15) in `riscv_insts_vext_mask.sail`. Besides, some arithmetic instructions involving mask registers (Spec 11.4, 11.8, 13.13) are collected in `riscv_insts_vext_vm.sail`, and this PR contains part of them for the help of running mask instruction ISA tests.

The model generated by this code can pass the vector ISA tests generated by the [rvv-atg](https://github.com/hushenwei2000/rvv-atg) for different configurations. (ELEN and VLEN are manually specified in `riscv_sys_control.sail` when compiling the model.) Please send me comments if there are issues in the new code. I'll do my best to get it right soon.