### PR TITLE
Rename ext_write_fcsr

### DIFF
--- a/model/riscv_fdext_control.sail
+++ b/model/riscv_fdext_control.sail
@@ -34,8 +34,8 @@ function clause read_CSR (0x001) = zero_extend(fcsr[FFLAGS])
 function clause read_CSR (0x002) = zero_extend(fcsr[FRM])
 function clause read_CSR (0x003) = zero_extend(fcsr.bits)
 
-function clause write_CSR (0x001, value) = { ext_write_fcsr(fcsr[FRM], value[4..0]); zero_extend(fcsr[FFLAGS]) }
-function clause write_CSR (0x002, value) = { ext_write_fcsr(value[2..0], fcsr[FFLAGS]); zero_extend(fcsr[FRM]) }
-function clause write_CSR (0x003, value) = { ext_write_fcsr(value[7..5], value[4..0]); zero_extend(fcsr.bits) }
+function clause write_CSR (0x001, value) = { write_fcsr(fcsr[FRM], value[4..0]); zero_extend(fcsr[FFLAGS]) }
+function clause write_CSR (0x002, value) = { write_fcsr(value[2..0], fcsr[FFLAGS]); zero_extend(fcsr[FRM]) }
+function clause write_CSR (0x003, value) = { write_fcsr(value[7..5], value[4..0]); zero_extend(fcsr.bits) }
 
 /* **************************************************************** */

--- a/model/riscv_fdext_regs.sail
+++ b/model/riscv_fdext_regs.sail
@@ -419,8 +419,8 @@ bitfield Fcsr : bits(32) = {
 
 register fcsr : Fcsr
 
-val ext_write_fcsr : (bits(3), bits(5)) -> unit
-function ext_write_fcsr (frm, fflags) = {
+val write_fcsr : (bits(3), bits(5)) -> unit
+function write_fcsr (frm, fflags) = {
   fcsr[FRM]    = frm;      /* Note: frm can be an illegal value, 101, 110, 111 */
   fcsr[FFLAGS] = fflags;
   dirty_fd_context_if_present();


### PR DESCRIPTION
This renames `ext_write_fcsr` to `write_fcsr`. As mentioned in #311, the current name is misleading since F is a standard RISC-V extension.