### PR TITLE
Implement callbacks for state-changing events

### DIFF
--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(EMULATOR_COMMON_SRCS
+    riscv_callbacks.cpp
+    riscv_callbacks.h
     riscv_config.h
     riscv_platform.cpp
     riscv_platform.h

--- a/c_emulator/riscv_callbacks.cpp
+++ b/c_emulator/riscv_callbacks.cpp
@@ -1,0 +1,136 @@
+#include "riscv_callbacks.h"
+#include "riscv_config.h"
+#include "riscv_platform_impl.h"
+#include <stdlib.h>
+#include <vector>
+#include <inttypes.h>
+
+bool config_enable_rvfi = true; // Only used if RVFI_DII is defined
+
+void print_lbits_hex(lbits val, int length = 0)
+{
+  if (length == 0) {
+    length = val.len;
+  }
+  std::vector<uint8_t> data(length);
+  mpz_export(data.data(), nullptr, -1, 1, 0, 0, *val.bits);
+  for (int i = length - 1; i >= 0; --i) {
+    fprintf(trace_log, "%02" PRIX8, data[i]);
+  }
+  fprintf(trace_log, "\n");
+}
+
+// Implementations of default callbacks for trace printing and RVFI.
+// The model assumes that these functions do not change the state of the model.
+unit mem_write_callback(uint64_t paddr, uint64_t width, lbits value)
+{
+  if (config_print_mem_access) {
+    fprintf(trace_log, "mem[0x%016" PRIX64 "] <- 0x", paddr);
+    print_lbits_hex(value, width);
+  }
+#ifdef RVFI_DII
+  if (config_enable_rvfi) {
+    zrvfi_write(paddr, width, value);
+  }
+#endif
+  return UNIT;
+}
+
+unit mem_read_callback(const char *type, uint64_t paddr, uint64_t width,
+                       lbits value)
+{
+  if (config_print_mem_access) {
+    fprintf(trace_log, "mem[%s,0x%016" PRIX64 "] -> 0x", type, paddr);
+    print_lbits_hex(value, width);
+  }
+#ifdef RVFI_DII
+  if (config_enable_rvfi) {
+    sail_int len;
+    CREATE(sail_int)(&len);
+    CONVERT_OF(sail_int, mach_int)(&len, width);
+    zrvfi_read(paddr, len, value);
+    KILL(sail_int)(&len);
+  }
+#endif
+  return UNIT;
+}
+
+unit mem_exception_callback(uint64_t paddr, uint64_t num_of_exception)
+{
+  (void)num_of_exception;
+#ifdef RVFI_DII
+  if (config_enable_rvfi) {
+    zrvfi_mem_exception(paddr);
+  }
+#else
+  (void)paddr;
+#endif
+  return UNIT;
+}
+
+unit xreg_write_callback(unsigned reg, uint64_t value)
+{
+  if (config_print_reg) {
+    fprintf(trace_log, "x%d <- 0x%016" PRIX64 "\n", reg, value);
+  }
+#ifdef RVFI_DII
+  if (config_enable_rvfi) {
+    zrvfi_wX(reg, value);
+  }
+#endif
+  return UNIT;
+}
+
+unit freg_write_callback(unsigned reg, uint64_t value)
+{
+  // TODO: will only print bits; should we print in floating point format?
+  if (config_print_reg) {
+    fprintf(trace_log, "f%d <- 0x%016" PRIX64 "\n", reg, value);
+  }
+  return UNIT;
+}
+
+unit csr_full_write_callback(const_sail_string csr_name, unsigned reg,
+                             uint64_t value)
+{
+  if (config_print_reg) {
+    fprintf(trace_log, "CSR %s (0x%03X) <- 0x%016" PRIX64 "\n", csr_name, reg,
+            value);
+  }
+  return UNIT;
+}
+
+unit csr_full_read_callback(const_sail_string csr_name, unsigned reg,
+                            uint64_t value)
+{
+  if (config_print_reg) {
+    fprintf(trace_log, "CSR %s (0x%03X) -> 0x%016" PRIX64 "\n", csr_name, reg,
+            value);
+  }
+  return UNIT;
+}
+
+unit vreg_write_callback(unsigned reg, lbits value)
+{
+  if (config_print_reg) {
+    fprintf(trace_log, "v%d <- ", reg);
+    print_lbits_hex(value);
+  }
+  return UNIT;
+}
+
+unit pc_write_callback(uint64_t value)
+{
+  (void)value;
+  return UNIT;
+}
+
+unit trap_callback(unit)
+{
+#ifdef RVFI_DII
+  if (config_enable_rvfi) {
+    zrvfi_trap();
+  }
+#endif
+  return UNIT;
+}

--- a/c_emulator/riscv_callbacks.h
+++ b/c_emulator/riscv_callbacks.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "sail.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+unit mem_write_callback(uint64_t paddr, uint64_t width, lbits value);
+unit mem_read_callback(const char *type, uint64_t paddr, uint64_t width,
+                       lbits value);
+unit mem_exception_callback(uint64_t paddr, uint64_t num_of_exception);
+unit xreg_write_callback(unsigned reg, uint64_t value);
+unit freg_write_callback(unsigned reg, uint64_t value);
+// `full` indicates that the name and index of the CSR are provided.
+// 64 bit CSRs use a long_csr_write_callback Sail function that automatically
+// makes two csr_full_write_callback calls on RV32.
+unit csr_full_write_callback(const_sail_string csr_name, unsigned reg,
+                             uint64_t value);
+unit csr_full_read_callback(const_sail_string csr_name, unsigned reg,
+                            uint64_t value);
+unit vreg_write_callback(unsigned reg, lbits value);
+unit pc_write_callback(uint64_t value);
+unit trap_callback(unit);
+
+#ifdef RVFI_DII
+// TODO: Move these implementations to C.
+unit zrvfi_write(uint64_t paddr, int64_t width, lbits value);
+unit zrvfi_read(uint64_t paddr, sail_int width, lbits value);
+unit zrvfi_mem_exception(uint64_t paddr);
+unit zrvfi_wX(int64_t reg, uint64_t value);
+unit zrvfi_trap();
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/c_emulator/riscv_prelude.cpp
+++ b/c_emulator/riscv_prelude.cpp
@@ -22,20 +22,6 @@ unit print_step(unit)
   return UNIT;
 }
 
-unit print_reg(sail_string s)
-{
-  if (config_print_reg)
-    fprintf(trace_log, "%s\n", s);
-  return UNIT;
-}
-
-unit print_mem_access(sail_string s)
-{
-  if (config_print_mem_access)
-    fprintf(trace_log, "%s\n", s);
-  return UNIT;
-}
-
 unit print_platform(sail_string s)
 {
   if (config_print_platform)
@@ -45,20 +31,10 @@ unit print_platform(sail_string s)
 
 bool get_config_print_instr(unit)
 {
-  return (config_print_instr) ? true : false;
-}
-
-bool get_config_print_reg(unit)
-{
-  return (config_print_reg) ? true : false;
-}
-
-bool get_config_print_mem(unit)
-{
-  return (config_print_mem_access) ? true : false;
+  return config_print_instr;
 }
 
 bool get_config_print_platform(unit)
 {
-  return (config_print_platform) ? true : false;
+  return config_print_platform;
 }

--- a/c_emulator/riscv_prelude.h
+++ b/c_emulator/riscv_prelude.h
@@ -11,13 +11,9 @@ unit print_string(sail_string prefix, sail_string msg);
 
 unit print_instr(sail_string s);
 unit print_step(unit);
-unit print_reg(sail_string s);
-unit print_mem_access(sail_string s);
 unit print_platform(sail_string s);
 
 bool get_config_print_instr(unit);
-bool get_config_print_reg(unit);
-bool get_config_print_mem(unit);
 bool get_config_print_platform(unit);
 
 #ifdef __cplusplus

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -155,6 +155,7 @@ foreach (xlen IN ITEMS 32 64)
 
             set(sail_regs_srcs
                 "riscv_csr_begin.sail"
+                "riscv_callbacks.sail"
                 "riscv_reg_type.sail"
                 "riscv_freg_type.sail"
                 "riscv_regs.sail"
@@ -263,6 +264,7 @@ foreach (xlen IN ITEMS 32 64)
                         # Extra #include's.
                         --c-include riscv_prelude.h
                         --c-include riscv_platform.h
+                        --c-include riscv_callbacks.h
                         # Don't dead-code eliminate these functions. These should match the
                         # ones used from riscv_sail.h
                         --c-preserve init_model
@@ -283,6 +285,11 @@ foreach (xlen IN ITEMS 32 64)
                         --c-preserve rvfi_halt_exec_packet
                         --c-preserve print_instr_packet
                         --c-preserve print_rvfi_exec
+                        --c-preserve rvfi_write
+                        --c-preserve rvfi_read
+                        --c-preserve rvfi_mem_exception
+                        --c-preserve rvfi_wX
+                        --c-preserve rvfi_trap
                         # Input files.
                         ${sail_srcs}
                 )

--- a/model/prelude.sail
+++ b/model/prelude.sail
@@ -62,8 +62,6 @@ overload max = {max_int}
 val print_string = pure "print_string" : (string, string) -> unit
 
 val print_instr    = pure {interpreter: "print_endline", c: "print_instr", lem: "print_dbg", _: "print_endline"} : string -> unit
-val print_reg      = pure {interpreter: "print_endline", c: "print_reg", lem: "print_dbg", _: "print_endline"} : string -> unit
-val print_mem      = pure {interpreter: "print_endline", c: "print_mem_access", lem: "print_dbg", _: "print_endline"} : string -> unit
 val print_platform = pure {interpreter: "print_endline", c: "print_platform", lem: "print_dbg", _: "print_endline"} : string -> unit
 
 val print_step = pure {c: "print_step"} : unit -> unit
@@ -71,14 +69,9 @@ val print_step = pure {c: "print_step"} : unit -> unit
 function print_step() = ()
 
 val get_config_print_instr = pure {c:"get_config_print_instr"} : unit -> bool
-val get_config_print_reg = pure {c:"get_config_print_reg"} : unit -> bool
-val get_config_print_mem = pure {c:"get_config_print_mem"} : unit -> bool
-
 val get_config_print_platform = pure {c:"get_config_print_platform"} : unit -> bool
 // defaults for other backends
 function get_config_print_instr () = false
-function get_config_print_reg () = false
-function get_config_print_mem () = false
 function get_config_print_platform () = false
 
 val sign_extend : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)

--- a/model/riscv_callbacks.sail
+++ b/model/riscv_callbacks.sail
@@ -1,0 +1,44 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+// Callbacks for state-changing events
+val mem_write_callback = pure {c: "mem_write_callback"} : forall 'n, 0 < 'n <= max_mem_access . (/* addr */ physaddrbits, /* width */ int('n), /* value */ bits(8 * 'n)) -> unit
+val mem_read_callback = pure {c: "mem_read_callback"} : forall 'n, 0 < 'n <= max_mem_access . (/* access type */ string, /* addr */ physaddrbits, /* width */ int('n), /* value */ bits(8 * 'n)) -> unit
+val mem_exception_callback = pure {c: "mem_exception_callback"} : forall 'n, 0 <= 'n < xlen . (/* addr */ physaddrbits, /* num_of_ExceptionType */ int('n)) -> unit
+val pc_write_callback = pure {c: "pc_write_callback"} : xlenbits -> unit
+val xreg_write_callback = pure {c: "xreg_write_callback"} : (regidx, xlenbits) -> unit
+val csr_full_write_callback = pure {c: "csr_full_write_callback"} : (string, csreg, xlenbits) -> unit
+val csr_full_read_callback = pure {c: "csr_full_read_callback"} : (string, csreg, xlenbits) -> unit
+val trap_callback = pure {c: "trap_callback"} : unit -> unit
+
+// Overloads for easier use of callbacks
+function csr_name_write_callback(name : string, value : xlenbits) -> unit = {
+  let csr = csr_name_map(name);
+  csr_full_write_callback(name, csr, value);
+}
+function csr_id_write_callback(csr : csreg, value : xlenbits) -> unit = {
+  let name = csr_name_map(csr);
+  csr_full_write_callback(name, csr, value);
+}
+function csr_name_read_callback(name : string, value : xlenbits) -> unit = {
+  let csr = csr_name_map(name);
+  csr_full_read_callback(name, csr, value);
+}
+function csr_id_read_callback(csr : csreg, value : xlenbits) -> unit = {
+  let name = csr_name_map(csr);
+  csr_full_read_callback(name, csr, value);
+}
+
+overload csr_write_callback = {csr_name_write_callback, csr_id_write_callback, csr_full_write_callback}
+overload csr_read_callback = {csr_name_read_callback, csr_id_read_callback, csr_full_read_callback}
+
+function long_csr_write_callback(name : string, name_high : string, value : bits(64)) -> unit = {
+  csr_write_callback(name, value[xlen - 1 .. 0]);
+  if xlen == 32
+  then csr_write_callback(name_high, value[63 .. 32]);
+}

--- a/model/riscv_fdext_regs.sail
+++ b/model/riscv_fdext_regs.sail
@@ -55,6 +55,7 @@ function nan_unbox(m, x) = if 'n == 'm then x else (
 newtype fregidx = Fregidx : bits(5)
 newtype fregno = Fregno : range(0, 31)
 function fregidx_to_fregno (Fregidx(b) : fregidx) -> fregno = Fregno(unsigned(b))
+function fregno_to_fregidx (Fregno(b) : fregno) -> fregidx = Fregidx(to_bits(5, b))
 function fregidx_offset(Fregidx(r) : fregidx, o : bits(5)) -> fregidx = Fregidx(r + o)
 function fregidx_bits(Fregidx(r) : fregidx) -> bits(5) = r
 
@@ -68,6 +69,8 @@ function fregidx_to_regidx (Fregidx(b) : fregidx) -> regidx =
   Regidx(trunc(b))
 
 mapping encdec_freg : fregidx <-> bits(5) = { Fregidx(r) <-> r }
+
+val freg_write_callback = pure {c: "freg_write_callback"} : (fregidx, flenbits) -> unit
 
 register f0  : fregtype
 register f1  : fregtype
@@ -106,6 +109,7 @@ function dirty_fd_context() -> unit = {
   assert(hartSupports(Ext_F));
   mstatus[FS] = extStatus_to_bits(Dirty);
   mstatus[SD] = 0b1;
+  long_csr_write_callback("mstatus", "mstatush", mstatus.bits);
 }
 
 function dirty_fd_context_if_present() -> unit = {
@@ -193,12 +197,8 @@ function wF (Fregno(r) : fregno, in_v : flenbits) -> unit = {
     _  => assert(false, "invalid floating point register number")
   };
 
+  freg_write_callback(fregno_to_fregidx(Fregno(r)), in_v);
   dirty_fd_context();
-
-  if   get_config_print_reg()
-  then
-      /* TODO: will only print bits; should we print in floating point format? */
-      print_reg("f" ^ dec_str(r) ^ " <- " ^ FRegStr(v));
 }
 
 function rF_bits(i: fregidx) -> flenbits = rF(fregidx_to_fregno(i))

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -167,7 +167,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
               if i == 0 then return Ext_DataAddr_Check_Failure(e)
               else {
                 vl = to_bits(xlen, i);
-                print_reg("CSR vl <- " ^ BitStr(vl));
+                csr_write_callback("vl", vl);
                 trimmed = true
               }
             },
@@ -176,7 +176,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
                 if i == 0 then return Memory_Exception(vaddr, E_Load_Addr_Align())
                 else {
                   vl = to_bits(xlen, i);
-                  print_reg("CSR vl <- " ^ BitStr(vl));
+                  csr_write_callback("vl", vl);
                   trimmed = true
                 }
               } else match translateAddr(vaddr, Read(Data)) {
@@ -184,7 +184,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
                   if i == 0 then return Memory_Exception(vaddr, e)
                   else {
                     vl = to_bits(xlen, i);
-                    print_reg("CSR vl <- " ^ BitStr(vl));
+                    csr_write_callback("vl", vl);
                     trimmed = true
                   }
                 },
@@ -195,7 +195,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
                       if i == 0 then return Memory_Exception(vaddr, e)
                       else {
                         vl = to_bits(xlen, i);
-                        print_reg("CSR vl <- " ^ BitStr(vl));
+                        csr_write_callback("vl", vl);
                         trimmed = true
                       }
                     }

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -48,8 +48,8 @@ function handle_illegal_vtype() = {
    */
   vtype.bits = 0b1 @ zeros(xlen - 1); /* set vtype.vill */
   vl = zeros();
-  print_reg("CSR vtype <- " ^ BitStr(vtype.bits));
-  print_reg("CSR vl <- " ^ BitStr(vl))
+  csr_write_callback("vtype", vtype.bits);
+  csr_write_callback("vl", vl);
 }
 
 function vl_use_ceil() -> bool = config extensions.V.vl_use_ceil
@@ -111,9 +111,9 @@ function clause execute VSETVLI(ma, ta, sew, lmul, rs1, rd) = {
   /* reset vstart to 0 */
   set_vstart(zeros());
 
-  print_reg("CSR vtype <- " ^ BitStr(vtype.bits));
-  print_reg("CSR vl <- " ^ BitStr(vl));
-  print_reg("CSR vstart <- " ^ BitStr(vstart));
+  csr_write_callback("vtype", vtype.bits);
+  csr_write_callback("vl", vl);
+  csr_write_callback("vstart", zero_extend(vstart));
 
   RETIRE_SUCCESS
 }
@@ -163,9 +163,9 @@ function clause execute VSETVL(rs2, rs1, rd) = {
   /* reset vstart to 0 */
   set_vstart(zeros());
 
-  print_reg("CSR vtype <- " ^ BitStr(vtype.bits));
-  print_reg("CSR vl <- " ^ BitStr(vl));
-  print_reg("CSR vstart <- " ^ BitStr(vstart));
+  csr_write_callback("vtype", vtype.bits);
+  csr_write_callback("vl", vl);
+  csr_write_callback("vstart", zero_extend(vstart));
 
   RETIRE_SUCCESS
 }
@@ -200,9 +200,9 @@ function clause execute VSETIVLI(ma, ta, sew, lmul, uimm, rd) = {
   /* reset vstart to 0 */
   set_vstart(zeros());
 
-  print_reg("CSR vtype <- " ^ BitStr(vtype.bits));
-  print_reg("CSR vl <- " ^ BitStr(vl));
-  print_reg("CSR vstart <- " ^ BitStr(vstart));
+  csr_write_callback("vtype", vtype.bits);
+  csr_write_callback("vl", vl);
+  csr_write_callback("vstart", zero_extend(vstart));
 
   RETIRE_SUCCESS
 }

--- a/model/riscv_insts_zicsr.sail
+++ b/model/riscv_insts_zicsr.sail
@@ -40,11 +40,9 @@ function doCSR(csr : csreg, rs1_val : xlenbits, rd : regidx, op : csrop, is_CSR_
         CSRRC => csr_val & ~(rs1_val)
       };
       let final_val = write_CSR(csr, new_val);
-      if get_config_print_reg()
-      then print_reg("CSR " ^ to_str(csr) ^ " <- " ^ bits_str(final_val) ^ " (input: " ^ bits_str(new_val) ^ ")")
+      csr_write_callback(csr, final_val);
     } else {
-      if get_config_print_reg()
-      then print_reg("CSR " ^ to_str(csr) ^ " -> " ^ bits_str(csr_val));
+      csr_read_callback(csr, csr_val);
     };
     X(rd) = csr_val;
     RETIRE_SUCCESS

--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -73,9 +73,7 @@ function phys_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext
     (InstructionFetch(), None()) => Err(E_Fetch_Access_Fault()),
     (Read(Data), None()) => Err(E_Load_Access_Fault()),
     (_,          None()) => Err(E_SAMO_Access_Fault()),
-    (_,      Some(v, m)) => { if   get_config_print_mem()
-                              then print_mem("mem[" ^ to_str(t) ^ "," ^ hex_bits_str(bits_of(paddr)) ^ "] -> " ^ BitStr(v));
-                              Ok(v, m) }
+    (_,      Some(v, m)) => Ok(v, m),
   }
 }
 
@@ -117,25 +115,6 @@ function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (
 
 /* Atomic accesses can be done to MMIO regions, e.g. in kernel access to device registers. */
 
-$ifdef RVFI_DII
-val rvfi_read : forall 'n, 'n > 0. (physaddr, int('n), MemoryOpResult((bits(8 * 'n), mem_meta))) -> unit
-function rvfi_read (Physaddr(addr), width, result) = {
-  rvfi_mem_data[rvfi_mem_addr] = zero_extend(addr);
-  rvfi_mem_data_present = true;
-  match result {
-    /* TODO: report tag bit for capability writes and extend mask by one bit. */
-    Ok(v, _) => if width <= 16
-                       then { rvfi_mem_data[rvfi_mem_rdata] = zero_extend(256, v);
-                              rvfi_mem_data[rvfi_mem_rmask] = rvfi_encode_width_mask(width) }
-                       else { internal_error(__FILE__, __LINE__, "Expected at most 16 bytes here!") },
-    Err(_)   => ()
-  };
-}
-$else
-val rvfi_read : forall 'n, 'n > 0. (physaddr, int('n), MemoryOpResult((bits(8 * 'n), mem_meta))) -> unit
-function rvfi_read (Physaddr(addr), width, result) = ()
-$endif
-
 val mem_read      : forall 'n, 0 < 'n <= max_mem_access . (AccessType(ext_access_type), physaddr, int('n), bool, bool, bool)       -> MemoryOpResult(bits(8 * 'n))
 val mem_read_priv : forall 'n, 0 < 'n <= max_mem_access . (AccessType(ext_access_type), Privilege, physaddr, int('n), bool, bool, bool)       -> MemoryOpResult(bits(8 * 'n))
 val mem_read_meta : forall 'n, 0 < 'n <= max_mem_access . (AccessType(ext_access_type), physaddr, int('n), bool, bool, bool, bool) -> MemoryOpResult((bits(8 * 'n), mem_meta))
@@ -151,7 +130,10 @@ function mem_read_priv_meta (typ, priv, paddr, width, aq, rl, res, meta) = {
       (false, true,  true)  => throw(Error_not_implemented("lr.rl")),
       (_, _, _)             => checked_mem_read(typ, priv, paddr, width, aq, rl, res, meta)
     };
-  rvfi_read(paddr, width, result);
+  match result {
+    Ok(value, _) => mem_read_callback(to_str(typ), bits_of(paddr), width, value),
+    Err(e) => mem_exception_callback(bits_of(paddr), num_of_ExceptionType(e)),
+  };
   result
 }
 
@@ -172,35 +154,9 @@ function mem_write_ea (addr, width, aq, rl, con) =
   then Err(E_SAMO_Addr_Align())
   else Ok(write_ram_ea(write_kind_of_flags(aq, rl, con), addr, width))
 
-$ifdef RVFI_DII
-val rvfi_write : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), mem_meta, MemoryOpResult(bool)) -> unit
-function rvfi_write (Physaddr(addr), width, value, meta, result) = {
-  rvfi_mem_data[rvfi_mem_addr] = zero_extend(addr);
-  rvfi_mem_data_present = true;
-  match result {
-    /* Log only the memory address (without the value) if the write fails. */
-    Ok(_) => if width <= 16 then {
-        /* TODO: report tag bit for capability writes and extend mask by one bit. */
-        rvfi_mem_data[rvfi_mem_wdata] = zero_extend(256, value);
-        rvfi_mem_data[rvfi_mem_wmask] = rvfi_encode_width_mask(width);
-      } else {
-        internal_error(__FILE__, __LINE__, "Expected at most 16 bytes here!");
-      },
-    Err(_) => ()
-  }
-}
-$else
-val rvfi_write : forall 'n, 'n > 0. (physaddr, int('n), bits(8 * 'n), mem_meta, MemoryOpResult(bool)) -> unit
-function rvfi_write (Physaddr(addr), width, value, meta, result) = ()
-$endif
-
 // only used for actual memory regions, to avoid MMIO effects
-function phys_mem_write forall 'n, 0 < 'n <= max_mem_access . (wk : write_kind, paddr : physaddr, width : int('n), data : bits(8 * 'n), meta : mem_meta) -> MemoryOpResult(bool) = {
-  let result = write_ram(wk, paddr, width, data, meta);
-  if   get_config_print_mem()
-  then print_mem("mem[" ^ BitStr(bits_of(paddr)) ^ "] <- " ^ BitStr(data));
-  Ok(result)
-}
+function phys_mem_write forall 'n, 0 < 'n <= max_mem_access . (wk : write_kind, paddr : physaddr, width : int('n), data : bits(8 * 'n), meta : mem_meta) -> MemoryOpResult(bool) =
+  Ok(write_ram(wk, paddr, width, data, meta))
 
 /* dispatches to MMIO regions or physical memory regions depending on physical memory map */
 function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
@@ -242,7 +198,10 @@ function mem_write_value_priv_meta (paddr, width, value, typ, priv, meta, aq, rl
   then Err(E_SAMO_Addr_Align())
   else {
     let result = checked_mem_write(paddr, width, value, typ, priv, meta, aq, rl, con);
-    rvfi_write(paddr, width, value, meta, result);
+    match result {
+      Ok(_) => mem_write_callback(bits_of(paddr), width, value),
+      Err(e) => mem_exception_callback(bits_of(paddr), num_of_ExceptionType(e)),
+    };
     result
   }
 }

--- a/model/riscv_pc_access.sail
+++ b/model/riscv_pc_access.sail
@@ -28,5 +28,6 @@ function set_next_pc(pc) = {
 
 val tick_pc : unit -> unit
 function tick_pc() = {
-  PC = nextPC
+  PC = nextPC;
+  pc_write_callback(PC);
 }

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -85,16 +85,6 @@ function rX (Regno(r) : regno) -> xlenbits = {
   regval_from_reg(v)
 }
 
-$ifdef RVFI_DII
-function rvfi_wX (Regno(r) : regno, v : xlenbits) -> unit = {
-  rvfi_int_data[rvfi_rd_wdata] = zero_extend(v);
-  rvfi_int_data[rvfi_rd_addr] = to_bits(8,r);
-  rvfi_int_data_present = true;
-}
-$else
-function rvfi_wX (r : regno, v : xlenbits) -> unit = ()
-$endif
-
 function wX (Regno(r) : regno, in_v : xlenbits) -> unit = {
   let v = regval_into_reg(in_v);
   match r {
@@ -132,11 +122,7 @@ function wX (Regno(r) : regno, in_v : xlenbits) -> unit = {
     31 => x31 = v,
     _  => assert(false, "invalid register number")
   };
-  if (r != 0) then {
-     rvfi_wX(Regno(r), in_v);
-     if   get_config_print_reg()
-     then print_reg("x" ^ dec_str(r) ^ " <- " ^ RegStr(v));
-  }
+  if (r != 0) then xreg_write_callback(regno_to_regidx(Regno(r)), in_v)
 }
 
 function rX_bits(i: regidx) -> xlenbits = rX(regidx_to_regno(i))

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -201,21 +201,27 @@ function tval(excinfo : option(xlenbits)) -> xlenbits = {
   }
 }
 
-$ifdef RVFI_DII
-val rvfi_trap : unit -> unit
-// TODO: record rvfi_trap_data
-function rvfi_trap () =
-  rvfi_inst_data[rvfi_trap] = 0x01
-$else
-val rvfi_trap : unit -> unit
-function rvfi_trap () = ()
-$endif
+function track_trap(p : Privilege) -> unit = {
+  long_csr_write_callback("mstatus", "mstatush", mstatus.bits);
+  match (p) {
+    Machine => {
+      csr_write_callback("mcause", mcause.bits);
+      csr_write_callback("mtval", mtval);
+      csr_write_callback("mepc", mepc);
+    },
+    Supervisor => {
+      csr_write_callback("scause", scause.bits);
+      csr_write_callback("stval", stval);
+      csr_write_callback("sepc", sepc);
+    },
+    User => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+  };
+}
 
 /* handle exceptional ctl flow by updating nextPC and operating privilege */
-
 function trap_handler(del_priv : Privilege, intr : bool, c : exc_code, pc : xlenbits, info : option(xlenbits), ext : option(ext_exception))
                      -> xlenbits = {
-  rvfi_trap();
+  trap_callback();
   if   get_config_print_platform()
   then print_platform("handling " ^ (if intr then "int#" else "exc#")
                       ^ BitStr(c) ^ " at priv " ^ to_str(del_priv)
@@ -229,15 +235,14 @@ function trap_handler(del_priv : Privilege, intr : bool, c : exc_code, pc : xlen
        mstatus[MPIE] = mstatus[MIE];
        mstatus[MIE]  = 0b0;
        mstatus[MPP]  = privLevel_to_bits(cur_privilege);
-       mtval           = tval(info);
-       mepc            = pc;
+       mtval         = tval(info);
+       mepc          = pc;
 
-       cur_privilege   = del_priv;
+       cur_privilege = del_priv;
 
        handle_trap_extension(del_priv, pc, ext);
 
-       if   get_config_print_reg()
-       then print_reg("CSR mstatus <- " ^ BitStr(mstatus.bits));
+       track_trap(del_priv);
 
        prepare_trap_vector(del_priv, mcause)
     },
@@ -261,8 +266,7 @@ function trap_handler(del_priv : Privilege, intr : bool, c : exc_code, pc : xlen
 
        handle_trap_extension(del_priv, pc, ext);
 
-       if   get_config_print_reg()
-       then print_reg("CSR mstatus <- " ^ BitStr(mstatus.bits));
+       track_trap(del_priv);
 
        prepare_trap_vector(del_priv, scause)
     },
@@ -289,8 +293,8 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
       if   cur_privilege != Machine
       then mstatus[MPRV] = 0b0;
 
-      if   get_config_print_reg()
-      then print_reg("CSR mstatus <- " ^ BitStr(mstatus.bits));
+      long_csr_write_callback("mstatus", "mstatush", mstatus.bits);
+
       if   get_config_print_platform()
       then print_platform("ret-ing from " ^ to_str(prev_priv) ^ " to " ^ to_str(cur_privilege));
 
@@ -305,8 +309,8 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
       if   cur_privilege != Machine
       then mstatus[MPRV] = 0b0;
 
-      if   get_config_print_reg()
-      then print_reg("CSR mstatus <- " ^ BitStr(mstatus.bits));
+      long_csr_write_callback("mstatus", "mstatush", mstatus.bits);
+
       if   get_config_print_platform()
       then print_platform("ret-ing from " ^ to_str(prev_priv)
                           ^ " to " ^ to_str(cur_privilege));
@@ -352,6 +356,7 @@ function reset_misa() -> unit = {
   misa[D]   = if   flen >= 64
               then bool_to_bits(hartSupports(Ext_D))  /* double-precision */
               else 0b0;
+  csr_write_callback("misa", misa.bits);
 }
 
 // This function is called on reset, so it should only perform the reset actions
@@ -372,6 +377,8 @@ function reset_sys() -> unit = {
   // See https://github.com/riscv/sail-riscv/issues/639
   // mstatus[MBE] = 0b0;
 
+  long_csr_write_callback("mstatus", "mstatush", mstatus.bits);
+
   // "The misa register is reset to enable the maximal set of supported extensions"
   reset_misa();
 
@@ -386,6 +393,7 @@ function reset_sys() -> unit = {
   // but the value 0 should be returned on implementations that do not
   // distinguish different reset conditions."
   mcause.bits = zeros();
+  csr_write_callback("mcause", mcause.bits);
 
   // "Writable PMP registers’ A and L fields are set to 0, unless the platform
   // mandates a different reset value for some PMP registers’ A and L fields."
@@ -393,6 +401,7 @@ function reset_sys() -> unit = {
 
   // TODO: Probably need to remove these vector resets too but it needs
   // refactoring anyway. See https://github.com/riscv/sail-riscv/issues/566 etc.
+  // If they are kept then callbacks need to be added.
 
   /* initialize vector csrs */
   vstart           = zeros();
@@ -405,10 +414,6 @@ function reset_sys() -> unit = {
   vtype[vta]       = 0b0;
   vtype[vsew]      = 0b000;
   vtype[vlmul]     = 0b000;
-
-  // log compatibility with spike
-  if   get_config_print_reg()
-  then print_reg("CSR mstatus <- " ^ BitStr(mstatus.bits) ^ " (input: " ^ BitStr(zeros() : xlenbits) ^ ")")
 }
 
 /* memory access exceptions, defined here for use by the platform model. */

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -34,6 +34,7 @@ function regidx_bits (Regidx(b) : regidx) -> bits(5) = b
 newtype regno = Regno : range(0, 31)
 
 function regidx_to_regno (Regidx(b) : regidx) -> regno = Regno(unsigned(b))
+function regno_to_regidx (Regno(b) : regno) -> regidx = Regidx(to_bits(5, b))
 
 /* mapping RVC register indices into normal indices */
 val creg2reg_idx : cregidx -> regidx

--- a/model/riscv_vext_control.sail
+++ b/model/riscv_vext_control.sail
@@ -16,6 +16,7 @@ function set_vstart(value : bits(16)) -> unit = {
   dirty_v_context();
   let vstart_length = get_vlen_pow();
   vstart = zero_extend(value[(vstart_length - 1) .. 0]);
+  csr_write_callback("vstart", zero_extend(vstart));
 }
 
 mapping clause csr_name_map = 0x008  <-> "vstart"

--- a/model/riscv_vext_regs.sail
+++ b/model/riscv_vext_regs.sail
@@ -9,10 +9,13 @@
 newtype vregidx = Vregidx : bits(5)
 newtype vregno = Vregno : range(0, 31)
 function vregidx_to_vregno (Vregidx(b) : vregidx) -> vregno = Vregno(unsigned(b))
+function vregno_to_vregidx (Vregno(b) : vregno) -> vregidx = Vregidx(to_bits(5, b))
 function vregidx_offset(Vregidx(r) : vregidx, o : bits(5)) -> vregidx = Vregidx(r + o)
 function vregidx_bits (Vregidx(b) : vregidx) -> bits(5) = b
 
 mapping encdec_vreg : vregidx <-> bits(5) = { Vregidx(r) <-> r }
+
+val vreg_write_callback = pure {c: "vreg_write_callback"} : (vregidx, vregtype) -> unit
 
 let zvreg : vregidx = Vregidx(0b00000) /* v0, zero register  */
 
@@ -91,6 +94,7 @@ function dirty_v_context() -> unit = {
   assert(hartSupports(Ext_V));
   mstatus[VS] = extStatus_to_bits(Dirty);
   mstatus[SD] = 0b1;
+  long_csr_write_callback("mstatus", "mstatush", mstatus.bits);
 }
 
 function rV (Vregno(r) : vregno) -> vregtype = {
@@ -169,8 +173,7 @@ function wV (Vregno(r) : vregno, v : vregtype) -> unit = {
   dirty_v_context();
 
   assert(0 < VLEN & VLEN <= sizeof(vlenmax));
-  if   get_config_print_reg()
-  then print_reg("v" ^ dec_str(r) ^ " <- " ^ BitStr(v[VLEN - 1 .. 0]));
+  vreg_write_callback(vregno_to_vregidx(Vregno(r)), v);
 }
 
 function rV_bits(i: vregidx) -> vregtype = rV(vregidx_to_vregno(i))

--- a/model/rvfi_dii.sail
+++ b/model/rvfi_dii.sail
@@ -325,3 +325,48 @@ function print_rvfi_exec () = {
   print_bits("rvfi_pc_rdata : ", rvfi_pc_data[rvfi_pc_rdata]);
   print_bits("rvfi_order    : ", rvfi_inst_data[rvfi_order]);
 }
+
+/* RVFI records */
+val rvfi_write : forall 'n, 0 < 'n <= max_mem_access . (xlenbits, int('n), bits(8 * 'n)) -> unit
+function rvfi_write (paddr, width, value) = {
+  rvfi_mem_data[rvfi_mem_addr] = zero_extend(paddr);
+  rvfi_mem_data_present = true;
+  if width <= 16 then {
+    /* TODO: report tag bit for capability writes and extend mask by one bit. */
+    rvfi_mem_data[rvfi_mem_wdata] = sail_zero_extend(value, 256);
+    rvfi_mem_data[rvfi_mem_wmask] = rvfi_encode_width_mask(width);
+  } else {
+    internal_error(__FILE__, __LINE__, "Expected at most 16 bytes here!");
+  };
+}
+
+val rvfi_read : forall 'n, 'n > 0. (xlenbits, int('n), bits(8 * 'n)) -> unit
+function rvfi_read (paddr, width, value) = {
+  rvfi_mem_data[rvfi_mem_addr] = zero_extend(paddr);
+  rvfi_mem_data_present = true;
+  if width <= 16 then {
+    /* TODO: report tag bit for capability writes and extend mask by one bit. */
+    rvfi_mem_data[rvfi_mem_rdata] = sail_zero_extend(value, 256);
+    rvfi_mem_data[rvfi_mem_rmask] = rvfi_encode_width_mask(width)
+  } else {
+    internal_error(__FILE__, __LINE__, "Expected at most 16 bytes here!")
+  };
+}
+
+val rvfi_mem_exception : xlenbits -> unit
+function rvfi_mem_exception (paddr) = {
+  /* Log only the memory address (without the value) if the write fails. */
+  rvfi_mem_data[rvfi_mem_addr] = zero_extend(paddr);
+  rvfi_mem_data_present = true;
+}
+
+val rvfi_wX : forall 'n, 0 <= 'n < 32. (int('n), xlenbits) -> unit
+function rvfi_wX (r,v) = {
+  rvfi_int_data[rvfi_rd_wdata] = zero_extend(v);
+  rvfi_int_data[rvfi_rd_addr] = to_bits(8, r);
+  rvfi_int_data_present = true;
+}
+
+val rvfi_trap : unit -> unit
+function rvfi_trap () =
+  rvfi_inst_data[rvfi_trap] = 0x01


### PR DESCRIPTION
Add a callback API for register, PC and CSR updates, memory writes and traps. This is used for logging and RVFI instead of embedding that code in the model itself.