### PR TITLE
Update Makefile about riscv.smt_model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ sail_doc/riscv_$(ARCH).json: $(SAIL_SRCS) model/main.sail
 	$(SAIL) -doc -doc_bundle riscv_$(ARCH).json -o sail_doc $(SAIL_FLAGS) $(SAIL_DOC_FLAGS) $(SAIL_SRCS) model/main.sail
 
 riscv.smt_model: $(SAIL_SRCS)
-	$(SAIL) -smt_serialize $(SAIL_FLAGS) $(SAIL_SRCS) -o riscv
+	$(SAIL) -smt $(SAIL_FLAGS) $(SAIL_SRCS) -o riscv
 
 cgen: $(SAIL_SRCS) model/main.sail
 	$(SAIL) -cgen $(SAIL_FLAGS) $(SAIL_SRCS) model/main.sail


### PR DESCRIPTION
Fix a typo of command in riscv.smt_model. According to sail 0.18.0 ` -smt_serialize` is not supported

#511 