### PR TITLE
Correct fcvtmod.w.d flag generation logic for exp == 31

### DIFF
--- a/model/riscv_insts_zfa.sail
+++ b/model/riscv_insts_zfa.sail
@@ -747,7 +747,8 @@ function fcvtmod_helper(x64) = {
     /* Raise FP exception flags, honoring the precedence of nV > nX */
     let max_integer = if sign == 0b1 then unsigned(0x80000000)
                                      else unsigned(0x7fffffff);
-    let flags : bits(5) = if (true_exp > 31 | unsigned(integer) > max_integer) then nvFlag()
+    let flags : bits(5) = if true_exp > 31 then nvFlag()
+                     else if unsigned(integer) > max_integer then nvFlag()
                      else if (fractional != zeros()) then nxFlag()
                      else                            zeros();
 

--- a/model/riscv_insts_zfa.sail
+++ b/model/riscv_insts_zfa.sail
@@ -745,7 +745,9 @@ function fcvtmod_helper(x64) = {
                                 else integer;
 
     /* Raise FP exception flags, honoring the precedence of nV > nX */
-    let flags : bits(5) = if (true_exp > 31)         then nvFlag()
+    let max_integer = if sign == 0b1 then unsigned(0x80000000)
+                                     else unsigned(0x7fffffff);
+    let flags : bits(5) = if (true_exp > 31 | unsigned(integer) > max_integer) then nvFlag()
                      else if (fractional != zeros()) then nxFlag()
                      else                            zeros();
 


### PR DESCRIPTION
Fixes #388 and fixes #268. fcvtmod.w.d is producing an inexact instead of invalid flag for numbers with an exponent of 31 that are not representable as a two's complement integer (> 2^31 - 1 or < -2^31).

Per #388, 

> According to the Zfa specification, "Floating-point exception flags are raised the same as they would be for FCVT.W.D with the same input operand." According to the unprivileged specification Table 11.4, the invalid exception should be set for inputs > 2^31 - 1 or < -2^31.

This is resolved by adding an additional check when determining the invalid flag for if the integer is > 2^31 - 1 or < -2^31. A similar approach is currently used by Spike.