### PR TITLE
Add PMP related stubs for Lem to Isabelle build

### DIFF
--- a/handwritten_support/riscv_extras.lem
+++ b/handwritten_support/riscv_extras.lem
@@ -169,6 +169,14 @@ val sys_enable_writable_fiom : unit -> bool
 let sys_enable_writable_fiom () = true
 declare ocaml target_rep function sys_enable_writable_fiom = `Platform.enable_writable_fiom`
 
+val sys_pmp_grain : unit -> integer
+let sys_pmp_grain () = 0
+declare ocaml target_rep function sys_pmp_grain = `Platform.sys_pmp_grain`
+
+val sys_pmp_count : unit -> integer
+let sys_pmp_count () = 0
+declare ocaml target_rep function sys_pmp_count = `Platform.sys_pmp_count`
+
 val plat_ram_base : unit -> bitvector
 let plat_ram_base () = []
 declare ocaml target_rep function plat_ram_base = `Platform.dram_base`


### PR DESCRIPTION
These stub functions are required for building the Riscv.thy file from the generated lem file.

This is required as part of fixing https://github.com/riscv/sail-riscv/issues/399
