### PR TITLE
Fix issue with trace_log in printf

### DIFF
--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -1047,7 +1047,7 @@ void init_logs()
   if (trace_log_path == NULL) {
     trace_log = stdout;
   } else if ((trace_log = fopen(trace_log_path, "w+")) < 0) {
-    fprintf(stderr, "Cannot create trace log '%s': %s\n", trace_log,
+    fprintf(stderr, "Cannot create trace log '%s': %s\n", trace_log_path,
             strerror(errno));
     exit(1);
   }


### PR DESCRIPTION
Currently when fopen fails, the code attempts to print trace_log, which has type `FILE *`. I think it intends to print the path instead. Fixes the clang warning:
```
c_emulator/riscv_sim.c:1050:48: warning: format ‘%s’ expects argument of type ‘char *’, but argument 3 has type ‘FILE *’ [-Wformat=]
 1050 |     fprintf(stderr, "Cannot create trace log '%s': %s\n", trace_log,
      |                                               ~^          ~~~~~~~~~
      |                                                |          |
      |                                                char *     FILE *
```