### PR TITLE
Add Zacas (atomic compare and swap) extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ For booting operating system images, see the information under the
 - Zaamo extension for atomic memory operations, v1.0
 - Zawrs extension for Wait-on-Reservation-Set instructions, v1.01
 - Zabha extension for byte and halfword atomic memory operations, v1.0
+- Zacas extension atomic Compare-and-Swap (CAS) instructions, v1.0.0
 - F and D extensions for single and double-precision floating-point, v2.2
 - Zfh and Zfhmin extensions for half-precision floating-point, v1.0
 - Zfa extension for additional floating-point instructions, v1.0

--- a/config/rv32d.json
+++ b/config/rv32d.json
@@ -111,6 +111,9 @@
     "Zabha": {
       "supported": true
     },
+    "Zacas": {
+      "supported": true
+    },
     "Zalrsc": {
       "supported": false
     },

--- a/config/rv64d.json
+++ b/config/rv64d.json
@@ -111,6 +111,9 @@
     "Zabha": {
       "supported": true
     },
+    "Zacas": {
+      "supported": true
+    },
     "Zalrsc": {
       "supported": false
     },

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -118,6 +118,10 @@ function clause hartSupports(Ext_Zaamo) = config extensions.Zaamo.supported
 enum clause extension = Ext_Zabha
 mapping clause extensionName = Ext_Zabha <-> "zabha"
 function clause hartSupports(Ext_Zabha) = config extensions.Zabha.supported
+// Atomic Compare-and-Swap (CAS) Instructions
+enum clause extension = Ext_Zacas
+mapping clause extensionName = Ext_Zacas <-> "zacas"
+function clause hartSupports(Ext_Zacas) = config extensions.Zacas.supported
 // Load-Reserved/Store-Conditional Instructions
 enum clause extension = Ext_Zalrsc
 mapping clause extensionName = Ext_Zalrsc <-> "zalrsc"
@@ -403,6 +407,7 @@ let extensions_ordered_for_isa_string = [
   // Za
   Ext_Zaamo,
   Ext_Zabha,
+  Ext_Zacas,
   Ext_Zalrsc,
   Ext_Zawrs,
 

--- a/model/riscv_insts_zaamo.sail
+++ b/model/riscv_insts_zaamo.sail
@@ -99,6 +99,9 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
                   // All operations except CAS where loaded != X(rd) write their value back.
                   if op == AMOCAS & loaded != (if width <= xlen_bytes then trunc(X(rd)) else trunc(X_pair(rd))) then {
                     // Compared, but didn't swap.
+                    if width <= xlen_bytes
+                    then X(rd) = sign_extend(loaded)
+                    else X_pair(rd) = sign_extend(loaded);
                     RETIRE_SUCCESS
                   } else {
                     match mem_write_value(addr, width, sign_extend(result), aq & rl, rl, true) {

--- a/model/riscv_insts_zaamo.sail
+++ b/model/riscv_insts_zaamo.sail
@@ -74,7 +74,7 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
           // AMOCAS.D for RV32 and AMOCAS.Q for RV64 operate on a pair of
           // registers. When the first register of a register pair is
           // x0, then both halves of the pair read/write as zero.
-          let rs2_val = X_pair(rs2, width)[width * 8 - 1 .. 0];
+          let rs2_val : bits('width * 8) = if width <= xlen_bytes then trunc(X(rs2)) else trunc(X_pair(rs2));
           match mem_write_ea(addr, width, aq & rl, rl, true) {
             Err(e) => Memory_Exception(vaddr, e),
             Ok(_) => {
@@ -97,13 +97,15 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
                     };
 
                   // All operations except CAS where loaded != X(rd) write their value back.
-                  if op == AMOCAS & loaded != X_pair(rd, width)[width * 8 - 1 .. 0] then {
+                  if op == AMOCAS & loaded != (if width <= xlen_bytes then trunc(X(rd)) else trunc(X_pair(rd))) then {
                     // Compared, but didn't swap.
                     RETIRE_SUCCESS
                   } else {
                     match mem_write_value(addr, width, sign_extend(result), aq & rl, rl, true) {
                       Ok(true)  => {
-                        X_pair(rd, width) = sign_extend(loaded);
+                        if width <= xlen_bytes
+                        then X(rd) = sign_extend(loaded)
+                        else X_pair(rd) = sign_extend(loaded);
                         RETIRE_SUCCESS
                       },
                       Ok(false) => { internal_error(__FILE__, __LINE__, "AMO got false from mem_write_value") },

--- a/model/riscv_insts_zaamo.sail
+++ b/model/riscv_insts_zaamo.sail
@@ -131,7 +131,8 @@ mapping amo_mnemonic : amoop <-> string = {
   AMOMIN  <-> "amomin",
   AMOMAX  <-> "amomax",
   AMOMINU <-> "amominu",
-  AMOMAXU <-> "amomaxu"
+  AMOMAXU <-> "amomaxu",
+  AMOCAS  <-> "amocas",
 }
 
 mapping maybe_aqrl : (bool, bool) <-> string = {

--- a/model/riscv_insts_zaamo.sail
+++ b/model/riscv_insts_zaamo.sail
@@ -52,29 +52,6 @@ mapping clause encdec = AMO(op, aq, rl, rs2, rs1, size, rd)
   <-> encdec_amoop(op) @ bool_bits(aq) @ bool_bits(rl) @ encdec_reg(rs2) @ encdec_reg(rs1) @ size_enc_wide(size) @ encdec_reg(rd) @ 0b0101111
   when amo_encoding_valid(size, op, rs2, rd)
 
-// AMOCAS.D for RV32 and AMOCAS.Q for RV64 operate on a pair of
-// registers. When the first register of a source register pair is
-// x0, then both halves of the pair read as zero.
-
-val rX_amo_bits : forall 'w, 'w in {1, 2, 4, 8, 16} & 'w <= xlen_bytes * 2 . (regidx, int('w)) -> bits('w * 8)
-function rX_amo_bits(i, width_bytes) =
-  if i != zreg then {
-    if width_bytes <= xlen_bytes then X(i)[width_bytes * 8 - 1 .. 0] else X(i + 1) @ X(i)
-  } else zeros()
-
-val wX_amo_bits : forall 'w, 'w in {1, 2, 4, 8, 16} & 'w <= xlen_bytes * 2 . (regidx, int('w), bits('w * 8)) -> unit
-function wX_amo_bits(i, width_bytes, data) =
-  if i != zreg then {
-    if width_bytes <= xlen_bytes then X(i) = sign_extend(data) else {
-      X(i) = data[xlen - 1 .. 0];
-      X(i + 1) = data[xlen * 2 - 1 .. xlen];
-    }
-  }
-
-// X_amo allows accessing parts of registers (writes are sign-extended),
-// or register pairs for AMOCAS.
-overload X_amo = {rX_amo_bits, wX_amo_bits}
-
 /* NOTE: Currently, we only EA if address translation is successful.
    This may need revisiting. */
 function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
@@ -94,7 +71,10 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
       else match translateAddr(vaddr, ReadWrite(Data, Data)) {
         Err(e, _) => Memory_Exception(vaddr, e),
         Ok(addr, _) => {
-          let rs2_val = X_amo(rs2, width);
+          // AMOCAS.D for RV32 and AMOCAS.Q for RV64 operate on a pair of
+          // registers. When the first register of a register pair is
+          // x0, then both halves of the pair read/write as zero.
+          let rs2_val = X_pair(rs2, width)[width * 8 - 1 .. 0];
           match mem_write_ea(addr, width, aq & rl, rl, true) {
             Err(e) => Memory_Exception(vaddr, e),
             Ok(_) => {
@@ -117,13 +97,13 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
                     };
 
                   // All operations except CAS where loaded != X(rd) write their value back.
-                  if op == AMOCAS & loaded != X_amo(rd, width) then {
+                  if op == AMOCAS & loaded != X_pair(rd, width)[width * 8 - 1 .. 0] then {
                     // Compared, but didn't swap.
                     RETIRE_SUCCESS
                   } else {
                     match mem_write_value(addr, width, sign_extend(result), aq & rl, rl, true) {
                       Ok(true)  => {
-                        X_amo(rd, width) = loaded;
+                        X_pair(rd, width) = sign_extend(loaded);
                         RETIRE_SUCCESS
                       },
                       Ok(false) => { internal_error(__FILE__, __LINE__, "AMO got false from mem_write_value") },

--- a/model/riscv_insts_zaamo.sail
+++ b/model/riscv_insts_zaamo.sail
@@ -9,21 +9,31 @@
 function clause currentlyEnabled(Ext_A) = hartSupports(Ext_A) & misa[A] == 0b1 // TODO: Move currentlyEnabled(Ext_A) to a more central file
 function clause currentlyEnabled(Ext_Zaamo) = hartSupports(Ext_Zaamo) | currentlyEnabled(Ext_A)
 function clause currentlyEnabled(Ext_Zabha) = hartSupports(Ext_Zabha) & currentlyEnabled(Ext_Zaamo)
+function clause currentlyEnabled(Ext_Zacas) = hartSupports(Ext_Zacas) & currentlyEnabled(Ext_Zaamo)
 
-// Zaamo defines AMOs for word and double
-// Zabha defines AMOs for byte and halfword
-function amo_width_valid(size : word_width) -> bool = {
-  match size {
-    1 => currentlyEnabled(Ext_Zabha),
-    2 => currentlyEnabled(Ext_Zabha),
-    4 => true,
-    8 => xlen >= 64,
-  }
-}
+// Zaamo defines AMOs for 32-bit and 64-bit.
+// Zabha defines AMOs for 8-bit and 16-bit.
+//
+// The Zacas extension adds a CAS operation which support 32, 64
+// and 128-bit operands. Only sizes up to XLEN*2 are supported
+// (so 128-bit is RV64-only). When XLEN*2 is used the operands
+// are stored in even-numbered register pairs.
+//
+// If Zabha and Zacas are implemented then CAS supports 8 and
+// 16-bit operands.
+//
+function amo_encoding_valid(width : word_width_wide, op : amoop, Regidx(rs2) : regidx, Regidx(rd) : regidx) -> bool =
+  // If AMOCAS, check that extension is enabled.
+  (if op == AMOCAS then currentlyEnabled(Ext_Zacas) else currentlyEnabled(Ext_Zaamo))
+  &
+  // Check the size and register alignment.
+  (if width < 4 then currentlyEnabled(Ext_Zabha) else (
+    width <= xlen_bytes | (op == AMOCAS & width <= xlen_bytes * 2 & rs2[0] == bitzero & rd[0] == bitzero)
+  ))
 
 /* ****************************************************************** */
 
-union clause instruction = AMO : (amoop, bool, bool, regidx, regidx, word_width, regidx)
+union clause instruction = AMO : (amoop, bool, bool, regidx, regidx, word_width_wide, regidx)
 
 mapping encdec_amoop : amoop <-> bits(5) = {
   AMOSWAP <-> 0b00001,
@@ -34,12 +44,36 @@ mapping encdec_amoop : amoop <-> bits(5) = {
   AMOMIN  <-> 0b10000,
   AMOMAX  <-> 0b10100,
   AMOMINU <-> 0b11000,
-  AMOMAXU <-> 0b11100
+  AMOMAXU <-> 0b11100,
+  AMOCAS  <-> 0b00101,
 }
 
 mapping clause encdec = AMO(op, aq, rl, rs2, rs1, size, rd)
-  <-> encdec_amoop(op) @ bool_bits(aq) @ bool_bits(rl) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ encdec_reg(rd) @ 0b0101111
-  when currentlyEnabled(Ext_Zaamo) & amo_width_valid(size)
+  <-> encdec_amoop(op) @ bool_bits(aq) @ bool_bits(rl) @ encdec_reg(rs2) @ encdec_reg(rs1) @ size_enc_wide(size) @ encdec_reg(rd) @ 0b0101111
+  when amo_encoding_valid(size, op, rs2, rd)
+
+// AMOCAS.D for RV32 and AMOCAS.Q for RV64 operate on a pair of
+// registers. When the first register of a source register pair is
+// x0, then both halves of the pair read as zero.
+
+val rX_amo_bits : forall 'w, 'w in {1, 2, 4, 8, 16} & 'w <= xlen_bytes * 2 . (regidx, int('w)) -> bits('w * 8)
+function rX_amo_bits(i, width_bytes) =
+  if i != zreg then {
+    if width_bytes <= xlen_bytes then X(i)[width_bytes * 8 - 1 .. 0] else X(i + 1) @ X(i)
+  } else zeros()
+
+val wX_amo_bits : forall 'w, 'w in {1, 2, 4, 8, 16} & 'w <= xlen_bytes * 2 . (regidx, int('w), bits('w * 8)) -> unit
+function wX_amo_bits(i, width_bytes, data) =
+  if i != zreg then {
+    if width_bytes <= xlen_bytes then X(i) = sign_extend(data) else {
+      X(i) = data[xlen - 1 .. 0];
+      X(i + 1) = data[xlen * 2 - 1 .. xlen];
+    }
+  }
+
+// X_amo allows accessing parts of registers (writes are sign-extended),
+// or register pairs for AMOCAS.
+overload X_amo = {rX_amo_bits, wX_amo_bits}
 
 /* NOTE: Currently, we only EA if address translation is successful.
    This may need revisiting. */
@@ -47,7 +81,7 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
   let 'width = width;
 
   // This is checked during decoding.
-  assert(width <= xlen_bytes);
+  assert(width <= xlen_bytes * 2);
 
   /* Get the address, X(rs1) (no offset).
     * Some extensions perform additional checks on address validity.
@@ -55,12 +89,12 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
   match ext_data_get_addr(rs1, zeros(), ReadWrite(Data, Data), width) {
     Ext_DataAddr_Error(e)  => Ext_DataAddr_Check_Failure(e),
     Ext_DataAddr_OK(vaddr) => {
-      if not(is_aligned_addr(bits_of(vaddr), width))
+      if not(is_aligned_addr(vaddr, width))
       then Memory_Exception(vaddr, E_SAMO_Addr_Align())
       else match translateAddr(vaddr, ReadWrite(Data, Data)) {
         Err(e, _) => Memory_Exception(vaddr, e),
         Ok(addr, _) => {
-          let rs2_val = X(rs2)[width * 8 - 1 .. 0];
+          let rs2_val = X_amo(rs2, width);
           match mem_write_ea(addr, width, aq & rl, rl, true) {
             Err(e) => Memory_Exception(vaddr, e),
             Ok(_) => {
@@ -78,11 +112,23 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
                       AMOMAX  => if rs2_val >_s loaded then rs2_val else loaded,
                       AMOMINU => if rs2_val <_u loaded then rs2_val else loaded,
                       AMOMAXU => if rs2_val >_u loaded then rs2_val else loaded,
+                      // If it *does* store a value, CAS always stores rs2.
+                      AMOCAS  => rs2_val,
                     };
-                  match mem_write_value(addr, width, sign_extend(result), aq & rl, rl, true) {
-                    Ok(true)  => { X(rd) = sign_extend(loaded); RETIRE_SUCCESS },
-                    Ok(false) => { internal_error(__FILE__, __LINE__, "AMO got false from mem_write_value") },
-                    Err(e)    => Memory_Exception(vaddr, e),
+
+                  // All operations except CAS where loaded != X(rd) write their value back.
+                  if op == AMOCAS & loaded != X_amo(rd, width) then {
+                    // Compared, but didn't swap.
+                    RETIRE_SUCCESS
+                  } else {
+                    match mem_write_value(addr, width, sign_extend(result), aq & rl, rl, true) {
+                      Ok(true)  => {
+                        X_amo(rd, width) = loaded;
+                        RETIRE_SUCCESS
+                      },
+                      Ok(false) => { internal_error(__FILE__, __LINE__, "AMO got false from mem_write_value") },
+                      Err(e)    => Memory_Exception(vaddr, e),
+                    }
                   }
                 }
               }
@@ -114,4 +160,4 @@ mapping maybe_aqrl : (bool, bool) <-> string = {
 }
 
 mapping clause assembly = AMO(op, aq, rl, rs2, rs1, width, rd)
-  <-> amo_mnemonic(op) ^ "." ^ size_mnemonic(width) ^ maybe_aqrl(aq, rl) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs2) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
+  <-> amo_mnemonic(op) ^ "." ^ size_mnemonic_wide(width) ^ maybe_aqrl(aq, rl) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs2) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -223,6 +223,30 @@ function wX_bits(Regidx(i) : regidx, data : xlenbits) -> unit = {
 
 overload X = {rX_bits, wX_bits, rX, wX}
 
+// X_pair allows accessing a single register or a pair of registers for
+// XLEN*2 accesses. When accessing (x0, x1) then the entire access
+// is read-only zero. This is used for Zacas and Zilsd.
+
+// `width_bytes` is the access width. If it is greater than XLEN then
+// a 2*XLEN bit vector will be returned.
+val rX_pair_bits : forall 'w, 'w <= xlen_bytes * 2 . (regidx, int('w)) -> bits((if 'w <= xlen_bytes then xlen_bytes else xlen_bytes * 2) * 8)
+function rX_pair_bits(i, width_bytes) =
+  if i != zreg then {
+    if width_bytes <= xlen_bytes then X(i) else X(i + 1) @ X(i)
+  } else zeros()
+
+val wX_pair_bits : forall 'w, 'w <= xlen_bytes * 2 . (regidx, int('w), bits((if 'w <= xlen_bytes then xlen_bytes else xlen_bytes * 2) * 8)) -> unit
+function wX_pair_bits(i, width_bytes, data) =
+  if i != zreg then {
+    if width_bytes <= xlen_bytes then X(i) = data else {
+      X(i) = data[xlen - 1 .. 0];
+      X(i + 1) = data[xlen * 2 - 1 .. xlen];
+    }
+  }
+
+overload X_pair = {rX_pair_bits, wX_pair_bits}
+
+
 /* Mappings for encoding */
 
 mapping encdec_reg : regidx <-> bits(5) = { Regidx(r) <-> r }

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -223,25 +223,16 @@ function wX_bits(Regidx(i) : regidx, data : xlenbits) -> unit = {
 
 overload X = {rX_bits, wX_bits, rX, wX}
 
-// X_pair allows accessing a single register or a pair of registers for
-// XLEN*2 accesses. When accessing (x0, x1) then the entire access
-// is read-only zero. This is used for Zacas and Zilsd.
+// X_pair accesses a pair of registers. If the index is x0 then
+// it acts as if both registers in the pair are x0.
 
-// `width_bytes` is the access width. If it is greater than XLEN then
-// a 2*XLEN bit vector will be returned.
-val rX_pair_bits : forall 'w, 'w <= xlen_bytes * 2 . (regidx, int('w)) -> bits((if 'w <= xlen_bytes then xlen_bytes else xlen_bytes * 2) * 8)
-function rX_pair_bits(i, width_bytes) =
-  if i != zreg then {
-    if width_bytes <= xlen_bytes then X(i) else X(i + 1) @ X(i)
-  } else zeros()
+function rX_pair_bits(i : regidx) -> bits(xlen * 2) =
+  if i != zreg then X(i + 1) @ X(i) else zeros()
 
-val wX_pair_bits : forall 'w, 'w <= xlen_bytes * 2 . (regidx, int('w), bits((if 'w <= xlen_bytes then xlen_bytes else xlen_bytes * 2) * 8)) -> unit
-function wX_pair_bits(i, width_bytes, data) =
+function wX_pair_bits(i : regidx, data : bits(xlen * 2)) -> unit =
   if i != zreg then {
-    if width_bytes <= xlen_bytes then X(i) = data else {
-      X(i) = data[xlen - 1 .. 0];
-      X(i + 1) = data[xlen * 2 - 1 .. xlen];
-    }
+    X(i) = data[xlen - 1 .. 0];
+    X(i + 1) = data[xlen * 2 - 1 .. xlen];
   }
 
 overload X_pair = {rX_pair_bits, wX_pair_bits}

--- a/model/riscv_termination.sail
+++ b/model/riscv_termination.sail
@@ -74,6 +74,7 @@ function currentlyEnabled_measure(ext : extension) -> int =
     Ext_H => 4,
     Ext_Smcntrpmf => 3,
     Ext_Zabha => 3,
+    Ext_Zacas => 3,
     Ext_Zcb => 3,
     Ext_Zcd => 3,
     Ext_Zcf => 3,

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -85,8 +85,6 @@ union AccessType ('a : Type) = {
   InstructionFetch : unit
 }
 
-type word_width = {1, 2, 4, 8}
-
 type is_mem_width('w) = 'w in {1, 2, 4, 8}
 
 /* architectural interrupt definitions */
@@ -273,8 +271,9 @@ enum rop = {ADD, SUB, SLL, SLT, SLTU, XOR,
 
 enum ropw  = {ADDW, SUBW, SLLW, SRLW, SRAW}           /* reg-reg 32-bit ops */
 enum sopw  = {SLLIW, SRLIW, SRAIW}                    /* RV64-only shift ops */
-enum amoop = {AMOSWAP, AMOADD, AMOXOR, AMOAND, AMOOR,
-              AMOMIN, AMOMAX, AMOMINU, AMOMAXU}       /* AMO ops */
+enum amoop = {AMOSWAP, AMOADD, AMOXOR, AMOAND, AMOOR, /* AMO ops */
+              AMOMIN, AMOMAX, AMOMINU, AMOMAXU,
+              AMOCAS}
 enum csrop = {CSRRW, CSRRS, CSRRC}                    /* CSR ops */
 
 enum cbop_zicbom = {CBO_CLEAN, CBO_FLUSH, CBO_INVAL}  /* Zicbom ops */
@@ -306,6 +305,11 @@ mapping wait_name : WaitReason <-> string = {
 
 overload to_str = {wait_name}
 
+// Width of access for most instructions (load/store, etc.).
+type word_width = {1, 2, 4, 8}
+// Some instructions allow 128-bit accesses.
+type word_width_wide = {1, 2, 4, 8, 16}
+
 // Get the bit encoding of word_width.
 mapping size_enc : word_width <-> bits(2) = {
   1 <-> 0b00,
@@ -319,6 +323,23 @@ mapping size_mnemonic : word_width <-> string = {
   2 <-> "h",
   4 <-> "w",
   8 <-> "d",
+}
+
+// Get the bit encoding of word_width.
+mapping size_enc_wide : word_width_wide <-> bits(3) = {
+  1  <-> 0b000,
+  2  <-> 0b001,
+  4  <-> 0b010,
+  8  <-> 0b011,
+  16 <-> 0b100,
+}
+
+mapping size_mnemonic_wide : word_width_wide <-> string = {
+  1  <-> "b",
+  2  <-> "h",
+  4  <-> "w",
+  8  <-> "d",
+  16 <-> "q",
 }
 
 struct mul_op = {


### PR DESCRIPTION
Add the Zacas extension that introduces the following instructions:

- amocas.w for RV32 and RV64
- amocas.d for RV32 and RV64
- amocas.q for RV64 only

Tested with these tests: https://github.com/riscv-non-isa/riscv-arch-test/tree/dev/riscv-test-suite/rv64i_m/Zacas/src 