### PR TITLE
Require Sail version 0.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ SAIL_COQ_SRCS  = $(addprefix model/,$(SAIL_ARCH_SRCS) $(SAIL_SEQ_INST_SRCS) $(SA
 
 PLATFORM_OCAML_SRCS = $(addprefix ocaml_emulator/,platform.ml platform_impl.ml softfloat.ml riscv_ocaml_sim.ml)
 
+SAIL_FLAGS += --require-version 0.18
 SAIL_FLAGS += --strict-var
 SAIL_FLAGS += -dno_cast
 SAIL_DOC_FLAGS ?= -doc_embed plain

--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ will build the 64-bit OCaml simulator in
 `ocaml_emulator/riscv_ocaml_sim_RV64` and the C simulator in
 `c_emulator/riscv_sim_RV64`.
 
+If you get an error message saying `sail: unknown option '--require-version'.` it's because your Sail compiler is too old. You need version 0.18 or later.
+
 One can build either the RV32 or the RV64 model by specifying
 `ARCH=RV32` or `ARCH=RV64` on the `make` line, and using the matching
 target suffix.  RV64 is built by default, but the RV32 model can be


### PR DESCRIPTION
Use the new `--require-version` flag to set the minimum version to 0.18 (the current latest release). If you have an older version that supports this flag you'll get an error like

    Sail version 0.17.1 is older than requested version 0.18

Currently there actually aren't any older versions that support this flag (unless you compiled from source) so you'd get this error instead:

    sail: unknown option '--require-version'.

Not ideal, but the problem will solve itself eventually so I don't think it's worth worrying about for now.