### PR TITLE
Refactor chip reset

### DIFF
--- a/c_emulator/riscv_sail.h
+++ b/c_emulator/riscv_sail.h
@@ -20,7 +20,6 @@ unit ztick_clock(unit);
 unit ztick_platform(unit);
 
 #ifdef RVFI_DII
-unit zext_rvfi_init(unit);
 unit zrvfi_set_instr_packet(mach_bits);
 mach_bits zrvfi_get_cmd(unit);
 mach_bits zrvfi_get_insn(unit);

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -658,17 +658,11 @@ void init_sail_reset_vector(uint64_t entry)
   zPC = rv_rom_base;
 }
 
-void preinit_sail()
-{
-  model_init();
-}
-
 void init_sail(uint64_t elf_entry)
 {
   zinit_model(UNIT);
 #ifdef RVFI_DII
   if (rvfi_dii) {
-    zext_rvfi_init(UNIT);
     rv_ram_base = UINT64_C(0x80000000);
     rv_ram_size = UINT64_C(0x800000);
     rv_rom_base = UINT64_C(0);
@@ -1138,8 +1132,7 @@ void init_logs()
 
 int main(int argc, char **argv)
 {
-  // Initialize model so that we can check or report its architecture.
-  preinit_sail();
+  model_init();
 
   int files_start = process_args(argc, argv);
   char *initial_elf_file = argv[files_start];

--- a/model/main.sail
+++ b/model/main.sail
@@ -24,9 +24,6 @@ function get_entry_point() = zero_extend(0x1000)
 $endif
 
 function main() : unit -> unit = {
-  // initialize extensions
-  ext_init();
-
   PC = get_entry_point();
   print_bits("PC = ", PC);
 

--- a/model/riscv_ext_regs.sail
+++ b/model/riscv_ext_regs.sail
@@ -10,20 +10,6 @@
  * overridden by extensions.
  */
 
-val ext_init_regs : unit -> unit
-function ext_init_regs () = ()
-
-/*!
-This function is called after above when running rvfi and allows the model
-to be initialised differently (e.g. CHERI cap regs are initialised
-to omnipotent instead of null).
- */
-val ext_rvfi_init : unit -> unit
-function ext_rvfi_init () = {
-  x1 = x1 // to avoid hook being optimized out
-}
-
-
 /*!
 THIS(csrno, priv, isWrite) allows an extension to block access to csrno,
 at Privilege level priv. It should return true if the access is allowed.

--- a/model/riscv_fdext_regs.sail
+++ b/model/riscv_fdext_regs.sail
@@ -353,42 +353,6 @@ mapping freg_or_reg_name = {
   reg if sys_enable_zfinx() <-> reg_name(reg)  if sys_enable_zfinx()
 }
 
-val init_fdext_regs : unit -> unit
-function init_fdext_regs () = {
-  f0  = zero_freg;
-  f1  = zero_freg;
-  f2  = zero_freg;
-  f3  = zero_freg;
-  f4  = zero_freg;
-  f5  = zero_freg;
-  f6  = zero_freg;
-  f7  = zero_freg;
-  f8  = zero_freg;
-  f9  = zero_freg;
-  f10 = zero_freg;
-  f11 = zero_freg;
-  f12 = zero_freg;
-  f13 = zero_freg;
-  f14 = zero_freg;
-  f15 = zero_freg;
-  f16 = zero_freg;
-  f17 = zero_freg;
-  f18 = zero_freg;
-  f19 = zero_freg;
-  f20 = zero_freg;
-  f21 = zero_freg;
-  f22 = zero_freg;
-  f23 = zero_freg;
-  f24 = zero_freg;
-  f25 = zero_freg;
-  f26 = zero_freg;
-  f27 = zero_freg;
-  f28 = zero_freg;
-  f29 = zero_freg;
-  f30 = zero_freg;
-  f31 = zero_freg
-}
-
 /* **************************************************************** */
 /* Floating Point CSR                                               */
 /*     fflags    address 0x001    same as fcrs [4..0]               */

--- a/model/riscv_pmp_control.sail
+++ b/model/riscv_pmp_control.sail
@@ -126,7 +126,7 @@ function pmpCheck forall 'n, 'n > 0. (addr: physaddr, width: int('n), acc: Acces
   if priv == Machine then None() else Some(accessToFault(acc))
 }
 
-function init_pmp() -> unit = {
+function reset_pmp() -> unit = {
   assert(
     sys_pmp_count() == 0 | sys_pmp_count() == 16 | sys_pmp_count() == 64,
     "sys_pmp_count() must be 0, 16, or 64"

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -198,38 +198,3 @@ mapping creg_name : cregidx <-> string = {
   0b110 <-> "a4",
   0b111 <-> "a5"
 }
-
-val init_base_regs : unit -> unit
-function init_base_regs () = {
-  x1  = zero_reg;
-  x2  = zero_reg;
-  x3  = zero_reg;
-  x4  = zero_reg;
-  x5  = zero_reg;
-  x6  = zero_reg;
-  x7  = zero_reg;
-  x8  = zero_reg;
-  x9  = zero_reg;
-  x10 = zero_reg;
-  x11 = zero_reg;
-  x12 = zero_reg;
-  x13 = zero_reg;
-  x14 = zero_reg;
-  x15 = zero_reg;
-  x16 = zero_reg;
-  x17 = zero_reg;
-  x18 = zero_reg;
-  x19 = zero_reg;
-  x20 = zero_reg;
-  x21 = zero_reg;
-  x22 = zero_reg;
-  x23 = zero_reg;
-  x24 = zero_reg;
-  x25 = zero_reg;
-  x26 = zero_reg;
-  x27 = zero_reg;
-  x28 = zero_reg;
-  x29 = zero_reg;
-  x30 = zero_reg;
-  x31 = zero_reg
-}

--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -123,13 +123,17 @@ function loop () : unit -> unit = {
   }
 }
 
-/* initialize model state */
-function init_model () -> unit = {
-  init_platform (); /* devices */
-  init_sys ();      /* processor */
-  init_vmem ();     /* virtual memory */
+// Chip reset. This only does the minimum resets required by the RISC-V spec.
+function reset() -> unit = {
+  reset_sys();
+  reset_vmem();
 
-  /* initialize extensions last */
-  ext_init ();
-  ext_init_regs ();
+  // To allow model extensions (code outside this repo) to perform additional reset.
+  ext_reset();
+}
+
+// Initialize model state. This is only called once; not for every chip reset.
+function init_model() -> unit = {
+  init_platform();
+  reset();
 }

--- a/model/riscv_step_ext.sail
+++ b/model/riscv_step_ext.sail
@@ -8,9 +8,9 @@
 
 /* The default implementation of hooks for the step() and main() functions. */
 
-function ext_init() -> unit = ()
-
 function ext_fetch_hook(f : FetchResult) -> FetchResult = f
 
 function ext_pre_step_hook()  -> unit = ()
 function ext_post_step_hook() -> unit = ()
+
+function ext_reset() -> unit = ()

--- a/model/riscv_step_rvfi.sail
+++ b/model/riscv_step_rvfi.sail
@@ -17,12 +17,4 @@ function ext_post_step_hook() -> unit = {
   rvfi_pc_data[rvfi_pc_wdata] = zero_extend(get_arch_pc())
 }
 
-val ext_init : unit -> unit
-function ext_init() = {
-  init_base_regs();
-  init_fdext_regs();
-  /* these are here so that the C backend doesn't prune them out. */
-  // let _ = rvfi_step(0);
-  ext_rvfi_init();
-  ()
-}
+function ext_reset() -> unit = ()

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -307,22 +307,15 @@ function handle_exception(e: ExceptionType) -> unit = {
 function handle_interrupt(i : InterruptType, del_priv : Privilege) -> unit =
   set_next_pc(trap_handler(del_priv, true, interruptType_to_bits(i), PC, None(), None()))
 
-/* state state initialization */
-
-function init_sys() -> unit = {
-  cur_privilege = Machine;
-
-  mhartid     = zeros();
-  mconfigptr  = zeros();
-
-  misa[MXL] = architecture(if xlen == 32 then RV32 else RV64);
+// Reset misa to enable the maximal set of supported extensions.
+function reset_misa() -> unit = {
   misa[A]   = 0b1;                             /* atomics */
   misa[C]   = bool_to_bits(sys_enable_rvc());  /* RVC */
   misa[B]   = bool_to_bits(sys_enable_bext()); /* Bit-manipulation */
   misa[I]   = 0b1;                             /* base integer ISA */
   misa[M]   = 0b1;                             /* integer multiply/divide */
-  misa[U]   = 0b1;                             /* user-mode */
-  misa[S]   = 0b1;                             /* supervisor-mode */
+  misa[U]   = bool_to_bits(sys_enable_user()); /* user-mode */
+  misa[S]   = bool_to_bits(sys_enable_supervisor()); /* supervisor-mode */
   misa[V]   = bool_to_bits(sys_enable_vext()); /* vector extension */
 
   if   sys_enable_fdext() & sys_enable_zfinx()
@@ -331,41 +324,50 @@ function init_sys() -> unit = {
   /* We currently support both F and D */
   misa[F]   = bool_to_bits(sys_enable_fdext());      /* single-precision */
   misa[D]   = if   flen >= 64
-                then bool_to_bits(sys_enable_fdext())  /* double-precision */
-                else 0b0;
+              then bool_to_bits(sys_enable_fdext())  /* double-precision */
+              else 0b0;
+}
 
-  mstatus = [mstatus with
-    SD_64 = 0b0,
-    SD_32 = 0b0,
-    /* SXL and UXL is only valid for 64-bit systems and in RV32 WPRI */
-    SXL = misa[MXL],
-    UXL = misa[MXL],
-    MPP = privLevel_to_bits(lowest_supported_privLevel()),
-    /* set to little-endian mode */
-    MBE = 0b0,
-    SBE = 0b0,
-  ];
+// This function is called on reset, so it should only perform the reset actions
+// described in the "Reset" section of the privileged architecture specification.
+function reset_sys() -> unit = {
 
-  mip.bits     = zeros();
-  mie.bits     = zeros();
-  mideleg.bits = zeros();
-  medeleg.bits = zeros();
-  mtvec.bits   = zeros();
-  mcause.bits  = zeros();
-  mepc            = zeros();
-  mtval           = zeros();
-  mscratch        = zeros();
+  // "Upon reset, a hart's privilege mode is set to M."
+  cur_privilege = Machine;
 
-  mcycle          = zeros();
-  mtime           = zeros();
+  // "The mstatus fields MIE and MPRV are reset to 0."
+  mstatus[MIE] = 0b0;
+  mstatus[MPRV] = 0b0;
 
-  mcounteren.bits = zeros();
+  // "If little-endian memory accesses are supported, the mstatus/mstatush field
+  // MBE is reset to 0."
+  // TODO: The handling of mstatush is a bit awkward currently, but the model
+  // currently only supports little endian so MBE is always 0.
+  // See https://github.com/riscv/sail-riscv/issues/639
+  // mstatus[MBE] = 0b0;
 
-  minstret           = zeros();
-  minstret_increment = true;
+  // "The misa register is reset to enable the maximal set of supported extensions"
+  reset_misa();
 
-  menvcfg.bits = zeros();
-  senvcfg.bits = zeros();
+  // "For implementations with the "A" standard extension, there is no valid load reservation."
+  cancel_reservation();
+
+  // "The pc is set to an implementation-defined reset vector."
+  // This is outside the scope of this function.
+
+  // "The mcause register is set to a value indicating the cause of the reset."
+  // "The mcause values after reset have implementation-specific interpretation,
+  // but the value 0 should be returned on implementations that do not
+  // distinguish different reset conditions."
+  mcause.bits = zeros();
+
+  // "Writable PMP registers’ A and L fields are set to 0, unless the platform
+  // mandates a different reset value for some PMP registers’ A and L fields."
+  reset_pmp();
+
+  // TODO: Probably need to remove these vector resets too but it needs
+  // refactoring anyway. See https://github.com/riscv/sail-riscv/issues/566 etc.
+
   /* initialize vector csrs */
   vstart             = zeros();
   vl                 = zeros();
@@ -377,9 +379,6 @@ function init_sys() -> unit = {
   vtype[vta]       = 0b0;
   vtype[vsew]      = 0b000;
   vtype[vlmul]     = 0b000;
-
-  // PMP's L and A fields are set to 0 on reset.
-  init_pmp();
 
   // log compatibility with spike
   if   get_config_print_reg()

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -76,7 +76,11 @@ bitfield Misa : xlenbits = {
   B    : 1,
   A    : 0
 }
-register misa : Misa
+register misa : Misa =
+  [ Mk_Misa(zeros()) with
+    // MXL is a read-only field that specifies the native XLEN.
+    MXL = architecture(if xlen == 32 then RV32 else RV64),
+  ]
 
 /* whether misa is R/W */
 val sys_enable_writable_misa = pure "sys_enable_writable_misa" : unit -> bool
@@ -145,8 +149,15 @@ function clause is_CSR_defined(0x301) = true // misa
 function clause read_CSR(0x301) = misa.bits
 function clause write_CSR(0x301, value) = { misa = legalize_misa(misa, value); misa.bits }
 
-function clause extensionEnabled(Ext_U) = misa[U] == 0b1
+// Are user and supervisor mode supported by the hardware?
+// TODO: Don't hard-code these.
+function sys_enable_user() -> bool = true
+function sys_enable_supervisor() -> bool = true
 
+// Are supervisor/user mode currently enabled? Although
+// unlikely and not currently supported by the model,
+// you are technically allowed to have writable misa[U/S].
+function clause extensionEnabled(Ext_U) = misa[U] == 0b1
 function clause extensionEnabled(Ext_S) = misa[S] == 0b1
 
 /*
@@ -203,7 +214,6 @@ bitfield Mstatus : bits(64) = {
   MIE  : 3,
   SIE  : 1,
 }
-register mstatus : Mstatus
 
 function effectivePrivilege(t : AccessType(ext_access_type), m : Mstatus, priv : Privilege) -> Privilege =
   if   t != Execute() & m[MPRV] == 0b1
@@ -285,6 +295,17 @@ function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
   [o with
     SD_64 = if xlen == 64 then bool_to_bits(dirty) else o[SD_64],
     SD_32 = if xlen == 32 then bool_to_bits(dirty) else o[SD_32],
+  ]
+}
+
+register mstatus : Mstatus = {
+  // Initialise SXL and UXL.
+  let mxl = architecture(if xlen == 32 then RV32 else RV64);
+  [ Mk_Mstatus(zeros()) with
+    // These fields do not exist on RV32 and are read-only zero
+    // if the corresponding mode is not supported.
+    SXL = if xlen != 32 & sys_enable_supervisor() then mxl else zeros(),
+    UXL = if xlen != 32 & sys_enable_user() then mxl else zeros(),
   ]
 }
 
@@ -658,12 +679,12 @@ function retire_instruction() -> unit = {
 }
 
 /* machine information registers */
-register mvendorid : bits(32)
-register mimpid : xlenbits
-register marchid : xlenbits
+register mvendorid : bits(32) = zeros()
+register mimpid : xlenbits = zeros()
+register marchid : xlenbits = zeros()
 /* TODO: this should be readonly, and always 0 for now */
-register mhartid : xlenbits
-register mconfigptr : xlenbits
+register mhartid : xlenbits = zeros()
+register mconfigptr : xlenbits = zeros()
 
 mapping clause csr_name_map = 0xF11  <-> "mvendorid"
 mapping clause csr_name_map = 0xF12  <-> "marchid"

--- a/model/riscv_vmem.sail
+++ b/model/riscv_vmem.sail
@@ -445,6 +445,6 @@ function translateAddr(vAddr   : virtaddr,
 // Initialize Virtual Memory state
 
 // PUBLIC: invoked from init_model()
-function init_vmem() -> unit = init_TLB()
+function reset_vmem() -> unit = reset_TLB()
 
 // ****************************************************************

--- a/model/riscv_vmem_tlb.sail
+++ b/model/riscv_vmem_tlb.sail
@@ -39,8 +39,8 @@ register tlb : vector(num_tlb_entries, option(TLB_Entry)) = vector_init(None())
 function tlb_hash(vaddr : bits(64)) -> tlb_index_range =
   unsigned(vaddr[17 .. 12])
 
-// PUBLIC: invoked in init_vmem() [riscv_vmem.sail]
-function init_TLB() -> unit = {
+// PUBLIC: invoked in reset_vmem() [riscv_vmem.sail]
+function reset_TLB() -> unit = {
   foreach (i from 0 to (length(tlb) - 1)) {
     tlb[i] = None();
   }


### PR DESCRIPTION
This simplifies, clarifies and fixes the reset functionality.

Until now the model conflates reset and initialisation, and does way more than it should on reset. The RISC-V spec only requires a very small number of things to be reset.

This change:

1. Renames the `init` functions to `reset`, to clarify that they correspond to resetting the chip.
2. Removes the `ext_init` and `ext_rvfi_init` functions. The latter is not used and the former is only used by the old CHERI code.
3. Removes the reset of the X and F registers. These are non-reset.
4. Removes the reset of various CSRs that are non-reset (`mip`, `mie`, `mideleg`, `mtvec`, `mepc`, etc).
5. Adds reset of `mstatus[MIE]` and `mstatus[MPRV]`. As far as I can see they were missing.
6. Add one-time init of `mhartid` etc to 0.

I didn't remove the vector register resets yet. That needs a bigger refactor.

Also note that currently there is no way to actually do a chip reset mid-simulation, but that will be needed eventually.