### PR TITLE
Update pre-commit-hooks version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,10 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 exclude: '^(prover_snapshots)|(generated_definitions)|(c_emulator/SoftFloat-3e)'
+minimum_pre_commit_version: 2.10.0
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.4.0
     hooks:
     -   id: trailing-whitespace
         # Do not strip trailing whitespace from patches or SVG images.


### PR DESCRIPTION
The template that I used when adding it uses hooks from 2020. Update this to the latest version and add a minimum pre-commit version check to ensure we get sensible error messages rather than obscure failures. The minimum chosen here is 2.10 as that is the version shipping with Debian 11 and most other distributions have newer versions. If needed a newer version can always be installed using pip.