### PR TITLE
Vector floating-point instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ SAIL_DEFAULT_INST += riscv_insts_zbkx.sail
 SAIL_DEFAULT_INST += riscv_insts_vext_utils.sail
 SAIL_DEFAULT_INST += riscv_insts_vext_vset.sail
 SAIL_DEFAULT_INST += riscv_insts_vext_arith.sail
+SAIL_DEFAULT_INST += riscv_insts_vext_fp.sail
 SAIL_DEFAULT_INST += riscv_insts_vext_mem.sail
 SAIL_DEFAULT_INST += riscv_insts_vext_mask.sail
 SAIL_DEFAULT_INST += riscv_insts_vext_vm.sail

--- a/c_emulator/SoftFloat-3e/build/Linux-386-GCC/Makefile
+++ b/c_emulator/SoftFloat-3e/build/Linux-386-GCC/Makefile
@@ -193,6 +193,7 @@ OBJS_OTHERS = \
   f16_le_quiet$(OBJ) \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
+  f16_classify$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
   f32_to_i32$(OBJ) \
@@ -220,6 +221,7 @@ OBJS_OTHERS = \
   f32_le_quiet$(OBJ) \
   f32_lt_quiet$(OBJ) \
   f32_isSignalingNaN$(OBJ) \
+  f32_classify$(OBJ) \
   f64_to_ui32$(OBJ) \
   f64_to_ui64$(OBJ) \
   f64_to_i32$(OBJ) \
@@ -247,6 +249,7 @@ OBJS_OTHERS = \
   f64_le_quiet$(OBJ) \
   f64_lt_quiet$(OBJ) \
   f64_isSignalingNaN$(OBJ) \
+  f64_classify$(OBJ) \
   extF80M_to_ui32$(OBJ) \
   extF80M_to_ui64$(OBJ) \
   extF80M_to_i32$(OBJ) \
@@ -299,12 +302,20 @@ OBJS_OTHERS = \
   f128M_le_quiet$(OBJ) \
   f128M_lt_quiet$(OBJ) \
 
-OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS)
+OBJS_RECIPROCAL = \
+  f16_rsqrte7$(OBJ) \
+  f16_recip7$(OBJ) \
+  f32_rsqrte7$(OBJ) \
+  f32_recip7$(OBJ) \
+  f64_rsqrte7$(OBJ) \
+  f64_recip7$(OBJ) \
+
+OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL)
 
 $(OBJS_ALL): \
   $(OTHER_HEADERS) platform.h $(SOURCE_DIR)/include/primitiveTypes.h \
   $(SOURCE_DIR)/include/primitives.h
-$(OBJS_SPECIALIZE) $(OBJS_OTHERS): \
+$(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL): \
   $(SOURCE_DIR)/include/softfloat_types.h $(SOURCE_DIR)/include/internals.h \
   $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/specialize.h \
   $(SOURCE_DIR)/include/softfloat.h
@@ -314,6 +325,9 @@ $(OBJS_PRIMITIVES) $(OBJS_OTHERS): %$(OBJ): $(SOURCE_DIR)/%.c
 
 $(OBJS_SPECIALIZE): %$(OBJ): $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/%.c
 	$(COMPILE_C) $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/$*.c
+
+$(OBJS_RECIPROCAL): %$(OBJ): $(SOURCE_DIR)/fall_reciprocal.c
+	$(COMPILE_C) $(SOURCE_DIR)/fall_reciprocal.c
 
 softfloat$(LIB): $(OBJS_ALL)
 	$(DELETE) $@

--- a/c_emulator/SoftFloat-3e/build/Linux-386-GCC/Makefile
+++ b/c_emulator/SoftFloat-3e/build/Linux-386-GCC/Makefile
@@ -166,8 +166,12 @@ OBJS_OTHERS = \
   i64_to_f64$(OBJ) \
   i64_to_extF80M$(OBJ) \
   i64_to_f128M$(OBJ) \
+  f16_to_ui8$(OBJ) \
+  f16_to_ui16$(OBJ) \
   f16_to_ui32$(OBJ) \
   f16_to_ui64$(OBJ) \
+  f16_to_i8$(OBJ) \
+  f16_to_i16$(OBJ) \
   f16_to_i32$(OBJ) \
   f16_to_i64$(OBJ) \
   f16_to_ui32_r_minMag$(OBJ) \
@@ -194,8 +198,10 @@ OBJS_OTHERS = \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
   f16_classify$(OBJ) \
+  f32_to_ui16$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
+  f32_to_i16$(OBJ) \
   f32_to_i32$(OBJ) \
   f32_to_i64$(OBJ) \
   f32_to_ui32_r_minMag$(OBJ) \

--- a/c_emulator/SoftFloat-3e/build/Linux-386-SSE2-GCC/Makefile
+++ b/c_emulator/SoftFloat-3e/build/Linux-386-SSE2-GCC/Makefile
@@ -193,6 +193,7 @@ OBJS_OTHERS = \
   f16_le_quiet$(OBJ) \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
+  f16_classify$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
   f32_to_i32$(OBJ) \
@@ -220,6 +221,7 @@ OBJS_OTHERS = \
   f32_le_quiet$(OBJ) \
   f32_lt_quiet$(OBJ) \
   f32_isSignalingNaN$(OBJ) \
+  f32_classify$(OBJ) \
   f64_to_ui32$(OBJ) \
   f64_to_ui64$(OBJ) \
   f64_to_i32$(OBJ) \
@@ -247,6 +249,7 @@ OBJS_OTHERS = \
   f64_le_quiet$(OBJ) \
   f64_lt_quiet$(OBJ) \
   f64_isSignalingNaN$(OBJ) \
+  f64_classify$(OBJ) \
   extF80M_to_ui32$(OBJ) \
   extF80M_to_ui64$(OBJ) \
   extF80M_to_i32$(OBJ) \
@@ -299,12 +302,20 @@ OBJS_OTHERS = \
   f128M_le_quiet$(OBJ) \
   f128M_lt_quiet$(OBJ) \
 
-OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS)
+OBJS_RECIPROCAL = \
+  f16_rsqrte7$(OBJ) \
+  f16_recip7$(OBJ) \
+  f32_rsqrte7$(OBJ) \
+  f32_recip7$(OBJ) \
+  f64_rsqrte7$(OBJ) \
+  f64_recip7$(OBJ) \
+
+OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL)
 
 $(OBJS_ALL): \
   $(OTHER_HEADERS) platform.h $(SOURCE_DIR)/include/primitiveTypes.h \
   $(SOURCE_DIR)/include/primitives.h
-$(OBJS_SPECIALIZE) $(OBJS_OTHERS): \
+$(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL): \
   $(SOURCE_DIR)/include/softfloat_types.h $(SOURCE_DIR)/include/internals.h \
   $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/specialize.h \
   $(SOURCE_DIR)/include/softfloat.h
@@ -314,6 +325,9 @@ $(OBJS_PRIMITIVES) $(OBJS_OTHERS): %$(OBJ): $(SOURCE_DIR)/%.c
 
 $(OBJS_SPECIALIZE): %$(OBJ): $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/%.c
 	$(COMPILE_C) $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/$*.c
+
+$(OBJS_RECIPROCAL): %$(OBJ): $(SOURCE_DIR)/fall_reciprocal.c
+	$(COMPILE_C) $(SOURCE_DIR)/fall_reciprocal.c
 
 softfloat$(LIB): $(OBJS_ALL)
 	$(DELETE) $@

--- a/c_emulator/SoftFloat-3e/build/Linux-386-SSE2-GCC/Makefile
+++ b/c_emulator/SoftFloat-3e/build/Linux-386-SSE2-GCC/Makefile
@@ -166,8 +166,12 @@ OBJS_OTHERS = \
   i64_to_f64$(OBJ) \
   i64_to_extF80M$(OBJ) \
   i64_to_f128M$(OBJ) \
+  f16_to_ui8$(OBJ) \
+  f16_to_ui16$(OBJ) \
   f16_to_ui32$(OBJ) \
   f16_to_ui64$(OBJ) \
+  f16_to_i8$(OBJ) \
+  f16_to_i16$(OBJ) \
   f16_to_i32$(OBJ) \
   f16_to_i64$(OBJ) \
   f16_to_ui32_r_minMag$(OBJ) \
@@ -194,8 +198,10 @@ OBJS_OTHERS = \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
   f16_classify$(OBJ) \
+  f32_to_ui16$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
+  f32_to_i16$(OBJ) \
   f32_to_i32$(OBJ) \
   f32_to_i64$(OBJ) \
   f32_to_ui32_r_minMag$(OBJ) \

--- a/c_emulator/SoftFloat-3e/build/Linux-ARM-VFPv2-GCC/Makefile
+++ b/c_emulator/SoftFloat-3e/build/Linux-ARM-VFPv2-GCC/Makefile
@@ -164,8 +164,12 @@ OBJS_OTHERS = \
   i64_to_f64$(OBJ) \
   i64_to_extF80M$(OBJ) \
   i64_to_f128M$(OBJ) \
+  f16_to_ui8$(OBJ) \
+  f16_to_ui16$(OBJ) \
   f16_to_ui32$(OBJ) \
   f16_to_ui64$(OBJ) \
+  f16_to_i8$(OBJ) \
+  f16_to_i16$(OBJ) \
   f16_to_i32$(OBJ) \
   f16_to_i64$(OBJ) \
   f16_to_ui32_r_minMag$(OBJ) \
@@ -192,8 +196,10 @@ OBJS_OTHERS = \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
   f16_classify$(OBJ) \
+  f32_to_ui16$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
+  f32_to_i16$(OBJ) \
   f32_to_i32$(OBJ) \
   f32_to_i64$(OBJ) \
   f32_to_ui32_r_minMag$(OBJ) \

--- a/c_emulator/SoftFloat-3e/build/Linux-ARM-VFPv2-GCC/Makefile
+++ b/c_emulator/SoftFloat-3e/build/Linux-ARM-VFPv2-GCC/Makefile
@@ -191,6 +191,7 @@ OBJS_OTHERS = \
   f16_le_quiet$(OBJ) \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
+  f16_classify$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
   f32_to_i32$(OBJ) \
@@ -218,6 +219,7 @@ OBJS_OTHERS = \
   f32_le_quiet$(OBJ) \
   f32_lt_quiet$(OBJ) \
   f32_isSignalingNaN$(OBJ) \
+  f32_classify$(OBJ) \
   f64_to_ui32$(OBJ) \
   f64_to_ui64$(OBJ) \
   f64_to_i32$(OBJ) \
@@ -245,6 +247,7 @@ OBJS_OTHERS = \
   f64_le_quiet$(OBJ) \
   f64_lt_quiet$(OBJ) \
   f64_isSignalingNaN$(OBJ) \
+  f64_classify$(OBJ) \
   extF80M_to_ui32$(OBJ) \
   extF80M_to_ui64$(OBJ) \
   extF80M_to_i32$(OBJ) \
@@ -297,12 +300,20 @@ OBJS_OTHERS = \
   f128M_le_quiet$(OBJ) \
   f128M_lt_quiet$(OBJ) \
 
-OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS)
+OBJS_RECIPROCAL = \
+  f16_rsqrte7$(OBJ) \
+  f16_recip7$(OBJ) \
+  f32_rsqrte7$(OBJ) \
+  f32_recip7$(OBJ) \
+  f64_rsqrte7$(OBJ) \
+  f64_recip7$(OBJ) \
+
+OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL)
 
 $(OBJS_ALL): \
   $(OTHER_HEADERS) platform.h $(SOURCE_DIR)/include/primitiveTypes.h \
   $(SOURCE_DIR)/include/primitives.h
-$(OBJS_SPECIALIZE) $(OBJS_OTHERS): \
+$(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL): \
   $(SOURCE_DIR)/include/softfloat_types.h $(SOURCE_DIR)/include/internals.h \
   $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/specialize.h \
   $(SOURCE_DIR)/include/softfloat.h
@@ -312,6 +323,9 @@ $(OBJS_PRIMITIVES) $(OBJS_OTHERS): %$(OBJ): $(SOURCE_DIR)/%.c
 
 $(OBJS_SPECIALIZE): %$(OBJ): $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/%.c
 	$(COMPILE_C) $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/$*.c
+
+$(OBJS_RECIPROCAL): %$(OBJ): $(SOURCE_DIR)/fall_reciprocal.c
+	$(COMPILE_C) $(SOURCE_DIR)/fall_reciprocal.c
 
 softfloat$(LIB): $(OBJS_ALL)
 	$(DELETE) $@

--- a/c_emulator/SoftFloat-3e/build/Linux-RISCV-GCC/Makefile
+++ b/c_emulator/SoftFloat-3e/build/Linux-RISCV-GCC/Makefile
@@ -163,8 +163,12 @@ OBJS_OTHERS = \
   i64_to_extF80M$(OBJ) \
   i64_to_f128$(OBJ) \
   i64_to_f128M$(OBJ) \
+  f16_to_ui8$(OBJ) \
+  f16_to_ui16$(OBJ) \
   f16_to_ui32$(OBJ) \
   f16_to_ui64$(OBJ) \
+  f16_to_i8$(OBJ) \
+  f16_to_i16$(OBJ) \
   f16_to_i32$(OBJ) \
   f16_to_i64$(OBJ) \
   f16_to_ui32_r_minMag$(OBJ) \
@@ -193,8 +197,10 @@ OBJS_OTHERS = \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
   f16_classify$(OBJ) \
+  f32_to_ui16$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
+  f32_to_i16$(OBJ) \
   f32_to_i32$(OBJ) \
   f32_to_i64$(OBJ) \
   f32_to_ui32_r_minMag$(OBJ) \

--- a/c_emulator/SoftFloat-3e/build/Linux-RISCV-GCC/Makefile
+++ b/c_emulator/SoftFloat-3e/build/Linux-RISCV-GCC/Makefile
@@ -38,6 +38,7 @@ SOURCE_DIR ?= ../../source
 SPECIALIZE_TYPE ?= RISCV
 
 SOFTFLOAT_OPTS ?= \
+  -DSOFTFLOAT_ROUND_ODD
 
 
 DELETE = rm -f
@@ -191,6 +192,7 @@ OBJS_OTHERS = \
   f16_le_quiet$(OBJ) \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
+  f16_classify$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
   f32_to_i32$(OBJ) \
@@ -220,6 +222,7 @@ OBJS_OTHERS = \
   f32_le_quiet$(OBJ) \
   f32_lt_quiet$(OBJ) \
   f32_isSignalingNaN$(OBJ) \
+  f32_classify$(OBJ) \
   f64_to_ui32$(OBJ) \
   f64_to_ui64$(OBJ) \
   f64_to_i32$(OBJ) \
@@ -249,6 +252,7 @@ OBJS_OTHERS = \
   f64_le_quiet$(OBJ) \
   f64_lt_quiet$(OBJ) \
   f64_isSignalingNaN$(OBJ) \
+  f64_classify$(OBJ) \
   extF80_to_ui32$(OBJ) \
   extF80_to_ui64$(OBJ) \
   extF80_to_i32$(OBJ) \
@@ -354,12 +358,20 @@ OBJS_OTHERS = \
   f128M_le_quiet$(OBJ) \
   f128M_lt_quiet$(OBJ) \
 
-OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS)
+OBJS_RECIPROCAL = \
+  f16_rsqrte7$(OBJ) \
+  f16_recip7$(OBJ) \
+  f32_rsqrte7$(OBJ) \
+  f32_recip7$(OBJ) \
+  f64_rsqrte7$(OBJ) \
+  f64_recip7$(OBJ) \
+
+OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL)
 
 $(OBJS_ALL): \
   $(OTHER_HEADERS) platform.h $(SOURCE_DIR)/include/primitiveTypes.h \
   $(SOURCE_DIR)/include/primitives.h
-$(OBJS_SPECIALIZE) $(OBJS_OTHERS): \
+$(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL): \
   $(SOURCE_DIR)/include/softfloat_types.h $(SOURCE_DIR)/include/internals.h \
   $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/specialize.h \
   $(SOURCE_DIR)/include/softfloat.h
@@ -369,6 +381,9 @@ $(OBJS_PRIMITIVES) $(OBJS_OTHERS): %$(OBJ): $(SOURCE_DIR)/%.c
 
 $(OBJS_SPECIALIZE): %$(OBJ): $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/%.c
 	$(COMPILE_C) $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/$*.c
+
+$(OBJS_RECIPROCAL): %$(OBJ): $(SOURCE_DIR)/fall_reciprocal.c
+	$(COMPILE_C) $(SOURCE_DIR)/fall_reciprocal.c
 
 softfloat$(LIB): $(OBJS_ALL)
 	$(DELETE) $@

--- a/c_emulator/SoftFloat-3e/build/Linux-x86_64-GCC/Makefile
+++ b/c_emulator/SoftFloat-3e/build/Linux-x86_64-GCC/Makefile
@@ -201,6 +201,7 @@ OBJS_OTHERS = \
   f16_le_quiet$(OBJ) \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
+  f16_classify$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
   f32_to_i32$(OBJ) \
@@ -230,6 +231,7 @@ OBJS_OTHERS = \
   f32_le_quiet$(OBJ) \
   f32_lt_quiet$(OBJ) \
   f32_isSignalingNaN$(OBJ) \
+  f32_classify$(OBJ) \
   f64_to_ui32$(OBJ) \
   f64_to_ui64$(OBJ) \
   f64_to_i32$(OBJ) \
@@ -259,6 +261,7 @@ OBJS_OTHERS = \
   f64_le_quiet$(OBJ) \
   f64_lt_quiet$(OBJ) \
   f64_isSignalingNaN$(OBJ) \
+  f64_classify$(OBJ) \
   extF80_to_ui32$(OBJ) \
   extF80_to_ui64$(OBJ) \
   extF80_to_i32$(OBJ) \
@@ -364,12 +367,20 @@ OBJS_OTHERS = \
   f128M_le_quiet$(OBJ) \
   f128M_lt_quiet$(OBJ) \
 
-OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS)
+OBJS_RECIPROCAL = \
+  f16_rsqrte7$(OBJ) \
+  f16_recip7$(OBJ) \
+  f32_rsqrte7$(OBJ) \
+  f32_recip7$(OBJ) \
+  f64_rsqrte7$(OBJ) \
+  f64_recip7$(OBJ) \
+
+OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL)
 
 $(OBJS_ALL): \
   $(OTHER_HEADERS) platform.h $(SOURCE_DIR)/include/primitiveTypes.h \
   $(SOURCE_DIR)/include/primitives.h
-$(OBJS_SPECIALIZE) $(OBJS_OTHERS): \
+$(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL): \
   $(SOURCE_DIR)/include/softfloat_types.h $(SOURCE_DIR)/include/internals.h \
   $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/specialize.h \
   $(SOURCE_DIR)/include/softfloat.h
@@ -379,6 +390,9 @@ $(OBJS_PRIMITIVES) $(OBJS_OTHERS): %$(OBJ): $(SOURCE_DIR)/%.c
 
 $(OBJS_SPECIALIZE): %$(OBJ): $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/%.c
 	$(COMPILE_C) $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/$*.c
+
+$(OBJS_RECIPROCAL): %$(OBJ): $(SOURCE_DIR)/fall_reciprocal.c
+	$(COMPILE_C) $(SOURCE_DIR)/fall_reciprocal.c
 
 softfloat$(LIB): $(OBJS_ALL)
 	$(DELETE) $@

--- a/c_emulator/SoftFloat-3e/build/Linux-x86_64-GCC/Makefile
+++ b/c_emulator/SoftFloat-3e/build/Linux-x86_64-GCC/Makefile
@@ -172,8 +172,12 @@ OBJS_OTHERS = \
   i64_to_extF80M$(OBJ) \
   i64_to_f128$(OBJ) \
   i64_to_f128M$(OBJ) \
+  f16_to_ui8$(OBJ) \
+  f16_to_ui16$(OBJ) \
   f16_to_ui32$(OBJ) \
   f16_to_ui64$(OBJ) \
+  f16_to_i8$(OBJ) \
+  f16_to_i16$(OBJ) \
   f16_to_i32$(OBJ) \
   f16_to_i64$(OBJ) \
   f16_to_ui32_r_minMag$(OBJ) \
@@ -202,8 +206,10 @@ OBJS_OTHERS = \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
   f16_classify$(OBJ) \
+  f32_to_ui16$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
+  f32_to_i16$(OBJ) \
   f32_to_i32$(OBJ) \
   f32_to_i64$(OBJ) \
   f32_to_ui32_r_minMag$(OBJ) \

--- a/c_emulator/SoftFloat-3e/build/Win32-MinGW/Makefile
+++ b/c_emulator/SoftFloat-3e/build/Win32-MinGW/Makefile
@@ -193,6 +193,7 @@ OBJS_OTHERS = \
   f16_le_quiet$(OBJ) \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
+  f16_classify$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
   f32_to_i32$(OBJ) \
@@ -220,6 +221,7 @@ OBJS_OTHERS = \
   f32_le_quiet$(OBJ) \
   f32_lt_quiet$(OBJ) \
   f32_isSignalingNaN$(OBJ) \
+  f32_classify$(OBJ) \
   f64_to_ui32$(OBJ) \
   f64_to_ui64$(OBJ) \
   f64_to_i32$(OBJ) \
@@ -247,6 +249,7 @@ OBJS_OTHERS = \
   f64_le_quiet$(OBJ) \
   f64_lt_quiet$(OBJ) \
   f64_isSignalingNaN$(OBJ) \
+  f64_classify$(OBJ) \
   extF80M_to_ui32$(OBJ) \
   extF80M_to_ui64$(OBJ) \
   extF80M_to_i32$(OBJ) \
@@ -299,12 +302,20 @@ OBJS_OTHERS = \
   f128M_le_quiet$(OBJ) \
   f128M_lt_quiet$(OBJ) \
 
-OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS)
+OBJS_RECIPROCAL = \
+  f16_rsqrte7$(OBJ) \
+  f16_recip7$(OBJ) \
+  f32_rsqrte7$(OBJ) \
+  f32_recip7$(OBJ) \
+  f64_rsqrte7$(OBJ) \
+  f64_recip7$(OBJ) \
+
+OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL)
 
 $(OBJS_ALL): \
   $(OTHER_HEADERS) platform.h $(SOURCE_DIR)/include/primitiveTypes.h \
   $(SOURCE_DIR)/include/primitives.h
-$(OBJS_SPECIALIZE) $(OBJS_OTHERS): \
+$(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL): \
   $(SOURCE_DIR)/include/softfloat_types.h $(SOURCE_DIR)/include/internals.h \
   $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/specialize.h \
   $(SOURCE_DIR)/include/softfloat.h
@@ -314,6 +325,9 @@ $(OBJS_PRIMITIVES) $(OBJS_OTHERS): %$(OBJ): $(SOURCE_DIR)/%.c
 
 $(OBJS_SPECIALIZE): %$(OBJ): $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/%.c
 	$(COMPILE_C) $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/$*.c
+
+$(OBJS_RECIPROCAL): %$(OBJ): $(SOURCE_DIR)/fall_reciprocal.c
+	$(COMPILE_C) $(SOURCE_DIR)/fall_reciprocal.c
 
 softfloat$(LIB): $(OBJS_ALL)
 	$(DELETE) $@

--- a/c_emulator/SoftFloat-3e/build/Win32-MinGW/Makefile
+++ b/c_emulator/SoftFloat-3e/build/Win32-MinGW/Makefile
@@ -166,8 +166,12 @@ OBJS_OTHERS = \
   i64_to_f64$(OBJ) \
   i64_to_extF80M$(OBJ) \
   i64_to_f128M$(OBJ) \
+  f16_to_ui8$(OBJ) \
+  f16_to_ui16$(OBJ) \
   f16_to_ui32$(OBJ) \
   f16_to_ui64$(OBJ) \
+  f16_to_i8$(OBJ) \
+  f16_to_i16$(OBJ) \
   f16_to_i32$(OBJ) \
   f16_to_i64$(OBJ) \
   f16_to_ui32_r_minMag$(OBJ) \
@@ -194,8 +198,10 @@ OBJS_OTHERS = \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
   f16_classify$(OBJ) \
+  f32_to_ui16$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
+  f32_to_i16$(OBJ) \
   f32_to_i32$(OBJ) \
   f32_to_i64$(OBJ) \
   f32_to_ui32_r_minMag$(OBJ) \

--- a/c_emulator/SoftFloat-3e/build/Win32-SSE2-MinGW/Makefile
+++ b/c_emulator/SoftFloat-3e/build/Win32-SSE2-MinGW/Makefile
@@ -193,6 +193,7 @@ OBJS_OTHERS = \
   f16_le_quiet$(OBJ) \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
+  f16_classify$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
   f32_to_i32$(OBJ) \
@@ -220,6 +221,7 @@ OBJS_OTHERS = \
   f32_le_quiet$(OBJ) \
   f32_lt_quiet$(OBJ) \
   f32_isSignalingNaN$(OBJ) \
+  f32_classify$(OBJ) \
   f64_to_ui32$(OBJ) \
   f64_to_ui64$(OBJ) \
   f64_to_i32$(OBJ) \
@@ -247,6 +249,7 @@ OBJS_OTHERS = \
   f64_le_quiet$(OBJ) \
   f64_lt_quiet$(OBJ) \
   f64_isSignalingNaN$(OBJ) \
+  f64_classify$(OBJ) \
   extF80M_to_ui32$(OBJ) \
   extF80M_to_ui64$(OBJ) \
   extF80M_to_i32$(OBJ) \
@@ -299,12 +302,20 @@ OBJS_OTHERS = \
   f128M_le_quiet$(OBJ) \
   f128M_lt_quiet$(OBJ) \
 
-OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS)
+OBJS_RECIPROCAL = \
+  f16_rsqrte7$(OBJ) \
+  f16_recip7$(OBJ) \
+  f32_rsqrte7$(OBJ) \
+  f32_recip7$(OBJ) \
+  f64_rsqrte7$(OBJ) \
+  f64_recip7$(OBJ) \
+
+OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL)
 
 $(OBJS_ALL): \
   $(OTHER_HEADERS) platform.h $(SOURCE_DIR)/include/primitiveTypes.h \
   $(SOURCE_DIR)/include/primitives.h
-$(OBJS_SPECIALIZE) $(OBJS_OTHERS): \
+$(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL): \
   $(SOURCE_DIR)/include/softfloat_types.h $(SOURCE_DIR)/include/internals.h \
   $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/specialize.h \
   $(SOURCE_DIR)/include/softfloat.h
@@ -314,6 +325,9 @@ $(OBJS_PRIMITIVES) $(OBJS_OTHERS): %$(OBJ): $(SOURCE_DIR)/%.c
 
 $(OBJS_SPECIALIZE): %$(OBJ): $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/%.c
 	$(COMPILE_C) $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/$*.c
+
+$(OBJS_RECIPROCAL): %$(OBJ): $(SOURCE_DIR)/fall_reciprocal.c
+	$(COMPILE_C) $(SOURCE_DIR)/fall_reciprocal.c
 
 softfloat$(LIB): $(OBJS_ALL)
 	$(DELETE) $@

--- a/c_emulator/SoftFloat-3e/build/Win32-SSE2-MinGW/Makefile
+++ b/c_emulator/SoftFloat-3e/build/Win32-SSE2-MinGW/Makefile
@@ -166,8 +166,12 @@ OBJS_OTHERS = \
   i64_to_f64$(OBJ) \
   i64_to_extF80M$(OBJ) \
   i64_to_f128M$(OBJ) \
+  f16_to_ui8$(OBJ) \
+  f16_to_ui16$(OBJ) \
   f16_to_ui32$(OBJ) \
   f16_to_ui64$(OBJ) \
+  f16_to_i8$(OBJ) \
+  f16_to_i16$(OBJ) \
   f16_to_i32$(OBJ) \
   f16_to_i64$(OBJ) \
   f16_to_ui32_r_minMag$(OBJ) \
@@ -194,8 +198,10 @@ OBJS_OTHERS = \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
   f16_classify$(OBJ) \
+  f32_to_ui16$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
+  f32_to_i16$(OBJ) \
   f32_to_i32$(OBJ) \
   f32_to_i64$(OBJ) \
   f32_to_ui32_r_minMag$(OBJ) \

--- a/c_emulator/SoftFloat-3e/build/Win64-MinGW-w64/Makefile
+++ b/c_emulator/SoftFloat-3e/build/Win64-MinGW-w64/Makefile
@@ -201,6 +201,7 @@ OBJS_OTHERS = \
   f16_le_quiet$(OBJ) \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
+  f16_classify$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
   f32_to_i32$(OBJ) \
@@ -230,6 +231,7 @@ OBJS_OTHERS = \
   f32_le_quiet$(OBJ) \
   f32_lt_quiet$(OBJ) \
   f32_isSignalingNaN$(OBJ) \
+  f32_classify$(OBJ) \
   f64_to_ui32$(OBJ) \
   f64_to_ui64$(OBJ) \
   f64_to_i32$(OBJ) \
@@ -259,6 +261,7 @@ OBJS_OTHERS = \
   f64_le_quiet$(OBJ) \
   f64_lt_quiet$(OBJ) \
   f64_isSignalingNaN$(OBJ) \
+  f64_classify$(OBJ) \
   extF80_to_ui32$(OBJ) \
   extF80_to_ui64$(OBJ) \
   extF80_to_i32$(OBJ) \
@@ -364,12 +367,20 @@ OBJS_OTHERS = \
   f128M_le_quiet$(OBJ) \
   f128M_lt_quiet$(OBJ) \
 
-OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS)
+OBJS_RECIPROCAL = \
+  f16_rsqrte7$(OBJ) \
+  f16_recip7$(OBJ) \
+  f32_rsqrte7$(OBJ) \
+  f32_recip7$(OBJ) \
+  f64_rsqrte7$(OBJ) \
+  f64_recip7$(OBJ) \
+
+OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL)
 
 $(OBJS_ALL): \
   $(OTHER_HEADERS) platform.h $(SOURCE_DIR)/include/primitiveTypes.h \
   $(SOURCE_DIR)/include/primitives.h
-$(OBJS_SPECIALIZE) $(OBJS_OTHERS): \
+$(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL): \
   $(SOURCE_DIR)/include/softfloat_types.h $(SOURCE_DIR)/include/internals.h \
   $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/specialize.h \
   $(SOURCE_DIR)/include/softfloat.h
@@ -379,6 +390,9 @@ $(OBJS_PRIMITIVES) $(OBJS_OTHERS): %$(OBJ): $(SOURCE_DIR)/%.c
 
 $(OBJS_SPECIALIZE): %$(OBJ): $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/%.c
 	$(COMPILE_C) $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/$*.c
+
+$(OBJS_RECIPROCAL): %$(OBJ): $(SOURCE_DIR)/fall_reciprocal.c
+	$(COMPILE_C) $(SOURCE_DIR)/fall_reciprocal.c
 
 softfloat$(LIB): $(OBJS_ALL)
 	$(DELETE) $@

--- a/c_emulator/SoftFloat-3e/build/Win64-MinGW-w64/Makefile
+++ b/c_emulator/SoftFloat-3e/build/Win64-MinGW-w64/Makefile
@@ -172,8 +172,12 @@ OBJS_OTHERS = \
   i64_to_extF80M$(OBJ) \
   i64_to_f128$(OBJ) \
   i64_to_f128M$(OBJ) \
+  f16_to_ui8$(OBJ) \
+  f16_to_ui16$(OBJ) \
   f16_to_ui32$(OBJ) \
   f16_to_ui64$(OBJ) \
+  f16_to_i8$(OBJ) \
+  f16_to_i16$(OBJ) \
   f16_to_i32$(OBJ) \
   f16_to_i64$(OBJ) \
   f16_to_ui32_r_minMag$(OBJ) \
@@ -202,8 +206,10 @@ OBJS_OTHERS = \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
   f16_classify$(OBJ) \
+  f32_to_ui16$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
+  f32_to_i16$(OBJ) \
   f32_to_i32$(OBJ) \
   f32_to_i64$(OBJ) \
   f32_to_ui32_r_minMag$(OBJ) \

--- a/c_emulator/SoftFloat-3e/build/template-FAST_INT64/Makefile
+++ b/c_emulator/SoftFloat-3e/build/template-FAST_INT64/Makefile
@@ -202,6 +202,7 @@ OBJS_OTHERS = \
   f16_le_quiet$(OBJ) \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
+  f16_classify$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
   f32_to_i32$(OBJ) \
@@ -231,6 +232,7 @@ OBJS_OTHERS = \
   f32_le_quiet$(OBJ) \
   f32_lt_quiet$(OBJ) \
   f32_isSignalingNaN$(OBJ) \
+  f32_classify$(OBJ) \
   f64_to_ui32$(OBJ) \
   f64_to_ui64$(OBJ) \
   f64_to_i32$(OBJ) \
@@ -260,6 +262,7 @@ OBJS_OTHERS = \
   f64_le_quiet$(OBJ) \
   f64_lt_quiet$(OBJ) \
   f64_isSignalingNaN$(OBJ) \
+  f64_classify$(OBJ) \
   extF80_to_ui32$(OBJ) \
   extF80_to_ui64$(OBJ) \
   extF80_to_i32$(OBJ) \
@@ -365,12 +368,20 @@ OBJS_OTHERS = \
   f128M_le_quiet$(OBJ) \
   f128M_lt_quiet$(OBJ) \
 
-OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS)
+OBJS_RECIPROCAL = \
+  f16_rsqrte7$(OBJ) \
+  f16_recip7$(OBJ) \
+  f32_rsqrte7$(OBJ) \
+  f32_recip7$(OBJ) \
+  f64_rsqrte7$(OBJ) \
+  f64_recip7$(OBJ) \
+
+OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL)
 
 $(OBJS_ALL): \
   $(OTHER_HEADERS) platform.h $(SOURCE_DIR)/include/primitiveTypes.h \
   $(SOURCE_DIR)/include/primitives.h
-$(OBJS_SPECIALIZE) $(OBJS_OTHERS): \
+$(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL): \
   $(SOURCE_DIR)/include/softfloat_types.h $(SOURCE_DIR)/include/internals.h \
   $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/specialize.h \
   $(SOURCE_DIR)/include/softfloat.h
@@ -380,6 +391,9 @@ $(OBJS_PRIMITIVES) $(OBJS_OTHERS): %$(OBJ): $(SOURCE_DIR)/%.c
 
 $(OBJS_SPECIALIZE): %$(OBJ): $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/%.c
 	$(COMPILE_C) $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/$*.c
+
+$(OBJS_RECIPROCAL): %$(OBJ): $(SOURCE_DIR)/fall_reciprocal.c
+	$(COMPILE_C) $(SOURCE_DIR)/fall_reciprocal.c
 
 softfloat$(LIB): $(OBJS_ALL)
 	$(DELETE) $@

--- a/c_emulator/SoftFloat-3e/build/template-FAST_INT64/Makefile
+++ b/c_emulator/SoftFloat-3e/build/template-FAST_INT64/Makefile
@@ -173,8 +173,12 @@ OBJS_OTHERS = \
   i64_to_extF80M$(OBJ) \
   i64_to_f128$(OBJ) \
   i64_to_f128M$(OBJ) \
+  f16_to_ui8$(OBJ) \
+  f16_to_ui16$(OBJ) \
   f16_to_ui32$(OBJ) \
   f16_to_ui64$(OBJ) \
+  f16_to_i8$(OBJ) \
+  f16_to_i16$(OBJ) \
   f16_to_i32$(OBJ) \
   f16_to_i64$(OBJ) \
   f16_to_ui32_r_minMag$(OBJ) \
@@ -203,8 +207,10 @@ OBJS_OTHERS = \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
   f16_classify$(OBJ) \
+  f32_to_ui16$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
+  f32_to_i16$(OBJ) \
   f32_to_i32$(OBJ) \
   f32_to_i64$(OBJ) \
   f32_to_ui32_r_minMag$(OBJ) \

--- a/c_emulator/SoftFloat-3e/build/template-not-FAST_INT64/Makefile
+++ b/c_emulator/SoftFloat-3e/build/template-not-FAST_INT64/Makefile
@@ -193,6 +193,7 @@ OBJS_OTHERS = \
   f16_le_quiet$(OBJ) \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
+  f16_classify$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
   f32_to_i32$(OBJ) \
@@ -220,6 +221,7 @@ OBJS_OTHERS = \
   f32_le_quiet$(OBJ) \
   f32_lt_quiet$(OBJ) \
   f32_isSignalingNaN$(OBJ) \
+  f32_classify$(OBJ) \
   f64_to_ui32$(OBJ) \
   f64_to_ui64$(OBJ) \
   f64_to_i32$(OBJ) \
@@ -247,6 +249,7 @@ OBJS_OTHERS = \
   f64_le_quiet$(OBJ) \
   f64_lt_quiet$(OBJ) \
   f64_isSignalingNaN$(OBJ) \
+  f64_classify$(OBJ) \
   extF80M_to_ui32$(OBJ) \
   extF80M_to_ui64$(OBJ) \
   extF80M_to_i32$(OBJ) \
@@ -299,12 +302,20 @@ OBJS_OTHERS = \
   f128M_le_quiet$(OBJ) \
   f128M_lt_quiet$(OBJ) \
 
-OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS)
+OBJS_RECIPROCAL = \
+  f16_rsqrte7$(OBJ) \
+  f16_recip7$(OBJ) \
+  f32_rsqrte7$(OBJ) \
+  f32_recip7$(OBJ) \
+  f64_rsqrte7$(OBJ) \
+  f64_recip7$(OBJ) \
+
+OBJS_ALL = $(OBJS_PRIMITIVES) $(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL)
 
 $(OBJS_ALL): \
   $(OTHER_HEADERS) platform.h $(SOURCE_DIR)/include/primitiveTypes.h \
   $(SOURCE_DIR)/include/primitives.h
-$(OBJS_SPECIALIZE) $(OBJS_OTHERS): \
+$(OBJS_SPECIALIZE) $(OBJS_OTHERS) $(OBJS_RECIPROCAL): \
   $(SOURCE_DIR)/include/softfloat_types.h $(SOURCE_DIR)/include/internals.h \
   $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/specialize.h \
   $(SOURCE_DIR)/include/softfloat.h
@@ -314,6 +325,9 @@ $(OBJS_PRIMITIVES) $(OBJS_OTHERS): %$(OBJ): $(SOURCE_DIR)/%.c
 
 $(OBJS_SPECIALIZE): %$(OBJ): $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/%.c
 	$(COMPILE_C) $(SOURCE_DIR)/$(SPECIALIZE_TYPE)/$*.c
+
+$(OBJS_RECIPROCAL): %$(OBJ): $(SOURCE_DIR)/fall_reciprocal.c
+	$(COMPILE_C) $(SOURCE_DIR)/fall_reciprocal.c
 
 softfloat$(LIB): $(OBJS_ALL)
 	$(DELETE) $@

--- a/c_emulator/SoftFloat-3e/build/template-not-FAST_INT64/Makefile
+++ b/c_emulator/SoftFloat-3e/build/template-not-FAST_INT64/Makefile
@@ -166,8 +166,12 @@ OBJS_OTHERS = \
   i64_to_f64$(OBJ) \
   i64_to_extF80M$(OBJ) \
   i64_to_f128M$(OBJ) \
+  f16_to_ui8$(OBJ) \
+  f16_to_ui16$(OBJ) \
   f16_to_ui32$(OBJ) \
   f16_to_ui64$(OBJ) \
+  f16_to_i8$(OBJ) \
+  f16_to_i16$(OBJ) \
   f16_to_i32$(OBJ) \
   f16_to_i64$(OBJ) \
   f16_to_ui32_r_minMag$(OBJ) \
@@ -194,8 +198,10 @@ OBJS_OTHERS = \
   f16_lt_quiet$(OBJ) \
   f16_isSignalingNaN$(OBJ) \
   f16_classify$(OBJ) \
+  f32_to_ui16$(OBJ) \
   f32_to_ui32$(OBJ) \
   f32_to_ui64$(OBJ) \
+  f32_to_i16$(OBJ) \
   f32_to_i32$(OBJ) \
   f32_to_i64$(OBJ) \
   f32_to_ui32_r_minMag$(OBJ) \

--- a/c_emulator/SoftFloat-3e/source/8086-SSE/specialize.h
+++ b/c_emulator/SoftFloat-3e/source/8086-SSE/specialize.h
@@ -51,6 +51,20 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 | The values to return on conversions to 32-bit integer formats that raise an
 | invalid exception.
 *----------------------------------------------------------------------------*/
+#define ui8_fromPosOverflow  0xFF
+#define ui8_fromNegOverflow  0
+#define ui8_fromNaN          0xFF
+#define i8_fromPosOverflow   0x7F
+#define i8_fromNegOverflow   (-0x7F - 1)
+#define i8_fromNaN           0x7F
+
+#define ui16_fromPosOverflow 0xFFFF
+#define ui16_fromNegOverflow 0
+#define ui16_fromNaN         0xFFFF
+#define i16_fromPosOverflow  0x7FFF
+#define i16_fromNegOverflow  (-0x7FFF - 1)
+#define i16_fromNaN          0x7FFF
+
 #define ui32_fromPosOverflow 0xFFFFFFFF
 #define ui32_fromNegOverflow 0xFFFFFFFF
 #define ui32_fromNaN         0xFFFFFFFF

--- a/c_emulator/SoftFloat-3e/source/8086/specialize.h
+++ b/c_emulator/SoftFloat-3e/source/8086/specialize.h
@@ -51,6 +51,20 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 | The values to return on conversions to 32-bit integer formats that raise an
 | invalid exception.
 *----------------------------------------------------------------------------*/
+#define ui8_fromPosOverflow  0xFF
+#define ui8_fromNegOverflow  0
+#define ui8_fromNaN          0xFF
+#define i8_fromPosOverflow   0x7F
+#define i8_fromNegOverflow   (-0x7F - 1)
+#define i8_fromNaN           0x7F
+
+#define ui16_fromPosOverflow 0xFFFF
+#define ui16_fromNegOverflow 0
+#define ui16_fromNaN         0xFFFF
+#define i16_fromPosOverflow  0x7FFF
+#define i16_fromNegOverflow  (-0x7FFF - 1)
+#define i16_fromNaN          0x7FFF
+
 #define ui32_fromPosOverflow 0xFFFFFFFF
 #define ui32_fromNegOverflow 0xFFFFFFFF
 #define ui32_fromNaN         0xFFFFFFFF

--- a/c_emulator/SoftFloat-3e/source/ARM-VFPv2-defaultNaN/specialize.h
+++ b/c_emulator/SoftFloat-3e/source/ARM-VFPv2-defaultNaN/specialize.h
@@ -51,6 +51,20 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 | The values to return on conversions to 32-bit integer formats that raise an
 | invalid exception.
 *----------------------------------------------------------------------------*/
+#define ui8_fromPosOverflow  0xFF
+#define ui8_fromNegOverflow  0
+#define ui8_fromNaN          0xFF
+#define i8_fromPosOverflow   0x7F
+#define i8_fromNegOverflow   (-0x7F - 1)
+#define i8_fromNaN           0x7F
+
+#define ui16_fromPosOverflow 0xFFFF
+#define ui16_fromNegOverflow 0
+#define ui16_fromNaN         0xFFFF
+#define i16_fromPosOverflow  0x7FFF
+#define i16_fromNegOverflow  (-0x7FFF - 1)
+#define i16_fromNaN          0x7FFF
+
 #define ui32_fromPosOverflow 0xFFFFFFFF
 #define ui32_fromNegOverflow 0
 #define ui32_fromNaN         0

--- a/c_emulator/SoftFloat-3e/source/ARM-VFPv2/specialize.h
+++ b/c_emulator/SoftFloat-3e/source/ARM-VFPv2/specialize.h
@@ -51,6 +51,20 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 | The values to return on conversions to 32-bit integer formats that raise an
 | invalid exception.
 *----------------------------------------------------------------------------*/
+#define ui8_fromPosOverflow  0xFF
+#define ui8_fromNegOverflow  0
+#define ui8_fromNaN          0xFF
+#define i8_fromPosOverflow   0x7F
+#define i8_fromNegOverflow   (-0x7F - 1)
+#define i8_fromNaN           0x7F
+
+#define ui16_fromPosOverflow 0xFFFF
+#define ui16_fromNegOverflow 0
+#define ui16_fromNaN         0xFFFF
+#define i16_fromPosOverflow  0x7FFF
+#define i16_fromNegOverflow  (-0x7FFF - 1)
+#define i16_fromNaN          0x7FFF
+
 #define ui32_fromPosOverflow 0xFFFFFFFF
 #define ui32_fromNegOverflow 0
 #define ui32_fromNaN         0

--- a/c_emulator/SoftFloat-3e/source/RISCV/specialize.h
+++ b/c_emulator/SoftFloat-3e/source/RISCV/specialize.h
@@ -51,6 +51,20 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 | The values to return on conversions to 32-bit integer formats that raise an
 | invalid exception.
 *----------------------------------------------------------------------------*/
+#define ui8_fromPosOverflow  0xFF
+#define ui8_fromNegOverflow  0
+#define ui8_fromNaN          0xFF
+#define i8_fromPosOverflow   0x7F
+#define i8_fromNegOverflow   (-0x7F - 1)
+#define i8_fromNaN           0x7F
+
+#define ui16_fromPosOverflow 0xFFFF
+#define ui16_fromNegOverflow 0
+#define ui16_fromNaN         0xFFFF
+#define i16_fromPosOverflow  0x7FFF
+#define i16_fromNegOverflow  (-0x7FFF - 1)
+#define i16_fromNaN          0x7FFF
+
 #define ui32_fromPosOverflow 0xFFFFFFFF
 #define ui32_fromNegOverflow 0
 #define ui32_fromNaN         0xFFFFFFFF

--- a/c_emulator/SoftFloat-3e/source/f16_classify.c
+++ b/c_emulator/SoftFloat-3e/source/f16_classify.c
@@ -1,0 +1,36 @@
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+uint_fast16_t f16_classify( float16_t a )
+{
+    union ui16_f16 uA;
+    uint_fast16_t uiA;
+
+    uA.f = a;
+    uiA = uA.ui;
+
+    uint_fast16_t infOrNaN = expF16UI( uiA ) == 0x1F;
+    uint_fast16_t subnormalOrZero = expF16UI( uiA ) == 0;
+    bool sign = signF16UI( uiA );
+    bool fracZero = fracF16UI( uiA ) == 0;
+    bool isNaN = isNaNF16UI( uiA );
+    bool isSNaN = softfloat_isSigNaNF16UI( uiA );
+
+    return
+        (  sign && infOrNaN && fracZero )          << 0 |
+        (  sign && !infOrNaN && !subnormalOrZero ) << 1 |
+        (  sign && subnormalOrZero && !fracZero )  << 2 |
+        (  sign && subnormalOrZero && fracZero )   << 3 |
+        ( !sign && infOrNaN && fracZero )          << 7 |
+        ( !sign && !infOrNaN && !subnormalOrZero ) << 6 |
+        ( !sign && subnormalOrZero && !fracZero )  << 5 |
+        ( !sign && subnormalOrZero && fracZero )   << 4 |
+        ( isNaN &&  isSNaN )                       << 8 |
+        ( isNaN && !isSNaN )                       << 9;
+}
+

--- a/c_emulator/SoftFloat-3e/source/f16_to_i16.c
+++ b/c_emulator/SoftFloat-3e/source/f16_to_i16.c
@@ -1,0 +1,56 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3d, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "specialize.h"
+#include "softfloat.h"
+
+int_fast16_t f16_to_i16( float16_t a, uint_fast8_t roundingMode, bool exact )
+{
+    uint_fast8_t old_flags = softfloat_exceptionFlags;
+
+    int_fast32_t sig32 = f16_to_i32(a, roundingMode, exact);
+
+    if (sig32 > INT16_MAX) {
+        softfloat_exceptionFlags = old_flags | softfloat_flag_invalid;
+        return i16_fromPosOverflow;
+    } else if (sig32 < INT16_MIN) {
+        softfloat_exceptionFlags = old_flags | softfloat_flag_invalid;
+        return i16_fromNegOverflow;
+    } else {
+        return sig32;
+    }
+}

--- a/c_emulator/SoftFloat-3e/source/f16_to_i8.c
+++ b/c_emulator/SoftFloat-3e/source/f16_to_i8.c
@@ -1,0 +1,56 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3d, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "specialize.h"
+#include "softfloat.h"
+
+int_fast8_t f16_to_i8( float16_t a, uint_fast8_t roundingMode, bool exact )
+{
+    uint_fast8_t old_flags = softfloat_exceptionFlags;
+
+    int_fast32_t sig32 = f16_to_i32(a, roundingMode, exact);
+
+    if (sig32 > INT8_MAX) {
+        softfloat_exceptionFlags = old_flags | softfloat_flag_invalid;
+        return i8_fromPosOverflow;
+    } else if (sig32 < INT8_MIN) {
+        softfloat_exceptionFlags = old_flags | softfloat_flag_invalid;
+        return i8_fromNegOverflow;
+    } else {
+        return sig32;
+    }
+}

--- a/c_emulator/SoftFloat-3e/source/f16_to_ui16.c
+++ b/c_emulator/SoftFloat-3e/source/f16_to_ui16.c
@@ -1,0 +1,53 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3d, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "specialize.h"
+#include "softfloat.h"
+
+uint_fast16_t f16_to_ui16( float16_t a, uint_fast8_t roundingMode, bool exact )
+{
+    uint_fast8_t old_flags = softfloat_exceptionFlags;
+
+    uint_fast32_t sig32 = f16_to_ui32(a, roundingMode, exact);
+
+    if (sig32 > UINT16_MAX) {
+        softfloat_exceptionFlags = old_flags | softfloat_flag_invalid;
+        return ui16_fromPosOverflow;
+    } else {
+        return sig32;
+    }
+}

--- a/c_emulator/SoftFloat-3e/source/f16_to_ui8.c
+++ b/c_emulator/SoftFloat-3e/source/f16_to_ui8.c
@@ -1,0 +1,53 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3d, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "specialize.h"
+#include "softfloat.h"
+
+uint_fast8_t f16_to_ui8( float16_t a, uint_fast8_t roundingMode, bool exact )
+{
+    uint_fast8_t old_flags = softfloat_exceptionFlags;
+
+    uint_fast32_t sig32 = f16_to_ui32(a, roundingMode, exact);
+
+    if (sig32 > UINT8_MAX) {
+        softfloat_exceptionFlags = old_flags | softfloat_flag_invalid;
+        return ui8_fromPosOverflow;
+    } else {
+        return sig32;
+    }
+}

--- a/c_emulator/SoftFloat-3e/source/f32_classify.c
+++ b/c_emulator/SoftFloat-3e/source/f32_classify.c
@@ -1,0 +1,36 @@
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+uint_fast16_t f32_classify( float32_t a )
+{
+    union ui32_f32 uA;
+    uint_fast32_t uiA;
+
+    uA.f = a;
+    uiA = uA.ui;
+
+    uint_fast16_t infOrNaN = expF32UI( uiA ) == 0xFF;
+    uint_fast16_t subnormalOrZero = expF32UI( uiA ) == 0;
+    bool sign = signF32UI( uiA );
+    bool fracZero = fracF32UI( uiA ) == 0;
+    bool isNaN = isNaNF32UI( uiA );
+    bool isSNaN = softfloat_isSigNaNF32UI( uiA );
+
+    return
+        (  sign && infOrNaN && fracZero )          << 0 |
+        (  sign && !infOrNaN && !subnormalOrZero ) << 1 |
+        (  sign && subnormalOrZero && !fracZero )  << 2 |
+        (  sign && subnormalOrZero && fracZero )   << 3 |
+        ( !sign && infOrNaN && fracZero )          << 7 |
+        ( !sign && !infOrNaN && !subnormalOrZero ) << 6 |
+        ( !sign && subnormalOrZero && !fracZero )  << 5 |
+        ( !sign && subnormalOrZero && fracZero )   << 4 |
+        ( isNaN &&  isSNaN )                       << 8 |
+        ( isNaN && !isSNaN )                       << 9;
+}
+

--- a/c_emulator/SoftFloat-3e/source/f32_to_i16.c
+++ b/c_emulator/SoftFloat-3e/source/f32_to_i16.c
@@ -1,0 +1,56 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3d, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "specialize.h"
+#include "softfloat.h"
+
+int_fast16_t f32_to_i16( float32_t a, uint_fast8_t roundingMode, bool exact )
+{
+    uint_fast8_t old_flags = softfloat_exceptionFlags;
+
+    int_fast32_t sig32 = f32_to_i32(a, roundingMode, exact);
+
+    if (sig32 > INT16_MAX) {
+        softfloat_exceptionFlags = old_flags | softfloat_flag_invalid;
+        return i16_fromPosOverflow;
+    } else if (sig32 < INT16_MIN) {
+        softfloat_exceptionFlags = old_flags | softfloat_flag_invalid;
+        return i16_fromNegOverflow;
+    } else {
+        return sig32;
+    }
+}

--- a/c_emulator/SoftFloat-3e/source/f32_to_ui16.c
+++ b/c_emulator/SoftFloat-3e/source/f32_to_ui16.c
@@ -1,0 +1,53 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3d, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016, 2017 The Regents of the
+University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <stdint.h>
+#include "specialize.h"
+#include "softfloat.h"
+
+uint_fast16_t f32_to_ui16( float32_t a, uint_fast8_t roundingMode, bool exact )
+{
+    uint_fast8_t old_flags = softfloat_exceptionFlags;
+
+    uint_fast32_t sig32 = f32_to_ui32(a, roundingMode, exact);
+
+    if (sig32 > UINT16_MAX) {
+        softfloat_exceptionFlags = old_flags | softfloat_flag_invalid;
+        return ui16_fromPosOverflow;
+    } else {
+        return sig32;
+    }
+}

--- a/c_emulator/SoftFloat-3e/source/f64_classify.c
+++ b/c_emulator/SoftFloat-3e/source/f64_classify.c
@@ -1,0 +1,36 @@
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+uint_fast16_t f64_classify( float64_t a )
+{
+    union ui64_f64 uA;
+    uint_fast64_t uiA;
+
+    uA.f = a;
+    uiA = uA.ui;
+
+    uint_fast16_t infOrNaN = expF64UI( uiA ) == 0x7FF;
+    uint_fast16_t subnormalOrZero = expF64UI( uiA ) == 0;
+    bool sign = signF64UI( uiA );
+    bool fracZero = fracF64UI( uiA ) == 0;
+    bool isNaN = isNaNF64UI( uiA );
+    bool isSNaN = softfloat_isSigNaNF64UI( uiA );
+
+    return
+        (  sign && infOrNaN && fracZero )          << 0 |
+        (  sign && !infOrNaN && !subnormalOrZero ) << 1 |
+        (  sign && subnormalOrZero && !fracZero )  << 2 |
+        (  sign && subnormalOrZero && fracZero )   << 3 |
+        ( !sign && infOrNaN && fracZero )          << 7 |
+        ( !sign && !infOrNaN && !subnormalOrZero ) << 6 |
+        ( !sign && subnormalOrZero && !fracZero )  << 5 |
+        ( !sign && subnormalOrZero && fracZero )   << 4 |
+        ( isNaN &&  isSNaN )                       << 8 |
+        ( isNaN && !isSNaN )                       << 9;
+}
+

--- a/c_emulator/SoftFloat-3e/source/fall_reciprocal.c
+++ b/c_emulator/SoftFloat-3e/source/fall_reciprocal.c
@@ -1,0 +1,392 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
+Package, Release 3d, by John R. Hauser.
+
+Copyright 2011, 2012, 2013, 2014, 2015, 2016 The Regents of the University of
+California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions, and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions, and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ 3. Neither the name of the University nor the names of its contributors may
+    be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS", AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ARE
+DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+=============================================================================*/
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "platform.h"
+#include "internals.h"
+#include "specialize.h"
+#include "softfloat.h"
+
+static inline uint64_t extract64(uint64_t val, int pos, int len)
+{
+  assert(pos >= 0 && len > 0 && len <= 64 - pos);
+  return (val >> pos) & (~UINT64_C(0) >> (64 - len));
+}
+
+static inline uint64_t make_mask64(int pos, int len)
+{
+    assert(pos >= 0 && len > 0 && pos < 64 && len <= 64);
+    return (UINT64_MAX >> (64 - len)) << pos;
+}
+
+//user needs to truncate output to required length
+static inline uint64_t rsqrte7(uint64_t val, int e, int s, bool sub) {
+  uint64_t exp = extract64(val, s, e);
+  uint64_t sig = extract64(val, 0, s);
+  uint64_t sign = extract64(val, s + e, 1);
+  const int p = 7;
+
+  static const uint8_t table[] = {
+      52, 51, 50, 48, 47, 46, 44, 43,
+      42, 41, 40, 39, 38, 36, 35, 34,
+      33, 32, 31, 30, 30, 29, 28, 27,
+      26, 25, 24, 23, 23, 22, 21, 20,
+      19, 19, 18, 17, 16, 16, 15, 14,
+      14, 13, 12, 12, 11, 10, 10, 9,
+      9, 8, 7, 7, 6, 6, 5, 4,
+      4, 3, 3, 2, 2, 1, 1, 0,
+      127, 125, 123, 121, 119, 118, 116, 114,
+      113, 111, 109, 108, 106, 105, 103, 102,
+      100, 99, 97, 96, 95, 93, 92, 91,
+      90, 88, 87, 86, 85, 84, 83, 82,
+      80, 79, 78, 77, 76, 75, 74, 73,
+      72, 71, 70, 70, 69, 68, 67, 66,
+      65, 64, 63, 63, 62, 61, 60, 59,
+      59, 58, 57, 56, 56, 55, 54, 53};
+
+  if (sub) {
+      while (extract64(sig, s - 1, 1) == 0)
+          exp--, sig <<= 1;
+
+      sig = (sig << 1) & make_mask64(0 ,s);
+  }
+
+  int idx = ((exp & 1) << (p-1)) | (sig >> (s-p+1));
+  uint64_t out_sig = (uint64_t)(table[idx]) << (s-p);
+  uint64_t out_exp = (3 * make_mask64(0, e - 1) + ~exp) / 2;
+
+  return (sign << (s+e)) | (out_exp << s) | out_sig;
+}
+
+float16_t f16_rsqrte7(float16_t in)
+{
+    union ui16_f16 uA;
+
+    uA.f = in;
+    unsigned int ret = f16_classify(in);
+    bool sub = false;
+    switch(ret) {
+    case 0x001: // -inf
+    case 0x002: // -normal
+    case 0x004: // -subnormal
+    case 0x100: // sNaN
+        softfloat_exceptionFlags |= softfloat_flag_invalid;
+    case 0x200: //qNaN
+        uA.ui = defaultNaNF16UI;
+        break;
+    case 0x008: // -0
+        uA.ui = 0xfc00;
+        softfloat_exceptionFlags |= softfloat_flag_infinite;
+        break;
+    case 0x010: // +0
+        uA.ui = 0x7c00;
+        softfloat_exceptionFlags |= softfloat_flag_infinite;
+        break;
+    case 0x080: //+inf
+        uA.ui = 0x0;
+        break;
+    case 0x020: //+ sub
+        sub = true;
+    default: // +num
+        uA.ui = rsqrte7(uA.ui, 5, 10, sub);
+        break;
+    }
+
+    return uA.f;
+}
+
+float32_t f32_rsqrte7(float32_t in)
+{
+    union ui32_f32 uA;
+
+    uA.f = in;
+    unsigned int ret = f32_classify(in);
+    bool sub = false;
+    switch(ret) {
+    case 0x001: // -inf
+    case 0x002: // -normal
+    case 0x004: // -subnormal
+    case 0x100: // sNaN
+        softfloat_exceptionFlags |= softfloat_flag_invalid;
+    case 0x200: //qNaN
+        uA.ui = defaultNaNF32UI;
+        break;
+    case 0x008: // -0
+        uA.ui = 0xff800000;
+        softfloat_exceptionFlags |= softfloat_flag_infinite;
+        break;
+    case 0x010: // +0
+        uA.ui = 0x7f800000;
+        softfloat_exceptionFlags |= softfloat_flag_infinite;
+        break;
+    case 0x080: //+inf
+        uA.ui = 0x0;
+        break;
+    case 0x020: //+ sub
+        sub = true;
+    default: // +num
+        uA.ui = rsqrte7(uA.ui, 8, 23, sub);
+        break;
+    }
+
+    return uA.f;
+}
+
+float64_t f64_rsqrte7(float64_t in)
+{
+    union ui64_f64 uA;
+
+    uA.f = in;
+    unsigned int ret = f64_classify(in);
+    bool sub = false;
+    switch(ret) {
+    case 0x001: // -inf
+    case 0x002: // -normal
+    case 0x004: // -subnormal
+    case 0x100: // sNaN
+        softfloat_exceptionFlags |= softfloat_flag_invalid;
+    case 0x200: //qNaN
+        uA.ui = defaultNaNF64UI;
+        break;
+    case 0x008: // -0
+        uA.ui = 0xfff0000000000000ul;
+        softfloat_exceptionFlags |= softfloat_flag_infinite;
+        break;
+    case 0x010: // +0
+        uA.ui = 0x7ff0000000000000ul;
+        softfloat_exceptionFlags |= softfloat_flag_infinite;
+        break;
+    case 0x080: //+inf
+        uA.ui = 0x0;
+        break;
+    case 0x020: //+ sub
+        sub = true;
+    default: // +num
+        uA.ui = rsqrte7(uA.ui, 11, 52, sub);
+        break;
+    }
+
+    return uA.f;
+}
+
+//user needs to truncate output to required length
+static inline uint64_t recip7(uint64_t val, int e, int s, int rm, bool sub,
+                              bool *round_abnormal)
+{
+    uint64_t exp = extract64(val, s, e);
+    uint64_t sig = extract64(val, 0, s);
+    uint64_t sign = extract64(val, s + e, 1);
+    const int p = 7;
+
+    static const uint8_t table[] = {
+        127, 125, 123, 121, 119, 117, 116, 114,
+        112, 110, 109, 107, 105, 104, 102, 100,
+        99, 97, 96, 94, 93, 91, 90, 88,
+        87, 85, 84, 83, 81, 80, 79, 77,
+        76, 75, 74, 72, 71, 70, 69, 68,
+        66, 65, 64, 63, 62, 61, 60, 59,
+        58, 57, 56, 55, 54, 53, 52, 51,
+        50, 49, 48, 47, 46, 45, 44, 43,
+        42, 41, 40, 40, 39, 38, 37, 36,
+        35, 35, 34, 33, 32, 31, 31, 30,
+        29, 28, 28, 27, 26, 25, 25, 24,
+        23, 23, 22, 21, 21, 20, 19, 19,
+        18, 17, 17, 16, 15, 15, 14, 14,
+        13, 12, 12, 11, 11, 10, 9, 9,
+        8, 8, 7, 7, 6, 5, 5, 4,
+        4, 3, 3, 2, 2, 1, 1, 0};
+
+    if (sub) {
+        while (extract64(sig, s - 1, 1) == 0)
+            exp--, sig <<= 1;
+
+        sig = (sig << 1) & make_mask64(0 ,s);
+
+        if (exp != 0 && exp != UINT64_MAX) {
+            *round_abnormal = true;
+            if (rm == 1 ||
+                (rm == 2 && !sign) ||
+                (rm == 3 && sign))
+                return ((sign << (s+e)) | make_mask64(s, e)) - 1;
+            else
+                return (sign << (s+e)) | make_mask64(s, e);
+        }
+    }
+
+    int idx = sig >> (s-p);
+    uint64_t out_sig = (uint64_t)(table[idx]) << (s-p);
+    uint64_t out_exp = 2 * make_mask64(0, e - 1) + ~exp;
+    if (out_exp == 0 || out_exp == UINT64_MAX) {
+        out_sig = (out_sig >> 1) | make_mask64(s - 1, 1);
+        if (out_exp == UINT64_MAX) {
+            out_sig >>= 1;
+            out_exp = 0;
+        }
+    }
+
+    return (sign << (s+e)) | (out_exp << s) | out_sig;
+}
+
+float16_t f16_recip7(float16_t in)
+{
+    union ui16_f16 uA;
+
+    uA.f = in;
+    unsigned int ret = f16_classify(in);
+    bool sub = false;
+    bool round_abnormal = false;
+    switch(ret) {
+    case 0x001: // -inf
+        uA.ui = 0x8000;
+        break;
+    case 0x080: //+inf
+        uA.ui = 0x0;
+        break;
+    case 0x008: // -0
+        uA.ui = 0xfc00;
+        softfloat_exceptionFlags |= softfloat_flag_infinite;
+        break;
+    case 0x010: // +0
+        uA.ui = 0x7c00;
+        softfloat_exceptionFlags |= softfloat_flag_infinite;
+        break;
+    case 0x100: // sNaN
+        softfloat_exceptionFlags |= softfloat_flag_invalid;
+    case 0x200: //qNaN
+        uA.ui = defaultNaNF16UI;
+        break;
+    case 0x004: // -subnormal
+    case 0x020: //+ sub
+        sub = true;
+    default: // +- normal
+        uA.ui = recip7(uA.ui, 5, 10,
+                       softfloat_roundingMode, sub, &round_abnormal);
+        if (round_abnormal)
+            softfloat_exceptionFlags |= softfloat_flag_inexact |
+                                        softfloat_flag_overflow;
+        break;
+    }
+
+    return uA.f;
+}
+
+float32_t f32_recip7(float32_t in)
+{
+    union ui32_f32 uA;
+
+    uA.f = in;
+    unsigned int ret = f32_classify(in);
+    bool sub = false;
+    bool round_abnormal = false;
+    switch(ret) {
+    case 0x001: // -inf
+        uA.ui = 0x80000000;
+        break;
+    case 0x080: //+inf
+        uA.ui = 0x0;
+        break;
+    case 0x008: // -0
+        uA.ui = 0xff800000;
+        softfloat_exceptionFlags |= softfloat_flag_infinite;
+        break;
+    case 0x010: // +0
+        uA.ui = 0x7f800000;
+        softfloat_exceptionFlags |= softfloat_flag_infinite;
+        break;
+    case 0x100: // sNaN
+        softfloat_exceptionFlags |= softfloat_flag_invalid;
+    case 0x200: //qNaN
+        uA.ui = defaultNaNF32UI;
+        break;
+    case 0x004: // -subnormal
+    case 0x020: //+ sub
+        sub = true;
+    default: // +- normal
+        uA.ui = recip7(uA.ui, 8, 23,
+                       softfloat_roundingMode, sub, &round_abnormal);
+        if (round_abnormal)
+          softfloat_exceptionFlags |= softfloat_flag_inexact |
+                                      softfloat_flag_overflow;
+        break;
+    }
+
+    return uA.f;
+}
+
+float64_t f64_recip7(float64_t in)
+{
+    union ui64_f64 uA;
+
+    uA.f = in;
+    unsigned int ret = f64_classify(in);
+    bool sub = false;
+    bool round_abnormal = false;
+    switch(ret) {
+    case 0x001: // -inf
+        uA.ui = 0x8000000000000000;
+        break;
+    case 0x080: //+inf
+        uA.ui = 0x0;
+        break;
+    case 0x008: // -0
+        uA.ui = 0xfff0000000000000;
+        softfloat_exceptionFlags |= softfloat_flag_infinite;
+        break;
+    case 0x010: // +0
+        uA.ui = 0x7ff0000000000000;
+        softfloat_exceptionFlags |= softfloat_flag_infinite;
+        break;
+    case 0x100: // sNaN
+        softfloat_exceptionFlags |= softfloat_flag_invalid;
+    case 0x200: //qNaN
+        uA.ui = defaultNaNF64UI;
+        break;
+    case 0x004: // -subnormal
+    case 0x020: //+ sub
+        sub = true;
+    default: // +- normal
+        uA.ui = recip7(uA.ui, 11, 52,
+                       softfloat_roundingMode, sub, &round_abnormal);
+        if (round_abnormal)
+            softfloat_exceptionFlags |= softfloat_flag_inexact |
+                                        softfloat_flag_overflow;
+        break;
+    }
+
+    return uA.f;
+}

--- a/c_emulator/SoftFloat-3e/source/include/softfloat.h
+++ b/c_emulator/SoftFloat-3e/source/include/softfloat.h
@@ -168,6 +168,9 @@ bool f16_eq_signaling( float16_t, float16_t );
 bool f16_le_quiet( float16_t, float16_t );
 bool f16_lt_quiet( float16_t, float16_t );
 bool f16_isSignalingNaN( float16_t );
+uint_fast16_t f16_classify( float16_t );
+float16_t f16_rsqrte7( float16_t );
+float16_t f16_recip7( float16_t );
 
 /*----------------------------------------------------------------------------
 | 32-bit (single-precision) floating-point operations.
@@ -203,6 +206,9 @@ bool f32_eq_signaling( float32_t, float32_t );
 bool f32_le_quiet( float32_t, float32_t );
 bool f32_lt_quiet( float32_t, float32_t );
 bool f32_isSignalingNaN( float32_t );
+uint_fast16_t f32_classify( float32_t );
+float32_t f32_rsqrte7( float32_t );
+float32_t f32_recip7( float32_t );
 
 /*----------------------------------------------------------------------------
 | 64-bit (double-precision) floating-point operations.
@@ -238,6 +244,9 @@ bool f64_eq_signaling( float64_t, float64_t );
 bool f64_le_quiet( float64_t, float64_t );
 bool f64_lt_quiet( float64_t, float64_t );
 bool f64_isSignalingNaN( float64_t );
+uint_fast16_t f64_classify( float64_t );
+float64_t f64_rsqrte7( float64_t );
+float64_t f64_recip7( float64_t );
 
 /*----------------------------------------------------------------------------
 | Rounding precision for 80-bit extended double-precision floating-point.

--- a/c_emulator/SoftFloat-3e/source/include/softfloat.h
+++ b/c_emulator/SoftFloat-3e/source/include/softfloat.h
@@ -137,8 +137,12 @@ void i64_to_f128M( int64_t, float128_t * );
 /*----------------------------------------------------------------------------
 | 16-bit (half-precision) floating-point operations.
 *----------------------------------------------------------------------------*/
+uint_fast8_t f16_to_ui8( float16_t, uint_fast8_t, bool );
+uint_fast16_t f16_to_ui16( float16_t, uint_fast8_t, bool );
 uint_fast32_t f16_to_ui32( float16_t, uint_fast8_t, bool );
 uint_fast64_t f16_to_ui64( float16_t, uint_fast8_t, bool );
+int_fast8_t f16_to_i8( float16_t, uint_fast8_t, bool );
+int_fast16_t f16_to_i16( float16_t, uint_fast8_t, bool );
 int_fast32_t f16_to_i32( float16_t, uint_fast8_t, bool );
 int_fast64_t f16_to_i64( float16_t, uint_fast8_t, bool );
 uint_fast32_t f16_to_ui32_r_minMag( float16_t, bool );
@@ -175,8 +179,10 @@ float16_t f16_recip7( float16_t );
 /*----------------------------------------------------------------------------
 | 32-bit (single-precision) floating-point operations.
 *----------------------------------------------------------------------------*/
+uint_fast16_t f32_to_ui16( float32_t, uint_fast8_t, bool );
 uint_fast32_t f32_to_ui32( float32_t, uint_fast8_t, bool );
 uint_fast64_t f32_to_ui64( float32_t, uint_fast8_t, bool );
+int_fast16_t f32_to_i16( float32_t, uint_fast8_t, bool );
 int_fast32_t f32_to_i32( float32_t, uint_fast8_t, bool );
 int_fast64_t f32_to_i64( float32_t, uint_fast8_t, bool );
 uint_fast32_t f32_to_ui32_r_minMag( float32_t, bool );

--- a/c_emulator/riscv_softfloat.c
+++ b/c_emulator/riscv_softfloat.c
@@ -251,6 +251,116 @@ unit softfloat_f64sqrt(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
+unit softfloat_f16rsqrte7(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a, res;
+  a.v = v;
+  res = f16_rsqrte7(a);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f32rsqrte7(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float32_t a, res;
+  a.v = v;
+  res = f32_rsqrte7(a);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f64rsqrte7(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float64_t a, res;
+  a.v = v;
+  res = f64_rsqrte7(a);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f16recip7(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a, res;
+  a.v = v;
+  res = f16_recip7(a);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f32recip7(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float32_t a, res;
+  a.v = v;
+  res = f32_recip7(a);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f64recip7(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float64_t a, res;
+  a.v = v;
+  res = f64_recip7(a);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f16class(mach_bits v) {
+  SOFTFLOAT_PRELUDE(0);
+
+  float16_t a;
+  float64_t res;
+  a.v = v;
+  res.v = f16_classify(a);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f32class(mach_bits v) {
+  SOFTFLOAT_PRELUDE(0);
+
+  float32_t a;
+  float64_t res;
+  a.v = v;
+  res.v = f32_classify(a);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f64class(mach_bits v) {
+  SOFTFLOAT_PRELUDE(0);
+
+  float64_t a, res;
+  a.v = v;
+  res.v = f64_classify(a);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
 // The boolean 'true' argument in the conversion calls below selects
 // 'exact' conversion, which sets the Inexact exception flag if
 // needed.
@@ -641,6 +751,19 @@ unit softfloat_f16lt(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
+unit softfloat_f16lt_quiet(mach_bits v1, mach_bits v2) {
+  SOFTFLOAT_PRELUDE(0);
+
+  float16_t a, b, res;
+  a.v = v1;
+  b.v = v2;
+  res.v = f16_lt_quiet(a, b);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
 unit softfloat_f16le(mach_bits v1, mach_bits v2) {
   SOFTFLOAT_PRELUDE(0);
 
@@ -680,6 +803,19 @@ unit softfloat_f32lt(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
+unit softfloat_f32lt_quiet(mach_bits v1, mach_bits v2) {
+  SOFTFLOAT_PRELUDE(0);
+
+  float32_t a, b, res;
+  a.v = v1;
+  b.v = v2;
+  res.v = f32_lt_quiet(a, b);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
 unit softfloat_f32le(mach_bits v1, mach_bits v2) {
   SOFTFLOAT_PRELUDE(0);
 
@@ -713,6 +849,19 @@ unit softfloat_f64lt(mach_bits v1, mach_bits v2) {
   a.v = v1;
   b.v = v2;
   res.v = f64_lt(a, b);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f64lt_quiet(mach_bits v1, mach_bits v2) {
+  SOFTFLOAT_PRELUDE(0);
+
+  float64_t a, b, res;
+  a.v = v1;
+  b.v = v2;
+  res.v = f64_lt_quiet(a, b);
 
   SOFTFLOAT_POSTLUDE(res);
 

--- a/c_emulator/riscv_softfloat.c
+++ b/c_emulator/riscv_softfloat.c
@@ -364,6 +364,64 @@ unit softfloat_f64class(mach_bits v) {
 // The boolean 'true' argument in the conversion calls below selects
 // 'exact' conversion, which sets the Inexact exception flag if
 // needed.
+unit softfloat_f16toi8(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a;
+  int_fast8_t res;
+  uint_fast8_t rm8 = uint8_of_rm(rm);
+  a.v = v;
+  res = f16_to_i8(a, rm8, true);
+
+  zfloat_result = res;
+  zfloat_fflags |= (mach_bits) softfloat_exceptionFlags;
+
+  return UNIT;
+}
+
+unit softfloat_f16toui8(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a;
+  uint_fast8_t res;
+  uint_fast8_t rm8 = uint8_of_rm(rm);
+  a.v = v;
+  res = f16_to_ui8(a, rm8, true);
+
+  zfloat_result = res;
+  zfloat_fflags |= (mach_bits) softfloat_exceptionFlags;
+
+  return UNIT;
+}
+
+unit softfloat_f16toi16(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a;
+  float16_t res;
+  uint_fast8_t rm8 = uint8_of_rm(rm);
+  a.v = v;
+  res.v = f16_to_i8(a, rm8, true);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f16toui16(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float16_t a;
+  float16_t res;
+  uint_fast8_t rm8 = uint8_of_rm(rm);
+  a.v = v;
+  res.v = f16_to_ui8(a, rm8, true);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
 unit softfloat_f16toi32(mach_bits rm, mach_bits v) {
   SOFTFLOAT_PRELUDE(rm);
 
@@ -414,6 +472,34 @@ unit softfloat_f16toui64(mach_bits rm, mach_bits v) {
   uint_fast8_t rm8 = uint8_of_rm(rm);
   a.v = v;
   res.v = f16_to_ui64(a, rm8, true);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f32toi16(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float32_t a;
+  float16_t res;
+  uint_fast8_t rm8 = uint8_of_rm(rm);
+  a.v = v;
+  res.v = f32_to_i16(a, rm8, true);
+
+  SOFTFLOAT_POSTLUDE(res);
+
+  return UNIT;
+}
+
+unit softfloat_f32toui16(mach_bits rm, mach_bits v) {
+  SOFTFLOAT_PRELUDE(rm);
+
+  float32_t a;
+  float16_t res;
+  uint_fast8_t rm8 = uint8_of_rm(rm);
+  a.v = v;
+  res.v = f32_to_ui16(a, rm8, true);
 
   SOFTFLOAT_POSTLUDE(res);
 

--- a/c_emulator/riscv_softfloat.h
+++ b/c_emulator/riscv_softfloat.h
@@ -23,6 +23,10 @@ unit softfloat_f16sqrt(mach_bits rm, mach_bits v);
 unit softfloat_f32sqrt(mach_bits rm, mach_bits v);
 unit softfloat_f64sqrt(mach_bits rm, mach_bits v);
 
+unit softfloat_f16toi8(mach_bits rm, mach_bits v);
+unit softfloat_f16toui8(mach_bits rm, mach_bits v);
+unit softfloat_f16toi16(mach_bits rm, mach_bits v);
+unit softfloat_f16toui16(mach_bits rm, mach_bits v);
 unit softfloat_f16toi32(mach_bits rm, mach_bits v);
 unit softfloat_f16toui32(mach_bits rm, mach_bits v);
 unit softfloat_f16toi64(mach_bits rm, mach_bits v);
@@ -40,6 +44,8 @@ unit softfloat_f16class(mach_bits v);
 unit softfloat_f32class(mach_bits v);
 unit softfloat_f64class(mach_bits v);
 
+unit softfloat_f32toi16(mach_bits rm, mach_bits v);
+unit softfloat_f32toui16(mach_bits rm, mach_bits v);
 unit softfloat_f32toi32(mach_bits rm, mach_bits v);
 unit softfloat_f32toui32(mach_bits rm, mach_bits v);
 unit softfloat_f32toi64(mach_bits rm, mach_bits v);

--- a/c_emulator/riscv_softfloat.h
+++ b/c_emulator/riscv_softfloat.h
@@ -28,6 +28,18 @@ unit softfloat_f16toui32(mach_bits rm, mach_bits v);
 unit softfloat_f16toi64(mach_bits rm, mach_bits v);
 unit softfloat_f16toui64(mach_bits rm, mach_bits v);
 
+unit softfloat_f16rsqrte7(mach_bits rm, mach_bits v);
+unit softfloat_f32rsqrte7(mach_bits rm, mach_bits v);
+unit softfloat_f64rsqrte7(mach_bits rm, mach_bits v);
+
+unit softfloat_f16recip7(mach_bits rm, mach_bits v);
+unit softfloat_f32recip7(mach_bits rm, mach_bits v);
+unit softfloat_f64recip7(mach_bits rm, mach_bits v);
+
+unit softfloat_f16class(mach_bits v);
+unit softfloat_f32class(mach_bits v);
+unit softfloat_f64class(mach_bits v);
+
 unit softfloat_f32toi32(mach_bits rm, mach_bits v);
 unit softfloat_f32toui32(mach_bits rm, mach_bits v);
 unit softfloat_f32toi64(mach_bits rm, mach_bits v);
@@ -62,11 +74,14 @@ unit softfloat_f64tof16(mach_bits rm, mach_bits v);
 unit softfloat_f64tof32(mach_bits rm, mach_bits v);
 
 unit softfloat_f16lt(mach_bits v1, mach_bits v2);
+unit softfloat_f16lt_quiet(mach_bits v1, mach_bits v2);
 unit softfloat_f16le(mach_bits v1, mach_bits v2);
 unit softfloat_f16eq(mach_bits v1, mach_bits v2);
 unit softfloat_f32lt(mach_bits v1, mach_bits v2);
+unit softfloat_f32lt_quiet(mach_bits v1, mach_bits v2);
 unit softfloat_f32le(mach_bits v1, mach_bits v2);
 unit softfloat_f32eq(mach_bits v1, mach_bits v2);
 unit softfloat_f64lt(mach_bits v1, mach_bits v2);
+unit softfloat_f64lt_quiet(mach_bits v1, mach_bits v2);
 unit softfloat_f64le(mach_bits v1, mach_bits v2);
 unit softfloat_f64eq(mach_bits v1, mach_bits v2);

--- a/handwritten_support/0.11/riscv_extras_fdext.lem
+++ b/handwritten_support/0.11/riscv_extras_fdext.lem
@@ -66,6 +66,33 @@ let softfloat_f32_sqrt _ _ = ()
 val softfloat_f64_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_f64_sqrt _ _ = ()
 
+val softfloat_f16_rsqrte7 : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_rsqrte7 _ _ = ()
+
+val softfloat_f32_rsqrte7 : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f32_rsqrte7 _ _ = ()
+
+val softfloat_f64_rsqrte7 : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f64_rsqrte7 _ _ = ()
+
+val softfloat_f16_recip7 : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_recip7 _ _ = ()
+
+val softfloat_f32_recip7 : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f32_recip7 _ _ = ()
+
+val softfloat_f64_recip7 : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f64_recip7 _ _ = ()
+
+val softfloat_f16_class : forall 's. Size 's => bitvector 's -> unit
+let softfloat_f16_class _ = ()
+
+val softfloat_f32_class : forall 's. Size 's => bitvector 's -> unit
+let softfloat_f32_class _ = ()
+
+val softfloat_f64_class : forall 's. Size 's => bitvector 's -> unit
+let softfloat_f64_class _ = ()
+
 
 val softfloat_f16_to_i32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_f16_to_i32 _ _ = ()
@@ -164,6 +191,9 @@ let softfloat_f64_to_f32 _ _ = ()
 val softfloat_f16_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
 let softfloat_f16_lt _ _ = ()
 
+val softfloat_f16_lt_quiet : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
+let softfloat_f16_lt_quiet _ _ = ()
+
 val softfloat_f16_le : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
 let softfloat_f16_le _ _ = ()
 
@@ -173,6 +203,9 @@ let softfloat_f16_eq _ _ = ()
 val softfloat_f32_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
 let softfloat_f32_lt _ _ = ()
 
+val softfloat_f32_lt_quiet : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
+let softfloat_f32_lt_quiet _ _ = ()
+
 val softfloat_f32_le : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
 let softfloat_f32_le _ _ = ()
 
@@ -181,6 +214,9 @@ let softfloat_f32_eq _ _ = ()
 
 val softfloat_f64_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
 let softfloat_f64_lt _ _ = ()
+
+val softfloat_f64_lt_quiet : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
+let softfloat_f64_lt_quiet _ _ = ()
 
 val softfloat_f64_le : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
 let softfloat_f64_le _ _ = ()

--- a/handwritten_support/0.11/riscv_extras_fdext.lem
+++ b/handwritten_support/0.11/riscv_extras_fdext.lem
@@ -94,6 +94,18 @@ val softfloat_f64_class : forall 's. Size 's => bitvector 's -> unit
 let softfloat_f64_class _ = ()
 
 
+val softfloat_f16_to_i8: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_i8 _ _ = ()
+
+val softfloat_f16_to_ui8: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_ui8 _ _ = ()
+
+val softfloat_f16_to_i16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_i16 _ _ = ()
+
+val softfloat_f16_to_ui16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_ui16 _ _ = ()
+
 val softfloat_f16_to_i32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_f16_to_i32 _ _ = ()
 
@@ -118,6 +130,12 @@ let softfloat_i64_to_f16 _ _ = ()
 val softfloat_ui64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_ui64_to_f16 _ _ = ()
 
+
+val softfloat_f32_to_i16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f32_to_i16 _ _ = ()
+
+val softfloat_f32_to_ui16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f32_to_ui16 _ _ = ()
 
 val softfloat_f32_to_i32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_f32_to_i32 _ _ = ()

--- a/handwritten_support/riscv_extras_fdext.lem
+++ b/handwritten_support/riscv_extras_fdext.lem
@@ -162,6 +162,18 @@ val softfloat_f64_class : forall 's. Size 's => bitvector 's -> unit
 let softfloat_f64_class _ = ()
 
 
+val softfloat_f16_to_i8: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_i8 _ _ = ()
+
+val softfloat_f16_to_ui8: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_ui8 _ _ = ()
+
+val softfloat_f16_to_i16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_i16 _ _ = ()
+
+val softfloat_f16_to_ui16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_to_ui16 _ _ = ()
+
 val softfloat_f16_to_i32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_f16_to_i32 _ _ = ()
 
@@ -186,6 +198,12 @@ let softfloat_i64_to_f16 _ _ = ()
 val softfloat_ui64_to_f16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_ui64_to_f16 _ _ = ()
 
+
+val softfloat_f32_to_i16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f32_to_i16 _ _ = ()
+
+val softfloat_f32_to_ui16: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f32_to_ui16 _ _ = ()
 
 val softfloat_f32_to_i32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_f32_to_i32 _ _ = ()

--- a/handwritten_support/riscv_extras_fdext.lem
+++ b/handwritten_support/riscv_extras_fdext.lem
@@ -134,6 +134,33 @@ let softfloat_f32_sqrt _ _ = ()
 val softfloat_f64_sqrt : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_f64_sqrt _ _ = ()
 
+val softfloat_f16_rsqrte7 : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_rsqrte7 _ _ = ()
+
+val softfloat_f32_rsqrte7 : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f32_rsqrte7 _ _ = ()
+
+val softfloat_f64_rsqrte7 : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f64_rsqrte7 _ _ = ()
+
+val softfloat_f16_recip7 : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f16_recip7 _ _ = ()
+
+val softfloat_f32_recip7 : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f32_recip7 _ _ = ()
+
+val softfloat_f64_recip7 : forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
+let softfloat_f64_recip7 _ _ = ()
+
+val softfloat_f16_class : forall 's. Size 's => bitvector 's -> unit
+let softfloat_f16_class _ = ()
+
+val softfloat_f32_class : forall 's. Size 's => bitvector 's -> unit
+let softfloat_f32_class _ = ()
+
+val softfloat_f64_class : forall 's. Size 's => bitvector 's -> unit
+let softfloat_f64_class _ = ()
+
 
 val softfloat_f16_to_i32: forall 'rm 's. Size 'rm, Size 's => bitvector 'rm -> bitvector 's -> unit
 let softfloat_f16_to_i32 _ _ = ()
@@ -232,6 +259,9 @@ let softfloat_f64_to_f32 _ _ = ()
 val softfloat_f16_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
 let softfloat_f16_lt _ _ = ()
 
+val softfloat_f16_lt_quiet : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
+let softfloat_f16_lt_quiet _ _ = ()
+
 val softfloat_f16_le : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
 let softfloat_f16_le _ _ = ()
 
@@ -241,6 +271,9 @@ let softfloat_f16_eq _ _ = ()
 val softfloat_f32_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
 let softfloat_f32_lt _ _ = ()
 
+val softfloat_f32_lt_quiet : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
+let softfloat_f32_lt_quiet _ _ = ()
+
 val softfloat_f32_le : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
 let softfloat_f32_le _ _ = ()
 
@@ -249,6 +282,9 @@ let softfloat_f32_eq _ _ = ()
 
 val softfloat_f64_lt : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
 let softfloat_f64_lt _ _ = ()
+
+val softfloat_f64_lt_quiet : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
+let softfloat_f64_lt_quiet _ _ = ()
 
 val softfloat_f64_le : forall 's. Size 's => bitvector 's -> bitvector 's -> unit
 let softfloat_f64_le _ _ = ()

--- a/model/riscv_fdext_regs.sail
+++ b/model/riscv_fdext_regs.sail
@@ -488,8 +488,12 @@ function ext_write_fcsr (frm, fflags) = {
 val write_fflags : (bits(5)) -> unit effect {rreg, wreg, escape}
 function write_fflags(fflags) = {
   if   fcsr.FFLAGS() != fflags
-  then dirty_fd_context_if_present();
-  fcsr->FFLAGS() = fflags;
+  then {
+    fcsr->FFLAGS() = fflags;
+    dirty_fd_context_if_present();
+    if   get_config_print_reg()
+    then print("fcsr.FFLAGS <- " ^ BitStr(fflags))
+  }
 }
 
 /* called for non-softfloat paths (softfloat flags need updating) */
@@ -501,5 +505,7 @@ function accrue_fflags(flags) = {
     fcsr->FFLAGS() = f;
     update_softfloat_fflags(f);
     dirty_fd_context_if_present();
+    if   get_config_print_reg()
+    then print("fcsr.FFLAGS <- " ^ BitStr(flags))
   }
 }

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -2,7 +2,7 @@
 /* This file implements part of the vector extension.                              */
 /* Chapter 11: Vector Integer Arithmetic Instructions                              */
 /* Chapter 12: Vector Fixed-Point Arithmetic Instructions                          */
-/* Chapter 16: Vector Permutation Instructions                                     */
+/* Chapter 16: Vector Permutation Instructions (integer part)                      */
 /* ******************************************************************************* */
 
 /* ******************************* OPIVV (VVTYPE) ******************************** */
@@ -42,7 +42,7 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -176,8 +176,8 @@ function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
-      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
+      not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
   then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
@@ -243,8 +243,8 @@ function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
-      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
+      not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
   then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
@@ -408,7 +408,7 @@ function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -526,8 +526,8 @@ function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
-      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
+      not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
   then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
@@ -593,8 +593,8 @@ function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
-      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
+      not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
   then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
@@ -661,7 +661,7 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -820,7 +820,7 @@ function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -914,8 +914,8 @@ function clause execute(NISTYPE(funct6, vm, vs2, simm, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
-      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
+      not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
   then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
@@ -981,8 +981,8 @@ function clause execute(NITYPE(funct6, vm, vs2, simm, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
-      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
+      not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
   then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
@@ -1049,7 +1049,7 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1194,7 +1194,7 @@ function clause execute(VMVRTYPE(vs2, simm, vd)) = {
   let imm_val = unsigned(EXTZ(sizeof(xlen), simm));
   let EMUL    = imm_val + 1;
 
-  if ~(EMUL == 1 | EMUL == 2 | EMUL == 4 | EMUL == 8) then { handle_illegal(); return RETIRE_FAIL };
+  if not(EMUL == 1 | EMUL == 2 | EMUL == 4 | EMUL == 8) then { handle_illegal(); return RETIRE_FAIL };
 
   let EMUL_pow = log2(EMUL);
   let num_elem = get_num_elem(EMUL_pow, SEW);
@@ -1225,7 +1225,7 @@ mapping simm_string : bits(5) <-> string = {
 mapping clause assembly = VMVRTYPE(vs2, simm, vd)
   <-> "vmv" ^ simm_string(simm) ^ "r.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)
 
-/* ******************************* OPMVV (MVVTYPE) ******************************* */
+/* ******************************* OPMVV (VVTYPE) ******************************** */
 union clause ast = MVVTYPE : (mvvfunct6, bits(1), regidx, regidx, regidx)
 
 mapping encdec_mvvfunct6 : mvvfunct6 <-> bits(6) = {
@@ -1251,7 +1251,7 @@ function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1341,7 +1341,7 @@ mapping mvvtype_mnemonic : mvvfunct6 <-> string = {
 mapping clause assembly = MVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> mvvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
-/* ************************ OPMVV (MVVtype Multiply-Add) ************************* */
+/* ************************* OPMVV (VVtype Multiply-Add) ************************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
 union clause ast = MVVMATYPE : (mvvmafunct6, bits(1), regidx, regidx, regidx)
 
@@ -1361,7 +1361,7 @@ function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let VLEN     = int_power(2, get_vlen_pow());
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1424,8 +1424,8 @@ function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) | 
-      ~(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) | 
+      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
   then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
@@ -1474,7 +1474,7 @@ mapping wvvtype_mnemonic : wvvfunct6 <-> string = {
 mapping clause assembly = WVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> wvvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
-/* ******************************* OPMVV (WVTYPE) ******************************** */
+/* *************************** OPMVV (WVTYPE Widening) *************************** */
 union clause ast = WVTYPE : (wvfunct6, bits(1), regidx, regidx, regidx)
 
 mapping encdec_wvfunct6 : wvfunct6 <-> bits(6) = {
@@ -1494,8 +1494,8 @@ function clause execute(WVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) | 
-      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) | 
+      not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
   then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
@@ -1538,7 +1538,7 @@ mapping wvtype_mnemonic : wvfunct6 <-> string = {
 mapping clause assembly = WVTYPE(funct6, vm, vs2, vs1, vd)
   <-> wvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
-/* ******************** OPMVV (MVVtype Widening Multiply-Add) ******************** */
+/* ******************** OPMVV (VVtype Widening Multiply-Add) ********************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
 union clause ast = WMVVTYPE : (wmvvfunct6, bits(1), regidx, regidx, regidx)
 
@@ -1558,8 +1558,8 @@ function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) | 
-      ~(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) | 
+      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
   then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
@@ -1619,8 +1619,8 @@ function clause execute(VEXT2TYPE(funct6, vm, vs2, vd)) = {
   let SEW_half = SEW / 2;
   let LMUL_pow_half = LMUL_pow - 1;
 
-  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_half, LMUL_pow)) | 
-      ~(valid_eew_emul(SEW_half, LMUL_pow_half)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs2, vd, LMUL_pow_half, LMUL_pow)) | 
+      not(valid_eew_emul(SEW_half, LMUL_pow_half)) 
   then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
@@ -1677,8 +1677,8 @@ function clause execute(VEXT4TYPE(funct6, vm, vs2, vd)) = {
   let SEW_quart = SEW / 4;
   let LMUL_pow_quart = LMUL_pow - 2;
 
-  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_quart, LMUL_pow)) | 
-      ~(valid_eew_emul(SEW_quart, LMUL_pow_quart)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs2, vd, LMUL_pow_quart, LMUL_pow)) | 
+      not(valid_eew_emul(SEW_quart, LMUL_pow_quart)) 
   then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
@@ -1735,8 +1735,8 @@ function clause execute(VEXT8TYPE(funct6, vm, vs2, vd)) = {
   let SEW_eighth = SEW / 8;
   let LMUL_pow_eighth = LMUL_pow - 3;
 
-  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow_eighth, LMUL_pow)) | 
-      ~(valid_eew_emul(SEW_eighth, LMUL_pow_eighth)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs2, vd, LMUL_pow_eighth, LMUL_pow)) | 
+      not(valid_eew_emul(SEW_eighth, LMUL_pow_eighth)) 
   then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
@@ -1856,7 +1856,7 @@ function clause execute(MVVCOMPRESS(vs2, vs1, vd)) = {
 mapping clause assembly = MVVCOMPRESS(vs2, vs1, vd)
   <-> "vcompress.vm" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1)
 
-/* ******************************* OPMVX (MVXTYPE) ******************************* */
+/* ******************************* OPMVX (VXTYPE) ******************************** */
 union clause ast = MVXTYPE : (mvxfunct6, bits(1), regidx, regidx, regidx)
 
 mapping encdec_mvxfunct6 : mvxfunct6 <-> bits(6) = {
@@ -1884,7 +1884,7 @@ function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1986,7 +1986,7 @@ mapping mvxtype_mnemonic : mvxfunct6 <-> string = {
 mapping clause assembly = MVXTYPE(funct6, vm, vs2, rs1, vd)
   <-> mvxtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm) 
 
-/* ************************ OPMVX (MVXtype Multiply-Add) ************************* */
+/* ************************* OPMVX (VXtype Multiply-Add) ************************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
 union clause ast = MVXMATYPE : (mvxmafunct6, bits(1), regidx, regidx, regidx)
 
@@ -2006,7 +2006,7 @@ function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let VLEN     = int_power(2, get_vlen_pow());
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -2070,8 +2070,8 @@ function clause execute(WVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | 
-      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | 
+      not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
   then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
@@ -2120,7 +2120,7 @@ mapping wvxtype_mnemonic : wvxfunct6 <-> string = {
 mapping clause assembly = WVXTYPE(funct6, vm, vs2, rs1, vd)
   <-> wvxtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
 
-/* ******************************* OPMVX (WXTYPE) ******************************** */
+/* *************************** OPMVX (WXTYPE Widening) *************************** */
 union clause ast = WXTYPE : (wxfunct6, bits(1), regidx, regidx, regidx)
 
 mapping encdec_wxfunct6 : wxfunct6 <-> bits(6) = {
@@ -2140,7 +2140,7 @@ function clause execute(WXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  ~(valid_rd_mask(vd, vm)) | ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
   then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
@@ -2183,7 +2183,7 @@ mapping wxtype_mnemonic : wxfunct6 <-> string = {
 mapping clause assembly = WXTYPE(funct6, vm, vs2, rs1, vd)
   <-> wxtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
 
-/* ******************** OPMVX (MVXtype Widening Multiply-Add) ******************** */
+/* ******************** OPMVX (VXtype Widening Multiply-Add) ********************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
 union clause ast =  WMVXTYPE : (wmvxfunct6, bits(1), regidx, regidx, regidx)
 
@@ -2204,8 +2204,8 @@ function clause execute(WMVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  ~(valid_rd_mask(vd, vm)) | ~(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | 
-      ~(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | 
+      not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) 
   then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -1,3 +1,41 @@
+/*=================================================================================*/
+/*  Copyright (c) 2021-2023                                                        */
+/*    Authors from RIOS Lab, Tsinghua University:                                  */
+/*      Xinlai Wan <xinlai.w@rioslab.org>                                          */
+/*      Xi Wang <xi.w@rioslab.org>                                                 */
+/*      Yifei Zhu <yifei.z@rioslab.org>                                            */
+/*      Shenwei Hu <shenwei.h@rioslab.org>                                         */
+/*      Kalvin Vu                                                                  */
+/*    Other contributors:                                                          */
+/*      Jessica Clarke <jrtc27@jrtc27.com>                                         */
+/*      Victor Moya <victor.moya@semidynamics.com>                                 */
+/*                                                                                 */
+/*  All rights reserved.                                                           */
+/*                                                                                 */
+/*  Redistribution and use in source and binary forms, with or without             */
+/*  modification, are permitted provided that the following conditions             */
+/*  are met:                                                                       */
+/*  1. Redistributions of source code must retain the above copyright              */
+/*     notice, this list of conditions and the following disclaimer.               */
+/*  2. Redistributions in binary form must reproduce the above copyright           */
+/*     notice, this list of conditions and the following disclaimer in             */
+/*     the documentation and/or other materials provided with the                  */
+/*     distribution.                                                               */
+/*                                                                                 */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''             */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED              */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR            */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                   */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT               */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF               */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND            */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,             */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT             */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF             */
+/*  SUCH DAMAGE.                                                                   */
+/*=================================================================================*/
+
 /* ******************************************************************************* */
 /* This file implements part of the vector extension.                              */
 /* Chapter 11: Vector Integer Arithmetic Instructions                              */

--- a/model/riscv_insts_vext_fp.sail
+++ b/model/riscv_insts_vext_fp.sail
@@ -1,0 +1,1311 @@
+/* ******************************************************************************* */
+/* This file implements part of the vector extension.                              */
+/* Chapter 13: Vector Floating-Point Instructions                                  */
+/* Chapter 16: Vector Permutation Instructions (floating-point part)               */
+/* ******************************************************************************* */
+
+/* ******************************* OPFVV (VVTYPE) ******************************** */
+union clause ast = FVVTYPE : (fvvfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_fvvfunct6 : fvvfunct6 <-> bits(6) = {
+  FVV_VADD       <-> 0b000000,
+  FVV_VSUB       <-> 0b000010,
+  FVV_VMIN       <-> 0b000100,
+  FVV_VMAX       <-> 0b000110,
+  FVV_VSGNJ      <-> 0b001000,
+  FVV_VSGNJN     <-> 0b001001,
+  FVV_VSGNJX     <-> 0b001010,
+  FVV_VDIV       <-> 0b100000,
+  FVV_VMUL       <-> 0b100100
+}
+
+mapping clause encdec = FVVTYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_fvvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b001 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(FVVTYPE(funct6, vm, vs2, vs1, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW != 8);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);    
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        FVV_VADD     => fp_add(rm_3b, vs2_val[i], vs1_val[i]),
+        FVV_VSUB     => fp_sub(rm_3b, vs2_val[i], vs1_val[i]),
+        FVV_VMIN     => fp_min(vs2_val[i], vs1_val[i]),
+        FVV_VMAX     => fp_max(vs2_val[i], vs1_val[i]),
+        FVV_VMUL     => fp_mul(rm_3b, vs2_val[i], vs1_val[i]),
+        FVV_VDIV     => fp_div(rm_3b, vs2_val[i], vs1_val[i]),
+        FVV_VSGNJ    => vs1_val[i][('m - 1)..('m - 1)] @ vs2_val[i][('m - 2)..0],
+        FVV_VSGNJN   => (0b1 ^ vs1_val[i][('m - 1)..('m - 1)]) @ vs2_val[i][('m - 2)..0],
+        FVV_VSGNJX   => (vs2_val[i][('m - 1)..('m - 1)] ^ vs1_val[i][('m - 1)..('m - 1)]) @ vs2_val[i][('m - 2)..0]
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping fvvtype_mnemonic : fvvfunct6 <-> string = {
+  FVV_VADD       <-> "vfadd.vv",
+  FVV_VSUB       <-> "vfsub.vv",
+  FVV_VMIN       <-> "vfmin.vv",
+  FVV_VMAX       <-> "vfmax.vv",
+  FVV_VSGNJ      <-> "vfsgnj.vv",
+  FVV_VSGNJN     <-> "vfsgnjn.vv",
+  FVV_VSGNJX     <-> "vfsgnjx.vv",
+  FVV_VDIV       <-> "vfdiv.vv",
+  FVV_VMUL       <-> "vfmul.vv"
+}
+
+mapping clause assembly = FVVTYPE(funct6, vm, vs2, vs1, vd)
+  <-> fvvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+/* ************************* OPFVV (VVtype Multiply-Add) ************************* */
+/* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
+union clause ast = FVVMATYPE : (fvvmafunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_fvvmafunct6 : fvvmafunct6 <-> bits(6) = {
+  FVV_VMADD      <-> 0b101000,
+  FVV_VNMADD     <-> 0b101001,
+  FVV_VMSUB      <-> 0b101010,
+  FVV_VNMSUB     <-> 0b101011,
+  FVV_VMACC      <-> 0b101100,
+  FVV_VNMACC     <-> 0b101101,
+  FVV_VMSAC      <-> 0b101110,
+  FVV_VNMSAC     <-> 0b101111
+}
+
+mapping clause encdec = FVVMATYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_fvvmafunct6(funct6) @ vm @ vs2 @ vs1 @ 0b001 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(FVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW != 8);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);    
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        FVV_VMACC    => fp_muladd(rm_3b, vs1_val[i], vs2_val[i], vd_val[i]),
+        FVV_VNMACC   => fp_nmulsub(rm_3b, vs1_val[i], vs2_val[i], vd_val[i]),
+        FVV_VMSAC    => fp_mulsub(rm_3b, vs1_val[i], vs2_val[i], vd_val[i]),
+        FVV_VNMSAC   => fp_nmuladd(rm_3b, vs1_val[i], vs2_val[i], vd_val[i]),
+        FVV_VMADD    => fp_muladd(rm_3b, vs1_val[i], vd_val[i], vs2_val[i]),
+        FVV_VNMADD   => fp_nmulsub(rm_3b, vs1_val[i], vd_val[i], vs2_val[i]),
+        FVV_VMSUB    => fp_mulsub(rm_3b, vs1_val[i], vd_val[i], vs2_val[i]),
+        FVV_VNMSUB   => fp_nmuladd(rm_3b, vs1_val[i], vd_val[i], vs2_val[i])
+      } 
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping fvvmatype_mnemonic : fvvmafunct6 <-> string = {
+  FVV_VMADD      <-> "vfmadd.vv",
+  FVV_VNMADD     <-> "vfnmadd.vv",
+  FVV_VMSUB      <-> "vfmsub.vv",
+  FVV_VNMSUB     <-> "vfnmsub.vv",
+  FVV_VMACC      <-> "vfmacc.vv",
+  FVV_VNMACC     <-> "vfnmacc.vv",
+  FVV_VMSAC      <-> "vfmsac.vv",
+  FVV_VNMSAC     <-> "vfnmsac.vv"
+}
+
+mapping clause assembly = FVVMATYPE(funct6, vm, vs2, vs1, vd)
+  <-> fvvmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* *************************** OPFVV (VVTYPE Widening) *************************** */
+union clause ast = FWVVTYPE : (fwvvfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_fwvvfunct6 : fwvvfunct6 <-> bits(6) = {
+  FWVV_VADD       <-> 0b110000,
+  FWVV_VSUB       <-> 0b110010,
+  FWVV_VMUL       <-> 0b111000
+}
+
+mapping clause encdec = FWVVTYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_fwvvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b001 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(FWVVTYPE(funct6, vm, vs2, vs1, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+
+  if  not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) | not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) |
+      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) | 
+      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) 
+  then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW >= 16 & SEW_widen <= 64);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  result      : vector('n, dec, bits('o)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        FWVV_VADD    => fp_add(rm_3b, fp_widen(vs2_val[i]), fp_widen(vs1_val[i])),
+        FWVV_VSUB    => fp_sub(rm_3b, fp_widen(vs2_val[i]), fp_widen(vs1_val[i])),
+        FWVV_VMUL    => fp_mul(rm_3b, fp_widen(vs2_val[i]), fp_widen(vs1_val[i]))
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping fwvvtype_mnemonic : fwvvfunct6 <-> string = {
+  FWVV_VADD       <-> "vfwadd.vv",
+  FWVV_VSUB       <-> "vfwsub.vv",
+  FWVV_VMUL       <-> "vfwmul.vv"
+}
+
+mapping clause assembly = FWVVTYPE(funct6, vm, vs2, vs1, vd)
+  <-> fwvvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+/* ******************** OPFVV (VVtype Widening Multiply-Add) ********************* */
+/* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
+union clause ast = FWVVMATYPE : (fwvvmafunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_fwvvmafunct6 : fwvvmafunct6 <-> bits(6) = {
+  FWVV_VMACC      <-> 0b111100,
+  FWVV_VNMACC     <-> 0b111101,
+  FWVV_VMSAC      <-> 0b111110,
+  FWVV_VNMSAC     <-> 0b111111
+}
+
+mapping clause encdec = FWVVMATYPE(funct6, vm, vs1, vs2, vd) if haveRVV()
+  <-> encdec_fwvvmafunct6(funct6) @ vm @ vs1 @ vs2 @ 0b001 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(FWVVMATYPE(funct6, vm, vs1, vs2, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+
+  if  not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) | not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) |
+      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) | 
+      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW >= 16 & SEW_widen <= 64);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  result      : vector('n, dec, bits('o)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        FWVV_VMACC   => fp_muladd(rm_3b, fp_widen(vs1_val[i]), fp_widen(vs2_val[i]), vd_val[i]),
+        FWVV_VNMACC  => fp_nmulsub(rm_3b, fp_widen(vs1_val[i]), fp_widen(vs2_val[i]), vd_val[i]),
+        FWVV_VMSAC   => fp_mulsub(rm_3b, fp_widen(vs1_val[i]), fp_widen(vs2_val[i]), vd_val[i]),
+        FWVV_VNMSAC  => fp_nmuladd(rm_3b, fp_widen(vs1_val[i]), fp_widen(vs2_val[i]), vd_val[i])
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping fwvvmatype_mnemonic : fwvvmafunct6 <-> string = {
+  FWVV_VMACC      <-> "vfwmacc.vv",
+  FWVV_VNMACC     <-> "vfwnmacc.vv",
+  FWVV_VMSAC      <-> "vfwmsac.vv",
+  FWVV_VNMSAC     <-> "vfwnmsac.vv"
+}
+
+mapping clause assembly = FWVVMATYPE(funct6, vm, vs1, vs2, vd)
+  <-> fwvvmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* *************************** OPFVV (WVTYPE Widening) *************************** */
+union clause ast = FWVTYPE : (fwvfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_fwvfunct6 : fwvfunct6 <-> bits(6) = {
+  FWV_VADD       <-> 0b110100,
+  FWV_VSUB       <-> 0b110110
+}
+
+mapping clause encdec = FWVTYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_fwvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b001 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(FWVTYPE(funct6, vm, vs2, vs1, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) | 
+      not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) | not(valid_fp_op(SEW, rm_3b)) 
+  then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW >= 16 & SEW_widen <= 64);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  result      : vector('n, dec, bits('o)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        FWV_VADD     => fp_add(rm_3b, vs2_val[i], fp_widen(vs1_val[i])),
+        FWV_VSUB     => fp_sub(rm_3b, vs2_val[i], fp_widen(vs1_val[i]))
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping fwvtype_mnemonic : fwvfunct6 <-> string = {
+  FWV_VADD       <-> "vfwadd.wv",
+  FWV_VSUB       <-> "vfwsub.wv"
+}
+
+mapping clause assembly = FWVTYPE(funct6, vm, vs2, vs1, vd)
+  <-> fwvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+/* ****************************** OPFVV (VFUNARY0) ******************************* */
+union clause ast = VFUNARY0 : (bits(1), regidx, vfunary0, regidx)
+
+mapping encdec_vfunary0_vs1 : vfunary0 <-> bits(5) = {
+  FV_CVT_XU_F       <-> 0b00000,
+  FV_CVT_X_F        <-> 0b00001,
+  FV_CVT_F_XU       <-> 0b00010,
+  FV_CVT_F_X        <-> 0b00011,
+  FV_CVT_RTZ_XU_F   <-> 0b00110,
+  FV_CVT_RTZ_X_F    <-> 0b00111
+}
+
+mapping clause encdec = VFUNARY0(vm, vs2, vfunary0, vd) if haveRVV()
+  <-> 0b010010 @ vm @ vs2 @ encdec_vfunary0_vs1(vfunary0) @ 0b001 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
+
+  /* Special case: 16-bit integers are not supported in single-width type-convert instructions */
+  if SEW == 16 then { handle_illegal(); return RETIRE_FAIL };
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match vfunary0 {
+        FV_CVT_XU_F      => {
+                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                32 => riscv_f32ToUi32(rm_3b, vs2_val[i]),
+                                64 => riscv_f64ToUi64(rm_3b, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem                                
+                            },
+        FV_CVT_X_F       => {
+                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                32 => riscv_f32ToI32(rm_3b, vs2_val[i]),
+                                64 => riscv_f64ToI64(rm_3b, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem                                
+                            },
+        FV_CVT_F_XU      => {
+                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                32 => riscv_ui32ToF32(rm_3b, vs2_val[i]),
+                                64 => riscv_ui64ToF64(rm_3b, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            },
+        FV_CVT_F_X       => {
+                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                32 => riscv_i32ToF32(rm_3b, vs2_val[i]),
+                                64 => riscv_i64ToF64(rm_3b, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem                                
+                            },
+        FV_CVT_RTZ_XU_F  => {
+                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                32 => riscv_f32ToUi32(0b001, vs2_val[i]),
+                                64 => riscv_f64ToUi64(0b001, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            },
+        FV_CVT_RTZ_X_F   => {
+                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                32 => riscv_f32ToI32(0b001, vs2_val[i]),
+                                64 => riscv_f64ToI64(0b001, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            }
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vfunary0_mnemonic : vfunary0 <-> string = {
+  FV_CVT_XU_F       <-> "vfcvt.xu.f.v",
+  FV_CVT_X_F        <-> "vfcvt.x.f.v",
+  FV_CVT_F_XU       <-> "vfcvt.f.xu.v",
+  FV_CVT_F_X        <-> "vfcvt.f.x.v",
+  FV_CVT_RTZ_XU_F   <-> "vfcvt.rtz.xu.f.v",
+  FV_CVT_RTZ_X_F    <-> "vfcvt.rtz.x.f.v"
+}
+
+mapping clause assembly = VFUNARY0(vm, vs2, vfunary0, vd)
+  <-> vfunary0_mnemonic(vfunary0) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* ************************** OPFVV (VFUNARY0 Widening) ************************** */
+union clause ast = VFWUNARY0 : (bits(1), regidx, vfwunary0, regidx)
+
+mapping encdec_vfwunary0_vs1 : vfwunary0 <-> bits(5) = {
+  FWV_CVT_XU_F      <-> 0b01000,
+  FWV_CVT_X_F       <-> 0b01001,
+  FWV_CVT_F_XU      <-> 0b01010,
+  FWV_CVT_F_X       <-> 0b01011,
+  FWV_CVT_F_F       <-> 0b01100,
+  FWV_CVT_RTZ_XU_F  <-> 0b01110,
+  FWV_CVT_RTZ_X_F   <-> 0b01111
+}
+
+mapping clause encdec = VFWUNARY0(vm, vs2, vfwunary0, vd) if haveRVV()
+  <-> 0b010010 @ vm @ vs2 @ encdec_vfwunary0_vs1(vfwunary0) @ 0b001 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | 
+      not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) | not(valid_fp_op(SEW, rm_3b)) 
+  then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW >= 16 & SEW_widen <= 64);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  result      : vector('n, dec, bits('o)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match vfwunary0 {
+        FWV_CVT_XU_F     => {
+                              let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                                16 => riscv_f16ToUi32(rm_3b, vs2_val[i]),
+                                32 => riscv_f32ToUi64(rm_3b, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem                                
+                            },
+        FWV_CVT_X_F      => {
+                              let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                                16 => riscv_f16ToI32(rm_3b, vs2_val[i]),
+                                32 => riscv_f32ToI64(rm_3b, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            },
+        FWV_CVT_F_XU     => {
+                              let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                                16 => { handle_illegal(); return RETIRE_FAIL },
+                                32 => riscv_ui32ToF64(rm_3b, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            },
+        FWV_CVT_F_X      => {
+                              let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                                16 => { handle_illegal(); return RETIRE_FAIL },
+                                32 => riscv_i32ToF64(rm_3b, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            },
+        FWV_CVT_F_F      => {
+                              let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                                16 => riscv_f16ToF32(rm_3b, vs2_val[i]),
+                                32 => riscv_f32ToF64(rm_3b, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            },
+        FWV_CVT_RTZ_XU_F => {
+                              let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                                16 => riscv_f16ToUi32(0b001, vs2_val[i]),
+                                32 => riscv_f32ToUi64(0b001, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            },
+        FWV_CVT_RTZ_X_F  => {
+                              let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                                16 => riscv_f16ToI32(0b001, vs2_val[i]),
+                                32 => riscv_f32ToI64(0b001, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            }
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vfwunary0_mnemonic : vfwunary0 <-> string = {
+  FWV_CVT_XU_F      <-> "vfwcvt.xu.f.v",
+  FWV_CVT_X_F       <-> "vfwcvt.x.f.v",
+  FWV_CVT_F_XU      <-> "vfwcvt.f.xu.v",
+  FWV_CVT_F_X       <-> "vfwcvt.f.x.v",
+  FWV_CVT_F_F       <-> "vfwcvt.f.f.v",
+  FWV_CVT_RTZ_XU_F  <-> "vfwcvt.rtz.xu.f.v",
+  FWV_CVT_RTZ_X_F   <-> "vfwcvt.rtz.x.f.v"
+}
+
+mapping clause assembly = VFWUNARY0(vm, vs2, vfwunary0, vd)
+  <-> vfwunary0_mnemonic(vfwunary0) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* ************************* OPFVV (VFUNARY0 Narrowing) ************************** */
+union clause ast = VFNUNARY0 : (bits(1), regidx, vfnunary0, regidx)
+
+mapping encdec_vfnunary0_vs1 : vfnunary0 <-> bits(5) = {
+  FNV_CVT_XU_F      <-> 0b10000,
+  FNV_CVT_X_F       <-> 0b10001,
+  FNV_CVT_F_XU      <-> 0b10010,
+  FNV_CVT_F_X       <-> 0b10011,
+  FNV_CVT_F_F       <-> 0b10100,
+  FNV_CVT_ROD_F_F   <-> 0b10101,
+  FNV_CVT_RTZ_XU_F  <-> 0b10110,
+  FNV_CVT_RTZ_X_F   <-> 0b10111
+}
+
+mapping clause encdec = VFNUNARY0(vm, vs2, vfnunary0, vd) if haveRVV()
+  <-> 0b010010 @ vm @ vs2 @ encdec_vfnunary0_vs1(vfnunary0) @ 0b001 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+
+  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
+      not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) | not(valid_fp_op(SEW, rm_3b)) 
+  then { handle_illegal(); return RETIRE_FAIL };
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs2_val : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match vfnunary0 {
+        FNV_CVT_XU_F     => {
+                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                16 => { handle_illegal(); return RETIRE_FAIL },
+                                32 => riscv_f64ToUi32(rm_3b, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            },
+        FNV_CVT_X_F      => {
+                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                16 => { handle_illegal(); return RETIRE_FAIL },
+                                32 => riscv_f64ToI32(rm_3b, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            },
+        FNV_CVT_F_XU     => {
+                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                16 => riscv_ui32ToF16(rm_3b, vs2_val[i]),
+                                32 => riscv_ui64ToF32(rm_3b, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            },
+        FNV_CVT_F_X      => {
+                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                16 => riscv_i32ToF16(rm_3b, vs2_val[i]),
+                                32 => riscv_i64ToF32(rm_3b, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            },
+        FNV_CVT_F_F      => {
+                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                16 => riscv_f32ToF16(rm_3b, vs2_val[i]),
+                                32 => riscv_f64ToF32(rm_3b, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            },
+        FNV_CVT_ROD_F_F  => {
+                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                16 => riscv_f32ToF16(0b110, vs2_val[i]),
+                                32 => riscv_f64ToF32(0b110, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            },
+        FNV_CVT_RTZ_XU_F => {
+                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                16 => { handle_illegal(); return RETIRE_FAIL },
+                                32 => riscv_f64ToUi32(0b001, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            },
+        FNV_CVT_RTZ_X_F  => {
+                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                16 => { handle_illegal(); return RETIRE_FAIL },
+                                32 => riscv_f64ToI32(0b001, vs2_val[i])
+                              };
+                              write_fflags(fflags);
+                              elem
+                            } 
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vfnunary0_mnemonic : vfnunary0 <-> string = {
+  FNV_CVT_XU_F      <-> "vfncvt.xu.f.w",
+  FNV_CVT_X_F       <-> "vfncvt.x.f.w",
+  FNV_CVT_F_XU      <-> "vfncvt.f.xu.w",
+  FNV_CVT_F_X       <-> "vfncvt.f.x.w",
+  FNV_CVT_F_F       <-> "vfncvt.f.f.w",
+  FNV_CVT_ROD_F_F   <-> "vfncvt.rod.f.f.w",
+  FNV_CVT_RTZ_XU_F  <-> "vfncvt.rtz.xu.f.w",
+  FNV_CVT_RTZ_X_F   <-> "vfncvt.rtz.x.f.w"
+}
+
+mapping clause assembly = VFNUNARY0(vm, vs2, vfnunary0, vd)
+  <-> vfnunary0_mnemonic(vfnunary0) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* ****************************** OPFVV (VFUNARY1) ******************************* */
+union clause ast = VFUNARY1 : (bits(1), regidx, vfunary1, regidx)
+
+mapping encdec_vfunary1_vs1 : vfunary1 <-> bits(5) = {
+  FVV_VSQRT       <-> 0b00000,
+  FVV_VRSQRT7     <-> 0b00100,
+  FVV_VREC7       <-> 0b00101,
+  FVV_VCLASS      <-> 0b10000
+}
+
+mapping clause encdec = VFUNARY1(vm, vs2, vfunary1, vd) if haveRVV()
+  <-> 0b010011 @ vm @ vs2 @ encdec_vfunary1_vs1(vfunary1) @ 0b001 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match vfunary1 {
+        FVV_VSQRT      => {
+                            let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              16  => riscv_f16Sqrt(rm_3b, vs2_val[i]),
+                              32  => riscv_f32Sqrt(rm_3b, vs2_val[i]),
+                              64  => riscv_f64Sqrt(rm_3b, vs2_val[i])
+                            };
+                            write_fflags(fflags);
+                            elem
+                          },
+        FVV_VRSQRT7    => {
+                            let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              16  => riscv_f16Rsqrte7(rm_3b, vs2_val[i]),
+                              32  => riscv_f32Rsqrte7(rm_3b, vs2_val[i]),
+                              64  => riscv_f64Rsqrte7(rm_3b, vs2_val[i])
+                            };
+                            write_fflags(fflags);
+                            elem
+                          },
+        FVV_VREC7      => {
+                            let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              16  => riscv_f16Recip7(rm_3b, vs2_val[i]),
+                              32  => riscv_f32Recip7(rm_3b, vs2_val[i]),
+                              64  => riscv_f64Recip7(rm_3b, vs2_val[i])
+                            };
+                            write_fflags(fflags);
+                            elem
+                          },         
+        FVV_VCLASS     => {
+                            let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              16  => riscv_f16Class(vs2_val[i]),
+                              32  => riscv_f32Class(vs2_val[i]),
+                              64  => riscv_f64Class(vs2_val[i])
+                            };
+                            write_fflags(fflags);
+                            elem
+                          }
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vfunary1_mnemonic : vfunary1 <-> string = {
+  FVV_VSQRT       <-> "vfsqrt.v",
+  FVV_VRSQRT7     <-> "vfrsqrt7.v",
+  FVV_VREC7       <-> "vfrec7.v",  
+  FVV_VCLASS      <-> "vfclass.v"
+}
+
+mapping clause assembly = VFUNARY1(vm, vs2, vfunary1, vd)
+  <-> vfunary1_mnemonic(vfunary1) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* ****************************** OPFVV (VWFUNARY0) ****************************** */
+union clause ast = VFMVFS : (regidx, regidx)
+
+mapping clause encdec = VFMVFS(vs2, rd) if haveRVV()
+  <-> 0b010000 @ 0b1 @ vs2 @ 0b00000 @ 0b001 @ rd @ 0b1010111 if haveRVV()
+
+function clause execute(VFMVFS(vs2, rd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let num_elem = get_num_elem(0, SEW);
+
+  if not(valid_fp_op(SEW, rm_3b)) | SEW > sizeof(flen) then { handle_illegal(); return RETIRE_FAIL };
+  assert(num_elem > 0 & SEW != 8);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, 0, vs2);
+  F(rd) = if sizeof(flen) == SEW then vs2_val[0]
+          else NaN_box(vs2_val[0]);
+  vstart = EXTZ(0b0);
+
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = VFMVFS(vs2, rd)
+  <-> "vfmv.f.s" ^ spc() ^ freg_name(rd) ^ sep() ^ vreg_name(vs2)
+
+/* ******************************* OPFVF (VFtype) ******************************** */
+union clause ast = FVFTYPE : (fvffunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_fvffunct6 : fvffunct6 <-> bits(6) = {
+  VF_VADD          <-> 0b000000,
+  VF_VSUB          <-> 0b000010,
+  VF_VMIN          <-> 0b000100,
+  VF_VMAX          <-> 0b000110,
+  VF_VSGNJ         <-> 0b001000,
+  VF_VSGNJN        <-> 0b001001,
+  VF_VSGNJX        <-> 0b001010,
+  VF_VSLIDE1UP     <-> 0b001110,
+  VF_VSLIDE1DOWN   <-> 0b001111,
+  VF_VDIV          <-> 0b100000,
+  VF_VRDIV         <-> 0b100001,
+  VF_VMUL          <-> 0b100100,
+  VF_VRSUB         <-> 0b100111
+}
+
+mapping clause encdec = FVFTYPE(funct6, vm, vs2, rs1, vd) if haveRVV()
+  <-> encdec_fvffunct6(funct6) @ vm @ vs2 @ rs1 @ 0b101 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW != 8);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let rs1_val : bits('m)                  = get_scalar_fp(rs1, 'm);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);    
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        VF_VADD          => fp_add(rm_3b, vs2_val[i], rs1_val),
+        VF_VSUB          => fp_sub(rm_3b, vs2_val[i], rs1_val),
+        VF_VRSUB         => fp_sub(rm_3b, rs1_val, vs2_val[i]),
+        VF_VMIN          => fp_min(vs2_val[i], rs1_val),
+        VF_VMAX          => fp_max(vs2_val[i], rs1_val),
+        VF_VMUL          => fp_mul(rm_3b, vs2_val[i], rs1_val),
+        VF_VDIV          => fp_div(rm_3b, vs2_val[i], rs1_val),
+        VF_VRDIV         => fp_div(rm_3b, rs1_val, vs2_val[i]),
+        VF_VSGNJ         => rs1_val[('m - 1)..('m - 1)] @ vs2_val[i][('m - 2)..0],
+        VF_VSGNJN        => (0b1 ^ rs1_val[('m - 1)..('m - 1)]) @ vs2_val[i][('m - 2)..0],
+        VF_VSGNJX        => (vs2_val[i][('m - 1)..('m - 1)] ^ rs1_val[('m - 1)..('m - 1)]) @ vs2_val[i][('m - 2)..0],
+        VF_VSLIDE1UP     => {
+                              if vs2 == vd then { handle_illegal(); return RETIRE_FAIL };
+                              if i == 0 then rs1_val else vs2_val[i - 1]
+                            },
+        VF_VSLIDE1DOWN   => {
+                              if vs2 == vd then { handle_illegal(); return RETIRE_FAIL };
+                              let last_elem = get_end_element();
+                              assert(last_elem < num_elem);
+                              if i < last_elem then vs2_val[i + 1] else rs1_val
+                            }
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping fvftype_mnemonic : fvffunct6 <-> string = {
+  VF_VADD          <-> "vfadd.vf",
+  VF_VSUB          <-> "vfsub.vf",
+  VF_VMIN          <-> "vfmin.vf",
+  VF_VMAX          <-> "vfmax.vf",
+  VF_VSGNJ         <-> "vfsgnj.vf",
+  VF_VSGNJN        <-> "vfsgnjn.vf",
+  VF_VSGNJX        <-> "vfsgnjx.vf",
+  VF_VSLIDE1UP     <-> "vfslide1up.vf",
+  VF_VSLIDE1DOWN   <-> "vfslide1down.vf",
+  VF_VDIV          <-> "vfdiv.vf",
+  VF_VRDIV         <-> "vfrdiv.vf",
+  VF_VMUL          <-> "vfmul.vf",
+  VF_VRSUB         <-> "vfrsub.vf"
+}
+
+mapping clause assembly = FVFTYPE(funct6, vm, vs2, rs1, vd)
+  <-> fvftype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+
+/* ************************* OPFVF (VFtype Multiply-Add) ************************* */
+/* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
+union clause ast = FVFMATYPE : (fvfmafunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_fvfmafunct6 : fvfmafunct6 <-> bits(6) = {
+  VF_VMADD      <-> 0b101000,
+  VF_VNMADD     <-> 0b101001,
+  VF_VMSUB      <-> 0b101010,
+  VF_VNMSUB     <-> 0b101011,
+  VF_VMACC      <-> 0b101100,
+  VF_VNMACC     <-> 0b101101,
+  VF_VMSAC      <-> 0b101110,
+  VF_VNMSAC     <-> 0b101111
+}
+
+mapping clause encdec = FVFMATYPE(funct6, vm, vs2, rs1, vd) if haveRVV()
+  <-> encdec_fvfmafunct6(funct6) @ vm @ vs2 @ rs1 @ 0b101 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(FVFMATYPE(funct6, vm, vs2, rs1, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW != 8);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let rs1_val : bits('m)                  = get_scalar_fp(rs1, 'm);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);    
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        VF_VMACC    => fp_muladd(rm_3b, rs1_val, vs2_val[i], vd_val[i]),
+        VF_VNMACC   => fp_nmulsub(rm_3b, rs1_val, vs2_val[i], vd_val[i]),
+        VF_VMSAC    => fp_mulsub(rm_3b, rs1_val, vs2_val[i], vd_val[i]),
+        VF_VNMSAC   => fp_nmuladd(rm_3b, rs1_val, vs2_val[i], vd_val[i]),
+        VF_VMADD    => fp_muladd(rm_3b, rs1_val, vd_val[i], vs2_val[i]),
+        VF_VNMADD   => fp_nmulsub(rm_3b, rs1_val, vd_val[i], vs2_val[i]),
+        VF_VMSUB    => fp_mulsub(rm_3b, rs1_val, vd_val[i], vs2_val[i]),
+        VF_VNMSUB   => fp_nmuladd(rm_3b, rs1_val, vd_val[i], vs2_val[i])
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping fvfmatype_mnemonic : fvfmafunct6 <-> string = {
+  VF_VMADD      <-> "vfmadd.vf",
+  VF_VNMADD     <-> "vfnmadd.vf",
+  VF_VMSUB      <-> "vfmsub.vf",
+  VF_VNMSUB     <-> "vfnmsub.vf",
+  VF_VMACC      <-> "vfmacc.vf",
+  VF_VNMACC     <-> "vfnmacc.vf",
+  VF_VMSAC      <-> "vfmsac.vf",
+  VF_VNMSAC     <-> "vfnmsac.vf"
+}
+
+mapping clause assembly = FVFMATYPE(funct6, vm, vs2, rs1, vd)
+  <-> fvfmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* *************************** OPFVF (VFTYPE Widening) *************************** */
+union clause ast = FWVFTYPE : (fwvffunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_fwvffunct6 : fwvffunct6 <-> bits(6) = {
+  FWVF_VADD       <-> 0b110000,
+  FWVF_VSUB       <-> 0b110010,
+  FWVF_VMUL       <-> 0b111000
+}
+
+mapping clause encdec = FWVFTYPE(funct6, vm, vs2, rs1, vd) if haveRVV()
+  <-> encdec_fwvffunct6(funct6) @ vm @ vs2 @ rs1 @ 0b101 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(FWVFTYPE(funct6, vm, vs2, rs1, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+
+  if  not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) | not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) |
+      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) 
+  then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW >= 16 & SEW_widen <= 64);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let rs1_val : bits('m)                  = get_scalar_fp(rs1, 'm);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  result      : vector('n, dec, bits('o)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        FWVF_VADD    => fp_add(rm_3b, fp_widen(vs2_val[i]), fp_widen(rs1_val)),
+        FWVF_VSUB    => fp_sub(rm_3b, fp_widen(vs2_val[i]), fp_widen(rs1_val)),
+        FWVF_VMUL    => fp_mul(rm_3b, fp_widen(vs2_val[i]), fp_widen(rs1_val))
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping fwvftype_mnemonic : fwvffunct6 <-> string = {
+  FWVF_VADD       <-> "vfwadd.vf",
+  FWVF_VSUB       <-> "vfwsub.vf",
+  FWVF_VMUL       <-> "vfwmul.vf"
+}
+
+mapping clause assembly = FWVFTYPE(funct6, vm, vs2, rs1, vd)
+  <-> fwvftype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+
+/* ******************** OPFVF (VFtype Widening Multiply-Add) ********************* */
+/* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
+union clause ast = FWVFMATYPE : (fwvfmafunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_fwvfmafunct6 : fwvfmafunct6 <-> bits(6) = {
+  FWVF_VMACC      <-> 0b111100,
+  FWVF_VNMACC     <-> 0b111101,
+  FWVF_VMSAC      <-> 0b111110,
+  FWVF_VNMSAC     <-> 0b111111
+}
+
+mapping clause encdec = FWVFMATYPE(funct6, vm, rs1, vs2, vd) if haveRVV()
+  <-> encdec_fwvfmafunct6(funct6) @ vm @ vs2 @ rs1 @ 0b101 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(FWVFMATYPE(funct6, vm, rs1, vs2, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+
+  if  not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) | not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) |
+      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW >= 16 & SEW_widen <= 64);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let rs1_val : bits('m)                  = get_scalar_fp(rs1, 'm);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  result      : vector('n, dec, bits('o)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        FWVF_VMACC   => fp_muladd(rm_3b, fp_widen(rs1_val), fp_widen(vs2_val[i]), vd_val[i]),
+        FWVF_VNMACC  => fp_nmulsub(rm_3b, fp_widen(rs1_val), fp_widen(vs2_val[i]), vd_val[i]),
+        FWVF_VMSAC   => fp_mulsub(rm_3b, fp_widen(rs1_val), fp_widen(vs2_val[i]), vd_val[i]),
+        FWVF_VNMSAC  => fp_nmuladd(rm_3b, fp_widen(rs1_val), fp_widen(vs2_val[i]), vd_val[i])
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping fwvfmatype_mnemonic : fwvfmafunct6 <-> string = {
+  FWVF_VMACC      <-> "vfwmacc.vf",
+  FWVF_VNMACC     <-> "vfwnmacc.vf",
+  FWVF_VMSAC      <-> "vfwmsac.vf",
+  FWVF_VNMSAC     <-> "vfwnmsac.vf"
+}
+
+mapping clause assembly = FWVFMATYPE(funct6, vm, rs1, vs2, vd)
+  <-> fwvfmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+/* *************************** OPFVF (WFTYPE Widening) *************************** */
+union clause ast = FWFTYPE : (fwffunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_fwffunct6 : fwffunct6 <-> bits(6) = {
+  FWF_VADD       <-> 0b110100,
+  FWF_VSUB       <-> 0b110110
+}
+
+mapping clause encdec = FWFTYPE(funct6, vm, vs2, rs1, vd) if haveRVV()
+  <-> encdec_fwffunct6(funct6) @ vm @ vs2 @ rs1 @ 0b101 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(FWFTYPE(funct6, vm, vs2, rs1, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+
+  if  not(valid_rd_mask(vd, vm)) | not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) | not(valid_fp_op(SEW, rm_3b)) 
+  then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW >= 16 & SEW_widen <= 64);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let rs1_val : bits('m)                  = get_scalar_fp(rs1, 'm);
+  let vs2_val : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  result      : vector('n, dec, bits('o)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        FWF_VADD     => fp_add(rm_3b, vs2_val[i], fp_widen(rs1_val)),
+        FWF_VSUB     => fp_sub(rm_3b, vs2_val[i], fp_widen(rs1_val))
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping fwftype_mnemonic : fwffunct6 <-> string = {
+  FWF_VADD       <-> "vfwadd.wf",
+  FWF_VSUB       <-> "vfwsub.wf"
+}
+
+mapping clause assembly = FWFTYPE(funct6, vm, vs2, rs1, vd)
+  <-> fwftype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+
+/* ************************** OPFVF (Merge Instruction) ************************** */
+/* This instruction operates on all body elements regardless of mask value */
+union clause ast = VFMERGE : (regidx, regidx, regidx)
+
+mapping clause encdec = VFMERGE(vs2, rs1, vd) if haveRVV()
+  <-> 0b010111 @ 0b0 @ vs2 @ rs1 @ 0b101 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VFMERGE(vs2, rs1, vd)) = {
+  let rm_3b         = fcsr.FRM();
+  let start_element = get_start_element();
+  let end_element   = get_end_element();
+  let SEW           = get_sew();
+  let LMUL_pow      = get_lmul_pow();
+  let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
+  let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
+
+  if vd == vreg_name("v0") | not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW != 8);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vreg_name("v0"));
+  let rs1_val : bits('m)                  = get_scalar_fp(rs1, 'm);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+
+  let tail_ag : agtype = get_vtype_vta();
+  foreach (i from 0 to (num_elem - 1)) {
+    if i < start_element then {
+      result[i] = vd_val[i]
+    } else if i > end_element | i >= real_num_elem then {
+      if tail_ag == UNDISTURBED then {
+        result[i] = vd_val[i]
+      } else if tail_ag == AGNOSTIC then {
+        result[i] = vd_val[i] /* TODO: configuration support */
+      }
+    } else {
+      /* the merge operates on all body elements */
+      result[i] = if vm_val[i] then rs1_val else vs2_val[i]
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = VFMERGE(vs2, rs1, vd)
+  <-> "vfmerge.vfm" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ sep() ^ "v0"
+
+/* ************************** OPFVF (Move Instruction) *************************** */
+/* This instruction shares the encoding with vfmerge.vfm, but with vm=1 and vs2=v0 */
+union clause ast = VFMV : (regidx, regidx)
+
+mapping clause encdec = VFMV(rs1, vd) if haveRVV()
+  <-> 0b010111 @ 0b1 @ 0b00000 @ rs1 @ 0b101 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VFMV(rs1, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW != 8);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let rs1_val : bits('m)                  = get_scalar_fp(rs1, 'm);
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then result[i] = rs1_val
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = VFMV(rs1, vd)
+  <-> "vfmv.v.f" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)
+
+/* ****************************** OPFVF (VRFUNARY0) ****************************** */
+union clause ast = VFMVSF : (regidx, regidx)
+
+mapping clause encdec = VFMVSF(rs1, vd) if haveRVV()
+  <-> 0b010000 @ 0b1 @ 0b00000 @ rs1 @ 0b101 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VFMVSF(rs1, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let num_elem = get_num_elem(0, SEW);
+
+  if not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
+  assert(num_elem > 0 & SEW != 8);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b1, vreg_name("v0"));
+  let rs1_val : bits('m)                  = get_scalar_fp(rs1, 'm);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, 0, vd_val, vm_val);
+
+  /* one body element */
+  if mask[0] then result[0] = rs1_val;
+
+  /* others treated as tail elements */
+  let tail_ag : agtype = get_vtype_vta();
+  if tail_ag == UNDISTURBED then {
+    foreach (i from 1 to (num_elem - 1)) result[i] = vd_val[i]
+  } else if tail_ag == AGNOSTIC then {
+    foreach (i from 1 to (num_elem - 1)) result[i] = vd_val[i] /* TODO: configuration support */
+  };
+
+  write_vreg(num_elem, SEW, 0, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = VFMVSF(rs1, vd)
+  <-> "vfmv.s.f" ^ spc() ^ vreg_name(vd) ^ sep() ^ freg_name(rs1)

--- a/model/riscv_insts_vext_fp.sail
+++ b/model/riscv_insts_vext_fp.sail
@@ -1,3 +1,41 @@
+/*=================================================================================*/
+/*  Copyright (c) 2021-2023                                                        */
+/*    Authors from RIOS Lab, Tsinghua University:                                  */
+/*      Xinlai Wan <xinlai.w@rioslab.org>                                          */
+/*      Xi Wang <xi.w@rioslab.org>                                                 */
+/*      Yifei Zhu <yifei.z@rioslab.org>                                            */
+/*      Shenwei Hu <shenwei.h@rioslab.org>                                         */
+/*      Kalvin Vu                                                                  */
+/*    Other contributors:                                                          */
+/*      Jessica Clarke <jrtc27@jrtc27.com>                                         */
+/*      Victor Moya <victor.moya@semidynamics.com>                                 */
+/*                                                                                 */
+/*  All rights reserved.                                                           */
+/*                                                                                 */
+/*  Redistribution and use in source and binary forms, with or without             */
+/*  modification, are permitted provided that the following conditions             */
+/*  are met:                                                                       */
+/*  1. Redistributions of source code must retain the above copyright              */
+/*     notice, this list of conditions and the following disclaimer.               */
+/*  2. Redistributions in binary form must reproduce the above copyright           */
+/*     notice, this list of conditions and the following disclaimer in             */
+/*     the documentation and/or other materials provided with the                  */
+/*     distribution.                                                               */
+/*                                                                                 */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''             */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED              */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR            */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                   */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT               */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF               */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND            */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,             */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT             */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF             */
+/*  SUCH DAMAGE.                                                                   */
+/*=================================================================================*/
+
 /* ******************************************************************************* */
 /* This file implements part of the vector extension.                              */
 /* Chapter 13: Vector Floating-Point Instructions                                  */

--- a/model/riscv_insts_vext_fp.sail
+++ b/model/riscv_insts_vext_fp.sail
@@ -364,9 +364,6 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
 
   if not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
 
-  /* Special case: 16-bit integers are not supported in single-width type-convert instructions */
-  if SEW == 16 then { handle_illegal(); return RETIRE_FAIL };
-
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -383,6 +380,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
       result[i] = match vfunary0 {
         FV_CVT_XU_F      => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                16 => riscv_f16ToUi16(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToUi32(rm_3b, vs2_val[i]),
                                 64 => riscv_f64ToUi64(rm_3b, vs2_val[i])
                               };
@@ -391,6 +389,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
                             },
         FV_CVT_X_F       => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                16 => riscv_f16ToI16(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToI32(rm_3b, vs2_val[i]),
                                 64 => riscv_f64ToI64(rm_3b, vs2_val[i])
                               };
@@ -399,6 +398,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
                             },
         FV_CVT_F_XU      => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                16 => riscv_ui32ToF16(rm_3b, EXTZ(vs2_val[i])),
                                 32 => riscv_ui32ToF32(rm_3b, vs2_val[i]),
                                 64 => riscv_ui64ToF64(rm_3b, vs2_val[i])
                               };
@@ -407,6 +407,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
                             },
         FV_CVT_F_X       => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                16 => riscv_i32ToF16(rm_3b, EXTS(vs2_val[i])),
                                 32 => riscv_i32ToF32(rm_3b, vs2_val[i]),
                                 64 => riscv_i64ToF64(rm_3b, vs2_val[i])
                               };
@@ -415,6 +416,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
                             },
         FV_CVT_RTZ_XU_F  => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                16 => riscv_f16ToUi16(0b001, vs2_val[i]),
                                 32 => riscv_f32ToUi32(0b001, vs2_val[i]),
                                 64 => riscv_f64ToUi64(0b001, vs2_val[i])
                               };
@@ -423,6 +425,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
                             },
         FV_CVT_RTZ_X_F   => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                16 => riscv_f16ToI16(0b001, vs2_val[i]),
                                 32 => riscv_f32ToI32(0b001, vs2_val[i]),
                                 64 => riscv_f64ToI64(0b001, vs2_val[i])
                               };
@@ -474,10 +477,10 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) | 
-      not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) | not(valid_fp_op(SEW, rm_3b)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) |
+      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then { handle_illegal(); return RETIRE_FAIL };
-  assert(SEW >= 16 & SEW_widen <= 64);
+  assert(SEW >= 8 & SEW_widen <= 64);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -496,6 +499,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
       result[i] = match vfwunary0 {
         FWV_CVT_XU_F     => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                                8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_f16ToUi32(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToUi64(rm_3b, vs2_val[i])
                               };
@@ -504,6 +508,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                             },
         FWV_CVT_X_F      => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                                8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_f16ToI32(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToI64(rm_3b, vs2_val[i])
                               };
@@ -512,7 +517,8 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                             },
         FWV_CVT_F_XU     => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
-                                16 => { handle_illegal(); return RETIRE_FAIL },
+                                8  => riscv_ui32ToF16(rm_3b, EXTZ(vs2_val[i])),
+                                16 => riscv_ui32ToF32(rm_3b, EXTZ(vs2_val[i])),
                                 32 => riscv_ui32ToF64(rm_3b, vs2_val[i])
                               };
                               write_fflags(fflags);
@@ -520,7 +526,8 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                             },
         FWV_CVT_F_X      => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
-                                16 => { handle_illegal(); return RETIRE_FAIL },
+                                8  => riscv_i32ToF16(rm_3b, EXTS(vs2_val[i])),
+                                16 => riscv_i32ToF32(rm_3b, EXTS(vs2_val[i])),
                                 32 => riscv_i32ToF64(rm_3b, vs2_val[i])
                               };
                               write_fflags(fflags);
@@ -528,6 +535,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                             },
         FWV_CVT_F_F      => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                                8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_f16ToF32(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToF64(rm_3b, vs2_val[i])
                               };
@@ -536,6 +544,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                             },
         FWV_CVT_RTZ_XU_F => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                                8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_f16ToUi32(0b001, vs2_val[i]),
                                 32 => riscv_f32ToUi64(0b001, vs2_val[i])
                               };
@@ -544,6 +553,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                             },
         FWV_CVT_RTZ_X_F  => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                                8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_f16ToI32(0b001, vs2_val[i]),
                                 32 => riscv_f32ToI64(0b001, vs2_val[i])
                               };
@@ -597,8 +607,8 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  not(valid_rd_mask(vd, vm)) | not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) | 
-      not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) | not(valid_fp_op(SEW, rm_3b)) 
+  if  not(valid_rd_mask(vd, vm)) | not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) |
+      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
   then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
@@ -618,7 +628,8 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
       result[i] = match vfnunary0 {
         FNV_CVT_XU_F     => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
-                                16 => { handle_illegal(); return RETIRE_FAIL },
+                                8  => riscv_f16ToUi8(rm_3b, vs2_val[i]),
+                                16 => riscv_f32ToUi16(rm_3b, vs2_val[i]),
                                 32 => riscv_f64ToUi32(rm_3b, vs2_val[i])
                               };
                               write_fflags(fflags);
@@ -626,7 +637,8 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                             },
         FNV_CVT_X_F      => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
-                                16 => { handle_illegal(); return RETIRE_FAIL },
+                                8  => riscv_f16ToI8(rm_3b, vs2_val[i]),
+                                16 => riscv_f32ToI16(rm_3b, vs2_val[i]),
                                 32 => riscv_f64ToI32(rm_3b, vs2_val[i])
                               };
                               write_fflags(fflags);
@@ -634,6 +646,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                             },
         FNV_CVT_F_XU     => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_ui32ToF16(rm_3b, vs2_val[i]),
                                 32 => riscv_ui64ToF32(rm_3b, vs2_val[i])
                               };
@@ -642,6 +655,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                             },
         FNV_CVT_F_X      => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_i32ToF16(rm_3b, vs2_val[i]),
                                 32 => riscv_i64ToF32(rm_3b, vs2_val[i])
                               };
@@ -650,6 +664,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                             },
         FNV_CVT_F_F      => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_f32ToF16(rm_3b, vs2_val[i]),
                                 32 => riscv_f64ToF32(rm_3b, vs2_val[i])
                               };
@@ -658,6 +673,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                             },
         FNV_CVT_ROD_F_F  => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                                8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_f32ToF16(0b110, vs2_val[i]),
                                 32 => riscv_f64ToF32(0b110, vs2_val[i])
                               };
@@ -666,7 +682,8 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                             },
         FNV_CVT_RTZ_XU_F => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
-                                16 => { handle_illegal(); return RETIRE_FAIL },
+                                8  => riscv_f16ToUi8(0b001, vs2_val[i]),
+                                16 => riscv_f32ToUi16(0b001, vs2_val[i]),
                                 32 => riscv_f64ToUi32(0b001, vs2_val[i])
                               };
                               write_fflags(fflags);
@@ -674,7 +691,8 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                             },
         FNV_CVT_RTZ_X_F  => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
-                                16 => { handle_illegal(); return RETIRE_FAIL },
+                                8  => riscv_f16ToI8(0b001, vs2_val[i]),
+                                16 => riscv_f32ToI16(0b001, vs2_val[i]),
                                 32 => riscv_f64ToI32(0b001, vs2_val[i])
                               };
                               write_fflags(fflags);

--- a/model/riscv_insts_vext_mask.sail
+++ b/model/riscv_insts_vext_mask.sail
@@ -1,3 +1,41 @@
+/*=================================================================================*/
+/*  Copyright (c) 2021-2023                                                        */
+/*    Authors from RIOS Lab, Tsinghua University:                                  */
+/*      Xinlai Wan <xinlai.w@rioslab.org>                                          */
+/*      Xi Wang <xi.w@rioslab.org>                                                 */
+/*      Yifei Zhu <yifei.z@rioslab.org>                                            */
+/*      Shenwei Hu <shenwei.h@rioslab.org>                                         */
+/*      Kalvin Vu                                                                  */
+/*    Other contributors:                                                          */
+/*      Jessica Clarke <jrtc27@jrtc27.com>                                         */
+/*      Victor Moya <victor.moya@semidynamics.com>                                 */
+/*                                                                                 */
+/*  All rights reserved.                                                           */
+/*                                                                                 */
+/*  Redistribution and use in source and binary forms, with or without             */
+/*  modification, are permitted provided that the following conditions             */
+/*  are met:                                                                       */
+/*  1. Redistributions of source code must retain the above copyright              */
+/*     notice, this list of conditions and the following disclaimer.               */
+/*  2. Redistributions in binary form must reproduce the above copyright           */
+/*     notice, this list of conditions and the following disclaimer in             */
+/*     the documentation and/or other materials provided with the                  */
+/*     distribution.                                                               */
+/*                                                                                 */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''             */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED              */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR            */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                   */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT               */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF               */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND            */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,             */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT             */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF             */
+/*  SUCH DAMAGE.                                                                   */
+/*=================================================================================*/
+
 /* ******************************************************************************* */
 /* This file implements part of the vector extension.                              */
 /* Chapter 15: vector mask instructions                                            */

--- a/model/riscv_insts_vext_mask.sail
+++ b/model/riscv_insts_vext_mask.sail
@@ -40,13 +40,13 @@ function clause execute(MMTYPE(funct6, vs2, vs1, vd)) = {
     if mask[i] then {
       let res : bool = match funct6 {
         MM_VMAND     => vs2_val[i] & vs1_val[i],
-        MM_VMNAND    => ~(vs2_val[i] & vs1_val[i]),
-        MM_VMANDNOT  => vs2_val[i] & ~(vs1_val[i]),
+        MM_VMNAND    => not(vs2_val[i] & vs1_val[i]),
+        MM_VMANDNOT  => vs2_val[i] & not(vs1_val[i]),
         MM_VMXOR     => vs2_val[i] ^ vs1_val[i],
         MM_VMOR      => vs2_val[i] | vs1_val[i],
-        MM_VMNOR     => ~(vs2_val[i] | vs1_val[i]),
-        MM_VMORNOT   => vs2_val[i] | ~(vs1_val[i]),
-        MM_VMXNOR    => ~(vs2_val[i] ^ vs1_val[i])
+        MM_VMNOR     => not(vs2_val[i] | vs1_val[i]),
+        MM_VMORNOT   => vs2_val[i] | not(vs1_val[i]),
+        MM_VMXNOR    => not(vs2_val[i] ^ vs1_val[i])
       };
       result[i] = res;
     }
@@ -91,7 +91,7 @@ function clause execute(VCPOP_M(vm, vs2, rd)) = {
   mask        : vector('n, dec, bool) = undefined;
 
   /* Value of vstart must be 0 */
-  if ~(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
 
   (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vs2_val, vm_val);
 
@@ -128,7 +128,7 @@ function clause execute(VFIRST_M(vm, vs2, rd)) = {
   mask        : vector('n, dec, bool) = undefined;
 
   /* Value of vstart must be 0 */
-  if ~(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
 
   (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vs2_val, vm_val);
 
@@ -168,10 +168,10 @@ function clause execute(VMSBF_M(vm, vs2, vd)) = {
   mask        : vector('n, dec, bool) = undefined;
 
   /* Value of vstart must be 0 */
-  if ~(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
 
   /* If masking is enabled, then dest reg cannot be v0 */
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   /* Dest reg cannot be the same as source reg */
   if vd == vs2 then { handle_illegal(); return RETIRE_FAIL };
@@ -215,10 +215,10 @@ function clause execute(VMSIF_M(vm, vs2, vd)) = {
   mask        : vector('n, dec, bool) = undefined;
 
   /* Value of vstart must be 0 */
-  if ~(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
 
   /* If masking is enabled, then dest reg cannot be v0 */
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   /* Dest reg cannot be the same as source reg */
   if vd == vs2 then { handle_illegal(); return RETIRE_FAIL };
@@ -262,10 +262,10 @@ function clause execute(VMSOF_M(vm, vs2, vd)) = {
   mask        : vector('n, dec, bool) = undefined;
 
   /* Value of vstart must be 0 */
-  if ~(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
 
   /* If masking is enabled, then dest reg cannot be v0 */
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   /* Dest reg cannot be the same as source reg */
   if vd == vs2 then { handle_illegal(); return RETIRE_FAIL };
@@ -275,7 +275,7 @@ function clause execute(VMSOF_M(vm, vs2, vd)) = {
   found_elem : bool = false;
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] then {
-      if vs2_val[i] & ~(found_elem) then {
+      if vs2_val[i] & not(found_elem) then {
         result[i] = true;
         found_elem = true
       } else {
@@ -313,10 +313,10 @@ function clause execute(VIOTA_M(vm, vs2, vd)) = {
   mask        : vector('n, dec, bool)     = undefined;
 
   /* Value of vstart must be 0 */
-  if ~(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
 
   /* If masking is enabled, then dest reg cannot be v0 */
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   /* Dest reg cannot be the same as source reg */
   if vd == vs2 then { handle_illegal(); return RETIRE_FAIL };
@@ -350,7 +350,7 @@ function clause execute(VID_V(vm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -1,7 +1,45 @@
-/* ************************************************************************ */
-/* This file implements part of the vector extension.                       */
-/* Chapter 7: Vector Loads and Stores                                       */
-/* ************************************************************************ */
+/*=================================================================================*/
+/*  Copyright (c) 2021-2023                                                        */
+/*    Authors from RIOS Lab, Tsinghua University:                                  */
+/*      Xinlai Wan <xinlai.w@rioslab.org>                                          */
+/*      Xi Wang <xi.w@rioslab.org>                                                 */
+/*      Yifei Zhu <yifei.z@rioslab.org>                                            */
+/*      Shenwei Hu <shenwei.h@rioslab.org>                                         */
+/*      Kalvin Vu                                                                  */
+/*    Other contributors:                                                          */
+/*      Jessica Clarke <jrtc27@jrtc27.com>                                         */
+/*      Victor Moya <victor.moya@semidynamics.com>                                 */
+/*                                                                                 */
+/*  All rights reserved.                                                           */
+/*                                                                                 */
+/*  Redistribution and use in source and binary forms, with or without             */
+/*  modification, are permitted provided that the following conditions             */
+/*  are met:                                                                       */
+/*  1. Redistributions of source code must retain the above copyright              */
+/*     notice, this list of conditions and the following disclaimer.               */
+/*  2. Redistributions in binary form must reproduce the above copyright           */
+/*     notice, this list of conditions and the following disclaimer in             */
+/*     the documentation and/or other materials provided with the                  */
+/*     distribution.                                                               */
+/*                                                                                 */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''             */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED              */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR            */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                   */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT               */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF               */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND            */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,             */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT             */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF             */
+/*  SUCH DAMAGE.                                                                   */
+/*=================================================================================*/
+
+/* ******************************************************************************* */
+/* This file implements part of the vector extension.                              */
+/* Chapter 7: Vector Loads and Stores                                              */
+/* ******************************************************************************* */
 
 mapping nfields_int : bits(3) <-> {|1, 2, 3, 4, 5, 6, 7, 8|} = {
   0b000     <-> 1,

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -115,7 +115,7 @@ function clause execute(VLETYPE(vm, rs1, width, vd)) = {
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vle(vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -128,7 +128,7 @@ mapping vletype_mnemonic : vlewidth <-> string = {
 }
 
 mapping clause assembly = VLETYPE(vm, rs1, width, vd)
-  <-> vletype_mnemonic(width) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
+  <-> vletype_mnemonic(width) ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ maybe_vmask(vm)
 
 /* ******************** Vector Store Unit-Stride Normal (nf=0, mop=0, sumop=0) ******************* */
 union clause ast = VSETYPE : (bits(1), regidx, vlewidth, regidx)
@@ -167,7 +167,7 @@ function process_vse (vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, vs3_val[i], false, false, false);
                     match (res) {
                       MemValue(true)  => status = RETIRE_SUCCESS,
-                      MemValue(false) => internal_error("store got false from mem_write_value"),
+                      MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                       MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
                     }
                   }
@@ -203,7 +203,7 @@ mapping vsetype_mnemonic : vlewidth <-> string = {
 }
 
 mapping clause assembly = VSETYPE(vm, rs1, width, vs3)
-  <-> vsetype_mnemonic(width) ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
+  <-> vsetype_mnemonic(width) ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ maybe_vmask(vm)
 
 /* ************************** Vector Load Strided Normal (nf=0, mop=10) ************************** */
 union clause ast = VLSETYPE : (bits(1), regidx, regidx, vlewidth, regidx)
@@ -261,7 +261,7 @@ function clause execute(VLSETYPE(vm, rs2, rs1, width, vd)) = {
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlse(vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
@@ -274,7 +274,7 @@ mapping vlsetype_mnemonic : vlewidth <-> string = {
 }
 
 mapping clause assembly = VLSETYPE(vm, rs2, rs1, width, vd)
-  <-> vlsetype_mnemonic(width) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)^ sep() ^ maybe_vmask(vm)
+  <-> vlsetype_mnemonic(width) ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(rs2)^ maybe_vmask(vm)
 
 /* ************************** Vector Store Strided Normal (nf=0, mop=10) ************************* */
 union clause ast = VSSETYPE : (bits(1), regidx, regidx, vlewidth, regidx)
@@ -314,7 +314,7 @@ function process_vsse (vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) 
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, vs3_val[i], false, false, false);
                     match (res) {
                       MemValue(true)  => status = RETIRE_SUCCESS,
-                      MemValue(false) => internal_error("store got false from mem_write_value"),
+                      MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                       MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
                     }
                   }
@@ -350,7 +350,7 @@ mapping vssetype_mnemonic : vlewidth <-> string = {
 }
 
 mapping clause assembly = VSSETYPE(vm, rs2, rs1, width, vs3)
-  <-> vssetype_mnemonic(width) ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)^ sep() ^ maybe_vmask(vm)
+  <-> vssetype_mnemonic(width) ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(rs2)^ maybe_vmask(vm)
 
 /* ************************ Vector Load Indexed Unordered (nf=0, mop=01) ************************* */
 union clause ast = VLUXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
@@ -408,13 +408,13 @@ function clause execute(VLUXEITYPE(vm, vs2, rs1, width, vd)) = {
   let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
   let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlxei(vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
 
 mapping clause assembly = VLUXEITYPE(vm, vs2, rs1, width, vd)
-  <-> "vluxei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+  <-> "vluxei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************* Vector Load Indexed Ordered (nf=0, mop=11) ************************** */
 union clause ast = VLOXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
@@ -431,13 +431,13 @@ function clause execute(VLOXEITYPE(vm, vs2, rs1, width, vd)) = {
   let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
   let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlxei(vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
 
 mapping clause assembly = VLOXEITYPE(vm, vs2, rs1, width, vd)
-  <-> "vloxei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+  <-> "vloxei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************ Vector Store Indexed Unordered (nf=0, mop=01) ************************ */
 union clause ast = VSUXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
@@ -477,7 +477,7 @@ function process_vsxei (vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow
                       let res : MemoryOpResult(bool) = mem_write_value(paddr, EEW_data_bytes, vs3_val[i], false, false, false);
                       match (res) {
                         MemValue(true)  => status = RETIRE_SUCCESS,
-                        MemValue(false) => internal_error("store got false from mem_write_value"),
+                        MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                         MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
                       }
                     }
@@ -506,7 +506,7 @@ function clause execute(VSUXEITYPE(vm, vs2, rs1, width, vs3)) = {
 }
 
 mapping clause assembly = VSUXEITYPE(vm, vs2, rs1, width, vs3)
-  <-> "vsuxei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+  <-> "vsuxei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************* Vector Store Indexed Ordered (nf=0, mop=11) ************************* */
 union clause ast = VSOXEITYPE : (bits(1), regidx, regidx, vlewidth, regidx)
@@ -527,7 +527,7 @@ function clause execute(VSOXEITYPE(vm, vs2, rs1, width, vs3)) = {
 }
 
 mapping clause assembly = VSOXEITYPE(vm, vs2, rs1, width, vs3)
-  <-> "vsoxei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+  <-> "vsoxei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************* Vector Load Unit-Stride Fault-Only-First (nf=0, mop=0, lumop=10000) ************* */
 union clause ast = VLEFFTYPE : (bits(1), regidx, vlewidth, regidx)
@@ -613,7 +613,7 @@ function clause execute(VLEFFTYPE(vm, rs1, width, vd)) = {
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vleff(vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -626,7 +626,7 @@ mapping vlefftype_mnemonic : vlewidth <-> string = {
 }
 
 mapping clause assembly = VLEFFTYPE(vm, rs1, width, vd)
-  <-> vlefftype_mnemonic(width) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
+  <-> vlefftype_mnemonic(width) ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ maybe_vmask(vm)
 
 /* ******************** Vector Load Unit-Stride Segment (mop=0, lumop=00000) ********************* */
 union clause ast = VLSEGTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
@@ -693,13 +693,13 @@ function clause execute(VLSEGTYPE(nf, vm, rs1, width, vd)) = {
   let num_elem = get_num_elem(EMUL_pow, EEW); /* # of element of each register group */
   let nf_int = nfields_int(nf);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlseg(nf_int, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
 
 mapping clause assembly = VLSEGTYPE(nf, vm, rs1, width, vd)
-  <-> "vlseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ maybe_vmask(vm)
+  <-> "vlseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ maybe_vmask(vm)
 
 /* ************ Vector Load Unit-Stride Segment Fault-Only-First (mop=0, lumop=10000) ************ */
 union clause ast = VLSEGFFTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
@@ -786,13 +786,13 @@ function clause execute(VLSEGFFTYPE(nf, vm, rs1, width, vd)) = {
   let num_elem = get_num_elem(EMUL_pow, EEW);
   let nf_int = nfields_int(nf);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlsegff(nf_int, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
 
 mapping clause assembly = VLSEGTYPE(nf, vm, rs1, width, vd)
-  <-> "vlseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ "ff.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
+  <-> "vlseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ "ff.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ maybe_vmask(vm)
 
 /* ******************** Vector Store Unit-Stride Segment (mop=0, sumop=00000) ******************** */
 union clause ast = VSSEGTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
@@ -831,7 +831,7 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
                       let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, one_elem_val, false, false, false);
                       match (res) {
                         MemValue(true)  => status = RETIRE_SUCCESS,
-                        MemValue(false) => internal_error("store got false from mem_write_value"),
+                        MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                         MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
                       }
                     }
@@ -862,7 +862,7 @@ function clause execute(VSSEGTYPE(nf, vm, rs1, width, vs3)) = {
 }
 
 mapping clause assembly = VSSEGTYPE(nf, vm, rs1, width, vs3)
-  <-> "vsseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
+  <-> "vsseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ maybe_vmask(vm)
 
 /* **************************** Vector Load Strided Segment (mop=10) ***************************** */
 union clause ast = VLSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
@@ -922,13 +922,13 @@ function clause execute(VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)) = {
   let num_elem = get_num_elem(EMUL_pow, EEW);
   let nf_int = nfields_int(nf);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlsseg(nf_int, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
 
 mapping clause assembly = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
-  <-> "vlsseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ maybe_vmask(vm)
+  <-> "vlsseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(rs2) ^ maybe_vmask(vm)
 
 /* **************************** Vector Store Strided Segment (mop=10) **************************** */
 union clause ast = VSSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
@@ -970,7 +970,7 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
                       let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, one_elem_val, false, false, false);
                       match (res) {
                         MemValue(true)  => status = RETIRE_SUCCESS,
-                        MemValue(false) => internal_error("store got false from mem_write_value"),
+                        MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                         MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
                       }
                     }
@@ -1001,7 +1001,7 @@ function clause execute(VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)) = {
 }
 
 mapping clause assembly = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
-  <-> "vssseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ maybe_vmask(vm)
+  <-> "vssseg" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(rs2) ^ maybe_vmask(vm)
 
 /* *********************** Vector Load Indexed Unordered Segment (mop=01) ************************ */
 union clause ast = VLUXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
@@ -1062,13 +1062,13 @@ function clause execute(VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
   let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8);
   let nf_int = nfields_int(nf);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlxseg(nf_int, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
 
 mapping clause assembly = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
-  <-> "vluxseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+  <-> "vluxseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************ Vector Load Indexed Ordered Segment (mop=11) ************************* */
 union clause ast = VLOXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
@@ -1086,13 +1086,13 @@ function clause execute(VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
   let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8);
   let nf_int = nfields_int(nf);
 
-  if ~(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlxseg(nf_int, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
 
 mapping clause assembly = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)
-  <-> "vloxseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+  <-> "vloxseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(vs2) ^ maybe_vmask(vm)
 
 /* *********************** Vector Store Indexed Unordered Segment (mop=01) *********************** */
 union clause ast = VSUXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
@@ -1135,7 +1135,7 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
                       let res : MemoryOpResult(bool) = mem_write_value(paddr, EEW_data_bytes, one_elem_val, false, false, false);
                       match (res) {
                         MemValue(true)  => status = RETIRE_SUCCESS,
-                        MemValue(false) => internal_error("store got false from mem_write_value"),
+                        MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                         MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
                       }
                     }
@@ -1166,7 +1166,7 @@ function clause execute(VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
 }
 
 mapping clause assembly = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
-  <-> "vsuxseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+  <-> "vsuxseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************ Vector Store Indexed Ordered Segment (mop=11) ************************ */
 union clause ast = VSOXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
@@ -1188,7 +1188,7 @@ function clause execute(VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
 }
 
 mapping clause assembly = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
-  <-> "vsoxseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+  <-> "vsoxseg" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************** Vector Load Unit-Stride Whole Register (vm=1, mop=0, lumop=01000) ************** */
 union clause ast = VLRETYPE : (bits(3), regidx, vlewidth, regidx)
@@ -1268,13 +1268,13 @@ function clause execute(VLRETYPE(nf, rs1, width, vd)) = {
   let nf_int = nfields_int(nf);
 
   assert(elem_per_reg >= 0);
-  if ~(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then { handle_illegal(); return RETIRE_FAIL };
+  if not(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vlre(nf_int, vd, load_width_bytes, rs1, elem_per_reg)
 }
 
 mapping clause assembly = VLRETYPE(nf, rs1, width, vd)
-  <-> "vl" ^ nfields_string(nf) ^ "re" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)
+  <-> "vl" ^ nfields_string(nf) ^ "re" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
 
 /* ************* Vector Store Unit-Stride Whole Register (vm=1, mop=0, lumop=01000) ************** */
 union clause ast = VSRETYPE : (bits(3), regidx, regidx)
@@ -1312,7 +1312,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, one_elem_val, false, false, false);
                     match (res) {
                       MemValue(true)  => status = RETIRE_SUCCESS,
-                      MemValue(false) => internal_error("store got false from mem_write_value"),
+                      MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                       MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
                     }
                   }
@@ -1347,7 +1347,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, vs_val[i], false, false, false);
                     match (res) {
                       MemValue(true)  => status = RETIRE_SUCCESS,
-                      MemValue(false) => internal_error("store got false from mem_write_value"),
+                      MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                       MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
                     }
                   }
@@ -1372,13 +1372,13 @@ function clause execute(VSRETYPE(nf, rs1, vs3)) = {
   let nf_int = nfields_int(nf);
 
   assert(elem_per_reg >= 0);
-  if ~(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then { handle_illegal(); return RETIRE_FAIL };
+  if not(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then { handle_illegal(); return RETIRE_FAIL };
 
   process_vsre(nf_int, load_width_bytes, rs1, vs3, elem_per_reg)
 }
 
 mapping clause assembly = VSRETYPE(nf, rs1, vs3)
-  <-> "vs" ^ nfields_string(nf) ^ "r.v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ reg_name(rs1)
+  <-> "vs" ^ nfields_string(nf) ^ "r.v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
 
 /* *********** Vector Mask Load/Store Unit-Stride (nf=0, mop=0, lumop or sumop=01011) ************ */
 union clause ast = VMTYPE : (regidx, regidx, vmlsop)
@@ -1442,7 +1442,7 @@ function process_vm(vd_or_vs3, rs1, EMUL_pow, num_elem, op) = {
                       let res : MemoryOpResult(bool) = mem_write_value(paddr, 1, vd_or_vs3_val[i], false, false, false);
                       match (res) {
                         MemValue(true)  => status = RETIRE_SUCCESS,
-                        MemValue(false) => internal_error("store got false from mem_write_value"),
+                        MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                         MemException(e) => { handle_mem_exception(vaddr, e); status = RETIRE_FAIL }
                       }
                     }
@@ -1477,4 +1477,4 @@ mapping vmtype_mnemonic : vmlsop <-> string = {
 }
 
 mapping clause assembly = VMTYPE(rs1, vd_or_vs3, op)
-  <-> vmtype_mnemonic(op) ^ spc() ^ vreg_name(vd_or_vs3) ^ sep() ^ reg_name(rs1)
+  <-> vmtype_mnemonic(op) ^ spc() ^ vreg_name(vd_or_vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -1,6 +1,44 @@
-/* ************************************************************************** */
-/* This file implements functions used by vector instructions.                */
-/* ************************************************************************** */
+/*=================================================================================*/
+/*  Copyright (c) 2021-2023                                                        */
+/*    Authors from RIOS Lab, Tsinghua University:                                  */
+/*      Xinlai Wan <xinlai.w@rioslab.org>                                          */
+/*      Xi Wang <xi.w@rioslab.org>                                                 */
+/*      Yifei Zhu <yifei.z@rioslab.org>                                            */
+/*      Shenwei Hu <shenwei.h@rioslab.org>                                         */
+/*      Kalvin Vu                                                                  */
+/*    Other contributors:                                                          */
+/*      Jessica Clarke <jrtc27@jrtc27.com>                                         */
+/*      Victor Moya <victor.moya@semidynamics.com>                                 */
+/*                                                                                 */
+/*  All rights reserved.                                                           */
+/*                                                                                 */
+/*  Redistribution and use in source and binary forms, with or without             */
+/*  modification, are permitted provided that the following conditions             */
+/*  are met:                                                                       */
+/*  1. Redistributions of source code must retain the above copyright              */
+/*     notice, this list of conditions and the following disclaimer.               */
+/*  2. Redistributions in binary form must reproduce the above copyright           */
+/*     notice, this list of conditions and the following disclaimer in             */
+/*     the documentation and/or other materials provided with the                  */
+/*     distribution.                                                               */
+/*                                                                                 */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''             */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED              */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR            */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                   */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT               */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF               */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND            */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,             */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT             */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF             */
+/*  SUCH DAMAGE.                                                                   */
+/*=================================================================================*/
+
+/* ******************************************************************************* */
+/* This file implements functions used by vector instructions.                     */
+/* ******************************************************************************* */
 
 /* Vector mask mapping */
 mapping maybe_vmask : string <-> bits(1) = {

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -12,13 +12,25 @@ mapping maybe_vmask : string <-> bits(1) = {
 val valid_eew_emul : (int, int) -> bool effect {rreg}
 function valid_eew_emul(EEW, EMUL_pow) = {
   let ELEN = int_power(2, get_elen_pow());
-  EEW >= 8 & EEW <= ELEN & EMUL_pow >= -3 & EMUL_pow <= 3;
+  EEW >= 8 & EEW <= ELEN & EMUL_pow >= -3 & EMUL_pow <= 3
 }
 
 /* Check for vstart value */
 val assert_vstart : int -> bool effect {rreg}
 function assert_vstart(i) = {
-  unsigned(vstart) == i;
+  unsigned(vstart) == i
+}
+
+/* Check for valid floating-point operation types
+ *  1. Valid element width of floating-point numbers
+ *  2. Valid floating-point rounding mode
+ */
+val valid_fp_op : ({|8, 16, 32, 64|}, bits(3)) -> bool
+function valid_fp_op(SEW, rm_3b) = {
+  /* 128-bit floating-point values will be supported in future extensions */
+  let valid_sew = (SEW >= 16 & SEW <= 128); 
+  let valid_rm = not(rm_3b == 0b101 | rm_3b == 0b110 | rm_3b == 0b111);
+  valid_sew & valid_rm
 }
 
 /* Check for valid destination register when vector masking is enabled: 
@@ -55,13 +67,13 @@ function valid_reg_overlap(rs, rd, EMUL_pow_rs, EMUL_pow_rd) = {
 
 /* Scalar register shaping */
 val get_scalar : forall 'n, 'n >= 8. (regidx, int('n)) -> bits('n) effect {escape, rreg}
-function get_scalar(rs1, vsew_bits) = {
-  if sizeof(xlen) > vsew_bits then {
+function get_scalar(rs1, SEW) = {
+  if sizeof(xlen) > SEW then {
     /* Least significant SEW bits */
-    X(rs1)[vsew_bits - 1 .. 0]
-  } else if sizeof(xlen) < vsew_bits then {
+    X(rs1)[SEW - 1 .. 0]
+  } else if sizeof(xlen) < SEW then {
     /* Sign extend to SEW */
-    EXTS(vsew_bits, X(rs1))
+    EXTS(SEW, X(rs1))
   } else {
     X(rs1)
   }
@@ -131,7 +143,7 @@ function init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
         result[i] = vd_val[i]; /* TODO: configuration support */
       };
       mask[i] = false
-    } else if ~(vm_val[i]) then {
+    } else if not(vm_val[i]) then {
       /* Inactive body elements defined by vm */
       if mask_ag == UNDISTURBED then {
         result[i] = vd_val[i]
@@ -213,7 +225,7 @@ function init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
       /* Mask tail is always agnostic */
       result[i] = vd_val[i]; /* TODO: configuration support */
       mask[i] = false
-    } else if ~(vm_val[i]) then {
+    } else if not(vm_val[i]) then {
       /* Inactive body elements defined by vm */
       if mask_ag == UNDISTURBED then {
         result[i] = vd_val[i]
@@ -256,7 +268,7 @@ function NaN_unbox(regval, 'm) = {
 }
 
 /* Check if the floating point number is a signaling NaN */
-val      f_is_SNaN : forall 'm, ('m in {16, 32, 64, 128} & 'm <= flen). bits('m) -> bool
+val      f_is_SNaN : forall 'm, 'm in {16, 32, 64, 128}. bits('m) -> bool
 function f_is_SNaN   xf = {
   match 'm {
     16   => (xf[14..10] == ones()) & (xf[9..9] == zeros()) & (xf[8..0] != zeros()),
@@ -267,7 +279,7 @@ function f_is_SNaN   xf = {
 }
 
 /* Either QNaN or SNan */
-val      f_is_NaN : forall 'm, ('m in {16, 32, 64, 128} & 'm <= flen). bits('m) -> bool
+val      f_is_NaN : forall 'm, 'm in {16, 32, 64, 128}. bits('m) -> bool
 function f_is_NaN   xf = {
   match 'm {
     16   => (xf[14..10] == ones()) & (xf[9..0] != zeros()),
@@ -277,7 +289,7 @@ function f_is_NaN   xf = {
   }
 }
 
-val      f_is_neg_zero : forall 'm, ('m in {16, 32, 64, 128} & 'm <= flen). bits('m) -> bool
+val      f_is_neg_zero : forall 'm, 'm in {16, 32, 64, 128}. bits('m) -> bool
 function f_is_neg_zero   xf = {
   match 'm {
     16   => (xf[15..15] == ones()) & (xf[14..0] == zeros()),
@@ -287,7 +299,7 @@ function f_is_neg_zero   xf = {
   }
 }
 
-val      f_is_pos_zero : forall 'm, ('m in {16, 32, 64, 128} & 'm <= flen). bits('m) -> bool
+val      f_is_pos_zero : forall 'm, 'm in {16, 32, 64, 128}. bits('m) -> bool
 function f_is_pos_zero   xf = {
   match 'm {
     16   => (xf == zeros()),
@@ -299,19 +311,20 @@ function f_is_pos_zero   xf = {
 
 /* Scalar register shaping for floating point operations */
 val get_scalar_fp : forall 'n, 'n in {16, 32, 64, 128}. (regidx, int('n)) -> bits('n) effect {escape, rreg}
-function get_scalar_fp(rs1, vsew_bits) = {
-  if sizeof(flen) > vsew_bits then {
+function get_scalar_fp(rs1, SEW) = {
+  if sizeof(flen) >= SEW then {
     /* Least significant SEW bits */
-    NaN_unbox(F(rs1), vsew_bits)
+    NaN_unbox(F(rs1), SEW)
   } else {
-    canonical_NaN(vsew_bits)
+    assert(false, "invalid vector floating-point type width: FLEN < SEW");
+    zeros()
   }
 }
 
 /* Shift amounts */
 val get_shift_amount : forall 'n 'm, 0 <= 'n & 'm in {8, 16, 32, 64}. (bits('n), int('m)) -> nat effect {escape}
-function get_shift_amount(bit_val, vsew_bits) = {
-  let lowlog2bits = log2(vsew_bits);
+function get_shift_amount(bit_val, SEW) = {
+  let lowlog2bits = log2(SEW);
   assert(0 < lowlog2bits & lowlog2bits < 'n);
   unsigned(bit_val[lowlog2bits - 1 .. 0]);
 }
@@ -328,7 +341,7 @@ function get_fixed_rounding_incr(vec_elem, shift_amount) = {
         (slice(vec_elem, shift_amount - 1, 1) == 0b1) & (slice(vec_elem, 0, shift_amount - 1) != zeros() | slice(vec_elem, shift_amount, 1) == 0b1)),
       0b10 => 0b0,
       0b11 => bool_to_bits(
-        ~(slice(vec_elem, shift_amount, 1) == 0b1) & (slice(vec_elem, 0, shift_amount) != zeros()))
+        not(slice(vec_elem, shift_amount, 1) == 0b1) & (slice(vec_elem, 0, shift_amount) != zeros()))
     } 
   }
 }
@@ -409,6 +422,44 @@ function fp_sub(rm_3b, op1, op2) = {
   result_val
 }
 
+val fp_min : forall 'n, 'n in {16, 32, 64}. (bits('n), bits('n)) -> bits('n) effect {escape, rreg, undef, wreg}
+function fp_min(op1, op2) = {
+  let (fflags, op1_lt_op2) : (bits_fflags, bool) = match 'n {
+    16  => riscv_f16Lt_quiet(op1, op2),
+    32  => riscv_f32Lt_quiet(op1, op2),
+    64  => riscv_f64Lt_quiet(op1, op2)
+  };
+
+  let result_val = if (f_is_NaN(op1) & f_is_NaN(op2)) then canonical_NaN('n)
+                else if f_is_NaN(op1) then op2
+                else if f_is_NaN(op2) then op1
+                else if (f_is_neg_zero(op1) & f_is_pos_zero(op2)) then op1
+                else if (f_is_neg_zero(op2) & f_is_pos_zero(op1)) then op2
+                else if op1_lt_op2 then op1
+                else op2;
+  write_fflags(fflags);
+  result_val
+}
+
+val fp_max : forall 'n, 'n in {16, 32, 64}. (bits('n), bits('n)) -> bits('n) effect {escape, rreg, undef, wreg}
+function fp_max(op1, op2) = {
+  let (fflags, op1_lt_op2) : (bits_fflags, bool) = match 'n {
+    16  => riscv_f16Lt_quiet(op1, op2),
+    32  => riscv_f32Lt_quiet(op1, op2),
+    64  => riscv_f64Lt_quiet(op1, op2)
+  };
+
+  let result_val = if (f_is_NaN(op1) & f_is_NaN(op2)) then canonical_NaN('n)
+                else if f_is_NaN(op1) then op2
+                else if f_is_NaN(op2) then op1
+                else if (f_is_neg_zero(op1) & f_is_pos_zero(op2)) then op2
+                else if (f_is_neg_zero(op2) & f_is_pos_zero(op1)) then op1
+                else if op1_lt_op2 then op2
+                else op1;
+  write_fflags(fflags);
+  result_val
+}
+
 val fp_eq : forall 'n, 'n in {16, 32, 64}. (bits('n), bits('n)) -> bool effect {escape, rreg, undef, wreg}
 function fp_eq(op1, op2) = {
   let (fflags, result_val) : (bits_fflags, bool) = match 'n {
@@ -427,7 +478,7 @@ function fp_gt(op1, op2) = {
     32  => riscv_f32Le(op1, op2),
     64  => riscv_f64Le(op1, op2)
   };
-  let result_val = (if fflags == 0b10000 then false else ~(temp_val));
+  let result_val = (if fflags == 0b10000 then false else not(temp_val));
   write_fflags(fflags);
   result_val
 }
@@ -439,7 +490,7 @@ function fp_ge(op1, op2) = {
     32  => riscv_f32Lt(op1, op2),
     64  => riscv_f64Lt(op1, op2)
   };
-  let result_val = (if fflags == 0b10000 then false else ~(temp_val));
+  let result_val = (if fflags == 0b10000 then false else not(temp_val));
   write_fflags(fflags);
   result_val
 }
@@ -536,7 +587,7 @@ function fp_nmulsub(rm_3b, op1, op2, opsub) = {
   result_val
 }
 
-val fp_widen : forall 'm, ('m in {16, 32} & 'm <= flen). bits('m) -> bits('m * 2) effect {escape, rreg, undef, wreg}
+val fp_widen : forall 'm, 'm in {16, 32}. bits('m) -> bits('m * 2) effect {escape, rreg, undef, wreg}
 function fp_widen(nval) = {
   let rm_3b = fcsr.FRM();
   let (fflags, wval) : (bits_fflags, bits('m * 2)) = match 'm {

--- a/model/riscv_insts_vext_vm.sail
+++ b/model/riscv_insts_vext_vm.sail
@@ -1,3 +1,41 @@
+/*=================================================================================*/
+/*  Copyright (c) 2021-2023                                                        */
+/*    Authors from RIOS Lab, Tsinghua University:                                  */
+/*      Xinlai Wan <xinlai.w@rioslab.org>                                          */
+/*      Xi Wang <xi.w@rioslab.org>                                                 */
+/*      Yifei Zhu <yifei.z@rioslab.org>                                            */
+/*      Shenwei Hu <shenwei.h@rioslab.org>                                         */
+/*      Kalvin Vu                                                                  */
+/*    Other contributors:                                                          */
+/*      Jessica Clarke <jrtc27@jrtc27.com>                                         */
+/*      Victor Moya <victor.moya@semidynamics.com>                                 */
+/*                                                                                 */
+/*  All rights reserved.                                                           */
+/*                                                                                 */
+/*  Redistribution and use in source and binary forms, with or without             */
+/*  modification, are permitted provided that the following conditions             */
+/*  are met:                                                                       */
+/*  1. Redistributions of source code must retain the above copyright              */
+/*     notice, this list of conditions and the following disclaimer.               */
+/*  2. Redistributions in binary form must reproduce the above copyright           */
+/*     notice, this list of conditions and the following disclaimer in             */
+/*     the documentation and/or other materials provided with the                  */
+/*     distribution.                                                               */
+/*                                                                                 */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''             */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED              */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR            */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                   */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT               */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF               */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND            */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,             */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT             */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF             */
+/*  SUCH DAMAGE.                                                                   */
+/*=================================================================================*/
+
 /* ******************************************************************************* */
 /* This file implements part of the vector extension.                              */
 /* Mask instructions from Chap 11 (integer arithmetic) and 13 (floating-point)     */

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -1,7 +1,45 @@
-/* ************************************************************************ */
-/* This file implements part of the vector extension.                       */
-/* Chapter 6: Configuration-Setting Instructions                            */
-/* ************************************************************************ */
+/*=================================================================================*/
+/*  Copyright (c) 2021-2023                                                        */
+/*    Authors from RIOS Lab, Tsinghua University:                                  */
+/*      Xinlai Wan <xinlai.w@rioslab.org>                                          */
+/*      Xi Wang <xi.w@rioslab.org>                                                 */
+/*      Yifei Zhu <yifei.z@rioslab.org>                                            */
+/*      Shenwei Hu <shenwei.h@rioslab.org>                                         */
+/*      Kalvin Vu                                                                  */
+/*    Other contributors:                                                          */
+/*      Jessica Clarke <jrtc27@jrtc27.com>                                         */
+/*      Victor Moya <victor.moya@semidynamics.com>                                 */
+/*                                                                                 */
+/*  All rights reserved.                                                           */
+/*                                                                                 */
+/*  Redistribution and use in source and binary forms, with or without             */
+/*  modification, are permitted provided that the following conditions             */
+/*  are met:                                                                       */
+/*  1. Redistributions of source code must retain the above copyright              */
+/*     notice, this list of conditions and the following disclaimer.               */
+/*  2. Redistributions in binary form must reproduce the above copyright           */
+/*     notice, this list of conditions and the following disclaimer in             */
+/*     the documentation and/or other materials provided with the                  */
+/*     distribution.                                                               */
+/*                                                                                 */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''             */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED              */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR            */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                   */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT               */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF               */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND            */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,             */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT             */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF             */
+/*  SUCH DAMAGE.                                                                   */
+/*=================================================================================*/
+
+/* ******************************************************************************* */
+/* This file implements part of the vector extension.                              */
+/* Chapter 6: Configuration-Setting Instructions                                   */
+/* ******************************************************************************* */
 
 mapping sew_flag : string <-> bits(3) = {
   "e8"    <-> 0b000,
@@ -37,7 +75,7 @@ mapping maybe_ma_flag : string <-> bits(1) = {
   sep() ^ "mu" <-> 0b0
 }
 
-/* ******************** vsetvli & vsetvl *********************** */
+/* ****************************** vsetvli & vsetvl ******************************* */
 union clause ast = VSET_TYPE : (vsetop, bits(1), bits(1), bits(3), bits(3), regidx, regidx)
 
 mapping encdec_vsetop : vsetop <-> bits(4) ={
@@ -107,8 +145,7 @@ mapping vsettype_mnemonic : vsetop <-> string ={
 mapping clause assembly = VSET_TYPE(op, ma, ta, sew, lmul, rs1, rd) 
   <-> vsettype_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ sew_flag(sew) ^ maybe_lmul_flag(lmul) ^ maybe_ta_flag(ta) ^ maybe_ma_flag(ma)
 
-
-/* ******************** vsetivli *********************** */
+/* ********************************* vsetivli ************************************ */
 union clause ast = VSETI_TYPE : ( bits(1), bits(1), bits(3), bits(3), regidx, regidx)
 
 mapping clause encdec = VSETI_TYPE(ma, ta, sew, lmul, uimm, rd) if haveRVV() 

--- a/model/riscv_softfloat_interface.sail
+++ b/model/riscv_softfloat_interface.sail
@@ -87,7 +87,7 @@
 
 type bits_rm     = bits(3)    /* Rounding mode */
 type bits_fflags = bits(5)    /* Accrued exceptions: NV,DZ,OF,UF,NX */
-type bits_H      = bits(16)   /* Half-precision float value */      
+type bits_H      = bits(16)   /* Half-precision float value */
 type bits_S      = bits(32)   /* Single-precision float value */
 type bits_D      = bits(64)   /* Double-precision float value */
 
@@ -242,6 +242,78 @@ val     extern_f64Sqrt = {c: "softfloat_f64sqrt", ocaml: "Softfloat.f64_sqrt", l
 val      riscv_f64Sqrt : (bits_rm, bits_D) -> (bits_fflags, bits_D) effect {rreg}
 function riscv_f64Sqrt (rm, v) = {
   extern_f64Sqrt(rm, v);
+  (float_fflags[4 .. 0], float_result)
+}
+
+/* **************************************************************** */
+/* RECIPROCAL SQUARE ROOT ESTIMATE                                  */
+
+val     extern_f16Rsqrte7 = {c: "softfloat_f16rsqrte7", ocaml: "Softfloat.f16_rsqrte7", lem: "softfloat_f16_rsqrte7"} : (bits_rm, bits_H) -> unit
+val      riscv_f16Rsqrte7 : (bits_rm, bits_H) -> (bits_fflags, bits_H) effect {rreg}
+function riscv_f16Rsqrte7 (rm, v) = {
+  extern_f16Rsqrte7(rm, v);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
+
+val     extern_f32Rsqrte7 = {c: "softfloat_f32rsqrte7", ocaml: "Softfloat.f32_rsqrte7", lem: "softfloat_f32_rsqrte7"} : (bits_rm, bits_S) -> unit
+val      riscv_f32Rsqrte7 : (bits_rm, bits_S) -> (bits_fflags, bits_S) effect {rreg}
+function riscv_f32Rsqrte7 (rm, v) = {
+  extern_f32Rsqrte7(rm, v);
+  (float_fflags[4 .. 0], float_result[31 .. 0])
+}
+
+val     extern_f64Rsqrte7 = {c: "softfloat_f64rsqrte7", ocaml: "Softfloat.f64_rsqrte7", lem: "softfloat_f64_rsqrte7"} : (bits_rm, bits_D) -> unit
+val      riscv_f64Rsqrte7 : (bits_rm, bits_D) -> (bits_fflags, bits_D) effect {rreg}
+function riscv_f64Rsqrte7 (rm, v) = {
+  extern_f64Rsqrte7(rm, v);
+  (float_fflags[4 .. 0], float_result)
+}
+
+/* **************************************************************** */
+/* RECIPROCAL ESTIMATE                                              */
+
+val     extern_f16Recip7 = {c: "softfloat_f16recip7", ocaml: "Softfloat.f16_recip7", lem: "softfloat_f16_recip7"} : (bits_rm, bits_H) -> unit
+val      riscv_f16Recip7 : (bits_rm, bits_H) -> (bits_fflags, bits_H) effect {rreg}
+function riscv_f16Recip7 (rm, v) = {
+  extern_f16Recip7(rm, v);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
+
+val     extern_f32Recip7 = {c: "softfloat_f32recip7", ocaml: "Softfloat.f32_recip7", lem: "softfloat_f32_recip7"} : (bits_rm, bits_S) -> unit
+val      riscv_f32Recip7 : (bits_rm, bits_S) -> (bits_fflags, bits_S) effect {rreg}
+function riscv_f32Recip7 (rm, v) = {
+  extern_f32Recip7(rm, v);
+  (float_fflags[4 .. 0], float_result[31 .. 0])
+}
+
+val     extern_f64Recip7 = {c: "softfloat_f64recip7", ocaml: "Softfloat.f64_recip7", lem: "softfloat_f64_recip7"} : (bits_rm, bits_D) -> unit
+val      riscv_f64Recip7 : (bits_rm, bits_D) -> (bits_fflags, bits_D) effect {rreg}
+function riscv_f64Recip7 (rm, v) = {
+  extern_f64Recip7(rm, v);
+  (float_fflags[4 .. 0], float_result)
+}
+
+/* **************************************************************** */
+/* CLASSIFY                                                         */
+
+val     extern_f16Class = {c: "softfloat_f16class", ocaml: "Softfloat.f16_class", lem: "softfloat_f16_class"} : bits_H -> unit
+val      riscv_f16Class : bits_H -> (bits_fflags, bits_H) effect {rreg}
+function riscv_f16Class (v) = {
+  extern_f16Class(v);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
+
+val     extern_f32Class = {c: "softfloat_f32class", ocaml: "Softfloat.f32_class", lem: "softfloat_f32_class"} : bits_S -> unit
+val      riscv_f32Class : bits_S -> (bits_fflags, bits_S) effect {rreg}
+function riscv_f32Class (v) = {
+  extern_f32Class(v);
+  (float_fflags[4 .. 0], float_result[31 .. 0])
+}
+
+val     extern_f64Class = {c: "softfloat_f64class", ocaml: "Softfloat.f64_class", lem: "softfloat_f64_class"} : bits_D -> unit
+val      riscv_f64Class : bits_D -> (bits_fflags, bits_D) effect {rreg}
+function riscv_f64Class (v) = {
+  extern_f64Class(v);
   (float_fflags[4 .. 0], float_result)
 }
 
@@ -468,6 +540,13 @@ function riscv_f16Lt (v1, v2) = {
   (float_fflags[4 .. 0], bit_to_bool(float_result[0]))
 }
 
+val     extern_f16Lt_quiet = {c: "softfloat_f16lt_quiet", ocaml: "Softfloat.f16_lt_quiet", lem: "softfloat_f16_lt_quiet"} : (bits_H, bits_H) -> unit
+val      riscv_f16Lt_quiet : (bits_H, bits_H) -> (bits_fflags, bool) effect {rreg}
+function riscv_f16Lt_quiet (v1, v2) = {
+  extern_f16Lt_quiet(v1, v2);
+  (float_fflags[4 .. 0], bit_to_bool(float_result[0]))
+}
+
 val     extern_f16Le = {c: "softfloat_f16le", ocaml: "Softfloat.f16_le", lem: "softfloat_f16_le"} : (bits_H, bits_H) -> unit
 val      riscv_f16Le : (bits_H, bits_H) -> (bits_fflags, bool) effect {rreg}
 function riscv_f16Le (v1, v2) = {
@@ -489,6 +568,13 @@ function riscv_f32Lt (v1, v2) = {
   (float_fflags[4 .. 0], bit_to_bool(float_result[0]))
 }
 
+val     extern_f32Lt_quiet = {c: "softfloat_f32lt_quiet", ocaml: "Softfloat.f32_lt_quiet", lem: "softfloat_f32_lt_quiet"} : (bits_S, bits_S) -> unit
+val      riscv_f32Lt_quiet : (bits_S, bits_S) -> (bits_fflags, bool) effect {rreg}
+function riscv_f32Lt_quiet (v1, v2) = {
+  extern_f32Lt_quiet(v1, v2);
+  (float_fflags[4 .. 0], bit_to_bool(float_result[0]))
+}
+
 val     extern_f32Le = {c: "softfloat_f32le", ocaml: "Softfloat.f32_le", lem: "softfloat_f32_le"} : (bits_S, bits_S) -> unit
 val      riscv_f32Le : (bits_S, bits_S) -> (bits_fflags, bool) effect {rreg}
 function riscv_f32Le (v1, v2) = {
@@ -507,6 +593,13 @@ val     extern_f64Lt = {c: "softfloat_f64lt", ocaml: "Softfloat.f64_lt", lem: "s
 val      riscv_f64Lt : (bits_D, bits_D) -> (bits_fflags, bool) effect {rreg}
 function riscv_f64Lt (v1, v2) = {
   extern_f64Lt(v1, v2);
+  (float_fflags[4 .. 0], bit_to_bool(float_result[0]))
+}
+
+val     extern_f64Lt_quiet = {c: "softfloat_f64lt_quiet", ocaml: "Softfloat.f64_lt_quiet", lem: "softfloat_f64_lt_quiet"} : (bits_D, bits_D) -> unit
+val      riscv_f64Lt_quiet : (bits_D, bits_D) -> (bits_fflags, bool) effect {rreg}
+function riscv_f64Lt_quiet (v1, v2) = {
+  extern_f64Lt_quiet(v1, v2);
   (float_fflags[4 .. 0], bit_to_bool(float_result[0]))
 }
 

--- a/model/riscv_softfloat_interface.sail
+++ b/model/riscv_softfloat_interface.sail
@@ -320,6 +320,34 @@ function riscv_f64Class (v) = {
 /* **************************************************************** */
 /* CONVERSIONS                                                      */
 
+val     extern_f16ToI8 = {c: "softfloat_f16toi8", ocaml: "Softfloat.f16_to_i8", lem: "softfloat_f16_to_i8"} : (bits_rm, bits_H) -> unit
+val      riscv_f16ToI8 : (bits_rm, bits_H) -> (bits_fflags, bits(8)) effect {rreg}
+function riscv_f16ToI8 (rm, v) = {
+  extern_f16ToI8(rm, v);
+  (float_fflags[4 .. 0], float_result[7 .. 0])
+}
+
+val     extern_f16ToUi8 = {c: "softfloat_f16toui8", ocaml: "Softfloat.f16_to_ui8", lem: "softfloat_f16_to_ui8"} : (bits_rm, bits_H) -> unit
+val      riscv_f16ToUi8 : (bits_rm, bits_H) -> (bits_fflags, bits(8)) effect {rreg}
+function riscv_f16ToUi8 (rm, v) = {
+  extern_f16ToUi8(rm, v);
+  (float_fflags[4 .. 0], float_result[7 .. 0])
+}
+
+val     extern_f16ToI16 = {c: "softfloat_f16toi16", ocaml: "Softfloat.f16_to_i16", lem: "softfloat_f16_to_i16"} : (bits_rm, bits_H) -> unit
+val      riscv_f16ToI16 : (bits_rm, bits_H) -> (bits_fflags, bits(16)) effect {rreg}
+function riscv_f16ToI16 (rm, v) = {
+  extern_f16ToI16(rm, v);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
+
+val     extern_f16ToUi16 = {c: "softfloat_f16toui16", ocaml: "Softfloat.f16_to_ui16", lem: "softfloat_f16_to_ui16"} : (bits_rm, bits_H) -> unit
+val      riscv_f16ToUi16 : (bits_rm, bits_H) -> (bits_fflags, bits(16)) effect {rreg}
+function riscv_f16ToUi16 (rm, v) = {
+  extern_f16ToUi16(rm, v);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
+
 val     extern_f16ToI32 = {c: "softfloat_f16toi32", ocaml: "Softfloat.f16_to_i32", lem: "softfloat_f16_to_i32"} : (bits_rm, bits_H) -> unit
 val      riscv_f16ToI32 : (bits_rm, bits_H) -> (bits_fflags, bits_W) effect {rreg}
 function riscv_f16ToI32 (rm, v) = {
@@ -373,6 +401,20 @@ val     extern_ui64ToF16 = {c: "softfloat_ui64tof16", ocaml: "Softfloat.ui64_to_
 val      riscv_ui64ToF16 : (bits_rm, bits_LU) -> (bits_fflags, bits_H) effect {rreg}
 function riscv_ui64ToF16 (rm, v) = {
   extern_ui64ToF16(rm, v);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
+
+val     extern_f32ToI16 = {c: "softfloat_f32toi16", ocaml: "Softfloat.f32_to_i16", lem: "softfloat_f32_to_i16"} : (bits_rm, bits_S) -> unit
+val      riscv_f32ToI16 : (bits_rm, bits_S) -> (bits_fflags, bits(16)) effect {rreg}
+function riscv_f32ToI16 (rm, v) = {
+  extern_f32ToI16(rm, v);
+  (float_fflags[4 .. 0], float_result[15 .. 0])
+}
+
+val     extern_f32ToUi16 = {c: "softfloat_f32toui16", ocaml: "Softfloat.f32_to_ui16", lem: "softfloat_f32_to_ui16"} : (bits_rm, bits_S) -> unit
+val      riscv_f32ToUi16 : (bits_rm, bits_S) -> (bits_fflags, bits(16)) effect {rreg}
+function riscv_f32ToUi16 (rm, v) = {
+  extern_f32ToUi16(rm, v);
   (float_fflags[4 .. 0], float_result[15 .. 0])
 }
 

--- a/model/riscv_vext_control.sail
+++ b/model/riscv_vext_control.sail
@@ -1,3 +1,41 @@
+/*=================================================================================*/
+/*  Copyright (c) 2021-2023                                                        */
+/*    Authors from RIOS Lab, Tsinghua University:                                  */
+/*      Xinlai Wan <xinlai.w@rioslab.org>                                          */
+/*      Xi Wang <xi.w@rioslab.org>                                                 */
+/*      Yifei Zhu <yifei.z@rioslab.org>                                            */
+/*      Shenwei Hu <shenwei.h@rioslab.org>                                         */
+/*      Kalvin Vu                                                                  */
+/*    Other contributors:                                                          */
+/*      Jessica Clarke <jrtc27@jrtc27.com>                                         */
+/*      Victor Moya <victor.moya@semidynamics.com>                                 */
+/*                                                                                 */
+/*  All rights reserved.                                                           */
+/*                                                                                 */
+/*  Redistribution and use in source and binary forms, with or without             */
+/*  modification, are permitted provided that the following conditions             */
+/*  are met:                                                                       */
+/*  1. Redistributions of source code must retain the above copyright              */
+/*     notice, this list of conditions and the following disclaimer.               */
+/*  2. Redistributions in binary form must reproduce the above copyright           */
+/*     notice, this list of conditions and the following disclaimer in             */
+/*     the documentation and/or other materials provided with the                  */
+/*     distribution.                                                               */
+/*                                                                                 */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''             */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED              */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR            */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                   */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT               */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF               */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND            */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,             */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT             */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF             */
+/*  SUCH DAMAGE.                                                                   */
+/*=================================================================================*/
+
 function clause ext_is_CSR_defined (0x008, _) = true
 function clause ext_is_CSR_defined (0xC20, _) = true
 function clause ext_is_CSR_defined (0xC21, _) = true

--- a/model/riscv_vext_regs.sail
+++ b/model/riscv_vext_regs.sail
@@ -1,3 +1,41 @@
+/*=================================================================================*/
+/*  Copyright (c) 2021-2023                                                        */
+/*    Authors from RIOS Lab, Tsinghua University:                                  */
+/*      Xinlai Wan <xinlai.w@rioslab.org>                                          */
+/*      Xi Wang <xi.w@rioslab.org>                                                 */
+/*      Yifei Zhu <yifei.z@rioslab.org>                                            */
+/*      Shenwei Hu <shenwei.h@rioslab.org>                                         */
+/*      Kalvin Vu                                                                  */
+/*    Other contributors:                                                          */
+/*      Jessica Clarke <jrtc27@jrtc27.com>                                         */
+/*      Victor Moya <victor.moya@semidynamics.com>                                 */
+/*                                                                                 */
+/*  All rights reserved.                                                           */
+/*                                                                                 */
+/*  Redistribution and use in source and binary forms, with or without             */
+/*  modification, are permitted provided that the following conditions             */
+/*  are met:                                                                       */
+/*  1. Redistributions of source code must retain the above copyright              */
+/*     notice, this list of conditions and the following disclaimer.               */
+/*  2. Redistributions in binary form must reproduce the above copyright           */
+/*     notice, this list of conditions and the following disclaimer in             */
+/*     the documentation and/or other materials provided with the                  */
+/*     distribution.                                                               */
+/*                                                                                 */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''             */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED              */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR            */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                   */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT               */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF               */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND            */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,             */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT             */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF             */
+/*  SUCH DAMAGE.                                                                   */
+/*=================================================================================*/
+
 /* vector registers */
 register vr0 : vregtype
 register vr1 : vregtype

--- a/model/riscv_vlen.sail
+++ b/model/riscv_vlen.sail
@@ -27,3 +27,13 @@ function get_vlen_pow() = match vlen {
 }
 
 type vlenmax : Int = 65536
+
+/* Note: At present, the values of elen and vlen need to be manually speficied
+ * in the init_sys() function of riscv_sys_control.sail before compiling the emulators,
+ * e.g.,
+ *  vlen = 0b0101;
+ *  elen = 0b1;
+ * means VLEN = 1024 and ELEN = 64,
+ * and the CSR vlenb is also not used.
+ * They will be configurable when user-specified configuration is supported in Sail.
+ */ 

--- a/model/riscv_vlen.sail
+++ b/model/riscv_vlen.sail
@@ -1,3 +1,41 @@
+/*=================================================================================*/
+/*  Copyright (c) 2021-2023                                                        */
+/*    Authors from RIOS Lab, Tsinghua University:                                  */
+/*      Xinlai Wan <xinlai.w@rioslab.org>                                          */
+/*      Xi Wang <xi.w@rioslab.org>                                                 */
+/*      Yifei Zhu <yifei.z@rioslab.org>                                            */
+/*      Shenwei Hu <shenwei.h@rioslab.org>                                         */
+/*      Kalvin Vu                                                                  */
+/*    Other contributors:                                                          */
+/*      Jessica Clarke <jrtc27@jrtc27.com>                                         */
+/*      Victor Moya <victor.moya@semidynamics.com>                                 */
+/*                                                                                 */
+/*  All rights reserved.                                                           */
+/*                                                                                 */
+/*  Redistribution and use in source and binary forms, with or without             */
+/*  modification, are permitted provided that the following conditions             */
+/*  are met:                                                                       */
+/*  1. Redistributions of source code must retain the above copyright              */
+/*     notice, this list of conditions and the following disclaimer.               */
+/*  2. Redistributions in binary form must reproduce the above copyright           */
+/*     notice, this list of conditions and the following disclaimer in             */
+/*     the documentation and/or other materials provided with the                  */
+/*     distribution.                                                               */
+/*                                                                                 */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''             */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED              */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR            */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                   */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT               */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF               */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND            */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,             */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT             */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF             */
+/*  SUCH DAMAGE.                                                                   */
+/*=================================================================================*/
+
 register elen : bits(1)
 
 val get_elen_pow : unit -> {|5, 6|} effect {rreg}
@@ -36,4 +74,4 @@ type vlenmax : Int = 65536
  * means VLEN = 1024 and ELEN = 64,
  * and the CSR vlenb is also not used.
  * They will be configurable when user-specified configuration is supported in Sail.
- */ 
+ */

--- a/model/riscv_vreg_type.sail
+++ b/model/riscv_vreg_type.sail
@@ -1,3 +1,41 @@
+/*=================================================================================*/
+/*  Copyright (c) 2021-2023                                                        */
+/*    Authors from RIOS Lab, Tsinghua University:                                  */
+/*      Xinlai Wan <xinlai.w@rioslab.org>                                          */
+/*      Xi Wang <xi.w@rioslab.org>                                                 */
+/*      Yifei Zhu <yifei.z@rioslab.org>                                            */
+/*      Shenwei Hu <shenwei.h@rioslab.org>                                         */
+/*      Kalvin Vu                                                                  */
+/*    Other contributors:                                                          */
+/*      Jessica Clarke <jrtc27@jrtc27.com>                                         */
+/*      Victor Moya <victor.moya@semidynamics.com>                                 */
+/*                                                                                 */
+/*  All rights reserved.                                                           */
+/*                                                                                 */
+/*  Redistribution and use in source and binary forms, with or without             */
+/*  modification, are permitted provided that the following conditions             */
+/*  are met:                                                                       */
+/*  1. Redistributions of source code must retain the above copyright              */
+/*     notice, this list of conditions and the following disclaimer.               */
+/*  2. Redistributions in binary form must reproduce the above copyright           */
+/*     notice, this list of conditions and the following disclaimer in             */
+/*     the documentation and/or other materials provided with the                  */
+/*     distribution.                                                               */
+/*                                                                                 */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''             */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED              */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR            */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                   */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT               */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF               */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND            */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,             */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT             */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF             */
+/*  SUCH DAMAGE.                                                                   */
+/*=================================================================================*/
+
 /* Definitions for vector registers (V extension) */
 
 type vreglenbits = bits(vlenmax) /* use the largest possible register length */

--- a/ocaml_emulator/softfloat.ml
+++ b/ocaml_emulator/softfloat.ml
@@ -80,6 +80,18 @@ let f32_class v =
 let f64_class v =
   ()
 
+let f16_to_i8 rm v =
+  ()
+
+let f16_to_ui8 rm v =
+  ()
+
+let f16_to_i16 rm v =
+  ()
+
+let f16_to_ui16 rm v =
+  ()
+
 let f16_to_i32 rm v =
   ()
 
@@ -102,6 +114,12 @@ let i64_to_f16 rm v =
   ()
 
 let ui64_to_f16 rm v =
+  ()
+
+let f32_to_i16 rm v =
+  ()
+
+let f32_to_ui16 rm v =
   ()
 
 let f32_to_i32 rm v =

--- a/ocaml_emulator/softfloat.ml
+++ b/ocaml_emulator/softfloat.ml
@@ -53,6 +53,33 @@ let f32_sqrt rm v =
 let f64_sqrt rm v =
   ()
 
+let f16_rsqrte7 rm v =
+  ()
+
+let f32_rsqrte7 rm v =
+  ()
+
+let f64_rsqrte7 rm v =
+  ()
+
+let f16_recip7 rm v =
+  ()
+
+let f32_recip7 rm v =
+  ()
+
+let f64_recip7 rm v =
+  ()
+
+let f16_class v =
+  ()
+
+let f32_class v =
+  ()
+
+let f64_class v =
+  ()
+
 let f16_to_i32 rm v =
   ()
 
@@ -146,6 +173,9 @@ let f64_to_f32 rm v =
 let f16_lt v1 v2 =
   ()
 
+let f16_lt_quiet v1 v2 =
+  ()
+
 let f16_le v1 v2 =
   ()
 
@@ -155,6 +185,9 @@ let f16_eq v1 v2 =
 let f32_lt v1 v2 =
   ()
 
+let f32_lt_quiet v1 v2 =
+  ()
+
 let f32_le v1 v2 =
   ()
 
@@ -162,6 +195,9 @@ let f32_eq v1 v2 =
   ()
 
 let f64_lt v1 v2 =
+  ()
+
+let f64_lt_quiet v1 v2 =
   ()
 
 let f64_le v1 v2 =


### PR DESCRIPTION
This PR contains vector floating-point instructions (Spec Chapter 13) in `riscv_insts_vext_fp.sail`. The current softfloat interface is extended to support some special instructions: `vfclass.v`, `vfrsqrt7.v`, `vfrec7.v`, and `vfmax`/`vfmin` which need quiet floating-point comparison functions (`f64_lt_quiet`, `f32_lt_quiet`, `f16_lt_quiet`). In the softfloat C source code, there are 4 new files: `f16_classify.c`, `f32_classify.c`, `f64_classify.c`, `fall_reciprocal.c`. They are from the softfloat directory of Spike (if allowed to use them). And I also sync with the master branch to catch up with the new commits in this update.

The model generated by this code is tested by the vector ISA tests generated by [rvv-atg](https://github.com/hushenwei2000/rvv-atg) for different configurations. (ELEN and VLEN are manually specified in `riscv_sys_control.sail` when compiling the model.) Please send me comments if there are issues in the new code, especially the modified softfloat part.