### PR TITLE
Vector reduction and mask instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ SAIL_DEFAULT_INST += riscv_insts_vext_fp.sail
 SAIL_DEFAULT_INST += riscv_insts_vext_mem.sail
 SAIL_DEFAULT_INST += riscv_insts_vext_mask.sail
 SAIL_DEFAULT_INST += riscv_insts_vext_vm.sail
+SAIL_DEFAULT_INST += riscv_insts_vext_red.sail
 
 SAIL_SEQ_INST  = $(SAIL_DEFAULT_INST) riscv_jalr_seq.sail
 SAIL_RMEM_INST = $(SAIL_DEFAULT_INST) riscv_jalr_rmem.sail riscv_insts_rmem.sail

--- a/model/riscv_insts_vext_mask.sail
+++ b/model/riscv_insts_vext_mask.sail
@@ -61,7 +61,7 @@ mapping clause encdec = MMTYPE(funct6, vs2, vs1, vd) if haveRVV()
 function clause execute(MMTYPE(funct6, vs2, vs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem = int_power(2, get_vlen_pow());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -72,7 +72,7 @@ function clause execute(MMTYPE(funct6, vs2, vs1, vd)) = {
   result      : vector('n, dec, bool) = undefined;
   mask        : vector('n, dec, bool) = undefined;
 
-  (result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+  (result, mask) = init_masked_result_carry(num_elem, SEW, 0, vd_val);
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] then {
@@ -118,7 +118,7 @@ mapping clause encdec = VCPOP_M(vm, vs2, rd) if haveRVV()
 function clause execute(VCPOP_M(vm, vs2, rd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem = int_power(2, get_vlen_pow());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -131,7 +131,7 @@ function clause execute(VCPOP_M(vm, vs2, rd)) = {
   /* Value of vstart must be 0 */
   if not(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
 
-  (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vs2_val, vm_val);
+  (result, mask) = init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val);
 
   count : nat = 0;
   foreach (i from 0 to (num_elem - 1)) {
@@ -155,7 +155,7 @@ mapping clause encdec = VFIRST_M(vm, vs2, rd) if haveRVV()
 function clause execute(VFIRST_M(vm, vs2, rd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem = int_power(2, get_vlen_pow());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -168,7 +168,7 @@ function clause execute(VFIRST_M(vm, vs2, rd)) = {
   /* Value of vstart must be 0 */
   if not(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
 
-  (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vs2_val, vm_val);
+  (result, mask) = init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val);
 
   index : int = -1;
   foreach (i from 0 to (num_elem - 1)) {
@@ -194,7 +194,7 @@ mapping clause encdec = VMSBF_M(vm, vs2, vd) if haveRVV()
 function clause execute(VMSBF_M(vm, vs2, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem = int_power(2, get_vlen_pow());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -214,7 +214,7 @@ function clause execute(VMSBF_M(vm, vs2, vd)) = {
   /* Dest reg cannot be the same as source reg */
   if vd == vs2 then { handle_illegal(); return RETIRE_FAIL };
 
-  (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  (result, mask) = init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val);
 
   found_elem : bool = false;
   foreach (i from 0 to (num_elem - 1)) {
@@ -241,7 +241,7 @@ mapping clause encdec = VMSIF_M(vm, vs2, vd) if haveRVV()
 function clause execute(VMSIF_M(vm, vs2, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem = int_power(2, get_vlen_pow());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -261,7 +261,7 @@ function clause execute(VMSIF_M(vm, vs2, vd)) = {
   /* Dest reg cannot be the same as source reg */
   if vd == vs2 then { handle_illegal(); return RETIRE_FAIL };
 
-  (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  (result, mask) = init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val);
 
   found_elem : bool = false;
   foreach (i from 0 to (num_elem - 1)) {
@@ -288,7 +288,7 @@ mapping clause encdec = VMSOF_M(vm, vs2, vd) if haveRVV()
 function clause execute(VMSOF_M(vm, vs2, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem = int_power(2, get_vlen_pow());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -308,7 +308,7 @@ function clause execute(VMSOF_M(vm, vs2, vd)) = {
   /* Dest reg cannot be the same as source reg */
   if vd == vs2 then { handle_illegal(); return RETIRE_FAIL };
 
-  (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  (result, mask) = init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val);
 
   found_elem : bool = false;
   foreach (i from 0 to (num_elem - 1)) {

--- a/model/riscv_insts_vext_red.sail
+++ b/model/riscv_insts_vext_red.sail
@@ -1,0 +1,280 @@
+/*=================================================================================*/
+/*  Copyright (c) 2021-2023                                                        */
+/*    Authors from RIOS Lab, Tsinghua University:                                  */
+/*      Xinlai Wan <xinlai.w@rioslab.org>                                          */
+/*      Xi Wang <xi.w@rioslab.org>                                                 */
+/*      Yifei Zhu <yifei.z@rioslab.org>                                            */
+/*      Shenwei Hu <shenwei.h@rioslab.org>                                         */
+/*      Kalvin Vu                                                                  */
+/*    Other contributors:                                                          */
+/*      Jessica Clarke <jrtc27@jrtc27.com>                                         */
+/*      Victor Moya <victor.moya@semidynamics.com>                                 */
+/*                                                                                 */
+/*  All rights reserved.                                                           */
+/*                                                                                 */
+/*  Redistribution and use in source and binary forms, with or without             */
+/*  modification, are permitted provided that the following conditions             */
+/*  are met:                                                                       */
+/*  1. Redistributions of source code must retain the above copyright              */
+/*     notice, this list of conditions and the following disclaimer.               */
+/*  2. Redistributions in binary form must reproduce the above copyright           */
+/*     notice, this list of conditions and the following disclaimer in             */
+/*     the documentation and/or other materials provided with the                  */
+/*     distribution.                                                               */
+/*                                                                                 */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''             */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED              */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR            */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                   */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT               */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF               */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND            */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,             */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT             */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF             */
+/*  SUCH DAMAGE.                                                                   */
+/*=================================================================================*/
+
+/* ******************************************************************************* */
+/* This file implements part of the vector extension.                              */
+/* Chapter 14: Vector Reduction Instructions                                       */
+/* ******************************************************************************* */
+
+/* ********************* OPIVV (Widening Integer Reduction) ********************** */
+union clause ast = RIVVTYPE : (rivvfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_rivvfunct6 : rivvfunct6 <-> bits(6) = {
+  IVV_VWREDSUMU   <-> 0b110000,
+  IVV_VWREDSUM    <-> 0b110001
+}
+
+mapping clause encdec = RIVVTYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_rivvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(RIVVTYPE(funct6, vm, vs2, vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+
+  if not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) then { handle_illegal(); return RETIRE_FAIL };
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  result      : vector('n, dec, bits('o)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  assert(8 <= SEW_widen & SEW_widen <= 64);
+  (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+
+  let scalar : bits('o) = read_single_element(SEW_widen, 0, LMUL_pow_widen, vs1);
+  sum : bits('o) = match funct6 {
+    IVV_VWREDSUMU  => to_bits(SEW_widen, unsigned(scalar)),
+    IVV_VWREDSUM   => to_bits(SEW_widen, signed(scalar))
+  };
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      sum = match funct6 {
+        IVV_VWREDSUMU  => to_bits(SEW_widen, unsigned(vs2_val[i]) + unsigned(sum)),
+        IVV_VWREDSUM   => to_bits(SEW_widen, signed(vs2_val[i]) + signed(sum))
+      }
+    }
+  };
+
+  write_single_element(SEW_widen, 0, LMUL_pow_widen, vd, sum);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping rivvtype_mnemonic : rivvfunct6 <-> string = {
+  IVV_VWREDSUMU  <-> "vwredsumu.vs",
+  IVV_VWREDSUM   <-> "vwredsum.vs"
+}
+
+mapping clause assembly = RIVVTYPE(funct6, vm, vs2, vs1, vd)
+  <-> rivvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+/* ******************* OPMVV (Single-Width Integer Reduction) ******************** */
+union clause ast = RMVVTYPE : (rmvvfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_rmvvfunct6 : rmvvfunct6 <-> bits(6) = {
+  MVV_VREDSUM     <-> 0b000000,
+  MVV_VREDAND     <-> 0b000001,
+  MVV_VREDOR      <-> 0b000010,
+  MVV_VREDXOR     <-> 0b000011,
+  MVV_VREDMINU    <-> 0b000100,
+  MVV_VREDMIN     <-> 0b000101,
+  MVV_VREDMAXU    <-> 0b000110,
+  MVV_VREDMAX     <-> 0b000111
+}
+
+mapping clause encdec = RMVVTYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_rmvvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(RMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if not(valid_rd_mask(vd, vm)) then { handle_illegal(); return RETIRE_FAIL };
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val   : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val   : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vs2_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  result       : vector('n, dec, bits('m)) = undefined;
+  mask         : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  sum : bits('m) = read_single_element(SEW, 0, LMUL_pow, vs1);
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      sum = match funct6 {
+        MVV_VREDSUM   => sum + vs2_val[i],
+        MVV_VREDAND   => sum & vs2_val[i],
+        MVV_VREDOR    => sum | vs2_val[i],
+        MVV_VREDXOR   => sum ^ vs2_val[i],
+        MVV_VREDMIN   => to_bits(SEW, min(signed(vs2_val[i]), signed(sum))),
+        MVV_VREDMINU  => to_bits(SEW, min(unsigned(vs2_val[i]), unsigned(sum))),
+        MVV_VREDMAX   => to_bits(SEW, max(signed(vs2_val[i]), signed(sum))),
+        MVV_VREDMAXU  => to_bits(SEW, max(unsigned(vs2_val[i]), unsigned(sum)))
+      }
+    }
+  };
+
+  write_single_element(SEW, 0, LMUL_pow, vd, sum);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping rmvvtype_mnemonic : rmvvfunct6 <-> string = {
+  MVV_VREDSUM   <-> "vredsum.vs",
+  MVV_VREDAND   <-> "vredand.vs",
+  MVV_VREDOR    <-> "vredor.vs",
+  MVV_VREDXOR   <-> "vredxor.vs",
+  MVV_VREDMINU  <-> "vredminu.vs",
+  MVV_VREDMIN   <-> "vredmin.vs",
+  MVV_VREDMAXU  <-> "vredmaxu.vs",
+  MVV_VREDMAX   <-> "vredmax.vs"
+}
+
+mapping clause assembly = RMVVTYPE(funct6, vm, vs2, vs1, vd)
+  <-> rmvvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)  
+
+/* ********************** OPFVV (Floating-Point Reduction) *********************** */
+union clause ast = RFVVTYPE : (rfvvfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_rfvvfunct6 : rfvvfunct6 <-> bits(6) = {
+  FVV_VFREDOSUM   <-> 0b000011,
+  FVV_VFREDUSUM   <-> 0b000001,
+  FVV_VFREDMAX    <-> 0b000111,
+  FVV_VFREDMIN    <-> 0b000101,
+  FVV_VFWREDOSUM  <-> 0b110011,
+  FVV_VFWREDUSUM  <-> 0b110001
+}
+
+mapping clause encdec = RFVVTYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_rfvvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b001 @ vd @ 0b1010111 if haveRVV()
+
+val process_rfvv_single: forall 'n 'm 'p, 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), regidx, regidx, regidx, int('n), int('m), int('p)) -> Retired effect {escape, rreg, undef, wreg}
+function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem, SEW, LMUL_pow) = {
+  let rm_3b = fcsr.FRM();
+  if not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW != 8);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  sum : bits('m) = read_single_element(SEW, 0, LMUL_pow, vs1);
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      sum = match funct6 {
+        FVV_VFREDOSUM   => fp_add(rm_3b, sum, vs2_val[i]),
+        FVV_VFREDUSUM   => fp_add(rm_3b, sum, vs2_val[i]),
+        FVV_VFREDMAX    => fp_max(sum, vs2_val[i]),
+        FVV_VFREDMIN    => fp_min(sum, vs2_val[i])
+      }
+    }
+  };
+
+  write_single_element(SEW, 0, LMUL_pow, vd, sum);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+val process_rfvv_widen: forall 'n 'm 'p, 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), regidx, regidx, regidx, int('n), int('m), int('p)) -> Retired effect {escape, rreg, undef, wreg}
+function process_rfvv_widen(funct6, vm, vs2, vs1, vd, num_elem, SEW, LMUL_pow) = {
+  let rm_3b          = fcsr.FRM();
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+
+  if   not(valid_eew_emul(SEW_widen, LMUL_pow_widen)) | not(valid_fp_op(SEW, rm_3b)) 
+  then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW >= 16 & SEW_widen <= 64);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val   : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vd_val   : vector('n, dec, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let vs2_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  result       : vector('n, dec, bits('o)) = undefined;
+  mask         : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+
+  sum : bits('o) = read_single_element(SEW_widen, 0, LMUL_pow_widen, vs1);
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      /* Currently ordered/unordered sum reductions do the same operations */
+      sum = fp_add(rm_3b, sum, fp_widen(vs2_val[i]))
+    }
+  };
+
+  write_single_element(SEW_widen, 0, LMUL_pow_widen, vd, sum);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+function clause execute(RFVVTYPE(funct6, vm, vs2, vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if funct6 == FVV_VFWREDOSUM | funct6 == FVV_VFWREDUSUM then 
+    process_rfvv_widen(funct6, vm, vs2, vs1, vd, num_elem, SEW, LMUL_pow)
+  else
+    process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem, SEW, LMUL_pow)
+}
+
+mapping rfvvtype_mnemonic : rfvvfunct6 <-> string = {
+  FVV_VFREDOSUM   <-> "vfredosum.vs",
+  FVV_VFREDUSUM   <-> "vfredusum.vs",
+  FVV_VFREDMAX    <-> "vfredmax.vs",
+  FVV_VFREDMIN    <-> "vfredmin.vs",
+  FVV_VFWREDOSUM  <-> "vfwredosum.vs",
+  FVV_VFWREDUSUM  <-> "vfwredusum.vs"
+}
+
+mapping clause assembly = RFVVTYPE(funct6, vm, vs2, vs1, vd)
+  <-> rfvvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)

--- a/model/riscv_insts_vext_vm.sail
+++ b/model/riscv_insts_vext_vm.sail
@@ -41,6 +41,176 @@
 /* Mask instructions from Chap 11 (integer arithmetic) and 13 (floating-point)     */
 /* ******************************************************************************* */
 
+/* ******************************* OPIVV (VVMTYPE) ******************************* */
+/* VVM instructions' destination is a mask register (e.g. carry out) */
+/* Instructions with no carry out will set mask result to current mask value */
+/* May or may not read from source mask register (e.g. carry in) */
+union clause ast = VVMTYPE : (vvmfunct6, regidx, regidx, regidx)
+
+mapping encdec_vvmfunct6 : vvmfunct6 <-> bits(6) = {
+  VVM_VMADC    <-> 0b010001, /* carry in, carry out */
+  VVM_VMSBC    <-> 0b010011
+}
+
+mapping clause encdec = VVMTYPE(funct6, vs2, vs1, vd) if haveRVV()
+  <-> encdec_vvmfunct6(funct6) @ 0b0 @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VVMTYPE(funct6, vs2, vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if vd == vreg_name("v0") then { handle_illegal(); return RETIRE_FAIL };
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask_carry(num_elem, 0b0, vreg_name("v0"));
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);
+  result      : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      let res : bool = match funct6 {
+        VVM_VMADC    => unsigned(vs2_val[i]) + unsigned(vs1_val[i]) + unsigned(bool_to_bits(vm_val[i])) > 2 ^ SEW - 1,
+        VVM_VMSBC    => unsigned(vs2_val[i]) - unsigned(vs1_val[i]) - unsigned(bool_to_bits(vm_val[i])) < 0
+      };
+      result[i] = res
+    }
+  };
+
+  write_vmask(num_elem, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vvmtype_mnemonic : vvmfunct6 <-> string = {
+  VVM_VMADC    <-> "vmadc.vvm", /* carry in, carry out */
+  VVM_VMSBC    <-> "vmsbc.vvm"
+}
+
+mapping clause assembly = VVMTYPE(funct6, vs2, vs1, vd)
+  <-> vvmtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ sep() ^ "v0"
+
+/* ****************************** OPIVV (VVMCTYPE) ******************************* */
+/* VVMC instructions' destination is a mask register (e.g. carry out) */
+/* Instructions with no carry out will set mask result to current mask value */
+/* May or may not read from source mask register (e.g. carry in) */
+union clause ast = VVMCTYPE : (vvmcfunct6, regidx, regidx, regidx)
+
+mapping encdec_vvmcfunct6 : vvmcfunct6 <-> bits(6) = {
+  VVMC_VMADC    <-> 0b010001, /* no carry in, carry out */
+  VVMC_VMSBC    <-> 0b010011
+}
+
+mapping clause encdec = VVMCTYPE(funct6, vs2, vs1, vd) if haveRVV()
+  <-> encdec_vvmcfunct6(funct6) @ 0b1 @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VVMCTYPE(funct6, vs2, vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);
+  result      : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      let res : bool = match funct6 {
+        VVMC_VMADC    => unsigned(vs2_val[i]) + unsigned(vs1_val[i]) > 2 ^ SEW - 1,
+        VVMC_VMSBC    => unsigned(vs2_val[i]) - unsigned(vs1_val[i]) < 0
+      };
+      result[i] = res
+    }
+  };
+
+  write_vmask(num_elem, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vvmctype_mnemonic : vvmcfunct6 <-> string = {
+  VVMC_VMADC    <-> "vmadc.vv", /* no carry in, carry out */
+  VVMC_VMSBC    <-> "vmsbc.vv"
+}
+
+mapping clause assembly = VVMCTYPE(funct6, vs2, vs1, vd)
+  <-> vvmctype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1)
+
+/* ****************************** OPIVV (VVMSTYPE) ******************************* */
+/* VVMS instructions' destination is a vector register (e.g. actual sum) */
+/* Instructions with no carry out will set mask result to current mask value */
+/* May or may not read from source mask register (e.g. carry in) */
+union clause ast = VVMSTYPE : (vvmsfunct6, regidx, regidx, regidx)
+
+mapping encdec_vvmsfunct6 : vvmsfunct6 <-> bits(6) = {
+  VVMS_VADC     <-> 0b010000, /* carry in, no carry out */
+  VVMS_VSBC     <-> 0b010010
+}
+
+mapping clause encdec = VVMSTYPE(funct6, vs2, vs1, vd) if haveRVV()
+  <-> encdec_vvmsfunct6(funct6) @ 0b0 @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VVMSTYPE(funct6, vs2, vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if vd == vreg_name("v0") then { handle_illegal(); return RETIRE_FAIL };
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  /* for bypassing normal masking in init_masked_result */
+  vec_trues : vector('n, dec, bool) = undefined;
+  foreach (i from 0 to (num_elem - 1)) {
+    vec_trues[i] = true
+  };
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask_carry(num_elem, 0b0, vreg_name("v0"));
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        VVMS_VADC     => to_bits(SEW, unsigned(vs2_val[i]) + unsigned(vs1_val[i]) + unsigned(bool_to_bits(vm_val[i]))),
+        VVMS_VSBC     => to_bits(SEW, unsigned(vs2_val[i]) - unsigned(vs1_val[i]) - unsigned(bool_to_bits(vm_val[i])))
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vvmstype_mnemonic : vvmsfunct6 <-> string = {
+  VVMS_VADC     <-> "vadc.vvm", /* carry in, no carry out */
+  VVMS_VSBC     <-> "vsbc.vvm"
+}
+
+mapping clause assembly = VVMSTYPE(funct6, vs2, vs1, vd)
+  <-> vvmstype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ sep() ^ "v0"
+
 /* ***************** OPIVV (Vector Integer Compare Instructions) ***************** */
 /* VVCMP instructions' destination is a mask register */
 union clause ast = VVCMPTYPE : (vvcmpfunct6, bits(1), regidx, regidx, regidx)
@@ -65,12 +235,12 @@ function clause execute(VVCMPTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val   : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
-  let vs1_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val   : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);
-  result       : vector('n, dec, bool)     = undefined;
-  mask         : vector('n, dec, bool)     = undefined;
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);
+  result      : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
 
   (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 
@@ -105,6 +275,176 @@ mapping vvcmptype_mnemonic : vvcmpfunct6 <-> string = {
 mapping clause assembly = VVCMPTYPE(funct6, vm, vs2, vs1, vd)
   <-> vvcmptype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
+/* ******************************* OPIVX (VXMTYPE) ******************************* */
+/* VXM instructions' destination is a mask register (e.g. carry out) */
+/* Instructions with no carry out will set mask result to current mask value */
+/* May or may not read from source mask register (e.g. carry in) */
+union clause ast = VXMTYPE : (vxmfunct6, regidx, regidx, regidx)
+
+mapping encdec_vxmfunct6 : vxmfunct6 <-> bits(6) = {
+  VXM_VMADC    <-> 0b010001, /* carry in, carry out */
+  VXM_VMSBC    <-> 0b010011
+}
+
+mapping clause encdec = VXMTYPE(funct6, vs2, rs1, vd) if haveRVV()
+  <-> encdec_vxmfunct6(funct6) @ 0b0 @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VXMTYPE(funct6, vs2, rs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if vd == vreg_name("v0") then { handle_illegal(); return RETIRE_FAIL };
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask_carry(num_elem, 0b0, vreg_name("v0"));
+  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);
+  result      : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      let res : bool = match funct6 {
+        VXM_VMADC    => unsigned(vs2_val[i]) + unsigned(rs1_val) + unsigned(bool_to_bits(vm_val[i])) > 2 ^ SEW - 1,
+        VXM_VMSBC    => unsigned(vs2_val[i]) - unsigned(rs1_val) - unsigned(bool_to_bits(vm_val[i])) < 0
+      };
+      result[i] = res
+    }
+  };
+
+  write_vmask(num_elem, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vxmtype_mnemonic : vxmfunct6 <-> string = {
+  VXM_VMADC    <-> "vmadc.vxm", /* carry in, carry out */
+  VXM_VMSBC    <-> "vmsbc.vxm"
+}
+
+mapping clause assembly = VXMTYPE(funct6, vs2, rs1, vd)
+  <-> vxmtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ sep() ^ "v0"
+
+/* ****************************** OPIVX (VXMCTYPE) ******************************* */
+/* VXMC instructions' destination is a mask register (e.g. carry out) */
+/* Instructions with no carry out will set mask result to current mask value */
+/* May or may not read from source mask register (e.g. carry in) */
+union clause ast = VXMCTYPE : (vxmcfunct6, regidx, regidx, regidx)
+
+mapping encdec_vxmcfunct6 : vxmcfunct6 <-> bits(6) = {
+  VXMC_VMADC    <-> 0b010001, /* carry in, carry out */
+  VXMC_VMSBC    <-> 0b010011
+}
+
+mapping clause encdec = VXMCTYPE(funct6, vs2, rs1, vd) if haveRVV()
+  <-> encdec_vxmcfunct6(funct6) @ 0b1 @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VXMCTYPE(funct6, vs2, rs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);
+  result      : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      let res : bool = match funct6 {
+        VXMC_VMADC    => unsigned(vs2_val[i]) + unsigned(rs1_val) > 2 ^ SEW - 1,
+        VXMC_VMSBC    => unsigned(vs2_val[i]) - unsigned(rs1_val) < 0
+      };
+      result[i] = res
+    }
+  };
+
+  write_vmask(num_elem, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vxmctype_mnemonic : vxmcfunct6 <-> string = {
+  VXMC_VMADC    <-> "vmadc.vx", /* carry in, carry out */
+  VXMC_VMSBC    <-> "vmsbc.vx"
+}
+
+mapping clause assembly = VXMCTYPE(funct6, vs2, rs1, vd)
+  <-> vxmctype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1)
+
+/* ****************************** OPIVX (VXMSTYPE) ******************************* */
+/* VXMS instructions' destination is a vector register (e.g. actual sum) */
+/* Instructions with no carry out will set mask result to current mask value */
+/* May or may not read from source mask register (e.g. carry in) */
+union clause ast = VXMSTYPE : (vxmsfunct6, regidx, regidx, regidx)
+
+mapping encdec_vxmsfunct6 : vxmsfunct6 <-> bits(6) = {
+  VXMS_VADC     <-> 0b010000, /* carry in, no carry out */
+  VXMS_VSBC     <-> 0b010010
+}
+
+mapping clause encdec = VXMSTYPE(funct6, vs2, rs1, vd) if haveRVV()
+  <-> encdec_vxmsfunct6(funct6) @ 0b0 @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VXMSTYPE(funct6, vs2, rs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if vd == vreg_name("v0") then { handle_illegal(); return RETIRE_FAIL };
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  /* for bypassing normal masking in init_masked_result */
+  vec_trues : vector('n, dec, bool) = undefined;
+  foreach (i from 0 to (num_elem - 1)) {
+    vec_trues[i] = true
+  };
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask_carry(num_elem, 0b0, vreg_name("v0"));
+  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        VXMS_VADC     => to_bits(SEW, unsigned(vs2_val[i]) + unsigned(rs1_val) + unsigned(bool_to_bits(vm_val[i]))),
+        VXMS_VSBC     => to_bits(SEW, unsigned(vs2_val[i]) - unsigned(rs1_val) - unsigned(bool_to_bits(vm_val[i])))
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vxmstype_mnemonic : vxmsfunct6 <-> string = {
+  VXMS_VADC     <-> "vadc.vxm", /* carry in, no carry out */
+  VXMS_VSBC     <-> "vsbc.vxm"
+}
+
+mapping clause assembly = VXMSTYPE(funct6, vs2, rs1, vd)
+  <-> vxmstype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ sep() ^ "v0"
+
 /* ***************** OPIVX (Vector Integer Compare Instructions) ***************** */
 /* VXCMP instructions' destination is a mask register */
 union clause ast = VXCMPTYPE : (vxcmpfunct6, bits(1), regidx, regidx, regidx)
@@ -131,12 +471,12 @@ function clause execute(VXCMPTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val   : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
-  let rs1_val  : bits('m)                  = get_scalar(rs1, SEW);
-  let vs2_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val   : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);
-  result       : vector('n, dec, bool)     = undefined;
-  mask         : vector('n, dec, bool)     = undefined;
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);
+  result      : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
 
   (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 
@@ -175,6 +515,167 @@ mapping vxcmptype_mnemonic : vxcmpfunct6 <-> string = {
 mapping clause assembly = VXCMPTYPE(funct6, vm, vs2, rs1, vd)
   <-> vxcmptype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
 
+/* ******************************* OPIVI (VIMTYPE) ******************************* */
+/* VIM instructions' destination is a mask register (e.g. carry out) */
+/* Instructions with no carry out will set mask result to current mask value */
+/* May or may not read from source mask register (e.g. carry in) */
+union clause ast = VIMTYPE : (vimfunct6, regidx, regidx, regidx)
+
+mapping encdec_vimfunct6 : vimfunct6 <-> bits(6) = {
+  VIM_VMADC    <-> 0b010001 /* carry in, carry out */
+}
+
+mapping clause encdec = VIMTYPE(funct6, vs2, simm, vd) if haveRVV()
+  <-> encdec_vimfunct6(funct6) @ 0b0 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VIMTYPE(funct6, vs2, simm, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if vd == vreg_name("v0") then { handle_illegal(); return RETIRE_FAIL };
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask_carry(num_elem, 0b0, vreg_name("v0"));
+  let imm_val : bits('m)                  = EXTS(simm);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);
+  result      : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      let res : bool = match funct6 {
+        VIM_VMADC    => unsigned(vs2_val[i]) + unsigned(imm_val) + unsigned(bool_to_bits(vm_val[i])) > 2 ^ SEW - 1
+      };
+      result[i] = res
+    }
+  };
+
+  write_vmask(num_elem, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vimtype_mnemonic : vimfunct6 <-> string = {
+  VIM_VMADC    <-> "vmadc.vim" /* carry in, carry out */
+}
+
+mapping clause assembly = VIMTYPE(funct6, vs2, simm, vd)
+  <-> vimtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ sep() ^ "v0"
+
+/* ****************************** OPIVI (VIMCTYPE) ******************************* */
+/* VIMC instructions' destination is a mask register (e.g. carry out) */
+/* Instructions with no carry out will set mask result to current mask value */
+/* May or may not read from source mask register (e.g. carry in) */
+union clause ast = VIMCTYPE : (vimcfunct6, regidx, regidx, regidx)
+
+mapping encdec_vimcfunct6 : vimcfunct6 <-> bits(6) = {
+  VIMC_VMADC    <-> 0b010001 /* carry in, carry out */
+}
+
+mapping clause encdec = VIMCTYPE(funct6, vs2, simm, vd) if haveRVV()
+  <-> encdec_vimcfunct6(funct6) @ 0b1 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VIMCTYPE(funct6, vs2, simm, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let imm_val : bits('m)                  = EXTS(simm);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);
+  result      : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      let res : bool = match funct6 {
+        VIMC_VMADC    => unsigned(vs2_val[i]) + unsigned(imm_val) > 2 ^ SEW - 1
+      };
+      result[i] = res
+    }
+  };
+
+  write_vmask(num_elem, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vimctype_mnemonic : vimcfunct6 <-> string = {
+  VIMC_VMADC    <-> "vmadc.vi" /* Carry in, carry out */
+}
+
+mapping clause assembly = VIMCTYPE(funct6, vs2, simm, vd)
+  <-> vimctype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm)
+
+/* ****************************** OPIVI (VIMSTYPE) ******************************* */
+/* VIMS instructions' destination is a vector register (e.g. actual sum) */
+/* Instructions with no carry out will set mask result to current mask value */
+/* May or may not read from source mask register (e.g. carry in) */
+union clause ast = VIMSTYPE : (vimsfunct6, regidx, regidx, regidx)
+
+mapping encdec_vimsfunct6 : vimsfunct6 <-> bits(6) = {
+  VIMS_VADC     <-> 0b010000 /* Carry in, no carry out */
+}
+
+mapping clause encdec = VIMSTYPE(funct6, vs2, simm, vd) if haveRVV()
+  <-> encdec_vimsfunct6(funct6) @ 0b0 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(VIMSTYPE(funct6, vs2, simm, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if vd == vreg_name("v0") then { handle_illegal(); return RETIRE_FAIL };
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  /* for bypassing normal masking in init_masked_result */
+  vec_trues : vector('n, dec, bool) = undefined;
+  foreach (i from 0 to (num_elem - 1)) {
+    vec_trues[i] = true
+  };
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask_carry(num_elem, 0b0, vreg_name("v0"));
+  let imm_val : bits('m)                  = EXTS(simm);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  result      : vector('n, dec, bits('m)) = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      result[i] = match funct6 {
+        VIMS_VADC     => to_bits(SEW, unsigned(vs2_val[i]) + unsigned(imm_val) + unsigned(bool_to_bits(vm_val[i])))
+      }
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping vimstype_mnemonic : vimsfunct6 <-> string = {
+  VIMS_VADC     <-> "vadc.vim" /* Carry in, no carry out */
+}
+
+mapping clause assembly = VIMSTYPE(funct6, vs2, simm, vd)
+  <-> vimstype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ sep() ^ "v0"
+
 /* ***************** OPIVI (Vector Integer Compare Instructions) ***************** */
 /* VICMP instructions' destination is a mask register */
 union clause ast = VICMPTYPE : (vicmpfunct6, bits(1), regidx, regidx, regidx)
@@ -199,12 +700,12 @@ function clause execute(VICMPTYPE(funct6, vm, vs2, simm, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val   : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
-  let imm_val  : bits('m)                  = EXTS(simm);
-  let vs2_val  : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val   : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);
-  result       : vector('n, dec, bool)     = undefined;
-  mask         : vector('n, dec, bool)     = undefined;
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let imm_val : bits('m)                  = EXTS(simm);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);
+  result      : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
 
   (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
 
@@ -238,3 +739,133 @@ mapping vicmptype_mnemonic : vicmpfunct6 <-> string = {
 
 mapping clause assembly = VICMPTYPE(funct6, vm, vs2, simm, vd)
   <-> vicmptype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ maybe_vmask(vm)
+
+/* ******************************* OPFVV (VVMTYPE) ******************************* */
+/* FVVM instructions' destination is a mask register */
+union clause ast = FVVMTYPE : (fvvmfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_fvvmfunct6 : fvvmfunct6 <-> bits(6) = {
+  FVVM_VMFEQ      <-> 0b011000,
+  FVVM_VMFLE      <-> 0b011001,
+  FVVM_VMFLT      <-> 0b011011,
+  FVVM_VMFNE      <-> 0b011100
+}
+
+mapping clause encdec = FVVMTYPE(funct6, vm, vs2, vs1, vd) if haveRVV()
+  <-> encdec_fvvmfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b001 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(FVVMTYPE(funct6, vm, vs2, vs1, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW != 8);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let vs1_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);  
+  result      : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      let res : bool = match funct6 {
+        FVVM_VMFEQ    => fp_eq(vs2_val[i], vs1_val[i]),
+        FVVM_VMFNE    => ~(fp_eq(vs2_val[i], vs1_val[i])),
+        FVVM_VMFLE    => fp_le(vs2_val[i], vs1_val[i]),
+        FVVM_VMFLT    => fp_lt(vs2_val[i], vs1_val[i])
+      };
+      result[i] = res
+    }
+  };
+
+  write_vmask(num_elem, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping fvvmtype_mnemonic : fvvmfunct6 <-> string = {
+  FVVM_VMFEQ      <-> "vmfeq.vv",
+  FVVM_VMFLE      <-> "vmfle.vv",
+  FVVM_VMFLT      <-> "vmflt.vv",
+  FVVM_VMFNE      <-> "vmfne.vv"
+}
+
+mapping clause assembly = FVVMTYPE(funct6, vm, vs2, vs1, vd)
+  <-> fvvmtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+/* ******************************* OPFVF (VFMTYPE) ******************************* */
+/* VFM instructions' destination is a mask register */
+union clause ast = FVFMTYPE : (fvfmfunct6, bits(1), regidx, regidx, regidx)
+
+mapping encdec_fvfmfunct6 : fvfmfunct6 <-> bits(6) = {
+  VFM_VMFEQ      <-> 0b011000,
+  VFM_VMFLE      <-> 0b011001,
+  VFM_VMFLT      <-> 0b011011,
+  VFM_VMFNE      <-> 0b011100,
+  VFM_VMFGT      <-> 0b011101,
+  VFM_VMFGE      <-> 0b011111
+}
+
+mapping clause encdec = FVFMTYPE(funct6, vm, vs2, rs1, vd) if haveRVV()
+  <-> encdec_fvfmfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b101 @ vd @ 0b1010111 if haveRVV()
+
+function clause execute(FVFMTYPE(funct6, vm, vs2, rs1, vd)) = {
+  let rm_3b    = fcsr.FRM();
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
+  assert(SEW != 8);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : vector('n, dec, bool)     = read_vmask(num_elem, vm, vreg_name("v0"));
+  let rs1_val : bits('m)                  = get_scalar_fp(rs1, 'm);
+  let vs2_val : vector('n, dec, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, dec, bool)     = read_vmask(num_elem, 0b0, vd);    
+  result      : vector('n, dec, bool)     = undefined;
+  mask        : vector('n, dec, bool)     = undefined;
+
+  (result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] then {
+      let res : bool = match funct6 {
+        VFM_VMFEQ    => fp_eq(vs2_val[i], rs1_val),
+        VFM_VMFNE    => ~(fp_eq(vs2_val[i], rs1_val)),
+        VFM_VMFLE    => fp_le(vs2_val[i], rs1_val),
+        VFM_VMFLT    => fp_lt(vs2_val[i], rs1_val),
+        VFM_VMFGE    => fp_ge(vs2_val[i], rs1_val),
+        VFM_VMFGT    => fp_gt(vs2_val[i], rs1_val)
+      };
+      result[i] = res
+    }
+  };
+
+  write_vmask(num_elem, vd, result);
+  vstart = EXTZ(0b0);
+  RETIRE_SUCCESS
+}
+
+mapping fvfmtype_mnemonic : fvfmfunct6 <-> string = {
+  VFM_VMFEQ      <-> "vmfeq.vf",
+  VFM_VMFLE      <-> "vmfle.vf",
+  VFM_VMFLT      <-> "vmflt.vf",
+  VFM_VMFNE      <-> "vmfne.vf",
+  VFM_VMFGT      <-> "vmfgt.vf",
+  VFM_VMFGE      <-> "vmfge.vf"
+}
+
+mapping clause assembly = FVFMTYPE(funct6, vm, vs2, rs1, vd)
+  <-> fvfmtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)

--- a/model/riscv_insts_vext_vm.sail
+++ b/model/riscv_insts_vext_vm.sail
@@ -60,8 +60,6 @@ function clause execute(VVMTYPE(funct6, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if vd == vreg_name("v0") then { handle_illegal(); return RETIRE_FAIL };
-
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -293,8 +291,6 @@ function clause execute(VXMTYPE(funct6, vs2, rs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-
-  if vd == vreg_name("v0") then { handle_illegal(); return RETIRE_FAIL };
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -533,8 +529,6 @@ function clause execute(VIMTYPE(funct6, vs2, simm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if vd == vreg_name("v0") then { handle_illegal(); return RETIRE_FAIL };
-
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -760,7 +754,7 @@ function clause execute(FVVMTYPE(funct6, vm, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -824,7 +818,7 @@ function clause execute(FVFMTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
+  if not(valid_fp_op(SEW, rm_3b)) then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW != 8);
 
   let 'n = num_elem;


### PR DESCRIPTION
This PR contains vector reduction instructions (Spec Chapter 14) in `riscv_insts_vext_red.sail` and mask instructions from Chap 11 (integer arithmetic) and 13 (floating-point) in `riscv_insts_vext_vm.sail`. The model generated by this code is tested by the vector ISA tests generated by [rvv-atg](https://github.com/hushenwei2000/rvv-atg) for different configurations. (ELEN and VLEN are manually specified in riscv_sys_control.sail when compiling the model.) Please send me comments if there are issues in the new code.