### PR TITLE
Writable mtime 

### DIFF
--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -243,6 +243,24 @@ function clint_store(addr, width, data) = {
     mtimecmp = vector_update_subrange(mtimecmp, 63, 32, sail_zero_extend(data, 32)); /* FIXME: Redundant zero_extend currently required by Lem backend */
     clint_dispatch();
     MemValue(true)
+    } else if addr == MTIME_BASE & 'n == 8 then {
+    if   get_config_print_platform()
+    then print_platform("clint<8>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtime)");
+    mtime = zero_extend(data);
+    clint_dispatch();
+    MemValue(true)
+  } else if addr == MTIME_BASE & 'n == 4 then {
+    if   get_config_print_platform()
+    then print_platform("clint<4>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtime)");
+    mtime[31 .. 0] = zero_extend(data);
+    clint_dispatch();
+    MemValue(true)
+  } else if addr == MTIME_BASE_HI & 'n == 4 then {
+    if   get_config_print_platform()
+    then print_platform("clint<4>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtime)");
+    mtime[63 .. 32] = zero_extend(data);
+    clint_dispatch();
+    MemValue(true)
   } else {
     if   get_config_print_platform()
     then print_platform("clint[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (<unmapped>)");

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -246,19 +246,19 @@ function clint_store(addr, width, data) = {
     } else if addr == MTIME_BASE & 'n == 8 then {
     if   get_config_print_platform()
     then print_platform("clint<8>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtime)");
-    mtime = zero_extend(data);
+    mtime = data;
     clint_dispatch();
     MemValue(true)
   } else if addr == MTIME_BASE & 'n == 4 then {
     if   get_config_print_platform()
     then print_platform("clint<4>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtime)");
-    mtime[31 .. 0] = zero_extend(data);
+    mtime[31 .. 0] = data;
     clint_dispatch();
     MemValue(true)
   } else if addr == MTIME_BASE_HI & 'n == 4 then {
     if   get_config_print_platform()
     then print_platform("clint<4>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtime)");
-    mtime[63 .. 32] = zero_extend(data);
+    mtime[63 .. 32] = data;
     clint_dispatch();
     MemValue(true)
   } else {

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -243,7 +243,7 @@ function clint_store(addr, width, data) = {
     mtimecmp = vector_update_subrange(mtimecmp, 63, 32, sail_zero_extend(data, 32)); /* FIXME: Redundant zero_extend currently required by Lem backend */
     clint_dispatch();
     MemValue(true)
-    } else if addr == MTIME_BASE & 'n == 8 then {
+  } else if addr == MTIME_BASE & 'n == 8 then {
     if   get_config_print_platform()
     then print_platform("clint<8>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtime)");
     mtime = data;


### PR DESCRIPTION
According to the priv. spec. `mtime` should be readable & writable:

> Platforms provide a real-time counter, exposed as a memory-mapped machine-mode read-write register, `mtime`.

However, the model currently does not allow writes to `mtime`. This pull requests modifies `clint_store` in order to support writes to the `mtime` memory-mapped register.