### PR TITLE
Add read-only CSR MCONFIGPTR

### DIFF
--- a/model/riscv_csr_map.sail
+++ b/model/riscv_csr_map.sail
@@ -58,6 +58,7 @@ mapping clause csr_name_map = 0xF11  <-> "mvendorid"
 mapping clause csr_name_map = 0xF12  <-> "marchid"
 mapping clause csr_name_map = 0xF13  <-> "mimpid"
 mapping clause csr_name_map = 0xF14  <-> "mhartid"
+mapping clause csr_name_map = 0xF15  <-> "mconfigptr"
 /* machine trap setup */
 mapping clause csr_name_map = 0x300  <-> "mstatus"
 mapping clause csr_name_map = 0x301  <-> "misa"

--- a/model/riscv_insts_zicsr.sail
+++ b/model/riscv_insts_zicsr.sail
@@ -29,6 +29,7 @@ function readCSR csr : csreg -> xlenbits = {
     (0xF12,  _) => marchid,
     (0xF13,  _) => mimpid,
     (0xF14,  _) => mhartid,
+    (0xF15,  _) => mconfigptr,
     (0x300,  _) => mstatus.bits,
     (0x301,  _) => misa.bits,
     (0x302,  _) => medeleg.bits,

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -21,6 +21,7 @@ function is_CSR_defined (csr : csreg, p : Privilege) -> bool =
     0xf12 => p == Machine, // marchdid
     0xf13 => p == Machine, // mimpid
     0xf14 => p == Machine, // mhartid
+    0xf15 => p == Machine, // mconfigptr
     /* machine mode: trap setup */
     0x300 => p == Machine, // mstatus
     0x301 => p == Machine, // misa
@@ -477,6 +478,7 @@ function init_sys() -> unit = {
   cur_privilege = Machine;
 
   mhartid     = zero_extend(0b0);
+  mconfigptr  = zero_extend(0b0);
 
   misa[MXL] = arch_to_bits(if sizeof(xlen) == 32 then RV32 else RV64);
   misa[A]   = 0b1;                             /* atomics */

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -510,6 +510,7 @@ register mimpid : xlenbits
 register marchid : xlenbits
 /* TODO: this should be readonly, and always 0 for now */
 register mhartid : xlenbits
+register mconfigptr : xlenbits
 
 /* S-mode registers */
 


### PR DESCRIPTION
This PR is a rebased version of: https://github.com/riscv/sail-riscv/pull/293

Original description:

CSR MCONFIGPTR is defined in RISCV priv spec 1.12 but is missing from the RISC-V SAIL model. This commit adds the read-only CSR MCONFIGPTR.