### PR TITLE
Fix fmaxm.d definition

### DIFF
--- a/model/riscv_insts_zfa.sail
+++ b/model/riscv_insts_zfa.sail
@@ -373,7 +373,7 @@ mapping clause encdec = RISCV_FMAXM_D(rs2, rs1, rd)     if haveDExt() & haveZfa(
   <-> 0b001_0101 @ rs2 @ rs1 @ 0b011 @ rd @ 0b101_0011  if haveDExt() & haveZfa()
 
 mapping clause assembly = RISCV_FMAXM_D(rs2, rs1, rd)
-  <-> "fmaxm.s" ^ spc() ^ freg_name(rd)
+  <-> "fmaxm.d" ^ spc() ^ freg_name(rd)
                 ^ spc() ^ freg_name(rs1)
                 ^ spc() ^ freg_name(rs2)
 


### PR DESCRIPTION
Likely a cut-and-paste error, the definition for fmaxm.d uses the fmaxm.s mnemonic, which is already used earlier in the same file.

Sadly, `make` fails with the current "master" branch:
```
lem -isa -outdir generated_definitions/isabelle/RV64 -lib Sail=/home/pc/.opam/default/share/sail/src/lem_interp -lib Sail=/home/pc/.opam/default/share/sail/src/gen_lib \
	handwritten_support/0.11/riscv_extras.lem handwritten_support/0.11/mem_metadata.lem handwritten_support/0.11/riscv_extras_fdext.lem \
	generated_definitions/lem/RV64/riscv_types.lem \
	generated_definitions/lem/RV64/riscv.lem
[WARNING] var was deprecated in version 2.1 of the opam CLI. Use opam var instead or set OPAMCLI environment variable to 2.0.
File "generated_definitions/lem/RV64/riscv.lem", line 50091, character 9 to line 50091, character 53
  Type error: type mismatch: application expression
    bool
  and
    Sail2_prompt_monad.monad _ bool _
make: *** [Makefile:318: generated_definitions/isabelle/RV64/Riscv.thy] Error 1
```
I backed up about 10 commits (861bd6f65593013381c905d7a54e538e5382bf31), and was able to `make`/`make check` successfully, including after reapplying this patch.