### PR TITLE
Add missing PTE checks

### DIFF
--- a/model/riscv_pte.sail
+++ b/model/riscv_pte.sail
@@ -106,7 +106,10 @@ function isPTEPtr(p : pteAttribs, ext : extPte) -> bool = {
 
 function isInvalidPTE(p : pteAttribs, ext : extPte) -> bool = {
   let a = Mk_PTE_Bits(p);
-  a.V() == 0b0 | (a.W() == 0b1 & a.R() == 0b0)
+  a.V() == 0b0                  |
+  (a.W() == 0b1 & a.R() == 0b0) |
+  (ext != 0b0000000000)         |
+  (isPTEPtr(p, ext) & (a.D() == 0b1 | a.A() == 0b1 | a.U() == 0b1))
 }
 
 union PTE_Check = {


### PR DESCRIPTION
The PTE checking in the sail model is missing part of the following rule that requires raising a page fault if reserved bits are set:
> If pte.v = 0, or if pte.r = 0 and pte.w = 1, or if any bits or encodings that are reserved for future standard use are set within pte, stop and raise a page-fault exception corresponding to the original access type

- The bits 63:54 are reserved for future standard extensions. The bit 63 is defined by Svnapot and bits 62:61 by Svpbmt - but both these extensions are not in the model presently. 
- For non-leaf PTEs, the D, A, and U bits are reserved for future standard use.

All tests pass.