### PR TITLE
csim: Fix C23 compatability warning

### DIFF
--- a/c_emulator/riscv_platform.c
+++ b/c_emulator/riscv_platform.c
@@ -108,7 +108,7 @@ mach_bits plat_rom_size(unit u)
 }
 
 // Provides entropy for the scalar cryptography extension.
-mach_bits plat_get_16_random_bits()
+mach_bits plat_get_16_random_bits(unit u)
 {
   return rv_16_random_bits();
 }

--- a/c_emulator/riscv_platform.h
+++ b/c_emulator/riscv_platform.h
@@ -26,7 +26,7 @@ mach_bits plat_rom_base(unit);
 mach_bits plat_rom_size(unit);
 
 // Provides entropy for the scalar cryptography extension.
-mach_bits plat_get_16_random_bits();
+mach_bits plat_get_16_random_bits(unit);
 
 mach_bits plat_clint_base(unit);
 mach_bits plat_clint_size(unit);


### PR DESCRIPTION
The plat_get_16_random_bits was missing its unit argument, which produces the following warning when using clang:

```
generated_definitions/c/riscv_model_RV64.c:28041:34: warning: passing arguments to 'plat_get_16_random_bits' without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
  zseed = plat_get_16_random_bits(UNIT);
```

This commit adds the appropriate argument to the function in the C simulator.
