### PR TITLE
Add support for the Zvkned extension

### DIFF
--- a/Makefile.old
+++ b/Makefile.old
@@ -68,6 +68,8 @@ SAIL_DEFAULT_INST += riscv_insts_vext_fp_red.sail
 SAIL_DEFAULT_INST += riscv_insts_zicbom.sail
 SAIL_DEFAULT_INST += riscv_insts_zicboz.sail
 
+SAIL_DEFAULT_INST += riscv_insts_zvkned.sail
+
 SAIL_SEQ_INST  = $(SAIL_DEFAULT_INST) riscv_jalr_seq.sail
 SAIL_RMEM_INST = $(SAIL_DEFAULT_INST) riscv_jalr_rmem.sail riscv_insts_rmem.sail
 

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -23,6 +23,7 @@ enum clause extension = Ext_C
 enum clause extension = Ext_B
 // Vector Operations
 enum clause extension = Ext_V
+enum clause extension = Ext_Zvkned
 // Supervisor
 enum clause extension = Ext_S
 // User

--- a/model/riscv_insts_zvkned.sail
+++ b/model/riscv_insts_zvkned.sail
@@ -1,5 +1,5 @@
 /*
- * Vector Cryptography Extension - NIST Suite: Vecttor AES Block Cipher
+ * Vector Cryptography Extension - NIST Suite: Vector AES Block Cipher
  * ----------------------------------------------------------------------
  */
 

--- a/model/riscv_insts_zvkned.sail
+++ b/model/riscv_insts_zvkned.sail
@@ -94,3 +94,81 @@ function clause execute (RISCV_VAESEF(vs2, vd, suffix)) = {
     RETIRE_SUCCESS
   }
 }
+
+/* VAESEM.[VV, VS] */
+
+mapping vaesem_mnemonic : bits(7) <-> string = {
+  0b1010001 <-> "vaesem.vv",
+  0b1010011 <-> "vaesem.vs",
+}
+
+union clause ast = RISCV_VAESEM : (regidx, regidx, string)
+
+mapping clause encdec = RISCV_VAESEM(vs2, vd, suffix)	       if (haveRVV() & haveZvkned())
+ <-> vv_or_vs(suffix) @ vs2 @ 0b00010 @ 0b010 @ vd @ 0b1110111 if (haveRVV() & haveZvkned())
+
+mapping clause assembly = RISCV_VAESEM(vs2, vd, suffix)
+ <-> vaesem_mnemonic(vv_or_vs(suffix)) ^ spc() ^ vreg_name(vd)
+				       ^ sep() ^ vreg_name(vs2)
+
+function clause execute (RISCV_VAESEM(vs2, vd, suffix)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let LMUL     = if LMUL_pow < 0 then 0 else LMUL_pow;
+  let VLEN     = int_power(2, get_vlen_pow());
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if (zvk_check_elements(VLEN, num_elem, LMUL, SEW) == false)
+  then {
+    handle_illegal();
+    RETIRE_FAIL
+  } else {
+    let 'n = num_elem;
+    let 'm = SEW;
+    assert('m == 32);
+
+    let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+    let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+    result      : vector('n, dec, bits('m)) = undefined;
+
+    vd_state : bits(128) = undefined;
+    vs2_key  : bits(128) = undefined;
+
+    eg_len = (unsigned(vl) / 'n);
+    eg_start = (unsigned(vstart) / 'n);
+
+    foreach (i from eg_start to (eg_len - 1)) {
+      assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < 'n);
+      vd_state[31..0]   = vd_val[i*4+0];
+      vd_state[63..32]  = vd_val[i*4+1];
+      vd_state[95..64]  = vd_val[i*4+2];
+      vd_state[127..96] = vd_val[i*4+3];
+
+      if suffix == "vv" then {
+	vs2_key[31..0]   = vs2_val[i*4+0];
+	vs2_key[63..32]  = vs2_val[i*4+1];
+	vs2_key[95..64]  = vs2_val[i*4+2];
+	vs2_key[127..96] = vs2_val[i*4+3];
+      } else {
+	vs2_key[31..0]   = vs2_val[0];
+	vs2_key[63..32]  = vs2_val[1];
+	vs2_key[95..64]  = vs2_val[2];
+	vs2_key[127..96] = vs2_val[3];
+      };
+
+      let sb       : bitvector(128, dec) = aes_subbytes_fwd(vd_state);
+      let sr       : bitvector(128, dec) = aes_shift_rows_fwd(sb);
+      let mix      : bitvector(128, dec) = aes_mixcolumns_fwd(sr);
+      let ark      : bitvector(128, dec) = mix ^ vs2_key;
+
+      result[i*4+0] = ark[31..0];
+      result[i*4+1] = ark[63..32];
+      result[i*4+2] = ark[95..64];
+      result[i*4+3] = ark[127..96];
+    };
+
+    write_single_vreg(num_elem, 'm, vd, result);
+    vstart = EXTZ(0b0);
+    RETIRE_SUCCESS
+  }
+}

--- a/model/riscv_insts_zvkned.sail
+++ b/model/riscv_insts_zvkned.sail
@@ -12,3 +12,85 @@ val	 zvk_check_elements : (int, int, int, int) -> bool
 function zvk_check_elements(VLEN, num_elem, LMUL, SEW) = {
   ((unsigned(vl)%num_elem) != 0) | ((unsigned(vstart)%num_elem) != 0) | (LMUL*VLEN) < (num_elem*SEW)
 }
+
+mapping vv_or_vs : string <-> bits(7) = {
+  "vv" <-> 0b1010001,
+  "vs" <-> 0b1010011,
+}
+
+/* VAESEF.[VV, VS] */
+
+mapping vaesef_mnemonic : bits(7) <-> string = {
+  0b1010001 <-> "vaesef.vv",
+  0b1010011 <-> "vaesef.vs",
+}
+
+union clause ast = RISCV_VAESEF : (regidx, regidx, string)
+
+mapping clause encdec = RISCV_VAESEF(vs2, vd, suffix)	       if (haveRVV() & haveZvkned())
+ <-> vv_or_vs(suffix) @ vs2 @ 0b00011 @ 0b010 @ vd @ 0b1110111 if (haveRVV() & haveZvkned())
+
+mapping clause assembly = RISCV_VAESEF(vs2, vd, suffix)
+ <-> vaesef_mnemonic(vv_or_vs(suffix)) ^ spc() ^ vreg_name(vd)
+				       ^ spc() ^ vreg_name(vs2)
+
+function clause execute (RISCV_VAESEF(vs2, vd, suffix)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let LMUL     = if LMUL_pow < 0 then 0 else LMUL_pow;
+  let VLEN     = int_power(2, get_vlen_pow());
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if (zvk_check_elements(VLEN, num_elem, LMUL, SEW) == false)
+  then {
+    handle_illegal();
+    RETIRE_FAIL
+  } else {
+    let 'n = num_elem;
+    let 'm = SEW;
+    assert('m == 32);
+
+    let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+    let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+    result      : vector('n, dec, bits('m)) = undefined;
+
+    vd_state : bits(128) = undefined;
+    vs2_key  : bits(128) = undefined;
+
+    eg_len = (unsigned(vl) / 'n);
+    eg_start = (unsigned(vstart) / 'n);
+
+    foreach (i from eg_start to (eg_len - 1)) {
+      assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < 'n);
+      vd_state[31..0]   = vd_val[i*4+0];
+      vd_state[63..32]  = vd_val[i*4+1];
+      vd_state[95..64]  = vd_val[i*4+2];
+      vd_state[127..96] = vd_val[i*4+3];
+
+      if suffix == "vv" then {
+	vs2_key[31..0]   = vs2_val[i*4+0];
+	vs2_key[63..32]  = vs2_val[i*4+1];
+	vs2_key[95..64]  = vs2_val[i*4+2];
+	vs2_key[127..96] = vs2_val[i*4+3];
+      } else {
+	vs2_key[31..0]   = vs2_val[0];
+	vs2_key[63..32]  = vs2_val[1];
+	vs2_key[95..64]  = vs2_val[2];
+	vs2_key[127..96] = vs2_val[3];
+      };
+
+      let sb       : bitvector(128, dec) = aes_subbytes_fwd(vd_state);
+      let sr       : bitvector(128, dec) = aes_shift_rows_fwd(sb);
+      ark		 : bitvector(128, dec) = sr ^ vs2_key;
+
+      result[i*4+0] = ark[31..0];
+      result[i*4+1] = ark[63..32];
+      result[i*4+2] = ark[95..64];
+      result[i*4+3] = ark[127..96];
+    };
+
+    write_single_vreg(num_elem, 'm, vd, result);
+    vstart = EXTZ(0b0);
+    RETIRE_SUCCESS
+  }
+}

--- a/model/riscv_insts_zvkned.sail
+++ b/model/riscv_insts_zvkned.sail
@@ -406,3 +406,82 @@ function clause execute (RISCV_VAESKF1_VI(vs2, rnd, vd)) = {
     RETIRE_SUCCESS
   }
 }
+
+/* VAESKF2.VI */
+
+union clause ast = RISCV_VAESKF2_VI : (regidx, regidx, regidx)
+
+mapping clause encdec = RISCV_VAESKF2_VI(vs2, rnd, vd) if (haveRVV() & haveZvkned())
+ <-> 0b1010101 @ vs2 @ rnd @ 0b010 @ vd @ 0b1110111    if (haveRVV() & haveZvkned())
+
+mapping clause assembly = RISCV_VAESKF2_VI(vs2, rnd, vd)
+ <-> "vaeskf2.vi" ^ sep() ^ vreg_name(vd)
+		  ^ sep() ^ vreg_name(vs2)
+		  ^ sep() ^ reg_name(rnd)
+
+function clause execute (RISCV_VAESKF2_VI(vs2, rnd, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let LMUL     = if LMUL_pow < 0 then 0 else LMUL_pow;
+  let VLEN     = int_power(2, get_vlen_pow());
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if (zvk_check_elements(VLEN, num_elem, LMUL, SEW) == false)
+  then {
+    handle_illegal();
+    RETIRE_FAIL
+  } else {
+    let 'n = num_elem;
+    let 'm = SEW;
+    assert('m == 32);
+
+    rnd_val : bits(4)                   = rnd[3..0];
+    let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+    let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+    result      : vector('n, dec, bits('m)) = undefined;
+
+    if (unsigned(rnd_val) < 2) | (unsigned(rnd_val) > 14)
+    then rnd_val[3] = not_bit(rnd_val[3]);
+
+    current_round_key : bits(128) = undefined;
+    round_key_b       : bits(128) = undefined;
+    w		      : bits(128) = undefined;
+
+    eg_len = (unsigned(vl) / 'n);
+    eg_start = (unsigned(vstart) / 'n);
+
+    foreach (i from eg_start to (eg_len - 1)) {
+      assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < 'n);
+      current_round_key[31..0]   = vs2_val[i*4+0];
+      current_round_key[63..32]  = vs2_val[i*4+1];
+      current_round_key[95..64]  = vs2_val[i*4+2];
+      current_round_key[127..96] = vs2_val[i*4+3];
+
+      round_key_b[31..0]   = vd_val[i*4+0];
+      round_key_b[63..32]  = vd_val[i*4+1];
+      round_key_b[95..64]  = vd_val[i*4+2];
+      round_key_b[127..96] = vd_val[i*4+3];
+
+      w[31..0] = if (rnd_val[0] == bitone)
+		 then
+		   aes_subword_fwd(current_round_key[127..96]) ^ round_key_b[31..0]
+		 else
+		   aes_subword_fwd(aes_rotword(current_round_key[127..96]))
+		     ^ aes_decode_rcon(rnd_val >> 1)
+		     ^ round_key_b[31..0];
+
+      w[63..32]  = w[31..0]  ^ round_key_b[63..32];
+      w[95..64]  = w[63..32] ^ round_key_b[95..64];
+      w[127..96] = w[95..64] ^ round_key_b[127..96];
+
+      result[i*4+0] = w[31..0];
+      result[i*4+1] = w[63..32];
+      result[i*4+2] = w[95..64];
+      result[i*4+3] = w[127..96];
+    };
+
+    write_single_vreg(num_elem, 'm, vd, result);
+    vstart = EXTZ(0b0);
+    RETIRE_SUCCESS
+  }
+}

--- a/model/riscv_insts_zvkned.sail
+++ b/model/riscv_insts_zvkned.sail
@@ -172,3 +172,80 @@ function clause execute (RISCV_VAESEM(vs2, vd, suffix)) = {
     RETIRE_SUCCESS
   }
 }
+
+/* VAESDF.VV */
+
+mapping vaesdf_mnemonic : bits(7) <-> string = {
+  0b1010001 <-> "vaesdf.vv",
+  0b1010011 <-> "vaesdf.vs",
+}
+
+union clause ast = RISCV_VAESDF : (regidx, regidx, string)
+
+mapping clause encdec = RISCV_VAESDF(vs2, vd, suffix)		if (haveRVV() & haveZvkned())
+ <-> vv_or_vs(suffix) @ vs2 @ 0b00001 @ 0b010 @ vd @ 0b1110111	if (haveRVV() & haveZvkned())
+
+mapping clause assembly = RISCV_VAESDF(vs2, vd, suffix)
+ <-> vaesdf_mnemonic(vv_or_vs(suffix)) ^ sep() ^ vreg_name(vd)
+				       ^ sep() ^ vreg_name(vs2)
+
+function clause execute (RISCV_VAESDF(vs2, vd, suffix)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let LMUL     = if LMUL_pow < 0 then 0 else LMUL_pow;
+  let VLEN     = int_power(2, get_vlen_pow());
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if (zvk_check_elements(VLEN, num_elem, LMUL, SEW) == false)
+  then {
+    handle_illegal();
+    RETIRE_FAIL
+  } else {
+    let 'n = num_elem;
+    let 'm = SEW;
+    assert('m == 32);
+
+    let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+    let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+    result      : vector('n, dec, bits('m)) = undefined;
+
+    vd_state : bits(128) = undefined;
+    vs2_key  : bits(128) = undefined;
+
+    eg_len = (unsigned(vl) / 'n);
+    eg_start = (unsigned(vstart) / 'n);
+
+    foreach (i from eg_start to (eg_len - 1)) {
+      assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < 'n);
+      vd_state[31..0]   = vd_val[i*4+0];
+      vd_state[63..32]  = vd_val[i*4+1];
+      vd_state[95..64]  = vd_val[i*4+2];
+      vd_state[127..96] = vd_val[i*4+3];
+
+      if suffix == "vv" then {
+	vs2_key[31..0]   = vs2_val[i*4+0];
+	vs2_key[63..32]  = vs2_val[i*4+1];
+	vs2_key[95..64]  = vs2_val[i*4+2];
+	vs2_key[127..96] = vs2_val[i*4+3];
+      } else {
+	vs2_key[31..0]   = vs2_val[0];
+	vs2_key[63..32]  = vs2_val[1];
+	vs2_key[95..64]  = vs2_val[2];
+	vs2_key[127..96] = vs2_val[3];
+      };
+
+      let sr       : bits(128) = aes_shift_rows_inv(vd_state);
+      let sb       : bits(128) = aes_subbytes_inv(sr);
+      let ark      : bits(128) = sb ^ vs2_key;
+
+      result[i*4+0] = ark[31..0];
+      result[i*4+1] = ark[63..32];
+      result[i*4+2] = ark[95..64];
+      result[i*4+3] = ark[127..96];
+    };
+
+    write_single_vreg(num_elem, 'm, vd, result);
+    vstart = EXTZ(0b0);
+    RETIRE_SUCCESS
+  }
+}

--- a/model/riscv_insts_zvkned.sail
+++ b/model/riscv_insts_zvkned.sail
@@ -249,3 +249,81 @@ function clause execute (RISCV_VAESDF(vs2, vd, suffix)) = {
     RETIRE_SUCCESS
   }
 }
+
+/* VAESDM.VV */
+
+mapping vaesdm_mnemonic : bits(7) <-> string = {
+  0b1010001 <-> "vaesem.vv",
+  0b1010011 <-> "vaesem.vs",
+}
+
+union clause ast = RISCV_VAESDM : (regidx, regidx, string)
+
+mapping clause encdec = RISCV_VAESDM(vs2, vd, suffix)	       if (haveRVV() & haveZvkned())
+ <-> vv_or_vs(suffix) @ vs2 @ 0b00000 @ 0b010 @ vd @ 0b1110111 if (haveRVV() & haveZvkned())
+
+mapping clause assembly = RISCV_VAESDM(vs2, vd, suffix)
+ <-> vaesdm_mnemonic(vv_or_vs(suffix)) ^ spc() ^ vreg_name(vd)
+				       ^ sep() ^ vreg_name(vs2)
+
+function clause execute (RISCV_VAESDM(vs2, vd, suffix)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let LMUL     = if LMUL_pow < 0 then 0 else LMUL_pow;
+  let VLEN     = int_power(2, get_vlen_pow());
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if (zvk_check_elements(VLEN, num_elem, LMUL, SEW) == false)
+  then {
+    handle_illegal();
+    RETIRE_FAIL
+  } else {
+    let 'n = num_elem;
+    let 'm = SEW;
+    assert('m == 32);
+
+    let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+    let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+    result      : vector('n, dec, bits('m)) = undefined;
+
+    vd_state : bits(128) = undefined;
+    vs2_key  : bits(128) = undefined;
+
+    eg_len = (unsigned(vl) / 'n);
+    eg_start = (unsigned(vstart) / 'n);
+
+    foreach (i from eg_start to (eg_len - 1)) {
+      assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < 'n);
+      vd_state[31..0]   = vd_val[i*4+0];
+      vd_state[63..32]  = vd_val[i*4+1];
+      vd_state[95..64]  = vd_val[i*4+2];
+      vd_state[127..96] = vd_val[i*4+3];
+
+      if suffix == "vv" then {
+	vs2_key[31..0]   = vs2_val[i*4+0];
+	vs2_key[63..32]  = vs2_val[i*4+1];
+	vs2_key[95..64]  = vs2_val[i*4+2];
+	vs2_key[127..96] = vs2_val[i*4+3];
+      } else {
+	vs2_key[31..0]   = vs2_val[0];
+	vs2_key[63..32]  = vs2_val[1];
+	vs2_key[95..64]  = vs2_val[2];
+	vs2_key[127..96] = vs2_val[3];
+      };
+
+      let sr       : bits(128) = aes_shift_rows_inv(vd_state);
+      let sb       : bits(128) = aes_subbytes_inv(sr);
+      let ark      : bits(128) = sb ^ vs2_key;
+      let mix      : bits(128) = aes_mixcolumns_inv(ark);
+
+      result[i*4+0] = mix[31..0];
+      result[i*4+1] = mix[63..32];
+      result[i*4+2] = mix[95..64];
+      result[i*4+3] = mix[127..96];
+    };
+
+    write_single_vreg(num_elem, 'm, vd, result);
+    vstart = EXTZ(0b0);
+    RETIRE_SUCCESS
+  }
+}

--- a/model/riscv_insts_zvkned.sail
+++ b/model/riscv_insts_zvkned.sail
@@ -485,3 +485,66 @@ function clause execute (RISCV_VAESKF2_VI(vs2, rnd, vd)) = {
     RETIRE_SUCCESS
   }
 }
+
+/* VAESZ.VS */
+
+union clause ast = RISCV_VAESZ_VS : (regidx, regidx)
+
+mapping clause encdec = RISCV_VAESZ_VS(vs2, vd)		if (haveRVV() & haveZvkned())
+ <-> 0b1010011 @ vs2 @ 0b00111 @ 0b010 @ vd @ 0b1110111 if (haveRVV() & haveZvkned())
+
+mapping clause assembly = RISCV_VAESZ_VS(vs2, vd)
+ <-> "vaesz.vs" ^ sep() ^ vreg_name(vd)
+		^ sep() ^ vreg_name(vs2)
+
+function clause execute (RISCV_VAESZ_VS(vs2, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let LMUL     = if LMUL_pow < 0 then 0 else LMUL_pow;
+  let VLEN     = int_power(2, get_vlen_pow());
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if (zvk_check_elements(VLEN, num_elem, LMUL, SEW) == false)
+  then {
+    handle_illegal();
+    RETIRE_FAIL
+  } else {
+    let 'n = num_elem;
+    let 'm = SEW;
+    assert('m == 32);
+
+    let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+    let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+    result      : vector('n, dec, bits('m)) = undefined;
+
+    vd_state : bits(128) = undefined;
+    vs2_key  : bits(128) = undefined;
+
+    eg_len = (unsigned(vl) / 'n);
+    eg_start = (unsigned(vstart) / 'n);
+
+    foreach (i from eg_start to (eg_len - 1)) {
+      assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < 'n);
+      vd_state[31..0]   = vd_val[i*4+0];
+      vd_state[63..32]  = vd_val[i*4+1];
+      vd_state[95..64]  = vd_val[i*4+2];
+      vd_state[127..96] = vd_val[i*4+3];
+
+      vs2_key[31..0]   = vs2_val[0];
+      vs2_key[63..32]  = vs2_val[1];
+      vs2_key[95..64]  = vs2_val[2];
+      vs2_key[127..96] = vs2_val[3];
+
+      let ark : bits(128) = vd_state ^ vs2_key;
+
+      result[i*4+0] = ark[31..0];
+      result[i*4+1] = ark[63..32];
+      result[i*4+2] = ark[95..64];
+      result[i*4+3] = ark[127..96];
+    };
+
+    write_single_vreg(num_elem, 'm, vd, result);
+    vstart = EXTZ(0b0);
+    RETIRE_SUCCESS
+  }
+}

--- a/model/riscv_insts_zvkned.sail
+++ b/model/riscv_insts_zvkned.sail
@@ -1,0 +1,14 @@
+/*
+ * Vector Cryptography Extension - NIST Suite: Vecttor AES Block Cipher
+ * ----------------------------------------------------------------------
+ */
+
+/*
+ * Helper functions.
+ * ----------------------------------------------------------------------
+ */
+
+val	 zvk_check_elements : (int, int, int, int) -> bool
+function zvk_check_elements(VLEN, num_elem, LMUL, SEW) = {
+  ((unsigned(vl)%num_elem) != 0) | ((unsigned(vstart)%num_elem) != 0) | (LMUL*VLEN) < (num_elem*SEW)
+}

--- a/model/riscv_insts_zvkned.sail
+++ b/model/riscv_insts_zvkned.sail
@@ -18,6 +18,15 @@ mapping vv_or_vs : string <-> bits(7) = {
   "vs" <-> 0b1010011,
 }
 
+val	 aes_rotword : bits(32) -> bits(32)
+function aes_rotword(x) = {
+  let a0 : bits (8) = x[ 7.. 0];
+  let a1 : bits (8) = x[15.. 8];
+  let a2 : bits (8) = x[23..16];
+  let a3 : bits (8) = x[31..24];
+  (a0 @ a3 @ a2 @ a1) /* Return Value */
+}
+
 /* VAESEF.[VV, VS] */
 
 mapping vaesef_mnemonic : bits(7) <-> string = {
@@ -320,6 +329,76 @@ function clause execute (RISCV_VAESDM(vs2, vd, suffix)) = {
       result[i*4+1] = mix[63..32];
       result[i*4+2] = mix[95..64];
       result[i*4+3] = mix[127..96];
+    };
+
+    write_single_vreg(num_elem, 'm, vd, result);
+    vstart = EXTZ(0b0);
+    RETIRE_SUCCESS
+  }
+}
+
+/* VAESKF1.VI */
+
+union clause ast = RISCV_VAESKF1_VI : (regidx, regidx, regidx)
+
+mapping clause encdec = RISCV_VAESKF1_VI(vs2, rnd, vd) if (haveRVV() & haveZvkned())
+ <-> 0b1000101 @ vs2 @ rnd @ 0b010 @ vd @ 0b1110111    if (haveRVV() & haveZvkned())
+
+mapping clause assembly = RISCV_VAESKF1_VI(vs2, rnd, vd)
+ <-> "vaeskf1.vi" ^ sep() ^ vreg_name(vd)
+		  ^ sep() ^ vreg_name(vs2)
+		  ^ sep() ^ reg_name(rnd)
+
+function clause execute (RISCV_VAESKF1_VI(vs2, rnd, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let LMUL     = if LMUL_pow < 0 then 0 else LMUL_pow;
+  let VLEN     = int_power(2, get_vlen_pow());
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if (zvk_check_elements(VLEN, num_elem, LMUL, SEW) == false)
+  then {
+    handle_illegal();
+    RETIRE_FAIL
+  } else {
+    let 'n = num_elem;
+    let 'm = SEW;
+    assert('m == 32);
+
+    rnd_val	: bits(5)		    = rnd;
+    let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+    let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+    result      : vector('n, dec, bits('m)) = undefined;
+
+    if (unsigned(rnd_val[3..0]) > 10) | (unsigned(rnd_val[3..0]) == 0)
+    then rnd_val[3] = not_bit(rnd_val[3]);
+
+    let r : bits(4) = rnd_val[3..0] - 1;
+
+    current_round_key : bits(128) = undefined;
+    w		      : bits(128) = undefined;
+
+    eg_len = (unsigned(vl) / 'n);
+    eg_start = (unsigned(vstart) / 'n);
+
+    foreach (i from eg_start to (eg_len - 1)) {
+      assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < 'n);
+      current_round_key[31..0]   = vs2_val[i*4+0];
+      current_round_key[63..32]  = vs2_val[i*4+1];
+      current_round_key[95..64]  = vs2_val[i*4+2];
+      current_round_key[127..96] = vs2_val[i*4+3];
+
+      w[31..0] = aes_subword_fwd(aes_rotword(current_round_key[127..96]))
+	       ^ aes_decode_rcon(r)
+	       ^ current_round_key[31..0];
+      w[63..32]  = w[31..0]  ^ current_round_key[63..32];
+      w[95..64]  = w[63..32] ^ current_round_key[95..64];
+      w[127..96] = w[95..64] ^ current_round_key[127..96];
+
+      result[i*4+0] = w[31..0];
+      result[i*4+1] = w[63..32];
+      result[i*4+2] = w[95..64];
+      result[i*4+3] = w[127..96];
     };
 
     write_single_vreg(num_elem, 'm, vd, result);

--- a/model/riscv_insts_zvkned.sail
+++ b/model/riscv_insts_zvkned.sail
@@ -8,6 +8,8 @@
  * ----------------------------------------------------------------------
  */
 
+function clause extensionEnabled(Ext_Zvkned) = true
+
 val	 zvk_check_elements : (int, int, int, int) -> bool
 function zvk_check_elements(VLEN, num_elem, LMUL, SEW) = {
   ((unsigned(vl)%num_elem) != 0) | ((unsigned(vstart)%num_elem) != 0) | (LMUL*VLEN) < (num_elem*SEW)
@@ -36,8 +38,8 @@ mapping vaesef_mnemonic : bits(7) <-> string = {
 
 union clause ast = RISCV_VAESEF : (regidx, regidx, string)
 
-mapping clause encdec = RISCV_VAESEF(vs2, vd, suffix)	       if (haveRVV() & haveZvkned())
- <-> vv_or_vs(suffix) @ vs2 @ 0b00011 @ 0b010 @ vd @ 0b1110111 if (haveRVV() & haveZvkned())
+mapping clause encdec = RISCV_VAESEF(vs2, vd, suffix)	       if extensionEnabled(Ext_Zvkned)
+ <-> vv_or_vs(suffix) @ vs2 @ 0b00011 @ 0b010 @ vd @ 0b1110111 if extensionEnabled(Ext_Zvkned)
 
 mapping clause assembly = RISCV_VAESEF(vs2, vd, suffix)
  <-> vaesef_mnemonic(vv_or_vs(suffix)) ^ spc() ^ vreg_name(vd)
@@ -113,8 +115,8 @@ mapping vaesem_mnemonic : bits(7) <-> string = {
 
 union clause ast = RISCV_VAESEM : (regidx, regidx, string)
 
-mapping clause encdec = RISCV_VAESEM(vs2, vd, suffix)	       if (haveRVV() & haveZvkned())
- <-> vv_or_vs(suffix) @ vs2 @ 0b00010 @ 0b010 @ vd @ 0b1110111 if (haveRVV() & haveZvkned())
+mapping clause encdec = RISCV_VAESEM(vs2, vd, suffix)	       if extensionEnabled(Ext_Zvkned)
+ <-> vv_or_vs(suffix) @ vs2 @ 0b00010 @ 0b010 @ vd @ 0b1110111 if extensionEnabled(Ext_Zvkned)
 
 mapping clause assembly = RISCV_VAESEM(vs2, vd, suffix)
  <-> vaesem_mnemonic(vv_or_vs(suffix)) ^ spc() ^ vreg_name(vd)
@@ -191,8 +193,8 @@ mapping vaesdf_mnemonic : bits(7) <-> string = {
 
 union clause ast = RISCV_VAESDF : (regidx, regidx, string)
 
-mapping clause encdec = RISCV_VAESDF(vs2, vd, suffix)		if (haveRVV() & haveZvkned())
- <-> vv_or_vs(suffix) @ vs2 @ 0b00001 @ 0b010 @ vd @ 0b1110111	if (haveRVV() & haveZvkned())
+mapping clause encdec = RISCV_VAESDF(vs2, vd, suffix)		if extensionEnabled(Ext_Zvkned)
+ <-> vv_or_vs(suffix) @ vs2 @ 0b00001 @ 0b010 @ vd @ 0b1110111	if extensionEnabled(Ext_Zvkned)
 
 mapping clause assembly = RISCV_VAESDF(vs2, vd, suffix)
  <-> vaesdf_mnemonic(vv_or_vs(suffix)) ^ sep() ^ vreg_name(vd)
@@ -268,8 +270,8 @@ mapping vaesdm_mnemonic : bits(7) <-> string = {
 
 union clause ast = RISCV_VAESDM : (regidx, regidx, string)
 
-mapping clause encdec = RISCV_VAESDM(vs2, vd, suffix)	       if (haveRVV() & haveZvkned())
- <-> vv_or_vs(suffix) @ vs2 @ 0b00000 @ 0b010 @ vd @ 0b1110111 if (haveRVV() & haveZvkned())
+mapping clause encdec = RISCV_VAESDM(vs2, vd, suffix)	       if extensionEnabled(Ext_Zvkned)
+ <-> vv_or_vs(suffix) @ vs2 @ 0b00000 @ 0b010 @ vd @ 0b1110111 if extensionEnabled(Ext_Zvkned)
 
 mapping clause assembly = RISCV_VAESDM(vs2, vd, suffix)
  <-> vaesdm_mnemonic(vv_or_vs(suffix)) ^ spc() ^ vreg_name(vd)
@@ -341,8 +343,8 @@ function clause execute (RISCV_VAESDM(vs2, vd, suffix)) = {
 
 union clause ast = RISCV_VAESKF1_VI : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_VAESKF1_VI(vs2, rnd, vd) if (haveRVV() & haveZvkned())
- <-> 0b1000101 @ vs2 @ rnd @ 0b010 @ vd @ 0b1110111    if (haveRVV() & haveZvkned())
+mapping clause encdec = RISCV_VAESKF1_VI(vs2, rnd, vd) if extensionEnabled(Ext_Zvkned)
+ <-> 0b1000101 @ vs2 @ rnd @ 0b010 @ vd @ 0b1110111    if extensionEnabled(Ext_Zvkned)
 
 mapping clause assembly = RISCV_VAESKF1_VI(vs2, rnd, vd)
  <-> "vaeskf1.vi" ^ sep() ^ vreg_name(vd)
@@ -411,8 +413,8 @@ function clause execute (RISCV_VAESKF1_VI(vs2, rnd, vd)) = {
 
 union clause ast = RISCV_VAESKF2_VI : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_VAESKF2_VI(vs2, rnd, vd) if (haveRVV() & haveZvkned())
- <-> 0b1010101 @ vs2 @ rnd @ 0b010 @ vd @ 0b1110111    if (haveRVV() & haveZvkned())
+mapping clause encdec = RISCV_VAESKF2_VI(vs2, rnd, vd) if extensionEnabled(Ext_Zvkned)
+ <-> 0b1010101 @ vs2 @ rnd @ 0b010 @ vd @ 0b1110111    if extensionEnabled(Ext_Zvkned)
 
 mapping clause assembly = RISCV_VAESKF2_VI(vs2, rnd, vd)
  <-> "vaeskf2.vi" ^ sep() ^ vreg_name(vd)
@@ -435,7 +437,7 @@ function clause execute (RISCV_VAESKF2_VI(vs2, rnd, vd)) = {
     let 'm = SEW;
     assert('m == 32);
 
-    rnd_val : bits(4)                   = rnd[3..0];
+    rnd_val : bits(4)			    = rnd[3..0];
     let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
     let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
     result      : vector('n, dec, bits('m)) = undefined;
@@ -467,7 +469,7 @@ function clause execute (RISCV_VAESKF2_VI(vs2, rnd, vd)) = {
 		   aes_subword_fwd(current_round_key[127..96]) ^ round_key_b[31..0]
 		 else
 		   aes_subword_fwd(aes_rotword(current_round_key[127..96]))
-		     ^ aes_decode_rcon(rnd_val >> 1)
+		     ^ aes_decode_rcon((rnd_val >> 1) - 1)
 		     ^ round_key_b[31..0];
 
       w[63..32]  = w[31..0]  ^ round_key_b[63..32];
@@ -490,8 +492,8 @@ function clause execute (RISCV_VAESKF2_VI(vs2, rnd, vd)) = {
 
 union clause ast = RISCV_VAESZ_VS : (regidx, regidx)
 
-mapping clause encdec = RISCV_VAESZ_VS(vs2, vd)		if (haveRVV() & haveZvkned())
- <-> 0b1010011 @ vs2 @ 0b00111 @ 0b010 @ vd @ 0b1110111 if (haveRVV() & haveZvkned())
+mapping clause encdec = RISCV_VAESZ_VS(vs2, vd)		if extensionEnabled(Ext_Zvkned)
+ <-> 0b1010011 @ vs2 @ 0b00111 @ 0b010 @ vd @ 0b1110111 if extensionEnabled(Ext_Zvkned)
 
 mapping clause assembly = RISCV_VAESZ_VS(vs2, vd)
  <-> "vaesz.vs" ^ sep() ^ vreg_name(vd)

--- a/model/riscv_insts_zvkned.sail
+++ b/model/riscv_insts_zvkned.sail
@@ -10,7 +10,7 @@
 
 function clause extensionEnabled(Ext_Zvkned) = true
 
-val	 zvk_check_elements : (int, int, int, int) -> bool
+val      zvk_check_elements : (int, int, int, int) -> bool
 function zvk_check_elements(VLEN, num_elem, LMUL, SEW) = {
   ((unsigned(vl)%num_elem) != 0) | ((unsigned(vstart)%num_elem) != 0) | (LMUL*VLEN) < (num_elem*SEW)
 }
@@ -20,7 +20,7 @@ mapping vv_or_vs : string <-> bits(7) = {
   "vs" <-> 0b1010011,
 }
 
-val	 aes_rotword : bits(32) -> bits(32)
+val      aes_rotword : bits(32) -> bits(32)
 function aes_rotword(x) = {
   let a0 : bits (8) = x[ 7.. 0];
   let a1 : bits (8) = x[15.. 8];
@@ -38,12 +38,12 @@ mapping vaesef_mnemonic : bits(7) <-> string = {
 
 union clause ast = RISCV_VAESEF : (regidx, regidx, string)
 
-mapping clause encdec = RISCV_VAESEF(vs2, vd, suffix)	       if extensionEnabled(Ext_Zvkned)
+mapping clause encdec = RISCV_VAESEF(vs2, vd, suffix)          if extensionEnabled(Ext_Zvkned)
  <-> vv_or_vs(suffix) @ vs2 @ 0b00011 @ 0b010 @ vd @ 0b1110111 if extensionEnabled(Ext_Zvkned)
 
 mapping clause assembly = RISCV_VAESEF(vs2, vd, suffix)
  <-> vaesef_mnemonic(vv_or_vs(suffix)) ^ spc() ^ vreg_name(vd)
-				       ^ spc() ^ vreg_name(vs2)
+                                       ^ spc() ^ vreg_name(vs2)
 
 function clause execute (RISCV_VAESEF(vs2, vd, suffix)) = {
   let SEW      = get_sew();
@@ -79,20 +79,20 @@ function clause execute (RISCV_VAESEF(vs2, vd, suffix)) = {
       vd_state[127..96] = vd_val[i*4+3];
 
       if suffix == "vv" then {
-	vs2_key[31..0]   = vs2_val[i*4+0];
-	vs2_key[63..32]  = vs2_val[i*4+1];
-	vs2_key[95..64]  = vs2_val[i*4+2];
-	vs2_key[127..96] = vs2_val[i*4+3];
+        vs2_key[31..0]   = vs2_val[i*4+0];
+        vs2_key[63..32]  = vs2_val[i*4+1];
+        vs2_key[95..64]  = vs2_val[i*4+2];
+        vs2_key[127..96] = vs2_val[i*4+3];
       } else {
-	vs2_key[31..0]   = vs2_val[0];
-	vs2_key[63..32]  = vs2_val[1];
-	vs2_key[95..64]  = vs2_val[2];
-	vs2_key[127..96] = vs2_val[3];
+        vs2_key[31..0]   = vs2_val[0];
+        vs2_key[63..32]  = vs2_val[1];
+        vs2_key[95..64]  = vs2_val[2];
+        vs2_key[127..96] = vs2_val[3];
       };
 
       let sb       : bitvector(128, dec) = aes_subbytes_fwd(vd_state);
       let sr       : bitvector(128, dec) = aes_shift_rows_fwd(sb);
-      ark		 : bitvector(128, dec) = sr ^ vs2_key;
+      ark                : bitvector(128, dec) = sr ^ vs2_key;
 
       result[i*4+0] = ark[31..0];
       result[i*4+1] = ark[63..32];
@@ -115,12 +115,12 @@ mapping vaesem_mnemonic : bits(7) <-> string = {
 
 union clause ast = RISCV_VAESEM : (regidx, regidx, string)
 
-mapping clause encdec = RISCV_VAESEM(vs2, vd, suffix)	       if extensionEnabled(Ext_Zvkned)
+mapping clause encdec = RISCV_VAESEM(vs2, vd, suffix)          if extensionEnabled(Ext_Zvkned)
  <-> vv_or_vs(suffix) @ vs2 @ 0b00010 @ 0b010 @ vd @ 0b1110111 if extensionEnabled(Ext_Zvkned)
 
 mapping clause assembly = RISCV_VAESEM(vs2, vd, suffix)
  <-> vaesem_mnemonic(vv_or_vs(suffix)) ^ spc() ^ vreg_name(vd)
-				       ^ sep() ^ vreg_name(vs2)
+                                       ^ sep() ^ vreg_name(vs2)
 
 function clause execute (RISCV_VAESEM(vs2, vd, suffix)) = {
   let SEW      = get_sew();
@@ -156,15 +156,15 @@ function clause execute (RISCV_VAESEM(vs2, vd, suffix)) = {
       vd_state[127..96] = vd_val[i*4+3];
 
       if suffix == "vv" then {
-	vs2_key[31..0]   = vs2_val[i*4+0];
-	vs2_key[63..32]  = vs2_val[i*4+1];
-	vs2_key[95..64]  = vs2_val[i*4+2];
-	vs2_key[127..96] = vs2_val[i*4+3];
+        vs2_key[31..0]   = vs2_val[i*4+0];
+        vs2_key[63..32]  = vs2_val[i*4+1];
+        vs2_key[95..64]  = vs2_val[i*4+2];
+        vs2_key[127..96] = vs2_val[i*4+3];
       } else {
-	vs2_key[31..0]   = vs2_val[0];
-	vs2_key[63..32]  = vs2_val[1];
-	vs2_key[95..64]  = vs2_val[2];
-	vs2_key[127..96] = vs2_val[3];
+        vs2_key[31..0]   = vs2_val[0];
+        vs2_key[63..32]  = vs2_val[1];
+        vs2_key[95..64]  = vs2_val[2];
+        vs2_key[127..96] = vs2_val[3];
       };
 
       let sb       : bitvector(128, dec) = aes_subbytes_fwd(vd_state);
@@ -193,12 +193,12 @@ mapping vaesdf_mnemonic : bits(7) <-> string = {
 
 union clause ast = RISCV_VAESDF : (regidx, regidx, string)
 
-mapping clause encdec = RISCV_VAESDF(vs2, vd, suffix)		if extensionEnabled(Ext_Zvkned)
- <-> vv_or_vs(suffix) @ vs2 @ 0b00001 @ 0b010 @ vd @ 0b1110111	if extensionEnabled(Ext_Zvkned)
+mapping clause encdec = RISCV_VAESDF(vs2, vd, suffix)           if extensionEnabled(Ext_Zvkned)
+ <-> vv_or_vs(suffix) @ vs2 @ 0b00001 @ 0b010 @ vd @ 0b1110111  if extensionEnabled(Ext_Zvkned)
 
 mapping clause assembly = RISCV_VAESDF(vs2, vd, suffix)
  <-> vaesdf_mnemonic(vv_or_vs(suffix)) ^ sep() ^ vreg_name(vd)
-				       ^ sep() ^ vreg_name(vs2)
+                                       ^ sep() ^ vreg_name(vs2)
 
 function clause execute (RISCV_VAESDF(vs2, vd, suffix)) = {
   let SEW      = get_sew();
@@ -234,15 +234,15 @@ function clause execute (RISCV_VAESDF(vs2, vd, suffix)) = {
       vd_state[127..96] = vd_val[i*4+3];
 
       if suffix == "vv" then {
-	vs2_key[31..0]   = vs2_val[i*4+0];
-	vs2_key[63..32]  = vs2_val[i*4+1];
-	vs2_key[95..64]  = vs2_val[i*4+2];
-	vs2_key[127..96] = vs2_val[i*4+3];
+        vs2_key[31..0]   = vs2_val[i*4+0];
+        vs2_key[63..32]  = vs2_val[i*4+1];
+        vs2_key[95..64]  = vs2_val[i*4+2];
+        vs2_key[127..96] = vs2_val[i*4+3];
       } else {
-	vs2_key[31..0]   = vs2_val[0];
-	vs2_key[63..32]  = vs2_val[1];
-	vs2_key[95..64]  = vs2_val[2];
-	vs2_key[127..96] = vs2_val[3];
+        vs2_key[31..0]   = vs2_val[0];
+        vs2_key[63..32]  = vs2_val[1];
+        vs2_key[95..64]  = vs2_val[2];
+        vs2_key[127..96] = vs2_val[3];
       };
 
       let sr       : bits(128) = aes_shift_rows_inv(vd_state);
@@ -270,12 +270,12 @@ mapping vaesdm_mnemonic : bits(7) <-> string = {
 
 union clause ast = RISCV_VAESDM : (regidx, regidx, string)
 
-mapping clause encdec = RISCV_VAESDM(vs2, vd, suffix)	       if extensionEnabled(Ext_Zvkned)
+mapping clause encdec = RISCV_VAESDM(vs2, vd, suffix)          if extensionEnabled(Ext_Zvkned)
  <-> vv_or_vs(suffix) @ vs2 @ 0b00000 @ 0b010 @ vd @ 0b1110111 if extensionEnabled(Ext_Zvkned)
 
 mapping clause assembly = RISCV_VAESDM(vs2, vd, suffix)
  <-> vaesdm_mnemonic(vv_or_vs(suffix)) ^ spc() ^ vreg_name(vd)
-				       ^ sep() ^ vreg_name(vs2)
+                                       ^ sep() ^ vreg_name(vs2)
 
 function clause execute (RISCV_VAESDM(vs2, vd, suffix)) = {
   let SEW      = get_sew();
@@ -311,15 +311,15 @@ function clause execute (RISCV_VAESDM(vs2, vd, suffix)) = {
       vd_state[127..96] = vd_val[i*4+3];
 
       if suffix == "vv" then {
-	vs2_key[31..0]   = vs2_val[i*4+0];
-	vs2_key[63..32]  = vs2_val[i*4+1];
-	vs2_key[95..64]  = vs2_val[i*4+2];
-	vs2_key[127..96] = vs2_val[i*4+3];
+        vs2_key[31..0]   = vs2_val[i*4+0];
+        vs2_key[63..32]  = vs2_val[i*4+1];
+        vs2_key[95..64]  = vs2_val[i*4+2];
+        vs2_key[127..96] = vs2_val[i*4+3];
       } else {
-	vs2_key[31..0]   = vs2_val[0];
-	vs2_key[63..32]  = vs2_val[1];
-	vs2_key[95..64]  = vs2_val[2];
-	vs2_key[127..96] = vs2_val[3];
+        vs2_key[31..0]   = vs2_val[0];
+        vs2_key[63..32]  = vs2_val[1];
+        vs2_key[95..64]  = vs2_val[2];
+        vs2_key[127..96] = vs2_val[3];
       };
 
       let sr       : bits(128) = aes_shift_rows_inv(vd_state);
@@ -348,8 +348,8 @@ mapping clause encdec = RISCV_VAESKF1_VI(vs2, rnd, vd) if extensionEnabled(Ext_Z
 
 mapping clause assembly = RISCV_VAESKF1_VI(vs2, rnd, vd)
  <-> "vaeskf1.vi" ^ sep() ^ vreg_name(vd)
-		  ^ sep() ^ vreg_name(vs2)
-		  ^ sep() ^ reg_name(rnd)
+                  ^ sep() ^ vreg_name(vs2)
+                  ^ sep() ^ reg_name(rnd)
 
 function clause execute (RISCV_VAESKF1_VI(vs2, rnd, vd)) = {
   let SEW      = get_sew();
@@ -367,7 +367,7 @@ function clause execute (RISCV_VAESKF1_VI(vs2, rnd, vd)) = {
     let 'm = SEW;
     assert('m == 32);
 
-    rnd_val	: bits(5)		    = rnd;
+    rnd_val     : bits(5)                   = rnd;
     let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
     let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
     result      : vector('n, dec, bits('m)) = undefined;
@@ -378,7 +378,7 @@ function clause execute (RISCV_VAESKF1_VI(vs2, rnd, vd)) = {
     let r : bits(4) = rnd_val[3..0] - 1;
 
     current_round_key : bits(128) = undefined;
-    w		      : bits(128) = undefined;
+    w                 : bits(128) = undefined;
 
     eg_len = (unsigned(vl) / 'n);
     eg_start = (unsigned(vstart) / 'n);
@@ -391,8 +391,8 @@ function clause execute (RISCV_VAESKF1_VI(vs2, rnd, vd)) = {
       current_round_key[127..96] = vs2_val[i*4+3];
 
       w[31..0] = aes_subword_fwd(aes_rotword(current_round_key[127..96]))
-	       ^ aes_decode_rcon(r)
-	       ^ current_round_key[31..0];
+               ^ aes_decode_rcon(r)
+               ^ current_round_key[31..0];
       w[63..32]  = w[31..0]  ^ current_round_key[63..32];
       w[95..64]  = w[63..32] ^ current_round_key[95..64];
       w[127..96] = w[95..64] ^ current_round_key[127..96];
@@ -418,8 +418,8 @@ mapping clause encdec = RISCV_VAESKF2_VI(vs2, rnd, vd) if extensionEnabled(Ext_Z
 
 mapping clause assembly = RISCV_VAESKF2_VI(vs2, rnd, vd)
  <-> "vaeskf2.vi" ^ sep() ^ vreg_name(vd)
-		  ^ sep() ^ vreg_name(vs2)
-		  ^ sep() ^ reg_name(rnd)
+                  ^ sep() ^ vreg_name(vs2)
+                  ^ sep() ^ reg_name(rnd)
 
 function clause execute (RISCV_VAESKF2_VI(vs2, rnd, vd)) = {
   let SEW      = get_sew();
@@ -437,7 +437,7 @@ function clause execute (RISCV_VAESKF2_VI(vs2, rnd, vd)) = {
     let 'm = SEW;
     assert('m == 32);
 
-    rnd_val : bits(4)			    = rnd[3..0];
+    rnd_val : bits(4)                       = rnd[3..0];
     let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
     let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
     result      : vector('n, dec, bits('m)) = undefined;
@@ -447,7 +447,7 @@ function clause execute (RISCV_VAESKF2_VI(vs2, rnd, vd)) = {
 
     current_round_key : bits(128) = undefined;
     round_key_b       : bits(128) = undefined;
-    w		      : bits(128) = undefined;
+    w                 : bits(128) = undefined;
 
     eg_len = (unsigned(vl) / 'n);
     eg_start = (unsigned(vstart) / 'n);
@@ -465,12 +465,12 @@ function clause execute (RISCV_VAESKF2_VI(vs2, rnd, vd)) = {
       round_key_b[127..96] = vd_val[i*4+3];
 
       w[31..0] = if (rnd_val[0] == bitone)
-		 then
-		   aes_subword_fwd(current_round_key[127..96]) ^ round_key_b[31..0]
-		 else
-		   aes_subword_fwd(aes_rotword(current_round_key[127..96]))
-		     ^ aes_decode_rcon((rnd_val >> 1) - 1)
-		     ^ round_key_b[31..0];
+                 then
+                   aes_subword_fwd(current_round_key[127..96]) ^ round_key_b[31..0]
+                 else
+                   aes_subword_fwd(aes_rotword(current_round_key[127..96]))
+                     ^ aes_decode_rcon((rnd_val >> 1) - 1)
+                     ^ round_key_b[31..0];
 
       w[63..32]  = w[31..0]  ^ round_key_b[63..32];
       w[95..64]  = w[63..32] ^ round_key_b[95..64];
@@ -492,12 +492,12 @@ function clause execute (RISCV_VAESKF2_VI(vs2, rnd, vd)) = {
 
 union clause ast = RISCV_VAESZ_VS : (regidx, regidx)
 
-mapping clause encdec = RISCV_VAESZ_VS(vs2, vd)		if extensionEnabled(Ext_Zvkned)
+mapping clause encdec = RISCV_VAESZ_VS(vs2, vd)         if extensionEnabled(Ext_Zvkned)
  <-> 0b1010011 @ vs2 @ 0b00111 @ 0b010 @ vd @ 0b1110111 if extensionEnabled(Ext_Zvkned)
 
 mapping clause assembly = RISCV_VAESZ_VS(vs2, vd)
  <-> "vaesz.vs" ^ sep() ^ vreg_name(vd)
-		^ sep() ^ vreg_name(vs2)
+                ^ sep() ^ vreg_name(vs2)
 
 function clause execute (RISCV_VAESZ_VS(vs2, vd)) = {
   let SEW      = get_sew();

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -175,6 +175,8 @@ function have_privLevel(priv : priv_level) -> bool =
     0b11 => true,
   }
 
+function haveZvkned() -> bool = true
+
 bitfield Mstatus : bits(64) = {
   SD   : xlen - 1,
 
@@ -276,8 +278,8 @@ function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
 
   // Set dirty bit to OR of other status bits.
   let dirty = extStatus_of_bits(o[FS]) == Dirty |
-              extStatus_of_bits(o[XS]) == Dirty |
-              extStatus_of_bits(o[VS]) == Dirty;
+	      extStatus_of_bits(o[XS]) == Dirty |
+	      extStatus_of_bits(o[VS]) == Dirty;
 
   [o with SD = bool_to_bits(dirty)]
 }
@@ -541,8 +543,8 @@ function tvec_addr(m : Mtvec, c : Mcause) -> option(xlenbits) = {
   match (trapVectorMode_of_bits(m[Mode])) {
     TV_Direct => Some(base),
     TV_Vector => if   c[IsInterrupt] == 0b1
-                 then Some(base + (zero_extend(c[Cause]) << 2))
-                 else Some(base),
+		 then Some(base + (zero_extend(c[Cause]) << 2))
+		 else Some(base),
     TV_Reserved => None()
   }
 }
@@ -729,7 +731,7 @@ function lower_mstatus(m : Mstatus) -> Sstatus = {
 
 function lift_sstatus(m : Mstatus, s : Sstatus) -> Mstatus = {
   let dirty = extStatus_of_bits(s[FS]) == Dirty | extStatus_of_bits(s[XS]) == Dirty |
-              extStatus_of_bits(s[VS]) == Dirty;
+	      extStatus_of_bits(s[VS]) == Dirty;
 
   [m with
     SD = bool_to_bits(dirty),

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -276,8 +276,8 @@ function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
 
   // Set dirty bit to OR of other status bits.
   let dirty = extStatus_of_bits(o[FS]) == Dirty |
-	      extStatus_of_bits(o[XS]) == Dirty |
-	      extStatus_of_bits(o[VS]) == Dirty;
+              extStatus_of_bits(o[XS]) == Dirty |
+              extStatus_of_bits(o[VS]) == Dirty;
 
   [o with SD = bool_to_bits(dirty)]
 }
@@ -541,8 +541,8 @@ function tvec_addr(m : Mtvec, c : Mcause) -> option(xlenbits) = {
   match (trapVectorMode_of_bits(m[Mode])) {
     TV_Direct => Some(base),
     TV_Vector => if   c[IsInterrupt] == 0b1
-		 then Some(base + (zero_extend(c[Cause]) << 2))
-		 else Some(base),
+                 then Some(base + (zero_extend(c[Cause]) << 2))
+                 else Some(base),
     TV_Reserved => None()
   }
 }
@@ -729,7 +729,7 @@ function lower_mstatus(m : Mstatus) -> Sstatus = {
 
 function lift_sstatus(m : Mstatus, s : Sstatus) -> Mstatus = {
   let dirty = extStatus_of_bits(s[FS]) == Dirty | extStatus_of_bits(s[XS]) == Dirty |
-	      extStatus_of_bits(s[VS]) == Dirty;
+              extStatus_of_bits(s[VS]) == Dirty;
 
   [m with
     SD = bool_to_bits(dirty),

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -175,8 +175,6 @@ function have_privLevel(priv : priv_level) -> bool =
     0b11 => true,
   }
 
-function haveZvkned() -> bool = true
-
 bitfield Mstatus : bits(64) = {
   SD   : xlen - 1,
 


### PR DESCRIPTION
Implements the Zvkned (NIST Suite: Vector AES Block Cipher) extension, as of version [Draft: 20230303
](https://github.com/riscv/riscv-crypto/releases/tag/v20230303).

The following instructions are included:
* vaesef.[vv,vs]
* vaesem.[vv,vs]
* vaesdf.[vv,vs]
* vaesdm.[vv,vs]
* vaeskf1.vi
* vaeskf2.vi
* vaesz.vs

All instructions were tested with VLEN=128 and results were compared with QEMU results of each instruction.

Current revision is rebased with the latest changes of `vector-dev` branch.

_Note_
It's better to merge all of Zvk extension support PRs in the created order, as this is going to create conflicts and it would be easier to resolve them.