### PR TITLE
CI: Update upload-artifact action to v4

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -22,13 +22,13 @@ jobs:
       run: eval $(opam env) && test/run_tests.sh
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tests.xml
         path: test/tests.xml
     - name: Upload event payload
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: event.json
         path: ${{ github.event_path }}


### PR DESCRIPTION
See https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/