### PR TITLE
Make calculate new vl configurable

### DIFF
--- a/c_emulator/riscv_platform.c
+++ b/c_emulator/riscv_platform.c
@@ -97,6 +97,11 @@ mach_bits sys_writable_hpm_counters(unit u)
   return rv_writable_hpm_counters;
 }
 
+bool sys_vext_vl_use_ceil(unit u)
+{
+  return rv_vext_vl_use_ceil;
+}
+
 bool plat_enable_dirty_update(unit u)
 {
   return rv_enable_dirty_update;

--- a/c_emulator/riscv_platform.h
+++ b/c_emulator/riscv_platform.h
@@ -16,6 +16,7 @@ bool sys_enable_zicboz(unit);
 uint64_t sys_pmp_count(unit);
 uint64_t sys_pmp_grain(unit);
 
+bool sys_vext_vl_use_ceil(unit);
 uint64_t sys_vector_vlen_exp(unit);
 uint64_t sys_vector_elen_exp(unit);
 

--- a/c_emulator/riscv_platform_impl.c
+++ b/c_emulator/riscv_platform_impl.c
@@ -32,6 +32,8 @@ uint64_t rv_ram_size = UINT64_C(0x4000000);
 uint64_t rv_rom_base = UINT64_C(0x1000);
 uint64_t rv_rom_size = UINT64_C(0x100);
 
+bool rv_vext_vl_use_ceil = false;
+
 // Default 64, which is mandated by RVA22.
 uint64_t rv_cache_block_size_exp = UINT64_C(6);
 

--- a/c_emulator/riscv_platform_impl.h
+++ b/c_emulator/riscv_platform_impl.h
@@ -38,6 +38,8 @@ extern uint64_t rv_rom_size;
 
 extern uint64_t rv_cache_block_size_exp;
 
+extern bool rv_vext_vl_use_ceil;
+
 // Provides entropy for the scalar cryptography extension.
 extern uint64_t rv_16_random_bits(void);
 

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -59,7 +59,7 @@ val sys_vext_vl_use_ceil = pure "sys_vext_vl_use_ceil" : unit -> bool
 
 function calculate_new_vl(AVL : int, VLMAX : int) -> xlenbits = {
   // See "Constraints on Setting vl" in the vector spec.
-  let vl =
+  let new_vl =
     if AVL <= VLMAX then AVL
     else if AVL < 2 * VLMAX then {
       // If VLMAX < AVL < 2 * VLMAX then we can use any value
@@ -69,7 +69,7 @@ function calculate_new_vl(AVL : int, VLMAX : int) -> xlenbits = {
     }
     else VLMAX;
 
-  to_bits(xlen, vl)
+  to_bits(xlen, new_vl)
 }
 
 /* *********************************** vsetvli *********************************** */

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -57,16 +57,19 @@ function handle_illegal_vtype() = {
 
 val sys_vext_vl_use_ceil = pure "sys_vext_vl_use_ceil" : unit -> bool
 
-val calculate_new_vl : (int, int) -> xlenbits
-function calculate_new_vl(AVL, VLMAX) = {
-  if(sys_vext_vl_use_ceil()) then {
-    if AVL <= VLMAX then to_bits(xlen, AVL)
-    else if AVL < 2 * VLMAX then to_bits(xlen, (AVL + 1) / 2)
-    else to_bits(xlen, VLMAX)
-  } else {
-    if AVL <= VLMAX then to_bits(xlen, AVL)
-    else to_bits(xlen, VLMAX)
-  }
+function calculate_new_vl(AVL : int, VLMAX : int) -> xlenbits = {
+  // See "Constraints on Setting vl" in the vector spec.
+  let vl =
+    if AVL <= VLMAX then AVL
+    else if AVL < 2 * VLMAX then {
+      // If VLMAX < AVL < 2 * VLMAX then we can use any value
+      // such that ceil(AVL / 2) <= vl <= VLMAX. Here we provide
+      // two options: ceil(AVL / 2) or VLMAX.
+      if sys_vext_vl_use_ceil() then (AVL + 1) / 2 else VLMAX
+    }
+    else VLMAX;
+
+  to_bits(xlen, vl)
 }
 
 /* *********************************** vsetvli *********************************** */

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -55,14 +55,18 @@ function handle_illegal_vtype() = {
   print_reg("CSR vl <- " ^ BitStr(vl))
 }
 
+val sys_vext_vl_use_ceil = pure "sys_vext_vl_use_ceil" : unit -> bool
+
 val calculate_new_vl : (int, int) -> xlenbits
 function calculate_new_vl(AVL, VLMAX) = {
-  /* Note: ceil(AVL / 2) ≤ vl ≤ VLMAX when VLMAX < AVL < (2 * VLMAX)
-   * TODO: configuration support for either using ceil(AVL / 2) or VLMAX
-   */
-  if AVL <= VLMAX then to_bits(xlen, AVL)
-  else if AVL < 2 * VLMAX then to_bits(xlen, (AVL + 1) / 2)
-  else to_bits(xlen, VLMAX)
+  if(sys_vext_vl_use_ceil()) then {
+    if AVL <= VLMAX then to_bits(xlen, AVL)
+    else if AVL < 2 * VLMAX then to_bits(xlen, (AVL + 1) / 2)
+    else to_bits(xlen, VLMAX)
+  } else {
+    if AVL <= VLMAX then to_bits(xlen, AVL)
+    else to_bits(xlen, VLMAX)
+  }
 }
 
 /* *********************************** vsetvli *********************************** */


### PR DESCRIPTION
I don't know whether sail-riscv needs this.
The spike uses VLMAX to calculate new vl, and sail-riscv uses (AVL + 1) / 2.

The [spec](https://drive.google.com/file/d/1uviu1nH-tScFfgrovvFCrj7Omv8tFtkp/view?usp=drive_link) says:
> The number of bits implemented in vl depends on the implementation’s maximum vector
> length of the smallest supported type. The smallest vector implementation with VLEN=32
> and supporting SEW=8 would need at least six bits in vl to hold the values 0-32
> (VLEN=32, with LMUL=8 and SEW=8, yields VLMAX=32).

