### PR TITLE
Add a Sail version check to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
+# Check the current Sail version
+SAIL_VERSION := $(shell etc/version_check.sh > /dev/null; echo $$?)
+ifeq ($(SAIL_VERSION),1)
+ifeq ($(SKIP_SAIL_VERSION_CHECK),)
+  $(info $(shell etc/version_check.sh))
+  $(error 'Sail version check failed. Set SKIP_SAIL_VERSION_CHECK=true to ignore.')
+endif
+endif
+
 # Select architecture: RV32 or RV64.
 ARCH ?= RV64
 

--- a/etc/version_check.sh
+++ b/etc/version_check.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+req_major="0"
+req_minor="17"
+req_patch="1"
+
+function check {
+    local version=$(sail -v | cut -d ' ' -f 2);
+
+    if [ "$?" -ne 0 ]; then
+        echo "Could not find Sail version: 'sail -v' command failed"
+        exit 1
+    fi
+
+    local message="Sail version must be at least ${req_major}.${req_minor}.${req_patch}, got ${version}"
+
+    local major=$(echo $version | cut -d '.' -f 1);
+    local minor=$(echo $version | cut -d '.' -f 2);
+    local patch=$(echo $version | cut -d '.' -f 3);
+
+    # Sail version string may be two digits without a patch version,
+    # in which case we treat it as zero.
+    if [ -z "$patch" ]; then
+        patch="0"
+    fi
+
+    if [ "$major" -lt "$req_major" ]; then
+        echo "${message}"
+        exit 1
+    elif [ "$major" -gt "$req_major" ]; then
+        exit 0
+    fi
+
+    if [ "$minor" -lt "$req_minor" ]; then
+        echo "${message}"
+        exit 1
+    elif [ "$minor" -gt "$req_minor" ]; then
+        exit 0
+    fi
+
+    if [ "$patch" -lt "$req_patch" ]; then
+        echo "${message}"
+        exit 1
+    fi
+
+    exit 0
+}
+
+check


### PR DESCRIPTION
In https://github.com/riscv/sail-riscv/issues/368#issuecomment-1846210592 it was suggested to add a Sail version check to prevent errors where some Makefile invocation fails mysteriously due to a too old version of Sail.

I'm not sure what the best way to do this is: Here I've added a small shell script and a check at the top of the Makefile.

There are some pathological cases where a Sail binary might not know its own version, which would be when it's built from source without either git or opam. I don't think this is likely to ever happen, but I've added an option to skip the version check by setting an environment variable.