### PR TITLE
Add sail_project file to modularise the specification

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -28,6 +28,7 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
         COMMAND
             ${SAIL_BIN}
             ${project_file}
+            --require-version ${SAIL_REQUIRED_VER}
             # include riscv_termination.sail in the list of dependencies
             --variable "TERMINATION_FILE = true"
             --all-modules

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -35,6 +35,7 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
             --list-files
         OUTPUT_VARIABLE sail_list_files
         OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND_ERROR_IS_FATAL ANY
     )
 
     separate_arguments(sail_srcs UNIX_COMMAND "${sail_list_files}")

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -17,206 +17,26 @@ set(sail_common
     --require-version ${SAIL_REQUIRED_VER}
 )
 
+set(project_file "riscv.sail_project")
+
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${project_file})
+
 foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
 
-    # Instruction sources, depending on target
-    set(sail_check_srcs
-        "riscv_addr_checks_common.sail"
-        "riscv_addr_checks.sail"
-        "riscv_misa_ext.sail"
+    execute_process(
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND
+            ${SAIL_BIN}
+            ${project_file}
+            # include riscv_termination.sail in the list of dependencies
+            --variable "TERMINATION_FILE = true"
+            --all-modules
+            --list-files
+        OUTPUT_VARIABLE sail_list_files
+        OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
-    set(vext_srcs
-        "riscv_insts_vext_utils.sail"
-        "riscv_insts_vext_fp_utils.sail"
-        "riscv_insts_vext_vset.sail"
-        "riscv_insts_vext_arith.sail"
-        "riscv_insts_vext_fp.sail"
-        "riscv_insts_vext_mem.sail"
-        "riscv_insts_vext_mask.sail"
-        "riscv_insts_vext_vm.sail"
-        "riscv_insts_vext_fp_vm.sail"
-        "riscv_insts_vext_red.sail"
-        "riscv_insts_vext_fp_red.sail"
-    )
-
-    set(sail_default_inst
-        "riscv_insts_base.sail"
-        "riscv_insts_zifencei.sail"
-        "riscv_insts_zaamo.sail"
-        "riscv_insts_zalrsc.sail"
-        "riscv_insts_zca.sail"
-        "riscv_insts_mext.sail"
-        "riscv_insts_zicsr.sail"
-        "riscv_insts_hext.sail"
-        "riscv_insts_reserved_fence.sail"
-        "riscv_insts_fext.sail"
-        "riscv_insts_zcf.sail"
-        "riscv_insts_dext.sail"
-        "riscv_insts_zcd.sail"
-        "riscv_insts_svinval.sail"
-        "riscv_insts_zba.sail"
-        "riscv_insts_zbb.sail"
-        "riscv_insts_zbc.sail"
-        "riscv_insts_zbs.sail"
-        "riscv_insts_zcb.sail"
-        "riscv_insts_zfh.sail"
-        # Zfa needs to be added after fext, dext and Zfh (as it needs
-        # definitions from those)
-        "riscv_insts_zfa.sail"
-        "riscv_insts_zkn.sail"
-        "riscv_insts_zks.sail"
-        "riscv_insts_zbkb.sail"
-        "riscv_insts_zbkx.sail"
-        "riscv_insts_zicond.sail"
-        ${vext_srcs}
-        "riscv_insts_zicbom.sail"
-        "riscv_insts_zicboz.sail"
-        "riscv_insts_zawrs.sail"
-        "riscv_insts_zvbb.sail"
-        "riscv_insts_zvbc.sail"
-        "riscv_insts_zvkg.sail"
-        "riscv_insts_zvkned.sail"
-        "riscv_insts_zvknhab.sail"
-        "riscv_insts_zvksed.sail"
-        "riscv_insts_zvksh.sail"
-        # Zimop and Zcmop should be at the end so they can be overridden by earlier extensions
-        "riscv_insts_zimop.sail"
-        "riscv_insts_zcmop.sail"
-    )
-
-    if (variant STREQUAL "rmem")
-        set(sail_seq_inst
-            ${sail_default_inst}
-            "riscv_jalr_rmem.sail"
-            "riscv_insts_rmem.sail"
-        )
-    else()
-        set(sail_seq_inst
-            ${sail_default_inst}
-            "riscv_jalr_seq.sail"
-        )
-    endif()
-
-    set(sail_seq_inst_srcs
-        "riscv_insts_begin.sail"
-        ${sail_seq_inst}
-        "riscv_insts_end.sail"
-        "riscv_csr_end.sail"
-    )
-
-    set(sail_sys_srcs
-        "riscv_vext_control.sail"
-        "riscv_sys_exceptions.sail"
-        "riscv_sync_exception.sail"
-        "riscv_zihpm.sail"
-        "riscv_sscofpmf.sail"
-        "riscv_zkr_control.sail"
-        "riscv_zicntr_control.sail"
-        "riscv_softfloat_interface.sail"
-        "riscv_fdext_regs.sail"
-        "riscv_fdext_control.sail"
-        "riscv_smcntrpmf.sail"
-        "riscv_sys_reservation.sail"
-        "riscv_sys_control.sail"
-    )
-
-    set(sail_vm_srcs
-        "riscv_vmem_pte.sail"
-        "riscv_vmem_ptw.sail"
-        "riscv_vmem_tlb.sail"
-        "riscv_vmem.sail"
-        "riscv_vmem_utils.sail"
-    )
-
-    set(prelude
-        "prelude.sail"
-        "riscv_errors.sail"
-        "riscv_xlen.sail"
-        "riscv_flen.sail"
-        "riscv_vlen.sail"
-        "prelude_mem_addrtype.sail"
-        "prelude_mem_metadata.sail"
-        "prelude_mem.sail"
-        "arithmetic.sail"
-        "rvfi_dii.sail"
-        "rvfi_dii_v1.sail"
-        "rvfi_dii_v2.sail"
-    )
-
-    set(sail_regs_srcs
-        "riscv_csr_begin.sail"
-        "riscv_callbacks.sail"
-        "riscv_reg_type.sail"
-        "riscv_freg_type.sail"
-        "riscv_regs.sail"
-        "riscv_pc_access.sail"
-        "riscv_sys_regs.sail"
-        "riscv_pmp_regs.sail"
-        "riscv_pmp_control.sail"
-        "riscv_ext_regs.sail"
-        ${sail_check_srcs}
-        "riscv_vreg_type.sail"
-        "riscv_vext_regs.sail"
-    )
-
-    set(sail_arch_srcs
-        ${prelude}
-        "riscv_extensions.sail"
-        "riscv_types_common.sail"
-        "riscv_types_ext.sail"
-        "riscv_types.sail"
-        "riscv_vmem_types.sail"
-        ${sail_regs_srcs}
-        ${sail_sys_srcs}
-        "riscv_platform.sail"
-        "riscv_sstc.sail"
-        "riscv_mem.sail"
-        "riscv_inst_retire.sail"
-        ${sail_vm_srcs}
-        # Shared/common code for the cryptography extension.
-        "riscv_types_kext.sail"
-        "riscv_zvk_utils.sail"
-    )
-
-    set(sail_step_srcs
-        "riscv_step_common.sail"
-        "riscv_step_ext.sail"
-        "riscv_decode_ext.sail"
-        "riscv_fetch_rvfi.sail"
-        "riscv_fetch.sail"
-        "riscv_step.sail"
-    )
-
-    if (variant STREQUAL "rocq" OR variant STREQUAL "lean")
-        list(APPEND sail_step_srcs
-            "riscv_termination.sail"
-        )
-    endif()
-
-    set(sail_cfg_srcs
-        "riscv_validate_config.sail"
-        "riscv_device_tree.sail"
-    )
-
-    set(sail_model_srcs
-        "riscv_model.sail"
-    )
-
-    set(test_srcs
-        "unit_tests/test_mstatus.sail"
-    )
-
-    # Final file list.
-    set(sail_srcs
-        ${sail_arch_srcs}
-        ${sail_seq_inst_srcs}
-        ${sail_step_srcs}
-        ${sail_cfg_srcs}
-        ${sail_model_srcs}
-        ${test_srcs}
-        "main.sail"
-    )
+    separate_arguments(sail_srcs UNIX_COMMAND "${sail_list_files}")
 
     # Generate C code from Sail model
     if (NOT variant)
@@ -235,7 +55,7 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
         endif()
 
         add_custom_command(
-            DEPENDS ${sail_srcs}
+            DEPENDS ${sail_srcs} ${project_file}
             OUTPUT ${c_model} ${c_model_header} ${branch_info_file} ${schema_file}
             VERBATIM
             COMMENT "Building C code from Sail model"
@@ -293,7 +113,8 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
                 --c-preserve rvfi_wX
                 --c-preserve rvfi_trap
                 # Input files.
-                ${sail_srcs}
+                --all-modules
+                ${project_file}
         )
 
         add_custom_target(generated_sail_riscv_model DEPENDS ${c_model} ${c_model_header})
@@ -307,7 +128,7 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
         set(model_doc "sail_riscv_model.json")
 
         add_custom_command(
-            DEPENDS ${sail_srcs}
+            DEPENDS ${sail_srcs} ${project_file}
             OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${model_doc}"
             VERBATIM
             COMMENT "Building documentation JSON from Sail model"
@@ -333,7 +154,8 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
                 # The name of the JSON file.
                 --doc-bundle ${model_doc}
                 # Input files.
-                ${sail_srcs}
+                --all-modules
+                ${project_file}
         )
 
         add_custom_target(generated_sail_riscv_docs DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${model_doc}")
@@ -351,7 +173,7 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
                 # generate a file to indicate that we have run this command.
                 set(smt_stamp_file "${CMAKE_CURRENT_BINARY_DIR}/smt_${arch}.stamp")
                 add_custom_command(
-                    DEPENDS ${sail_srcs}
+                    DEPENDS ${sail_srcs} ${project_file}
                     VERBATIM
                     OUTPUT ${smt_stamp_file}
                     COMMENT "Building smtlib2 from Sail model (${arch})"
@@ -365,7 +187,8 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
                         -o "${CMAKE_CURRENT_BINARY_DIR}/model"
                         --config ${config_file}
                         # Input files.
-                        ${sail_srcs}
+                        --all-modules
+                        ${project_file}
                     COMMAND ${CMAKE_COMMAND} -E touch ${smt_stamp_file}
                 )
 
@@ -404,7 +227,7 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
                 # Generate riscv.lem, riscv_toFromInterp2.ml and riscv.defs
                 # These are used for "rmem".
                 add_custom_command(
-                    DEPENDS ${sail_srcs}
+                    DEPENDS ${sail_srcs} ${project_file}
                     VERBATIM
                     OUTPUT "rmem_${arch}.lem"
                     COMMENT "Building rmem lem from Sail model (${arch})"
@@ -427,10 +250,11 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
                         -o "lem_${arch}"
                         --config ${config_file}
                         # Input files.
-                        ${sail_srcs}
+                        --all-modules
+                        ${project_file}
                 )
                 add_custom_command(
-                    DEPENDS ${sail_srcs}
+                    DEPENDS ${sail_srcs} ${project_file}
                     VERBATIM
                     OUTPUT "rmem_${arch}_toFromInterp2.ml"
                     COMMENT "Building rmem toFromInterp2.ml from Sail model (${arch})"
@@ -446,10 +270,11 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
                         -o "rmem_${arch}"
                         --config ${config_file}
                         # Input files.
-                        ${sail_srcs}
+                        --all-modules
+                        ${project_file}
                 )
                 add_custom_command(
-                    DEPENDS ${sail_srcs}
+                    DEPENDS ${sail_srcs} ${project_file}
                     VERBATIM
                     OUTPUT "rmem_${arch}.defs"
                     COMMENT "Building rmem defs from Sail model (${arch})"
@@ -462,7 +287,8 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
                         -o "rmem_${arch}"
                         --config ${config_file}
                         # Input files.
-                        ${sail_srcs}
+                        --all-modules
+                        ${project_file}
                 )
 
                 add_custom_target(generated_rmem_${arch} DEPENDS
@@ -475,7 +301,7 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
             # Build Rocq (formerly Coq) definitions.
             if (variant STREQUAL "rocq")
                 add_custom_command(
-                    DEPENDS ${sail_srcs}
+                    DEPENDS ${sail_srcs} ${project_file}
                     VERBATIM
                     OUTPUT "${CMAKE_BINARY_DIR}/rocq/${arch}.v" "${CMAKE_BINARY_DIR}/rocq/${arch}_types.v"
                     COMMENT "Building Rocq definitions from Sail model (${arch})"
@@ -492,7 +318,9 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
                         -o "${arch}"
                         --config ${config_file}
                         # Input files.
-                        ${sail_srcs}
+                        --all-modules
+                        --variable "TERMINATION_FILE = true"
+                        ${project_file}
                 )
                 add_custom_command(
                     DEPENDS build_rocq_common "${CMAKE_BINARY_DIR}/rocq/${arch}.v" "${CMAKE_BINARY_DIR}/rocq/${arch}_types.v"
@@ -540,6 +368,7 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
                 add_custom_command(
                     DEPENDS
                         ${sail_srcs}
+                        ${project_file}
                         ${config_file}
                         ${CMAKE_SOURCE_DIR}/handwritten_support/RiscvExtrasExecutable.lean
                     VERBATIM
@@ -551,11 +380,14 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
                         ${sail_common}
                         ${lean_sail_common}
                         ${lean_sail_default}
-                        ${sail_srcs}
+                        --all-modules
+                        --variable "TERMINATION_FILE = true"
+                        ${project_file}
                 )
                 add_custom_command(
                     DEPENDS
                         ${sail_srcs}
+                        ${project_file}
                         ${config_file}
                         ${CMAKE_SOURCE_DIR}/handwritten_support/RiscvExtras.lean
                     VERBATIM
@@ -567,7 +399,9 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
                         ${sail_common}
                         ${lean_sail_common}
                         ${lean_sail_executable}
-                        ${sail_srcs}
+                        --all-modules
+                        --variable "TERMINATION_FILE = true"
+                        ${project_file}
                 )
 
                 add_custom_target(generated_lean_${arch} DEPENDS "lean_${arch_uppercase}.lean")
@@ -596,7 +430,8 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
                         -o "${arch}"
                         --config ${config_file}
                         # Input files.
-                        ${sail_srcs}
+                        --all-modules
+                        ${project_file}
                     COMMAND
                         echo
                         "declare {isabelle} rename field sync_exception_ext = sync_exception_ext_exception"

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -267,7 +267,7 @@ extensions {
   }
 
   Sstc {
-    requires riscv, Zihpm
+    requires riscv
     files riscv_sstc.sail
   }
 

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -66,8 +66,10 @@ riscv {
 }
 
 extensions {
+  requires riscv_core
+
   I {
-    requires riscv_core, riscv_exceptions, riscv
+    requires riscv_exceptions, riscv
 
     files
       riscv_insts_base.sail,
@@ -76,7 +78,7 @@ extensions {
   }
 
   A {
-    requires riscv_core, riscv_exceptions, riscv, I
+    requires riscv_exceptions, riscv, I
     Zaamo {
       files riscv_insts_zaamo.sail
     }
@@ -87,13 +89,13 @@ extensions {
   }
 
   M {
-    requires riscv_core, riscv, I
+    requires riscv, I
     files riscv_insts_mext.sail
   }
 
   // RISC-V Bit manipulation extensions
   B {
-    requires riscv_core, riscv
+    requires riscv
 
     Zba {
       files riscv_insts_zba.sail
@@ -112,27 +114,23 @@ extensions {
   // Compressed instructions
   C {
     Zca {
-      requires riscv_core, riscv_exceptions, riscv, I
+      requires riscv_exceptions, riscv, I
       files riscv_insts_zca.sail
     }
     Zcb {
-      requires riscv_core, riscv_exceptions, riscv, I, B, M
+      requires riscv_exceptions, riscv, I, B, M
       files riscv_insts_zcb.sail
     }
   }
 
   // Hypervisor
   H {
-    requires riscv_core
-
     files
       riscv_insts_hext.sail
   }
 
   // Floating point (F and D extensions)
   FD {
-    requires riscv_core
-
     FD_core {
       before riscv
       files
@@ -155,8 +153,6 @@ extensions {
 
   // RISC-V vector extension
   V {
-    requires riscv_core
-
     V_core {
       requires FD_core
       files
@@ -184,8 +180,6 @@ extensions {
 
   // RISC-V Cryptography Extension
   K {
-    requires riscv_core
-
     K_core {
       files riscv_types_kext.sail
     }
@@ -212,8 +206,6 @@ extensions {
   }
 
   vector_crypto {
-    requires riscv_core
-
     Zvk_core {
       requires V_core, K_core
       before riscv
@@ -252,62 +244,61 @@ extensions {
 
   // Control and Status Register (CSR) Instructions
   Zicsr {
-    requires riscv_core, riscv, riscv_exceptions, pmp, V_core
+    requires riscv, riscv_exceptions, pmp, V_core
     files riscv_insts_zicsr.sail
   }
 
   Svinval {
-    requires riscv_core, riscv, I
+    requires riscv, I
     files riscv_insts_svinval.sail
   }
 
   Zihpm {
-    requires riscv_core, riscv
+    requires riscv
     files riscv_zihpm.sail
   }
 
   Smcntrpmf {
-    requires riscv_core
     files riscv_smcntrpmf.sail
   }
 
   Sscofpmf {
-    requires riscv_core, riscv, Zihpm
+    requires riscv, Zihpm
     files riscv_sscofpmf.sail
   }
 
   Sstc {
-    requires riscv_core, riscv, Zihpm
+    requires riscv, Zihpm
     files riscv_sstc.sail
   }
 
   Zawrs {
-    requires riscv_core, riscv
+    requires riscv
     files riscv_insts_zawrs.sail
   }
 
   Zicond {
-    requires riscv_core, riscv
+    requires riscv
     files riscv_insts_zicond.sail
   }
 
   Zicntr {
-    requires riscv_core, riscv
+    requires riscv
     files riscv_zicntr_control.sail
   }
 
   Zicbom {
-    requires riscv_core, riscv
+    requires riscv
     files riscv_insts_zicbom.sail
   }
 
   Zicboz {
-    requires riscv_core, riscv
+    requires riscv
     files riscv_insts_zicboz.sail
   }
 
   Zifenci {
-    requires riscv_core, riscv
+    requires riscv
     files riscv_insts_zifencei.sail
   }
 }

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -254,7 +254,6 @@ extensions {
   }
 
   Zihpm {
-    requires riscv
     files riscv_zihpm.sail
   }
 
@@ -263,7 +262,7 @@ extensions {
   }
 
   Sscofpmf {
-    requires riscv, Zihpm
+    requires Zihpm
     files riscv_sscofpmf.sail
   }
 
@@ -283,7 +282,6 @@ extensions {
   }
 
   Zicntr {
-    requires riscv
     files riscv_zicntr_control.sail
   }
 

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -1,0 +1,365 @@
+variable TERMINATION_FILE = false
+
+riscv_core {
+  files
+    prelude.sail,
+    riscv_errors.sail,
+    riscv_xlen.sail,
+    riscv_flen.sail,
+    riscv_vlen.sail,
+    prelude_mem_addrtype.sail,
+    prelude_mem_metadata.sail,
+    prelude_mem.sail,
+    arithmetic.sail,
+    rvfi_dii.sail,
+    rvfi_dii_v1.sail,
+    rvfi_dii_v2.sail,
+    riscv_extensions.sail,
+    riscv_types_common.sail,
+    riscv_types_ext.sail,
+    riscv_types.sail,
+    riscv_vmem_types.sail,
+    riscv_csr_begin.sail,
+    riscv_callbacks.sail,
+    riscv_reg_type.sail,
+    riscv_regs.sail,
+    riscv_pc_access.sail,
+    riscv_sys_regs.sail,
+    riscv_ext_regs.sail,
+    riscv_addr_checks_common.sail,
+    riscv_addr_checks.sail,
+    riscv_misa_ext.sail,
+    riscv_softfloat_interface.sail,
+}
+
+riscv_exceptions {
+  requires riscv_core
+
+  files
+    riscv_sys_exceptions.sail,
+    riscv_sync_exception.sail,
+}
+
+pmp {
+  requires riscv_core
+
+  files
+    riscv_pmp_regs.sail,
+    riscv_pmp_control.sail,
+}
+
+riscv {
+  requires riscv_core, riscv_exceptions, pmp, V_core, Smcntrpmf
+
+  files
+    riscv_sys_reservation.sail,
+    riscv_sys_control.sail,
+    riscv_platform.sail,
+    riscv_mem.sail,
+    riscv_inst_retire.sail,
+    riscv_vmem_pte.sail,
+    riscv_vmem_ptw.sail,
+    riscv_vmem_tlb.sail,
+    riscv_vmem.sail,
+    riscv_vmem_utils.sail,
+    riscv_insts_begin.sail,
+}
+
+extensions {
+  I {
+    requires riscv_core, riscv_exceptions, riscv
+
+    files
+      riscv_insts_base.sail,
+      riscv_insts_reserved_fence.sail,
+      riscv_jalr_seq.sail
+  }
+
+  A {
+    requires riscv_core, riscv_exceptions, riscv, I
+    Zaamo {
+      files riscv_insts_zaamo.sail
+    }
+    Zalrsc {
+      requires Zaamo
+      files riscv_insts_zalrsc.sail
+    }
+  }
+
+  M {
+    requires riscv_core, riscv, I
+    files riscv_insts_mext.sail
+  }
+
+  // RISC-V Bit manipulation extensions
+  B {
+    requires riscv_core, riscv
+
+    Zba {
+      files riscv_insts_zba.sail
+    }
+    Zbb {
+      files riscv_insts_zbb.sail
+    }
+    Zbc {
+      files riscv_insts_zbc.sail
+    }
+    Zbs {
+      files riscv_insts_zbs.sail
+    }
+  }
+
+  // Compressed instructions
+  C {
+    Zca {
+      requires riscv_core, riscv_exceptions, riscv, I
+      files riscv_insts_zca.sail
+    }
+    Zcb {
+      requires riscv_core, riscv_exceptions, riscv, I, B, M
+      files riscv_insts_zcb.sail
+    }
+  }
+
+  // Hypervisor
+  H {
+    requires riscv_core
+
+    files
+      riscv_insts_hext.sail
+  }
+
+  // Floating point (F and D extensions)
+  FD {
+    requires riscv_core
+
+    FD_core {
+      before riscv
+      files
+        riscv_freg_type.sail,
+        riscv_fdext_regs.sail,
+        riscv_fdext_control.sail,
+    }
+
+    FD_instructions {
+      requires riscv, I, FD_core
+      files
+        riscv_insts_fext.sail,
+        riscv_insts_zcf.sail,
+        riscv_insts_dext.sail,
+        riscv_insts_zcd.sail,
+        riscv_insts_zfh.sail,
+        riscv_insts_zfa.sail,
+    }
+  }
+
+  // RISC-V vector extension
+  V {
+    requires riscv_core
+
+    V_core {
+      requires FD_core
+      files
+        riscv_vreg_type.sail,
+        riscv_vext_regs.sail,
+        riscv_vext_control.sail,
+    }
+
+    V_instructions {
+      requires riscv, I, FD, V_core
+      files
+        riscv_insts_vext_utils.sail,
+        riscv_insts_vext_fp_utils.sail,
+        riscv_insts_vext_vset.sail,
+        riscv_insts_vext_arith.sail,
+        riscv_insts_vext_fp.sail,
+        riscv_insts_vext_mem.sail,
+        riscv_insts_vext_mask.sail,
+        riscv_insts_vext_vm.sail,
+        riscv_insts_vext_fp_vm.sail,
+        riscv_insts_vext_red.sail,
+        riscv_insts_vext_fp_red.sail,
+     }
+  }
+
+  // RISC-V Cryptography Extension
+  K {
+    requires riscv_core
+
+    K_core {
+      files riscv_types_kext.sail
+    }
+    Zkn {
+      requires riscv, K_core
+      files riscv_insts_zkn.sail
+    }
+    Zks {
+      requires riscv, K_core
+      files riscv_insts_zks.sail
+    }
+    Zkr {
+      requires riscv, K_core
+      files riscv_zkr_control.sail
+    }
+    Zbkb {
+      requires riscv
+      files riscv_insts_zbkb.sail
+    }
+    Zbkx {
+      requires riscv
+      files riscv_insts_zbkx.sail
+    }
+  }
+
+  vector_crypto {
+    requires riscv_core
+
+    Zvk_core {
+      requires V_core, K_core
+      before riscv
+      files riscv_zvk_utils.sail
+    }
+
+    Zvbb {
+      requires riscv, V, K, Zvk_core
+      files riscv_insts_zvbb.sail
+    }
+    Zvbc {
+      requires riscv, V, K, Zvk_core
+      files riscv_insts_zvbc.sail
+    }
+    Zvkg {
+      requires riscv, V, K, Zvk_core
+      files riscv_insts_zvkg.sail
+    }
+    Zvkned {
+      requires riscv, V, K, Zvk_core
+      files riscv_insts_zvkned.sail
+    }
+    Zvksed {
+      requires riscv, V, K, Zvk_core
+      files riscv_insts_zvksed.sail
+    }
+    Zvknhab {
+      requires riscv, V, K, Zvk_core
+      files riscv_insts_zvknhab.sail
+    }
+    Zvksh {
+      requires riscv, V, K, Zvk_core
+      files riscv_insts_zvksh.sail
+    }
+  }
+
+  // Control and Status Register (CSR) Instructions
+  Zicsr {
+    requires riscv_core, riscv, riscv_exceptions, pmp, V_core
+    files riscv_insts_zicsr.sail
+  }
+
+  Svinval {
+    requires riscv_core, riscv, I
+    files riscv_insts_svinval.sail
+  }
+
+  Zihpm {
+    requires riscv_core, riscv
+    files riscv_zihpm.sail
+  }
+
+  Smcntrpmf {
+    requires riscv_core
+    files riscv_smcntrpmf.sail
+  }
+
+  Sscofpmf {
+    requires riscv_core, riscv, Zihpm
+    files riscv_sscofpmf.sail
+  }
+
+  Sstc {
+    requires riscv_core, riscv, Zihpm
+    files riscv_sstc.sail
+  }
+
+  Zawrs {
+    requires riscv_core, riscv
+    files riscv_insts_zawrs.sail
+  }
+
+  Zicond {
+    requires riscv_core, riscv
+    files riscv_insts_zicond.sail
+  }
+
+  Zicntr {
+    requires riscv_core, riscv
+    files riscv_zicntr_control.sail
+  }
+
+  Zicbom {
+    requires riscv_core, riscv
+    files riscv_insts_zicbom.sail
+  }
+
+  Zicboz {
+    requires riscv_core, riscv
+    files riscv_insts_zicboz.sail
+  }
+
+  Zifenci {
+    requires riscv_core, riscv
+    files riscv_insts_zifencei.sail
+  }
+}
+
+// May-be-operations (MOPS) defined after extensions so they can be
+// overriden by earlier extensions
+mops {
+  after extensions
+
+  Zimop {
+    requires riscv_core, riscv
+    files riscv_insts_zimop.sail
+  }
+
+  Zcmop {
+    requires riscv_core, riscv
+    files riscv_insts_zcmop.sail
+  }
+}
+
+riscv_postlude {
+  after extensions, mops
+
+  requires riscv_core, riscv, riscv_exceptions, Smcntrpmf, pmp
+
+  files
+    riscv_insts_end.sail,
+    riscv_csr_end.sail,
+    riscv_step_common.sail,
+    riscv_step_ext.sail,
+    riscv_decode_ext.sail,
+    riscv_fetch_rvfi.sail,
+    riscv_fetch.sail,
+    riscv_step.sail,
+    riscv_validate_config.sail,
+    riscv_device_tree.sail,
+    riscv_model.sail
+}
+
+riscv_termination {
+  after riscv_postlude
+  requires riscv_core, riscv, extensions
+
+  files
+    if $TERMINATION_FILE then
+      riscv_termination.sail
+    else []
+}
+
+riscv_main {
+  after riscv_termination
+  requires riscv_core, riscv, riscv_exceptions, riscv_postlude
+
+  files main.sail
+}

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -316,14 +316,13 @@ extensions {
 // overriden by earlier extensions
 mops {
   after extensions
+  requires riscv_core, riscv
 
   Zimop {
-    requires riscv_core, riscv
     files riscv_insts_zimop.sail
   }
 
   Zcmop {
-    requires riscv_core, riscv
     files riscv_insts_zcmop.sail
   }
 }

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -357,8 +357,18 @@ riscv_termination {
     else []
 }
 
-riscv_main {
+unit_tests {
   after riscv_termination
+  requires riscv_core, riscv, riscv_exceptions, riscv_postlude
+
+  files
+    unit_tests/test_mstatus.sail,
+}
+
+riscv_main {
+  // Currently this must be the very last thing due to limitations
+  // in the Sail compiler's Lean backend.
+  after unit_tests
   requires riscv_core, riscv, riscv_exceptions, riscv_postlude
 
   files main.sail


### PR DESCRIPTION
Use the Sail module system to organise the files in the model. Rather than passing a list of files on the command line, the files are specified using the `model/riscv.sail_project` file.

The previous version uses a big flat list of files which is unwieldy and hard to understand as it is not clear immediately what the high level structure of the model is, and the way we configure the model does not allow for extensions to easily be added and removed without hand-modifying the CMake. This doesn't matter for the C backend but it does for formal/SV backends.

To solve this problem, I have added a basic module system to Sail, which allows for the structure of the specification to be specified as a collection of modules in a `.sail_project` file. The key ideas here are as follows:

- Each of these modules consists of a list of files (much like how we passed a list of files to Sail on the command line previously), as well as a list of modules that module requires.

- The module system ensures that if a module does not require another module, it cannot refer to any definitions contained within it. There is also a `private` keyword which can be used to encapsulate implementation details.

- Modules can specify other modules that must come before or after them, but without requiring them. This is to support the scattered definition feature.

- The `.sail_project` file serves as an instant reference to the overall model structure, it isn't embedded in the files. You can also have multiple `.sail_project` files, so you could pass `riscv.sail_project cheri.sail_project` to Sail, and it would be able to link them together in much the same way we do now.

- There is some basic support for conditional includes.

With this, building the model becomes as simple as:

    sail --project model/riscv.sail_project --variable ARCH=RV64 --all-modules
