### PR TITLE
Remove effect annotation in vext_vset

### DIFF
--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -41,7 +41,7 @@ mapping maybe_ma_flag : string <-> bits(1) = {
   sep() ^ "mu" <-> 0b0
 }
 
-val handle_illegal_vtype : unit -> unit effect {rreg}
+val handle_illegal_vtype : unit -> unit
 function handle_illegal_vtype() = {
   /* Note: Implementations can set vill or trap if the vtype setting is not supported.
    * TODO: configuration support for both solutions


### PR DESCRIPTION
This removes the effect annotation introduced in PR #359 to eliminate the warning when building the model, as effects are no longer used.