### PR TITLE
Zcb requires Zca

### DIFF
--- a/model/riscv_insts_zcb.sail
+++ b/model/riscv_insts_zcb.sail
@@ -7,7 +7,7 @@
 /*=======================================================================================*/
 
 enum clause extension = Ext_Zcb
-function clause extensionEnabled(Ext_Zcb) = sys_enable_zcb()
+function clause extensionEnabled(Ext_Zcb) = sys_enable_zcb() & extensionEnabled(Ext_Zca)
 
 union clause ast = C_LBU : (bits(2), cregidx, cregidx)
 


### PR DESCRIPTION
Per section 29.8 of the Unprivileged ISA manual, extension Zcb requires Zca. This updates the extensionEnabled clause to capture this requirement. 