### PR TITLE
Upstream formats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,45 +23,46 @@ SAIL_VLEN := riscv_vlen.sail
 
 # Instruction sources, depending on target
 SAIL_CHECK_SRCS = riscv_addr_checks_common.sail riscv_addr_checks.sail riscv_misa_ext.sail
-SAIL_DEFAULT_INST = riscv_insts_base.sail riscv_insts_aext.sail riscv_insts_zca.sail riscv_insts_mext.sail riscv_insts_zicsr.sail riscv_insts_next.sail riscv_insts_hints.sail
-SAIL_DEFAULT_INST += riscv_insts_fext.sail riscv_insts_zcf.sail
-SAIL_DEFAULT_INST += riscv_insts_dext.sail riscv_insts_zcd.sail
+#SAIL_DEFAULT_INST = riscv_insts_base.sail riscv_insts_aext.sail riscv_insts_zca.sail riscv_insts_mext.sail riscv_insts_zicsr.sail riscv_insts_next.sail riscv_insts_hints.sail
+#SAIL_DEFAULT_INST += riscv_insts_fext.sail riscv_insts_zcf.sail
+#SAIL_DEFAULT_INST += riscv_insts_dext.sail riscv_insts_zcd.sail
+SAIL_DEFAULT_INST = riscv_insts_base.sail riscv_insts_zicsr.sail riscv_insts_next.sail
 
-SAIL_DEFAULT_INST += riscv_insts_svinval.sail
+#SAIL_DEFAULT_INST += riscv_insts_svinval.sail
 
-SAIL_DEFAULT_INST += riscv_insts_zba.sail
-SAIL_DEFAULT_INST += riscv_insts_zbb.sail
-SAIL_DEFAULT_INST += riscv_insts_zbc.sail
-SAIL_DEFAULT_INST += riscv_insts_zbs.sail
+#SAIL_DEFAULT_INST += riscv_insts_zba.sail
+#SAIL_DEFAULT_INST += riscv_insts_zbb.sail
+#SAIL_DEFAULT_INST += riscv_insts_zbc.sail
+#SAIL_DEFAULT_INST += riscv_insts_zbs.sail
 
-SAIL_DEFAULT_INST += riscv_insts_zcb.sail
+#SAIL_DEFAULT_INST += riscv_insts_zcb.sail
 
-SAIL_DEFAULT_INST += riscv_insts_zfh.sail
+#SAIL_DEFAULT_INST += riscv_insts_zfh.sail
 # Zfa needs to be added after fext, dext and Zfh (as it needs
 # definitions from those)
-SAIL_DEFAULT_INST += riscv_insts_zfa.sail
+#SAIL_DEFAULT_INST += riscv_insts_zfa.sail
 
-SAIL_DEFAULT_INST += riscv_insts_zkn.sail
-SAIL_DEFAULT_INST += riscv_insts_zks.sail
+#SAIL_DEFAULT_INST += riscv_insts_zkn.sail
+#SAIL_DEFAULT_INST += riscv_insts_zks.sail
 
-SAIL_DEFAULT_INST += riscv_insts_zbkb.sail
-SAIL_DEFAULT_INST += riscv_insts_zbkx.sail
+#SAIL_DEFAULT_INST += riscv_insts_zbkb.sail
+#SAIL_DEFAULT_INST += riscv_insts_zbkx.sail
 
-SAIL_DEFAULT_INST += riscv_insts_zicond.sail
+#SAIL_DEFAULT_INST += riscv_insts_zicond.sail
 
-SAIL_DEFAULT_INST += riscv_insts_vext_utils.sail
-SAIL_DEFAULT_INST += riscv_insts_vext_fp_utils.sail
-SAIL_DEFAULT_INST += riscv_insts_vext_vset.sail
-SAIL_DEFAULT_INST += riscv_insts_vext_arith.sail
-SAIL_DEFAULT_INST += riscv_insts_vext_fp.sail
-SAIL_DEFAULT_INST += riscv_insts_vext_mem.sail
-SAIL_DEFAULT_INST += riscv_insts_vext_mask.sail
-SAIL_DEFAULT_INST += riscv_insts_vext_vm.sail
-SAIL_DEFAULT_INST += riscv_insts_vext_fp_vm.sail
-SAIL_DEFAULT_INST += riscv_insts_vext_red.sail
-SAIL_DEFAULT_INST += riscv_insts_vext_fp_red.sail
-SAIL_DEFAULT_INST += riscv_insts_zicbom.sail
-SAIL_DEFAULT_INST += riscv_insts_zicboz.sail
+#SAIL_DEFAULT_INST += riscv_insts_vext_utils.sail
+#SAIL_DEFAULT_INST += riscv_insts_vext_fp_utils.sail
+#SAIL_DEFAULT_INST += riscv_insts_vext_vset.sail
+#SAIL_DEFAULT_INST += riscv_insts_vext_arith.sail
+#SAIL_DEFAULT_INST += riscv_insts_vext_fp.sail
+#SAIL_DEFAULT_INST += riscv_insts_vext_mem.sail
+#SAIL_DEFAULT_INST += riscv_insts_vext_mask.sail
+#SAIL_DEFAULT_INST += riscv_insts_vext_vm.sail
+#SAIL_DEFAULT_INST += riscv_insts_vext_fp_vm.sail
+#SAIL_DEFAULT_INST += riscv_insts_vext_red.sail
+#SAIL_DEFAULT_INST += riscv_insts_vext_fp_red.sail
+#SAIL_DEFAULT_INST += riscv_insts_zicbom.sail
+#SAIL_DEFAULT_INST += riscv_insts_zicboz.sail
 
 SAIL_SEQ_INST  = $(SAIL_DEFAULT_INST) riscv_jalr_seq.sail
 SAIL_RMEM_INST = $(SAIL_DEFAULT_INST) riscv_jalr_rmem.sail riscv_insts_rmem.sail

--- a/model/riscv_decode_ext.sail
+++ b/model/riscv_decode_ext.sail
@@ -15,4 +15,7 @@ val ext_decode_compressed : bits(16) -> ast
 function ext_decode_compressed(bv) = encdec_compressed(bv)
 
 val ext_decode : bits(32) -> ast
+/*
 function ext_decode(bv) = encdec(bv)
+*/
+function ext_decode(bv) = fmtencdec(fmt2bits(bv))

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -23,8 +23,13 @@ mapping encdec_uop : uop <-> bits(7) = {
   RISCV_AUIPC <-> 0b0010111
 }
 
-mapping clause encdec = UTYPE(imm, rd, op)
+mapping clause oldencdec = UTYPE(imm, rd, op)
   <-> imm @ rd @ encdec_uop(op)
+
+function clause opcode2format 0b0110111 = U_Format
+function clause opcode2format 0b0010111 = U_Format
+mapping clause fmtencdec = UTYPE(imm, rd, op)
+  <-> UFormat(struct { imm = imm, rd = rd, opcode = encdec_uop(op) })
 
 function clause execute UTYPE(imm, rd, op) = {
   let off : xlenbits = sign_extend(imm @ 0x000);
@@ -47,13 +52,17 @@ mapping clause assembly = UTYPE(imm, rd, op)
 /* ****************************************************************** */
 union clause ast = RISCV_JAL : (bits(21), regidx)
 
-mapping clause encdec = RISCV_JAL(imm_19 @ imm_7_0 @ imm_8 @ imm_18_13 @ imm_12_9 @ 0b0, rd)
+mapping clause oldencdec = RISCV_JAL(imm_19 @ imm_7_0 @ imm_8 @ imm_18_13 @ imm_12_9 @ 0b0, rd)
   <-> imm_19 : bits(1) @ imm_18_13 : bits(6) @ imm_12_9 : bits(4) @ imm_8 : bits(1) @ imm_7_0 : bits(8) @ rd @ 0b1101111
+
+function clause opcode2format 0b1101111 = J_Format
+mapping clause fmtencdec = RISCV_JAL(imm, rd)
+  <-> JFormat(struct { imm = imm, rd = rd, opcode = 0b1101111 })
 
 /*
 ideally we want some syntax like
 
-mapping clause encdec = RISCV_JAL(imm @ 0b0, rd) <-> imm[19] @ imm[9..0] @ imm[10] @ imm[18..11] @ rd @ 0b1101111
+mapping clause oldencdec = RISCV_JAL(imm @ 0b0, rd) <-> imm[19] @ imm[9..0] @ imm[10] @ imm[18..11] @ rd @ 0b1101111
 
 match bv {
   imm[19] @ imm[9..0] @ imm[10] @ imm[18..11] -> imm @ 0b0
@@ -93,8 +102,12 @@ mapping clause assembly = RISCV_JAL(imm, rd)
 /* ****************************************************************** */
 union clause ast = RISCV_JALR : (bits(12), regidx, regidx)
 
-mapping clause encdec = RISCV_JALR(imm, rs1, rd)
+mapping clause oldencdec = RISCV_JALR(imm, rs1, rd)
   <-> imm @ rs1 @ 0b000 @ rd @ 0b1100111
+
+function clause opcode2format 0b1100111 = I_Format
+mapping clause fmtencdec = RISCV_JALR(imm, rs1, rd)
+  <-> IFormat(struct { imm = imm, rs1 = rs1, funct3 = 0b000, rd = rd, opcode = 0b1100111 })
 
 mapping clause assembly = RISCV_JALR(imm, rs1, rd)
   <-> "jalr" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_signed_12(imm) ^ "(" ^ reg_name(rs1) ^ ")"
@@ -113,8 +126,12 @@ mapping encdec_bop : bop <-> bits(3) = {
   RISCV_BGEU <-> 0b111
 }
 
-mapping clause encdec = BTYPE(imm7_6 @ imm5_0 @ imm7_5_0 @ imm5_4_1 @ 0b0, rs2, rs1, op)
+mapping clause oldencdec = BTYPE(imm7_6 @ imm5_0 @ imm7_5_0 @ imm5_4_1 @ 0b0, rs2, rs1, op)
   <-> imm7_6 : bits(1) @ imm7_5_0 : bits(6) @ rs2 @ rs1 @ encdec_bop(op) @ imm5_4_1 : bits(4) @ imm5_0 : bits(1) @ 0b1100011
+
+function clause opcode2format 0b1100011 = B_Format
+mapping clause fmtencdec = BTYPE(imm, rs2, rs1, op)
+  <-> BFormat(struct { imm = imm, rs2 = rs2, rs1 = rs1, funct3 = encdec_bop(op), opcode = 0b1100011 })
 
 function clause execute (BTYPE(imm, rs2, rs1, op)) = {
   let rs1_val = X(rs1);
@@ -172,8 +189,12 @@ mapping encdec_iop : iop <-> bits(3) = {
   RISCV_XORI  <-> 0b100
 }
 
-mapping clause encdec = ITYPE(imm, rs1, rd, op)
+mapping clause oldencdec = ITYPE(imm, rs1, rd, op)
   <-> imm @ rs1 @ encdec_iop(op) @ rd @ 0b0010011
+
+function clause opcode2format 0b0010011 = I_Format
+mapping clause fmtencdec = ITYPE(imm, rs1, rd, op)
+  <-> IFormat(struct { imm = imm, rs1 = rs1, funct3 = encdec_iop(op), rd = rd, opcode = 0b0010011 })
 
 function clause execute (ITYPE (imm, rs1, rd, op)) = {
   let rs1_val = X(rs1);
@@ -211,9 +232,17 @@ mapping encdec_sop : sop <-> bits(3) = {
   RISCV_SRAI <-> 0b101
 }
 
-mapping clause encdec = SHIFTIOP(shamt, rs1, rd, RISCV_SLLI) <-> 0b000000 @ shamt @ rs1 @ 0b001 @ rd @ 0b0010011 if sizeof(xlen) == 64 | shamt[5] == bitzero
-mapping clause encdec = SHIFTIOP(shamt, rs1, rd, RISCV_SRLI) <-> 0b000000 @ shamt @ rs1 @ 0b101 @ rd @ 0b0010011 if sizeof(xlen) == 64 | shamt[5] == bitzero
-mapping clause encdec = SHIFTIOP(shamt, rs1, rd, RISCV_SRAI) <-> 0b010000 @ shamt @ rs1 @ 0b101 @ rd @ 0b0010011 if sizeof(xlen) == 64 | shamt[5] == bitzero
+mapping clause oldencdec = SHIFTIOP(shamt, rs1, rd, RISCV_SLLI) <-> 0b000000 @ shamt @ rs1 @ 0b001 @ rd @ 0b0010011 if sizeof(xlen) == 64 | shamt[5] == bitzero
+mapping clause oldencdec = SHIFTIOP(shamt, rs1, rd, RISCV_SRLI) <-> 0b000000 @ shamt @ rs1 @ 0b101 @ rd @ 0b0010011 if sizeof(xlen) == 64 | shamt[5] == bitzero
+mapping clause oldencdec = SHIFTIOP(shamt, rs1, rd, RISCV_SRAI) <-> 0b010000 @ shamt @ rs1 @ 0b101 @ rd @ 0b0010011 if sizeof(xlen) == 64 | shamt[5] == bitzero
+
+function clause opcode2format 0b0010011 = I_Format
+mapping clause fmtencdec = SHIFTIOP(shamt, rs1, rd, RISCV_SLLI) if sizeof(xlen) == 64 | shamt[5] == bitzero
+  <-> IFormat(struct { imm = 0b000000 @ shamt, rs1 = rs1, funct3 = 0b001, rd = rd, opcode = 0b0010011 }) if sizeof(xlen) == 64 | shamt[5] == bitzero
+mapping clause fmtencdec = SHIFTIOP(shamt, rs1, rd, RISCV_SRLI) if sizeof(xlen) == 64 | shamt[5] == bitzero
+  <-> IFormat(struct { imm = 0b000000 @ shamt, rs1 = rs1, funct3 = 0b101, rd = rd, opcode = 0b0010011 }) if sizeof(xlen) == 64 | shamt[5] == bitzero
+mapping clause fmtencdec = SHIFTIOP(shamt, rs1, rd, RISCV_SRAI) if sizeof(xlen) == 64 | shamt[5] == bitzero
+  <-> IFormat(struct { imm = 0b010000 @ shamt, rs1 = rs1, funct3 = 0b101, rd = rd, opcode = 0b0010011 }) if sizeof(xlen) == 64 | shamt[5] == bitzero
 
 function clause execute (SHIFTIOP(shamt, rs1, rd, op)) = {
   let rs1_val = X(rs1);
@@ -245,16 +274,38 @@ mapping clause assembly = SHIFTIOP(shamt, rs1, rd, op)
 /* ****************************************************************** */
 union clause ast = RTYPE : (regidx, regidx, regidx, rop)
 
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_ADD)  <-> 0b0000000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SLT)  <-> 0b0000000 @ rs2 @ rs1 @ 0b010 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SLTU) <-> 0b0000000 @ rs2 @ rs1 @ 0b011 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_AND)  <-> 0b0000000 @ rs2 @ rs1 @ 0b111 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_OR)   <-> 0b0000000 @ rs2 @ rs1 @ 0b110 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_XOR)  <-> 0b0000000 @ rs2 @ rs1 @ 0b100 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SLL)  <-> 0b0000000 @ rs2 @ rs1 @ 0b001 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SRL)  <-> 0b0000000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SUB)  <-> 0b0100000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SRA)  <-> 0b0100000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0110011
+mapping clause oldencdec = RTYPE(rs2, rs1, rd, RISCV_ADD)  <-> 0b0000000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011
+mapping clause oldencdec = RTYPE(rs2, rs1, rd, RISCV_SLT)  <-> 0b0000000 @ rs2 @ rs1 @ 0b010 @ rd @ 0b0110011
+mapping clause oldencdec = RTYPE(rs2, rs1, rd, RISCV_SLTU) <-> 0b0000000 @ rs2 @ rs1 @ 0b011 @ rd @ 0b0110011
+mapping clause oldencdec = RTYPE(rs2, rs1, rd, RISCV_AND)  <-> 0b0000000 @ rs2 @ rs1 @ 0b111 @ rd @ 0b0110011
+mapping clause oldencdec = RTYPE(rs2, rs1, rd, RISCV_OR)   <-> 0b0000000 @ rs2 @ rs1 @ 0b110 @ rd @ 0b0110011
+mapping clause oldencdec = RTYPE(rs2, rs1, rd, RISCV_XOR)  <-> 0b0000000 @ rs2 @ rs1 @ 0b100 @ rd @ 0b0110011
+mapping clause oldencdec = RTYPE(rs2, rs1, rd, RISCV_SLL)  <-> 0b0000000 @ rs2 @ rs1 @ 0b001 @ rd @ 0b0110011
+mapping clause oldencdec = RTYPE(rs2, rs1, rd, RISCV_SRL)  <-> 0b0000000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0110011
+mapping clause oldencdec = RTYPE(rs2, rs1, rd, RISCV_SUB)  <-> 0b0100000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011
+mapping clause oldencdec = RTYPE(rs2, rs1, rd, RISCV_SRA)  <-> 0b0100000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0110011
+
+function clause opcode2format 0b0110011 = R_Format
+mapping clause fmtencdec = RTYPE(rs2, rs1, rd, RISCV_ADD)
+  <-> RFormat(struct { funct7 = 0b0000000, rs2 = rs2, rs1 = rs1, funct3 = 0b000, rd = rd, opcode = 0b0110011 })
+mapping clause fmtencdec = RTYPE(rs2, rs1, rd, RISCV_SLT)
+  <-> RFormat(struct { funct7 = 0b0000000, rs2 = rs2, rs1 = rs1, funct3 = 0b010, rd = rd, opcode = 0b0110011 })
+mapping clause fmtencdec = RTYPE(rs2, rs1, rd, RISCV_SLTU)
+  <-> RFormat(struct { funct7 = 0b0000000, rs2 = rs2, rs1 = rs1, funct3 = 0b011, rd = rd, opcode = 0b0110011 })
+mapping clause fmtencdec = RTYPE(rs2, rs1, rd, RISCV_AND)
+  <-> RFormat(struct { funct7 = 0b0000000, rs2 = rs2, rs1 = rs1, funct3 = 0b111, rd = rd, opcode = 0b0110011 })
+mapping clause fmtencdec = RTYPE(rs2, rs1, rd, RISCV_OR)
+  <-> RFormat(struct { funct7 = 0b0000000, rs2 = rs2, rs1 = rs1, funct3 = 0b110, rd = rd, opcode = 0b0110011 })
+mapping clause fmtencdec = RTYPE(rs2, rs1, rd, RISCV_XOR)
+  <-> RFormat(struct { funct7 = 0b0000000, rs2 = rs2, rs1 = rs1, funct3 = 0b100, rd = rd, opcode = 0b0110011 })
+mapping clause fmtencdec = RTYPE(rs2, rs1, rd, RISCV_SLL)
+  <-> RFormat(struct { funct7 = 0b0000000, rs2 = rs2, rs1 = rs1, funct3 = 0b001, rd = rd, opcode = 0b0110011 })
+mapping clause fmtencdec = RTYPE(rs2, rs1, rd, RISCV_SRL)
+  <-> RFormat(struct { funct7 = 0b0000000, rs2 = rs2, rs1 = rs1, funct3 = 0b101, rd = rd, opcode = 0b0110011 })
+mapping clause fmtencdec = RTYPE(rs2, rs1, rd, RISCV_SUB)
+  <-> RFormat(struct { funct7 = 0b0100000, rs2 = rs2, rs1 = rs1, funct3 = 0b000, rd = rd, opcode = 0b0110011 })
+mapping clause fmtencdec = RTYPE(rs2, rs1, rd, RISCV_SRA)
+  <-> RFormat(struct { funct7 = 0b0100000, rs2 = rs2, rs1 = rs1, funct3 = 0b101, rd = rd, opcode = 0b0110011 })
 
 function clause execute (RTYPE(rs2, rs1, rd, op)) = {
   let rs1_val = X(rs1);
@@ -302,8 +353,12 @@ union clause ast = LOAD : (bits(12), regidx, regidx, bool, word_width, bool, boo
 
 /* unsigned loads are only present for widths strictly less than xlen,
    signed loads also present for widths equal to xlen */
-mapping clause encdec = LOAD(imm, rs1, rd, is_unsigned, size, false, false) if (size_bytes(size) < sizeof(xlen_bytes)) | (not(is_unsigned) & size_bytes(size) <= sizeof(xlen_bytes))
+mapping clause oldencdec = LOAD(imm, rs1, rd, is_unsigned, size, false, false) if (size_bytes(size) < sizeof(xlen_bytes)) | (not(is_unsigned) & size_bytes(size) <= sizeof(xlen_bytes))
   <-> imm @ rs1 @ bool_bits(is_unsigned) @ size_enc(size) @ rd @ 0b0000011 if (size_bytes(size) < sizeof(xlen_bytes)) | (not(is_unsigned) & size_bytes(size) <= sizeof(xlen_bytes))
+
+function clause opcode2format 0b0000011 = I_Format
+mapping clause fmtencdec = LOAD(imm, rs1, rd, is_unsigned, size, false, false) if (size_bytes(size) < sizeof(xlen_bytes)) | (not(is_unsigned) & size_bytes(size) <= sizeof(xlen_bytes))
+  <-> IFormat(struct { imm = imm, rs1 = rs1, funct3 = bool_bits(is_unsigned) @ size_enc(size), rd = rd, opcode = 0b0000011 }) if (size_bytes(size) < sizeof(xlen_bytes)) | (not(is_unsigned) & size_bytes(size) <= sizeof(xlen_bytes))
 
 val extend_value : forall 'n, 0 < 'n <= xlen. (bool, bits('n)) -> xlenbits
 function extend_value(is_unsigned, value) = if is_unsigned then zero_extend(value) else sign_extend(value)
@@ -371,8 +426,12 @@ mapping clause assembly = LOAD(imm, rs1, rd, is_unsigned, size, aq, rl)
 /* ****************************************************************** */
 union clause ast = STORE : (bits(12), regidx, regidx, word_width, bool, bool)
 
-mapping clause encdec = STORE(imm7 @ imm5, rs2, rs1, size, false, false)              if size_bytes(size) <= sizeof(xlen_bytes)
+mapping clause oldencdec = STORE(imm7 @ imm5, rs2, rs1, size, false, false)              if size_bytes(size) <= sizeof(xlen_bytes)
   <-> imm7 : bits(7) @ rs2 @ rs1 @ 0b0 @ size_enc(size) @ imm5 : bits(5) @ 0b0100011 if size_bytes(size) <= sizeof(xlen_bytes)
+
+function clause opcode2format 0b0100011 = S_Format
+mapping clause fmtencdec = STORE(imm, rs2, rs1, size, false, false) if size_bytes(size) <= sizeof(xlen_bytes)
+  <-> SFormat(struct { imm = imm, rs2 = rs2, rs1 = rs1, funct3 = 0b0 @ size_enc(size), opcode = 0b0100011 }) if size_bytes(size) <= sizeof(xlen_bytes)
 
 /* NOTE: Currently, we only EA if address translation is successful.
    This may need revisiting. */
@@ -416,10 +475,14 @@ mapping clause assembly = STORE(imm, rs2, rs1, size, aq, rl)
 /* ****************************************************************** */
 union clause ast = ADDIW : (bits(12), regidx, regidx)
 
-mapping clause encdec = ADDIW(imm, rs1, rd)
+mapping clause oldencdec = ADDIW(imm, rs1, rd)
       if sizeof(xlen) == 64
   <-> imm @ rs1 @ 0b000 @ rd @ 0b0011011
       if sizeof(xlen) == 64
+
+function clause opcode2format 0b0011011 = I_Format
+mapping clause fmtencdec = ADDIW(imm, rs1, rd) if sizeof(xlen) == 64
+  <-> IFormat(struct { imm = imm, rs1 = rs1, funct3 = 0b000, rd = rd, opcode = 0b0011011 }) if sizeof(xlen) == 64
 
 function clause execute (ADDIW(imm, rs1, rd)) = {
   let result : xlenbits = sign_extend(imm) + X(rs1);
@@ -435,26 +498,40 @@ mapping clause assembly = ADDIW(imm, rs1, rd)
 /* ****************************************************************** */
 union clause ast = RTYPEW : (regidx, regidx, regidx, ropw)
 
-mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_ADDW)
+let RTYPEW_opcode : bits(7) = 0b0110011
+
+mapping clause oldencdec = RTYPEW(rs2, rs1, rd, RISCV_ADDW)
       if sizeof(xlen) == 64
-  <-> 0b0000000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0111011
+  <-> 0b0000000 @ rs2 @ rs1 @ 0b000 @ rd @ RTYPEW_opcode
       if sizeof(xlen) == 64
-mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_SUBW)
+mapping clause oldencdec = RTYPEW(rs2, rs1, rd, RISCV_SUBW)
       if sizeof(xlen) == 64
-  <-> 0b0100000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0111011
+  <-> 0b0100000 @ rs2 @ rs1 @ 0b000 @ rd @ RTYPEW_opcode
       if sizeof(xlen) == 64
-mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_SLLW)
+mapping clause oldencdec = RTYPEW(rs2, rs1, rd, RISCV_SLLW)
       if sizeof(xlen) == 64
-  <-> 0b0000000 @ rs2 @ rs1 @ 0b001 @ rd @ 0b0111011
+  <-> 0b0000000 @ rs2 @ rs1 @ 0b001 @ rd @ RTYPEW_opcode
       if sizeof(xlen) == 64
-mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_SRLW)
+mapping clause oldencdec = RTYPEW(rs2, rs1, rd, RISCV_SRLW)
       if sizeof(xlen) == 64
-  <-> 0b0000000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0111011
+  <-> 0b0000000 @ rs2 @ rs1 @ 0b101 @ rd @ RTYPEW_opcode
       if sizeof(xlen) == 64
-mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_SRAW)
+mapping clause oldencdec = RTYPEW(rs2, rs1, rd, RISCV_SRAW)
       if sizeof(xlen) == 64
-  <-> 0b0100000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0111011
+  <-> 0b0100000 @ rs2 @ rs1 @ 0b101 @ rd @ RTYPEW_opcode
       if sizeof(xlen) == 64
+
+function clause opcode2format 0b0110011 = R_Format
+mapping clause fmtencdec = RTYPEW(rs2, rs1, rd, RISCV_ADDW) if sizeof(xlen) == 64
+  <-> RFormat(struct { funct7 = 0b0000000, rs2 = rs2, rs1 = rs1, funct3 = 0b000, rd = rd, opcode = RTYPEW_opcode }) if sizeof(xlen) == 64
+mapping clause fmtencdec = RTYPEW(rs2, rs1, rd, RISCV_SUBW) if sizeof(xlen) == 64
+  <-> RFormat(struct { funct7 = 0b0100000, rs2 = rs2, rs1 = rs1, funct3 = 0b000, rd = rd, opcode = RTYPEW_opcode }) if sizeof(xlen) == 64
+mapping clause fmtencdec = RTYPEW(rs2, rs1, rd, RISCV_SLLW) if sizeof(xlen) == 64
+  <-> RFormat(struct { funct7 = 0b0000000, rs2 = rs2, rs1 = rs1, funct3 = 0b001, rd = rd, opcode = RTYPEW_opcode }) if sizeof(xlen) == 64
+mapping clause fmtencdec = RTYPEW(rs2, rs1, rd, RISCV_SRLW) if sizeof(xlen) == 64
+  <-> RFormat(struct { funct7 = 0b0000000, rs2 = rs2, rs1 = rs1, funct3 = 0b101, rd = rd, opcode = RTYPEW_opcode }) if sizeof(xlen) == 64
+mapping clause fmtencdec = RTYPEW(rs2, rs1, rd, RISCV_SRAW) if sizeof(xlen) == 64
+  <-> RFormat(struct { funct7 = 0b0100000, rs2 = rs2, rs1 = rs1, funct3 = 0b101, rd = rd, opcode = RTYPEW_opcode }) if sizeof(xlen) == 64
 
 function clause execute (RTYPEW(rs2, rs1, rd, op)) = {
   let rs1_val = (X(rs1))[31..0];
@@ -486,18 +563,26 @@ mapping clause assembly = RTYPEW(rs2, rs1, rd, op)
 /* ****************************************************************** */
 union clause ast = SHIFTIWOP : (bits(5), regidx, regidx, sopw)
 
-mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SLLIW)
+mapping clause oldencdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SLLIW)
       if sizeof(xlen) == 64
   <-> 0b0000000 @ shamt @ rs1 @ 0b001 @ rd @ 0b0011011
       if sizeof(xlen) == 64
-mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SRLIW)
+mapping clause oldencdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SRLIW)
       if sizeof(xlen) == 64
   <-> 0b0000000 @ shamt @ rs1 @ 0b101 @ rd @ 0b0011011
       if sizeof(xlen) == 64
-mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SRAIW)
+mapping clause oldencdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SRAIW)
       if sizeof(xlen) == 64
   <-> 0b0100000 @ shamt @ rs1 @ 0b101 @ rd @ 0b0011011
       if sizeof(xlen) == 64
+
+function clause opcode2format 0b0011011 = I_Format
+mapping clause fmtencdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SLLIW) if sizeof(xlen) == 64
+  <-> IFormat(struct { imm = 0b0000000 @ shamt, rs1 = rs1, funct3 = 0b001, rd = rd, opcode = 0b0011011 }) if sizeof(xlen) == 64
+mapping clause fmtencdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SRLIW) if sizeof(xlen) == 64
+  <-> IFormat(struct { imm = 0b0000000 @ shamt, rs1 = rs1, funct3 = 0b101, rd = rd, opcode = 0b0011011 }) if sizeof(xlen) == 64
+mapping clause fmtencdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SRAIW) if sizeof(xlen) == 64
+  <-> IFormat(struct { imm = 0b0100000 @ shamt, rs1 = rs1, funct3 = 0b101, rd = rd, opcode = 0b0011011 }) if sizeof(xlen) == 64
 
 function clause execute (SHIFTIWOP(shamt, rs1, rd, op)) = {
   let rs1_val = (X(rs1))[31..0];
@@ -524,8 +609,12 @@ mapping clause assembly = SHIFTIWOP(shamt, rs1, rd, op)
 /* ****************************************************************** */
 union clause ast = FENCE : (bits(4), bits(4))
 
-mapping clause encdec = FENCE(pred, succ)
+mapping clause oldencdec = FENCE(pred, succ)
   <-> 0b0000 @ pred @ succ @ 0b00000 @ 0b000 @ 0b00000 @ 0b0001111
+
+function clause opcode2format 0b0001111 = I_Format
+mapping clause fmtencdec = FENCE(pred, succ)
+  <-> IFormat(struct { imm = 0b0000 @ pred @ succ, rs1 = 0b00000, funct3 = 0b000, rd = 0b00000, opcode = 0b0001111 })
 
 function effective_fence_set(set : bits(4), fiom : bool) -> bits(4) = {
   // The bits are IORW. If FIOM is set then I implies R and O implies W.
@@ -590,8 +679,11 @@ mapping clause assembly = FENCE(pred, succ)
 /* ****************************************************************** */
 union clause ast = FENCE_TSO : (bits(4), bits(4))
 
-mapping clause encdec = FENCE_TSO(pred, succ)
+mapping clause oldencdec = FENCE_TSO(pred, succ)
   <-> 0b1000 @ pred @ succ @ 0b00000 @ 0b000 @ 0b00000 @ 0b0001111
+
+mapping clause fmtencdec = FENCE_TSO(pred, succ)
+  <-> IFormat(struct { imm = 0b1000 @ pred @ succ, rs1 = 0b00000, funct3 = 0b000, rd = 0b00000, opcode = 0b0001111 })
 
 function clause execute (FENCE_TSO(pred, succ)) = {
   match (pred, succ) {
@@ -610,8 +702,11 @@ mapping clause assembly = FENCE_TSO(pred, succ)
 /* ****************************************************************** */
 union clause ast = FENCEI : unit
 
-mapping clause encdec = FENCEI()
+mapping clause oldencdec = FENCEI()
   <-> 0b000000000000 @ 0b00000 @ 0b001 @ 0b00000 @ 0b0001111
+
+mapping clause fmtencdec = FENCEI()
+  <-> IFormat(struct { imm = 0b000000000000, rs1 = 0b00000, funct3 = 0b001, rd = 0b00000, opcode = 0b0001111 })
 
 /* fence.i is a nop for the memory model */
 function clause execute FENCEI() = { /* __barrier(Barrier_RISCV_i); */ RETIRE_SUCCESS }
@@ -621,8 +716,12 @@ mapping clause assembly = FENCEI() <-> "fence.i"
 /* ****************************************************************** */
 union clause ast = ECALL : unit
 
-mapping clause encdec = ECALL()
+mapping clause oldencdec = ECALL()
   <-> 0b000000000000 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
+
+function clause opcode2format 0b1110011 = I_Format
+mapping clause fmtencdec = ECALL()
+  <-> IFormat(struct { imm = 0b000000000000, rs1 = 0b00000, funct3 = 0b000, rd = 0b00000, opcode = 0b1110011 })
 
 function clause execute ECALL() = {
   let t : sync_exception =
@@ -642,8 +741,11 @@ mapping clause assembly = ECALL() <-> "ecall"
 /* ****************************************************************** */
 union clause ast = MRET : unit
 
-mapping clause encdec = MRET()
+mapping clause oldencdec = MRET()
   <-> 0b0011000 @ 0b00010 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
+
+mapping clause fmtencdec = MRET()
+  <-> IFormat(struct { imm = 0b001100000010, rs1 = 0b00000, funct3 = 0b000, rd = 0b00000, opcode = 0b1110011 })
 
 function clause execute MRET() = {
   if   cur_privilege != Machine
@@ -661,8 +763,11 @@ mapping clause assembly = MRET() <-> "mret"
 /* ****************************************************************** */
 union clause ast = SRET : unit
 
-mapping clause encdec = SRET()
+mapping clause oldencdec = SRET()
   <-> 0b0001000 @ 0b00010 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
+
+mapping clause fmtencdec = SRET()
+  <-> IFormat(struct { imm = 0b000100000010, rs1 = 0b00000, funct3 = 0b000, rd = 0b00000, opcode = 0b1110011 })
 
 function clause execute SRET() = {
   let sret_illegal : bool = match cur_privilege {
@@ -685,8 +790,11 @@ mapping clause assembly = SRET() <-> "sret"
 /* ****************************************************************** */
 union clause ast = EBREAK : unit
 
-mapping clause encdec = EBREAK()
+mapping clause oldencdec = EBREAK()
   <-> 0b000000000001 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
+
+mapping clause fmtencdec = EBREAK()
+  <-> IFormat(struct { imm = 0b000000000001, rs1 = 0b00000, funct3 = 0b000, rd = 0b00000, opcode = 0b1110011 })
 
 function clause execute EBREAK() = {
   handle_mem_exception(PC, E_Breakpoint());
@@ -698,8 +806,11 @@ mapping clause assembly = EBREAK() <-> "ebreak"
 /* ****************************************************************** */
 union clause ast = WFI : unit
 
-mapping clause encdec = WFI()
+mapping clause oldencdec = WFI()
   <-> 0b000100000101 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
+
+mapping clause fmtencdec = WFI()
+  <-> IFormat(struct { imm = 0b000100000101, rs1 = 0b00000, funct3 = 0b000, rd = 0b00000, opcode = 0b1110011 })
 
 function clause execute WFI() =
   match cur_privilege {
@@ -715,8 +826,11 @@ mapping clause assembly = WFI() <-> "wfi"
 /* ****************************************************************** */
 union clause ast = SFENCE_VMA : (regidx, regidx)
 
-mapping clause encdec = SFENCE_VMA(rs1, rs2)
+mapping clause oldencdec = SFENCE_VMA(rs1, rs2)
   <-> 0b0001001 @ rs2 @ rs1 @ 0b000 @ 0b00000 @ 0b1110011
+
+mapping clause fmtencdec = SFENCE_VMA(rs1, rs2)
+  <-> RFormat(struct { funct7 = 0b0001001, rs2 = rs2, rs1 = rs1, funct3 = 0b000, rd = 0b00000, opcode = 0b1110011 })
 
 function clause execute SFENCE_VMA(rs1, rs2) = {
   let addr : option(xlenbits) = if rs1 == 0b00000 then None() else Some(X(rs1));

--- a/model/riscv_insts_begin.sail
+++ b/model/riscv_insts_begin.sail
@@ -20,11 +20,49 @@ scattered function execute
 val assembly : ast <-> string
 scattered mapping assembly
 
-val encdec : ast <-> bits(32)
-scattered mapping encdec
+val oldencdec : ast <-> bits(32)
+scattered mapping oldencdec
+
+union instruction_input = {
+  RFormat: { funct7: bits(7), rs2: regidx, rs1: regidx, funct3: bits(3), rd: regidx, opcode: bits(7) },
+  IFormat: { imm: bits(12), rs1: regidx, funct3: bits(3), rd: regidx, opcode: bits(7) },
+  SFormat: { imm: bits(12), rs2: regidx, rs1: regidx, funct3: bits(3), opcode: bits(7) },
+  BFormat: { imm: bits(13), rs2: regidx, rs1: regidx, funct3: bits(3), opcode: bits(7) },
+  UFormat: { imm: bits(20), rd: regidx, opcode: bits(7) },
+  JFormat: { imm: bits(21), rd: regidx, opcode: bits(7) }
+}
 
 val encdec_compressed : ast <-> bits(16)
 scattered mapping encdec_compressed
+
+union instruction_input_compressed = {
+  CRFormat: { funct4: bits(4), rd: regidx, rs2: regidx, op: bits(2) },
+  // CIFormat: { funct3: bits(3), imm1: bits(1), rd: regidx, imm5: bits(5), op: bits(2) },
+  CIFormat: { funct3: bits(3), imm: bits(6), rd: regidx, op: bits(2) },
+  CSSFormat: { funct3: bits(3), imm6: bits(6), rs2: regidx, op: bits(2) },
+  CIWFormat: { funct3: bits(3), imm8: bits(8), rd: cregidx, op: bits(2) },
+  CLFormat: { funct3: bits(3), imm: bits(5), rs1: cregidx, rd: cregidx, op: bits(2) },
+  CSFormat: { funct3: bits(3), imm: bits(5), rs1: cregidx, rs2: cregidx, op: bits(2) },
+  CAFormat: { funct6: bits(6), rd: cregidx, imm2: bits(2), rs2: cregidx, op: bits(2) },
+  CBFormat: { funct3: bits(3), offset3: bits(3), rs1: cregidx, offset5: bits(5), op: bits(2) },
+  CJFormat: { funct3: bits(3), target: bits(11), op: bits(2) }
+}
+
+val fmtencdec : ast <-> instruction_input
+scattered mapping fmtencdec
+
+val fmtencdec_compressed : ast <-> instruction_input_compressed
+scattered mapping fmtencdec_compressed
+
+enum Format = { R_Format, U_Format, I_Format, J_Format, S_Format, B_Format, Unknown_Format }
+val opcode2format : bits(7) -> Format
+scattered function opcode2format
+
+val fmt2bits16 : instruction_input_compressed <-> bits(16)
+scattered mapping fmt2bits16
+
+mapping clause fmt2bits16 = CIFormat(struct { imm = imm1 : bits(1) @ imm5: bits(5), rd = rd, funct3 = funct3, op = op })
+  <-> funct3 @ imm1 @ rd @ imm5 @ op
 
 /*
  * We declare the ILLEGAL/C_ILLEGAL ast clauses here instead of in

--- a/model/riscv_insts_end.sail
+++ b/model/riscv_insts_end.sail
@@ -6,11 +6,34 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
+function clause opcode2format _ = Unknown_Format
+
+mapping fmt2bits : instruction_input <-> bits(32) = {
+
+  UFormat(struct { imm = imm, rd = rd, opcode = opcode }) if opcode2format(opcode) == U_Format
+    <-> imm @ rd @ opcode if opcode2format(opcode) == U_Format,
+
+  RFormat(struct { funct7 = funct7, rs2 = rs2, rs1 = rs1, funct3 = funct3, rd = rd, opcode = opcode }) if opcode2format(opcode) == R_Format
+    <-> funct7 @ rs2 @ rs1 @ funct3 @ rd @ opcode if opcode2format(opcode) == R_Format,
+
+  JFormat(struct { imm = imm_20 : bits(1) @ imm_19_12 : bits(8) @ imm_11 : bits(1) @ imm_10_1 : bits(10) @ 0b0, rd = rd, opcode = opcode }) if opcode2format(opcode) == J_Format
+    <-> imm_20 @ imm_10_1 @ imm_11 @ imm_19_12 @ rd @ opcode if opcode2format(opcode) == J_Format,
+
+  BFormat(struct { imm = imm_12 : bits(1) @ imm_11 : bits(1) @ imm_10_5 : bits(6) @ imm_4_1 : bits(4) @ 0b0, rs2 = rs2, rs1 = rs1, funct3 = funct3, opcode = opcode }) if opcode2format(opcode) == B_Format
+    <-> imm_12 @ imm_10_5 @ rs2 @ rs1 @ funct3 @ imm_4_1 @ imm_11 @ opcode if opcode2format(opcode) == B_Format,
+
+  SFormat(struct { imm = imm7 : bits(7) @ imm5 : bits(5), rs2 = rs2, rs1 = rs1, funct3 = funct3, opcode = opcode }) if opcode2format(opcode) == S_Format
+    <-> imm7 @ rs2 @ rs1 @ funct3 @ imm5 @ opcode if opcode2format(opcode) == S_Format,
+
+  IFormat(struct { imm = imm, rs1 = rs1, funct3 = funct3, rd = rd, opcode = opcode }) if opcode2format(opcode) == I_Format
+    <-> imm @ rs1 @ funct3 @ rd @ opcode if opcode2format(opcode) == I_Format,
+}
+
 /* Put the illegal instructions last to use their wildcard match. */
 
 /* ****************************************************************** */
 
-mapping clause encdec = ILLEGAL(s) <-> s
+mapping clause oldencdec = ILLEGAL(s) <-> s
 
 function clause execute (ILLEGAL(s)) = { handle_illegal(); RETIRE_FAIL }
 

--- a/model/riscv_insts_next.sail
+++ b/model/riscv_insts_next.sail
@@ -11,8 +11,12 @@
 
 union clause ast = URET : unit
 
-mapping clause encdec = URET()
+mapping clause oldencdec = URET()
   <-> 0b0000000 @ 0b00010 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
+
+function clause opcode2format 0b1110011 = R_Format
+mapping clause fmtencdec = URET()
+  <-> RFormat(struct { funct7 = 0b0000000, rs2 = 0b00000, rs1 = 0b00000, funct3 = 0b000, rd = 0b00000, opcode = 0b1110011 })
 
 function clause execute URET() = {
   if   not(extensionEnabled(Ext_U)) | not(sys_enable_next())

--- a/model/riscv_insts_zcf.sail
+++ b/model/riscv_insts_zcf.sail
@@ -23,6 +23,9 @@ union clause ast = C_FLWSP : (bits(6), regidx)
 mapping clause encdec_compressed = C_FLWSP(ui76 @ ui5 @ ui42, rd)                  if extensionEnabled(Ext_Zcf)
   <-> 0b011 @ ui5 : bits(1) @ rd : regidx @ ui42 : bits(3) @ ui76 : bits(2) @ 0b10 if extensionEnabled(Ext_Zcf)
 
+mapping clause fmtencdec_compressed = C_FLWSP(imm, rd)
+  <-> CIFormat(struct { funct3 = 0b011, imm = imm, rd = rd, op = 0b10 })
+
 function clause execute (C_FLWSP(imm, rd)) = {
   let imm : bits(12) = zero_extend(imm @ 0b00);
   execute(LOAD_FP(imm, sp, rd, WORD))
@@ -39,6 +42,9 @@ union clause ast = C_FSWSP : (bits(6), regidx)
 mapping clause encdec_compressed = C_FSWSP(ui76 @ ui52, rs2)        if extensionEnabled(Ext_Zcf)
   <-> 0b111 @ ui52 : bits(4) @ ui76 : bits(2) @ rs2 : regidx @ 0b10 if extensionEnabled(Ext_Zcf)
 
+mapping clause fmtencdec_compressed = C_FSWSP(imm, rs2)
+  <-> CIFormat(struct { funct3 = 0b111, imm = imm, rd = rs2, op = 0b10 })
+
 function clause execute (C_FSWSP(uimm, rs2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   execute(STORE_FP(imm, rs2, sp, WORD))
@@ -54,6 +60,9 @@ union clause ast = C_FLW : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_FLW(ui6 @ ui53 @ ui2, rs1, rd)                                if extensionEnabled(Ext_Zcf)
   <-> 0b011 @ ui53 : bits(3) @ rs1 : cregidx @ ui2 : bits(1) @ ui6 : bits(1) @ rd : cregidx @ 0b00 if extensionEnabled(Ext_Zcf)
+
+mapping clause fmtencdec_compressed = C_FLW(imm, rs1, rd)
+  <-> CLFormat(struct { funct3 = 0b011, imm = imm, rs1 = rs1, rd = rd, op = 0b00 })
 
 function clause execute (C_FLW(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
@@ -72,6 +81,9 @@ union clause ast = C_FSW : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_FSW(ui6 @ ui53 @ ui2, rs1, rs2)                                if extensionEnabled(Ext_Zcf)
   <-> 0b111 @ ui53 : bits(3) @ rs1 : cregidx @ ui2 : bits(1) @ ui6 : bits(1) @ rs2 : cregidx @ 0b00 if extensionEnabled(Ext_Zcf)
+
+mapping clause fmtencdec_compressed = C_FSW(imm, rs1, rs2)
+  <-> CSFormat(struct { funct3 = 0b111, imm = imm, rs1 = rs1, rs2 = rs2, op = 0b00 })
 
 function clause execute (C_FSW(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);

--- a/model/riscv_insts_zicsr.sail
+++ b/model/riscv_insts_zicsr.sail
@@ -18,8 +18,11 @@ mapping encdec_csrop : csrop <-> bits(2) = {
   CSRRC <-> 0b11
 }
 
-mapping clause encdec = CSR(csr, rs1, rd, is_imm, op)
+mapping clause oldencdec = CSR(csr, rs1, rd, is_imm, op)
   <-> csr @ rs1 @ bool_bits(is_imm) @ encdec_csrop(op) @ rd @ 0b1110011
+
+mapping clause fmtencdec = CSR(csr, rs1, rd, is_imm, op)
+  <-> IFormat(struct { imm = csr, rs1 = rs1, funct3 = bool_bits(is_imm) @ encdec_csrop(op), rd = rd, opcode = 0b1110011 })
 
 function readCSR csr : csreg -> xlenbits = {
   let res : xlenbits =

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -51,81 +51,81 @@ SAILLIBDIR="$DIR/../../lib/"
 
 cd $RISCVDIR
 
-# Do 'make clean' to avoid cross-arch pollution.
+## Do 'make clean' to avoid cross-arch pollution.
+#make clean
+#
+#printf "Building 32-bit RISCV specification...\n"
+#if ARCH=RV32 make ocaml_emulator/riscv_ocaml_sim_RV32 ;
+#then
+#    green "Building 32-bit RISCV OCaml emulator" "ok"
+#else
+#    red "Building 32-bit RISCV OCaml emulator" "fail"
+#fi
+#for test in $DIR/riscv-tests/rv32*.elf; do
+#    # skip F/D tests on OCaml for now
+#    pat='rv32ud-.+elf'
+#    if [[ $(basename $test) =~ $pat ]];
+#    then continue
+#    fi
+#    pat='rv32uf-.+elf'
+#    if [[ $(basename $test) =~ $pat ]];
+#    then continue
+#    fi
+#    if $RISCVDIR/ocaml_emulator/riscv_ocaml_sim_RV32 "$test" >"${test/.elf/.out}" 2>&1 && grep -q SUCCESS "${test/.elf/.out}"
+#    then
+#       green "OCaml-32 $(basename $test)" "ok"
+#    else
+#       red "OCaml-32 $(basename $test)" "fail"
+#    fi
+#done
+#finish_suite "32-bit RISCV OCaml tests"
+#
+#
+#if ARCH=RV32 make c_emulator/riscv_sim_RV32;
+#then
+#    green "Building 32-bit RISCV C emulator" "ok"
+#else
+#    red "Building 32-bit RISCV C emulator" "fail"
+#fi
+#for test in $DIR/riscv-tests/rv32*.elf; do
+#    if timeout 5 $RISCVDIR/c_emulator/riscv_sim_RV32 -p $test > ${test%.elf}.cout 2>&1 && grep -q SUCCESS ${test%.elf}.cout
+#    then
+#	green "C-32 $(basename $test)" "ok"
+#    else
+#	red "C-32 $(basename $test)" "fail"
+#    fi
+#done
+#finish_suite "32-bit RISCV C tests"
+#
+## Do 'make clean' to avoid cross-arch pollution.
 make clean
-
-printf "Building 32-bit RISCV specification...\n"
-if ARCH=RV32 make ocaml_emulator/riscv_ocaml_sim_RV32 ;
-then
-    green "Building 32-bit RISCV OCaml emulator" "ok"
-else
-    red "Building 32-bit RISCV OCaml emulator" "fail"
-fi
-for test in $DIR/riscv-tests/rv32*.elf; do
-    # skip F/D tests on OCaml for now
-    pat='rv32ud-.+elf'
-    if [[ $(basename $test) =~ $pat ]];
-    then continue
-    fi
-    pat='rv32uf-.+elf'
-    if [[ $(basename $test) =~ $pat ]];
-    then continue
-    fi
-    if $RISCVDIR/ocaml_emulator/riscv_ocaml_sim_RV32 "$test" >"${test/.elf/.out}" 2>&1 && grep -q SUCCESS "${test/.elf/.out}"
-    then
-       green "OCaml-32 $(basename $test)" "ok"
-    else
-       red "OCaml-32 $(basename $test)" "fail"
-    fi
-done
-finish_suite "32-bit RISCV OCaml tests"
-
-
-if ARCH=RV32 make c_emulator/riscv_sim_RV32;
-then
-    green "Building 32-bit RISCV C emulator" "ok"
-else
-    red "Building 32-bit RISCV C emulator" "fail"
-fi
-for test in $DIR/riscv-tests/rv32*.elf; do
-    if timeout 5 $RISCVDIR/c_emulator/riscv_sim_RV32 -p $test > ${test%.elf}.cout 2>&1 && grep -q SUCCESS ${test%.elf}.cout
-    then
-	green "C-32 $(basename $test)" "ok"
-    else
-	red "C-32 $(basename $test)" "fail"
-    fi
-done
-finish_suite "32-bit RISCV C tests"
-
-# Do 'make clean' to avoid cross-arch pollution.
-make clean
-
-printf "Building 64-bit RISCV specification...\n"
-
-if make ocaml_emulator/riscv_ocaml_sim_RV64 ;
-then
-    green "Building 64-bit RISCV OCaml emulator" "ok"
-else
-    red "Building 64-bit RISCV OCaml emulator" "fail"
-fi
-for test in $DIR/riscv-tests/rv64*.elf; do
-    # skip F/D tests on OCaml for now
-    pat='rv64ud-.+elf'
-    if [[ $(basename $test) =~ $pat ]];
-    then continue
-    fi
-    pat='rv64uf-.+elf'
-    if [[ $(basename $test) =~ $pat ]];
-    then continue
-    fi
-    if $RISCVDIR/ocaml_emulator/riscv_ocaml_sim_RV64 "$test" >"${test/.elf/.out}" 2>&1 && grep -q SUCCESS "${test/.elf/.out}"
-    then
-       green "OCaml-64 $(basename $test)" "ok"
-    else
-       red "OCaml-64 $(basename $test)" "fail"
-    fi
-done
-finish_suite "64-bit RISCV OCaml tests"
+#
+#printf "Building 64-bit RISCV specification...\n"
+#
+#if make ocaml_emulator/riscv_ocaml_sim_RV64 ;
+#then
+#    green "Building 64-bit RISCV OCaml emulator" "ok"
+#else
+#    red "Building 64-bit RISCV OCaml emulator" "fail"
+#fi
+#for test in $DIR/riscv-tests/rv64*.elf; do
+#    # skip F/D tests on OCaml for now
+#    pat='rv64ud-.+elf'
+#    if [[ $(basename $test) =~ $pat ]];
+#    then continue
+#    fi
+#    pat='rv64uf-.+elf'
+#    if [[ $(basename $test) =~ $pat ]];
+#    then continue
+#    fi
+#    if $RISCVDIR/ocaml_emulator/riscv_ocaml_sim_RV64 "$test" >"${test/.elf/.out}" 2>&1 && grep -q SUCCESS "${test/.elf/.out}"
+#    then
+#       green "OCaml-64 $(basename $test)" "ok"
+#    else
+#       red "OCaml-64 $(basename $test)" "fail"
+#    fi
+#done
+#finish_suite "64-bit RISCV OCaml tests"
 
 if make c_emulator/riscv_sim_RV64;
 then
@@ -143,27 +143,27 @@ for test in $DIR/riscv-tests/rv64*.elf; do
 done
 finish_suite "64-bit RISCV C tests"
 
-# Do 'make clean' to avoid cross-arch pollution.
-make clean
-
-if ARCH=RV32 make c_emulator/riscv_rvfi_RV32;
-then
-    green "Building 32-bit RISCV RVFI C emulator" "ok"
-else
-    red "Building 32-bit RISCV RVFI C emulator" "fail"
-fi
-finish_suite "32-bit RISCV RVFI C tests"
-
-# Do 'make clean' to avoid cross-arch pollution.
-make clean
-
-if ARCH=RV64 make c_emulator/riscv_rvfi_RV64;
-then
-    green "Building 64-bit RISCV RVFI C emulator" "ok"
-else
-    red "Building 64-bit RISCV RVFI C emulator" "fail"
-fi
-finish_suite "64-bit RISCV RVFI C tests"
+## Do 'make clean' to avoid cross-arch pollution.
+#make clean
+#
+#if ARCH=RV32 make c_emulator/riscv_rvfi_RV32;
+#then
+#    green "Building 32-bit RISCV RVFI C emulator" "ok"
+#else
+#    red "Building 32-bit RISCV RVFI C emulator" "fail"
+#fi
+#finish_suite "32-bit RISCV RVFI C tests"
+#
+## Do 'make clean' to avoid cross-arch pollution.
+#make clean
+#
+#if ARCH=RV64 make c_emulator/riscv_rvfi_RV64;
+#then
+#    green "Building 64-bit RISCV RVFI C emulator" "ok"
+#else
+#    red "Building 64-bit RISCV RVFI C emulator" "fail"
+#fi
+#finish_suite "64-bit RISCV RVFI C tests"
 
 printf "Passed ${all_pass} out of $(( all_pass + all_fail ))\n\n"
 XML="<testsuites tests=\"$(( all_pass + all_fail ))\" failures=\"${all_fail}\">\n$SUITES_XML</testsuites>\n"


### PR DESCRIPTION
This is a draft, with some extraneous commits included that greatly facilitate testing. The only important commit is marked "[DRAFT]", and reviews should be confined to that.

There's still a lot of content, so if I may direct the reviewers eyes:
- `model/riscv_insts_begin.sail`: This sets up the new global data content. In particular:
  - `union instruction_input`: A tagged union for all of the inputs for each instruction format.
  - `scattered mapping fmtencdec`: A new mapping from `ast` to `instruction_input`. Intended to replace `scattered mapping encdec`.
  - `enum Format`: one enum value per format.
  - `scattered function opcode2format`: maps 7-bit opcode values to the associated format enum.
- `model/riscv_insts_end.sail:
  - `mapping fmt2bits`: A new mapping from `instruction_input` to the 32-bit opcode value. This contains one bidirectional mapping for each format. This is a central location for enforcing opcode layouts, including field order and width, as well as important things like clipping low-order bits of field values where those bits have presumed/enforced values.
- `model/riscv_insts_base.sail`, `model/riscv_insts_next.sail`, `model/riscv_insts_zicsr.sail`:
  - Examples of use of `opcode2format` to explicitly bind an instruction to its respective format.
  - Examples of use of `fmtencdec`: to map `ast` inputs and constant values to the appropriate `instruction_input` tagged union member.
  - Note here that the `encdec` (renamed `oldencdec`) is obsoleted, and can be ignored, but I left it in for comparison/review purposes.