### PR TITLE
Makefile: Make sure OPAMCLI is 2.0 in all subshells

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,14 +128,16 @@ export SAIL_DIR
 EXPLICIT_COQ_SAIL=yes
 else
 # Use sail from opam package
-SAIL_DIR:=$(shell opam config var sail:share)
+SAIL_DIR:=$(shell OPAMCLI=$(OPAMCLI) opam config var sail:share)
 SAIL:=sail
 endif
 SAIL_LIB_DIR:=$(SAIL_DIR)/lib
 export SAIL_LIB_DIR
 SAIL_SRC_DIR:=$(SAIL_DIR)/src
 
-LEM_DIR?=$(shell opam config var lem:share)
+ifndef LEM_DIR
+LEM_DIR:=$(shell OPAMCLI=$(OPAMCLI) opam config var lem:share)
+endif
 export LEM_DIR
 
 C_WARNINGS ?=
@@ -366,9 +368,9 @@ riscv_hol_build: generated_definitions/hol4/$(ARCH)/riscvTheory.uo
 .PHONY: riscv_hol riscv_hol_build
 
 ifdef BBV_DIR
-  EXPLICIT_COQ_BBV = yes
+  EXPLICIT_COQ_BBV := yes
 else
-  EXPLICIT_COQ_BBV = $(shell if opam config var coq-bbv:share >/dev/null 2>/dev/null; then echo no; else echo yes; fi)
+  EXPLICIT_COQ_BBV := $(shell if OPAMCLI=$(OPAMCLI) opam config var coq-bbv:share >/dev/null 2>/dev/null; then echo no; else echo yes; fi)
   ifeq ($(EXPLICIT_COQ_BBV),yes)
     #Coq BBV library hopefully checked out in directory above us
     BBV_DIR = ../bbv
@@ -376,7 +378,7 @@ else
 endif
 
 ifndef EXPLICIT_COQ_SAIL
-  EXPLICIT_COQ_SAIL = $(shell if opam config var coq-sail:share >/dev/null 2>/dev/null; then echo no; else echo yes; fi)
+  EXPLICIT_COQ_SAIL := $(shell if OPAMCLI=$(OPAMCLI) opam config var coq-sail:share >/dev/null 2>/dev/null; then echo no; else echo yes; fi)
 endif
 
 COQ_LIBS = -R generated_definitions/coq Riscv -R generated_definitions/coq/$(ARCH) $(ARCH) -R handwritten_support Riscv_common


### PR DESCRIPTION
Follow up to https://github.com/riscv/sail-riscv/pull/364 to make sure OPAMCLI is defined when it is used within the shell commands. Also implement Brian's suggestion that variables defined with opam should use `:=` to avoid calling opam each time the variable is expanded.
