### PR TITLE
Makefile: Set OPAMCLI to 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ else ifeq ($(ARCH),64)
   override ARCH := RV64
 endif
 
+# Set OPAMCLI to 2.0 to supress warnings about opam config var
+export OPAMCLI := 2.0
+
 ifeq ($(ARCH),RV32)
   SAIL_XLEN := riscv_xlen32.sail
 else ifeq ($(ARCH),RV64)


### PR DESCRIPTION
This removes the warning about `opam config var`. Setting OPAMCLI in this way is the correct thing to do if we want to continue supporting opam 2.0.

If we decide to require opam 2.1+ then all `opam var` invocations should become `opam --cli=2.1 var`, as per the opam CLI versioning spec:

https://github.com/ocaml/opam/wiki/Spec-for-opam-CLI-versioning