### PR TITLE
Add a clang-format configuration and reformat C code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+Language: Cpp
+BasedOnStyle: WebKit
+AlignArrayOfStructures: Left
+AlignAfterOpenBracket: Align
+AllowShortFunctionsOnASingleLine: Empty
+ColumnLimit: 80
+Cpp11BracedListStyle: true
+IndentWidth: 2
+PointerAlignment: Right
+SortIncludes: Never
+AlignTrailingComments: true

--- a/c_emulator/SoftFloat-3e/.clang-format
+++ b/c_emulator/SoftFloat-3e/.clang-format
@@ -1,0 +1,3 @@
+# This is third-party code and should not be reformatted
+DisableFormat: true
+SortIncludes: Never

--- a/c_emulator/riscv_platform.c
+++ b/c_emulator/riscv_platform.c
@@ -4,6 +4,14 @@
 #include "riscv_platform_impl.h"
 #include "riscv_sail.h"
 
+#ifdef DEBUG_RESERVATION
+#include <stdio.h>
+#include <inttypes.h>
+#define RESERVATION_DBG(args...) fprintf(stderr, args)
+#else
+#define RESERVATION_DBG(args...)
+#endif
+
 /* This file contains the definitions of the C externs of Sail model. */
 
 static mach_bits reservation = 0;
@@ -94,7 +102,7 @@ unit load_reservation(mach_bits addr)
 {
   reservation = addr;
   reservation_valid = true;
-  /* fprintf(stderr, "reservation <- %0" PRIx64 "\n", reservation); */
+  RESERVATION_DBG("reservation <- %0" PRIx64 "\n", reservation);
   return UNIT;
 }
 
@@ -112,17 +120,15 @@ bool match_reservation(mach_bits addr)
 {
   mach_bits mask = check_mask();
   bool ret = reservation_valid && (reservation & mask) == (addr & mask);
-  /*
-  fprintf(stderr, "reservation(%c): %0" PRIx64 ", key=%0" PRIx64 ": %s\n",
-          reservation_valid ? 'v' : 'i', reservation, addr, ret ? "ok" :
-  "fail");
-  */
-
+  RESERVATION_DBG("reservation(%c): %0" PRIx64 ", key=%0" PRIx64 ": %s\n",
+                  reservation_valid ? 'v' : 'i', reservation, addr,
+                  ret ? "ok" : "fail");
   return ret;
 }
 
 unit cancel_reservation(unit u)
-{ /* fprintf(stderr, "reservation <- none\n"); */
+{
+  RESERVATION_DBG("reservation <- none\n");
   reservation_valid = false;
   return UNIT;
 }

--- a/c_emulator/riscv_platform.c
+++ b/c_emulator/riscv_platform.c
@@ -10,53 +10,85 @@ static mach_bits reservation = 0;
 static bool reservation_valid = false;
 
 bool sys_enable_rvc(unit u)
-{ return rv_enable_rvc; }
+{
+  return rv_enable_rvc;
+}
 
 bool sys_enable_next(unit u)
-{ return rv_enable_next; }
+{
+  return rv_enable_next;
+}
 
 bool sys_enable_fdext(unit u)
-{ return rv_enable_fdext; }
+{
+  return rv_enable_fdext;
+}
 
 bool sys_enable_zfinx(unit u)
-{ return rv_enable_zfinx; }
+{
+  return rv_enable_zfinx;
+}
 
 bool sys_enable_writable_misa(unit u)
-{ return rv_enable_writable_misa; }
+{
+  return rv_enable_writable_misa;
+}
 
 bool plat_enable_dirty_update(unit u)
-{ return rv_enable_dirty_update; }
+{
+  return rv_enable_dirty_update;
+}
 
 bool plat_enable_misaligned_access(unit u)
-{ return rv_enable_misaligned; }
+{
+  return rv_enable_misaligned;
+}
 
 bool plat_mtval_has_illegal_inst_bits(unit u)
-{ return rv_mtval_has_illegal_inst_bits; }
+{
+  return rv_mtval_has_illegal_inst_bits;
+}
 
 bool plat_enable_pmp(unit u)
-{ return rv_enable_pmp; }
+{
+  return rv_enable_pmp;
+}
 
 mach_bits plat_ram_base(unit u)
-{ return rv_ram_base; }
+{
+  return rv_ram_base;
+}
 
 mach_bits plat_ram_size(unit u)
-{ return rv_ram_size; }
+{
+  return rv_ram_size;
+}
 
 mach_bits plat_rom_base(unit u)
-{ return rv_rom_base; }
+{
+  return rv_rom_base;
+}
 
 mach_bits plat_rom_size(unit u)
-{ return rv_rom_size; }
+{
+  return rv_rom_size;
+}
 
 // Provides entropy for the scalar cryptography extension.
 mach_bits plat_get_16_random_bits()
-{ return rv_16_random_bits(); }
+{
+  return rv_16_random_bits();
+}
 
 mach_bits plat_clint_base(unit u)
-{ return rv_clint_base; }
+{
+  return rv_clint_base;
+}
 
 mach_bits plat_clint_size(unit u)
-{ return rv_clint_size; }
+{
+  return rv_clint_size;
+}
 
 unit load_reservation(mach_bits addr)
 {
@@ -67,7 +99,9 @@ unit load_reservation(mach_bits addr)
 }
 
 bool speculate_conditional(unit u)
-{ return true; }
+{
+  return true;
+}
 
 static mach_bits check_mask(void)
 {
@@ -80,7 +114,8 @@ bool match_reservation(mach_bits addr)
   bool ret = reservation_valid && (reservation & mask) == (addr & mask);
   /*
   fprintf(stderr, "reservation(%c): %0" PRIx64 ", key=%0" PRIx64 ": %s\n",
-	  reservation_valid ? 'v' : 'i', reservation, addr, ret ? "ok" : "fail");
+          reservation_valid ? 'v' : 'i', reservation, addr, ret ? "ok" :
+  "fail");
   */
 
   return ret;
@@ -93,13 +128,13 @@ unit cancel_reservation(unit u)
 }
 
 unit plat_term_write(mach_bits s)
-{ char c = s & 0xff;
+{
+  char c = s & 0xff;
   plat_term_write_impl(c);
   return UNIT;
 }
 
-void plat_insns_per_tick(sail_int *rop, unit u)
-{ }
+void plat_insns_per_tick(sail_int *rop, unit u) { }
 
 mach_bits plat_htif_tohost(unit u)
 {

--- a/c_emulator/riscv_platform.h
+++ b/c_emulator/riscv_platform.h
@@ -36,4 +36,3 @@ unit plat_term_write(mach_bits);
 mach_bits plat_htif_tohost(unit);
 
 unit memea(mach_bits, sail_int);
-

--- a/c_emulator/riscv_platform_impl.c
+++ b/c_emulator/riscv_platform_impl.c
@@ -3,15 +3,15 @@
 #include <stdio.h>
 
 /* Settings of the platform implementation, with common defaults. */
-bool rv_enable_pmp                  = false;
-bool rv_enable_zfinx                = false;
-bool rv_enable_rvc                  = true;
-bool rv_enable_next                 = false;
-bool rv_enable_writable_misa        = true;
-bool rv_enable_fdext                = true;
+bool rv_enable_pmp = false;
+bool rv_enable_zfinx = false;
+bool rv_enable_rvc = true;
+bool rv_enable_next = false;
+bool rv_enable_writable_misa = true;
+bool rv_enable_fdext = true;
 
-bool rv_enable_dirty_update         = false;
-bool rv_enable_misaligned           = false;
+bool rv_enable_dirty_update = false;
+bool rv_enable_misaligned = false;
 bool rv_mtval_has_illegal_inst_bits = false;
 
 uint64_t rv_ram_base = UINT64_C(0x80000000);
@@ -21,7 +21,8 @@ uint64_t rv_rom_base = UINT64_C(0x1000);
 uint64_t rv_rom_size = UINT64_C(0x100);
 
 // Provides entropy for the scalar cryptography extension.
-uint64_t rv_16_random_bits(void) {
+uint64_t rv_16_random_bits(void)
+{
   // This function can be changed to support deterministic sequences of
   // pseudo-random bytes. This is useful for testing.
   const char *name = "/dev/urandom";

--- a/c_emulator/riscv_platform_impl.h
+++ b/c_emulator/riscv_platform_impl.h
@@ -5,7 +5,7 @@
 
 /* Settings of the platform implementation. */
 
-#define DEFAULT_RSTVEC     0x00001000
+#define DEFAULT_RSTVEC 0x00001000
 
 extern bool rv_enable_pmp;
 extern bool rv_enable_zfinx;

--- a/c_emulator/riscv_prelude.c
+++ b/c_emulator/riscv_prelude.c
@@ -9,25 +9,29 @@ unit print_string(sail_string prefix, sail_string msg)
 
 unit print_instr(sail_string s)
 {
-  if (config_print_instr) printf("%s\n", s);
+  if (config_print_instr)
+    printf("%s\n", s);
   return UNIT;
 }
 
 unit print_reg(sail_string s)
 {
-  if (config_print_reg) printf("%s\n", s);
+  if (config_print_reg)
+    printf("%s\n", s);
   return UNIT;
 }
 
 unit print_mem_access(sail_string s)
 {
-  if (config_print_mem_access) printf("%s\n", s);
+  if (config_print_mem_access)
+    printf("%s\n", s);
   return UNIT;
 }
 
 unit print_platform(sail_string s)
 {
-  if (config_print_platform) printf("%s\n", s);
+  if (config_print_platform)
+    printf("%s\n", s);
   return UNIT;
 }
 

--- a/c_emulator/riscv_sail.h
+++ b/c_emulator/riscv_sail.h
@@ -6,7 +6,9 @@ typedef int unit;
 #define UNIT 0
 typedef uint64_t mach_bits;
 
-struct zMisa {mach_bits zMisa_chunk_0;};
+struct zMisa {
+  mach_bits zMisa_chunk_0;
+};
 extern struct zMisa zmisa;
 
 void model_init(void);
@@ -17,9 +19,9 @@ bool zstep(sail_int);
 unit ztick_clock(unit);
 unit ztick_platform(unit);
 
-unit z_set_Misa_C(struct zMisa*, mach_bits);
-unit z_set_Misa_D(struct zMisa*, mach_bits);
-unit z_set_Misa_F(struct zMisa*, mach_bits);
+unit z_set_Misa_C(struct zMisa *, mach_bits);
+unit z_set_Misa_D(struct zMisa *, mach_bits);
+unit z_set_Misa_F(struct zMisa *, mach_bits);
 
 #ifdef RVFI_DII
 unit zext_rvfi_init(unit);
@@ -54,11 +56,9 @@ extern uint32_t zcur_privilege;
 
 extern mach_bits zPC;
 
-extern mach_bits
-        zx1,  zx2,  zx3,  zx4,  zx5,  zx6,  zx7,
-  zx8,  zx9,  zx10, zx11, zx12, zx13, zx14, zx15,
-  zx16, zx17, zx18, zx19, zx20, zx21, zx22, zx23,
-  zx24, zx25, zx26, zx27, zx28, zx29, zx30, zx31;
+extern mach_bits zx1, zx2, zx3, zx4, zx5, zx6, zx7, zx8, zx9, zx10, zx11, zx12,
+    zx13, zx14, zx15, zx16, zx17, zx18, zx19, zx20, zx21, zx22, zx23, zx24,
+    zx25, zx26, zx27, zx28, zx29, zx30, zx31;
 
 extern mach_bits zmstatus;
 extern mach_bits zmepc, zmtval;
@@ -66,7 +66,9 @@ extern mach_bits zsepc, zstval;
 
 extern mach_bits zfloat_result, zfloat_fflags;
 
-struct zMcause {mach_bits zMcause_chunk_0;};
+struct zMcause {
+  mach_bits zMcause_chunk_0;
+};
 extern struct zMcause zmcause, zscause;
 
 extern mach_bits zminstret;

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -57,7 +57,8 @@ unsigned char *dtb = NULL;
 size_t dtb_len = 0;
 #ifdef RVFI_DII
 static bool rvfi_dii = false;
-/* Needs to be global to avoid the needed for a set-version packet on each trace */
+/* Needs to be global to avoid the needed for a set-version packet on each trace
+ */
 static unsigned rvfi_trace_version = 1;
 static int rvfi_dii_port;
 static int rvfi_dii_sock;
@@ -77,7 +78,8 @@ bool config_print_mem_access = true;
 bool config_print_platform = true;
 bool config_print_rvfi = false;
 
-void set_config_print(char *var, bool val) {
+void set_config_print(char *var, bool val)
+{
   if (var == NULL || strcmp("all", var) == 0) {
     config_print_instr = val;
     config_print_mem_access = val;
@@ -95,7 +97,10 @@ void set_config_print(char *var, bool val) {
   } else if (strcmp("platform", var) == 0) {
     config_print_platform = val;
   } else {
-    fprintf(stderr, "Unknown trace category: '%s' (should be instr|reg|mem|platform|all)\n", var);
+    fprintf(
+        stderr,
+        "Unknown trace category: '%s' (should be instr|reg|mem|platform|all)\n",
+        var);
     exit(1);
   }
 }
@@ -108,39 +113,41 @@ char *sailcov_file = NULL;
 #endif
 
 static struct option options[] = {
-  {"enable-dirty-update",         no_argument,       0, 'd'},
-  {"enable-misaligned",           no_argument,       0, 'm'},
-  {"enable-pmp",                  no_argument,       0, 'P'},
-  {"enable-next",                 no_argument,       0, 'N'},
-  {"ram-size",                    required_argument, 0, 'z'},
-  {"disable-compressed",          no_argument,       0, 'C'},
-  {"disable-writable-misa",       no_argument,       0, 'I'},
-  {"disable-fdext",               no_argument,       0, 'F'},
-  {"mtval-has-illegal-inst-bits", no_argument,       0, 'i'},
-  {"device-tree-blob",            required_argument, 0, 'b'},
-  {"terminal-log",                required_argument, 0, 't'},
-  {"show-times",                  required_argument, 0, 'p'},
-  {"report-arch",                 no_argument,       0, 'a'},
-  {"test-signature",              required_argument, 0, 'T'},
-  {"signature-granularity",       required_argument, 0, 'g'},
+    {"enable-dirty-update",         no_argument,       0, 'd'},
+    {"enable-misaligned",           no_argument,       0, 'm'},
+    {"enable-pmp",                  no_argument,       0, 'P'},
+    {"enable-next",                 no_argument,       0, 'N'},
+    {"ram-size",                    required_argument, 0, 'z'},
+    {"disable-compressed",          no_argument,       0, 'C'},
+    {"disable-writable-misa",       no_argument,       0, 'I'},
+    {"disable-fdext",               no_argument,       0, 'F'},
+    {"mtval-has-illegal-inst-bits", no_argument,       0, 'i'},
+    {"device-tree-blob",            required_argument, 0, 'b'},
+    {"terminal-log",                required_argument, 0, 't'},
+    {"show-times",                  required_argument, 0, 'p'},
+    {"report-arch",                 no_argument,       0, 'a'},
+    {"test-signature",              required_argument, 0, 'T'},
+    {"signature-granularity",       required_argument, 0, 'g'},
 #ifdef RVFI_DII
-  {"rvfi-dii",                    required_argument, 0, 'r'},
+    {"rvfi-dii",                    required_argument, 0, 'r'},
 #endif
-  {"help",                        no_argument,       0, 'h'},
-  {"trace",                       optional_argument, 0, 'v'},
-  {"no-trace",                    optional_argument, 0, 'V'},
-  {"inst-limit",                  required_argument, 0, 'l'},
-  {"enable-zfinx",                no_argument,       0, 'x'},
+    {"help",                        no_argument,       0, 'h'},
+    {"trace",                       optional_argument, 0, 'v'},
+    {"no-trace",                    optional_argument, 0, 'V'},
+    {"inst-limit",                  required_argument, 0, 'l'},
+    {"enable-zfinx",                no_argument,       0, 'x'},
 #ifdef SAILCOV
-  {"sailcov-file",                required_argument, 0, 'c'},
+    {"sailcov-file",                required_argument, 0, 'c'},
 #endif
-  {0, 0, 0, 0}
+    {0,                             0,                 0, 0  }
 };
 
 static void print_usage(const char *argv0, int ec)
 {
 #ifdef RVFI_DII
-  fprintf(stdout, "Usage: %s [options] <elf_file>\n       %s [options] -r <port>\n", argv0, argv0);
+  fprintf(stdout,
+          "Usage: %s [options] <elf_file>\n       %s [options] -r <port>\n",
+          argv0, argv0);
 #else
   fprintf(stdout, "Usage: %s [options] <elf_file>\n", argv0);
 #endif
@@ -216,7 +223,7 @@ char *process_args(int argc, char **argv)
 {
   int c;
   uint64_t ram_size = 0;
-  while(true) {
+  while (true) {
     c = getopt_long(argc, argv,
                     "a"
                     "d"
@@ -245,8 +252,10 @@ char *process_args(int argc, char **argv)
 #ifdef SAILCOV
                     "c:"
 #endif
-                         , options, NULL);
-    if (c == -1) break;
+                    ,
+                    options, NULL);
+    if (c == -1)
+      break;
     switch (c) {
     case 'a':
       report_arch();
@@ -314,7 +323,8 @@ char *process_args(int argc, char **argv)
       break;
     case 'g':
       signature_granularity = atoi(optarg);
-      fprintf(stderr, "setting signature-granularity to %d bytes\n", signature_granularity);
+      fprintf(stderr, "setting signature-granularity to %d bytes\n",
+              signature_granularity);
       break;
     case 'h':
       print_usage(argv[0], 0);
@@ -350,21 +360,24 @@ char *process_args(int argc, char **argv)
       break;
     }
   }
-  if (do_dump_dts) dump_dts();
+  if (do_dump_dts)
+    dump_dts();
 #ifdef RVFI_DII
-  if (optind > argc || (optind == argc && !rvfi_dii)) print_usage(argv[0], 0);
+  if (optind > argc || (optind == argc && !rvfi_dii))
+    print_usage(argv[0], 0);
 #else
   if (optind >= argc) {
     fprintf(stderr, "No elf file provided.\n");
     print_usage(argv[0], 0);
   }
 #endif
-  if (dtb_file) read_dtb(dtb_file);
+  if (dtb_file)
+    read_dtb(dtb_file);
 
 #ifdef RVFI_DII
   if (!rvfi_dii)
 #endif
-  fprintf(stdout, "Running file %s.\n", argv[optind]);
+    fprintf(stdout, "Running file %s.\n", argv[optind]);
   return argv[optind];
 }
 
@@ -372,12 +385,14 @@ void check_elf(bool is32bit)
 {
   if (is32bit) {
     if (zxlen_val != 32) {
-      fprintf(stderr, "32-bit ELF not supported by RV%" PRIu64 " model.\n", zxlen_val);
+      fprintf(stderr, "32-bit ELF not supported by RV%" PRIu64 " model.\n",
+              zxlen_val);
       exit(1);
     }
   } else {
     if (zxlen_val != 64) {
-      fprintf(stderr, "64-bit ELF not supported by RV%" PRIu64 " model.\n", zxlen_val);
+      fprintf(stderr, "64-bit ELF not supported by RV%" PRIu64 " model.\n",
+              zxlen_val);
       exit(1);
     }
   }
@@ -416,22 +431,28 @@ void init_spike(const char *f, uint64_t entry, uint64_t ram_size)
   s = tv_init(isa, ram_size, 1);
   if (tv_is_dirty_enabled(s) != rv_enable_dirty_update) {
     mismatch = true;
-    fprintf(stderr, "inconsistent enable-dirty-update setting: spike %s, sail %s\n",
+    fprintf(stderr,
+            "inconsistent enable-dirty-update setting: spike %s, sail %s\n",
             tv_is_dirty_enabled(s) ? "on" : "off",
             rv_enable_dirty_update ? "on" : "off");
   }
   if (tv_is_misaligned_enabled(s) != rv_enable_misaligned) {
     mismatch = true;
-    fprintf(stderr, "inconsistent enable-misaligned-access setting: spike %s, sail %s\n",
-            tv_is_misaligned_enabled(s) ? "on" : "off",
-            rv_enable_misaligned        ? "on" : "off");
+    fprintf(
+        stderr,
+        "inconsistent enable-misaligned-access setting: spike %s, sail %s\n",
+        tv_is_misaligned_enabled(s) ? "on" : "off",
+        rv_enable_misaligned ? "on" : "off");
   }
   if (tv_ram_size(s) != rv_ram_size) {
     mismatch = true;
-    fprintf(stderr, "inconsistent ram-size setting: spike 0x%" PRIx64 ", sail 0x%" PRIx64 "\n",
+    fprintf(stderr,
+            "inconsistent ram-size setting: spike 0x%" PRIx64
+            ", sail 0x%" PRIx64 "\n",
             tv_ram_size(s), rv_ram_size);
   }
-  if (mismatch) exit(1);
+  if (mismatch)
+    exit(1);
 
   /* The initialization order below matters. */
   tv_set_verbose(s, 1);
@@ -448,7 +469,8 @@ void init_spike(const char *f, uint64_t entry, uint64_t ram_size)
     spike_dtb = (unsigned char *)malloc(spike_dtb_len + 1);
     spike_dtb[spike_dtb_len] = '\0';
     if (!tv_get_dtb(s, spike_dtb, &spike_dtb_len)) {
-      fprintf(stderr, "Got %" PRIu64 " bytes of dtb at %p\n", spike_dtb_len, spike_dtb);
+      fprintf(stderr, "Got %" PRIu64 " bytes of dtb at %p\n", spike_dtb_len,
+              spike_dtb);
     } else {
       fprintf(stderr, "Error getting DTB from Spike.\n");
       exit(1);
@@ -472,18 +494,16 @@ void tick_spike()
 void init_sail_reset_vector(uint64_t entry)
 {
 #define RST_VEC_SIZE 8
-  uint32_t reset_vec[RST_VEC_SIZE] = {
-    0x297,                                      // auipc  t0,0x0
-    0x28593 + (RST_VEC_SIZE * 4 << 20),         // addi   a1, t0, &dtb
-    0xf1402573,                                 // csrr   a0, mhartid
-    is_32bit_model() ?
-      0x0182a283u :                             // lw     t0,24(t0)
-      0x0182b283u,                              // ld     t0,24(t0)
-    0x28067,                                    // jr     t0
-    0,
-    (uint32_t) (entry & 0xffffffff),
-    (uint32_t) (entry >> 32)
-  };
+  uint32_t reset_vec[RST_VEC_SIZE]
+      = {0x297,                              // auipc  t0,0x0
+         0x28593 + (RST_VEC_SIZE * 4 << 20), // addi   a1, t0, &dtb
+         0xf1402573,                         // csrr   a0, mhartid
+         is_32bit_model() ? 0x0182a283u :    // lw     t0,24(t0)
+             0x0182b283u,                    // ld     t0,24(t0)
+         0x28067,                            // jr     t0
+         0,
+         (uint32_t)(entry & 0xffffffff),
+         (uint32_t)(entry >> 32)};
 
   rv_rom_base = DEFAULT_RSTVEC;
   uint64_t addr = rv_rom_base;
@@ -520,7 +540,7 @@ void init_sail_reset_vector(uint64_t entry)
 
   /* zero-fill to page boundary */
   const int align = 0x1000;
-  uint64_t rom_end = (addr + align -1)/align * align;
+  uint64_t rom_end = (addr + align - 1) / align * align;
   for (int i = addr; i < rom_end; i++)
     write_mem(addr++, 0);
 
@@ -551,10 +571,11 @@ void init_sail(uint64_t elf_entry)
     zPC = elf_entry;
   } else
 #endif
-  init_sail_reset_vector(elf_entry);
+    init_sail_reset_vector(elf_entry);
 
   // this is probably unnecessary now; remove
-  if (!rv_enable_rvc) z_set_Misa_C(&zmisa, 0);
+  if (!rv_enable_rvc)
+    z_set_Misa_C(&zmisa, 0);
 }
 
 /* reinitialize to clear state and memory, typically across tests runs */
@@ -577,7 +598,8 @@ int init_check(struct tv_spike_t *s)
 void write_signature(const char *file)
 {
   if (mem_sig_start >= mem_sig_end) {
-    fprintf(stderr, "Invalid signature region [0x%0" PRIx64 ",0x%0" PRIx64 "] to %s.\n",
+    fprintf(stderr,
+            "Invalid signature region [0x%0" PRIx64 ",0x%0" PRIx64 "] to %s.\n",
             mem_sig_start, mem_sig_end, file);
     return;
   }
@@ -587,10 +609,11 @@ void write_signature(const char *file)
     return;
   }
   /* write out words depending on signature granularity in signature area */
-  for (uint64_t addr = mem_sig_start; addr < mem_sig_end; addr += signature_granularity) {
+  for (uint64_t addr = mem_sig_start; addr < mem_sig_end;
+       addr += signature_granularity) {
     /* most-significant byte first */
     for (int i = signature_granularity - 1; i >= 0; i--) {
-      uint8_t byte = (uint8_t) read_mem(addr+i);
+      uint8_t byte = (uint8_t)read_mem(addr + i);
       fprintf(f, "%02x", byte);
     }
     fprintf(f, "\n");
@@ -598,7 +621,8 @@ void write_signature(const char *file)
   fclose(f);
 }
 
-void close_logs(void) {
+void close_logs(void)
+{
 #ifdef SAILCOV
   if (sail_coverage_exit() != 0) {
     fprintf(stderr, "Could not write coverage information!\n");
@@ -609,7 +633,8 @@ void close_logs(void) {
 
 void finish(int ec)
 {
-  if (sig_file) write_signature(sig_file);
+  if (sig_file)
+    write_signature(sig_file);
 
   model_fini();
 #ifdef ENABLE_SPIKE
@@ -620,9 +645,11 @@ void finish(int ec)
     exit(1);
   }
   if (do_show_times) {
-    int init_msecs = (init_end.tv_sec - init_start.tv_sec)*1000 + (init_end.tv_usec - init_start.tv_usec)/1000;
-    int exec_msecs = (run_end.tv_sec - init_end.tv_sec)*1000 + (run_end.tv_usec - init_end.tv_usec)/1000;
-    double Kips    = ((double)total_insns)/((double)exec_msecs);
+    int init_msecs = (init_end.tv_sec - init_start.tv_sec) * 1000
+        + (init_end.tv_usec - init_start.tv_usec) / 1000;
+    int exec_msecs = (run_end.tv_sec - init_end.tv_sec) * 1000
+        + (run_end.tv_usec - init_end.tv_usec) / 1000;
+    double Kips = ((double)total_insns) / ((double)exec_msecs);
     fprintf(stderr, "Initialization:   %d msecs\n", init_msecs);
     fprintf(stderr, "Execution:        %d msecs\n", exec_msecs);
     fprintf(stderr, "Instructions:     %d\n", total_insns);
@@ -637,8 +664,8 @@ int compare_states(struct tv_spike_t *s)
   int passed = 1;
 
 #ifdef ENABLE_SPIKE
-#define TV_CHECK(reg, spike_reg, sail_reg)   \
-  passed &= tv_check_ ## reg(s, spike_reg, sail_reg);
+#define TV_CHECK(reg, spike_reg, sail_reg)                                     \
+  passed &= tv_check_##reg(s, spike_reg, sail_reg);
 
   // fix default C enum map for cur_privilege
   uint8_t priv = (zcur_privilege == 2) ? 3 : zcur_privilege;
@@ -699,7 +726,7 @@ int compare_states(struct tv_spike_t *s)
 
 void flush_logs(void)
 {
-  if(config_print_instr) {
+  if (config_print_instr) {
     fprintf(stderr, "\n");
     fflush(stderr);
     fprintf(stdout, "\n");
@@ -709,14 +736,16 @@ void flush_logs(void)
 
 #ifdef RVFI_DII
 
-typedef void (packet_reader_fn)(lbits *rop, unit);
-static void get_and_send_rvfi_packet(packet_reader_fn *reader) {
+typedef void(packet_reader_fn)(lbits *rop, unit);
+static void get_and_send_rvfi_packet(packet_reader_fn *reader)
+{
   lbits packet;
   CREATE(lbits)(&packet);
   reader(&packet, UNIT);
   /* Note: packet.len is the size in bits, not bytes. */
   if (packet.len % 8 != 0) {
-    fprintf(stderr, "RVFI-DII trace packet not byte aligned: %d\n", (int)packet.len);
+    fprintf(stderr, "RVFI-DII trace packet not byte aligned: %d\n",
+            (int)packet.len);
     exit(1);
   }
   const size_t send_size = packet.len / 8;
@@ -743,7 +772,8 @@ static void get_and_send_rvfi_packet(packet_reader_fn *reader) {
   KILL(lbits)(&packet);
 }
 
-void rvfi_send_trace(unsigned version) {
+void rvfi_send_trace(unsigned version)
+{
   if (config_print_rvfi) {
     fprintf(stderr, "Sending v%d trace response...\n", version);
   }
@@ -826,7 +856,8 @@ void run_sail(void)
            * we support version 2.
            */
           if (config_print_rvfi) {
-            fprintf(stderr, "EndOfTrace was actually a version negotiation packet.\n");
+            fprintf(stderr,
+                    "EndOfTrace was actually a version negotiation packet.\n");
           }
           get_and_send_rvfi_packet(&zrvfi_get_v2_support_packet);
           continue;
@@ -841,23 +872,28 @@ void run_sail(void)
       case 'v': { /* Set wire format version */
         mach_bits insn = zrvfi_get_insn(UNIT);
         if (config_print_rvfi) {
-          fprintf(stderr, "Got request for v%jd trace format!\n", (intmax_t)insn);
+          fprintf(stderr, "Got request for v%jd trace format!\n",
+                  (intmax_t)insn);
         }
         if (insn == 1) {
           fprintf(stderr, "Requested trace in legacy format!\n");
         } else if (insn == 2) {
           fprintf(stderr, "Requested trace in v2 format!\n");
         } else {
-          fprintf(stderr, "Requested trace in unsupported format %jd!\n", (intmax_t)insn);
+          fprintf(stderr, "Requested trace in unsupported format %jd!\n",
+                  (intmax_t)insn);
           exit(1);
         }
-        rvfi_trace_version = insn; // From now on send traces in the requested format
+        rvfi_trace_version
+            = insn; // From now on send traces in the requested format
         struct {
           char msg[8];
           uint64_t version;
-        } version_response = { "version=", rvfi_trace_version };
-        if (write(rvfi_dii_sock, &version_response, sizeof(version_response)) != sizeof(version_response)) {
-          fprintf(stderr, "Sending version response failed: %s\n", strerror(errno));
+        } version_response = {"version=", rvfi_trace_version};
+        if (write(rvfi_dii_sock, &version_response, sizeof(version_response))
+            != sizeof(version_response)) {
+          fprintf(stderr, "Sending version response failed: %s\n",
+                  strerror(errno));
           exit(1);
         }
         continue;
@@ -870,7 +906,8 @@ void run_sail(void)
       CREATE(sail_int)(&sail_step);
       CONVERT_OF(sail_int, mach_int)(&sail_step, step_no);
       stepped = zstep(sail_step);
-      if (have_exception) goto step_exception;
+      if (have_exception)
+        goto step_exception;
       flush_logs();
       KILL(sail_int)(&sail_step);
       rvfi_send_trace(rvfi_trace_version);
@@ -881,7 +918,8 @@ void run_sail(void)
       CREATE(sail_int)(&sail_step);
       CONVERT_OF(sail_int, mach_int)(&sail_step, step_no);
       stepped = zstep(sail_step);
-      if (have_exception) goto step_exception;
+      if (have_exception)
+        goto step_exception;
       flush_logs();
       KILL(sail_int)(&sail_step);
     }
@@ -892,13 +930,16 @@ void run_sail(void)
     }
 
     if (do_show_times && (total_insns & 0xfffff) == 0) {
-      uint64_t start_us = 1000000 * ((uint64_t) interval_start.tv_sec)  + ((uint64_t)interval_start.tv_usec);
+      uint64_t start_us = 1000000 * ((uint64_t)interval_start.tv_sec)
+          + ((uint64_t)interval_start.tv_usec);
       if (gettimeofday(&interval_start, NULL) < 0) {
         fprintf(stderr, "Cannot gettimeofday: %s\n", strerror(errno));
-         exit(1);
+        exit(1);
       }
-      uint64_t end_us = 1000000 * ((uint64_t) interval_start.tv_sec)  + ((uint64_t)interval_start.tv_usec);
-      fprintf(stdout, "kips: %" PRIu64 "\n", ((uint64_t)1000) * 0x100000 / (end_us - start_us));
+      uint64_t end_us = 1000000 * ((uint64_t)interval_start.tv_sec)
+          + ((uint64_t)interval_start.tv_usec);
+      fprintf(stdout, "kips: %" PRIu64 "\n",
+              ((uint64_t)1000) * 0x100000 / (end_us - start_us));
     }
 #ifdef ENABLE_SPIKE
     { /* run a Spike step */
@@ -909,7 +950,8 @@ void run_sail(void)
 
     if (zhtif_done) {
       if (!spike_done) {
-        fprintf(stdout, "Sail done (exit-code %" PRIi64 "), but not Spike!\n", zhtif_exit_code);
+        fprintf(stdout, "Sail done (exit-code %" PRIi64 "), but not Spike!\n",
+                zhtif_exit_code);
         exit(1);
       }
     } else {
@@ -940,13 +982,13 @@ void run_sail(void)
     }
   }
 
- dump_state:
+dump_state:
   if (diverged) {
     /* TODO */
   }
   finish(diverged);
 
- step_exception:
+step_exception:
   fprintf(stderr, "Sail exception!");
   goto dump_state;
 }
@@ -962,8 +1004,12 @@ void init_logs()
   }
 #endif
 
-  if (term_log != NULL && (term_fd = open(term_log, O_WRONLY|O_CREAT|O_TRUNC, S_IRUSR|S_IRGRP|S_IROTH|S_IWUSR)) < 0) {
-    fprintf(stderr, "Cannot create terminal log '%s': %s\n", term_log, strerror(errno));
+  if (term_log != NULL
+      && (term_fd = open(term_log, O_WRONLY | O_CREAT | O_TRUNC,
+                         S_IRUSR | S_IRGRP | S_IROTH | S_IWUSR))
+          < 0) {
+    fprintf(stderr, "Cannot create terminal log '%s': %s\n", term_log,
+            strerror(errno));
     exit(1);
   }
 
@@ -997,15 +1043,16 @@ int main(int argc, char **argv)
       return 1;
     }
     int reuseaddr = 1;
-    if (setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &reuseaddr, sizeof(reuseaddr)) == -1) {
-      fprintf(stderr, "Unable to set reuseaddr on socket: %s\n", strerror(errno));
+    if (setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &reuseaddr,
+                   sizeof(reuseaddr))
+        == -1) {
+      fprintf(stderr, "Unable to set reuseaddr on socket: %s\n",
+              strerror(errno));
       return 1;
     }
-    struct sockaddr_in addr = {
-      .sin_family = AF_INET,
-      .sin_addr.s_addr = htonl(INADDR_LOOPBACK),
-      .sin_port = htons(rvfi_dii_port)
-    };
+    struct sockaddr_in addr = {.sin_family = AF_INET,
+                               .sin_addr.s_addr = htonl(INADDR_LOOPBACK),
+                               .sin_port = htons(rvfi_dii_port)};
     if (bind(listen_sock, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
       fprintf(stderr, "Unable to set bind socket: %s\n", strerror(errno));
       return 1;
@@ -1015,14 +1062,16 @@ int main(int argc, char **argv)
       return 1;
     }
     socklen_t addrlen = sizeof(addr);
-    if (getsockname(listen_sock, (struct sockaddr *) &addr, &addrlen) == -1) {
-        fprintf(stderr, "Unable to getsockname() on socket: %s\n", strerror(errno));
+    if (getsockname(listen_sock, (struct sockaddr *)&addr, &addrlen) == -1) {
+      fprintf(stderr, "Unable to getsockname() on socket: %s\n",
+              strerror(errno));
       return 1;
     }
     printf("Waiting for connection on port %d.\n", ntohs(addr.sin_port));
     rvfi_dii_sock = accept(listen_sock, NULL, NULL);
     if (rvfi_dii_sock == -1) {
-      fprintf(stderr, "Unable to accept connection on socket: %s\n", strerror(errno));
+      fprintf(stderr, "Unable to accept connection on socket: %s\n",
+              strerror(errno));
       return 1;
     }
     close(listen_sock);
@@ -1053,7 +1102,8 @@ int main(int argc, char **argv)
   init_spike(file, entry, rv_ram_size);
   init_sail(entry);
 
-  if (!init_check(s)) finish(1);
+  if (!init_check(s))
+    finish(1);
 
   if (gettimeofday(&init_end, NULL) < 0) {
     fprintf(stderr, "Cannot gettimeofday: %s\n", strerror(errno));

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -435,11 +435,11 @@ void init_spike(const char *f, uint64_t entry, uint64_t ram_size)
   }
   if (tv_is_misaligned_enabled(s) != rv_enable_misaligned) {
     mismatch = true;
-    fprintf(
-        stderr,
-        "inconsistent enable-misaligned-access setting: spike %s, sail %s\n",
-        tv_is_misaligned_enabled(s) ? "on" : "off",
-        rv_enable_misaligned ? "on" : "off");
+    fprintf(stderr,
+            "inconsistent enable-misaligned-access setting: "
+            "spike %s, sail %s\n",
+            tv_is_misaligned_enabled(s) ? "on" : "off",
+            rv_enable_misaligned ? "on" : "off");
   }
   if (tv_ram_size(s) != rv_ram_size) {
     mismatch = true;

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -734,8 +734,8 @@ void flush_logs(void)
 
 #ifdef RVFI_DII
 
-typedef void(packet_reader_fn)(lbits *rop, unit);
-static void get_and_send_rvfi_packet(packet_reader_fn *reader)
+typedef void (*packet_reader_fn)(lbits *rop, unit);
+static void get_and_send_rvfi_packet(packet_reader_fn reader)
 {
   lbits packet;
   CREATE(lbits)(&packet);

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -97,10 +97,8 @@ void set_config_print(char *var, bool val)
   } else if (strcmp("platform", var) == 0) {
     config_print_platform = val;
   } else {
-    fprintf(
-        stderr,
-        "Unknown trace category: '%s' (should be instr|reg|mem|platform|all)\n",
-        var);
+    fprintf(stderr, "Unknown trace category: '%s' (should be %s)\n",
+            "instr|reg|mem|platform|all", var);
     exit(1);
   }
 }

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -243,14 +243,13 @@ char *process_args(int argc, char **argv)
 #ifdef RVFI_DII
                     "r:"
 #endif
-                    "V::"
-                    "v::"
-                    "l:"
-                    "x"
 #ifdef SAILCOV
                     "c:"
 #endif
-                    ,
+                    "V::"
+                    "v::"
+                    "l:"
+                    "x",
                     options, NULL);
     if (c == -1)
       break;

--- a/c_emulator/riscv_softfloat.c
+++ b/c_emulator/riscv_softfloat.c
@@ -4,20 +4,22 @@
 #include "riscv_softfloat.h"
 #include "softfloat.h"
 
-static uint_fast8_t uint8_of_rm(mach_bits rm) {
+static uint_fast8_t uint8_of_rm(mach_bits rm)
+{
   // TODO.
   return (uint_fast8_t)rm;
 }
 
-#define SOFTFLOAT_PRELUDE(rm)                           \
-  softfloat_exceptionFlags = 0;                         \
-  softfloat_roundingMode = (uint_fast8_t) rm
+#define SOFTFLOAT_PRELUDE(rm)                                                  \
+  softfloat_exceptionFlags = 0;                                                \
+  softfloat_roundingMode = (uint_fast8_t)rm
 
-#define SOFTFLOAT_POSTLUDE(res)                             \
-  zfloat_result = res.v;                                    \
-  zfloat_fflags |= (mach_bits) softfloat_exceptionFlags     \
+#define SOFTFLOAT_POSTLUDE(res)                                                \
+  zfloat_result = res.v;                                                       \
+  zfloat_fflags |= (mach_bits)softfloat_exceptionFlags
 
-unit softfloat_f16add(mach_bits rm, mach_bits v1, mach_bits v2) {
+unit softfloat_f16add(mach_bits rm, mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a, b, res;
@@ -30,7 +32,8 @@ unit softfloat_f16add(mach_bits rm, mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f16sub(mach_bits rm, mach_bits v1, mach_bits v2) {
+unit softfloat_f16sub(mach_bits rm, mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a, b, res;
@@ -43,7 +46,8 @@ unit softfloat_f16sub(mach_bits rm, mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f16mul(mach_bits rm, mach_bits v1, mach_bits v2) {
+unit softfloat_f16mul(mach_bits rm, mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a, b, res;
@@ -56,7 +60,8 @@ unit softfloat_f16mul(mach_bits rm, mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f16div(mach_bits rm, mach_bits v1, mach_bits v2) {
+unit softfloat_f16div(mach_bits rm, mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a, b, res;
@@ -69,7 +74,8 @@ unit softfloat_f16div(mach_bits rm, mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f32add(mach_bits rm, mach_bits v1, mach_bits v2) {
+unit softfloat_f32add(mach_bits rm, mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, b, res;
@@ -82,7 +88,8 @@ unit softfloat_f32add(mach_bits rm, mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f32sub(mach_bits rm, mach_bits v1, mach_bits v2) {
+unit softfloat_f32sub(mach_bits rm, mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, b, res;
@@ -95,7 +102,8 @@ unit softfloat_f32sub(mach_bits rm, mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f32mul(mach_bits rm, mach_bits v1, mach_bits v2) {
+unit softfloat_f32mul(mach_bits rm, mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, b, res;
@@ -108,7 +116,8 @@ unit softfloat_f32mul(mach_bits rm, mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f32div(mach_bits rm, mach_bits v1, mach_bits v2) {
+unit softfloat_f32div(mach_bits rm, mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, b, res;
@@ -121,7 +130,8 @@ unit softfloat_f32div(mach_bits rm, mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f64add(mach_bits rm, mach_bits v1, mach_bits v2) {
+unit softfloat_f64add(mach_bits rm, mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, b, res;
@@ -134,7 +144,8 @@ unit softfloat_f64add(mach_bits rm, mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f64sub(mach_bits rm, mach_bits v1, mach_bits v2) {
+unit softfloat_f64sub(mach_bits rm, mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, b, res;
@@ -147,7 +158,8 @@ unit softfloat_f64sub(mach_bits rm, mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f64mul(mach_bits rm, mach_bits v1, mach_bits v2) {
+unit softfloat_f64mul(mach_bits rm, mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, b, res;
@@ -160,7 +172,8 @@ unit softfloat_f64mul(mach_bits rm, mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f64div(mach_bits rm, mach_bits v1, mach_bits v2) {
+unit softfloat_f64div(mach_bits rm, mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, b, res;
@@ -173,7 +186,8 @@ unit softfloat_f64div(mach_bits rm, mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f16muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3) {
+unit softfloat_f16muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a, b, c, res;
@@ -187,7 +201,8 @@ unit softfloat_f16muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3)
   return UNIT;
 }
 
-unit softfloat_f32muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3) {
+unit softfloat_f32muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, b, c, res;
@@ -201,7 +216,8 @@ unit softfloat_f32muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3)
   return UNIT;
 }
 
-unit softfloat_f64muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3) {
+unit softfloat_f64muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, b, c, res;
@@ -215,7 +231,8 @@ unit softfloat_f64muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3)
   return UNIT;
 }
 
-unit softfloat_f16sqrt(mach_bits rm, mach_bits v) {
+unit softfloat_f16sqrt(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a, res;
@@ -227,7 +244,8 @@ unit softfloat_f16sqrt(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f32sqrt(mach_bits rm, mach_bits v) {
+unit softfloat_f32sqrt(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, res;
@@ -239,7 +257,8 @@ unit softfloat_f32sqrt(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f64sqrt(mach_bits rm, mach_bits v) {
+unit softfloat_f64sqrt(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, res;
@@ -254,7 +273,8 @@ unit softfloat_f64sqrt(mach_bits rm, mach_bits v) {
 // The boolean 'true' argument in the conversion calls below selects
 // 'exact' conversion, which sets the Inexact exception flag if
 // needed.
-unit softfloat_f16toi32(mach_bits rm, mach_bits v) {
+unit softfloat_f16toi32(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a;
@@ -268,7 +288,8 @@ unit softfloat_f16toi32(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f16toui32(mach_bits rm, mach_bits v) {
+unit softfloat_f16toui32(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a;
@@ -282,7 +303,8 @@ unit softfloat_f16toui32(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f16toi64(mach_bits rm, mach_bits v) {
+unit softfloat_f16toi64(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a;
@@ -296,7 +318,8 @@ unit softfloat_f16toi64(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f16toui64(mach_bits rm, mach_bits v) {
+unit softfloat_f16toui64(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a;
@@ -310,7 +333,8 @@ unit softfloat_f16toui64(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f32toi32(mach_bits rm, mach_bits v) {
+unit softfloat_f32toi32(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, res;
@@ -323,7 +347,8 @@ unit softfloat_f32toi32(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f32toui32(mach_bits rm, mach_bits v) {
+unit softfloat_f32toui32(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, res;
@@ -336,7 +361,8 @@ unit softfloat_f32toui32(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f32toi64(mach_bits rm, mach_bits v) {
+unit softfloat_f32toi64(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a;
@@ -350,7 +376,8 @@ unit softfloat_f32toi64(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f32toui64(mach_bits rm, mach_bits v) {
+unit softfloat_f32toui64(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a;
@@ -364,7 +391,8 @@ unit softfloat_f32toui64(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f64toi32(mach_bits rm, mach_bits v) {
+unit softfloat_f64toi32(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a;
@@ -378,7 +406,8 @@ unit softfloat_f64toi32(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f64toui32(mach_bits rm, mach_bits v) {
+unit softfloat_f64toui32(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a;
@@ -392,7 +421,8 @@ unit softfloat_f64toui32(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f64toi64(mach_bits rm, mach_bits v) {
+unit softfloat_f64toi64(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, res;
@@ -405,7 +435,8 @@ unit softfloat_f64toi64(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f64toui64(mach_bits rm, mach_bits v) {
+unit softfloat_f64toui64(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, res;
@@ -418,7 +449,8 @@ unit softfloat_f64toui64(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_i32tof16(mach_bits rm, mach_bits v) {
+unit softfloat_i32tof16(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t res;
@@ -429,7 +461,8 @@ unit softfloat_i32tof16(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_ui32tof16(mach_bits rm, mach_bits v) {
+unit softfloat_ui32tof16(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t res;
@@ -440,7 +473,8 @@ unit softfloat_ui32tof16(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_i64tof16(mach_bits rm, mach_bits v) {
+unit softfloat_i64tof16(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t res;
@@ -451,7 +485,8 @@ unit softfloat_i64tof16(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_ui64tof16(mach_bits rm, mach_bits v) {
+unit softfloat_ui64tof16(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t res;
@@ -462,7 +497,8 @@ unit softfloat_ui64tof16(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_i32tof32(mach_bits rm, mach_bits v) {
+unit softfloat_i32tof32(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t res;
@@ -473,7 +509,8 @@ unit softfloat_i32tof32(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_ui32tof32(mach_bits rm, mach_bits v) {
+unit softfloat_ui32tof32(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t res;
@@ -484,7 +521,8 @@ unit softfloat_ui32tof32(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_i64tof32(mach_bits rm, mach_bits v) {
+unit softfloat_i64tof32(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t res;
@@ -495,7 +533,8 @@ unit softfloat_i64tof32(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_ui64tof32(mach_bits rm, mach_bits v) {
+unit softfloat_ui64tof32(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t res;
@@ -506,7 +545,8 @@ unit softfloat_ui64tof32(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_i32tof64(mach_bits rm, mach_bits v) {
+unit softfloat_i32tof64(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t res;
@@ -517,7 +557,8 @@ unit softfloat_i32tof64(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_ui32tof64(mach_bits rm, mach_bits v) {
+unit softfloat_ui32tof64(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t res;
@@ -528,7 +569,8 @@ unit softfloat_ui32tof64(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_i64tof64(mach_bits rm, mach_bits v) {
+unit softfloat_i64tof64(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t res;
@@ -539,7 +581,8 @@ unit softfloat_i64tof64(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_ui64tof64(mach_bits rm, mach_bits v) {
+unit softfloat_ui64tof64(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t res;
@@ -550,7 +593,8 @@ unit softfloat_ui64tof64(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f16tof32(mach_bits rm, mach_bits v) {
+unit softfloat_f16tof32(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a;
@@ -563,7 +607,8 @@ unit softfloat_f16tof32(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f16tof64(mach_bits rm, mach_bits v) {
+unit softfloat_f16tof64(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a;
@@ -576,7 +621,8 @@ unit softfloat_f16tof64(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f32tof64(mach_bits rm, mach_bits v) {
+unit softfloat_f32tof64(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a;
@@ -589,7 +635,8 @@ unit softfloat_f32tof64(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f32tof16(mach_bits rm, mach_bits v) {
+unit softfloat_f32tof16(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a;
@@ -602,7 +649,8 @@ unit softfloat_f32tof16(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f64tof16(mach_bits rm, mach_bits v) {
+unit softfloat_f64tof16(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a;
@@ -615,7 +663,8 @@ unit softfloat_f64tof16(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f64tof32(mach_bits rm, mach_bits v) {
+unit softfloat_f64tof32(mach_bits rm, mach_bits v)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a;
@@ -628,7 +677,8 @@ unit softfloat_f64tof32(mach_bits rm, mach_bits v) {
   return UNIT;
 }
 
-unit softfloat_f16lt(mach_bits v1, mach_bits v2) {
+unit softfloat_f16lt(mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(0);
 
   float16_t a, b, res;
@@ -641,7 +691,8 @@ unit softfloat_f16lt(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f16lt_quiet(mach_bits v1, mach_bits v2) {
+unit softfloat_f16lt_quiet(mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(0);
 
   float16_t a, b, res;
@@ -654,7 +705,8 @@ unit softfloat_f16lt_quiet(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f16le(mach_bits v1, mach_bits v2) {
+unit softfloat_f16le(mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(0);
 
   float16_t a, b, res;
@@ -667,7 +719,8 @@ unit softfloat_f16le(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f16le_quiet(mach_bits v1, mach_bits v2) {
+unit softfloat_f16le_quiet(mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(0);
 
   float16_t a, b, res;
@@ -680,7 +733,8 @@ unit softfloat_f16le_quiet(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f16eq(mach_bits v1, mach_bits v2) {
+unit softfloat_f16eq(mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(0);
 
   float16_t a, b, res;
@@ -693,7 +747,8 @@ unit softfloat_f16eq(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f32lt(mach_bits v1, mach_bits v2) {
+unit softfloat_f32lt(mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(0);
 
   float32_t a, b, res;
@@ -706,7 +761,8 @@ unit softfloat_f32lt(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f32lt_quiet(mach_bits v1, mach_bits v2) {
+unit softfloat_f32lt_quiet(mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(0);
 
   float32_t a, b, res;
@@ -719,7 +775,8 @@ unit softfloat_f32lt_quiet(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f32le(mach_bits v1, mach_bits v2) {
+unit softfloat_f32le(mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(0);
 
   float32_t a, b, res;
@@ -732,8 +789,8 @@ unit softfloat_f32le(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-
-unit softfloat_f32le_quiet(mach_bits v1, mach_bits v2) {
+unit softfloat_f32le_quiet(mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(0);
 
   float32_t a, b, res;
@@ -746,7 +803,8 @@ unit softfloat_f32le_quiet(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f32eq(mach_bits v1, mach_bits v2) {
+unit softfloat_f32eq(mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(0);
 
   float32_t a, b, res;
@@ -759,7 +817,8 @@ unit softfloat_f32eq(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f64lt(mach_bits v1, mach_bits v2) {
+unit softfloat_f64lt(mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(0);
 
   float64_t a, b, res;
@@ -772,7 +831,8 @@ unit softfloat_f64lt(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f64lt_quiet(mach_bits v1, mach_bits v2) {
+unit softfloat_f64lt_quiet(mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(0);
 
   float64_t a, b, res;
@@ -785,7 +845,8 @@ unit softfloat_f64lt_quiet(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f64le(mach_bits v1, mach_bits v2) {
+unit softfloat_f64le(mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(0);
 
   float64_t a, b, res;
@@ -798,7 +859,8 @@ unit softfloat_f64le(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f64le_quiet(mach_bits v1, mach_bits v2) {
+unit softfloat_f64le_quiet(mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(0);
 
   float64_t a, b, res;
@@ -811,7 +873,8 @@ unit softfloat_f64le_quiet(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f64eq(mach_bits v1, mach_bits v2) {
+unit softfloat_f64eq(mach_bits v1, mach_bits v2)
+{
   SOFTFLOAT_PRELUDE(0);
 
   float64_t a, b, res;
@@ -824,7 +887,8 @@ unit softfloat_f64eq(mach_bits v1, mach_bits v2) {
   return UNIT;
 }
 
-unit softfloat_f16roundToInt(mach_bits rm, mach_bits v, bool exact) {
+unit softfloat_f16roundToInt(mach_bits rm, mach_bits v, bool exact)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a, res;
@@ -837,7 +901,8 @@ unit softfloat_f16roundToInt(mach_bits rm, mach_bits v, bool exact) {
   return UNIT;
 }
 
-unit softfloat_f32roundToInt(mach_bits rm, mach_bits v, bool exact) {
+unit softfloat_f32roundToInt(mach_bits rm, mach_bits v, bool exact)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, res;
@@ -850,7 +915,8 @@ unit softfloat_f32roundToInt(mach_bits rm, mach_bits v, bool exact) {
   return UNIT;
 }
 
-unit softfloat_f64roundToInt(mach_bits rm, mach_bits v, bool exact) {
+unit softfloat_f64roundToInt(mach_bits rm, mach_bits v, bool exact)
+{
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, res;

--- a/c_emulator/riscv_softfloat.h
+++ b/c_emulator/riscv_softfloat.h
@@ -15,9 +15,12 @@ unit softfloat_f64sub(mach_bits rm, mach_bits v1, mach_bits v2);
 unit softfloat_f64mul(mach_bits rm, mach_bits v1, mach_bits v2);
 unit softfloat_f64div(mach_bits rm, mach_bits v1, mach_bits v2);
 
-unit softfloat_f16muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3);
-unit softfloat_f32muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3);
-unit softfloat_f64muladd(mach_bits rm, mach_bits v1, mach_bits v2, mach_bits v3);
+unit softfloat_f16muladd(mach_bits rm, mach_bits v1, mach_bits v2,
+                         mach_bits v3);
+unit softfloat_f32muladd(mach_bits rm, mach_bits v1, mach_bits v2,
+                         mach_bits v3);
+unit softfloat_f64muladd(mach_bits rm, mach_bits v1, mach_bits v2,
+                         mach_bits v3);
 
 unit softfloat_f16sqrt(mach_bits rm, mach_bits v);
 unit softfloat_f32sqrt(mach_bits rm, mach_bits v);


### PR DESCRIPTION
From my testing it turns out the built-in WebKit style is the closest to the current style. I added a few config options to further reduce the diff and I think the current output looks reasonable. In the future it would be good to add a CI and pre-commit check to enforce that all C code is consistently formatted to reduce the need for reviewers to look for formatting issues.