### PR TITLE
Saturation remove set 0

### DIFF
--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -313,7 +313,7 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
   let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val  : vector('n, bool) = read_vmask(num_elem, vm, 0b00000);
   let vd_seg  : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
-  let rs2_val : int = unsigned(get_scalar(rs2, xlen));
+  let rs2_val : int = signed(get_scalar(rs2, xlen));
 
   let (result, mask) = init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val);
 
@@ -380,7 +380,7 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
   let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val  : vector('n, bool) = read_vmask(num_elem, vm, 0b00000);
   let vs3_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
-  let rs2_val : int = unsigned(get_scalar(rs2, xlen));
+  let rs2_val : int = signed(get_scalar(rs2, xlen));
   let mask    : vector('n, bool) = init_masked_source(num_elem, EMUL_pow, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -459,7 +459,7 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
     if mask[i] then { /* active segments */
       vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
-        let elem_offset : int = unsigned(vs2_val[i]) + j * EEW_data_bytes;
+        let elem_offset : int = signed(vs2_val[i]) + j * EEW_data_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), EEW_data_bytes) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) =>
@@ -550,7 +550,7 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
     if mask[i] then { /* active segments */
       vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
-        let elem_offset : int = unsigned(vs2_val[i]) + j * EEW_data_bytes;
+        let elem_offset : int = signed(vs2_val[i]) + j * EEW_data_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), EEW_data_bytes) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) =>

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -313,7 +313,7 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
   let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val  : vector('n, bool) = read_vmask(num_elem, vm, 0b00000);
   let vd_seg  : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
-  let rs2_val : int = signed(get_scalar(rs2, xlen));
+  let rs2_val : int = unsigned(get_scalar(rs2, xlen));
 
   let (result, mask) = init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val);
 
@@ -380,7 +380,7 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
   let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val  : vector('n, bool) = read_vmask(num_elem, vm, 0b00000);
   let vs3_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
-  let rs2_val : int = signed(get_scalar(rs2, xlen));
+  let rs2_val : int = unsigned(get_scalar(rs2, xlen));
   let mask    : vector('n, bool) = init_masked_source(num_elem, EMUL_pow, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -459,7 +459,7 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
     if mask[i] then { /* active segments */
       vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
-        let elem_offset : int = signed(vs2_val[i]) + j * EEW_data_bytes;
+        let elem_offset : int = unsigned(vs2_val[i]) + j * EEW_data_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), EEW_data_bytes) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) =>
@@ -550,7 +550,7 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
     if mask[i] then { /* active segments */
       vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
-        let elem_offset : int = signed(vs2_val[i]) + j * EEW_data_bytes;
+        let elem_offset : int = unsigned(vs2_val[i]) + j * EEW_data_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), EEW_data_bytes) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) =>

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -418,7 +418,6 @@ function unsigned_saturation(len, elem) = {
     vcsr[vxsat] = 0b1;
     ones('m)
   } else {
-    vcsr[vxsat] = 0b0;
     elem['m - 1 .. 0]
   }
 }
@@ -433,7 +432,6 @@ function signed_saturation(len, elem) = {
     vcsr[vxsat] = 0b1;
     0b1 @ zeros('m - 1)
   } else {
-    vcsr[vxsat] = 0b0;
     elem['m - 1 .. 0]
   };
 }


### PR DESCRIPTION
I ran the test for VNClip and noticed that the saturation function includes logic that sets vxsat to zero. This caused the test to fail. After reviewing the Spike implementation, I found that it does not set vxsat to zero. The [spec](https://riscv-specs.timhutt.co.uk/spec/20240411/unpriv-isa-asciidoc.html#_vector_single_width_fractional_multiply_with_rounding_and_saturation) only mentions setting it to one, without specifying any case where it should be reset to zero.

> then saturates the result to fit into SEW bits. If the result causes saturation, the vxsat bit is set.

In vector instructions, if a situation causes saturation midway, vxsat is set to one but is later reset to zero. As a result, the information that vxsat was once set to one is discarded, as shown in the case in the picture.



![image](https://github.com/user-attachments/assets/add7c3f0-f73e-460a-a106-fb54e7bee581)

Here is the spike.
![image](https://github.com/user-attachments/assets/7eb80455-9cc5-49df-9ba0-61c5a89b4544)

