### PR TITLE
Separate Zifencei extension from base ISA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SAIL_VLEN := riscv_vlen.sail
 
 # Instruction sources, depending on target
 SAIL_CHECK_SRCS = riscv_addr_checks_common.sail riscv_addr_checks.sail riscv_misa_ext.sail
-SAIL_DEFAULT_INST = riscv_insts_base.sail riscv_insts_aext.sail riscv_insts_zca.sail riscv_insts_mext.sail riscv_insts_zicsr.sail riscv_insts_hints.sail
+SAIL_DEFAULT_INST = riscv_insts_base.sail riscv_insts_zifencei.sail riscv_insts_aext.sail riscv_insts_zca.sail riscv_insts_mext.sail riscv_insts_zicsr.sail riscv_insts_hints.sail
 SAIL_DEFAULT_INST += riscv_insts_fext.sail riscv_insts_zcf.sail
 SAIL_DEFAULT_INST += riscv_insts_dext.sail riscv_insts_zcd.sail
 

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -608,17 +608,6 @@ mapping clause assembly = FENCE_TSO(pred, succ)
   <-> "fence.tso" ^ spc() ^ fence_bits(pred) ^ sep() ^ fence_bits(succ)
 
 /* ****************************************************************** */
-union clause ast = FENCEI : unit
-
-mapping clause encdec = FENCEI()
-  <-> 0b000000000000 @ 0b00000 @ 0b001 @ 0b00000 @ 0b0001111
-
-/* fence.i is a nop for the memory model */
-function clause execute FENCEI() = { /* __barrier(Barrier_RISCV_i); */ RETIRE_SUCCESS }
-
-mapping clause assembly = FENCEI() <-> "fence.i"
-
-/* ****************************************************************** */
 union clause ast = ECALL : unit
 
 mapping clause encdec = ECALL()

--- a/model/riscv_insts_zifencei.sail
+++ b/model/riscv_insts_zifencei.sail
@@ -1,0 +1,24 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+/* ****************************************************************** */
+/* This file specifies the instructions in the 'Zifencei' extension.     */
+
+/* ****************************************************************** */
+enum clause extension = Ext_Zifencei
+function clause extensionEnabled(Ext_Zifencei) = true
+
+union clause ast = FENCEI : unit
+
+mapping clause encdec = FENCEI() if extensionEnabled(Ext_Zifencei)
+  <-> 0b000000000000 @ 0b00000 @ 0b001 @ 0b00000 @ 0b0001111 if extensionEnabled(Ext_Zifencei)
+
+/* fence.i is a nop for the memory model */
+function clause execute FENCEI() = { /* __barrier(Barrier_RISCV_i); */ RETIRE_SUCCESS }
+
+mapping clause assembly = FENCEI() <-> "fence.i"


### PR DESCRIPTION
The `fence.i` instruction has been part of the Zifencei extension instead of the base ISA since version 2.1 in 2019. This updates the model to separate it into its own file and gates it on `extensionEnabled(Ext_Zifencei)`.