### PR TITLE
Update bitfield syntax

### DIFF
--- a/model/riscv_pmp_regs.sail
+++ b/model/riscv_pmp_regs.sail
@@ -68,7 +68,7 @@ function pmpReadCfgReg(n : range(0, 15)) -> xlenbits = {
 
 function pmpReadAddrReg(n : range(0, 63)) -> xlenbits = {
   let G = sys_pmp_grain();
-  let match_type = pmpcfg_n[n].A();
+  let match_type = pmpcfg_n[n][A];
   let addr = pmpaddr_n[n];
 
   match match_type[1] {
@@ -104,12 +104,12 @@ function pmpWriteCfg(n: range(0, 63), cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent
     // "The R, W, and X fields form a collective WARL field for which the combinations with R=0 and W=1 are reserved."
     // In this implementation if R=0 and W=1 then R, W and X are all set to 0.
     // This is the least risky option from a security perspective.
-    let cfg = if cfg.W() == 0b1 & cfg.R() == 0b0 then [cfg with X = 0b0, W = 0b0, R = 0b0] else cfg;
+    let cfg = if cfg[W] == 0b1 & cfg[R] == 0b0 then [cfg with X = 0b0, W = 0b0, R = 0b0] else cfg;
 
     // "When G >= 1, the NA4 mode is not selectable."
     // In this implementation we set it to OFF if NA4 is selected.
     // This is the least risky option from a security perspective.
-    let cfg = if sys_pmp_grain() >= 1 & pmpAddrMatchType_of_bits(cfg.A()) == NA4
+    let cfg = if sys_pmp_grain() >= 1 & pmpAddrMatchType_of_bits(cfg[A]) == NA4
               then [cfg with A = pmpAddrMatchType_to_bits(OFF)]
               else cfg;
 

--- a/model/riscv_vmem.sail
+++ b/model/riscv_vmem.sail
@@ -426,8 +426,8 @@ function translateAddr(vAddr   : xlenbits,
   if not(valid_va) then
     TR_Failure(translationException(ac, PTW_Invalid_Addr()), init_ext_ptw)
   else {
-    let mxr               = mstatus.MXR() == 0b1;
-    let do_sum            = mstatus.SUM() == 0b1;
+    let mxr               = mstatus[MXR] == 0b1;
+    let do_sum            = mstatus[SUM] == 0b1;
     let asid   : asidbits = satp_to_asid(satp);
     let ptb    : bits(64) = satp_to_PT_base(satp);
     let tr_result1 = translate(sv_params,

--- a/model/riscv_vmem_pte.sail
+++ b/model/riscv_vmem_pte.sail
@@ -128,7 +128,7 @@ function update_PTE_Bits(sv_params : SV_Params,
     let pte_flags = [pte_flags with
                       A = 0b1,
                       D = (if update_d then 0b1 else pte_flags[D])];
-    Some(pte[63 .. 8] @ pte_flags.bits())
+    Some(pte[63 .. 8] @ pte_flags.bits)
   }
   else
     None()


### PR DESCRIPTION
Update remaining uses of old bitfield syntax and replace with the newer syntax (see #373).

The latest version of the sail repo gives the below deprecation warning, which I assume will be included in the next release of sail. This prevents warning messages when that happens.

```
Warning: Deprecated model/riscv_pmp_regs.sail:71.19-34:
71 |  let match_type = pmpcfg_n[n].A();
   |                   ^-------------^
   | 
Old bitfield syntax, use '<bitfield>[A]' instead
```