### PR TITLE
Add an option to delimit instructions in the trace

### DIFF
--- a/c_emulator/riscv_config.h
+++ b/c_emulator/riscv_config.h
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 
 extern bool config_print_instr;
+extern bool config_print_step;
 extern bool config_print_reg;
 extern bool config_print_mem_access;
 extern bool config_print_platform;

--- a/c_emulator/riscv_prelude.c
+++ b/c_emulator/riscv_prelude.c
@@ -15,6 +15,13 @@ unit print_instr(sail_string s)
   return UNIT;
 }
 
+unit print_step(unit u)
+{
+  if (config_print_step)
+    fprintf(trace_log, "\n");
+  return UNIT;
+}
+
 unit print_reg(sail_string s)
 {
   if (config_print_reg)

--- a/c_emulator/riscv_prelude.h
+++ b/c_emulator/riscv_prelude.h
@@ -6,6 +6,7 @@
 unit print_string(sail_string prefix, sail_string msg);
 
 unit print_instr(sail_string s);
+unit print_step(unit u);
 unit print_reg(sail_string s);
 unit print_mem_access(sail_string s);
 unit print_platform(sail_string s);

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -89,6 +89,7 @@ bool config_print_reg = true;
 bool config_print_mem_access = true;
 bool config_print_platform = true;
 bool config_print_rvfi = false;
+bool config_print_step = false;
 
 void set_config_print(char *var, bool val)
 {
@@ -108,9 +109,11 @@ void set_config_print(char *var, bool val)
     config_print_rvfi = val;
   } else if (strcmp("platform", var) == 0) {
     config_print_platform = val;
+  } else if (strcmp("step", var) == 0) {
+    config_print_step = val;
   } else {
-    fprintf(stderr, "Unknown trace category: '%s' (should be %s)\n",
-            "instr|reg|mem|platform|all", var);
+    fprintf(stderr, "Unknown trace category: '%s' (should be %s)\n", var,
+            "instr|reg|mem|rvfi|platform|step|all");
     exit(1);
   }
 }
@@ -989,6 +992,9 @@ void run_sail(void)
       KILL(sail_int)(&sail_step);
     }
     if (stepped) {
+      if (config_print_step) {
+        fprintf(trace_log, "\n");
+      }
       step_no++;
       insn_cnt++;
       total_insns++;

--- a/model/prelude.sail
+++ b/model/prelude.sail
@@ -75,6 +75,10 @@ val print_reg      = {ocaml: "Platform.print_reg", interpreter: "print_endline",
 val print_mem      = {ocaml: "Platform.print_mem_access", interpreter: "print_endline", c: "print_mem_access", lem: "print_dbg", _: "print_endline"} : string -> unit
 val print_platform = {ocaml: "Platform.print_platform", interpreter: "print_endline", c: "print_platform", lem: "print_dbg", _: "print_endline"} : string -> unit
 
+val print_step = {ocaml: "Platform.print_step", c: "print_step"} : unit -> unit
+
+function print_step() = ()
+
 val get_config_print_instr = {ocaml: "Platform.get_config_print_instr", c:"get_config_print_instr"} : unit -> bool
 val get_config_print_reg = {ocaml: "Platform.get_config_print_reg", c:"get_config_print_reg"} : unit -> bool
 val get_config_print_mem = {ocaml: "Platform.get_config_print_mem", c:"get_config_print_mem"} : unit -> bool

--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -99,6 +99,9 @@ function loop () : unit -> unit = {
     let stepped = step(step_no);
     if stepped then {
       step_no = step_no + 1;
+      if get_config_print_instr() then {
+        print_step()
+      };
       sail_end_cycle()
     };
 

--- a/ocaml_emulator/platform.ml
+++ b/ocaml_emulator/platform.ml
@@ -26,6 +26,7 @@ let platform_arch = ref P.RV64
 (* logging *)
 
 let config_print_instr       = ref true
+let config_print_step        = ref false
 let config_print_reg         = ref true
 let config_print_mem_access  = ref true
 let config_print_platform    = ref true
@@ -33,6 +34,11 @@ let config_print_platform    = ref true
 let print_instr s =
   if !config_print_instr
   then print_endline s
+  else ()
+
+let print_step () =
+  if !config_print_step
+  then print_endline ""
   else ()
 
 let print_reg s =

--- a/ocaml_emulator/riscv_ocaml_sim.ml
+++ b/ocaml_emulator/riscv_ocaml_sim.ml
@@ -86,6 +86,9 @@ let options = Arg.align ([("-dump-dts",
                           ("-signature-granularity",
                            Arg.Int set_signature_granularity,
                            " test signature granularity (in bytes)");
+                          ("-trace-delimit-step",
+                           Arg.Set P.config_print_step,
+                           " delimit instructions in the trace output");
                           ("-isa",
                            Arg.String (fun s -> opt_isa := Some s),
                            " requested isa");


### PR DESCRIPTION
See: https://github.com/riscv/sail-riscv/issues/526

An extra newline is inserted after each 'step' in the simulator, if the appropriate trace option is provided. The spaces that were previously in the trace were just an artifact of an extra space inserted when we flushed the trace output (which just happened to coincide with the step). These should actually be guaranteed to delimit each instruction.

Supports both the OCaml and C emulators. For the C emulator this is enabled with `--trace=step`, and for OCaml `-trace-delimit-step`. It works slightly differently in both cases, because of how the two emulators handle the toplevel loop differently - but care was taken to ensure if you did run the sail `loop` function in C, it will behave the same.

The C simulator `--trace` option had it's error message formatted oddly when the passed option was unrecognised, with the expected and provided argument flipped, so that has also been fixed.