### PR TITLE
Add clang-format to the pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,8 @@ repos:
         exclude: '.*\.(diff|dump|patch|svg)'
     -   id: check-yaml
     -   id: check-added-large-files
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: 'v15.0.7'
+    hooks:
+    -   id: clang-format
+        types_or: [c, c++]  # Don't try running clang-format on .json files


### PR DESCRIPTION
This formats the code with clang-format 15 since the pre-commit hook for clang-format 16 would require a newer version of pre-commit.