### PR TITLE
Fixed an issue with the -g switch: seg fault occurred with required argument

### DIFF
--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -233,7 +233,7 @@ char *process_args(int argc, char **argv)
                     "b:"
                     "t:"
                     "T:"
-                    "g"
+                    "g:"
                     "h"
 #ifdef RVFI_DII
                     "r:"


### PR DESCRIPTION
The -g switch requires an argument.  When an argument is provided,  a seg fault ensues.

Note: This does not happen with the long form of the switch (--signature-granularity).

This fix is quite simple;  a single character addition.  See the single line change.