### PR TITLE
Add parameter name to sys_vector_vlen_exp and sys_vector_elen_exp

### DIFF
--- a/c_emulator/riscv_platform.c
+++ b/c_emulator/riscv_platform.c
@@ -82,12 +82,12 @@ uint64_t sys_pmp_grain(unit u)
   return rv_pmp_grain;
 }
 
-uint64_t sys_vector_vlen_exp(unit)
+uint64_t sys_vector_vlen_exp(unit u)
 {
   return rv_vector_vlen_exp;
 }
 
-uint64_t sys_vector_elen_exp(unit)
+uint64_t sys_vector_elen_exp(unit u)
 {
   return rv_vector_elen_exp;
 }


### PR DESCRIPTION
PR #590 added new functions to `riscv_platform.c` that omit a parameter name. While this works with newer versions of GCC, it causes an error on GCC 10 and earlier. This adds the parameter name like all of the other functions in that file to avoid breaking compatibility with older GCC.