### PR TITLE
remove function sys_enable_next

### DIFF
--- a/c_emulator/riscv_platform.c
+++ b/c_emulator/riscv_platform.c
@@ -22,11 +22,6 @@ bool sys_enable_rvc(unit u)
   return rv_enable_rvc;
 }
 
-bool sys_enable_next(unit u)
-{
-  return rv_enable_next;
-}
-
 bool sys_enable_fdext(unit u)
 {
   return rv_enable_fdext;

--- a/c_emulator/riscv_platform.h
+++ b/c_emulator/riscv_platform.h
@@ -2,7 +2,6 @@
 #include "sail.h"
 
 bool sys_enable_rvc(unit);
-bool sys_enable_next(unit);
 bool sys_enable_fdext(unit);
 bool sys_enable_svinval(unit);
 bool sys_enable_zcb(unit);

--- a/c_emulator/riscv_platform_impl.c
+++ b/c_emulator/riscv_platform_impl.c
@@ -13,7 +13,6 @@ bool rv_enable_svinval = false;
 bool rv_enable_zcb = false;
 bool rv_enable_zfinx = false;
 bool rv_enable_rvc = true;
-bool rv_enable_next = false;
 bool rv_enable_writable_misa = true;
 bool rv_enable_fdext = true;
 bool rv_enable_vext = true;

--- a/c_emulator/riscv_platform_impl.h
+++ b/c_emulator/riscv_platform_impl.h
@@ -18,7 +18,6 @@ extern bool rv_enable_svinval;
 extern bool rv_enable_zcb;
 extern bool rv_enable_zfinx;
 extern bool rv_enable_rvc;
-extern bool rv_enable_next;
 extern bool rv_enable_fdext;
 extern bool rv_enable_vext;
 extern bool rv_enable_bext;

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -133,7 +133,6 @@ static struct option options[] = {
     {"enable-misaligned",           no_argument,       0, 'm'                     },
     {"pmp-count",                   required_argument, 0, OPT_PMP_COUNT           },
     {"pmp-grain",                   required_argument, 0, OPT_PMP_GRAIN           },
-    {"enable-next",                 no_argument,       0, 'N'                     },
     {"ram-size",                    required_argument, 0, 'z'                     },
     {"disable-compressed",          no_argument,       0, 'C'                     },
     {"disable-writable-misa",       no_argument,       0, 'I'                     },
@@ -276,7 +275,6 @@ static int process_args(int argc, char **argv)
                     "m"
                     "P"
                     "C"
-                    "N"
                     "I"
                     "F"
                     "W"
@@ -339,10 +337,6 @@ static int process_args(int argc, char **argv)
     case 'C':
       fprintf(stderr, "disabling RVC compressed instructions.\n");
       rv_enable_rvc = false;
-      break;
-    case 'N':
-      fprintf(stderr, "enabling N extension.\n");
-      rv_enable_next = true;
       break;
     case 'I':
       fprintf(stderr, "disabling writable misa CSR.\n");


### PR DESCRIPTION
In the master branch, the N extension has been removed, but at that time, the [commit](https://github.com/riscv/sail-riscv/commit/d79e0bab7b18e0d505383b29db4fa3e76f97ab81) only removed the code in the SAIL section, ignoring the C simulator's support for the N extension (Maybe my fault) , i.e., the sys_enable_next switching function in it was not removed, so pr removed this to avoid inconsistency between the two