### PR TITLE
Add Zicbop extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For booting operating system images, see the information under the
 - Zicsr extension for CSR instructions, v2.0
 - Zicntr and Zihpm extensions for counters, v2.0
 - Zicond extension for integer conditional operations, v1.0
-- Zicbom and Zicboz extensions for cache-block management (Zicbop not currently supported), v1.0
+- Zicbom, Zicbop and Zicboz extensions for cache-block management, v1.0
 - Zimop extension for May-Be-Operations, v1.0
 - Zihintntl extension for Non-temporal Locality Hints, v1.0
 - Zihintpause extension for Pause Hint, v2.0

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -81,6 +81,9 @@
     "Zicbom": {
       "supported": true
     },
+    "Zicbop": {
+      "supported": true
+    },
     "Zicboz": {
       "supported": true
     },

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -7,6 +7,7 @@
 
 - The following extensions have been added:
 
+  - Zicbop
   - Zihintntl
   - Zihintpause
 

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -338,6 +338,19 @@ extensions {
     }
   }
 
+  Zicbop {
+    Zicbop_types {
+      before riscv
+      files riscv_zicbop_types.sail
+    }
+    Zicbop_insts {
+      // PREFETCH.{I,R,W} instructions override ORI hints (rd=0)
+      before I_insts
+      requires riscv, Zicbop_types
+      files riscv_insts_zicbop.sail
+    }
+  }
+
   Zicboz {
     requires riscv
     files riscv_insts_zicboz.sail

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -76,6 +76,10 @@ function clause hartSupports(Ext_H) = false
 enum clause extension = Ext_Zicbom
 mapping clause extensionName = Ext_Zicbom <-> "zicbom"
 function clause hartSupports(Ext_Zicbom) = config extensions.Zicbom.supported
+// Cache-Block Prefetch Instructions
+enum clause extension = Ext_Zicbop
+mapping clause extensionName = Ext_Zicbop <-> "zicbop"
+function clause hartSupports(Ext_Zicbop) = config extensions.Zicbop.supported
 // Cache-Block Zero Instructions
 enum clause extension = Ext_Zicboz
 mapping clause extensionName = Ext_Zicboz <-> "zicboz"
@@ -401,6 +405,7 @@ let extensions_ordered_for_isa_string = [
   // Z extensions, ordered by category and then alphabetically.
   // Zi
   Ext_Zicbom,
+  Ext_Zicbop,
   Ext_Zicboz,
   Ext_Zicntr,
   Ext_Zicond,

--- a/model/riscv_insts_zicbop.sail
+++ b/model/riscv_insts_zicbop.sail
@@ -1,0 +1,35 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+// Cache Block Operations - Prefetch
+
+function clause currentlyEnabled(Ext_Zicbop) = hartSupports(Ext_Zicbop)
+
+/* ****************************************************************** */
+union clause instruction = ZICBOP : (cbop_zicbop, regidx, bits(12))
+
+mapping encdec_cbop_zicbop : cbop_zicbop <-> bits(5) = {
+  PREFETCH_I <-> 0b00000,
+  PREFETCH_R <-> 0b00001,
+  PREFETCH_W <-> 0b00011,
+}
+
+mapping clause encdec = ZICBOP(cbop, rs1, offset11_5 @ 0b00000)
+  <-> offset11_5 @ encdec_cbop_zicbop(cbop) @ encdec_reg(rs1) @ 0b110 @ 0b00000 @ 0b0010011
+  when currentlyEnabled(Ext_Zicbop)
+
+mapping prefetch_mnemonic : cbop_zicbop <-> string = {
+  PREFETCH_I <-> "prefetch.i",
+  PREFETCH_R <-> "prefetch.r",
+  PREFETCH_W <-> "prefetch.w"
+}
+
+mapping clause assembly = ZICBOP(cbop, rs1, offset)
+  <-> prefetch_mnemonic(cbop) ^ spc() ^ hex_bits_12(offset) ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
+
+function clause execute(ZICBOP(cbop, rs1, offset)) = RETIRE_SUCCESS

--- a/model/riscv_zicbop_types.sail
+++ b/model/riscv_zicbop_types.sail
@@ -1,0 +1,9 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+enum cbop_zicbop = {PREFETCH_I, PREFETCH_R, PREFETCH_W}


### PR DESCRIPTION
Add prefetch hint instructions. The Sail model has no caches so this has no effect on execution, however it does make the disassembly output more useful and show what the encoding should be.