### PR TITLE
Fix TLB bug

### DIFF
--- a/model/riscv_vmem.sail
+++ b/model/riscv_vmem.sail
@@ -384,16 +384,13 @@ function translate_TLB_miss(sv_params : SV_Params,
 function translate(sv_params : SV_Params,
                    asid      : asidbits,
                    ptb       : bits(64),
-                   vAddr_arg : bits(64),
+                   vAddr     : bits(64),
                    ac        : AccessType(ext_access_type),
                    priv      : Privilege,
                    mxr       : bool,
                    do_sum    : bool,
                    ext_ptw   : ext_ptw)
                   -> TR_Result(bits(64), PTW_Error) = {
-  let va_mask : bits(64) = zero_extend(ones(sv_params.va_size_bits));
-  let vAddr              = (vAddr_arg & va_mask);
-
   // On first reading, assume lookup_TLB returns None(), since TLBs
   // are not part of RISC-V archticture spec (see TLB_NOTE above)
   match lookup_TLB(asid, vAddr) {


### PR DESCRIPTION
These lines of code zeroed the top 25 bits of an Sv39 address before translating it. That meant an address like 0xFFFFFFFFFFFFFFFF would be stored in the TLB as 0x0000007fffffffff. This caused a bug with `sfence.vma` when the `rs1` (virtual address) argument was not zero. If you did `sfence.vma 0xFFFFFFFFFFFFFFFF, x0` it should clear the TLB entry but it doesn't because it naively checks `0xFFFFFFFFFFFFF000 == 0x0000007ffffff000`.

Currently there is only one TLB entry so it would need to do an `sfence.vma` for the page that was currently executing to be visible, otherwise the next fetch would clear it anyway.

An alternative fix would be to clear the upper 25 bits of `vMatchMask`, but this is simpler.