### PR TITLE
Fix innocuous issues with extension tagging

### DIFF
--- a/model/riscv_insts_end.sail
+++ b/model/riscv_insts_end.sail
@@ -27,7 +27,8 @@ mapping clause assembly = C_ILLEGAL(s) <-> "c.illegal" ^ spc() ^ hex_bits_16(s)
 /* ****************************************************************** */
 
 /* End definitions */
-end extensions
+end extension
+end extensionEnabled
 end ast
 end execute
 end assembly


### PR DESCRIPTION
- The `end` statement for `scattered enum extension` misspelled `extension`.
- `end extensionEnabled` was inadvertently dropped, and now been restored.