### PR TITLE
Add unratified Zimop and Zcmop extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ SAIL_DEFAULT_INST += riscv_insts_zbkx.sail
 
 SAIL_DEFAULT_INST += riscv_insts_zicond.sail
 SAIL_DEFAULT_INST += riscv_insts_zimop.sail
+SAIL_DEFAULT_INST += riscv_insts_zcmop.sail
 
 SAIL_SEQ_INST  = $(SAIL_DEFAULT_INST) riscv_jalr_seq.sail
 SAIL_RMEM_INST = $(SAIL_DEFAULT_INST) riscv_jalr_rmem.sail riscv_insts_rmem.sail

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ SAIL_DEFAULT_INST += riscv_insts_zbkb.sail
 SAIL_DEFAULT_INST += riscv_insts_zbkx.sail
 
 SAIL_DEFAULT_INST += riscv_insts_zicond.sail
+SAIL_DEFAULT_INST += riscv_insts_zimop.sail
 
 SAIL_SEQ_INST  = $(SAIL_DEFAULT_INST) riscv_jalr_seq.sail
 SAIL_RMEM_INST = $(SAIL_DEFAULT_INST) riscv_jalr_rmem.sail riscv_insts_rmem.sail

--- a/model/riscv_insts_zcmop.sail
+++ b/model/riscv_insts_zcmop.sail
@@ -78,8 +78,8 @@
 /* ****************************************************************** */
 
 union clause ast = ZCMOP : (bits(3))
-mapping clause encdec_compressed = ZCMOP(mop_10_08) if haveZcmop()
-  <-> 0b01100 @ mop_10_08 : bits(3) @ 0b100000 @ 0b01
+mapping clause encdec_compressed = ZCMOP(mop) if haveZcmop()
+  <-> 0b01100 @ mop : bits(3) @ 0b100000 @ 0b01
 
 mapping zcmop_mnemonic : bits(3) <-> string = {
   0b000 <-> "c.mop.1",

--- a/model/riscv_insts_zcmop.sail
+++ b/model/riscv_insts_zcmop.sail
@@ -1,0 +1,100 @@
+/*=======================================================================================*/
+/*  RISCV Sail Model                                                                     */
+/*                                                                                       */
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except for the snapshots of the Lem and Sail libraries                   */
+/*  in the prover_snapshots directory (which include copies of their                     */
+/*  licences), is subject to the BSD two-clause licence below.                           */
+/*                                                                                       */
+/*  Copyright (c) 2017-2023                                                              */
+/*    Ved Shanbhogue                                                                     */
+/*    Prashanth Mundkur                                                                  */
+/*    Rishiyur S. Nikhil and Bluespec, Inc.                                              */
+/*    Jon French                                                                         */
+/*    Brian Campbell                                                                     */
+/*    Robert Norton-Wright                                                               */
+/*    Alasdair Armstrong                                                                 */
+/*    Thomas Bauereiss                                                                   */
+/*    Shaked Flur                                                                        */
+/*    Christopher Pulte                                                                  */
+/*    Peter Sewell                                                                       */
+/*    Alexander Richardson                                                               */
+/*    Hesham Almatary                                                                    */
+/*    Jessica Clarke                                                                     */
+/*    Microsoft, for contributions by Robert Norton-Wright and Nathaniel Wesley Filardo  */
+/*    Peter Rugg                                                                         */
+/*    Aril Computer Corp., for contributions by Scott Johnson                            */
+/*    Philipp Tomsich                                                                    */
+/*    VRULL GmbH, for contributions by its employees                                     */
+/*                                                                                       */
+/*  All rights reserved.                                                                 */
+/*                                                                                       */
+/*  This software was developed by the above within the Rigorous                         */
+/*  Engineering of Mainstream Systems (REMS) project, partly funded by                   */
+/*  EPSRC grant EP/K008528/1, at the Universities of Cambridge and                       */
+/*  Edinburgh.                                                                           */
+/*                                                                                       */
+/*  This software was developed by SRI International and the University of               */
+/*  Cambridge Computer Laboratory (Department of Computer Science and                    */
+/*  Technology) under DARPA/AFRL contract FA8650-18-C-7809 ("CIFV"), and                 */
+/*  under DARPA contract HR0011-18-C-0016 ("ECATS") as part of the DARPA                 */
+/*  SSITH research programme.                                                            */
+/*                                                                                       */
+/*  This project has received funding from the European Research Council                 */
+/*  (ERC) under the European Union’s Horizon 2020 research and innovation                */
+/*  programme (grant agreement 789108, ELVER).                                           */
+/*                                                                                       */
+/*                                                                                       */
+/*  Redistribution and use in source and binary forms, with or without                   */
+/*  modification, are permitted provided that the following conditions                   */
+/*  are met:                                                                             */
+/*  1. Redistributions of source code must retain the above copyright                    */
+/*     notice, this list of conditions and the following disclaimer.                     */
+/*  2. Redistributions in binary form must reproduce the above copyright                 */
+/*     notice, this list of conditions and the following disclaimer in                   */
+/*     the documentation and/or other materials provided with the                        */
+/*     distribution.                                                                     */
+/*                                                                                       */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''                   */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED                    */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                      */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR                  */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                         */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT                     */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF                     */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND                  */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,                   */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT                   */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF                   */
+/*  SUCH DAMAGE.                                                                         */
+/*=======================================================================================*/
+
+/* ********************************************************************* */
+/* This file specifies the compressed insts. in the 'Zcmop' extension.   */
+
+/* These instructions are only legal if misa.C() is true and is checked in
+ * the fetch-execute logic.
+ */
+/* ****************************************************************** */
+
+union clause ast = ZCMOP : (bits(3))
+mapping clause encdec_compressed = ZCMOP(mop_10_08) if haveZcmop()
+  <-> 0b01100 @ mop_10_08 : bits(3) @ 0b100000 @ 0b01
+
+mapping zcmop_mnemonic : bits(3) <-> string = {
+  0b000 <-> "c.mop.1",
+  0b001 <-> "c.mop.3",
+  0b010 <-> "c.mop.5",
+  0b011 <-> "c.mop.7",
+  0b100 <-> "c.mop.9",
+  0b101 <-> "c.mop.11",
+  0b110 <-> "c.mop.13",
+  0b111 <-> "c.mop.15"
+}
+
+mapping clause assembly = ZCMOP(mop)
+  <-> zcmop_mnemonic(mop)
+
+function clause execute ZCMOP(mop) = {
+  RETIRE_SUCCESS
+}

--- a/model/riscv_insts_zimop.sail
+++ b/model/riscv_insts_zimop.sail
@@ -1,0 +1,145 @@
+/*=======================================================================================*/
+/*  RISCV Sail Model                                                                     */
+/*                                                                                       */
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except for the snapshots of the Lem and Sail libraries                   */
+/*  in the prover_snapshots directory (which include copies of their                     */
+/*  licences), is subject to the BSD two-clause licence below.                           */
+/*                                                                                       */
+/*  Copyright (c) 2017-2023                                                              */
+/*    Ved Shanbhogue                                                                     */
+/*    Prashanth Mundkur                                                                  */
+/*    Rishiyur S. Nikhil and Bluespec, Inc.                                              */
+/*    Jon French                                                                         */
+/*    Brian Campbell                                                                     */
+/*    Robert Norton-Wright                                                               */
+/*    Alasdair Armstrong                                                                 */
+/*    Thomas Bauereiss                                                                   */
+/*    Shaked Flur                                                                        */
+/*    Christopher Pulte                                                                  */
+/*    Peter Sewell                                                                       */
+/*    Alexander Richardson                                                               */
+/*    Hesham Almatary                                                                    */
+/*    Jessica Clarke                                                                     */
+/*    Microsoft, for contributions by Robert Norton-Wright and Nathaniel Wesley Filardo  */
+/*    Peter Rugg                                                                         */
+/*    Aril Computer Corp., for contributions by Scott Johnson                            */
+/*    Philipp Tomsich                                                                    */
+/*    VRULL GmbH, for contributions by its employees                                     */
+/*                                                                                       */
+/*  All rights reserved.                                                                 */
+/*                                                                                       */
+/*  This software was developed by the above within the Rigorous                         */
+/*  Engineering of Mainstream Systems (REMS) project, partly funded by                   */
+/*  EPSRC grant EP/K008528/1, at the Universities of Cambridge and                       */
+/*  Edinburgh.                                                                           */
+/*                                                                                       */
+/*  This software was developed by SRI International and the University of               */
+/*  Cambridge Computer Laboratory (Department of Computer Science and                    */
+/*  Technology) under DARPA/AFRL contract FA8650-18-C-7809 ("CIFV"), and                 */
+/*  under DARPA contract HR0011-18-C-0016 ("ECATS") as part of the DARPA                 */
+/*  SSITH research programme.                                                            */
+/*                                                                                       */
+/*  This project has received funding from the European Research Council                 */
+/*  (ERC) under the European Union’s Horizon 2020 research and innovation                */
+/*  programme (grant agreement 789108, ELVER).                                           */
+/*                                                                                       */
+/*                                                                                       */
+/*  Redistribution and use in source and binary forms, with or without                   */
+/*  modification, are permitted provided that the following conditions                   */
+/*  are met:                                                                             */
+/*  1. Redistributions of source code must retain the above copyright                    */
+/*     notice, this list of conditions and the following disclaimer.                     */
+/*  2. Redistributions in binary form must reproduce the above copyright                 */
+/*     notice, this list of conditions and the following disclaimer in                   */
+/*     the documentation and/or other materials provided with the                        */
+/*     distribution.                                                                     */
+/*                                                                                       */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''                   */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED                    */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                      */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR                  */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                         */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT                     */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF                     */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND                  */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,                   */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT                   */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF                   */
+/*  SUCH DAMAGE.                                                                         */
+/*=======================================================================================*/
+
+/* ****************************************************************** */
+/* This file specifies the instructions in the Zimop extension.       */
+/* mop.r.0-31: 1-00--0111--sssss100ddddd1110011                       */
+/* mop.rr.0-7: 1-00--1tttttsssss100ddddd1110011                       */
+union clause ast = ZIMOP_MOP_R : (bits(5), regidx, regidx)
+union clause ast = ZIMOP_MOP_RR : (bits(3), regidx, regidx, regidx)
+
+mapping clause encdec = ZIMOP_MOP_R(mop_30 @ mop_27_26 @ mop_21_20, rs1, rd) if haveZimop()
+  <-> 0b1 @ mop_30 : bits(1) @ 0b00 @ mop_27_26 : bits(2) @ 0b0111 @ mop_21_20 : bits(2) @ rs1 @ 0b100 @ rd @ 0b1110011 if haveZimop()
+
+mapping clause encdec = ZIMOP_MOP_RR(mop_30 @ mop_27_26, rs2, rs1, rd) if haveZimop()
+  <-> 0b1 @ mop_30 : bits(1) @ 0b00 @ mop_27_26 : bits(2) @ 0b1 @ rs2 @ rs1 @ 0b100 @ rd @ 0b1110011 if haveZimop()
+
+mapping zimop_r_mnemonic : bits(5) <-> string = {
+  0b00000 <-> "mop.r.0",
+  0b00001 <-> "mop.r.1",
+  0b00010 <-> "mop.r.2",
+  0b00011 <-> "mop.r.3",
+  0b00100 <-> "mop.r.4",
+  0b00101 <-> "mop.r.5",
+  0b00110 <-> "mop.r.6",
+  0b00111 <-> "mop.r.7",
+  0b01000 <-> "mop.r.8",
+  0b01001 <-> "mop.r.9",
+  0b01010 <-> "mop.r.10",
+  0b01011 <-> "mop.r.11",
+  0b01100 <-> "mop.r.12",
+  0b01101 <-> "mop.r.13",
+  0b01110 <-> "mop.r.14",
+  0b01111 <-> "mop.r.15",
+  0b10000 <-> "mop.r.16",
+  0b10001 <-> "mop.r.17",
+  0b10010 <-> "mop.r.18",
+  0b10011 <-> "mop.r.19",
+  0b10100 <-> "mop.r.20",
+  0b10101 <-> "mop.r.21",
+  0b10110 <-> "mop.r.22",
+  0b10111 <-> "mop.r.23",
+  0b11000 <-> "mop.r.24",
+  0b11001 <-> "mop.r.25",
+  0b11010 <-> "mop.r.26",
+  0b11011 <-> "mop.r.27",
+  0b11100 <-> "mop.r.28",
+  0b11101 <-> "mop.r.29",
+  0b11110 <-> "mop.r.30",
+  0b11111 <-> "mop.r.31"
+}
+
+mapping zimop_rr_mnemonic : bits(3) <-> string = {
+  0b000 <-> "mop.rr.0",
+  0b001 <-> "mop.rr.1",
+  0b010 <-> "mop.rr.2",
+  0b011 <-> "mop.rr.3",
+  0b100 <-> "mop.rr.4",
+  0b101 <-> "mop.rr.5",
+  0b110 <-> "mop.rr.6",
+  0b111 <-> "mop.rr.7"
+}
+
+mapping clause assembly = ZIMOP_MOP_R(mop, rs1, rd)
+  <-> zimop_r_mnemonic(mop) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
+
+mapping clause assembly = ZIMOP_MOP_RR(mop, rs2, rs1, rd)
+  <-> zimop_rr_mnemonic(mop) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
+
+function clause execute ZIMOP_MOP_R(mop, rs1, rd) = {
+  X(rd) = zeros();
+  RETIRE_SUCCESS
+}
+
+function clause execute ZIMOP_MOP_RR(mop, rs2, rs1, rd) = {
+  X(rd) = zeros();
+  RETIRE_SUCCESS
+}

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -216,6 +216,9 @@ function haveZicond() -> bool = true
 /* Zimop extension support */
 function haveZimop() -> bool = true
 
+/* Zcmop extension support */
+function haveZcmop() -> bool = true
+
 bitfield Mstatush : bits(32) = {
   MBE  : 5,
   SBE  : 4

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -213,6 +213,9 @@ function haveZmmul()  -> bool = true
 /* Zicond extension support */
 function haveZicond() -> bool = true
 
+/* Zimop extension support */
+function haveZimop() -> bool = true
+
 bitfield Mstatush : bits(32) = {
   MBE  : 5,
   SBE  : 4


### PR DESCRIPTION
Add unratified Zimop and Zcmop extension specified in:
https://github.com/riscv/riscv-isa-manual/blob/main/src/zimop.adoc