### PR TITLE
Add missing check for RV64 on float conversion instructions

### DIFF
--- a/model/riscv_insts_dext.sail
+++ b/model/riscv_insts_dext.sail
@@ -902,11 +902,11 @@ mapping clause encdec = F_UN_TYPE_D(rs1, rd, FCLASS_D)                        if
 
 /* D instructions, RV64 only */
 
-mapping clause encdec = F_UN_TYPE_D(rs1, rd, FMV_X_D)                         if haveDExt()
-                    <-> 0b111_0001 @ 0b00000 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveDExt()
+mapping clause encdec = F_UN_TYPE_D(rs1, rd, FMV_X_D)                         if haveDExt() & sizeof(xlen) >= 64
+                    <-> 0b111_0001 @ 0b00000 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveDExt() & sizeof(xlen) >= 64
 
-mapping clause encdec = F_UN_TYPE_D(rs1, rd, FMV_D_X)                         if haveDExt()
-                    <-> 0b111_1001 @ 0b00000 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveDExt()
+mapping clause encdec = F_UN_TYPE_D(rs1, rd, FMV_D_X)                         if haveDExt() & sizeof(xlen) >= 64
+                    <-> 0b111_1001 @ 0b00000 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveDExt() & sizeof(xlen) >= 64
 
 /* Execution semantics ================================ */
 


### PR DESCRIPTION
These two instructions are RV64-only, as noted in the comment, but were missing the check. There are other instructions in this file that did have the check so it was just an omission.