### PR TITLE
Setting F=0 and D=1 should result in both F and D being cleared

### DIFF
--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -164,10 +164,10 @@ function legalize_misa(m : Misa, v : xlenbits) -> Misa = {
   else {
     /* Suppress enabling C if C was disabled at boot (i.e. not supported) */
     let m = if not(sys_enable_rvc()) then m else update_C(m, v.C());
-    /* Handle updates for F/D. */
-    if   not(sys_enable_fdext()) | (v.D() == 0b1 & v.F() == 0b0)
+    /* Suppress updates to misa.{f,d} if disabled at boot */
+    if   not(sys_enable_fdext())
     then m
-    else update_D(update_F(m, v.F()), v.D())
+    else update_D(update_F(m, v.F()), v.D() & v.F())
   }
 }
 


### PR DESCRIPTION
### Changed
- Updated `legalize_misa` function in the `riscv_sys_regs.sail` in the `model/` directory to add condition by setting F=0 and D=1 should clear both F and D.
### Issue Fixed
- Fix for issue #300 