### PR TITLE
Add missing mstatus.MPP legalization

### DIFF
--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -561,6 +561,7 @@ function init_sys() -> unit = {
   mstatus = set_mstatus_SXL(mstatus, misa[MXL]);
   mstatus = set_mstatus_UXL(mstatus, misa[MXL]);
   mstatus[SD]   = 0b0;
+  mstatus[MPP] = privLevel_to_bits(lowest_supported_privLevel());
 
   /* set to little-endian mode */
   if sizeof(xlen) == 64 then {

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -222,6 +222,21 @@ function haveZmmul()  -> bool = true
 /* Zicond extension support */
 function haveZicond() -> bool = true
 
+/*
+ * Illegal values legalized to least privileged mode supported.
+ * Note: the only valid combinations of supported modes are M, M+U, M+S+U.
+ */
+function lowest_supported_privLevel() -> Privilege =
+  if haveUsrMode() then User else Machine
+
+function have_privLevel(priv : priv_level) -> bool =
+  match priv {
+    0b00 => haveUsrMode(),
+    0b01 => haveSupMode(),
+    0b10 => false,
+    0b11 => true,
+  }
+
 bitfield Mstatush : bits(32) = {
   MBE  : 5,
   SBE  : 4
@@ -308,6 +323,10 @@ function legalize_mstatus(o : Mstatus, v : xlenbits) -> Mstatus = {
    * explicitly later.
    */
   let m : Mstatus = Mk_Mstatus(zero_extend(v[22 .. 7] @ 0b0 @ v[5 .. 3] @ 0b0 @ v[1 .. 0]));
+
+  /* Legalize MPP */
+  let m = [m with MPP = if have_privLevel(m[MPP]) then m[MPP]
+                        else privLevel_to_bits(lowest_supported_privLevel())];
 
   /* We don't have any extension context yet. */
   let m = [m with XS = extStatus_to_bits(Off)];


### PR DESCRIPTION
`mstatus.MPP` legal values are User (`00) (if U-mode implemented), Supervisor (`01) (if S-mode implemented) and Machine (`11). Encoding `10 is illegal. 