### PR TITLE
Install Sail from binary in CI

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -7,19 +7,19 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Install packages
-      run: sudo apt install -y opam zlib1g-dev pkg-config libgmp-dev z3 device-tree-compiler
+      run: sudo apt install -y --no-install-recommends zlib1g-dev pkg-config libgmp-dev curl
     - name: Check out repository code
       uses: actions/checkout@HEAD
       with:
         submodules: true
     - name: Ensure pre-commit checks pass
-      run: pip install pre-commit && pre-commit run --all-files --show-diff-on-failure --color=always
-    - name: Init opam
-      run: opam init --disable-sandboxing -y
-    - name: Install sail
-      run: opam install -y sail
+      run: python3 -m pip install pre-commit && pre-commit run --all-files --show-diff-on-failure --color=always
+    - name: Install sail from binary
+      run: |
+        sudo mkdir -p /usr/local
+        curl --location https://github.com/rems-project/sail/releases/download/0.18-linux-binary/sail.tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
     - name: Build and test simulators
-      run: eval $(opam env) && test/run_tests.sh
+      run: test/run_tests.sh
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -256,13 +256,13 @@ Getting started
 
 ### Building the model
 
-Install [Sail](https://github.com/rems-project/sail/) [using opam](https://github.com/rems-project/sail/blob/sail2/INSTALL.md) then:
+Install [Sail](https://github.com/rems-project/sail/). On Linux you can download a [binary release](https://github.com/rems-project/sail/releases) (strongly recommended), or you can install from source [using opam](https://github.com/rems-project/sail/blob/sail2/INSTALL.md). Then:
 
 ```
 $ make
 ```
 
-will build the C simulator in `c_emulator/riscv_sim_RV64`.
+will build the simulator in `c_emulator/riscv_sim_RV64`.
 
 If you get an error message saying `sail: unknown option '--require-version'.` it's because your Sail compiler is too old. You need version 0.18 or later.
 
@@ -275,7 +275,7 @@ built using:
 $ ARCH=RV32 make
 ```
 
-which creates the C simulator in `c_emulator/riscv_sim_RV32`.
+which creates the simulator in `c_emulator/riscv_sim_RV32`.
 
 The Makefile targets `riscv_isa_build`, `riscv_coq_build`, and
 `riscv_hol_build` invoke the respective prover to process the
@@ -291,7 +291,7 @@ corresponding prover libraries in the Sail directory
 
 ### Executing test binaries
 
-The C simulator can be used to execute small test binaries.
+The simulator can be used to execute small test binaries.
 
 ```
 $ ./c_emulator/riscv_sim_<arch> <elf-file>


### PR DESCRIPTION
This should be a lot faster. It also means the version is pinned properly which wasn't the case before.

I also recommended users to do the same in the README do they don't have to deal with OPAM.