### PR TITLE
Add a simpler default Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,8 @@ endif
 
 .PHONY:
 
+default: c_emulator/riscv_sim_$(ARCH)
+
 all: ocaml_emulator/riscv_ocaml_sim_$(ARCH) c_emulator/riscv_sim_$(ARCH) riscv_isa riscv_coq riscv_hol riscv_rmem
 .PHONY: all
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -55,30 +55,33 @@ cd $RISCVDIR
 make clean
 
 printf "Building 32-bit RISCV specification...\n"
-if ARCH=RV32 make ocaml_emulator/riscv_ocaml_sim_RV32 ;
-then
-    green "Building 32-bit RISCV OCaml emulator" "ok"
-else
-    red "Building 32-bit RISCV OCaml emulator" "fail"
-fi
-for test in $DIR/riscv-tests/rv32*.elf; do
-    # skip F/D tests on OCaml for now
-    pat='rv32ud-.+elf'
-    if [[ $(basename $test) =~ $pat ]];
-    then continue
-    fi
-    pat='rv32uf-.+elf'
-    if [[ $(basename $test) =~ $pat ]];
-    then continue
-    fi
-    if $RISCVDIR/ocaml_emulator/riscv_ocaml_sim_RV32 "$test" >"${test/.elf/.out}" 2>&1 && grep -q SUCCESS "${test/.elf/.out}"
+
+if [ -n "$TEST_OCAML" ]; then
+    if ARCH=RV32 make ocaml_emulator/riscv_ocaml_sim_RV32 ;
     then
-       green "OCaml-32 $(basename $test)" "ok"
+        green "Building 32-bit RISCV OCaml emulator" "ok"
     else
-       red "OCaml-32 $(basename $test)" "fail"
+        red "Building 32-bit RISCV OCaml emulator" "fail"
     fi
-done
-finish_suite "32-bit RISCV OCaml tests"
+    for test in $DIR/riscv-tests/rv32*.elf; do
+        # skip F/D tests on OCaml for now
+        pat='rv32ud-.+elf'
+        if [[ $(basename $test) =~ $pat ]];
+        then continue
+        fi
+        pat='rv32uf-.+elf'
+        if [[ $(basename $test) =~ $pat ]];
+        then continue
+        fi
+        if $RISCVDIR/ocaml_emulator/riscv_ocaml_sim_RV32 "$test" >"${test/.elf/.out}" 2>&1 && grep -q SUCCESS "${test/.elf/.out}"
+        then
+            green "OCaml-32 $(basename $test)" "ok"
+        else
+            red "OCaml-32 $(basename $test)" "fail"
+        fi
+    done
+    finish_suite "32-bit RISCV OCaml tests"
+fi
 
 
 if ARCH=RV32 make c_emulator/riscv_sim_RV32;
@@ -102,30 +105,32 @@ make clean
 
 printf "Building 64-bit RISCV specification...\n"
 
-if make ocaml_emulator/riscv_ocaml_sim_RV64 ;
-then
-    green "Building 64-bit RISCV OCaml emulator" "ok"
-else
-    red "Building 64-bit RISCV OCaml emulator" "fail"
-fi
-for test in $DIR/riscv-tests/rv64*.elf; do
-    # skip F/D tests on OCaml for now
-    pat='rv64ud-.+elf'
-    if [[ $(basename $test) =~ $pat ]];
-    then continue
-    fi
-    pat='rv64uf-.+elf'
-    if [[ $(basename $test) =~ $pat ]];
-    then continue
-    fi
-    if $RISCVDIR/ocaml_emulator/riscv_ocaml_sim_RV64 "$test" >"${test/.elf/.out}" 2>&1 && grep -q SUCCESS "${test/.elf/.out}"
+if [ -n "$TEST_OCAML" ]; then
+    if make ocaml_emulator/riscv_ocaml_sim_RV64 ;
     then
-       green "OCaml-64 $(basename $test)" "ok"
+        green "Building 64-bit RISCV OCaml emulator" "ok"
     else
-       red "OCaml-64 $(basename $test)" "fail"
+        red "Building 64-bit RISCV OCaml emulator" "fail"
     fi
-done
-finish_suite "64-bit RISCV OCaml tests"
+    for test in $DIR/riscv-tests/rv64*.elf; do
+        # skip F/D tests on OCaml for now
+        pat='rv64ud-.+elf'
+        if [[ $(basename $test) =~ $pat ]];
+        then continue
+        fi
+        pat='rv64uf-.+elf'
+        if [[ $(basename $test) =~ $pat ]];
+        then continue
+        fi
+        if $RISCVDIR/ocaml_emulator/riscv_ocaml_sim_RV64 "$test" >"${test/.elf/.out}" 2>&1 && grep -q SUCCESS "${test/.elf/.out}"
+        then
+            green "OCaml-64 $(basename $test)" "ok"
+        else
+            red "OCaml-64 $(basename $test)" "fail"
+        fi
+    done
+    finish_suite "64-bit RISCV OCaml tests"
+fi
 
 if make c_emulator/riscv_sim_RV64;
 then


### PR DESCRIPTION
Changes the Makefile so it has a `default` target that just builds the C simulator. Previously running `make` ran `make all` which would try to build targets for Isabelle/HOL4/Coq, which probably isn't useful for most users. Furthermore, these targets all try to produce more usable definitions for users of these tools by avoiding doing things like renaming and name-mangling, but this can sometimes make them slightly brittle when underlying libraries change.

Adding a simpler default target for what is most likely the common use case should provide a better experience.

In addition, I have adjusted the run_test script so it only uses the OCaml emulator if `TEST_OCAML` is set. In addition to matching the default Makefile behavior, this is also because the generated OCaml we produce hits some bad performance issues with certain versions of OCaml. I also want to improve the OCaml generation in some other ways, and not having it be the default should give me some more flexibility to do so.