### PR TITLE
Remove theorem prover targets from default Makefile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ RISCV_EXTRAS_LEM = $(addprefix handwritten_support/,$(RISCV_EXTRAS_LEM_FILES))
 
 .PHONY:
 
-all: ocaml_emulator/riscv_ocaml_sim_$(ARCH) c_emulator/riscv_sim_$(ARCH) riscv_isa riscv_coq riscv_hol riscv_rmem
+all: ocaml_emulator/riscv_ocaml_sim_$(ARCH) c_emulator/riscv_sim_$(ARCH)
 .PHONY: all
 
 # the following ensures empty sail-generated .c files don't hang around and


### PR DESCRIPTION
In general we aren't requiring contributors to implement the correct Lem/Isabelle/HOL4/Coq stubs for new extensions (this would almost certainly be way too high a bar for new contributors anyway) so having these in the default set of build targets just means that typing 'make' is broken until those of us who are invested in maintaining those targets can add updates for those stubs.