### PR TITLE
Sail Crosscheck Testing with ACT Against Spike

### DIFF
--- a/.github/workflows/apt-packages.txt
+++ b/.github/workflows/apt-packages.txt
@@ -1,0 +1,8 @@
+opam
+zlib1g-dev
+pkg-config
+libgmp-dev
+z3
+device-tree-compiler
+build-essential
+python3-setuptools

--- a/.github/workflows/arch-tests.yml
+++ b/.github/workflows/arch-tests.yml
@@ -1,0 +1,84 @@
+name: arch-test
+
+on:
+    push:
+      branches:
+        - master
+    pull_request:
+      branches:
+        - master
+
+jobs:
+    model-testing:
+        runs-on: ubuntu-latest
+
+        steps:
+        - uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+
+        - name: Install Dependencies
+          run: |
+            sudo xargs apt-get install -y < .github/workflows/apt-packages.txt
+            pip3 install git+https://github.com/riscv/riscof.git
+            wget -c https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/2024.04.12/riscv64-elf-ubuntu-22.04-gcc-nightly-2024.04.12-nightly.tar.gz
+            tar -xzf riscv64-elf-ubuntu-22.04-gcc-nightly-2024.04.12-nightly.tar.gz
+            echo $GITHUB_WORKSPACE/riscv/bin >> $GITHUB_PATH
+
+        - name: Build spike
+          run: |
+            ci-tests/build-spike
+            echo $GITHUB_WORKSPACE/install/bin >> $GITHUB_PATH
+
+        - name: Build Sail
+          run: |
+            ci-tests/build-sail
+            echo $GITHUB_WORKSPACE/c_emulator >> $GITHUB_PATH
+
+        - name: Init arch-tests
+          run: |
+            cd ci-tests/riscof
+            git clone https://github.com/riscv-non-isa/riscv-arch-test
+            cd riscv-arch-test && git fetch --tags && git checkout tags/3.8.10
+
+        - name: Run RV32E
+          run: |
+            cd ci-tests/riscof
+            sed -i 's/\(ispec=\)\(.*\)/\1spike\/spike_isa32e.yaml/' config.ini
+            ./run-tests.sh rv32e_work
+
+        - name: Upload Artifacts
+          uses: actions/upload-artifact@v3
+          with:
+            name: artifacts_rv32e
+            path: |
+              ci-tests/riscof/rv32e_work/report.html
+              ci-tests/riscof/rv32e_work/style.css
+
+        - name: Run RV32I
+          run: |
+            cd ci-tests/riscof
+            sed -i 's/\(ispec=\)\(.*\)/\1spike\/spike_isa32.yaml/' config.ini
+            ./run-tests.sh rv32i_work
+
+        - name: Upload Artifacts
+          uses: actions/upload-artifact@v3
+          with:
+            name: artifacts_rv32i
+            path: |
+              ci-tests/riscof/rv32i_work/report.html
+              ci-tests/riscof/rv32i_work/style.css
+
+        - name: Run RV64I
+          run: |
+            cd ci-tests/riscof
+            sed -i 's/\(ispec=\)\(.*\)/\1spike\/spike_isa64.yaml/' config.ini
+            ./run-tests.sh rv64i_work
+
+        - name: Upload Artifacts
+          uses: actions/upload-artifact@v3
+          with:
+            name: artifacts_rv64i
+            path: |
+              ci-tests/riscof/rv64i_work/report.html
+              ci-tests/riscof/rv64i_work/style.css

--- a/build_simulators.sh
+++ b/build_simulators.sh
@@ -10,8 +10,8 @@ function test_build () {
     fi
 }
 
-test_build make ARCH=RV32 ocaml_emulator/riscv_ocaml_sim_RV32
-test_build make ARCH=RV64 ocaml_emulator/riscv_ocaml_sim_RV64
+test_build make -j"$(nproc 2> /dev/null || sysctl -n hw.ncpu)" ARCH=RV32 ocaml_emulator/riscv_ocaml_sim_RV32
+test_build make -j"$(nproc 2> /dev/null || sysctl -n hw.ncpu)" ARCH=RV64 ocaml_emulator/riscv_ocaml_sim_RV64
 
-test_build make ARCH=RV32 c_emulator/riscv_sim_RV32
-test_build make ARCH=RV64 c_emulator/riscv_sim_RV64
+test_build make -j"$(nproc 2> /dev/null || sysctl -n hw.ncpu)" ARCH=RV32 c_emulator/riscv_sim_RV32
+test_build make -j"$(nproc 2> /dev/null || sysctl -n hw.ncpu)" ARCH=RV64 c_emulator/riscv_sim_RV64

--- a/ci-tests/build-sail
+++ b/ci-tests/build-sail
@@ -1,0 +1,8 @@
+# !bin/bash
+
+set -e
+
+opam init --disable-sandboxing -y
+eval $(opam config env)
+opam install -y sail
+./build_simulators.sh

--- a/ci-tests/build-spike
+++ b/ci-tests/build-spike
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+rm -rf riscv-isa-sim install
+mkdir install
+git clone https://github.com/riscv-software-src/riscv-isa-sim
+cd riscv-isa-sim
+mkdir build && cd build
+CXXFLAGS="-Wnon-virtual-dtor" CFLAGS="-Werror -Wignored-qualifiers -Wunused-function -Wunused-parameter -Wunused-variable" ../configure --prefix=`pwd`/../../install
+make -j"$(nproc 2> /dev/null || sysctl -n hw.ncpu)"
+make check
+make install

--- a/ci-tests/riscof/config.ini
+++ b/ci-tests/riscof/config.ini
@@ -1,0 +1,14 @@
+[RISCOF]
+ReferencePlugin=sail_cSim
+ReferencePluginPath=sail_cSim
+DUTPlugin=spike
+DUTPluginPath=spike
+
+[spike]
+pluginpath=spike
+ispec=spike/spike_isa32.yaml
+pspec=spike/spike_platform.yaml
+target_run=1
+
+[sail_cSim]
+pluginpath=sail_cSim

--- a/ci-tests/riscof/run-tests.sh
+++ b/ci-tests/riscof/run-tests.sh
@@ -1,0 +1,23 @@
+# !bin/bash
+
+set -e
+
+# Check if argument (work directory name) provided
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <argument>"
+    exit 1
+fi
+
+riscof -v debug run --config=config.ini \
+           --suite=riscv-arch-test/riscv-test-suite/ \
+           --env=riscv-arch-test/riscv-test-suite/env \
+           --no-browser --work-dir "$1"
+
+if grep -rniq "$1"/report.html -e '>0failed<'
+then
+    echo "Test successful!"
+    exit 0
+else
+    echo "Test FAILED!"
+    exit 1
+fi

--- a/ci-tests/riscof/sail_cSim/env/link.ld
+++ b/ci-tests/riscof/sail_cSim/env/link.ld
@@ -1,0 +1,17 @@
+OUTPUT_ARCH( "riscv" )
+ENTRY(rvtest_entry_point)
+
+SECTIONS
+{
+  . = 0x80000000;
+  .text.init : { *(.text.init) }
+  . = ALIGN(0x1000);
+  .tohost : { *(.tohost) }
+  . = ALIGN(0x1000);
+  .text : { *(.text) }
+  . = ALIGN(0x1000);
+  .data : { *(.data) }
+  .data.string : { *(.data.string)}
+  .bss : { *(.bss) }
+  _end = .;
+}

--- a/ci-tests/riscof/sail_cSim/env/model_test.h
+++ b/ci-tests/riscof/sail_cSim/env/model_test.h
@@ -1,0 +1,33 @@
+#ifndef _COMPLIANCE_MODEL_H
+#define _COMPLIANCE_MODEL_H
+
+#define RVMODEL_HALT                                                           \
+  li x1, 1;                                                                    \
+  write_tohost:                                                                \
+  sw x1, tohost, x3;                                                           \
+  j write_tohost;
+
+#define RVMODEL_BOOT
+
+#define RVMODEL_DATA_BEGIN                                                     \
+  RVMODEL_DATA_SECTION.align 4;                                                \
+  .global begin_signature;                                                     \
+  begin_signature:
+
+#define RVMODEL_DATA_END                                                       \
+  .align 4;                                                                    \
+  .global end_signature;                                                       \
+  end_signature:
+
+#define RVMODEL_IO_INIT
+#define RVMODEL_IO_WRITE_STR(_R, _STR)
+#define RVMODEL_IO_CHECK()
+#define RVMODEL_IO_ASSERT_GPR_EQ(_S, _R, _I)
+#define RVMODEL_IO_ASSERT_SFPR_EQ(_F, _R, _I)
+#define RVMODEL_IO_ASSERT_DFPR_EQ(_D, _R, _I)
+#define RVMODEL_SET_MSW_INT
+#define RVMODEL_CLEAR_MSW_INT
+#define RVMODEL_CLEAR_MTIMER_INT
+#define RVMODEL_CLEAR_MEXT_INT
+
+#endif

--- a/ci-tests/riscof/sail_cSim/riscof_sail_cSim.py
+++ b/ci-tests/riscof/sail_cSim/riscof_sail_cSim.py
@@ -1,0 +1,146 @@
+import os
+import re
+import shutil
+import subprocess
+import shlex
+import logging
+import random
+import string
+from string import Template
+
+import riscof.utils as utils
+from riscof.pluginTemplate import pluginTemplate
+import riscof.constants as constants
+from riscv_isac.isac import isac
+
+logger = logging.getLogger()
+
+class sail_cSim(pluginTemplate):
+    __model__ = "sail_c_simulator"
+    __version__ = "0.5.0"
+
+    def __init__(self, *args, **kwargs):
+        sclass = super().__init__(*args, **kwargs)
+
+        config = kwargs.get('config')
+        if config is None:
+            logger.error("Config node for sail_cSim missing.")
+            raise SystemExit(1)
+        self.num_jobs = str(config['jobs'] if 'jobs' in config else 1)
+        self.pluginpath = os.path.abspath(config['pluginpath'])
+        self.sail_exe = { '32' : os.path.join(config['PATH'] if 'PATH' in config else "","riscv_sim_RV32"),
+                '64' : os.path.join(config['PATH'] if 'PATH' in config else "","riscv_sim_RV64")}
+        self.isa_spec = os.path.abspath(config['ispec']) if 'ispec' in config else ''
+        self.platform_spec = os.path.abspath(config['pspec']) if 'ispec' in config else ''
+        self.make = config['make'] if 'make' in config else 'make'
+        logger.debug("SAIL CSim plugin initialised using the following configuration.")
+        for entry in config:
+            logger.debug(entry+' : '+config[entry])
+        return sclass
+
+    def initialise(self, suite, work_dir, archtest_env):
+        self.suite = suite
+        self.work_dir = work_dir
+        self.objdump_cmd = 'riscv64-unknown-elf-objdump -D {0} > {1};'
+        # self.archtest_env = archtest_env.replace("riscv-arch-test", "../my-repo/riscv-arch-test")
+        self.compile_cmd = 'riscv64-unknown-elf-gcc -march={0} \
+         -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles\
+         -T '+self.pluginpath+'/env/link.ld\
+         -I '+self.pluginpath+'/env/\
+         -I ' + archtest_env
+
+        # workaround to avoid clang format error in sail-riscv CI.
+        # *clang suggest style that is syntactically incorrect*
+        # Insert the following macro at run-time.
+        modelTest_path = 'sail_cSim/env/model_test.h'
+        macro = """
+#define RVMODEL_DATA_SECTION .pushsection                                      \\
+  .tohost, "aw", @progbits;                                                    \\
+  .align 8;                                                                    \\
+  .global tohost;                                                              \\
+  tohost:                                                                      \\
+  .dword 0;                                                                    \\
+  .align 8;                                                                    \\
+  .global fromhost;                                                            \\
+  fromhost:                                                                    \\
+  .dword 0;                                                                    \\
+  .popsection;                                                                 \\
+  .align 8;                                                                    \\
+  .global begin_regstate;                                                      \\
+  begin_regstate:                                                              \\
+  .word 128;                                                                   \\
+  .align 8;                                                                    \\
+  .global end_regstate;                                                        \\
+  end_regstate:                                                                \\
+  .word 4;
+"""
+        with open(modelTest_path, 'r') as file:
+            modelTest = file.readlines()
+        modelTest.insert(2, macro)
+        with open(modelTest_path, 'w') as file:
+            file.writelines(modelTest)
+
+    def build(self, isa_yaml, platform_yaml):
+        ispec = utils.load_yaml(isa_yaml)['hart0']
+        self.xlen = ('64' if 64 in ispec['supported_xlen'] else '32')
+        self.isa = ' '  # 'rv' + self.xlen
+        ilp32 = 'ilp32e ' if "E" in ispec["ISA"] else 'ilp32 '
+        self.compile_cmd = self.compile_cmd+' -mabi='+('lp64 ' if 64 in ispec['supported_xlen'] else ilp32)
+        # if "I" in ispec["ISA"]:
+        #     self.isa += 'i'
+        # if "M" in ispec["ISA"]:
+        #     self.isa += 'm'
+        # if "C" in ispec["ISA"]:
+        #     self.isa += 'c'
+        # if "F" in ispec["ISA"]:
+        #     self.isa += 'f'
+        # if "D" in ispec["ISA"]:
+        #     self.isa += 'd'
+
+        # flag for sail-riscv to enable zcb extension.
+        # sail model does not yet offer flags for other extensions, supported extensions are enabled by default
+        if "Zcb" in ispec["ISA"]:
+            self.isa += ' --enable-zcb'
+
+        objdump = "riscv64-unknown-elf-objdump"
+        if shutil.which(objdump) is None:
+            logger.error(objdump+": executable not found. Please check environment setup.")
+            raise SystemExit(1)
+        compiler = "riscv64-unknown-elf-gcc"
+        if shutil.which(compiler) is None:
+            logger.error(compiler+": executable not found. Please check environment setup.")
+            raise SystemExit(1)
+        if shutil.which(self.sail_exe[self.xlen]) is None:
+            logger.error(self.sail_exe[self.xlen]+ ": executable not found. Please check environment setup.")
+            raise SystemExit(1)
+        if shutil.which(self.make) is None:
+            logger.error(self.make+": executable not found. Please check environment setup.")
+            raise SystemExit(1)
+
+    def runTests(self, testList, cgf_file=None):
+        if os.path.exists(self.work_dir+ "/Makefile." + self.name[:-1]):
+            os.remove(self.work_dir+ "/Makefile." + self.name[:-1])
+        make = utils.makeUtil(makefilePath=os.path.join(self.work_dir, "Makefile." + self.name[:-1]))
+        make.makeCommand = self.make + ' -j' + self.num_jobs
+        for file in testList:
+            testentry = testList[file]
+            test = testentry['test_path']
+            test_dir = testentry['work_dir']
+            test_name = test.rsplit('/',1)[1][:-2]
+
+            elf = 'ref.elf'
+
+            execute = "@cd "+testentry['work_dir']+";"
+
+            cmd = self.compile_cmd.format(testentry['isa'].lower(), self.xlen) + ' ' + test + ' -o ' + elf
+            compile_cmd = cmd + ' -D' + " -D".join(testentry['macros'])
+            execute+=compile_cmd+";"
+
+            # execute += self.objdump_cmd.format(elf, 'ref.disass')
+            sig_file = os.path.join(test_dir, self.name[:-1] + ".signature")
+
+            # execute += self.sail_exe[self.xlen] + ' --test-signature={0} {1} > {2}.log 2>&1;'.format(sig_file, elf, test_name)
+            execute += self.sail_exe[self.xlen] + ' {0} --no-trace --test-signature={1} {2} > /dev/null;'.format(self.isa, sig_file, elf)
+
+            make.add_target(execute)
+        make.execute_all(self.work_dir)

--- a/ci-tests/riscof/spike/env/link.ld
+++ b/ci-tests/riscof/spike/env/link.ld
@@ -1,0 +1,17 @@
+OUTPUT_ARCH( "riscv" )
+ENTRY(rvtest_entry_point)
+
+SECTIONS
+{
+  . = 0x80000000;
+  .text.init : { *(.text.init) }
+  . = ALIGN(0x1000);
+  .tohost : { *(.tohost) }
+  . = ALIGN(0x1000);
+  .text : { *(.text) }
+  . = ALIGN(0x1000);
+  .data : { *(.data) }
+  .data.string : { *(.data.string)}
+  .bss : { *(.bss) }
+  _end = .;
+}

--- a/ci-tests/riscof/spike/env/model_test.h
+++ b/ci-tests/riscof/spike/env/model_test.h
@@ -1,0 +1,41 @@
+#ifndef _COMPLIANCE_MODEL_H
+#define _COMPLIANCE_MODEL_H
+
+#define RVMODEL_HALT                                                           \
+  li x1, 1;                                                                    \
+  write_tohost:                                                                \
+  sw x1, tohost, x3;                                                           \
+  j write_tohost;
+
+#define RVMODEL_BOOT
+
+#define RVMODEL_DATA_BEGIN                                                     \
+  RVMODEL_DATA_SECTION.align 4;                                                \
+  .global begin_signature;                                                     \
+  begin_signature:
+
+#define RVMODEL_DATA_END                                                       \
+  .align 4;                                                                    \
+  .global end_signature;                                                       \
+  end_signature:
+
+#define RVMODEL_IO_INIT
+#define RVMODEL_IO_WRITE_STR(_R, _STR)
+#define RVMODEL_IO_CHECK()
+#define RVMODEL_IO_ASSERT_GPR_EQ(_S, _R, _I)
+#define RVMODEL_IO_ASSERT_SFPR_EQ(_F, _R, _I)
+#define RVMODEL_IO_ASSERT_DFPR_EQ(_D, _R, _I)
+
+#define RVMODEL_SET_MSW_INT                                                    \
+  li t1, 1;                                                                    \
+  li t2, 0x2000000;                                                            \
+  sw t1, 0(t2);
+
+#define RVMODEL_CLEAR_MSW_INT                                                  \
+  li t2, 0x2000000;                                                            \
+  sw x0, 0(t2);
+
+#define RVMODEL_CLEAR_MTIMER_INT
+#define RVMODEL_CLEAR_MEXT_INT
+
+#endif

--- a/ci-tests/riscof/spike/riscof_spike.py
+++ b/ci-tests/riscof/spike/riscof_spike.py
@@ -1,0 +1,179 @@
+import os
+import re
+import shutil
+import subprocess
+import shlex
+import logging
+import random
+import string
+from string import Template
+import sys
+
+import riscof.utils as utils
+import riscof.constants as constants
+from riscof.pluginTemplate import pluginTemplate
+
+logger = logging.getLogger()
+
+class spike(pluginTemplate):
+    __model__ = "spike"
+
+    __version__ = "XXX"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        config = kwargs.get('config')
+
+        if config is None:
+            print("Please enter input file paths in configuration.")
+            raise SystemExit(1)
+
+        self.dut_exe = os.path.join(config['PATH'] if 'PATH' in config else "","spike")
+
+        self.num_jobs = str(config['jobs'] if 'jobs' in config else 1)
+
+        self.pluginpath=os.path.abspath(config['pluginpath'])
+        self.isa_spec = os.path.abspath(config['ispec'])
+        self.platform_spec = os.path.abspath(config['pspec'])
+
+        if 'target_run' in config and config['target_run']=='0':
+            self.target_run = False
+        else:
+            self.target_run = True
+
+    def initialise(self, suite, work_dir, archtest_env):
+
+       self.work_dir = work_dir
+
+       # capture the architectural test-suite directory.
+       self.suite_dir = suite
+
+       self.compile_cmd = 'riscv64-unknown-elf-gcc -march={0} \
+         -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g\
+         -T '+self.pluginpath+'/env/link.ld\
+         -I '+self.pluginpath+'/env/\
+         -I ' + archtest_env + ' {1} -o {2} {3}'
+
+       # workaround to avoid clang format error in sail-riscv CI.
+       # *clang suggest style that is syntactically incorrect*
+       # Insert the following macro at run-time.
+       modelTest_path = 'spike/env/model_test.h'
+       macro = """
+#define RVMODEL_DATA_SECTION .pushsection                                      \\
+  .tohost, "aw", @progbits;                                                    \\
+  .align 8;                                                                    \\
+  .global tohost;                                                              \\
+  tohost:                                                                      \\
+  .dword 0;                                                                    \\
+  .align 8;                                                                    \\
+  .global fromhost;                                                            \\
+  fromhost:                                                                    \\
+  .dword 0;                                                                    \\
+  .popsection;                                                                 \\
+  .align 8;                                                                    \\
+  .global begin_regstate;                                                      \\
+  begin_regstate:                                                              \\
+  .word 128;                                                                   \\
+  .align 8;                                                                    \\
+  .global end_regstate;                                                        \\
+  end_regstate:                                                                \\
+  .word 4;
+"""
+       with open(modelTest_path, 'r') as file:
+           modelTest = file.readlines()
+       modelTest.insert(2, macro)
+       with open(modelTest_path, 'w') as file:
+           file.writelines(modelTest)
+
+    def build(self, isa_yaml, platform_yaml):
+
+      # load the isa yaml as a dictionary in python.
+      ispec = utils.load_yaml(isa_yaml)['hart0']
+
+      self.xlen = ('64' if 64 in ispec['supported_xlen'] else '32')
+
+      # incorporate rv32e along with rv32i and rv64i
+      ilp32 = 'ilp32e ' if "E" in ispec["ISA"] else 'ilp32 '
+      self.compile_cmd = self.compile_cmd+' -mabi='+('lp64 ' if 64 in ispec['supported_xlen'] else ilp32)
+      # for spike start building the '--isa' argument.
+      self.isa = 'rv' + self.xlen
+      if "I" in ispec["ISA"]:
+          self.isa += 'i'
+      if "E" in ispec["ISA"]:
+          self.isa += 'e'
+      if "M" in ispec["ISA"]:
+          self.isa += 'm'
+      if "A" in ispec["ISA"]:
+          self.isa += 'a'
+      if "F" in ispec["ISA"]:
+          self.isa += 'f'
+      if "D" in ispec["ISA"]:
+          self.isa += 'd'
+      if "C" in ispec["ISA"]:
+          self.isa += 'c'
+      if "Zca" in ispec["ISA"]:
+          self.isa += '_zca'
+      if "Zcb" in ispec["ISA"]:
+          self.isa += '_zcb'
+      if "Zba" in ispec["ISA"]:
+          self.isa += '_zba'
+      if "Zbb" in ispec["ISA"]:
+          self.isa += '_zbb'
+      if "Zbc" in ispec["ISA"]:
+          self.isa += '_zbc'
+      if "Zbs" in ispec["ISA"]:
+          self.isa += '_zbs'
+      if "Zicond" in ispec["ISA"]:
+          self.isa += '_zicond'
+      if "Zicboz" in ispec["ISA"]:
+          self.isa += '_zicboz'
+      if "Zfa" in ispec["ISA"]:
+          self.isa += '_zfa'
+      if "Zfa" in ispec["ISA"]:
+          self.isa += '_zfh'
+      if "Zfinx" in ispec["ISA"]:
+          self.isa += '_zfinx'
+
+    def runTests(self, testList):
+
+      # Delete Makefile if it already exists.
+      if os.path.exists(self.work_dir+ "/Makefile." + self.name[:-1]):
+            os.remove(self.work_dir+ "/Makefile." + self.name[:-1])
+      # create an instance the makeUtil class that we will use to create targets.
+      make = utils.makeUtil(makefilePath=os.path.join(self.work_dir, "Makefile." + self.name[:-1]))
+
+      make.makeCommand = 'make -k -j' + self.num_jobs
+
+      for testname in testList:
+
+          # for each testname we get all its fields (as described by the testList format)
+          testentry = testList[testname]
+
+          test = testentry['test_path']
+
+          test_dir = testentry['work_dir']
+
+          elf = 'dut.elf'
+
+          sig_file = os.path.join(test_dir, self.name[:-1] + ".signature")
+
+          compile_macros= ' -D' + " -D".join(testentry['macros'])
+
+          cmd = self.compile_cmd.format(testentry['isa'].lower(), test, elf, compile_macros)
+
+          if self.target_run:
+            # set up the simulation command. Template is for spike. Please change.
+            simcmd = self.dut_exe + ' --isa={0} +signature={1} +signature-granularity=4 {2}'.format(self.isa, sig_file, elf)
+          else:
+            simcmd = 'echo "NO RUN"'
+
+          # concatenate all commands that need to be executed within a make-target.
+          execute = '@cd {0}; {1}; {2};'.format(testentry['work_dir'], cmd, simcmd)
+
+          make.add_target(execute)
+
+      make.execute_all(self.work_dir)
+
+      if not self.target_run:
+          raise SystemExit(0)

--- a/ci-tests/riscof/spike/spike_isa32.yaml
+++ b/ci-tests/riscof/spike/spike_isa32.yaml
@@ -1,0 +1,28 @@
+hart_ids: [0]
+hart0:
+  ISA: RV32IMAFDCZicsr_Zicond_Zifencei_Zca_Zcb_Zba_Zbb_Zbc_Zbs
+  physical_addr_sz: 32
+  User_Spec_Version: '2.3'
+  supported_xlen: [32]
+  misa:
+   reset-val: 0x4000112D
+   rv32:
+     accessible: true
+     mxl:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - mxl[1:0] in [0x1]
+              wr_illegal:
+                - Unchanged
+     extensions:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - extensions[25:0] bitmask [0x000112D, 0x0000000]
+              wr_illegal:
+                - Unchanged

--- a/ci-tests/riscof/spike/spike_isa32e.yaml
+++ b/ci-tests/riscof/spike/spike_isa32e.yaml
@@ -1,0 +1,28 @@
+hart_ids: [0]
+hart0:
+  ISA: RV32EMCZicsr_Zifencei
+  physical_addr_sz: 32
+  User_Spec_Version: '2.3'
+  supported_xlen: [32]
+  misa:
+   reset-val: 0x40001014
+   rv32:
+     accessible: true
+     mxl:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - mxl[1:0] in [0x1]
+              wr_illegal:
+                - Unchanged
+     extensions:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - extensions[25:0] bitmask [0x0001014, 0x0000000]
+              wr_illegal:
+                - Unchanged

--- a/ci-tests/riscof/spike/spike_isa64.yaml
+++ b/ci-tests/riscof/spike/spike_isa64.yaml
@@ -1,0 +1,28 @@
+hart_ids: [0]
+hart0:
+  ISA: RV64IMAFDCZicsr_Zicond_Zifencei_Zca_Zcb_Zba_Zbb_Zbc_Zbs
+  physical_addr_sz: 56
+  User_Spec_Version: '2.3'
+  supported_xlen: [64]
+  misa:
+   reset-val: 0x800000000000112d
+   rv64:
+     accessible: true
+     mxl:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - mxl[1:0] in [0x2]
+              wr_illegal:
+                - Unchanged
+     extensions:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - extensions[25:0] bitmask [0x000112D, 0x0000000]
+              wr_illegal:
+                - Unchanged

--- a/ci-tests/riscof/spike/spike_platform.yaml
+++ b/ci-tests/riscof/spike/spike_platform.yaml
@@ -1,0 +1,10 @@
+mtime:
+  implemented: true
+  address: 0xbff8
+mtimecmp:
+  implemented: true
+  address: 0x4000
+nmi:
+  label: nmi_vector
+reset:
+  label: reset_vector


### PR DESCRIPTION
This PR should complete [this](https://github.com/riscv-admin/dev-partners/issues/38) SOW.

PR adds the RISCOF-based CI infrastructure to test sail-riscv against Spike using ACTs. Both Sail and Spike are configured using ISA yaml configuration (provided under `ci-tests/riscof/`) which are validated by riscv-config using RISCOF

Current infrastructure uses [3.8.10](https://github.com/riscv-non-isa/riscv-arch-test/releases/tag/3.8.10) release of arch-test-suites. The later releases of arch-tests (that add Zfa and Zfh tests) are partially broken for RISCOF - and should be fixed shortly. 


CI runs ACTS in RV32I, RV64I, and RV32E configurations. Details are as follows. After successful completion, test reports for each configuration are uploaded to GitHub Workspace.  

Kindly review, and make suggestions how the CI should be pulled in to this repo. I'll be happy to make the requested changes.