### PR TITLE
Make consistent operand names

### DIFF
--- a/model/riscv_insts_cext.sail
+++ b/model/riscv_insts_cext.sail
@@ -529,8 +529,8 @@ function clause execute (C_SWSP(uimm, rs2)) = {
   execute(STORE(imm, rs2, sp, WORD, false, false))
 }
 
-mapping clause assembly = C_SWSP(uimm, rd)
-  <-> "c.swsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm)
+mapping clause assembly = C_SWSP(uimm, rs2)
+  <-> "c.swsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm)
 
 /* ****************************************************************** */
 union clause ast = C_SDSP : (bits(6), regidx)

--- a/model/riscv_insts_cfext.sail
+++ b/model/riscv_insts_cfext.sail
@@ -106,9 +106,9 @@ function clause execute (C_FSWSP(uimm, rs2)) = {
   execute(STORE_FP(imm, rs2, sp, WORD))
 }
 
-mapping clause assembly = C_FSWSP(uimm, rd)
+mapping clause assembly = C_FSWSP(uimm, rs2)
       if sizeof(xlen) == 32
-  <-> "c.fswsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm)
+  <-> "c.fswsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm)
       if sizeof(xlen) == 32
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zkn.sail
+++ b/model/riscv_insts_zkn.sail
@@ -328,8 +328,8 @@ mapping clause encdec = AES64DSM (rs2, rs1, rd) if haveZknd() & sizeof(xlen) == 
 mapping clause encdec = AES64DS (rs2, rs1, rd) if haveZknd() & sizeof(xlen) == 64
   <-> 0b00 @ 0b11101 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011
 
-mapping clause assembly = AES64KS1I (rcon, rs1, rd)
-  <-> "aes64ks1i" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_4(rcon)
+mapping clause assembly = AES64KS1I (rnum, rs1, rd)
+  <-> "aes64ks1i" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_4(rnum)
 
 mapping clause assembly = AES64KS2 (rs2, rs1, rd)
   <-> "aes64ks2" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)


### PR DESCRIPTION
There are a few places where operand/field names are not consistent across scattered definitions for an instruction.

Here, parameter `rs2` is used for encode/decode and execute, but `rd` is used for the same purpose in the assembly clause:
```
mapping clause encdec_compressed = C_SWSP(ui76 @ ui52, rs2)
  <-> 0b110 @ ui52 : bits(4) @ ui76 : bits(2) @ rs2 : regidx @ 0b10

function clause execute (C_SWSP(uimm, rs2)) = {
  let imm : bits(12) = zero_extend(uimm @ 0b00);
  execute(STORE(imm, rs2, sp, WORD, false, false))
}

mapping clause assembly = C_SWSP(uimm, rd)
  <-> "c.swsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm)
```

Fix these by using the operand names found in
"The RISC-V Instruction Set Manual, Volume I: Unprivileged ISA", document version 20191213, and "RISC-V Cryptography Extensions Volumn I: Scalar & Entropy Source Instructions", version v1.0.1.