### PR TITLE
Make VLEN and ELEN configurable and remove registers

### DIFF
--- a/c_emulator/riscv_platform.c
+++ b/c_emulator/riscv_platform.c
@@ -86,6 +86,7 @@ uint64_t sys_vector_vlen_exp(unit)
 {
   return rv_vector_vlen_exp;
 }
+
 uint64_t sys_vector_elen_exp(unit)
 {
   return rv_vector_elen_exp;

--- a/c_emulator/riscv_platform.c
+++ b/c_emulator/riscv_platform.c
@@ -82,6 +82,15 @@ uint64_t sys_pmp_grain(unit u)
   return rv_pmp_grain;
 }
 
+uint64_t sys_vector_vlen_exp(unit)
+{
+  return rv_vector_vlen_exp;
+}
+uint64_t sys_vector_elen_exp(unit)
+{
+  return rv_vector_elen_exp;
+}
+
 bool sys_enable_writable_misa(unit u)
 {
   return rv_enable_writable_misa;

--- a/c_emulator/riscv_platform.h
+++ b/c_emulator/riscv_platform.h
@@ -17,6 +17,9 @@ bool sys_enable_zicboz(unit);
 uint64_t sys_pmp_count(unit);
 uint64_t sys_pmp_grain(unit);
 
+uint64_t sys_vector_vlen_exp(unit);
+uint64_t sys_vector_elen_exp(unit);
+
 bool plat_enable_dirty_update(unit);
 bool plat_enable_misaligned_access(unit);
 bool plat_mtval_has_illegal_inst_bits(unit);

--- a/c_emulator/riscv_platform_impl.c
+++ b/c_emulator/riscv_platform_impl.c
@@ -6,6 +6,9 @@
 uint64_t rv_pmp_count = 0;
 uint64_t rv_pmp_grain = 0;
 
+uint64_t rv_vector_vlen_exp = 0x4;
+uint64_t rv_vector_elen_exp = 0x1;
+
 bool rv_enable_svinval = false;
 bool rv_enable_zcb = false;
 bool rv_enable_zfinx = false;

--- a/c_emulator/riscv_platform_impl.c
+++ b/c_emulator/riscv_platform_impl.c
@@ -6,8 +6,8 @@
 uint64_t rv_pmp_count = 0;
 uint64_t rv_pmp_grain = 0;
 
-uint64_t rv_vector_vlen_exp = 0x4;
-uint64_t rv_vector_elen_exp = 0x1;
+uint64_t rv_vector_vlen_exp = 0x7;
+uint64_t rv_vector_elen_exp = 0x6;
 
 bool rv_enable_svinval = false;
 bool rv_enable_zcb = false;

--- a/c_emulator/riscv_platform_impl.c
+++ b/c_emulator/riscv_platform_impl.c
@@ -6,7 +6,7 @@
 uint64_t rv_pmp_count = 0;
 uint64_t rv_pmp_grain = 0;
 
-uint64_t rv_vector_vlen_exp = 0x7;
+uint64_t rv_vector_vlen_exp = 0x9;
 uint64_t rv_vector_elen_exp = 0x6;
 
 bool rv_enable_svinval = false;

--- a/c_emulator/riscv_platform_impl.h
+++ b/c_emulator/riscv_platform_impl.h
@@ -11,6 +11,9 @@
 extern uint64_t rv_pmp_count;
 extern uint64_t rv_pmp_grain;
 
+extern uint64_t rv_vector_vlen_exp;
+extern uint64_t rv_vector_elen_exp;
+
 extern bool rv_enable_svinval;
 extern bool rv_enable_zcb;
 extern bool rv_enable_zfinx;

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -313,7 +313,7 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
   let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val  : vector('n, bool) = read_vmask(num_elem, vm, 0b00000);
   let vd_seg  : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
-  let rs2_val : int = signed(get_scalar(rs2, xlen));
+  let rs2_val : int = unsigned(get_scalar(rs2, xlen));
 
   let (result, mask) = init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val);
 
@@ -380,7 +380,7 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
   let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val  : vector('n, bool) = read_vmask(num_elem, vm, 0b00000);
   let vs3_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
-  let rs2_val : int = signed(get_scalar(rs2, xlen));
+  let rs2_val : int = unsigned(get_scalar(rs2, xlen));
   let mask    : vector('n, bool) = init_masked_source(num_elem, EMUL_pow, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -459,7 +459,7 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
     if mask[i] then { /* active segments */
       vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
-        let elem_offset : int = signed(vs2_val[i]) + j * EEW_data_bytes;
+        let elem_offset : int = unsigned(vs2_val[i]) + j * EEW_data_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), EEW_data_bytes) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) =>
@@ -550,7 +550,7 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
     if mask[i] then { /* active segments */
       vstart = to_bits(16, i);
       foreach (j from 0 to (nf - 1)) {
-        let elem_offset : int = signed(vs2_val[i]) + j * EEW_data_bytes;
+        let elem_offset : int = unsigned(vs2_val[i]) + j * EEW_data_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), EEW_data_bytes) {
           Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
           Ext_DataAddr_OK(vaddr) =>

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -550,8 +550,6 @@ function init_sys() -> unit = {
   menvcfg.bits = zero_extend(0b0);
   senvcfg.bits = zero_extend(0b0);
   /* initialize vector csrs */
-  elen               = 0b1; /* ELEN=64 as the common case */
-  vlen               = 0b0100; /* VLEN=512 as a default value */
   vlenb              = to_bits(xlen, 2 ^ (get_vlen_pow() - 3)); /* vlenb holds the constant value VLEN/8 */
   /* VLEN value needs to be manually changed currently.
    * See riscv_vlen.sail for details.

--- a/model/riscv_vlen.sail
+++ b/model/riscv_vlen.sail
@@ -19,7 +19,7 @@ val sys_vector_vlen_exp = pure "sys_vector_vlen_exp" : unit -> range(3, 16)
 
 function get_vlen_pow() -> range(3, 16) = sys_vector_vlen_exp()
 
-type vlenmax : Int = 128
+type vlenmax : Int = 65536
 
 /* Note: At present, the values of elen and vlen need to be manually speficied
  * in the init_sys() function of riscv_sys_control.sail before compiling the emulators,

--- a/model/riscv_vlen.sail
+++ b/model/riscv_vlen.sail
@@ -8,9 +8,13 @@
 
 register elen : bits(1)
 
+val sys_vector_elen_exp = pure "sys_vector_elen_exp" : unit -> bits(1)
+
+function get_elen() -> bits(1) = sys_vector_elen_exp()
+
 val get_elen_pow : unit -> {5, 6}
 
-function get_elen_pow() = match elen {
+function get_elen_pow() = match get_elen() {
     0b0 => 5,
     0b1 => 6
 }
@@ -21,9 +25,13 @@ function get_elen_pow() = match elen {
 
 register vlen : bits(4)
 
+val sys_vector_vlen_exp = pure "sys_vector_vlen_exp" : unit -> bits(4)
+
+function get_vlen() -> bits(4) = sys_vector_vlen_exp()
+
 val get_vlen_pow : unit -> {5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 
-function get_vlen_pow() = match vlen {
+function get_vlen_pow() = match get_vlen() {
     0b0000 => 5,
     0b0001 => 6,
     0b0010 => 7,

--- a/model/riscv_vlen.sail
+++ b/model/riscv_vlen.sail
@@ -6,11 +6,12 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-register elen : bits(1)
+val sys_vector_elen_exp = pure "sys_vector_elen_exp" : unit -> range(3, 16)
 
-val sys_vector_elen_exp = pure "sys_vector_elen_exp" : unit -> bits(1)
-
-function get_elen() -> bits(1) = sys_vector_elen_exp()
+function get_elen() -> bits(1) = {
+    let vector_elen_exp = sys_vector_elen_exp();
+    to_bits(1, 2 ^ vector_elen_exp)
+}
 
 val get_elen_pow : unit -> {5, 6}
 
@@ -23,11 +24,12 @@ function get_elen_pow() = match get_elen() {
  * TODO: the configurarion of ELEN and its corresponding vtype implementations.
  */
 
-register vlen : bits(4)
+val sys_vector_vlen_exp = pure "sys_vector_vlen_exp" : unit -> range(3, 16)
 
-val sys_vector_vlen_exp = pure "sys_vector_vlen_exp" : unit -> bits(4)
-
-function get_vlen() -> bits(4) = sys_vector_vlen_exp()
+function get_vlen() -> bits(4) = {
+    let vector_vlen_exp = sys_vector_vlen_exp();
+    to_bits(4, 2 ^ vector_vlen_exp)
+}
 
 val get_vlen_pow : unit -> {5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 

--- a/model/riscv_vlen.sail
+++ b/model/riscv_vlen.sail
@@ -20,15 +20,3 @@ val sys_vector_vlen_exp = pure "sys_vector_vlen_exp" : unit -> range(3, 16)
 function get_vlen_pow() -> range(3, 16) = sys_vector_vlen_exp()
 
 type vlenmax : Int = 65536
-
-/* Note: At present, the values of elen and vlen need to be manually speficied
- * in the init_sys() function of riscv_sys_control.sail before compiling the emulators,
- * e.g.,
- *  vlen = 0b0101;
- *  elen = 0b1;
- * means VLEN = 1024 and ELEN = 64,
- * They will be configurable when user-specified configuration is supported in Sail.
- *
- * Also, VLEN >= ELEN must be satisfied and this condition check should be added
- * after their initialization.
- */

--- a/model/riscv_vlen.sail
+++ b/model/riscv_vlen.sail
@@ -8,17 +8,8 @@
 
 val sys_vector_elen_exp = pure "sys_vector_elen_exp" : unit -> range(3, 16)
 
-function get_elen() -> bits(1) = {
-    let vector_elen_exp = sys_vector_elen_exp();
-    to_bits(1, 2 ^ vector_elen_exp)
-}
+function get_elen_pow() -> range(3, 16) = sys_vector_elen_exp()
 
-val get_elen_pow : unit -> {5, 6}
-
-function get_elen_pow() = match get_elen() {
-    0b0 => 5,
-    0b1 => 6
-}
 /* Note: ELEN=32 requires a different encoding of the CSR vtype.
  * The current version of vtype implementation corresponds to the ELEN=64 configuration.
  * TODO: the configurarion of ELEN and its corresponding vtype implementations.
@@ -26,29 +17,9 @@ function get_elen_pow() = match get_elen() {
 
 val sys_vector_vlen_exp = pure "sys_vector_vlen_exp" : unit -> range(3, 16)
 
-function get_vlen() -> bits(4) = {
-    let vector_vlen_exp = sys_vector_vlen_exp();
-    to_bits(4, 2 ^ vector_vlen_exp)
-}
+function get_vlen_pow() -> range(3, 16) = sys_vector_vlen_exp()
 
-val get_vlen_pow : unit -> {5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-
-function get_vlen_pow() = match get_vlen() {
-    0b0000 => 5,
-    0b0001 => 6,
-    0b0010 => 7,
-    0b0011 => 8,
-    0b0100 => 9,
-    0b0101 => 10,
-    0b0110 => 11,
-    0b0111 => 12,
-    0b1000 => 13,
-    0b1001 => 14,
-    0b1010 => 15,
-    _      => 16
-}
-
-type vlenmax : Int = 65536
+type vlenmax : Int = 128
 
 /* Note: At present, the values of elen and vlen need to be manually speficied
  * in the init_sys() function of riscv_sys_control.sail before compiling the emulators,


### PR DESCRIPTION
Should sail-riscv use a "--isa=zvl512b_zve64d" like option in spike to implement configurable vlen and elen.
If it should I will do it.