### PR TITLE
Fix aes_shift_rows_fwd and aes_shift_rows_inv functions from latest vector spec.

### DIFF
--- a/model/riscv_types_kext.sail
+++ b/model/riscv_types_kext.sail
@@ -351,10 +351,10 @@ function aes_shift_rows_fwd(x) = {
   let ic2 : bits(32) = aes_get_column(x, 2);
   let ic1 : bits(32) = aes_get_column(x, 1);
   let ic0 : bits(32) = aes_get_column(x, 0);
-  let oc0 : bits(32) = ic0[31..24] @ ic1[23..16] @ ic2[15.. 8] @ ic3[ 7.. 0];
-  let oc1 : bits(32) = ic1[31..24] @ ic2[23..16] @ ic3[15.. 8] @ ic0[ 7.. 0];
-  let oc2 : bits(32) = ic2[31..24] @ ic3[23..16] @ ic0[15.. 8] @ ic1[ 7.. 0];
-  let oc3 : bits(32) = ic3[31..24] @ ic0[23..16] @ ic1[15.. 8] @ ic2[ 7.. 0];
+  let oc0 : bits(32) = ic3[31..24] @ ic2[23..16] @ ic1[15.. 8] @ ic0[ 7.. 0];
+  let oc1 : bits(32) = ic0[31..24] @ ic3[23..16] @ ic2[15.. 8] @ ic1[ 7.. 0];
+  let oc2 : bits(32) = ic1[31..24] @ ic0[23..16] @ ic3[15.. 8] @ ic2[ 7.. 0];
+  let oc3 : bits(32) = ic2[31..24] @ ic1[23..16] @ ic0[15.. 8] @ ic3[ 7.. 0];
   (oc3 @ oc2 @ oc1 @ oc0) /* Return value */
 }
 
@@ -368,10 +368,10 @@ function aes_shift_rows_inv(x) = {
   let ic2 : bits(32) = aes_get_column(x, 2);
   let ic1 : bits(32) = aes_get_column(x, 1);
   let ic0 : bits(32) = aes_get_column(x, 0);
-  let oc0 : bits(32) = ic0[31..24] @ ic3[23..16] @ ic2[15.. 8] @ ic1[ 7.. 0];
-  let oc1 : bits(32) = ic1[31..24] @ ic0[23..16] @ ic3[15.. 8] @ ic2[ 7.. 0];
-  let oc2 : bits(32) = ic2[31..24] @ ic1[23..16] @ ic0[15.. 8] @ ic3[ 7.. 0];
-  let oc3 : bits(32) = ic3[31..24] @ ic2[23..16] @ ic1[15.. 8] @ ic0[ 7.. 0];
+  let oc0 : bits(32) = ic1[31..24] @ ic2[23..16] @ ic3[15.. 8] @ ic0[ 7.. 0];
+  let oc1 : bits(32) = ic2[31..24] @ ic3[23..16] @ ic0[15.. 8] @ ic1[ 7.. 0];
+  let oc2 : bits(32) = ic3[31..24] @ ic0[23..16] @ ic1[15.. 8] @ ic2[ 7.. 0];
+  let oc3 : bits(32) = ic0[31..24] @ ic1[23..16] @ ic2[15.. 8] @ ic3[ 7.. 0];
   (oc3 @ oc2 @ oc1 @ oc0) /* Return value */
 }
 


### PR DESCRIPTION
This PR updates the `aes_shift_rows_fwd` and `aes_shift_rows_inv` functions to match the versions defined in the latest vector crypto spec after this fix: https://github.com/riscv/riscv-crypto/commit/a19ae2086efcb87b6988f4510bf19cd642b16740.

These functions are not used in any scalar instructions and are not currently called anywhere, so no existing functionality should be affected, but this change is necessary for the upcoming vector crypto implementation and ensures the versions in the scalar spec match the vector crypto spec (as the Sail versions are used directly in the scalar spec).