### PR TITLE
Fix various Sail compilation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _build/
 _sbuild/
 *.o
 *.a
+/z3_problems

--- a/model/prelude.sail
+++ b/model/prelude.sail
@@ -138,8 +138,6 @@ function string_of_bit(b: bit) -> string =
 
 overload BitStr = {string_of_bits, string_of_bit}
 
-val xor_vec = {c: "xor_bits", _: "xor_vec"} : forall 'n. (bits('n), bits('n)) -> bits('n)
-
 val int_power = {ocaml: "int_power", interpreter: "int_power", lem: "pow", coq: "pow", c: "pow_int"} : (int, int) -> int
 
 overload operator ^ = {xor_vec, int_power, concat_str}

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -205,7 +205,6 @@ function check_seed_CSR (csr : csreg, p : Privilege, isWrite : bool) -> bool = {
       Machine => true,
       Supervisor => false, /* TODO: base this on mseccfg */
       User => false, /* TODO: base this on mseccfg */
-      _ => false
     }
   }
 }

--- a/model/riscv_vmem_sv32.sail
+++ b/model/riscv_vmem_sv32.sail
@@ -237,7 +237,7 @@ function translate32(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = 
                 /* pte needs dirty/accessed update but that is not enabled */
                 TR_Failure(PTW_PTE_Update(), ext_ptw)
               } else {
-                w_pte : SV32_PTE = update_BITS(pte, pbits.bits());
+                var w_pte : SV32_PTE = update_BITS(pte, pbits.bits());
                 /* ext is unused since there are no reserved bits for extensions */
                 match mem_write_value_priv(to_phys_addr(pteAddr), 4, w_pte.bits(), Supervisor, false, false, false) {
                   MemValue(_) => {

--- a/model/riscv_vmem_sv39.sail
+++ b/model/riscv_vmem_sv39.sail
@@ -231,8 +231,8 @@ function translate39(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = 
                 /* pte needs dirty/accessed update but that is not enabled */
                 TR_Failure(PTW_PTE_Update(), ext_ptw)
               } else {
-                w_pte : SV39_PTE = update_BITS(pte, pbits.bits());
-                w_pte : SV39_PTE = update_Ext(w_pte, ext);
+                var w_pte : SV39_PTE = update_BITS(pte, pbits.bits());
+                w_pte = update_Ext(w_pte, ext);
                 match mem_write_value_priv(zero_extend(pteAddr), 8, w_pte.bits(), Supervisor, false, false, false) {
                   MemValue(_) => {
                     add_to_TLB39(asid, vAddr, pAddr, w_pte, pteAddr, level, global);

--- a/model/riscv_vmem_sv39.sail
+++ b/model/riscv_vmem_sv39.sail
@@ -111,7 +111,7 @@ function walk39(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
           }
         } else { /* leaf PTE */
           match checkPTEPermission(ac, priv, mxr, do_sum, pattr, ext_pte, ext_ptw) {
-	    PTE_Check_Failure(ext_ptw, ext_ptw_fail) => {
+            PTE_Check_Failure(ext_ptw, ext_ptw_fail) => {
 /*            print("walk39: pte permission check failure"); */
               PTW_Failure(ext_get_ptw_error(ext_ptw_fail), ext_ptw)
             },
@@ -232,7 +232,7 @@ function translate39(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = 
                 TR_Failure(PTW_PTE_Update(), ext_ptw)
               } else {
                 w_pte : SV39_PTE = update_BITS(pte, pbits.bits());
-		w_pte : SV39_PTE = update_Ext(w_pte, ext);
+                w_pte : SV39_PTE = update_Ext(w_pte, ext);
                 match mem_write_value_priv(zero_extend(pteAddr), 8, w_pte.bits(), Supervisor, false, false, false) {
                   MemValue(_) => {
                     add_to_TLB39(asid, vAddr, pAddr, w_pte, pteAddr, level, global);

--- a/model/riscv_vmem_sv48.sail
+++ b/model/riscv_vmem_sv48.sail
@@ -115,7 +115,7 @@ function walk48(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
 /*            print("walk48: pte permission check failure"); */
               PTW_Failure(ext_get_ptw_error(ext_ptw_fail), ext_ptw)
             },
-	    PTE_Check_Success(ext_ptw) => {
+            PTE_Check_Success(ext_ptw) => {
               if level > 0 then { /* superpage */
                 /* fixme hack: to get a mask of appropriate size */
                 let mask = shiftl(pte.PPNi() ^ pte.PPNi() ^ zero_extend(0b1), level * SV48_LEVEL_BITS) - 1;
@@ -196,7 +196,7 @@ function translate48(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = 
             TR_Failure(PTW_PTE_Update(), ext_ptw)
           } else {
             w_pte : SV48_PTE = update_BITS(pte, pbits.bits());
-	    w_pte : SV48_PTE = update_Ext(w_pte, ext);
+            w_pte : SV48_PTE = update_Ext(w_pte, ext);
             match mem_write_value_priv(zero_extend(pteAddr), 8, w_pte.bits(), Supervisor, false, false, false) {
               MemValue(_) => {
                 add_to_TLB48(asid, vAddr, pAddr, w_pte, pteAddr, level, global);

--- a/model/riscv_vmem_sv48.sail
+++ b/model/riscv_vmem_sv48.sail
@@ -195,8 +195,8 @@ function translate48(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = 
             /* pte needs dirty/accessed update but that is not enabled */
             TR_Failure(PTW_PTE_Update(), ext_ptw)
           } else {
-            w_pte : SV48_PTE = update_BITS(pte, pbits.bits());
-            w_pte : SV48_PTE = update_Ext(w_pte, ext);
+            var w_pte : SV48_PTE = update_BITS(pte, pbits.bits());
+            w_pte = update_Ext(w_pte, ext);
             match mem_write_value_priv(zero_extend(pteAddr), 8, w_pte.bits(), Supervisor, false, false, false) {
               MemValue(_) => {
                 add_to_TLB48(asid, vAddr, pAddr, w_pte, pteAddr, level, global);


### PR DESCRIPTION
Various minor Sail compilation warning fixes.

* Fix warning about duplicated xor_vec
* Fix warning about redundant `_` case in match.
* Fix warning about redundant type annotations on w_pte

Also some minor improvements

* Add `z3_problems` to `.gitignore`.
* Add explicit `var` to `w_pte`. That is good practice and will (hopefully) be required in a future Sail release.
* Fix some accidental hard tabs.