### PR TITLE
Enhances RISC-V Sail test execution within a container

### DIFF
--- a/.github/workflows/build-container-img.yml
+++ b/.github/workflows/build-container-img.yml
@@ -1,0 +1,43 @@
+name: Build and Publish Base Container Image for SAIL
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'container/Dockerfile'
+
+jobs:
+  build-and-push-docker-image:
+    name: Build and Push to RISC-V Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        if: github.event_name == 'push'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Get Current Date
+        id: date
+        run: echo "::set-output name=now::$(date +'%m%d%Y')"
+
+      - name: Build image and push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./container/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            riscvintl/riscv-sail-toolchain-base-image:${{ github.sha }}
+            riscvintl/riscv-sail-toolchain-base-image:latest
+          push: ${{ github.event_name == 'push' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM ocaml/opam
-USER root
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install zlib1g-dev pkg-config libgmp-dev z3
-USER opam
-RUN opam install sail

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,33 @@
+# This Dockerfile creates a Docker image with the required \
+# dependencies to build and run the Sail programming language \
+# toolchain.
+
+# Specifies the base image to be Ubuntu 22.04
+FROM ubuntu:22.04
+
+# Sets an environment variable ARCH with the value RV64. \
+# This variable can be used within the Dockerfile or the \
+# container to represent the architecture the Sail toolchain \
+# will be working with.
+ENV ARCH=RV64
+
+# Sets the working directory for the Docker container to /build. \
+# Any subsequent commands will be executed in this directory.
+WORKDIR /build
+
+# Copies the build.sh script from the local \
+# filesystem to the /build directory.
+COPY ./build.sh ./build.sh
+
+# Install all dependencies, sail, make ./build.sh executable \
+# and remove unecessary files.
+RUN DEBIAN_FRONTEND=noninteractive; apt-get update; \
+apt-get -y install zlib1g-dev pkg-config libgmp-dev z3 \
+opam zlib1g-dev pkg-config libgmp-dev z3 device-tree-compiler build-essential; \
+opam init --disable-sandboxing -y; opam install sail -y; \
+chmod +x ./build.sh; rm -rf /var/lib/apt/lists/*
+
+# Sets the default command to run when the Docker container is started. \
+# In this case, it will run the build.sh script located in the /build \
+# directory using the /bin/bash shell. 
+ENTRYPOINT ["/bin/bash", "./container/build.sh"]

--- a/container/README.md
+++ b/container/README.md
@@ -1,0 +1,56 @@
+# Building the Sail Programming Language Toolchain Container Image
+
+This guide provides instructions on how to build a container image for the Sail programming language toolchain using the provided Dockerfile.
+
+## Prerequisites
+
+Docker, Podman, or any OCI-compatible container runtime installed on your machine.
+
+## Building the Container Image
+
+Clone the Sail RISC-V repository:
+
+```bash
+git clone https://github.com/riscv/sail-riscv.git
+```
+
+Navigate to the container directory:
+
+```bash
+cd sail-riscv/container
+```
+
+Build the container image and tag it as riscv-sail-toolchain-base-image:
+
+```bash
+docker build -t riscv-sail-toolchain-base-image .
+```
+
+Wait for the build process to complete. Upon successful completion, you will see a message similar to the following:
+
+```bash
+Successfully built <image_id>
+Successfully tagged riscv-sail-toolchain-base-image:latest
+```
+
+## Running the Container Image and RISC-V Sail Tests
+
+Go back to the sail-riscv directory:
+
+```bash
+cd ..
+```
+
+Run the container image and execute the tests targeting RV64 (default):
+
+```bash
+docker run -it -v $(pwd):/build riscv-sail-toolchain-base-image:latest
+```
+
+(Optional) To target RV32, run the following command:
+
+```bash
+docker run -it -e ARCH=RV32 -v $(pwd):/build riscv-sail-toolchain-base-image:latest
+```
+
+At the end of the build, the binaries and test results will be available in the host filesystem.

--- a/container/build.sh
+++ b/container/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+eval $(opam env) && ./test/run_tests.sh


### PR DESCRIPTION
This commit enhances RISC-V Sail test execution within a container introducing the following updates:

* Improved Dockerfile for better container setup.
* Simplified entrypoint script for streamlined build execution.
* GitHub action that triggers image builds only when the Dockerfile is modified.
* Comprehensive documentation for seamless user experience.