### PR TITLE
Remove unused (f)reg_name_abi functions

### DIFF
--- a/model/riscv_fdext_regs.sail
+++ b/model/riscv_fdext_regs.sail
@@ -327,47 +327,6 @@ overload F_or_X_H = { rF_or_X_H, wF_or_X_H }
 overload F_or_X_S = { rF_or_X_S, wF_or_X_S }
 overload F_or_X_D = { rF_or_X_D, wF_or_X_D }
 
-/* register names */
-
-val freg_name_abi : regidx <-> string
-
-mapping freg_name_abi = {
-    0b00000 <-> "ft0",
-    0b00001 <-> "ft1",
-    0b00010 <-> "ft2",
-    0b00011 <-> "ft3",
-    0b00100 <-> "ft4",
-    0b00101 <-> "ft5",
-    0b00110 <-> "ft6",
-    0b00111 <-> "ft7",
-    0b01000 <-> "fs0",
-    0b01001 <-> "fs1",
-    0b01010 <-> "fa0",
-    0b01011 <-> "fa1",
-    0b01100 <-> "fa2",
-    0b01101 <-> "fa3",
-    0b01110 <-> "fa4",
-    0b01111 <-> "fa5",
-    0b10000 <-> "fa6",
-    0b10001 <-> "fa7",
-    0b10010 <-> "fs2",
-    0b10011 <-> "fs3",
-    0b10100 <-> "fs4",
-    0b10101 <-> "fs5",
-    0b10110 <-> "fs6",
-    0b10111 <-> "fs7",
-    0b11000 <-> "fs8",
-    0b11001 <-> "fs9",
-    0b11010 <-> "fs10",
-    0b11011 <-> "fs11",
-    0b11100 <-> "ft8",
-    0b11101 <-> "ft9",
-    0b11110 <-> "ft10",
-    0b11111 <-> "ft11"
-}
-
-overload to_str = {freg_name_abi}
-
 /* mappings for assembly */
 
 val freg_name : bits(5) <-> string

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -154,49 +154,6 @@ function wX_bits(i: bits(5), data: xlenbits) -> unit = {
 
 overload X = {rX_bits, wX_bits, rX, wX}
 
-/* register names */
-
-val reg_name_abi : regidx -> string
-
-function reg_name_abi(r) = {
-  match (r) {
-    0b00000 => "zero",
-    0b00001 => "ra",
-    0b00010 => "sp",
-    0b00011 => "gp",
-    0b00100 => "tp",
-    0b00101 => "t0",
-    0b00110 => "t1",
-    0b00111 => "t2",
-    0b01000 => "fp",
-    0b01001 => "s1",
-    0b01010 => "a0",
-    0b01011 => "a1",
-    0b01100 => "a2",
-    0b01101 => "a3",
-    0b01110 => "a4",
-    0b01111 => "a5",
-    0b10000 => "a6",
-    0b10001 => "a7",
-    0b10010 => "s2",
-    0b10011 => "s3",
-    0b10100 => "s4",
-    0b10101 => "s5",
-    0b10110 => "s6",
-    0b10111 => "s7",
-    0b11000 => "s8",
-    0b11001 => "s9",
-    0b11010 => "s10",
-    0b11011 => "s11",
-    0b11100 => "t3",
-    0b11101 => "t4",
-    0b11110 => "t5",
-    0b11111 => "t6"
-  }
-}
-
-overload to_str = {reg_name_abi}
-
 /* mappings for assembly */
 
 val reg_name : bits(5) <-> string


### PR DESCRIPTION
There seem to be duplicate functions right now for reg and freg names, (f)reg_name_abi and (f)reg_name. These mappings are the same and only (f)reg_name is used, so remove the unused ones.