### PR TITLE
Simplify softfloat interface by removing write_fflags

### DIFF
--- a/c_emulator/riscv_softfloat.c
+++ b/c_emulator/riscv_softfloat.c
@@ -16,7 +16,7 @@ static uint_fast8_t uint8_of_rm(mach_bits rm)
 
 #define SOFTFLOAT_POSTLUDE(res)                                                \
   zfloat_result = res.v;                                                       \
-  zfloat_fflags |= (mach_bits)softfloat_exceptionFlags
+  zfloat_fflags = (mach_bits)softfloat_exceptionFlags
 
 unit softfloat_f16add(mach_bits rm, mach_bits v1, mach_bits v2)
 {

--- a/model/riscv_fdext_regs.sail
+++ b/model/riscv_fdext_regs.sail
@@ -528,26 +528,16 @@ val ext_write_fcsr : (bits(3), bits(5)) -> unit
 function ext_write_fcsr (frm, fflags) = {
   fcsr->FRM()    = frm;      /* Note: frm can be an illegal value, 101, 110, 111 */
   fcsr->FFLAGS() = fflags;
-  update_softfloat_fflags(fflags);
   dirty_fd_context_if_present();
 }
 
-/* called for softfloat paths (softfloat flags are consistent) */
-val write_fflags : (bits(5)) -> unit
-function write_fflags(fflags) = {
-  if   fcsr.FFLAGS() != fflags
-  then dirty_fd_context_if_present();
-  fcsr->FFLAGS() = fflags;
-}
-
-/* called for non-softfloat paths (softfloat flags need updating) */
+/* OR flags into the fflags register. */
 val accrue_fflags : (bits(5)) -> unit
 function accrue_fflags(flags) = {
   let f = fcsr.FFLAGS() | flags;
   if  fcsr.FFLAGS() != f
   then {
     fcsr->FFLAGS() = f;
-    update_softfloat_fflags(f);
     dirty_fd_context_if_present();
   }
 }

--- a/model/riscv_insts_dext.sail
+++ b/model/riscv_insts_dext.sail
@@ -349,7 +349,7 @@ function clause execute (F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, op)) = {
           FNMSUB_D => riscv_f64MulAdd (rm_3b, negate_D (rs1_val_64b), rs2_val_64b, rs3_val_64b),
           FNMADD_D => riscv_f64MulAdd (rm_3b, negate_D (rs1_val_64b), rs2_val_64b, negate_D (rs3_val_64b))
         };
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_64b;
       RETIRE_SUCCESS
     }
@@ -413,7 +413,7 @@ function clause execute (F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, op)) = {
         FMUL_D  => riscv_f64Mul (rm_3b, rs1_val_64b, rs2_val_64b),
         FDIV_D  => riscv_f64Div (rm_3b, rs1_val_64b, rs2_val_64b)
       };
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_64b;
       RETIRE_SUCCESS
     }
@@ -501,7 +501,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FSQRT_D)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_f64Sqrt   (rm_3b, rs1_val_D);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_D;
       RETIRE_SUCCESS
     }
@@ -516,7 +516,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_W_D)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_W) = riscv_f64ToI32 (rm_3b, rs1_val_D);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       X(rd) = sign_extend (rd_val_W);
       RETIRE_SUCCESS
     }
@@ -531,7 +531,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_WU_D)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_WU) = riscv_f64ToUi32 (rm_3b, rs1_val_D);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       X(rd) = sign_extend (rd_val_WU);
       RETIRE_SUCCESS
     }
@@ -546,7 +546,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_W)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_i32ToF64 (rm_3b, rs1_val_W);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_D;
       RETIRE_SUCCESS
     }
@@ -561,7 +561,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_WU)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_ui32ToF64 (rm_3b, rs1_val_WU);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_D;
       RETIRE_SUCCESS
     }
@@ -576,7 +576,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_S_D)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_f64ToF32 (rm_3b, rs1_val_D);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_S;
       RETIRE_SUCCESS
     }
@@ -591,7 +591,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_S)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_f32ToF64 (rm_3b, rs1_val_S);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_D;
       RETIRE_SUCCESS
     }
@@ -607,7 +607,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_L_D)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_L) = riscv_f64ToI64 (rm_3b, rs1_val_D);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       X(rd) = sign_extend(rd_val_L);
       RETIRE_SUCCESS
     }
@@ -623,7 +623,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_LU_D)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_LU) = riscv_f64ToUi64 (rm_3b, rs1_val_D);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       X(rd) = sign_extend(rd_val_LU);
       RETIRE_SUCCESS
     }
@@ -639,7 +639,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_L)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_i64ToF64 (rm_3b, rs1_val_L);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_D;
       RETIRE_SUCCESS
     }
@@ -655,7 +655,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_LU)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_ui64ToF64 (rm_3b, rs1_val_LU);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_D;
       RETIRE_SUCCESS
     }
@@ -862,7 +862,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FEQ_D)) = {
   let (fflags, rd_val) : (bits_fflags, bool) =
       riscv_f64Eq (rs1_val_D, rs2_val_D);
 
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
   RETIRE_SUCCESS
 }
@@ -874,7 +874,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FLT_D)) = {
   let (fflags, rd_val) : (bits_fflags, bool) =
       riscv_f64Lt (rs1_val_D, rs2_val_D);
 
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
   RETIRE_SUCCESS
 }
@@ -886,7 +886,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FLE_D)) = {
   let (fflags, rd_val) : (bits_fflags, bool) =
       riscv_f64Le (rs1_val_D, rs2_val_D);
 
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
   RETIRE_SUCCESS
 }

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -526,7 +526,7 @@ function clause execute (F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, op)) = {
           FNMSUB_S => riscv_f32MulAdd (rm_3b, negate_S (rs1_val_32b), rs2_val_32b, rs3_val_32b),
           FNMADD_S => riscv_f32MulAdd (rm_3b, negate_S (rs1_val_32b), rs2_val_32b, negate_S (rs3_val_32b))
         };
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_32b;
       RETIRE_SUCCESS
     }
@@ -590,7 +590,7 @@ function clause execute (F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, op)) = {
         FMUL_S  => riscv_f32Mul (rm_3b, rs1_val_32b, rs2_val_32b),
         FDIV_S  => riscv_f32Div (rm_3b, rs1_val_32b, rs2_val_32b)
       };
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_32b;
       RETIRE_SUCCESS
     }
@@ -670,7 +670,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FSQRT_S)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_f32Sqrt   (rm_3b, rs1_val_S);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_S;
       RETIRE_SUCCESS
     }
@@ -685,7 +685,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_W_S)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_W) = riscv_f32ToI32 (rm_3b, rs1_val_S);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       X(rd) = sign_extend (rd_val_W);
       RETIRE_SUCCESS
     }
@@ -700,7 +700,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_WU_S)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_WU) = riscv_f32ToUi32 (rm_3b, rs1_val_S);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       X(rd) = sign_extend (rd_val_WU);
       RETIRE_SUCCESS
     }
@@ -715,7 +715,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_W)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_i32ToF32 (rm_3b, rs1_val_W);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_S;
       RETIRE_SUCCESS
     }
@@ -730,7 +730,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_WU)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_ui32ToF32 (rm_3b, rs1_val_WU);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_S;
       RETIRE_SUCCESS
     }
@@ -746,7 +746,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_L_S)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_L) = riscv_f32ToI64 (rm_3b, rs1_val_S);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       X(rd) = sign_extend(rd_val_L);
       RETIRE_SUCCESS
     }
@@ -762,7 +762,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_LU_S)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_LU) = riscv_f32ToUi64 (rm_3b, rs1_val_S);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       X(rd) = sign_extend(rd_val_LU);
       RETIRE_SUCCESS
     }
@@ -778,7 +778,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_L)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_i64ToF32 (rm_3b, rs1_val_L);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_S;
       RETIRE_SUCCESS
     }
@@ -794,7 +794,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_LU)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_ui64ToF32 (rm_3b, rs1_val_LU);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_S;
       RETIRE_SUCCESS
     }
@@ -986,7 +986,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FEQ_S)) = {
   let (fflags, rd_val) : (bits_fflags, bool) =
       riscv_f32Eq (rs1_val_S, rs2_val_S);
 
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
   RETIRE_SUCCESS
 }
@@ -998,7 +998,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FLT_S)) = {
   let (fflags, rd_val) : (bits_fflags, bool) =
       riscv_f32Lt (rs1_val_S, rs2_val_S);
 
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
   RETIRE_SUCCESS
 }
@@ -1010,7 +1010,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FLE_S)) = {
   let (fflags, rd_val) : (bits_fflags, bool) =
       riscv_f32Le (rs1_val_S, rs2_val_S);
 
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
   RETIRE_SUCCESS
 }

--- a/model/riscv_insts_vext_fp.sail
+++ b/model/riscv_insts_vext_fp.sail
@@ -440,7 +440,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
                                 32 => riscv_ui32ToF32(rm_3b, vs2_val[i]),
                                 64 => riscv_ui64ToF64(rm_3b, vs2_val[i])
                               };
-                              write_fflags(fflags);
+                              accrue_fflags(fflags);
                               elem
                             },
         FV_CVT_F_X       => {
@@ -449,7 +449,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
                                 32 => riscv_i32ToF32(rm_3b, vs2_val[i]),
                                 64 => riscv_i64ToF64(rm_3b, vs2_val[i])
                               };
-                              write_fflags(fflags);
+                              accrue_fflags(fflags);
                               elem
                             },
         FV_CVT_RTZ_XU_F  => {
@@ -541,7 +541,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                                 16 => riscv_f16ToUi32(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToUi64(rm_3b, vs2_val[i])
                               };
-                              write_fflags(fflags);
+                              accrue_fflags(fflags);
                               elem
                             },
         FWV_CVT_X_F      => {
@@ -550,7 +550,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                                 16 => riscv_f16ToI32(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToI64(rm_3b, vs2_val[i])
                               };
-                              write_fflags(fflags);
+                              accrue_fflags(fflags);
                               elem
                             },
         FWV_CVT_F_XU     => {
@@ -559,7 +559,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                                 16 => riscv_ui32ToF32(rm_3b, zero_extend(vs2_val[i])),
                                 32 => riscv_ui32ToF64(rm_3b, vs2_val[i])
                               };
-                              write_fflags(fflags);
+                              accrue_fflags(fflags);
                               elem
                             },
         FWV_CVT_F_X      => {
@@ -568,7 +568,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                                 16 => riscv_i32ToF32(rm_3b, sign_extend(vs2_val[i])),
                                 32 => riscv_i32ToF64(rm_3b, vs2_val[i])
                               };
-                              write_fflags(fflags);
+                              accrue_fflags(fflags);
                               elem
                             },
         FWV_CVT_F_F      => {
@@ -577,7 +577,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                                 16 => riscv_f16ToF32(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToF64(rm_3b, vs2_val[i])
                               };
-                              write_fflags(fflags);
+                              accrue_fflags(fflags);
                               elem
                             },
         FWV_CVT_RTZ_XU_F => {
@@ -586,7 +586,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                                 16 => riscv_f16ToUi32(0b001, vs2_val[i]),
                                 32 => riscv_f32ToUi64(0b001, vs2_val[i])
                               };
-                              write_fflags(fflags);
+                              accrue_fflags(fflags);
                               elem
                             },
         FWV_CVT_RTZ_X_F  => {
@@ -595,7 +595,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                                 16 => riscv_f16ToI32(0b001, vs2_val[i]),
                                 32 => riscv_f32ToI64(0b001, vs2_val[i])
                               };
-                              write_fflags(fflags);
+                              accrue_fflags(fflags);
                               elem
                             }
       }
@@ -688,7 +688,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                                 16 => riscv_ui32ToF16(rm_3b, vs2_val[i]),
                                 32 => riscv_ui64ToF32(rm_3b, vs2_val[i])
                               };
-                              write_fflags(fflags);
+                              accrue_fflags(fflags);
                               elem
                             },
         FNV_CVT_F_X      => {
@@ -697,7 +697,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                                 16 => riscv_i32ToF16(rm_3b, vs2_val[i]),
                                 32 => riscv_i64ToF32(rm_3b, vs2_val[i])
                               };
-                              write_fflags(fflags);
+                              accrue_fflags(fflags);
                               elem
                             },
         FNV_CVT_F_F      => {
@@ -706,7 +706,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                                 16 => riscv_f32ToF16(rm_3b, vs2_val[i]),
                                 32 => riscv_f64ToF32(rm_3b, vs2_val[i])
                               };
-                              write_fflags(fflags);
+                              accrue_fflags(fflags);
                               elem
                             },
         FNV_CVT_ROD_F_F  => {
@@ -715,7 +715,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                                 16 => riscv_f32ToF16(0b110, vs2_val[i]),
                                 32 => riscv_f64ToF32(0b110, vs2_val[i])
                               };
-                              write_fflags(fflags);
+                              accrue_fflags(fflags);
                               elem
                             },
         FNV_CVT_RTZ_XU_F => {
@@ -801,7 +801,7 @@ function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
                               32  => riscv_f32Sqrt(rm_3b, vs2_val[i]),
                               64  => riscv_f64Sqrt(rm_3b, vs2_val[i])
                             };
-                            write_fflags(fflags);
+                            accrue_fflags(fflags);
                             elem
                           },
         FVV_VRSQRT7    => {

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -663,7 +663,7 @@ function fp_add(rm_3b, op1, op2) = {
     32  => riscv_f32Add(rm_3b, op1, op2),
     64  => riscv_f64Add(rm_3b, op1, op2)
   };
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   result_val
 }
 
@@ -674,7 +674,7 @@ function fp_sub(rm_3b, op1, op2) = {
     32  => riscv_f32Sub(rm_3b, op1, op2),
     64  => riscv_f64Sub(rm_3b, op1, op2)
   };
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   result_val
 }
 
@@ -693,7 +693,7 @@ function fp_min(op1, op2) = {
                 else if (f_is_neg_zero(op2) & f_is_pos_zero(op1)) then op2
                 else if op1_lt_op2 then op1
                 else op2;
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   result_val
 }
 
@@ -712,7 +712,7 @@ function fp_max(op1, op2) = {
                 else if (f_is_neg_zero(op2) & f_is_pos_zero(op1)) then op1
                 else if op1_lt_op2 then op2
                 else op1;
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   result_val
 }
 
@@ -723,7 +723,7 @@ function fp_eq(op1, op2) = {
     32  => riscv_f32Eq(op1, op2),
     64  => riscv_f64Eq(op1, op2)
   };
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   result_val
 }
 
@@ -735,7 +735,7 @@ function fp_gt(op1, op2) = {
     64  => riscv_f64Le(op1, op2)
   };
   let result_val = (if fflags == 0b10000 then false else not(temp_val));
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   result_val
 }
 
@@ -747,7 +747,7 @@ function fp_ge(op1, op2) = {
     64  => riscv_f64Lt(op1, op2)
   };
   let result_val = (if fflags == 0b10000 then false else not(temp_val));
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   result_val
 }
 
@@ -758,7 +758,7 @@ function fp_lt(op1, op2) = {
     32  => riscv_f32Lt(op1, op2),
     64  => riscv_f64Lt(op1, op2)
   };
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   result_val
 }
 
@@ -769,7 +769,7 @@ function fp_le(op1, op2) = {
     32  => riscv_f32Le(op1, op2),
     64  => riscv_f64Le(op1, op2)
   };
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   result_val
 }
 
@@ -780,7 +780,7 @@ function fp_mul(rm_3b, op1, op2) = {
     32  => riscv_f32Mul(rm_3b, op1, op2),
     64  => riscv_f64Mul(rm_3b, op1, op2)
   };
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   result_val
 }
 
@@ -791,7 +791,7 @@ function fp_div(rm_3b, op1, op2) = {
     32  => riscv_f32Div(rm_3b, op1, op2),
     64  => riscv_f64Div(rm_3b, op1, op2)
   };
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   result_val
 }
 
@@ -802,7 +802,7 @@ function fp_muladd(rm_3b, op1, op2, opadd) = {
     32  => riscv_f32MulAdd(rm_3b, op1, op2, opadd),
     64  => riscv_f64MulAdd(rm_3b, op1, op2, opadd)
   };
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   result_val
 }
 
@@ -814,7 +814,7 @@ function fp_nmuladd(rm_3b, op1, op2, opadd) = {
     32  => riscv_f32MulAdd(rm_3b, op1, op2, opadd),
     64  => riscv_f64MulAdd(rm_3b, op1, op2, opadd)
   };
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   result_val
 }
 
@@ -826,7 +826,7 @@ function fp_mulsub(rm_3b, op1, op2, opsub) = {
     32  => riscv_f32MulAdd(rm_3b, op1, op2, opsub),
     64  => riscv_f64MulAdd(rm_3b, op1, op2, opsub)
   };
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   result_val
 }
 
@@ -839,7 +839,7 @@ function fp_nmulsub(rm_3b, op1, op2, opsub) = {
     32  => riscv_f32MulAdd(rm_3b, op1, op2, opsub),
     64  => riscv_f64MulAdd(rm_3b, op1, op2, opsub)
   };
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   result_val
 }
 

--- a/model/riscv_insts_zfa.sail
+++ b/model/riscv_insts_zfa.sail
@@ -416,7 +416,7 @@ function clause execute (RISCV_FROUND_H(rs1, rm, rd)) = {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_f16roundToInt(rm_3b, rs1_val_H, false);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_H(rd) = rd_val_H;
       RETIRE_SUCCESS
     }
@@ -444,7 +444,7 @@ function clause execute (RISCV_FROUNDNX_H(rs1, rm, rd)) = {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_f16roundToInt(rm_3b, rs1_val_H, true);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_H(rd) = rd_val_H;
       RETIRE_SUCCESS
     }
@@ -472,7 +472,7 @@ function clause execute (RISCV_FROUND_S(rs1, rm, rd)) = {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_f32roundToInt(rm_3b, rs1_val_S, false);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_S(rd) = rd_val_S;
       RETIRE_SUCCESS
     }
@@ -500,7 +500,7 @@ function clause execute (RISCV_FROUNDNX_S(rs1, rm, rd)) = {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_f32roundToInt(rm_3b, rs1_val_S, true);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_S(rd) = rd_val_S;
       RETIRE_SUCCESS
     }
@@ -528,7 +528,7 @@ function clause execute (RISCV_FROUND_D(rs1, rm, rd)) = {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_f64roundToInt(rm_3b, rs1_val_D, false);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F(rd) = rd_val_D;
       RETIRE_SUCCESS
     }
@@ -556,7 +556,7 @@ function clause execute (RISCV_FROUNDNX_D(rs1, rm, rd)) = {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_f64roundToInt(rm_3b, rs1_val_D, true);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_D(rd) = rd_val_D;
       RETIRE_SUCCESS
     }
@@ -627,7 +627,7 @@ function clause execute(RISCV_FLEQ_H(rs2, rs1, rd)) = {
   let (fflags, rd_val) : (bits_fflags, bool) =
       riscv_f16Le_quiet   (rs1_val_H, rs2_val_H);
 
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
   RETIRE_SUCCESS
 }
@@ -651,7 +651,7 @@ function clause execute(RISCV_FLTQ_H(rs2, rs1, rd)) = {
   let (fflags, rd_val) : (bits_fflags, bool) =
       riscv_f16Lt_quiet   (rs1_val_H, rs2_val_H);
 
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
   RETIRE_SUCCESS
 }
@@ -675,7 +675,7 @@ function clause execute(RISCV_FLEQ_S(rs2, rs1, rd)) = {
   let (fflags, rd_val) : (bits_fflags, bool) =
       riscv_f32Le_quiet   (rs1_val_S, rs2_val_S);
 
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
   RETIRE_SUCCESS
 }
@@ -699,7 +699,7 @@ function clause execute(RISCV_FLTQ_S(rs2, rs1, rd)) = {
   let (fflags, rd_val) : (bits_fflags, bool) =
       riscv_f32Lt_quiet   (rs1_val_S, rs2_val_S);
 
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
   RETIRE_SUCCESS
 }
@@ -724,7 +724,7 @@ function clause execute(RISCV_FLEQ_D(rs2, rs1, rd)) = {
   let (fflags, rd_val) : (bits_fflags, bool) =
       riscv_f64Le_quiet   (rs1_val_D, rs2_val_D);
 
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
   RETIRE_SUCCESS
 }
@@ -748,7 +748,7 @@ function clause execute(RISCV_FLTQ_D(rs2, rs1, rd)) = {
   let (fflags, rd_val) : (bits_fflags, bool) =
       riscv_f64Lt_quiet   (rs1_val_D, rs2_val_D);
 
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
   RETIRE_SUCCESS
 }
@@ -828,7 +828,7 @@ mapping clause assembly = RISCV_FCVTMOD_W_D(rs1, rd)
 function clause execute(RISCV_FCVTMOD_W_D(rs1, rd)) = {
   let rs1_val_D = F_D(rs1);
   let (fflags, rd_val) = fcvtmod_helper(rs1_val_D);
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   X(rd) = sign_extend(rd_val);
   RETIRE_SUCCESS
 }

--- a/model/riscv_insts_zfh.sail
+++ b/model/riscv_insts_zfh.sail
@@ -273,7 +273,7 @@ function clause execute (F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, op)) = {
         FMUL_H  => riscv_f16Mul (rm_3b, rs1_val_16b, rs2_val_16b),
         FDIV_H  => riscv_f16Div (rm_3b, rs1_val_16b, rs2_val_16b)
       };
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_16b;
       RETIRE_SUCCESS
     }
@@ -338,7 +338,7 @@ function clause execute (F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, op)) = {
           FNMSUB_H => riscv_f16MulAdd (rm_3b, negate_H (rs1_val_16b), rs2_val_16b, rs3_val_16b),
           FNMADD_H => riscv_f16MulAdd (rm_3b, negate_H (rs1_val_16b), rs2_val_16b, negate_H (rs3_val_16b))
         };
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_16b;
       RETIRE_SUCCESS
     }
@@ -477,7 +477,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FEQ_H)) = {
   let (fflags, rd_val) : (bits_fflags, bool) =
       riscv_f16Eq (rs1_val_H, rs2_val_H);
 
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
   RETIRE_SUCCESS
 }
@@ -489,7 +489,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FLT_H)) = {
   let (fflags, rd_val) : (bits_fflags, bool) =
       riscv_f16Lt (rs1_val_H, rs2_val_H);
 
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
   RETIRE_SUCCESS
 }
@@ -501,7 +501,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FLE_H)) = {
   let (fflags, rd_val) : (bits_fflags, bool) =
       riscv_f16Le (rs1_val_H, rs2_val_H);
 
-  write_fflags(fflags);
+  accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
   RETIRE_SUCCESS
 }
@@ -643,7 +643,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FSQRT_H)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_f16Sqrt   (rm_3b, rs1_val_H);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_H;
       RETIRE_SUCCESS
     }
@@ -658,7 +658,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_W_H)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_W) = riscv_f16ToI32 (rm_3b, rs1_val_H);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       X(rd) = sign_extend (rd_val_W);
       RETIRE_SUCCESS
     }
@@ -673,7 +673,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_WU_H)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_WU) = riscv_f16ToUi32 (rm_3b, rs1_val_H);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       X(rd) = sign_extend (rd_val_WU);
       RETIRE_SUCCESS
     }
@@ -688,7 +688,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_W)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_i32ToF16 (rm_3b, rs1_val_W);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_H;
       RETIRE_SUCCESS
     }
@@ -703,7 +703,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_WU)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_ui32ToF16 (rm_3b, rs1_val_WU);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_H;
       RETIRE_SUCCESS
     }
@@ -718,7 +718,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_S)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_f32ToF16 (rm_3b, rs1_val_S);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_H;
       RETIRE_SUCCESS
     }
@@ -733,7 +733,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_D)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_f64ToF16 (rm_3b, rs1_val_D);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_H;
       RETIRE_SUCCESS
     }
@@ -748,7 +748,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_S_H)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_f16ToF32 (rm_3b, rs1_val_H);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_S;
       RETIRE_SUCCESS
     }
@@ -764,7 +764,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_D_H)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_f16ToF64 (rm_3b, rs1_val_H);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_D;
       RETIRE_SUCCESS
     }
@@ -780,7 +780,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_L_H)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_L) = riscv_f16ToI64 (rm_3b, rs1_val_H);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       X(rd) = sign_extend(rd_val_L);
       RETIRE_SUCCESS
     }
@@ -796,7 +796,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_LU_H)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_LU) = riscv_f16ToUi64 (rm_3b, rs1_val_H);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       X(rd) = sign_extend(rd_val_LU);
       RETIRE_SUCCESS
     }
@@ -812,7 +812,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_L)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_i64ToF16 (rm_3b, rs1_val_L);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_H;
       RETIRE_SUCCESS
     }
@@ -828,7 +828,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_LU)) = {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_ui64ToF16 (rm_3b, rs1_val_LU);
 
-      write_fflags(fflags);
+      accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_H;
       RETIRE_SUCCESS
     }

--- a/model/riscv_softfloat_interface.sail
+++ b/model/riscv_softfloat_interface.sail
@@ -106,12 +106,6 @@ type bits_LU     = bits(64)   /* Unsigned integer */
 register float_result : bits(64)
 register float_fflags : bits(64)
 
-/* updater to keep the flags in sync with fcsr.fflags */
-val update_softfloat_fflags : bits(5) -> unit
-function update_softfloat_fflags(flags) = {
-  float_fflags = sail_zero_extend(flags, 64);
-}
-
 /* **************************************************************** */
 /* ADD/SUB/MUL/DIV                                                  */
 


### PR DESCRIPTION
Instead of keeping a mirror register in sync with fflags, just return the new flags. This removes the need for `write_fflags()` and `update_softfloat_fflags()`.