### PR TITLE
Remove trailing whitespace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ engineer-friendly language, much like earlier vendor pseudocode, but more precis
 <p>
 
 Given a Sail specification, the tool can type-check it, generate documentation snippets (in LaTeX or AsciiDoc), generate executable emulators (in C or OCaml), show specification coverage, generate versions of the ISA for relaxed memory model tools, support automated instruction-sequence test generation, generate  theorem-prover definitions for
-interactive proof (in Isabelle, HOL4, and Coq), support proof about binary code (in Islaris), and (in progress) generate a reference ISA model in SystemVerilog that can be used for formal hardware verification. 
+interactive proof (in Isabelle, HOL4, and Coq), support proof about binary code (in Islaris), and (in progress) generate a reference ISA model in SystemVerilog that can be used for formal hardware verification.
 <p>
 
   <img width="800" src="https://www.cl.cam.ac.uk/~pes20/sail/overview-sail.png?">


### PR DESCRIPTION
The pre-commit check is strict about this, and even checks non code files such as the README.

This is a one character change that only affects the README, so if this PR makes the CI go green again I will just merge.