### PR TITLE
Use newtypes for register indices and numbers

### DIFF
--- a/model/riscv_fdext_regs.sail
+++ b/model/riscv_fdext_regs.sail
@@ -96,7 +96,7 @@ function dirty_fd_context_if_present() -> unit = {
   if sys_enable_fdext() then dirty_fd_context()
 }
 
-function rF (r : regno) -> flenbits = {
+function rF (Regno(r) : regno) -> flenbits = {
   assert(sys_enable_fdext());
   let v : fregtype =
     match r {
@@ -137,7 +137,7 @@ function rF (r : regno) -> flenbits = {
   fregval_from_freg(v)
 }
 
-function wF (r : regno, in_v : flenbits) -> unit = {
+function wF (Regno(r) : regno, in_v : flenbits) -> unit = {
   assert(sys_enable_fdext());
   let v = fregval_into_freg(in_v);
   match r {
@@ -184,10 +184,10 @@ function wF (r : regno, in_v : flenbits) -> unit = {
       print_reg("f" ^ dec_str(r) ^ " <- " ^ FRegStr(v));
 }
 
-function rF_bits(i: regidx) -> flenbits = rF(unsigned(i))
+function rF_bits(i: regidx) -> flenbits = rF(regidx_to_regno(i))
 
 function wF_bits(i: regidx, data: flenbits) -> unit = {
-  wF(unsigned(i)) = data
+  wF(regidx_to_regno(i)) = data
 }
 
 overload F = {rF_bits, wF_bits, rF, wF}
@@ -265,8 +265,8 @@ function rF_or_X_D(i) = {
   else if xlen >= 64
   then X(i)[63..0]
   else {
-    assert(i[0] == bitzero);
-    if i == zeros() then zeros() else X(i + 1) @ X(i)
+    assert(regidx_bits(i)[0] == bitzero);
+    if i == zreg then zeros() else X(regidx_offset(i, 0b00001)) @ X(i)
   }
 }
 
@@ -297,10 +297,10 @@ function wF_or_X_D(i, data) = {
   else if xlen >= 64
   then X(i) = sign_extend(data)
   else {
-    assert (i[0] == bitzero);
-    if i != zeros() then {
-      X(i)     = data[31..0];
-      X(i + 1) = data[63..32];
+    assert (regidx_bits(i)[0] == bitzero);
+    if i != zreg then {
+      X(i)                         = data[31..0];
+      X(regidx_offset(i, 0b00001)) = data[63..32];
     }
   }
 }
@@ -311,8 +311,7 @@ overload F_or_X_D = { rF_or_X_D, wF_or_X_D }
 
 /* mappings for assembly */
 
-val freg_name : regidx <-> string
-mapping freg_name = {
+mapping freg_name_raw : bits(5) <-> string = {
     0b00000 <-> "ft0",
     0b00001 <-> "ft1",
     0b00010 <-> "ft2",
@@ -346,6 +345,8 @@ mapping freg_name = {
     0b11110 <-> "ft10",
     0b11111 <-> "ft11"
 }
+
+mapping freg_name : regidx <-> string = { Regidx(i) <-> freg_name_raw(i) }
 
 val freg_or_reg_name : regidx <-> string
 mapping freg_or_reg_name = {

--- a/model/riscv_fdext_regs.sail
+++ b/model/riscv_fdext_regs.sail
@@ -52,6 +52,23 @@ function nan_unbox(m, x) = if 'n == 'm then x else (
 /* **************************************************************** */
 /* Floating point register file                                     */
 
+newtype fregidx = Fregidx : bits(5)
+newtype fregno = Fregno : range(0, 31)
+function fregidx_to_fregno (Fregidx(b) : fregidx) -> fregno = Fregno(unsigned(b))
+function fregidx_offset(Fregidx(r) : fregidx, o : bits(5)) -> fregidx = Fregidx(r + o)
+function fregidx_bits(Fregidx(r) : fregidx) -> bits(5) = r
+
+function cregidx_to_fregidx (Cregidx(b) : cregidx) -> fregidx = Fregidx(0b01 @ b)
+
+/*
+ * TODO: This is not quite right for having both Zfinx and E, but at least it
+ * marks the places we need to consider it
+ */
+function fregidx_to_regidx (Fregidx(b) : fregidx) -> regidx =
+  Regidx(truncate(b, let Regidx(zreg_bits) = zreg in length(zreg_bits)))
+
+mapping encdec_freg : fregidx <-> bits(5) = { Fregidx(r) <-> r }
+
 register f0  : fregtype
 register f1  : fregtype
 register f2  : fregtype
@@ -96,7 +113,7 @@ function dirty_fd_context_if_present() -> unit = {
   if sys_enable_fdext() then dirty_fd_context()
 }
 
-function rF (Regno(r) : regno) -> flenbits = {
+function rF (Fregno(r) : fregno) -> flenbits = {
   assert(sys_enable_fdext());
   let v : fregtype =
     match r {
@@ -137,7 +154,7 @@ function rF (Regno(r) : regno) -> flenbits = {
   fregval_from_freg(v)
 }
 
-function wF (Regno(r) : regno, in_v : flenbits) -> unit = {
+function wF (Fregno(r) : fregno, in_v : flenbits) -> unit = {
   assert(sys_enable_fdext());
   let v = fregval_into_freg(in_v);
   match r {
@@ -184,50 +201,50 @@ function wF (Regno(r) : regno, in_v : flenbits) -> unit = {
       print_reg("f" ^ dec_str(r) ^ " <- " ^ FRegStr(v));
 }
 
-function rF_bits(i: regidx) -> flenbits = rF(regidx_to_regno(i))
+function rF_bits(i: fregidx) -> flenbits = rF(fregidx_to_fregno(i))
 
-function wF_bits(i: regidx, data: flenbits) -> unit = {
-  wF(regidx_to_regno(i)) = data
+function wF_bits(i: fregidx, data: flenbits) -> unit = {
+  wF(fregidx_to_fregno(i)) = data
 }
 
 overload F = {rF_bits, wF_bits, rF, wF}
 
-val rF_H : regidx -> bits(16)
+val rF_H : fregidx -> bits(16)
 function rF_H(i) = {
   assert(flen >= 16);
   assert(sys_enable_fdext() & not(sys_enable_zfinx()));
   nan_unbox(F(i))
 }
 
-val wF_H : (regidx, bits(16)) -> unit
+val wF_H : (fregidx, bits(16)) -> unit
 function wF_H(i, data) = {
   assert(flen >= 16);
   assert(sys_enable_fdext() & not(sys_enable_zfinx()));
   F(i) = nan_box(data)
 }
 
-val rF_S : regidx -> bits(32)
+val rF_S : fregidx -> bits(32)
 function rF_S(i) = {
   assert(flen >= 32);
   assert(sys_enable_fdext() & not(sys_enable_zfinx()));
   nan_unbox(F(i))
 }
 
-val wF_S : (regidx, bits(32)) -> unit
+val wF_S : (fregidx, bits(32)) -> unit
 function wF_S(i, data) = {
   assert(flen >= 32);
   assert(sys_enable_fdext() & not(sys_enable_zfinx()));
   F(i) = nan_box(data)
 }
 
-val rF_D : regidx -> bits(64)
+val rF_D : fregidx -> bits(64)
 function rF_D(i) = {
   assert(flen >= 64);
   assert(sys_enable_fdext() & not(sys_enable_zfinx()));
   F(i)
 }
 
-val wF_D : (regidx, bits(64)) -> unit
+val wF_D : (fregidx, bits(64)) -> unit
 function wF_D(i, data) = {
   assert(flen >= 64);
   assert(sys_enable_fdext() & not(sys_enable_zfinx()));
@@ -238,69 +255,71 @@ overload F_H = { rF_H, wF_H }
 overload F_S = { rF_S, wF_S }
 overload F_D = { rF_D, wF_D }
 
-val rF_or_X_H : regidx -> bits(16)
+val rF_or_X_H : fregidx -> bits(16)
 function rF_or_X_H(i) = {
   assert(flen >= 16);
   assert(sys_enable_fdext() != sys_enable_zfinx());
   if   sys_enable_fdext()
   then F_H(i)
-  else X(i)[15..0]
+  else X(fregidx_to_regidx(i))[15..0]
 }
 
-val rF_or_X_S : regidx -> bits(32)
+val rF_or_X_S : fregidx -> bits(32)
 function rF_or_X_S(i) = {
   assert(flen >= 32);
   assert(sys_enable_fdext() != sys_enable_zfinx());
   if   sys_enable_fdext()
   then F_S(i)
-  else X(i)[31..0]
+  else X(fregidx_to_regidx(i))[31..0]
 }
 
-val rF_or_X_D : regidx -> bits(64)
+val rF_or_X_D : fregidx -> bits(64)
 function rF_or_X_D(i) = {
   assert(flen >= 64);
   assert(sys_enable_fdext() != sys_enable_zfinx());
   if   sys_enable_fdext()
   then F_D(i)
   else if xlen >= 64
-  then X(i)[63..0]
+  then X(fregidx_to_regidx(i))[63..0]
   else {
-    assert(regidx_bits(i)[0] == bitzero);
-    if i == zreg then zeros() else X(regidx_offset(i, 0b00001)) @ X(i)
+    let ridx = fregidx_to_regidx(i);
+    assert(regidx_bits(ridx)[0] == bitzero);
+    if ridx == zreg then zeros() else X(regidx_offset(ridx, 0b00001)) @ X(ridx)
   }
 }
 
-val wF_or_X_H : (regidx, bits(16)) -> unit
+val wF_or_X_H : (fregidx, bits(16)) -> unit
 function wF_or_X_H(i, data) = {
   assert(flen >= 16);
   assert(sys_enable_fdext() != sys_enable_zfinx());
   if   sys_enable_fdext()
   then F_H(i) = data
-  else X(i) = sign_extend(data)
+  else X(fregidx_to_regidx(i)) = sign_extend(data)
 }
 
-val wF_or_X_S : (regidx, bits(32)) -> unit
+val wF_or_X_S : (fregidx, bits(32)) -> unit
 function wF_or_X_S(i, data) = {
   assert(flen >= 32);
   assert(sys_enable_fdext() != sys_enable_zfinx());
   if   sys_enable_fdext()
   then F_S(i) = data
-  else X(i) = sign_extend(data)
+  else X(fregidx_to_regidx(i)) = sign_extend(data)
 }
 
-val wF_or_X_D : (regidx, bits(64)) -> unit
+val wF_or_X_D : (fregidx, bits(64)) -> unit
 function wF_or_X_D(i, data) = {
   assert (flen >= 64);
   assert(sys_enable_fdext() != sys_enable_zfinx());
   if   sys_enable_fdext()
   then F_D(i) = data
   else if xlen >= 64
-  then X(i) = sign_extend(data)
+  then X(fregidx_to_regidx(i)) = sign_extend(data)
   else {
-    assert (regidx_bits(i)[0] == bitzero);
-    if i != zreg then {
-      X(i)                         = data[31..0];
-      X(regidx_offset(i, 0b00001)) = data[63..32];
+    let ridx = fregidx_to_regidx(i);
+    assert (regidx_bits(ridx)[0] == bitzero);
+    if ridx != zreg then {
+      X(ridx)                         = data[31..0];
+      X(regidx_offset(ridx, 0b00001)) = data[63..32];
     }
   }
 }
@@ -346,12 +365,12 @@ mapping freg_name_raw : bits(5) <-> string = {
     0b11111 <-> "ft11"
 }
 
-mapping freg_name : regidx <-> string = { Regidx(i) <-> freg_name_raw(i) }
+mapping freg_name : fregidx <-> string = { Fregidx(i) <-> freg_name_raw(i) }
 
-val freg_or_reg_name : regidx <-> string
-mapping freg_or_reg_name = {
-  reg if sys_enable_fdext() <-> freg_name(reg) if sys_enable_fdext(),
-  reg if sys_enable_zfinx() <-> reg_name(reg)  if sys_enable_zfinx()
+mapping freg_or_reg_name : fregidx <-> string = {
+  forwards f if sys_enable_zfinx() => reg_name(fregidx_to_regidx(f)),
+  backwards reg_name(Regidx(i)) if sys_enable_zfinx() => Fregidx(zero_extend(i)),
+  f <-> freg_name(f)
 }
 
 /* **************************************************************** */

--- a/model/riscv_freg_type.sail
+++ b/model/riscv_freg_type.sail
@@ -37,13 +37,21 @@ enum f_madd_op_H = {FMADD_H, FMSUB_H, FNMSUB_H, FNMADD_H}
 
 enum f_bin_rm_op_H = {FADD_H, FSUB_H, FMUL_H, FDIV_H}
 
-enum f_un_rm_op_H = {FSQRT_H, FCVT_W_H, FCVT_WU_H, FCVT_H_W, FCVT_H_WU,    // RV32 and RV64
-                     FCVT_H_S, FCVT_H_D, FCVT_S_H, FCVT_D_H,
-                     FCVT_L_H, FCVT_LU_H, FCVT_H_L, FCVT_H_LU}             // RV64 only
+enum f_un_rm_ff_op_H = {FSQRT_H, FCVT_H_S, FCVT_H_D, FCVT_S_H, FCVT_D_H}
 
-enum f_un_op_H = {FCLASS_H, FMV_X_H, FMV_H_X}    /* RV32 and RV64 */
+enum f_un_rm_fx_op_H = { FCVT_W_H, FCVT_WU_H, // RV32 and RV64
+                         FCVT_L_H, FCVT_LU_H} // RV64 only
 
-enum f_bin_op_H = {FSGNJ_H, FSGNJN_H, FSGNJX_H, FMIN_H, FMAX_H, FEQ_H, FLT_H, FLE_H}
+enum f_un_rm_xf_op_H = { FCVT_H_W, FCVT_H_WU, // RV32 and RV64
+                         FCVT_H_L, FCVT_H_LU} // RV64 only
+
+enum f_un_x_op_H = {FCLASS_H, FMV_X_H}
+
+enum f_un_f_op_H = {FMV_H_X}
+
+enum f_bin_f_op_H = {FSGNJ_H, FSGNJN_H, FSGNJX_H, FMIN_H, FMAX_H}
+
+enum f_bin_x_op_H = {FEQ_H, FLT_H, FLE_H}
 
 enum rounding_mode = {RM_RNE, RM_RTZ, RM_RDN, RM_RUP, RM_RMM, RM_DYN}
 
@@ -51,22 +59,39 @@ enum f_madd_op_S = {FMADD_S, FMSUB_S, FNMSUB_S, FNMADD_S}
 
 enum f_bin_rm_op_S = {FADD_S, FSUB_S, FMUL_S, FDIV_S}
 
-enum f_un_rm_op_S = {FSQRT_S, FCVT_W_S, FCVT_WU_S, FCVT_S_W, FCVT_S_WU,    // RV32 and RV64
-                     FCVT_L_S, FCVT_LU_S, FCVT_S_L, FCVT_S_LU}             // RV64 only
+enum f_un_rm_ff_op_S = {FSQRT_S}
 
-enum f_un_op_S = {FCLASS_S, FMV_X_W, FMV_W_X}    /* RV32 and RV64 */
+enum f_un_rm_fx_op_S = { FCVT_W_S, FCVT_WU_S, // RV32 and RV64
+                         FCVT_L_S, FCVT_LU_S } // RV64 only
 
-enum f_bin_op_S = {FSGNJ_S, FSGNJN_S, FSGNJX_S, FMIN_S, FMAX_S, FEQ_S, FLT_S, FLE_S}
+enum f_un_rm_xf_op_S = { FCVT_S_W, FCVT_S_WU, // RV32 and RV64
+                         FCVT_S_L, FCVT_S_LU } // RV64 only
+
+enum f_un_op_f_S = {FMV_W_X}    /* RV32 and RV64 */
+
+enum f_un_op_x_S = {FCLASS_S, FMV_X_W}    /* RV32 and RV64 */
+
+enum f_bin_op_f_S = {FSGNJ_S, FSGNJN_S, FSGNJX_S, FMIN_S, FMAX_S}
+
+enum f_bin_op_x_S = {FEQ_S, FLT_S, FLE_S}
 
 enum f_madd_op_D = {FMADD_D, FMSUB_D, FNMSUB_D, FNMADD_D}
 
 enum f_bin_rm_op_D = {FADD_D, FSUB_D, FMUL_D, FDIV_D}
 
-enum f_un_rm_op_D = {FSQRT_D, FCVT_W_D, FCVT_WU_D, FCVT_D_W, FCVT_D_WU,    // RV32 and RV64
-                     FCVT_S_D, FCVT_D_S,
-                     FCVT_L_D, FCVT_LU_D, FCVT_D_L, FCVT_D_LU}             // RV64 only
+enum f_un_rm_ff_op_D = {FSQRT_D, FCVT_S_D, FCVT_D_S}
 
-enum f_bin_op_D = {FSGNJ_D, FSGNJN_D, FSGNJX_D, FMIN_D, FMAX_D, FEQ_D, FLT_D, FLE_D}
+enum f_un_rm_fx_op_D = {FCVT_W_D, FCVT_WU_D,    // RV32 and RV64
+                        FCVT_L_D, FCVT_LU_D}    // RV64 only
 
-enum f_un_op_D = {FCLASS_D,            /* RV32 and RV64 */
-                  FMV_X_D, FMV_D_X}    /* RV64 only */
+enum f_un_rm_xf_op_D = {FCVT_D_W, FCVT_D_WU,    // RV32 and RV64
+                        FCVT_D_L, FCVT_D_LU}    // RV64 only
+
+enum f_bin_f_op_D = {FSGNJ_D, FSGNJN_D, FSGNJX_D, FMIN_D, FMAX_D}
+
+enum f_bin_x_op_D = {FEQ_D, FLT_D, FLE_D}
+
+enum f_un_x_op_D = {FCLASS_D,   /* RV32 and RV64 */
+                    FMV_X_D}    /* RV64 only */
+
+enum f_un_f_op_D = {FMV_D_X}

--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -57,8 +57,8 @@ function clause extensionEnabled(Ext_Zalrsc) = misa[A] == 0b1
 
 union clause ast = LOADRES : (bool, bool, regidx, word_width, regidx)
 
-mapping clause encdec = LOADRES(aq, rl, rs1, size, rd)                                                if extensionEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
-  <-> 0b00010 @ bool_bits(aq) @ bool_bits(rl) @ 0b00000 @ rs1 @ 0b0 @ size_enc(size) @ rd @ 0b0101111 if extensionEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
+mapping clause encdec = LOADRES(aq, rl, rs1, size, rd)                                                                        if extensionEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
+  <-> 0b00010 @ bool_bits(aq) @ bool_bits(rl) @ 0b00000 @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ encdec_reg(rd) @ 0b0101111 if extensionEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
 
 /* We could set load-reservations on physical or virtual addresses.
  * However most chips (especially multi-core) will use physical addresses.
@@ -105,8 +105,8 @@ mapping clause assembly = LOADRES(aq, rl, rs1, size, rd)
 /* ****************************************************************** */
 union clause ast = STORECON : (bool, bool, regidx, regidx, word_width, regidx)
 
-mapping clause encdec = STORECON(aq, rl, rs2, rs1, size, rd)                                      if extensionEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
-  <-> 0b00011 @ bool_bits(aq) @ bool_bits(rl) @ rs2 @ rs1 @ 0b0 @ size_enc(size) @ rd @ 0b0101111 if extensionEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
+mapping clause encdec = STORECON(aq, rl, rs2, rs1, size, rd)                                                                          if extensionEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
+  <-> 0b00011 @ bool_bits(aq) @ bool_bits(rl) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ encdec_reg(rd) @ 0b0101111 if extensionEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
 
 /* NOTE: Currently, we only EA if address translation is successful. This may need revisiting. */
 function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
@@ -183,8 +183,8 @@ mapping encdec_amoop : amoop <-> bits(5) = {
   AMOMAXU <-> 0b11100
 }
 
-mapping clause encdec = AMO(op, aq, rl, rs2, rs1, size, rd)                                                if extensionEnabled(Ext_Zaamo) & amo_width_valid(size)
-  <-> encdec_amoop(op) @ bool_bits(aq) @ bool_bits(rl) @ rs2 @ rs1 @ 0b0 @ size_enc(size) @ rd @ 0b0101111 if extensionEnabled(Ext_Zaamo) & amo_width_valid(size)
+mapping clause encdec = AMO(op, aq, rl, rs2, rs1, size, rd)                                                                                    if extensionEnabled(Ext_Zaamo) & amo_width_valid(size)
+  <-> encdec_amoop(op) @ bool_bits(aq) @ bool_bits(rl) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ encdec_reg(rd) @ 0b0101111 if extensionEnabled(Ext_Zaamo) & amo_width_valid(size)
 
 /* NOTE: Currently, we only EA if address translation is successful.
    This may need revisiting. */

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -21,7 +21,7 @@ mapping encdec_uop : uop <-> bits(7) = {
 }
 
 mapping clause encdec = UTYPE(imm, rd, op)
-  <-> imm @ rd @ encdec_uop(op)
+  <-> imm @ encdec_reg(rd) @ encdec_uop(op)
 
 function clause execute (UTYPE(imm, rd, op)) = {
   let off : xlenbits = sign_extend(imm @ 0x000);
@@ -44,12 +44,12 @@ mapping clause assembly = UTYPE(imm, rd, op)
 union clause ast = RISCV_JAL : (bits(21), regidx)
 
 mapping clause encdec = RISCV_JAL(imm_19 @ imm_7_0 @ imm_8 @ imm_18_13 @ imm_12_9 @ 0b0, rd)
-  <-> imm_19 : bits(1) @ imm_18_13 : bits(6) @ imm_12_9 : bits(4) @ imm_8 : bits(1) @ imm_7_0 : bits(8) @ rd @ 0b1101111
+  <-> imm_19 : bits(1) @ imm_18_13 : bits(6) @ imm_12_9 : bits(4) @ imm_8 : bits(1) @ imm_7_0 : bits(8) @ encdec_reg(rd) @ 0b1101111
 
 /*
 ideally we want some syntax like
 
-mapping clause encdec = RISCV_JAL(imm @ 0b0, rd) <-> imm[19] @ imm[9..0] @ imm[10] @ imm[18..11] @ rd @ 0b1101111
+mapping clause encdec = RISCV_JAL(imm @ 0b0, rd) <-> imm[19] @ imm[9..0] @ imm[10] @ imm[18..11] @ encdec_reg(rd) @ 0b1101111
 
 match bv {
   imm[19] @ imm[9..0] @ imm[10] @ imm[18..11] -> imm @ 0b0
@@ -90,7 +90,7 @@ mapping clause assembly = RISCV_JAL(imm, rd)
 union clause ast = RISCV_JALR : (bits(12), regidx, regidx)
 
 mapping clause encdec = RISCV_JALR(imm, rs1, rd)
-  <-> imm @ rs1 @ 0b000 @ rd @ 0b1100111
+  <-> imm @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b1100111
 
 mapping clause assembly = RISCV_JALR(imm, rs1, rd)
   <-> "jalr" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_signed_12(imm) ^ "(" ^ reg_name(rs1) ^ ")"
@@ -110,7 +110,7 @@ mapping encdec_bop : bop <-> bits(3) = {
 }
 
 mapping clause encdec = BTYPE(imm7_6 @ imm5_0 @ imm7_5_0 @ imm5_4_1 @ 0b0, rs2, rs1, op)
-  <-> imm7_6 : bits(1) @ imm7_5_0 : bits(6) @ rs2 @ rs1 @ encdec_bop(op) @ imm5_4_1 : bits(4) @ imm5_0 : bits(1) @ 0b1100011
+  <-> imm7_6 : bits(1) @ imm7_5_0 : bits(6) @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_bop(op) @ imm5_4_1 : bits(4) @ imm5_0 : bits(1) @ 0b1100011
 
 function clause execute (BTYPE(imm, rs2, rs1, op)) = {
   let taken : bool = match op {
@@ -168,7 +168,7 @@ mapping encdec_iop : iop <-> bits(3) = {
 }
 
 mapping clause encdec = ITYPE(imm, rs1, rd, op)
-  <-> imm @ rs1 @ encdec_iop(op) @ rd @ 0b0010011
+  <-> imm @ encdec_reg(rs1) @ encdec_iop(op) @ encdec_reg(rd) @ 0b0010011
 
 function clause execute (ITYPE (imm, rs1, rd, op)) = {
   let immext : xlenbits = sign_extend(imm);
@@ -204,9 +204,9 @@ mapping encdec_sop : sop <-> bits(3) = {
   RISCV_SRAI <-> 0b101
 }
 
-mapping clause encdec = SHIFTIOP(shamt, rs1, rd, RISCV_SLLI) if xlen == 64 | shamt[5] == bitzero <-> 0b000000 @ shamt @ rs1 @ 0b001 @ rd @ 0b0010011 if xlen == 64 | shamt[5] == bitzero
-mapping clause encdec = SHIFTIOP(shamt, rs1, rd, RISCV_SRLI) if xlen == 64 | shamt[5] == bitzero <-> 0b000000 @ shamt @ rs1 @ 0b101 @ rd @ 0b0010011 if xlen == 64 | shamt[5] == bitzero
-mapping clause encdec = SHIFTIOP(shamt, rs1, rd, RISCV_SRAI) if xlen == 64 | shamt[5] == bitzero <-> 0b010000 @ shamt @ rs1 @ 0b101 @ rd @ 0b0010011 if xlen == 64 | shamt[5] == bitzero
+mapping clause encdec = SHIFTIOP(shamt, rs1, rd, RISCV_SLLI) if xlen == 64 | shamt[5] == bitzero <-> 0b000000 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if xlen == 64 | shamt[5] == bitzero
+mapping clause encdec = SHIFTIOP(shamt, rs1, rd, RISCV_SRLI) if xlen == 64 | shamt[5] == bitzero <-> 0b000000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011 if xlen == 64 | shamt[5] == bitzero
+mapping clause encdec = SHIFTIOP(shamt, rs1, rd, RISCV_SRAI) if xlen == 64 | shamt[5] == bitzero <-> 0b010000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011 if xlen == 64 | shamt[5] == bitzero
 
 function clause execute (SHIFTIOP(shamt, rs1, rd, op)) = {
   // The decoder guard ensures that shamt[5] = 0 for RV32.
@@ -230,16 +230,16 @@ mapping clause assembly = SHIFTIOP(shamt, rs1, rd, op)
 /* ****************************************************************** */
 union clause ast = RTYPE : (regidx, regidx, regidx, rop)
 
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_ADD)  <-> 0b0000000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SLT)  <-> 0b0000000 @ rs2 @ rs1 @ 0b010 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SLTU) <-> 0b0000000 @ rs2 @ rs1 @ 0b011 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_AND)  <-> 0b0000000 @ rs2 @ rs1 @ 0b111 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_OR)   <-> 0b0000000 @ rs2 @ rs1 @ 0b110 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_XOR)  <-> 0b0000000 @ rs2 @ rs1 @ 0b100 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SLL)  <-> 0b0000000 @ rs2 @ rs1 @ 0b001 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SRL)  <-> 0b0000000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SUB)  <-> 0b0100000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SRA)  <-> 0b0100000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_ADD)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SLT)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SLTU) <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b011 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_AND)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_OR)   <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_XOR)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SLL)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SRL)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SUB)  <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SRA)  <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
 
 function clause execute (RTYPE(rs2, rs1, rd, op)) = {
   X(rd) = match op {
@@ -278,8 +278,8 @@ union clause ast = LOAD : (bits(12), regidx, regidx, bool, word_width, bool, boo
 
 /* unsigned loads are only present for widths strictly less than xlen,
    signed loads also present for widths equal to xlen */
-mapping clause encdec = LOAD(imm, rs1, rd, is_unsigned, size, false, false) if (size_bytes(size) < xlen_bytes) | (not(is_unsigned) & size_bytes(size) <= xlen_bytes)
-  <-> imm @ rs1 @ bool_bits(is_unsigned) @ size_enc(size) @ rd @ 0b0000011 if (size_bytes(size) < xlen_bytes) | (not(is_unsigned) & size_bytes(size) <= xlen_bytes)
+mapping clause encdec = LOAD(imm, rs1, rd, is_unsigned, size, false, false)                        if (size_bytes(size) < xlen_bytes) | (not(is_unsigned) & size_bytes(size) <= xlen_bytes)
+  <-> imm @ encdec_reg(rs1) @ bool_bits(is_unsigned) @ size_enc(size) @ encdec_reg(rd) @ 0b0000011 if (size_bytes(size) < xlen_bytes) | (not(is_unsigned) & size_bytes(size) <= xlen_bytes)
 
 val extend_value : forall 'n, 0 < 'n <= xlen. (bool, bits('n)) -> xlenbits
 function extend_value(is_unsigned, value) = if is_unsigned then zero_extend(value) else sign_extend(value)
@@ -347,8 +347,8 @@ mapping clause assembly = LOAD(imm, rs1, rd, is_unsigned, size, aq, rl)
 /* ****************************************************************** */
 union clause ast = STORE : (bits(12), regidx, regidx, word_width, bool, bool)
 
-mapping clause encdec = STORE(imm7 @ imm5, rs2, rs1, size, false, false)              if size_bytes(size) <= xlen_bytes
-  <-> imm7 : bits(7) @ rs2 @ rs1 @ 0b0 @ size_enc(size) @ imm5 : bits(5) @ 0b0100011 if size_bytes(size) <= xlen_bytes
+mapping clause encdec = STORE(imm7 @ imm5, rs2, rs1, size, false, false)                                     if size_bytes(size) <= xlen_bytes
+  <-> imm7 : bits(7) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ imm5 : bits(5) @ 0b0100011 if size_bytes(size) <= xlen_bytes
 
 /* NOTE: Currently, we only EA if address translation is successful.
    This may need revisiting. */
@@ -394,7 +394,7 @@ union clause ast = ADDIW : (bits(12), regidx, regidx)
 
 mapping clause encdec = ADDIW(imm, rs1, rd)
       if xlen == 64
-  <-> imm @ rs1 @ 0b000 @ rd @ 0b0011011
+  <-> imm @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0011011
       if xlen == 64
 
 function clause execute (ADDIW(imm, rs1, rd)) = {
@@ -413,23 +413,23 @@ union clause ast = RTYPEW : (regidx, regidx, regidx, ropw)
 
 mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_ADDW)
       if xlen == 64
-  <-> 0b0000000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0111011
+  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0111011
       if xlen == 64
 mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_SUBW)
       if xlen == 64
-  <-> 0b0100000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0111011
+  <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0111011
       if xlen == 64
 mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_SLLW)
       if xlen == 64
-  <-> 0b0000000 @ rs2 @ rs1 @ 0b001 @ rd @ 0b0111011
+  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0111011
       if xlen == 64
 mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_SRLW)
       if xlen == 64
-  <-> 0b0000000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0111011
+  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0111011
       if xlen == 64
 mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_SRAW)
       if xlen == 64
-  <-> 0b0100000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0111011
+  <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0111011
       if xlen == 64
 
 function clause execute (RTYPEW(rs2, rs1, rd, op)) = {
@@ -464,15 +464,15 @@ union clause ast = SHIFTIWOP : (bits(5), regidx, regidx, sopw)
 
 mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SLLIW)
       if xlen == 64
-  <-> 0b0000000 @ shamt @ rs1 @ 0b001 @ rd @ 0b0011011
+  <-> 0b0000000 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
       if xlen == 64
 mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SRLIW)
       if xlen == 64
-  <-> 0b0000000 @ shamt @ rs1 @ 0b101 @ rd @ 0b0011011
+  <-> 0b0000000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0011011
       if xlen == 64
 mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SRAIW)
       if xlen == 64
-  <-> 0b0100000 @ shamt @ rs1 @ 0b101 @ rd @ 0b0011011
+  <-> 0b0100000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0011011
       if xlen == 64
 
 function clause execute (SHIFTIWOP(shamt, rs1, rd, op)) = {
@@ -681,7 +681,7 @@ mapping clause assembly = WFI() <-> "wfi"
 union clause ast = SFENCE_VMA : (regidx, regidx)
 
 mapping clause encdec = SFENCE_VMA(rs1, rs2)
-  <-> 0b0001001 @ rs2 @ rs1 @ 0b000 @ 0b00000 @ 0b1110011
+  <-> 0b0001001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ 0b00000 @ 0b1110011
 
 function clause execute SFENCE_VMA(rs1, rs2) = {
   let addr = if rs1 != zreg then Some(X(rs1)) else None();

--- a/model/riscv_insts_dext.sail
+++ b/model/riscv_insts_dext.sail
@@ -232,9 +232,11 @@ function haveDoubleFPU() -> bool = extensionEnabled(Ext_D) | extensionEnabled(Ex
 /* not used for RV32Zdinx (i.e. RV64-only or D-only).               */
 val validDoubleRegs : forall 'n, 'n > 0. (implicit('n), vector('n, regidx)) -> bool
 function validDoubleRegs(n, regs) = {
-  if extensionEnabled(Ext_Zdinx) & xlen == 32 then
-    foreach (i from 0 to (n - 1))
-      if (regs[i][0] == bitone) then return false;
+  if extensionEnabled(Ext_Zdinx) & xlen == 32 then {
+    foreach (i from 0 to (n - 1)) {
+      if (regidx_bits(regs[i])[0] == bitone) then return false;
+    }
+  };
   true
 }
 
@@ -256,20 +258,20 @@ union clause ast = F_MADD_TYPE_D : (regidx, regidx, regidx, rounding_mode, regid
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FMADD_D)                         if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
-<-> rs3 @ 0b01 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b100_0011  if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
+    F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FMADD_D)                                                                        if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
+<-> encdec_reg(rs3) @ 0b01 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_0011 if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
 
 mapping clause encdec =
-    F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FMSUB_D)                         if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
-<-> rs3 @ 0b01 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b100_0111  if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
+    F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FMSUB_D)                                                                        if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
+<-> encdec_reg(rs3) @ 0b01 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_0111 if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
 
 mapping clause encdec =
-    F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FNMSUB_D)                        if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
-<-> rs3 @ 0b01 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b100_1011  if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
+    F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FNMSUB_D)                                                                       if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
+<-> encdec_reg(rs3) @ 0b01 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_1011 if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
 
 mapping clause encdec =
-    F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FNMADD_D)                        if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
-<-> rs3 @ 0b01 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b100_1111  if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
+    F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FNMADD_D)                                                                       if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
+<-> encdec_reg(rs3) @ 0b01 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_1111 if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
 
 /* Execution semantics ================================ */
 
@@ -323,20 +325,20 @@ union clause ast = F_BIN_RM_TYPE_D : (regidx, regidx, rounding_mode, regidx, f_b
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FADD_D)                             if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-<-> 0b000_0001 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+    F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FADD_D)                                                                if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+<-> 0b000_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FSUB_D)                             if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-<-> 0b000_0101 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+    F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FSUB_D)                                                                if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+<-> 0b000_0101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FMUL_D)                             if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-<-> 0b000_1001 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+    F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FMUL_D)                                                                if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+<-> 0b000_1001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FDIV_D)                             if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-<-> 0b000_1101 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+    F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FDIV_D)                                                                if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+<-> 0b000_1101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
 /* Execution semantics ================================ */
 
@@ -386,50 +388,50 @@ union clause ast = F_UN_RM_TYPE_D : (regidx, rounding_mode, regidx, f_un_rm_op_D
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FSQRT_D)                                      if haveDoubleFPU() & validDoubleRegs([rs1, rd])
-<-> 0b010_1101 @ 0b00000 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs1, rd])
+    F_UN_RM_TYPE_D(rs1, rm, rd, FSQRT_D)                                                             if haveDoubleFPU() & validDoubleRegs([rs1, rd])
+<-> 0b010_1101 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs1, rd])
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_W_D)                                     if haveDoubleFPU() & validDoubleRegs([rs1])
-<-> 0b110_0001 @ 0b00000 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs1])
+    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_W_D)                                                            if haveDoubleFPU() & validDoubleRegs([rs1])
+<-> 0b110_0001 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs1])
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_WU_D)                                    if haveDoubleFPU() & validDoubleRegs([rs1])
-<-> 0b110_0001 @ 0b00001 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs1])
+    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_WU_D)                                                           if haveDoubleFPU() & validDoubleRegs([rs1])
+<-> 0b110_0001 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs1])
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_W)                                     if haveDoubleFPU() & validDoubleRegs([rd])
-<-> 0b110_1001 @ 0b00000 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rd])
+    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_W)                                                            if haveDoubleFPU() & validDoubleRegs([rd])
+<-> 0b110_1001 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rd])
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_WU)                                    if haveDoubleFPU() & validDoubleRegs([rd])
-<-> 0b110_1001 @ 0b00001 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rd])
+    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_WU)                                                           if haveDoubleFPU() & validDoubleRegs([rd])
+<-> 0b110_1001 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rd])
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_S_D)                                     if haveDoubleFPU() & validDoubleRegs([rs1])
-<-> 0b010_0000 @ 0b00001 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs1])
+    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_S_D)                                                            if haveDoubleFPU() & validDoubleRegs([rs1])
+<-> 0b010_0000 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs1])
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_S)                                     if haveDoubleFPU() & validDoubleRegs([rd])
-<-> 0b010_0001 @ 0b00000 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rd])
+    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_S)                                                            if haveDoubleFPU() & validDoubleRegs([rd])
+<-> 0b010_0001 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rd])
 
 /* D instructions, RV64 only */
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_L_D)                                     if haveDoubleFPU() & xlen >= 64
-<-> 0b110_0001 @ 0b00010 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveDoubleFPU() & xlen >= 64
+    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_L_D)                                                            if haveDoubleFPU() & xlen >= 64
+<-> 0b110_0001 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_LU_D)                                    if haveDoubleFPU() & xlen >= 64
-<-> 0b110_0001 @ 0b00011 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveDoubleFPU() & xlen >= 64
+    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_LU_D)                                                           if haveDoubleFPU() & xlen >= 64
+<-> 0b110_0001 @ 0b00011 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_L)                                     if haveDoubleFPU() & xlen >= 64
-<-> 0b110_1001 @ 0b00010 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveDoubleFPU() & xlen >= 64
+    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_L)                                                            if haveDoubleFPU() & xlen >= 64
+<-> 0b110_1001 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_LU)                                    if haveDoubleFPU() & xlen >= 64
-<-> 0b110_1001 @ 0b00011 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveDoubleFPU() & xlen >= 64
+    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_LU)                                                           if haveDoubleFPU() & xlen >= 64
+<-> 0b110_1001 @ 0b00011 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & xlen >= 64
 
 /* Execution semantics ================================ */
 
@@ -695,29 +697,29 @@ union clause ast = F_BIN_TYPE_D : (regidx, regidx, regidx, f_bin_op_D)
 
 /* AST <-> Binary encoding ================================ */
 
-mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FSGNJ_D)               if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-                    <-> 0b001_0001 @ rs2 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FSGNJ_D)                                                  if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+                    <-> 0b001_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
-mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FSGNJN_D)              if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-                    <-> 0b001_0001 @ rs2 @ rs1 @ 0b001 @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FSGNJN_D)                                                 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+                    <-> 0b001_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
-mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FSGNJX_D)              if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-                    <-> 0b001_0001 @ rs2 @ rs1 @ 0b010 @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FSGNJX_D)                                                 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+                    <-> 0b001_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
-mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FMIN_D)                if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-                    <-> 0b001_0101 @ rs2 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FMIN_D)                                                   if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+                    <-> 0b001_0101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
-mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FMAX_D)                if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-                    <-> 0b001_0101 @ rs2 @ rs1 @ 0b001 @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FMAX_D)                                                   if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+                    <-> 0b001_0101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
-mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FEQ_D)                 if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
-                    <-> 0b101_0001 @ rs2 @ rs1 @ 0b010 @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
+mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FEQ_D)                                                    if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
+                    <-> 0b101_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
 
-mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FLT_D)                 if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
-                    <-> 0b101_0001 @ rs2 @ rs1 @ 0b001 @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
+mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FLT_D)                                                    if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
+                    <-> 0b101_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
 
-mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FLE_D)                 if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
-                    <-> 0b101_0001 @ rs2 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
+mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FLE_D)                                                    if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
+                    <-> 0b101_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
 
 /* Execution semantics ================================ */
 
@@ -899,16 +901,16 @@ union clause ast = F_UN_TYPE_D : (regidx, regidx, f_un_op_D)
 
 /* AST <-> Binary encoding ================================ */
 
-mapping clause encdec = F_UN_TYPE_D(rs1, rd, FCLASS_D)                        if haveDoubleFPU() & validDoubleRegs([rs1])
-                    <-> 0b111_0001 @ 0b00000 @ rs1 @ 0b001 @ rd @ 0b101_0011  if haveDoubleFPU() & validDoubleRegs([rs1])
+mapping clause encdec = F_UN_TYPE_D(rs1, rd, FCLASS_D)                                               if haveDoubleFPU() & validDoubleRegs([rs1])
+                    <-> 0b111_0001 @ 0b00000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs1])
 
 /* D instructions, RV64 only */
 
-mapping clause encdec = F_UN_TYPE_D(rs1, rd, FMV_X_D)                         if extensionEnabled(Ext_D) & xlen >= 64
-                    <-> 0b111_0001 @ 0b00000 @ rs1 @ 0b000 @ rd @ 0b101_0011  if extensionEnabled(Ext_D) & xlen >= 64
+mapping clause encdec = F_UN_TYPE_D(rs1, rd, FMV_X_D)                                                if extensionEnabled(Ext_D) & xlen >= 64
+                    <-> 0b111_0001 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & xlen >= 64
 
-mapping clause encdec = F_UN_TYPE_D(rs1, rd, FMV_D_X)                         if extensionEnabled(Ext_D) & xlen >= 64
-                    <-> 0b111_1001 @ 0b00000 @ rs1 @ 0b000 @ rd @ 0b101_0011  if extensionEnabled(Ext_D) & xlen >= 64
+mapping clause encdec = F_UN_TYPE_D(rs1, rd, FMV_D_X)                                                if extensionEnabled(Ext_D) & xlen >= 64
+                    <-> 0b111_1001 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & xlen >= 64
 
 /* Execution semantics ================================ */
 

--- a/model/riscv_insts_dext.sail
+++ b/model/riscv_insts_dext.sail
@@ -230,11 +230,11 @@ function haveDoubleFPU() -> bool = extensionEnabled(Ext_D) | extensionEnabled(Ex
 
 /* RV32Zdinx requires even register pairs; can be omitted for code  */
 /* not used for RV32Zdinx (i.e. RV64-only or D-only).               */
-val validDoubleRegs : forall 'n, 'n > 0. (implicit('n), vector('n, regidx)) -> bool
+val validDoubleRegs : forall 'n, 'n > 0. (implicit('n), vector('n, fregidx)) -> bool
 function validDoubleRegs(n, regs) = {
   if extensionEnabled(Ext_Zdinx) & xlen == 32 then {
     foreach (i from 0 to (n - 1)) {
-      if (regidx_bits(regs[i])[0] == bitone) then return false;
+      if (fregidx_bits(regs[i])[0] == bitone) then return false;
     }
   };
   true
@@ -253,25 +253,25 @@ function validDoubleRegs(n, regs) = {
 
 /* AST */
 
-union clause ast = F_MADD_TYPE_D : (regidx, regidx, regidx, rounding_mode, regidx, f_madd_op_D)
+union clause ast = F_MADD_TYPE_D : (fregidx, fregidx, fregidx, rounding_mode, fregidx, f_madd_op_D)
 
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FMADD_D)                                                                        if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
-<-> encdec_reg(rs3) @ 0b01 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_0011 if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
+    F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FMADD_D)                                                                            if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
+<-> encdec_freg(rs3) @ 0b01 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b100_0011 if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
 
 mapping clause encdec =
-    F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FMSUB_D)                                                                        if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
-<-> encdec_reg(rs3) @ 0b01 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_0111 if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
+    F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FMSUB_D)                                                                            if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
+<-> encdec_freg(rs3) @ 0b01 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b100_0111 if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
 
 mapping clause encdec =
-    F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FNMSUB_D)                                                                       if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
-<-> encdec_reg(rs3) @ 0b01 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_1011 if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
+    F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FNMSUB_D)                                                                           if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
+<-> encdec_freg(rs3) @ 0b01 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b100_1011 if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
 
 mapping clause encdec =
-    F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FNMADD_D)                                                                       if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
-<-> encdec_reg(rs3) @ 0b01 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_1111 if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
+    F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FNMADD_D)                                                                           if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
+<-> encdec_freg(rs3) @ 0b01 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b100_1111 if haveDoubleFPU() & validDoubleRegs([rs3, rs2, rs1, rd])
 
 /* Execution semantics ================================ */
 
@@ -320,25 +320,25 @@ mapping clause assembly = F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, op)
 
 /* AST */
 
-union clause ast = F_BIN_RM_TYPE_D : (regidx, regidx, rounding_mode, regidx, f_bin_rm_op_D)
+union clause ast = F_BIN_RM_TYPE_D : (fregidx, fregidx, rounding_mode, fregidx, f_bin_rm_op_D)
 
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FADD_D)                                                                if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-<-> 0b000_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+    F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FADD_D)                                                                   if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+<-> 0b000_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FSUB_D)                                                                if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-<-> 0b000_0101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+    F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FSUB_D)                                                                   if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+<-> 0b000_0101 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FMUL_D)                                                                if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-<-> 0b000_1001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+    F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FMUL_D)                                                                   if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+<-> 0b000_1001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FDIV_D)                                                                if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-<-> 0b000_1101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+    F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FDIV_D)                                                                   if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+<-> 0b000_1101 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
 /* Execution semantics ================================ */
 
@@ -383,59 +383,61 @@ mapping clause assembly = F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, op)
 
 /* AST */
 
-union clause ast = F_UN_RM_TYPE_D : (regidx, rounding_mode, regidx, f_un_rm_op_D)
+union clause ast = F_UN_RM_FF_TYPE_D : (fregidx, rounding_mode, fregidx, f_un_rm_ff_op_D)
+union clause ast = F_UN_RM_XF_TYPE_D : (regidx, rounding_mode, fregidx, f_un_rm_xf_op_D)
+union clause ast = F_UN_RM_FX_TYPE_D : (fregidx, rounding_mode, regidx, f_un_rm_fx_op_D)
 
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FSQRT_D)                                                             if haveDoubleFPU() & validDoubleRegs([rs1, rd])
-<-> 0b010_1101 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs1, rd])
+    F_UN_RM_FF_TYPE_D(rs1, rm, rd, FSQRT_D)                                                            if haveDoubleFPU() & validDoubleRegs([rs1, rd])
+<-> 0b010_1101 @ 0b00000 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs1, rd])
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_W_D)                                                            if haveDoubleFPU() & validDoubleRegs([rs1])
-<-> 0b110_0001 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs1])
+    F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_W_D)                                                          if haveDoubleFPU() & validDoubleRegs([rs1])
+<-> 0b110_0001 @ 0b00000 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs1])
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_WU_D)                                                           if haveDoubleFPU() & validDoubleRegs([rs1])
-<-> 0b110_0001 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs1])
+    F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_WU_D)                                                         if haveDoubleFPU() & validDoubleRegs([rs1])
+<-> 0b110_0001 @ 0b00001 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs1])
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_W)                                                            if haveDoubleFPU() & validDoubleRegs([rd])
-<-> 0b110_1001 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rd])
+    F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_W)                                                          if haveDoubleFPU() & validDoubleRegs([rd])
+<-> 0b110_1001 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rd])
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_WU)                                                           if haveDoubleFPU() & validDoubleRegs([rd])
-<-> 0b110_1001 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rd])
+    F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_WU)                                                         if haveDoubleFPU() & validDoubleRegs([rd])
+<-> 0b110_1001 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rd])
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_S_D)                                                            if haveDoubleFPU() & validDoubleRegs([rs1])
-<-> 0b010_0000 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs1])
+    F_UN_RM_FF_TYPE_D(rs1, rm, rd, FCVT_S_D)                                                           if haveDoubleFPU() & validDoubleRegs([rs1])
+<-> 0b010_0000 @ 0b00001 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs1])
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_S)                                                            if haveDoubleFPU() & validDoubleRegs([rd])
-<-> 0b010_0001 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rd])
+    F_UN_RM_FF_TYPE_D(rs1, rm, rd, FCVT_D_S)                                                           if haveDoubleFPU() & validDoubleRegs([rd])
+<-> 0b010_0001 @ 0b00000 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rd])
 
 /* D instructions, RV64 only */
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_L_D)                                                            if haveDoubleFPU() & xlen >= 64
-<-> 0b110_0001 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & xlen >= 64
+    F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_L_D)                                                          if haveDoubleFPU() & xlen >= 64
+<-> 0b110_0001 @ 0b00010 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_LU_D)                                                           if haveDoubleFPU() & xlen >= 64
-<-> 0b110_0001 @ 0b00011 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & xlen >= 64
+    F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_LU_D)                                                         if haveDoubleFPU() & xlen >= 64
+<-> 0b110_0001 @ 0b00011 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_L)                                                            if haveDoubleFPU() & xlen >= 64
-<-> 0b110_1001 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & xlen >= 64
+    F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_L)                                                          if haveDoubleFPU() & xlen >= 64
+<-> 0b110_1001 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveDoubleFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_LU)                                                           if haveDoubleFPU() & xlen >= 64
-<-> 0b110_1001 @ 0b00011 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & xlen >= 64
+    F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_LU)                                                         if haveDoubleFPU() & xlen >= 64
+<-> 0b110_1001 @ 0b00011 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveDoubleFPU() & xlen >= 64
 
 /* Execution semantics ================================ */
 
-function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FSQRT_D)) = {
+function clause execute (F_UN_RM_FF_TYPE_D(rs1, rm, rd, FSQRT_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -450,7 +452,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FSQRT_D)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_W_D)) = {
+function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_W_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -465,7 +467,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_W_D)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_WU_D)) = {
+function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_WU_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -480,7 +482,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_WU_D)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_W)) = {
+function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_W)) = {
   let rs1_val_W = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -495,7 +497,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_W)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_WU)) = {
+function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_WU)) = {
   let rs1_val_WU = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -510,7 +512,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_WU)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_S_D)) = {
+function clause execute (F_UN_RM_FF_TYPE_D(rs1, rm, rd, FCVT_S_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -525,7 +527,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_S_D)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_S)) = {
+function clause execute (F_UN_RM_FF_TYPE_D(rs1, rm, rd, FCVT_D_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -540,7 +542,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_S)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_L_D)) = {
+function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_L_D)) = {
   assert(xlen >= 64);
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
@@ -556,7 +558,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_L_D)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_LU_D)) = {
+function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_LU_D)) = {
   assert(xlen >= 64);
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
@@ -572,7 +574,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_LU_D)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_L)) = {
+function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_L)) = {
   assert(xlen >= 64);
   let rs1_val_L = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
@@ -588,7 +590,7 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_L)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_LU)) = {
+function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_LU)) = {
   assert(xlen >= 64);
   let rs1_val_LU = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
@@ -606,86 +608,42 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_LU)) = {
 
 /* AST -> Assembly notation ================================ */
 
-mapping f_un_rm_type_mnemonic_D : f_un_rm_op_D <-> string = {
+mapping f_un_rm_ff_type_mnemonic_D : f_un_rm_ff_op_D <-> string = {
     FSQRT_D   <-> "fsqrt.d",
-    FCVT_W_D  <-> "fcvt.w.d",
-    FCVT_WU_D <-> "fcvt.wu.d",
-    FCVT_D_W  <-> "fcvt.d.w",
-    FCVT_D_WU <-> "fcvt.d.wu",
-
-    FCVT_L_D  <-> "fcvt.l.d",
-    FCVT_LU_D <-> "fcvt.lu.d",
-    FCVT_D_L  <-> "fcvt.d.l",
-    FCVT_D_LU <-> "fcvt.d.lu",
-
     FCVT_S_D  <-> "fcvt.s.d",
     FCVT_D_S  <-> "fcvt.d.s"
 }
 
-mapping clause assembly = F_UN_RM_TYPE_D(rs1, rm, rd, FSQRT_D)
-                      <-> f_un_rm_type_mnemonic_D(FSQRT_D)
+mapping clause assembly = F_UN_RM_FF_TYPE_D(rs1, rm, rd, op)
+                      <-> f_un_rm_ff_type_mnemonic_D(op)
                           ^ spc() ^ freg_or_reg_name(rd)
                           ^ sep() ^ freg_or_reg_name(rs1)
                           ^ sep() ^ frm_mnemonic(rm)
 
-mapping clause assembly = F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_W_D)
-                      <-> f_un_rm_type_mnemonic_D(FCVT_W_D)
+mapping f_un_rm_fx_type_mnemonic_D : f_un_rm_fx_op_D <-> string = {
+    FCVT_W_D  <-> "fcvt.w.d",
+    FCVT_WU_D <-> "fcvt.wu.d",
+    FCVT_L_D  <-> "fcvt.l.d",
+    FCVT_LU_D <-> "fcvt.lu.d",
+}
+
+mapping clause assembly = F_UN_RM_FX_TYPE_D(rs1, rm, rd, op)
+                      <-> f_un_rm_fx_type_mnemonic_D(op)
                           ^ spc() ^ reg_name(rd)
                           ^ sep() ^ freg_or_reg_name(rs1)
                           ^ sep() ^ frm_mnemonic(rm)
 
-mapping clause assembly = F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_WU_D)
-                      <-> f_un_rm_type_mnemonic_D(FCVT_WU_D)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
+mapping f_un_rm_xf_type_mnemonic_D : f_un_rm_xf_op_D <-> string = {
+    FCVT_D_W  <-> "fcvt.d.w",
+    FCVT_D_WU <-> "fcvt.d.wu",
+    FCVT_D_L  <-> "fcvt.d.l",
+    FCVT_D_LU <-> "fcvt.d.lu",
+}
 
-mapping clause assembly = F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_W)
-                      <-> f_un_rm_type_mnemonic_D(FCVT_D_W)
+mapping clause assembly = F_UN_RM_XF_TYPE_D(rs1, rm, rd, op)
+                      <-> f_un_rm_xf_type_mnemonic_D(op)
                           ^ spc() ^ freg_or_reg_name(rd)
                           ^ sep() ^ reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_WU)
-                      <-> f_un_rm_type_mnemonic_D(FCVT_D_WU)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_L_D)
-                      <-> f_un_rm_type_mnemonic_D(FCVT_L_D)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_LU_D)
-                      <-> f_un_rm_type_mnemonic_D(FCVT_LU_D)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_L)
-                      <-> f_un_rm_type_mnemonic_D(FCVT_D_L)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_LU)
-                      <-> f_un_rm_type_mnemonic_D(FCVT_D_LU)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_S_D)
-                      <-> f_un_rm_type_mnemonic_D(FCVT_S_D)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_S)
-                      <-> f_un_rm_type_mnemonic_D(FCVT_D_S)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
                           ^ sep() ^ frm_mnemonic(rm)
 
 /* ****************************************************************** */
@@ -693,37 +651,38 @@ mapping clause assembly = F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_S)
 
 /* AST */
 
-union clause ast = F_BIN_TYPE_D : (regidx, regidx, regidx, f_bin_op_D)
+union clause ast = F_BIN_F_TYPE_D : (fregidx, fregidx, fregidx, f_bin_f_op_D)
+union clause ast = F_BIN_X_TYPE_D : (fregidx, fregidx, regidx, f_bin_x_op_D)
 
 /* AST <-> Binary encoding ================================ */
 
-mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FSGNJ_D)                                                  if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-                    <-> 0b001_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+mapping clause encdec = F_BIN_F_TYPE_D(rs2, rs1, rd, FSGNJ_D)                                                   if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+                    <-> 0b001_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
-mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FSGNJN_D)                                                 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-                    <-> 0b001_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+mapping clause encdec = F_BIN_F_TYPE_D(rs2, rs1, rd, FSGNJN_D)                                                  if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+                    <-> 0b001_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b001 @ encdec_freg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
-mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FSGNJX_D)                                                 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-                    <-> 0b001_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+mapping clause encdec = F_BIN_F_TYPE_D(rs2, rs1, rd, FSGNJX_D)                                                  if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+                    <-> 0b001_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
-mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FMIN_D)                                                   if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-                    <-> 0b001_0101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+mapping clause encdec = F_BIN_F_TYPE_D(rs2, rs1, rd, FMIN_D)                                                    if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+                    <-> 0b001_0101 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
-mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FMAX_D)                                                   if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
-                    <-> 0b001_0101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+mapping clause encdec = F_BIN_F_TYPE_D(rs2, rs1, rd, FMAX_D)                                                    if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
+                    <-> 0b001_0101 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b001 @ encdec_freg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1, rd])
 
-mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FEQ_D)                                                    if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
-                    <-> 0b101_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
+mapping clause encdec = F_BIN_X_TYPE_D(rs2, rs1, rd, FEQ_D)                                                    if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
+                    <-> 0b101_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
 
-mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FLT_D)                                                    if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
-                    <-> 0b101_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
+mapping clause encdec = F_BIN_X_TYPE_D(rs2, rs1, rd, FLT_D)                                                    if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
+                    <-> 0b101_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
 
-mapping clause encdec = F_BIN_TYPE_D(rs2, rs1, rd, FLE_D)                                                    if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
-                    <-> 0b101_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
+mapping clause encdec = F_BIN_X_TYPE_D(rs2, rs1, rd, FLE_D)                                                    if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
+                    <-> 0b101_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs2, rs1])
 
 /* Execution semantics ================================ */
 
-function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FSGNJ_D)) = {
+function clause execute (F_BIN_F_TYPE_D(rs2, rs1, rd, FSGNJ_D)) = {
   let rs1_val_D    = F_or_X_D(rs1);
   let rs2_val_D    = F_or_X_D(rs2);
 
@@ -735,7 +694,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FSGNJ_D)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FSGNJN_D)) = {
+function clause execute (F_BIN_F_TYPE_D(rs2, rs1, rd, FSGNJN_D)) = {
   let rs1_val_D    = F_or_X_D(rs1);
   let rs2_val_D    = F_or_X_D(rs2);
   let (s1, e1, m1) = fsplit_D (rs1_val_D);
@@ -746,7 +705,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FSGNJN_D)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FSGNJX_D)) = {
+function clause execute (F_BIN_F_TYPE_D(rs2, rs1, rd, FSGNJX_D)) = {
   let rs1_val_D    = F_or_X_D(rs1);
   let rs2_val_D    = F_or_X_D(rs2);
   let (s1, e1, m1) = fsplit_D (rs1_val_D);
@@ -757,7 +716,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FSGNJX_D)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FMIN_D)) = {
+function clause execute (F_BIN_F_TYPE_D(rs2, rs1, rd, FMIN_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   let rs2_val_D = F_or_X_D(rs2);
 
@@ -777,7 +736,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FMIN_D)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FMAX_D)) = {
+function clause execute (F_BIN_F_TYPE_D(rs2, rs1, rd, FMAX_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   let rs2_val_D = F_or_X_D(rs2);
 
@@ -797,7 +756,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FMAX_D)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FEQ_D)) = {
+function clause execute (F_BIN_X_TYPE_D(rs2, rs1, rd, FEQ_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   let rs2_val_D = F_or_X_D(rs2);
 
@@ -809,7 +768,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FEQ_D)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FLT_D)) = {
+function clause execute (F_BIN_X_TYPE_D(rs2, rs1, rd, FLT_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   let rs2_val_D = F_or_X_D(rs2);
 
@@ -821,7 +780,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FLT_D)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FLE_D)) = {
+function clause execute (F_BIN_X_TYPE_D(rs2, rs1, rd, FLE_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   let rs2_val_D = F_or_X_D(rs2);
 
@@ -835,61 +794,28 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FLE_D)) = {
 
 /* AST -> Assembly notation ================================ */
 
-mapping f_bin_type_mnemonic_D : f_bin_op_D <-> string = {
+mapping f_bin_f_type_mnemonic_D : f_bin_f_op_D <-> string = {
     FSGNJ_D  <-> "fsgnj.d",
     FSGNJN_D <-> "fsgnjn.d",
     FSGNJX_D <-> "fsgnjx.d",
     FMIN_D   <-> "fmin.d",
     FMAX_D   <-> "fmax.d",
+}
+
+mapping clause assembly = F_BIN_F_TYPE_D(rs2, rs1, rd, op)
+                      <-> f_bin_f_type_mnemonic_D(op)
+                          ^ spc() ^ freg_or_reg_name(rd)
+                          ^ sep() ^ freg_or_reg_name(rs1)
+                          ^ sep() ^ freg_or_reg_name(rs2)
+
+mapping f_bin_x_type_mnemonic_D : f_bin_x_op_D <-> string = {
     FEQ_D    <-> "feq.d",
     FLT_D    <-> "flt.d",
     FLE_D    <-> "fle.d"
 }
 
-mapping clause assembly = F_BIN_TYPE_D(rs2, rs1, rd, FSGNJ_D)
-                      <-> f_bin_type_mnemonic_D(FSGNJ_D)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_D(rs2, rs1, rd, FSGNJN_D)
-                      <-> f_bin_type_mnemonic_D(FSGNJN_D)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_D(rs2, rs1, rd, FSGNJX_D)
-                      <-> f_bin_type_mnemonic_D(FSGNJX_D)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_D(rs2, rs1, rd, FMIN_D)
-                      <-> f_bin_type_mnemonic_D(FMIN_D)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_D(rs2, rs1, rd, FMAX_D)
-                      <-> f_bin_type_mnemonic_D(FMAX_D)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_D(rs2, rs1, rd, FEQ_D)
-                      <-> f_bin_type_mnemonic_D(FEQ_D)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_D(rs2, rs1, rd, FLT_D)
-                      <-> f_bin_type_mnemonic_D(FLT_D)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_D(rs2, rs1, rd, FLE_D)
-                      <-> f_bin_type_mnemonic_D(FLE_D)
+mapping clause assembly = F_BIN_X_TYPE_D(rs2, rs1, rd, op)
+                      <-> f_bin_x_type_mnemonic_D(op)
                           ^ spc() ^ reg_name(rd)
                           ^ sep() ^ freg_or_reg_name(rs1)
                           ^ sep() ^ freg_or_reg_name(rs2)
@@ -897,24 +823,25 @@ mapping clause assembly = F_BIN_TYPE_D(rs2, rs1, rd, FLE_D)
 /* ****************************************************************** */
 /* Unary, no rounding mode */
 
-union clause ast = F_UN_TYPE_D : (regidx, regidx, f_un_op_D)
+union clause ast = F_UN_X_TYPE_D : (fregidx, regidx, f_un_x_op_D)
+union clause ast = F_UN_F_TYPE_D : (regidx, fregidx, f_un_f_op_D)
 
 /* AST <-> Binary encoding ================================ */
 
-mapping clause encdec = F_UN_TYPE_D(rs1, rd, FCLASS_D)                                               if haveDoubleFPU() & validDoubleRegs([rs1])
-                    <-> 0b111_0001 @ 0b00000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs1])
+mapping clause encdec = F_UN_X_TYPE_D(rs1, rd, FCLASS_D)                                              if haveDoubleFPU() & validDoubleRegs([rs1])
+                    <-> 0b111_0001 @ 0b00000 @ encdec_freg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveDoubleFPU() & validDoubleRegs([rs1])
 
 /* D instructions, RV64 only */
 
-mapping clause encdec = F_UN_TYPE_D(rs1, rd, FMV_X_D)                                                if extensionEnabled(Ext_D) & xlen >= 64
-                    <-> 0b111_0001 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & xlen >= 64
+mapping clause encdec = F_UN_X_TYPE_D(rs1, rd, FMV_X_D)                                               if extensionEnabled(Ext_D) & xlen >= 64
+                    <-> 0b111_0001 @ 0b00000 @ encdec_freg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & xlen >= 64
 
-mapping clause encdec = F_UN_TYPE_D(rs1, rd, FMV_D_X)                                                if extensionEnabled(Ext_D) & xlen >= 64
-                    <-> 0b111_1001 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & xlen >= 64
+mapping clause encdec = F_UN_F_TYPE_D(rs1, rd, FMV_D_X)                                               if extensionEnabled(Ext_D) & xlen >= 64
+                    <-> 0b111_1001 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & xlen >= 64
 
 /* Execution semantics ================================ */
 
-function clause execute (F_UN_TYPE_D(rs1, rd, FCLASS_D)) = {
+function clause execute (F_UN_X_TYPE_D(rs1, rd, FCLASS_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
 
   let rd_val_10b : bits (10) =
@@ -934,13 +861,13 @@ function clause execute (F_UN_TYPE_D(rs1, rd, FCLASS_D)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_UN_TYPE_D(rs1, rd, FMV_X_D)) = {
+function clause execute (F_UN_X_TYPE_D(rs1, rd, FMV_X_D)) = {
   assert(xlen >= 64 & flen >= 64);
   X(rd) = sign_extend(F(rs1)[63..0]);
   RETIRE_SUCCESS
 }
 
-function clause execute (F_UN_TYPE_D(rs1, rd, FMV_D_X)) = {
+function clause execute (F_UN_F_TYPE_D(rs1, rd, FMV_D_X)) = {
   assert(xlen >= 64 & flen >= 64);
   F(rd) = nan_box(X(rs1)[63..0]);
   RETIRE_SUCCESS
@@ -948,25 +875,23 @@ function clause execute (F_UN_TYPE_D(rs1, rd, FMV_D_X)) = {
 
 /* AST -> Assembly notation ================================ */
 
-mapping f_un_type_mnemonic_D : f_un_op_D <-> string = {
+mapping f_un_x_type_mnemonic_D : f_un_x_op_D <-> string = {
     FMV_X_D  <-> "fmv.x.d",
     FCLASS_D <-> "fclass.d",
-    FMV_D_X  <-> "fmv.d.x"
 }
 
-mapping clause assembly = F_UN_TYPE_D(rs1, rd, FMV_X_D)
-                      <-> f_un_type_mnemonic_D(FMV_X_D)
+mapping clause assembly = F_UN_X_TYPE_D(rs1, rd, op)
+                      <-> f_un_x_type_mnemonic_D(op)
                           ^ spc() ^ reg_name(rd)
                           ^ sep() ^ freg_name(rs1)
 
-mapping clause assembly = F_UN_TYPE_D(rs1, rd, FMV_D_X)
-                      <-> f_un_type_mnemonic_D(FMV_D_X)
+mapping f_un_f_type_mnemonic_D : f_un_f_op_D <-> string = {
+    FMV_D_X  <-> "fmv.d.x"
+}
+
+mapping clause assembly = F_UN_F_TYPE_D(rs1, rd, op)
+                      <-> f_un_f_type_mnemonic_D(op)
                           ^ spc() ^ freg_name(rd)
                           ^ sep() ^ reg_name(rs1)
-
-mapping clause assembly = F_UN_TYPE_D(rs1, rd, FCLASS_D)
-                      <-> f_un_type_mnemonic_D(FCLASS_D)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
 
 /* ****************************************************************** */

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -277,14 +277,14 @@ union clause ast = LOAD_FP : (bits(12), regidx, regidx, word_width)
 
 /* AST <-> Binary encoding ================================ */
 
-mapping clause encdec = LOAD_FP(imm, rs1, rd, HALF)          if extensionEnabled(Ext_Zfhmin)
-                    <-> imm @ rs1 @ 0b001 @ rd @ 0b000_0111  if extensionEnabled(Ext_Zfhmin)
+mapping clause encdec = LOAD_FP(imm, rs1, rd, HALF)               if extensionEnabled(Ext_Zfhmin)
+  <-> imm @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b000_0111 if extensionEnabled(Ext_Zfhmin)
 
-mapping clause encdec = LOAD_FP(imm, rs1, rd, WORD)          if extensionEnabled(Ext_F)
-                    <-> imm @ rs1 @ 0b010 @ rd @ 0b000_0111  if extensionEnabled(Ext_F)
+mapping clause encdec = LOAD_FP(imm, rs1, rd, WORD)               if extensionEnabled(Ext_F)
+  <-> imm @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b000_0111 if extensionEnabled(Ext_F)
 
-mapping clause encdec = LOAD_FP(imm, rs1, rd, DOUBLE)        if extensionEnabled(Ext_D)
-                    <-> imm @ rs1 @ 0b011 @ rd @ 0b000_0111  if extensionEnabled(Ext_D)
+mapping clause encdec = LOAD_FP(imm, rs1, rd, DOUBLE)             if extensionEnabled(Ext_D)
+  <-> imm @ encdec_reg(rs1) @ 0b011 @ encdec_reg(rd) @ 0b000_0111 if extensionEnabled(Ext_D)
 
 /* Execution semantics ================================ */
 
@@ -334,14 +334,14 @@ union clause ast = STORE_FP : (bits(12), regidx, regidx, word_width)
 
 /* AST <-> Binary encoding ================================ */
 
-mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, HALF)                             if extensionEnabled(Ext_Zfhmin)
-                    <-> imm7 : bits(7) @ rs2 @ rs1 @ 0b001 @ imm5 : bits(5) @ 0b010_0111  if extensionEnabled(Ext_Zfhmin)
+mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, HALF)                                  if extensionEnabled(Ext_Zfhmin)
+  <-> imm7 : bits(7) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ imm5 : bits(5) @ 0b010_0111 if extensionEnabled(Ext_Zfhmin)
 
-mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, WORD)                             if extensionEnabled(Ext_F)
-                    <-> imm7 : bits(7) @ rs2 @ rs1 @ 0b010 @ imm5 : bits(5) @ 0b010_0111  if extensionEnabled(Ext_F)
+mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, WORD)                                  if extensionEnabled(Ext_F)
+  <-> imm7 : bits(7) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ imm5 : bits(5) @ 0b010_0111 if extensionEnabled(Ext_F)
 
-mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, DOUBLE)                           if extensionEnabled(Ext_D)
-                    <-> imm7 : bits(7) @ rs2 @ rs1 @ 0b011 @ imm5 : bits(5) @ 0b010_0111  if extensionEnabled(Ext_D)
+mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, DOUBLE)                                if extensionEnabled(Ext_D)
+  <-> imm7 : bits(7) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b011 @ imm5 : bits(5) @ 0b010_0111 if extensionEnabled(Ext_D)
 
 /* Execution semantics ================================ */
 
@@ -398,20 +398,20 @@ union clause ast = F_MADD_TYPE_S : (regidx, regidx, regidx, rounding_mode, regid
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FMADD_S)                         if haveSingleFPU()
-<-> rs3 @ 0b00 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b100_0011  if haveSingleFPU()
+    F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FMADD_S)                                                                        if haveSingleFPU()
+<-> encdec_reg(rs3) @ 0b00 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_0011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FMSUB_S)                         if haveSingleFPU()
-<-> rs3 @ 0b00 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b100_0111  if haveSingleFPU()
+    F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FMSUB_S)                                                                        if haveSingleFPU()
+<-> encdec_reg(rs3) @ 0b00 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_0111 if haveSingleFPU()
 
 mapping clause encdec =
-    F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FNMSUB_S)                        if haveSingleFPU()
-<-> rs3 @ 0b00 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b100_1011  if haveSingleFPU()
+    F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FNMSUB_S)                                                                       if haveSingleFPU()
+<-> encdec_reg(rs3) @ 0b00 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_1011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FNMADD_S)                        if haveSingleFPU()
-<-> rs3 @ 0b00 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b100_1111  if haveSingleFPU()
+    F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FNMADD_S)                                                                       if haveSingleFPU()
+<-> encdec_reg(rs3) @ 0b00 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_1111 if haveSingleFPU()
 
 /* Execution semantics ================================ */
 
@@ -464,20 +464,20 @@ union clause ast = F_BIN_RM_TYPE_S : (regidx, regidx, rounding_mode, regidx, f_b
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FADD_S)                             if haveSingleFPU()
-<-> 0b000_0000 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveSingleFPU()
+    F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FADD_S)                                                                if haveSingleFPU()
+<-> 0b000_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FSUB_S)                             if haveSingleFPU()
-<-> 0b000_0100 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveSingleFPU()
+    F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FSUB_S)                                                                if haveSingleFPU()
+<-> 0b000_0100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FMUL_S)                             if haveSingleFPU()
-<-> 0b000_1000 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveSingleFPU()
+    F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FMUL_S)                                                                if haveSingleFPU()
+<-> 0b000_1000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FDIV_S)                             if haveSingleFPU()
-<-> 0b000_1100 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveSingleFPU()
+    F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FDIV_S)                                                                if haveSingleFPU()
+<-> 0b000_1100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
 /* Execution semantics ================================ */
 
@@ -527,42 +527,42 @@ union clause ast = F_UN_RM_TYPE_S : (regidx, rounding_mode, regidx, f_un_rm_op_S
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FSQRT_S)                                      if haveSingleFPU()
-<-> 0b010_1100 @ 0b00000 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveSingleFPU()
+    F_UN_RM_TYPE_S(rs1, rm, rd, FSQRT_S)                                                             if haveSingleFPU()
+<-> 0b010_1100 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_W_S)                                     if haveSingleFPU()
-<-> 0b110_0000 @ 0b00000 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveSingleFPU()
+    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_W_S)                                                            if haveSingleFPU()
+<-> 0b110_0000 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_WU_S)                                    if haveSingleFPU()
-<-> 0b110_0000 @ 0b00001 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveSingleFPU()
+    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_WU_S)                                                           if haveSingleFPU()
+<-> 0b110_0000 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_W)                                     if haveSingleFPU()
-<-> 0b110_1000 @ 0b00000 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveSingleFPU()
+    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_W)                                                            if haveSingleFPU()
+<-> 0b110_1000 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_WU)                                    if haveSingleFPU()
-<-> 0b110_1000 @ 0b00001 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveSingleFPU()
+    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_WU)                                                           if haveSingleFPU()
+<-> 0b110_1000 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
 /* F instructions, RV64 only */
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_L_S)                                     if haveSingleFPU() & xlen >= 64
-<-> 0b110_0000 @ 0b00010 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveSingleFPU() & xlen >= 64
+    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_L_S)                                                            if haveSingleFPU() & xlen >= 64
+<-> 0b110_0000 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_LU_S)                                    if haveSingleFPU() & xlen >= 64
-<-> 0b110_0000 @ 0b00011 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveSingleFPU() & xlen >= 64
+    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_LU_S)                                                           if haveSingleFPU() & xlen >= 64
+<-> 0b110_0000 @ 0b00011 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_L)                                     if haveSingleFPU() & xlen >= 64
-<-> 0b110_1000 @ 0b00010 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveSingleFPU() & xlen >= 64
+    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_L)                                                            if haveSingleFPU() & xlen >= 64
+<-> 0b110_1000 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_LU)                                    if haveSingleFPU() & xlen >= 64
-<-> 0b110_1000 @ 0b00011 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveSingleFPU() & xlen >= 64
+    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_LU)                                                           if haveSingleFPU() & xlen >= 64
+<-> 0b110_1000 @ 0b00011 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU() & xlen >= 64
 
 /* Execution semantics ================================ */
 
@@ -784,29 +784,29 @@ union clause ast = F_BIN_TYPE_S : (regidx, regidx, regidx, f_bin_op_S)
 
 /* AST <-> Binary encoding ================================ */
 
-mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FSGNJ_S)               if haveSingleFPU()
-                    <-> 0b001_0000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveSingleFPU()
+mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FSGNJ_S)                                                  if haveSingleFPU()
+                    <-> 0b001_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
-mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FSGNJN_S)              if haveSingleFPU()
-                    <-> 0b001_0000 @ rs2 @ rs1 @ 0b001 @ rd @ 0b101_0011  if haveSingleFPU()
+mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FSGNJN_S)                                                 if haveSingleFPU()
+                    <-> 0b001_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
-mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FSGNJX_S)              if haveSingleFPU()
-                    <-> 0b001_0000 @ rs2 @ rs1 @ 0b010 @ rd @ 0b101_0011  if haveSingleFPU()
+mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FSGNJX_S)                                                 if haveSingleFPU()
+                    <-> 0b001_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
-mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FMIN_S)                if haveSingleFPU()
-                    <-> 0b001_0100 @ rs2 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveSingleFPU()
+mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FMIN_S)                                                   if haveSingleFPU()
+                    <-> 0b001_0100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
-mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FMAX_S)                if haveSingleFPU()
-                    <-> 0b001_0100 @ rs2 @ rs1 @ 0b001 @ rd @ 0b101_0011  if haveSingleFPU()
+mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FMAX_S)                                                   if haveSingleFPU()
+                    <-> 0b001_0100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
-mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FEQ_S)                 if haveSingleFPU()
-                    <-> 0b101_0000 @ rs2 @ rs1 @ 0b010 @ rd @ 0b101_0011  if haveSingleFPU()
+mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FEQ_S)                                                    if haveSingleFPU()
+                    <-> 0b101_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
-mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FLT_S)                 if haveSingleFPU()
-                    <-> 0b101_0000 @ rs2 @ rs1 @ 0b001 @ rd @ 0b101_0011  if haveSingleFPU()
+mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FLT_S)                                                    if haveSingleFPU()
+                    <-> 0b101_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
-mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FLE_S)                 if haveSingleFPU()
-                    <-> 0b101_0000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveSingleFPU()
+mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FLE_S)                                                    if haveSingleFPU()
+                    <-> 0b101_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
 /* Execution semantics ================================ */
 
@@ -987,14 +987,14 @@ union clause ast = F_UN_TYPE_S : (regidx, regidx, f_un_op_S)
 
 /* AST <-> Binary encoding ================================ */
 
-mapping clause encdec = F_UN_TYPE_S(rs1, rd, FCLASS_S)                        if haveSingleFPU()
-                    <-> 0b111_0000 @ 0b00000 @ rs1 @ 0b001 @ rd @ 0b101_0011  if haveSingleFPU()
+mapping clause encdec = F_UN_TYPE_S(rs1, rd, FCLASS_S)                                               if haveSingleFPU()
+                    <-> 0b111_0000 @ 0b00000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
-mapping clause encdec = F_UN_TYPE_S(rs1, rd, FMV_X_W)                         if extensionEnabled(Ext_F)
-                    <-> 0b111_0000 @ 0b00000 @ rs1 @ 0b000 @ rd @ 0b101_0011  if extensionEnabled(Ext_F)
+mapping clause encdec = F_UN_TYPE_S(rs1, rd, FMV_X_W)                                                if extensionEnabled(Ext_F)
+                    <-> 0b111_0000 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_F)
 
-mapping clause encdec = F_UN_TYPE_S(rs1, rd, FMV_W_X)                         if extensionEnabled(Ext_F)
-                    <-> 0b111_1000 @ 0b00000 @ rs1 @ 0b000 @ rd @ 0b101_0011  if extensionEnabled(Ext_F)
+mapping clause encdec = F_UN_TYPE_S(rs1, rd, FMV_W_X)                                                if extensionEnabled(Ext_F)
+                    <-> 0b111_1000 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_F)
 
 /* Execution semantics ================================ */
 

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -273,18 +273,18 @@ function haveSingleFPU() -> bool = extensionEnabled(Ext_F) | extensionEnabled(Ex
 /* AST */
 /* FLH, FLW and FLD; H/W/D is encoded in 'word_width' */
 
-union clause ast = LOAD_FP : (bits(12), regidx, regidx, word_width)
+union clause ast = LOAD_FP : (bits(12), regidx, fregidx, word_width)
 
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec = LOAD_FP(imm, rs1, rd, HALF)               if extensionEnabled(Ext_Zfhmin)
-  <-> imm @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b000_0111 if extensionEnabled(Ext_Zfhmin)
+  <-> imm @ encdec_reg(rs1) @ 0b001 @ encdec_freg(rd) @ 0b000_0111 if extensionEnabled(Ext_Zfhmin)
 
 mapping clause encdec = LOAD_FP(imm, rs1, rd, WORD)               if extensionEnabled(Ext_F)
-  <-> imm @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b000_0111 if extensionEnabled(Ext_F)
+  <-> imm @ encdec_reg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b000_0111 if extensionEnabled(Ext_F)
 
 mapping clause encdec = LOAD_FP(imm, rs1, rd, DOUBLE)             if extensionEnabled(Ext_D)
-  <-> imm @ encdec_reg(rs1) @ 0b011 @ encdec_reg(rd) @ 0b000_0111 if extensionEnabled(Ext_D)
+  <-> imm @ encdec_reg(rs1) @ 0b011 @ encdec_freg(rd) @ 0b000_0111 if extensionEnabled(Ext_D)
 
 /* Execution semantics ================================ */
 
@@ -330,18 +330,18 @@ mapping clause assembly = LOAD_FP(imm, rs1, rd, width)
 /* AST */
 /* FSH, FSW and FSD; H/W/D is encoded in 'word_width' */
 
-union clause ast = STORE_FP : (bits(12), regidx, regidx, word_width)
+union clause ast = STORE_FP : (bits(12), fregidx, regidx, word_width)
 
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, HALF)                                  if extensionEnabled(Ext_Zfhmin)
-  <-> imm7 : bits(7) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ imm5 : bits(5) @ 0b010_0111 if extensionEnabled(Ext_Zfhmin)
+  <-> imm7 : bits(7) @ encdec_freg(rs2) @ encdec_reg(rs1) @ 0b001 @ imm5 : bits(5) @ 0b010_0111 if extensionEnabled(Ext_Zfhmin)
 
 mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, WORD)                                  if extensionEnabled(Ext_F)
-  <-> imm7 : bits(7) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ imm5 : bits(5) @ 0b010_0111 if extensionEnabled(Ext_F)
+  <-> imm7 : bits(7) @ encdec_freg(rs2) @ encdec_reg(rs1) @ 0b010 @ imm5 : bits(5) @ 0b010_0111 if extensionEnabled(Ext_F)
 
 mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, DOUBLE)                                if extensionEnabled(Ext_D)
-  <-> imm7 : bits(7) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b011 @ imm5 : bits(5) @ 0b010_0111 if extensionEnabled(Ext_D)
+  <-> imm7 : bits(7) @ encdec_freg(rs2) @ encdec_reg(rs1) @ 0b011 @ imm5 : bits(5) @ 0b010_0111 if extensionEnabled(Ext_D)
 
 /* Execution semantics ================================ */
 
@@ -393,25 +393,25 @@ mapping clause assembly = STORE_FP(imm, rs2, rs1, width)
 
 /* AST */
 
-union clause ast = F_MADD_TYPE_S : (regidx, regidx, regidx, rounding_mode, regidx, f_madd_op_S)
+union clause ast = F_MADD_TYPE_S : (fregidx, fregidx, fregidx, rounding_mode, fregidx, f_madd_op_S)
 
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FMADD_S)                                                                        if haveSingleFPU()
-<-> encdec_reg(rs3) @ 0b00 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_0011 if haveSingleFPU()
+    F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FMADD_S)                                                                            if haveSingleFPU()
+<-> encdec_freg(rs3) @ 0b00 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b100_0011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FMSUB_S)                                                                        if haveSingleFPU()
-<-> encdec_reg(rs3) @ 0b00 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_0111 if haveSingleFPU()
+    F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FMSUB_S)                                                                            if haveSingleFPU()
+<-> encdec_freg(rs3) @ 0b00 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b100_0111 if haveSingleFPU()
 
 mapping clause encdec =
-    F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FNMSUB_S)                                                                       if haveSingleFPU()
-<-> encdec_reg(rs3) @ 0b00 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_1011 if haveSingleFPU()
+    F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FNMSUB_S)                                                                           if haveSingleFPU()
+<-> encdec_freg(rs3) @ 0b00 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b100_1011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FNMADD_S)                                                                       if haveSingleFPU()
-<-> encdec_reg(rs3) @ 0b00 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_1111 if haveSingleFPU()
+    F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FNMADD_S)                                                                           if haveSingleFPU()
+<-> encdec_freg(rs3) @ 0b00 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b100_1111 if haveSingleFPU()
 
 /* Execution semantics ================================ */
 
@@ -459,25 +459,25 @@ mapping clause assembly = F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, op)
 
 /* AST */
 
-union clause ast = F_BIN_RM_TYPE_S : (regidx, regidx, rounding_mode, regidx, f_bin_rm_op_S)
+union clause ast = F_BIN_RM_TYPE_S : (fregidx, fregidx, rounding_mode, fregidx, f_bin_rm_op_S)
 
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FADD_S)                                                                if haveSingleFPU()
-<-> 0b000_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+    F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FADD_S)                                                                   if haveSingleFPU()
+<-> 0b000_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FSUB_S)                                                                if haveSingleFPU()
-<-> 0b000_0100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+    F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FSUB_S)                                                                   if haveSingleFPU()
+<-> 0b000_0100 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FMUL_S)                                                                if haveSingleFPU()
-<-> 0b000_1000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+    F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FMUL_S)                                                                   if haveSingleFPU()
+<-> 0b000_1000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FDIV_S)                                                                if haveSingleFPU()
-<-> 0b000_1100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+    F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FDIV_S)                                                                   if haveSingleFPU()
+<-> 0b000_1100 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveSingleFPU()
 
 /* Execution semantics ================================ */
 
@@ -522,51 +522,53 @@ mapping clause assembly = F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, op)
 
 /* AST */
 
-union clause ast = F_UN_RM_TYPE_S : (regidx, rounding_mode, regidx, f_un_rm_op_S)
+union clause ast = F_UN_RM_FF_TYPE_S : (fregidx, rounding_mode, fregidx, f_un_rm_ff_op_S)
+union clause ast = F_UN_RM_FX_TYPE_S : (fregidx, rounding_mode, regidx, f_un_rm_fx_op_S)
+union clause ast = F_UN_RM_XF_TYPE_S : (regidx, rounding_mode, fregidx, f_un_rm_xf_op_S)
 
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FSQRT_S)                                                             if haveSingleFPU()
-<-> 0b010_1100 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+    F_UN_RM_FF_TYPE_S(rs1, rm, rd, FSQRT_S)                                                            if haveSingleFPU()
+<-> 0b010_1100 @ 0b00000 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_W_S)                                                            if haveSingleFPU()
-<-> 0b110_0000 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+    F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_W_S)                                                          if haveSingleFPU()
+<-> 0b110_0000 @ 0b00000 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_WU_S)                                                           if haveSingleFPU()
-<-> 0b110_0000 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+    F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_WU_S)                                                         if haveSingleFPU()
+<-> 0b110_0000 @ 0b00001 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_W)                                                            if haveSingleFPU()
-<-> 0b110_1000 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+    F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_W)                                                          if haveSingleFPU()
+<-> 0b110_1000 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveSingleFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_WU)                                                           if haveSingleFPU()
-<-> 0b110_1000 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+    F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_WU)                                                         if haveSingleFPU()
+<-> 0b110_1000 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveSingleFPU()
 
 /* F instructions, RV64 only */
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_L_S)                                                            if haveSingleFPU() & xlen >= 64
-<-> 0b110_0000 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU() & xlen >= 64
+    F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_L_S)                                                          if haveSingleFPU() & xlen >= 64
+<-> 0b110_0000 @ 0b00010 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_LU_S)                                                           if haveSingleFPU() & xlen >= 64
-<-> 0b110_0000 @ 0b00011 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU() & xlen >= 64
+    F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_LU_S)                                                         if haveSingleFPU() & xlen >= 64
+<-> 0b110_0000 @ 0b00011 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_L)                                                            if haveSingleFPU() & xlen >= 64
-<-> 0b110_1000 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU() & xlen >= 64
+    F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_L)                                                          if haveSingleFPU() & xlen >= 64
+<-> 0b110_1000 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveSingleFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_LU)                                                           if haveSingleFPU() & xlen >= 64
-<-> 0b110_1000 @ 0b00011 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU() & xlen >= 64
+    F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_LU)                                                         if haveSingleFPU() & xlen >= 64
+<-> 0b110_1000 @ 0b00011 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveSingleFPU() & xlen >= 64
 
 /* Execution semantics ================================ */
 
-function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FSQRT_S)) = {
+function clause execute (F_UN_RM_FF_TYPE_S(rs1, rm, rd, FSQRT_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -581,7 +583,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FSQRT_S)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_W_S)) = {
+function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_W_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -596,7 +598,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_W_S)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_WU_S)) = {
+function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_WU_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -611,7 +613,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_WU_S)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_W)) = {
+function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_W)) = {
   let rs1_val_W = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -626,7 +628,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_W)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_WU)) = {
+function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_WU)) = {
   let rs1_val_WU = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -641,7 +643,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_WU)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_L_S)) = {
+function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_L_S)) = {
   assert(xlen >= 64);
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
@@ -657,7 +659,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_L_S)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_LU_S)) = {
+function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_LU_S)) = {
   assert(xlen >= 64);
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
@@ -673,7 +675,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_LU_S)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_L)) = {
+function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_L)) = {
   assert(xlen >= 64);
   let rs1_val_L = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
@@ -689,7 +691,7 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_L)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_LU)) = {
+function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_LU)) = {
   assert(xlen >= 64);
   let rs1_val_LU = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
@@ -707,110 +709,76 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_LU)) = {
 
 /* AST -> Assembly notation ================================ */
 
-mapping f_un_rm_type_mnemonic_S : f_un_rm_op_S <-> string = {
-    FSQRT_S   <-> "fsqrt.s",
+mapping clause assembly = F_UN_RM_FF_TYPE_S(rs1, rm, rd, FSQRT_S)
+                      <-> "fsqrt.s"
+                          ^ spc() ^ freg_or_reg_name(rd)
+                          ^ sep() ^ freg_or_reg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+
+mapping f_un_rm_fx_type_mnemonic_S : f_un_rm_fx_op_S <-> string = {
     FCVT_W_S  <-> "fcvt.w.s",
     FCVT_WU_S <-> "fcvt.wu.s",
-    FCVT_S_W  <-> "fcvt.s.w",
-    FCVT_S_WU <-> "fcvt.s.wu",
-
     FCVT_L_S  <-> "fcvt.l.s",
     FCVT_LU_S <-> "fcvt.lu.s",
+}
+
+mapping clause assembly = F_UN_RM_FX_TYPE_S(rs1, rm, rd, op)
+                      <-> f_un_rm_fx_type_mnemonic_S(op)
+                          ^ spc() ^ reg_name(rd)
+                          ^ sep() ^ freg_or_reg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+mapping f_un_rm_xf_type_mnemonic_S : f_un_rm_xf_op_S <-> string = {
+    FCVT_S_W  <-> "fcvt.s.w",
+    FCVT_S_WU <-> "fcvt.s.wu",
     FCVT_S_L  <-> "fcvt.s.l",
     FCVT_S_LU <-> "fcvt.s.lu"
 }
 
-mapping clause assembly = F_UN_RM_TYPE_S(rs1, rm, rd, FSQRT_S)
-                      <-> f_un_rm_type_mnemonic_S(FSQRT_S)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_W_S)
-                      <-> f_un_rm_type_mnemonic_S(FCVT_W_S)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_WU_S)
-                      <-> f_un_rm_type_mnemonic_S(FCVT_WU_S)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_W)
-                      <-> f_un_rm_type_mnemonic_S(FCVT_S_W)
+mapping clause assembly = F_UN_RM_XF_TYPE_S(rs1, rm, rd, op)
+                      <-> f_un_rm_xf_type_mnemonic_S(op)
                           ^ spc() ^ freg_or_reg_name(rd)
                           ^ sep() ^ reg_name(rs1)
                           ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_WU)
-                      <-> f_un_rm_type_mnemonic_S(FCVT_S_WU)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_L_S)
-                      <-> f_un_rm_type_mnemonic_S(FCVT_L_S)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_LU_S)
-                      <-> f_un_rm_type_mnemonic_S(FCVT_LU_S)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_L)
-                      <-> f_un_rm_type_mnemonic_S(FCVT_S_L)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_LU)
-                      <-> f_un_rm_type_mnemonic_S(FCVT_S_LU)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
 
 /* ****************************************************************** */
 /* Binary, no rounding mode */
 
 /* AST */
 
-union clause ast = F_BIN_TYPE_S : (regidx, regidx, regidx, f_bin_op_S)
+union clause ast = F_BIN_TYPE_F_S : (fregidx, fregidx, fregidx, f_bin_op_f_S)
+union clause ast = F_BIN_TYPE_X_S : (fregidx, fregidx, regidx, f_bin_op_x_S)
 
 /* AST <-> Binary encoding ================================ */
 
-mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FSGNJ_S)                                                  if haveSingleFPU()
-                    <-> 0b001_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+mapping clause encdec = F_BIN_TYPE_F_S(rs2, rs1, rd, FSGNJ_S)                                                   if haveSingleFPU()
+                    <-> 0b001_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011 if haveSingleFPU()
 
-mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FSGNJN_S)                                                 if haveSingleFPU()
-                    <-> 0b001_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+mapping clause encdec = F_BIN_TYPE_F_S(rs2, rs1, rd, FSGNJN_S)                                                  if haveSingleFPU()
+                    <-> 0b001_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b001 @ encdec_freg(rd) @ 0b101_0011 if haveSingleFPU()
 
-mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FSGNJX_S)                                                 if haveSingleFPU()
-                    <-> 0b001_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+mapping clause encdec = F_BIN_TYPE_F_S(rs2, rs1, rd, FSGNJX_S)                                                  if haveSingleFPU()
+                    <-> 0b001_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b101_0011 if haveSingleFPU()
 
-mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FMIN_S)                                                   if haveSingleFPU()
-                    <-> 0b001_0100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+mapping clause encdec = F_BIN_TYPE_F_S(rs2, rs1, rd, FMIN_S)                                                    if haveSingleFPU()
+                    <-> 0b001_0100 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011 if haveSingleFPU()
 
-mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FMAX_S)                                                   if haveSingleFPU()
-                    <-> 0b001_0100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+mapping clause encdec = F_BIN_TYPE_F_S(rs2, rs1, rd, FMAX_S)                                                    if haveSingleFPU()
+                    <-> 0b001_0100 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b001 @ encdec_freg(rd) @ 0b101_0011 if haveSingleFPU()
 
-mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FEQ_S)                                                    if haveSingleFPU()
-                    <-> 0b101_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+mapping clause encdec = F_BIN_TYPE_X_S(rs2, rs1, rd, FEQ_S)                                                    if haveSingleFPU()
+                    <-> 0b101_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
-mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FLT_S)                                                    if haveSingleFPU()
-                    <-> 0b101_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+mapping clause encdec = F_BIN_TYPE_X_S(rs2, rs1, rd, FLT_S)                                                    if haveSingleFPU()
+                    <-> 0b101_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
-mapping clause encdec = F_BIN_TYPE_S(rs2, rs1, rd, FLE_S)                                                    if haveSingleFPU()
-                    <-> 0b101_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+mapping clause encdec = F_BIN_TYPE_X_S(rs2, rs1, rd, FLE_S)                                                    if haveSingleFPU()
+                    <-> 0b101_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
 /* Execution semantics ================================ */
 
-function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FSGNJ_S)) = {
+function clause execute (F_BIN_TYPE_F_S(rs2, rs1, rd, FSGNJ_S)) = {
   let rs1_val_S    = F_or_X_S(rs1);
   let rs2_val_S    = F_or_X_S(rs2);
   let (s1, e1, m1) = fsplit_S (rs1_val_S);
@@ -821,7 +789,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FSGNJ_S)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FSGNJN_S)) = {
+function clause execute (F_BIN_TYPE_F_S(rs2, rs1, rd, FSGNJN_S)) = {
   let rs1_val_S    = F_or_X_S(rs1);
   let rs2_val_S    = F_or_X_S(rs2);
   let (s1, e1, m1) = fsplit_S (rs1_val_S);
@@ -832,7 +800,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FSGNJN_S)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FSGNJX_S)) = {
+function clause execute (F_BIN_TYPE_F_S(rs2, rs1, rd, FSGNJX_S)) = {
   let rs1_val_S    = F_or_X_S(rs1);
   let rs2_val_S    = F_or_X_S(rs2);
   let (s1, e1, m1) = fsplit_S (rs1_val_S);
@@ -843,7 +811,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FSGNJX_S)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FMIN_S)) = {
+function clause execute (F_BIN_TYPE_F_S(rs2, rs1, rd, FMIN_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   let rs2_val_S = F_or_X_S(rs2);
 
@@ -863,7 +831,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FMIN_S)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FMAX_S)) = {
+function clause execute (F_BIN_TYPE_F_S(rs2, rs1, rd, FMAX_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   let rs2_val_S = F_or_X_S(rs2);
 
@@ -883,7 +851,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FMAX_S)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FEQ_S)) = {
+function clause execute (F_BIN_TYPE_X_S(rs2, rs1, rd, FEQ_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   let rs2_val_S = F_or_X_S(rs2);
 
@@ -895,7 +863,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FEQ_S)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FLT_S)) = {
+function clause execute (F_BIN_TYPE_X_S(rs2, rs1, rd, FLT_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   let rs2_val_S = F_or_X_S(rs2);
 
@@ -907,7 +875,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FLT_S)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FLE_S)) = {
+function clause execute (F_BIN_TYPE_X_S(rs2, rs1, rd, FLE_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   let rs2_val_S = F_or_X_S(rs2);
 
@@ -921,61 +889,28 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FLE_S)) = {
 
 /* AST -> Assembly notation ================================ */
 
-mapping f_bin_type_mnemonic_S : f_bin_op_S <-> string = {
+mapping f_bin_type_mnemonic_f_S : f_bin_op_f_S <-> string = {
     FSGNJ_S  <-> "fsgnj.s",
     FSGNJN_S <-> "fsgnjn.s",
     FSGNJX_S <-> "fsgnjx.s",
     FMIN_S   <-> "fmin.s",
-    FMAX_S   <-> "fmax.s",
+    FMAX_S   <-> "fmax.s"
+}
+
+mapping clause assembly = F_BIN_TYPE_F_S(rs2, rs1, rd, op)
+                      <-> f_bin_type_mnemonic_f_S(op)
+                          ^ spc() ^ freg_or_reg_name(rd)
+                          ^ sep() ^ freg_or_reg_name(rs1)
+                          ^ sep() ^ freg_or_reg_name(rs2)
+
+mapping f_bin_type_mnemonic_x_S : f_bin_op_x_S <-> string = {
     FEQ_S    <-> "feq.s",
     FLT_S    <-> "flt.s",
     FLE_S    <-> "fle.s"
 }
 
-mapping clause assembly = F_BIN_TYPE_S(rs2, rs1, rd, FSGNJ_S)
-                      <-> f_bin_type_mnemonic_S(FSGNJ_S)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_S(rs2, rs1, rd, FSGNJN_S)
-                      <-> f_bin_type_mnemonic_S(FSGNJN_S)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_S(rs2, rs1, rd, FSGNJX_S)
-                      <-> f_bin_type_mnemonic_S(FSGNJX_S)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_S(rs2, rs1, rd, FMIN_S)
-                      <-> f_bin_type_mnemonic_S(FMIN_S)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_S(rs2, rs1, rd, FMAX_S)
-                      <-> f_bin_type_mnemonic_S(FMAX_S)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_S(rs2, rs1, rd, FEQ_S)
-                      <-> f_bin_type_mnemonic_S(FEQ_S)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_S(rs2, rs1, rd, FLT_S)
-                      <-> f_bin_type_mnemonic_S(FLT_S)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_S(rs2, rs1, rd, FLE_S)
-                      <-> f_bin_type_mnemonic_S(FLE_S)
+mapping clause assembly = F_BIN_TYPE_X_S(rs2, rs1, rd, op)
+                      <-> f_bin_type_mnemonic_x_S(op)
                           ^ spc() ^ reg_name(rd)
                           ^ sep() ^ freg_or_reg_name(rs1)
                           ^ sep() ^ freg_or_reg_name(rs2)
@@ -983,22 +918,23 @@ mapping clause assembly = F_BIN_TYPE_S(rs2, rs1, rd, FLE_S)
 /* ****************************************************************** */
 /* Unary, no rounding mode */
 
-union clause ast = F_UN_TYPE_S : (regidx, regidx, f_un_op_S)
+union clause ast = F_UN_TYPE_F_S : (regidx, fregidx, f_un_op_f_S)
+union clause ast = F_UN_TYPE_X_S : (fregidx, regidx, f_un_op_x_S)
 
 /* AST <-> Binary encoding ================================ */
 
-mapping clause encdec = F_UN_TYPE_S(rs1, rd, FCLASS_S)                                               if haveSingleFPU()
-                    <-> 0b111_0000 @ 0b00000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
+mapping clause encdec = F_UN_TYPE_X_S(rs1, rd, FCLASS_S)                                              if haveSingleFPU()
+                    <-> 0b111_0000 @ 0b00000 @ encdec_freg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveSingleFPU()
 
-mapping clause encdec = F_UN_TYPE_S(rs1, rd, FMV_X_W)                                                if extensionEnabled(Ext_F)
-                    <-> 0b111_0000 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_F)
+mapping clause encdec = F_UN_TYPE_X_S(rs1, rd, FMV_X_W)                                               if extensionEnabled(Ext_F)
+                    <-> 0b111_0000 @ 0b00000 @ encdec_freg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_F)
 
-mapping clause encdec = F_UN_TYPE_S(rs1, rd, FMV_W_X)                                                if extensionEnabled(Ext_F)
-                    <-> 0b111_1000 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_F)
+mapping clause encdec = F_UN_TYPE_F_S(rs1, rd, FMV_W_X)                                               if extensionEnabled(Ext_F)
+                    <-> 0b111_1000 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_F)
 
 /* Execution semantics ================================ */
 
-function clause execute (F_UN_TYPE_S(rs1, rd, FCLASS_S)) = {
+function clause execute (F_UN_TYPE_X_S(rs1, rd, FCLASS_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
 
   let rd_val_10b : bits (10) =
@@ -1018,37 +954,37 @@ function clause execute (F_UN_TYPE_S(rs1, rd, FCLASS_S)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_UN_TYPE_S(rs1, rd, FMV_X_W)) = {
+function clause execute (F_UN_TYPE_X_S(rs1, rd, FMV_X_W)) = {
   X(rd) = sign_extend(F(rs1)[31..0]);
   RETIRE_SUCCESS
 }
 
-function clause execute (F_UN_TYPE_S(rs1, rd, FMV_W_X)) = {
+function clause execute (F_UN_TYPE_F_S(rs1, rd, FMV_W_X)) = {
   F(rd) = nan_box(X(rs1)[31..0]);
   RETIRE_SUCCESS
 }
 
 /* AST -> Assembly notation ================================ */
 
-mapping f_un_type_mnemonic_S : f_un_op_S <-> string = {
-    FMV_X_W  <-> "fmv.x.w",
+mapping f_un_type_mnemonic_x_S : f_un_op_x_S <-> string = {
     FCLASS_S <-> "fclass.s",
-    FMV_W_X  <-> "fmv.w.x"
+    FMV_X_W  <-> "fmv.x.w",
 }
 
-mapping clause assembly = F_UN_TYPE_S(rs1, rd, FMV_X_W)
-                      <-> f_un_type_mnemonic_S(FMV_X_W)
+mapping clause assembly = F_UN_TYPE_X_S(rs1, rd, op)
+                      <-> f_un_type_mnemonic_x_S(op)
                           ^ spc() ^ reg_name(rd)
                           ^ sep() ^ freg_name(rs1)
 
-mapping clause assembly = F_UN_TYPE_S(rs1, rd, FMV_W_X)
-                      <-> f_un_type_mnemonic_S(FMV_W_X)
+mapping f_un_type_mnemonic_f_S : f_un_op_f_S <-> string = {
+    FMV_W_X  <-> "fmv.w.x"
+}
+
+mapping clause assembly = F_UN_TYPE_F_S(rs1, rd, op)
+                      <-> f_un_type_mnemonic_f_S(op)
                           ^ spc() ^ freg_name(rd)
                           ^ sep() ^ reg_name(rs1)
 
-mapping clause assembly = F_UN_TYPE_S(rs1, rd, FCLASS_S)
-                      <-> f_un_type_mnemonic_S(FCLASS_S)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
+
 
 /* ****************************************************************** */

--- a/model/riscv_insts_hints.sail
+++ b/model/riscv_insts_hints.sail
@@ -27,7 +27,7 @@ union clause ast = C_ADDI_HINT : (regidx)
 
 mapping clause encdec_compressed = C_ADDI_HINT(rsd)
       if rsd != zreg
-  <-> 0b000 @ 0b0 @ rsd : regidx @ 0b00000 @ 0b01
+  <-> 0b000 @ 0b0 @ encdec_reg(rsd) @ 0b00000 @ 0b01
       if rsd != zreg
 
 function clause execute (C_ADDI_HINT(rsd)) = RETIRE_SUCCESS
@@ -68,7 +68,7 @@ union clause ast = C_MV_HINT : (regidx)
 
 mapping clause encdec_compressed = C_MV_HINT(rs2)
       if rs2 != zreg
-  <-> 0b100 @ 0b0 @ 0b00000 @ rs2 : regidx @ 0b10
+  <-> 0b100 @ 0b0 @ 0b00000 @ encdec_reg(rs2) @ 0b10
       if rs2 != zreg
 
 function clause execute (C_MV_HINT(rs2)) = RETIRE_SUCCESS
@@ -83,7 +83,7 @@ union clause ast = C_ADD_HINT : (regidx)
 
 mapping clause encdec_compressed = C_ADD_HINT(rs2)
       if rs2 != zreg
-  <-> 0b100 @ 0b1 @ 0b00000 @ rs2 : regidx @ 0b10
+  <-> 0b100 @ 0b1 @ 0b00000 @ encdec_reg(rs2) @ 0b10
       if rs2 != zreg
 
 function clause execute (C_ADD_HINT(rs2)) = RETIRE_SUCCESS
@@ -98,7 +98,7 @@ union clause ast = C_SLLI_HINT : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_SLLI_HINT(nzui5 @ nzui40, rsd)
       if (nzui5 @ nzui40 == 0b000000 | rsd == zreg) & (xlen == 64 | nzui5 == 0b0)
-  <-> 0b000 @ nzui5 : bits(1) @ rsd : regidx @ nzui40 : bits(5) @ 0b10
+  <-> 0b000 @ nzui5 : bits(1) @ encdec_reg(rsd) @ nzui40 : bits(5) @ 0b10
       if (nzui5 @ nzui40 == 0b000000 | rsd == zreg) & (xlen == 64 | nzui5 == 0b0)
 
 function clause execute (C_SLLI_HINT(shamt, rsd)) = RETIRE_SUCCESS
@@ -112,7 +112,7 @@ mapping clause assembly = C_SLLI_HINT(shamt, rsd)
 union clause ast = C_SRLI_HINT : (cregidx)
 
 mapping clause encdec_compressed = C_SRLI_HINT(rsd)
-  <-> 0b100 @ 0b0 @ 0b00 @ rsd : cregidx @ 0b00000 @ 0b01
+  <-> 0b100 @ 0b0 @ 0b00 @ encdec_creg(rsd) @ 0b00000 @ 0b01
 
 function clause execute (C_SRLI_HINT(rsd)) = RETIRE_SUCCESS
 
@@ -123,7 +123,7 @@ mapping clause assembly = C_SRLI_HINT(rsd)
 union clause ast = C_SRAI_HINT : (cregidx)
 
 mapping clause encdec_compressed = C_SRAI_HINT(rsd)
-  <-> 0b100 @ 0b0 @ 0b01 @ rsd : cregidx @ 0b00000 @ 0b01
+  <-> 0b100 @ 0b0 @ 0b01 @ encdec_creg(rsd) @ 0b00000 @ 0b01
 
 function clause execute (C_SRAI_HINT(rsd)) = RETIRE_SUCCESS
 
@@ -138,24 +138,24 @@ mapping clause assembly = C_SRAI_HINT(rsd)
 union clause ast = FENCE_RESERVED : (bits(4), bits(4), bits(4), regidx, regidx)
 
 mapping clause encdec = FENCE_RESERVED(fm, pred, succ, rs, rd)
-      if (fm != 0b0000 & fm != 0b1000) | rs != 0b00000 | rd != 0b00000
-  <-> fm : bits(4) @ pred : bits(4) @ succ : bits(4) @ rs : regidx @ 0b000 @ rd : regidx @ 0b0001111
-      if (fm != 0b0000 & fm != 0b1000) | rs != 0b00000 | rd != 0b00000
+      if (fm != 0b0000 & fm != 0b1000) | rs != zreg | rd != zreg
+  <-> fm : bits(4) @ pred : bits(4) @ succ : bits(4) @ encdec_reg(rs) @ 0b000 @ encdec_reg(rd) @ 0b0001111
+      if (fm != 0b0000 & fm != 0b1000) | rs != zreg | rd != zreg
 
 function clause execute (FENCE_RESERVED(fm, pred, succ, rs, rd)) = RETIRE_SUCCESS
 
 mapping clause assembly = FENCE_RESERVED(fm, pred, succ, rs, rd)
-      if (fm != 0b0000 & fm != 0b1000) | rs != 0b00000 | rd != 0b00000
+      if (fm != 0b0000 & fm != 0b1000) | rs != zreg | rd != zreg
   <-> "fence.reserved." ^ fence_bits(pred) ^ "." ^ fence_bits(succ) ^ "."
       ^ reg_name(rs) ^ "." ^ reg_name(rd) ^ "." ^ hex_bits_4(fm)
-      if (fm != 0b0000 & fm != 0b1000) | rs != 0b00000 | rd != 0b00000
+      if (fm != 0b0000 & fm != 0b1000) | rs != zreg | rd != zreg
 
 /* ****************************************************************** */
 union clause ast = FENCEI_RESERVED : (bits(12), regidx, regidx)
 
 mapping clause encdec = FENCEI_RESERVED(imm, rs, rd)
       if imm != 0b000000000000 | rs != zreg | rd != zreg
-  <-> imm : bits(12) @ rs : regidx @ 0b001 @ rd : regidx @ 0b0001111
+  <-> imm : bits(12) @ encdec_reg(rs) @ 0b001 @ encdec_reg(rd) @ 0b0001111
       if imm != 0b000000000000 | rs != zreg | rd != zreg
 
 function clause execute FENCEI_RESERVED(imm, rs, rd) = RETIRE_SUCCESS

--- a/model/riscv_insts_mext.sail
+++ b/model/riscv_insts_mext.sail
@@ -24,8 +24,8 @@ mapping encdec_mul_op : mul_op <-> bits(3) = {
   struct { high = true,  signed_rs1 = false, signed_rs2 = false } <-> 0b011
 }
 
-mapping clause encdec = MUL(rs2, rs1, rd, mul_op)                    if extensionEnabled(Ext_M) | extensionEnabled(Ext_Zmmul)
-  <-> 0b0000001 @ rs2 @ rs1 @ encdec_mul_op(mul_op) @ rd @ 0b0110011 if extensionEnabled(Ext_M) | extensionEnabled(Ext_Zmmul)
+mapping clause encdec = MUL(rs2, rs1, rd, mul_op)                                                        if extensionEnabled(Ext_M) | extensionEnabled(Ext_Zmmul)
+  <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_mul_op(mul_op) @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_M) | extensionEnabled(Ext_Zmmul)
 
 function clause execute (MUL(rs2, rs1, rd, mul_op)) = {
   let rs1_val = X(rs1);
@@ -53,8 +53,8 @@ mapping clause assembly = MUL(rs2, rs1, rd, mul_op)
 /* ****************************************************************** */
 union clause ast = DIV : (regidx, regidx, regidx, bool)
 
-mapping clause encdec = DIV(rs2, rs1, rd, s)                           if extensionEnabled(Ext_M)
-  <-> 0b0000001 @ rs2 @ rs1 @ 0b10 @ bool_not_bits(s) @ rd @ 0b0110011 if extensionEnabled(Ext_M)
+mapping clause encdec = DIV(rs2, rs1, rd, s)                                                               if extensionEnabled(Ext_M)
+  <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b10 @ bool_not_bits(s) @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_M)
 
 function clause execute (DIV(rs2, rs1, rd, s)) = {
   let rs1_val = X(rs1);
@@ -79,8 +79,8 @@ mapping clause assembly = DIV(rs2, rs1, rd, s)
 /* ****************************************************************** */
 union clause ast = REM : (regidx, regidx, regidx, bool)
 
-mapping clause encdec = REM(rs2, rs1, rd, s)                           if extensionEnabled(Ext_M)
-  <-> 0b0000001 @ rs2 @ rs1 @ 0b11 @ bool_not_bits(s) @ rd @ 0b0110011 if extensionEnabled(Ext_M)
+mapping clause encdec = REM(rs2, rs1, rd, s)                                                               if extensionEnabled(Ext_M)
+  <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b11 @ bool_not_bits(s) @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_M)
 
 function clause execute (REM(rs2, rs1, rd, s)) = {
   let rs1_val = X(rs1);
@@ -101,7 +101,7 @@ union clause ast = MULW : (regidx, regidx, regidx)
 
 mapping clause encdec = MULW(rs2, rs1, rd)
       if xlen == 64 & (extensionEnabled(Ext_M) | extensionEnabled(Ext_Zmmul))
-  <-> 0b0000001 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0111011
+  <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0111011
       if xlen == 64 & (extensionEnabled(Ext_M) | extensionEnabled(Ext_Zmmul))
 
 function clause execute (MULW(rs2, rs1, rd)) = {
@@ -126,7 +126,7 @@ union clause ast = DIVW : (regidx, regidx, regidx, bool)
 
 mapping clause encdec = DIVW(rs2, rs1, rd, s)
       if xlen == 64 & extensionEnabled(Ext_M)
-  <-> 0b0000001 @ rs2 @ rs1 @ 0b10 @ bool_not_bits(s) @ rd @ 0b0111011
+  <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b10 @ bool_not_bits(s) @ encdec_reg(rd) @ 0b0111011
       if xlen == 64 & extensionEnabled(Ext_M)
 
 function clause execute (DIVW(rs2, rs1, rd, s)) = {
@@ -151,7 +151,7 @@ union clause ast = REMW : (regidx, regidx, regidx, bool)
 
 mapping clause encdec = REMW(rs2, rs1, rd, s)
       if xlen == 64 & extensionEnabled(Ext_M)
-  <-> 0b0000001 @ rs2 @ rs1 @ 0b11 @ bool_not_bits(s) @ rd @ 0b0111011
+  <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b11 @ bool_not_bits(s) @ encdec_reg(rd) @ 0b0111011
       if xlen == 64 & extensionEnabled(Ext_M)
 
 function clause execute (REMW(rs2, rs1, rd, s)) = {

--- a/model/riscv_insts_svinval.sail
+++ b/model/riscv_insts_svinval.sail
@@ -11,8 +11,8 @@ function clause extensionEnabled(Ext_Svinval) = sys_enable_svinval()
 union clause ast = SINVAL_VMA : (regidx, regidx)
 
 mapping clause encdec =
-      SINVAL_VMA(rs1, rs2)                                                  if extensionEnabled(Ext_Svinval)
-  <-> 0b0001011 @ rs2 : regidx @ rs1 : regidx @ 0b000 @ 0b00000 @ 0b1110011 if extensionEnabled(Ext_Svinval)
+      SINVAL_VMA(rs1, rs2)                                                        if extensionEnabled(Ext_Svinval)
+  <-> 0b0001011 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ 0b00000 @ 0b1110011 if extensionEnabled(Ext_Svinval)
 
 function clause execute SINVAL_VMA(rs1, rs2) = {
   execute(SFENCE_VMA(rs1, rs2))

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -40,8 +40,8 @@ mapping encdec_vvfunct6 : vvfunct6 <-> bits(6) = {
   VV_VSSRA         <-> 0b101011
 }
 
-mapping clause encdec = VVTYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_vvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_vvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW_pow  = get_sew_pow();
@@ -55,7 +55,7 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -173,8 +173,8 @@ mapping encdec_nvsfunct6 : nvsfunct6 <-> bits(6) = {
   NVS_VNSRA       <-> 0b101101
 }
 
-mapping clause encdec = NVSTYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_nvsfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = NVSTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_nvsfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -191,7 +191,7 @@ function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -239,8 +239,8 @@ mapping encdec_nvfunct6 : nvfunct6 <-> bits(6) = {
   NV_VNCLIP      <-> 0b101111
 }
 
-mapping clause encdec = NVTYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_nvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = NVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_nvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -257,7 +257,7 @@ function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -300,8 +300,8 @@ mapping clause assembly = NVTYPE(funct6, vm, vs2, vs1, vd)
 /* ********************** OPIVV (Integer Merge Instruction) ********************** */
 union clause ast = MASKTYPEV : (regidx, regidx, regidx)
 
-mapping clause encdec = MASKTYPEV (vs2, vs1,  vd) if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b0 @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MASKTYPEV (vs2, vs1,  vd)                                             if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b0 @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MASKTYPEV(vs2, vs1, vd)) = {
   let start_element = get_start_element();
@@ -316,7 +316,7 @@ function clause execute(MASKTYPEV(vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, 0b0, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, 0b0, zreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -348,8 +348,8 @@ mapping clause assembly = MASKTYPEV(vs2, vs1, vd)
 /* ********************** OPIVV (Integer Move Instruction) *********************** */
 union clause ast = MOVETYPEV : (regidx, regidx)
 
-mapping clause encdec = MOVETYPEV (vs1, vd) if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b1 @ 0b00000 @ vs1 @ 0b000 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MOVETYPEV (vs1, vd)                                           if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MOVETYPEV(vs1, vd)) = {
   let SEW      = get_sew();
@@ -361,7 +361,7 @@ function clause execute(MOVETYPEV(vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, 0b1, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, 0b1, zreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
@@ -406,8 +406,8 @@ mapping encdec_vxfunct6 : vxfunct6 <-> bits(6) = {
   VX_VSSRA      <-> 0b101011
 }
 
-mapping clause encdec = VXTYPE(funct6, vm, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_vxfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VXTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_vxfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -419,7 +419,7 @@ function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -521,8 +521,8 @@ mapping encdec_nxsfunct6 : nxsfunct6 <-> bits(6) = {
   NXS_VNSRA       <-> 0b101101
 }
 
-mapping clause encdec = NXSTYPE(funct6, vm, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_nxsfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = NXSTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_nxsfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -539,7 +539,7 @@ function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -587,8 +587,8 @@ mapping encdec_nxfunct6 : nxfunct6 <-> bits(6) = {
   NX_VNCLIP      <-> 0b101111
 }
 
-mapping clause encdec = NXTYPE(funct6, vm, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_nxfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = NXTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_nxfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -605,7 +605,7 @@ function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -655,8 +655,8 @@ mapping encdec_vxsgfunct6 : vxsgfunct6 <-> bits(6) = {
   VX_VRGATHER     <-> 0b001100
 }
 
-mapping clause encdec = VXSG(funct6, vm, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_vxsgfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VXSG(funct6, vm, vs2, rs1, vd)                                                        if extensionEnabled(Ext_V)
+  <-> encdec_vxsgfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let SEW_pow  = get_sew_pow();
@@ -670,7 +670,7 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let rs1_val : nat                  = unsigned(X(rs1));
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -717,8 +717,8 @@ mapping clause assembly = VXSG(funct6, vm, vs2, rs1, vd)
 /* ********************** OPIVX (Integer Merge Instruction) ********************** */
 union clause ast = MASKTYPEX : (regidx, regidx, regidx)
 
-mapping clause encdec = MASKTYPEX(vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b0 @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MASKTYPEX(vs2, rs1, vd)                                               if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b0 @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MASKTYPEX(vs2, rs1, vd)) = {
   let start_element = get_start_element();
@@ -733,7 +733,7 @@ function clause execute(MASKTYPEX(vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b0, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b0, zreg);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -765,8 +765,8 @@ mapping clause assembly = MASKTYPEX(vs2, rs1, vd)
 /* ********************** OPIVX (Integer Move Instruction) *********************** */
 union clause ast = MOVETYPEX : (regidx, regidx)
 
-mapping clause encdec = MOVETYPEX (rs1, vd) if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b1 @ 0b00000 @ rs1 @ 0b100 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MOVETYPEX (rs1, vd)                                           if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MOVETYPEX(rs1, vd)) = {
   let SEW      = get_sew();
@@ -779,7 +779,7 @@ function clause execute(MOVETYPEX(rs1, vd)) = {
   let 'm = SEW;
 
   let rs1_val : bits('m)             = get_scalar(rs1, 'm);
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
@@ -815,8 +815,8 @@ mapping encdec_vifunct6 : vifunct6 <-> bits(6) = {
   VI_VSSRA      <-> 0b101011
 }
 
-mapping clause encdec = VITYPE(funct6, vm, vs2, simm, vd) if extensionEnabled(Ext_V)
-  <-> encdec_vifunct6(funct6) @ vm @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VITYPE(funct6, vm, vs2, simm, vd)                                        if extensionEnabled(Ext_V)
+  <-> encdec_vifunct6(funct6) @ vm @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -828,7 +828,7 @@ function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let imm_val : bits('m)             = sign_extend(simm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -899,15 +899,15 @@ mapping clause assembly = VITYPE(funct6, vm, vs2, simm, vd)
 
 /* ************************** OPIVI (WITYPE Narrowing) *************************** */
 /* ************** Vector Narrowing Integer Right Shift Instructions ************** */
-union clause ast = NISTYPE : (nisfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = NISTYPE : (nisfunct6, bits(1), regidx, bits(5), regidx)
 
 mapping encdec_nisfunct6 : nisfunct6 <-> bits(6) = {
   NIS_VNSRL       <-> 0b101100,
   NIS_VNSRA       <-> 0b101101
 }
 
-mapping clause encdec = NISTYPE(funct6, vm, vs2, simm, vd) if extensionEnabled(Ext_V)
-  <-> encdec_nisfunct6(funct6) @ vm @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = NISTYPE(funct6, vm, vs2, simm, vd)                                        if extensionEnabled(Ext_V)
+  <-> encdec_nisfunct6(funct6) @ vm @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(NISTYPE(funct6, vm, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -924,7 +924,7 @@ function clause execute(NISTYPE(funct6, vm, vs2, simm, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let imm_val : bits('m)             = sign_extend(simm);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -965,15 +965,15 @@ mapping clause assembly = NISTYPE(funct6, vm, vs2, simm, vd)
 
 /* ************************** OPIVI (WITYPE Narrowing) *************************** */
 /* *************** Vector Narrowing Fixed-Point Clip Instructions **************** */
-union clause ast = NITYPE : (nifunct6, bits(1), regidx, regidx, regidx)
+union clause ast = NITYPE : (nifunct6, bits(1), regidx, bits(5), regidx)
 
 mapping encdec_nifunct6 : nifunct6 <-> bits(6) = {
   NI_VNCLIPU     <-> 0b101110,
   NI_VNCLIP      <-> 0b101111
 }
 
-mapping clause encdec = NITYPE(funct6, vm, vs2, simm, vd) if extensionEnabled(Ext_V)
-  <-> encdec_nifunct6(funct6) @ vm @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = NITYPE(funct6, vm, vs2, simm, vd)                                        if extensionEnabled(Ext_V)
+  <-> encdec_nifunct6(funct6) @ vm @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(NITYPE(funct6, vm, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -990,7 +990,7 @@ function clause execute(NITYPE(funct6, vm, vs2, simm, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let imm_val : bits('m)             = sign_extend(simm);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -1040,8 +1040,8 @@ mapping encdec_visgfunct6 : visgfunct6 <-> bits(6) = {
   VI_VRGATHER     <-> 0b001100
 }
 
-mapping clause encdec = VISG(funct6, vm, vs2, simm, vd) if extensionEnabled(Ext_V)
-  <-> encdec_visgfunct6(funct6) @ vm @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VISG(funct6, vm, vs2, simm, vd)                                            if extensionEnabled(Ext_V)
+  <-> encdec_visgfunct6(funct6) @ vm @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let SEW_pow  = get_sew_pow();
@@ -1055,7 +1055,7 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let imm_val : nat                  = unsigned(zero_extend(xlen, simm));
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -1097,13 +1097,13 @@ mapping visg_mnemonic : visgfunct6 <-> string = {
 }
 
 mapping clause assembly = VISG(funct6, vm, vs2, simm, vd)
-  <-> visg_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(simm) ^ maybe_vmask(vm)
+  <-> visg_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ maybe_vmask(vm)
 
 /* ********************** OPIVI (Integer Merge Instruction) ********************** */
 union clause ast = MASKTYPEI : (regidx, bits(5), regidx)
 
-mapping clause encdec = MASKTYPEI(vs2, simm, vd) if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b0 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MASKTYPEI(vs2, simm, vd)                                   if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b0 @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MASKTYPEI(vs2, simm, vd)) = {
   let start_element = get_start_element();
@@ -1118,7 +1118,7 @@ function clause execute(MASKTYPEI(vs2, simm, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b0, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b0, zreg);
   let imm_val : bits('m)             = sign_extend(simm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -1150,8 +1150,8 @@ mapping clause assembly = MASKTYPEI(vs2, simm, vd)
 /* ********************** OPIVI (Integer Move Instruction) *********************** */
 union clause ast = MOVETYPEI : (regidx, bits(5))
 
-mapping clause encdec = MOVETYPEI (vd, simm) if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b1 @ 0b00000 @ simm @ 0b011 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MOVETYPEI (vd, simm)                               if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b1 @ 0b00000 @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MOVETYPEI(vd, simm)) = {
   let SEW      = get_sew();
@@ -1163,7 +1163,7 @@ function clause execute(MOVETYPEI(vd, simm)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zreg);
   let imm_val : bits('m)             = sign_extend(simm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
@@ -1185,8 +1185,8 @@ mapping clause assembly = MOVETYPEI(vd, simm)
 /* ********************* OPIVI (Whole Vector Register Move) ********************** */
 union clause ast = VMVRTYPE : (regidx, bits(5), regidx)
 
-mapping clause encdec = VMVRTYPE(vs2, simm, vd) if extensionEnabled(Ext_V)
-  <-> 0b100111 @ 0b1 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VMVRTYPE(vs2, simm, vd)                                    if extensionEnabled(Ext_V)
+  <-> 0b100111 @ 0b1 @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VMVRTYPE(vs2, simm, vd)) = {
   let start_element = get_start_element();
@@ -1201,7 +1201,7 @@ function clause execute(VMVRTYPE(vs2, simm, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zreg);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, EMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, EMUL_pow, vd);
   var result  : vector('n, bits('m)) = vector_init(zeros());
@@ -1243,8 +1243,8 @@ mapping encdec_mvvfunct6 : mvvfunct6 <-> bits(6) = {
   MVV_VREM        <-> 0b100011
 }
 
-mapping clause encdec = MVVTYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_mvvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MVVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_mvvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -1256,7 +1256,7 @@ function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -1351,8 +1351,8 @@ mapping encdec_mvvmafunct6 : mvvmafunct6 <-> bits(6) = {
   MVV_VNMSUB      <-> 0b101011
 }
 
-mapping clause encdec = MVVMATYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_mvvmafunct6(funct6) @ vm @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MVVMATYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_mvvmafunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -1364,7 +1364,7 @@ function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -1410,8 +1410,8 @@ mapping encdec_wvvfunct6 : wvvfunct6 <-> bits(6) = {
   WVV_VWMULSU    <-> 0b111010
 }
 
-mapping clause encdec = WVVTYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_wvvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = WVVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_wvvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -1429,7 +1429,7 @@ function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
@@ -1479,8 +1479,8 @@ mapping encdec_wvfunct6 : wvfunct6 <-> bits(6) = {
   WV_VSUBU      <-> 0b110110
 }
 
-mapping clause encdec = WVTYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_wvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = WVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_wvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(WVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -1497,7 +1497,7 @@ function clause execute(WVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -1541,8 +1541,8 @@ mapping encdec_wmvvfunct6 : wmvvfunct6 <-> bits(6) = {
   WMVV_VWMACCSU  <-> 0b111111
 }
 
-mapping clause encdec =  WMVVTYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_wmvvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec =  WMVVTYPE(funct6, vm, vs2, vs1, vd)                                                   if extensionEnabled(Ext_V)
+  <-> encdec_wmvvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -1560,7 +1560,7 @@ function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
@@ -1601,8 +1601,8 @@ mapping vext2_vs1 : vext2funct6 <-> bits(5) = {
   VEXT2_SVF2  <-> 0b00111
 }
 
-mapping clause encdec = VEXT2TYPE(funct6, vm, vs2, vd) if extensionEnabled(Ext_V)
-  <-> 0b010010 @ vm @ vs2 @ vext2_vs1(funct6) @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VEXT2TYPE(funct6, vm, vs2, vd)                                         if extensionEnabled(Ext_V)
+  <-> 0b010010 @ vm @ encdec_reg(vs2) @ vext2_vs1(funct6) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VEXT2TYPE(funct6, vm, vs2, vd)) = {
   let SEW = get_sew();
@@ -1619,7 +1619,7 @@ function clause execute(VEXT2TYPE(funct6, vm, vs2, vd)) = {
   let 'm = SEW;
   let 'o = SEW_half;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_half, LMUL_pow_half, vs2);
 
@@ -1657,8 +1657,8 @@ mapping vext4_vs1 : vext4funct6 <-> bits(5) = {
   VEXT4_SVF4  <-> 0b00101
 }
 
-mapping clause encdec = VEXT4TYPE(funct6, vm, vs2, vd) if extensionEnabled(Ext_V)
-  <-> 0b010010 @ vm @ vs2 @ vext4_vs1(funct6) @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VEXT4TYPE(funct6, vm, vs2, vd)                                         if extensionEnabled(Ext_V)
+  <-> 0b010010 @ vm @ encdec_reg(vs2) @ vext4_vs1(funct6) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VEXT4TYPE(funct6, vm, vs2, vd)) = {
   let SEW = get_sew();
@@ -1675,7 +1675,7 @@ function clause execute(VEXT4TYPE(funct6, vm, vs2, vd)) = {
   let 'm = SEW;
   let 'o = SEW_quart;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_quart, LMUL_pow_quart, vs2);
 
@@ -1713,8 +1713,8 @@ mapping vext8_vs1 : vext8funct6 <-> bits(5) = {
   VEXT8_SVF8  <-> 0b00011
 }
 
-mapping clause encdec = VEXT8TYPE(funct6, vm, vs2, vd) if extensionEnabled(Ext_V)
-  <-> 0b010010 @ vm @ vs2 @ vext8_vs1(funct6) @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VEXT8TYPE(funct6, vm, vs2, vd)                                         if extensionEnabled(Ext_V)
+  <-> 0b010010 @ vm @ encdec_reg(vs2) @ vext8_vs1(funct6) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VEXT8TYPE(funct6, vm, vs2, vd)) = {
   let SEW = get_sew();
@@ -1731,7 +1731,7 @@ function clause execute(VEXT8TYPE(funct6, vm, vs2, vd)) = {
   let 'm = SEW;
   let 'o = SEW_eighth;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_eighth, LMUL_pow_eighth, vs2);
 
@@ -1764,8 +1764,8 @@ mapping clause assembly = VEXT8TYPE(funct6, vm, vs2, vd)
 /* ************************ OPMVV (vmv.x.s in VWXUNARY0) ************************* */
 union clause ast = VMVXS : (regidx, regidx)
 
-mapping clause encdec = VMVXS(vs2, rd) if extensionEnabled(Ext_V)
-  <-> 0b010000 @ 0b1 @ vs2 @ 0b00000 @ 0b010 @ rd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VMVXS(vs2, rd)                                                if extensionEnabled(Ext_V)
+  <-> 0b010000 @ 0b1 @ encdec_reg(vs2) @ 0b00000 @ 0b010 @ encdec_reg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VMVXS(vs2, rd)) = {
   let SEW      = get_sew();
@@ -1792,8 +1792,8 @@ mapping clause assembly = VMVXS(vs2, rd)
 /* ********************* OPMVV (Vector Compress Instruction) ********************* */
 union clause ast = MVVCOMPRESS : (regidx, regidx, regidx)
 
-mapping clause encdec = MVVCOMPRESS(vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b1 @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MVVCOMPRESS(vs2, vs1, vd)                                             if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b1 @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MVVCOMPRESS(vs2, vs1, vd)) = {
   let start_element = get_start_element();
@@ -1866,8 +1866,8 @@ mapping encdec_mvxfunct6 : mvxfunct6 <-> bits(6) = {
   MVX_VREM          <-> 0b100011
 }
 
-mapping clause encdec = MVXTYPE(funct6, vm, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_mvxfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b110 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MVXTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_mvxfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -1879,7 +1879,7 @@ function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -1985,8 +1985,8 @@ mapping encdec_mvxmafunct6 : mvxmafunct6 <-> bits(6) = {
   MVX_VNMSUB        <-> 0b101011
 }
 
-mapping clause encdec = MVXMATYPE(funct6, vm, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_mvxmafunct6(funct6) @ vm @ vs2 @ rs1 @ 0b110 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MVXMATYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_mvxmafunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -1998,7 +1998,7 @@ function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -2045,8 +2045,8 @@ mapping encdec_wvxfunct6 : wvxfunct6 <-> bits(6) = {
   WVX_VWMULSU    <-> 0b111010
 }
 
-mapping clause encdec = WVXTYPE(funct6, vm, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_wvxfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b110 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = WVXTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_wvxfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(WVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -2063,7 +2063,7 @@ function clause execute(WVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
@@ -2113,8 +2113,8 @@ mapping encdec_wxfunct6 : wxfunct6 <-> bits(6) = {
   WX_VSUBU      <-> 0b110110
 }
 
-mapping clause encdec = WXTYPE(funct6, vm, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_wxfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b110 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = WXTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_wxfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(WXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -2130,7 +2130,7 @@ function clause execute(WXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -2175,8 +2175,8 @@ mapping encdec_wmvxfunct6 : wmvxfunct6 <-> bits(6) = {
   WMVX_VWMACCSU   <-> 0b111111
 }
 
-mapping clause encdec = WMVXTYPE(funct6, vm, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_wmvxfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b110 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = WMVXTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_wmvxfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(WMVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -2193,7 +2193,7 @@ function clause execute(WMVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
@@ -2230,8 +2230,8 @@ mapping clause assembly = WMVXTYPE(funct6, vm, vs2, rs1, vd)
 /* ****************************** OPMVX (VRXUNARY0) ****************************** */
 union clause ast = VMVSX : (regidx, regidx)
 
-mapping clause encdec = VMVSX(rs1, vd) if extensionEnabled(Ext_V)
-  <-> 0b010000 @ 0b1 @ 0b00000 @ rs1 @ 0b110 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VMVSX(rs1, vd)                                                if extensionEnabled(Ext_V)
+  <-> 0b010000 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b110 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VMVSX(rs1, vd)) = {
   let SEW      = get_sew();
@@ -2243,7 +2243,7 @@ function clause execute(VMVSX(rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zreg);
   let rs1_val : bits('m)             = get_scalar(rs1, 'm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
 

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -14,7 +14,7 @@
 /* ******************************************************************************* */
 
 /* ******************************* OPIVV (VVTYPE) ******************************** */
-union clause ast = VVTYPE : (vvfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = VVTYPE : (vvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_vvfunct6 : vvfunct6 <-> bits(6) = {
   VV_VADD          <-> 0b000000,
@@ -40,8 +40,8 @@ mapping encdec_vvfunct6 : vvfunct6 <-> bits(6) = {
   VV_VSSRA         <-> 0b101011
 }
 
-mapping clause encdec = VVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_vvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VVTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_vvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW_pow  = get_sew_pow();
@@ -55,7 +55,7 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -166,15 +166,15 @@ mapping clause assembly = VVTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ************************** OPIVV (WVTYPE Narrowing) *************************** */
 /* ************** Vector Narrowing Integer Right Shift Instructions ************** */
-union clause ast = NVSTYPE : (nvsfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = NVSTYPE : (nvsfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_nvsfunct6 : nvsfunct6 <-> bits(6) = {
   NVS_VNSRL       <-> 0b101100,
   NVS_VNSRA       <-> 0b101101
 }
 
-mapping clause encdec = NVSTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_nvsfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = NVSTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_nvsfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -191,7 +191,7 @@ function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -232,15 +232,15 @@ mapping clause assembly = NVSTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ************************** OPIVV (WVTYPE Narrowing) *************************** */
 /* *************** Vector Narrowing Fixed-Point Clip Instructions **************** */
-union clause ast = NVTYPE : (nvfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = NVTYPE : (nvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_nvfunct6 : nvfunct6 <-> bits(6) = {
   NV_VNCLIPU     <-> 0b101110,
   NV_VNCLIP      <-> 0b101111
 }
 
-mapping clause encdec = NVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_nvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = NVTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_nvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -257,7 +257,7 @@ function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -298,10 +298,10 @@ mapping clause assembly = NVTYPE(funct6, vm, vs2, vs1, vd)
   <-> nvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
 /* ********************** OPIVV (Integer Merge Instruction) ********************** */
-union clause ast = MASKTYPEV : (regidx, regidx, regidx)
+union clause ast = MASKTYPEV : (vregidx, vregidx, vregidx)
 
-mapping clause encdec = MASKTYPEV (vs2, vs1,  vd)                                             if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b0 @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MASKTYPEV (vs2, vs1,  vd)                                                if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MASKTYPEV(vs2, vs1, vd)) = {
   let start_element = get_start_element();
@@ -316,7 +316,7 @@ function clause execute(MASKTYPEV(vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, 0b0, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, 0b0, zvreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -346,10 +346,10 @@ mapping clause assembly = MASKTYPEV(vs2, vs1, vd)
 <-> "vmerge.vvm" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ sep() ^ "v0"
 
 /* ********************** OPIVV (Integer Move Instruction) *********************** */
-union clause ast = MOVETYPEV : (regidx, regidx)
+union clause ast = MOVETYPEV : (vregidx, vregidx)
 
-mapping clause encdec = MOVETYPEV (vs1, vd)                                           if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MOVETYPEV (vs1, vd)                                             if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MOVETYPEV(vs1, vd)) = {
   let SEW      = get_sew();
@@ -361,7 +361,7 @@ function clause execute(MOVETYPEV(vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, 0b1, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, 0b1, zvreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
@@ -381,7 +381,7 @@ mapping clause assembly = MOVETYPEV(vs1, vd)
   <-> "vmv.v.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1)
 
 /* ******************************* OPIVX (VXTYPE) ******************************** */
-union clause ast = VXTYPE : (vxfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = VXTYPE : (vxfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_vxfunct6 : vxfunct6 <-> bits(6) = {
   VX_VADD       <-> 0b000000,
@@ -406,8 +406,8 @@ mapping encdec_vxfunct6 : vxfunct6 <-> bits(6) = {
   VX_VSSRA      <-> 0b101011
 }
 
-mapping clause encdec = VXTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_vxfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VXTYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
+  <-> encdec_vxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -419,7 +419,7 @@ function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -514,15 +514,15 @@ mapping clause assembly = VXTYPE(funct6, vm, vs2, rs1, vd)
 
 /* ************************** OPIVX (WXTYPE Narrowing) *************************** */
 /* ************** Vector Narrowing Integer Right Shift Instructions ************** */
-union clause ast = NXSTYPE : (nxsfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = NXSTYPE : (nxsfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_nxsfunct6 : nxsfunct6 <-> bits(6) = {
   NXS_VNSRL       <-> 0b101100,
   NXS_VNSRA       <-> 0b101101
 }
 
-mapping clause encdec = NXSTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_nxsfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = NXSTYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
+  <-> encdec_nxsfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -539,7 +539,7 @@ function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -580,15 +580,15 @@ mapping clause assembly = NXSTYPE(funct6, vm, vs2, rs1, vd)
 
 /* ************************** OPIVX (WXTYPE Narrowing) *************************** */
 /* *************** Vector Narrowing Fixed-Point Clip Instructions **************** */
-union clause ast = NXTYPE : (nxfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = NXTYPE : (nxfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_nxfunct6 : nxfunct6 <-> bits(6) = {
   NX_VNCLIPU     <-> 0b101110,
   NX_VNCLIP      <-> 0b101111
 }
 
-mapping clause encdec = NXTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_nxfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = NXTYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
+  <-> encdec_nxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -605,7 +605,7 @@ function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -647,7 +647,7 @@ mapping clause assembly = NXTYPE(funct6, vm, vs2, rs1, vd)
 
 /* ***************** OPIVX (Vector Slide & Gather Instructions) ****************** */
 /* Slide and gather instructions extend rs1/imm to XLEN intead of SEW bits */
-union clause ast = VXSG : (vxsgfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = VXSG : (vxsgfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_vxsgfunct6 : vxsgfunct6 <-> bits(6) = {
   VX_VSLIDEUP     <-> 0b001110,
@@ -655,8 +655,8 @@ mapping encdec_vxsgfunct6 : vxsgfunct6 <-> bits(6) = {
   VX_VRGATHER     <-> 0b001100
 }
 
-mapping clause encdec = VXSG(funct6, vm, vs2, rs1, vd)                                                        if extensionEnabled(Ext_V)
-  <-> encdec_vxsgfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VXSG(funct6, vm, vs2, rs1, vd)                                                          if extensionEnabled(Ext_V)
+  <-> encdec_vxsgfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let SEW_pow  = get_sew_pow();
@@ -670,7 +670,7 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let rs1_val : nat                  = unsigned(X(rs1));
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -715,10 +715,10 @@ mapping clause assembly = VXSG(funct6, vm, vs2, rs1, vd)
   <-> vxsg_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
 
 /* ********************** OPIVX (Integer Merge Instruction) ********************** */
-union clause ast = MASKTYPEX : (regidx, regidx, regidx)
+union clause ast = MASKTYPEX : (vregidx, regidx, vregidx)
 
-mapping clause encdec = MASKTYPEX(vs2, rs1, vd)                                               if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b0 @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MASKTYPEX(vs2, rs1, vd)                                                 if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MASKTYPEX(vs2, rs1, vd)) = {
   let start_element = get_start_element();
@@ -733,7 +733,7 @@ function clause execute(MASKTYPEX(vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b0, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b0, zvreg);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -763,10 +763,10 @@ mapping clause assembly = MASKTYPEX(vs2, rs1, vd)
   <-> "vmerge.vxm" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ sep() ^ "v0"
 
 /* ********************** OPIVX (Integer Move Instruction) *********************** */
-union clause ast = MOVETYPEX : (regidx, regidx)
+union clause ast = MOVETYPEX : (regidx, vregidx)
 
-mapping clause encdec = MOVETYPEX (rs1, vd)                                           if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MOVETYPEX (rs1, vd)                                            if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MOVETYPEX(rs1, vd)) = {
   let SEW      = get_sew();
@@ -779,7 +779,7 @@ function clause execute(MOVETYPEX(rs1, vd)) = {
   let 'm = SEW;
 
   let rs1_val : bits('m)             = get_scalar(rs1, 'm);
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zvreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
@@ -798,7 +798,7 @@ mapping clause assembly = MOVETYPEX(rs1, vd)
   <-> "vmv.v.x" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)
 
 /* ******************************* OPIVI (VITYPE) ******************************** */
-union clause ast = VITYPE : (vifunct6, bits(1), regidx, bits(5), regidx)
+union clause ast = VITYPE : (vifunct6, bits(1), vregidx, bits(5), vregidx)
 
 mapping encdec_vifunct6 : vifunct6 <-> bits(6) = {
   VI_VADD       <-> 0b000000,
@@ -815,8 +815,8 @@ mapping encdec_vifunct6 : vifunct6 <-> bits(6) = {
   VI_VSSRA      <-> 0b101011
 }
 
-mapping clause encdec = VITYPE(funct6, vm, vs2, simm, vd)                                        if extensionEnabled(Ext_V)
-  <-> encdec_vifunct6(funct6) @ vm @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VITYPE(funct6, vm, vs2, simm, vd)                                          if extensionEnabled(Ext_V)
+  <-> encdec_vifunct6(funct6) @ vm @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -828,7 +828,7 @@ function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let imm_val : bits('m)             = sign_extend(simm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -899,15 +899,15 @@ mapping clause assembly = VITYPE(funct6, vm, vs2, simm, vd)
 
 /* ************************** OPIVI (WITYPE Narrowing) *************************** */
 /* ************** Vector Narrowing Integer Right Shift Instructions ************** */
-union clause ast = NISTYPE : (nisfunct6, bits(1), regidx, bits(5), regidx)
+union clause ast = NISTYPE : (nisfunct6, bits(1), vregidx, bits(5), vregidx)
 
 mapping encdec_nisfunct6 : nisfunct6 <-> bits(6) = {
   NIS_VNSRL       <-> 0b101100,
   NIS_VNSRA       <-> 0b101101
 }
 
-mapping clause encdec = NISTYPE(funct6, vm, vs2, simm, vd)                                        if extensionEnabled(Ext_V)
-  <-> encdec_nisfunct6(funct6) @ vm @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = NISTYPE(funct6, vm, vs2, simm, vd)                                          if extensionEnabled(Ext_V)
+  <-> encdec_nisfunct6(funct6) @ vm @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(NISTYPE(funct6, vm, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -924,7 +924,7 @@ function clause execute(NISTYPE(funct6, vm, vs2, simm, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let imm_val : bits('m)             = sign_extend(simm);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -965,15 +965,15 @@ mapping clause assembly = NISTYPE(funct6, vm, vs2, simm, vd)
 
 /* ************************** OPIVI (WITYPE Narrowing) *************************** */
 /* *************** Vector Narrowing Fixed-Point Clip Instructions **************** */
-union clause ast = NITYPE : (nifunct6, bits(1), regidx, bits(5), regidx)
+union clause ast = NITYPE : (nifunct6, bits(1), vregidx, bits(5), vregidx)
 
 mapping encdec_nifunct6 : nifunct6 <-> bits(6) = {
   NI_VNCLIPU     <-> 0b101110,
   NI_VNCLIP      <-> 0b101111
 }
 
-mapping clause encdec = NITYPE(funct6, vm, vs2, simm, vd)                                        if extensionEnabled(Ext_V)
-  <-> encdec_nifunct6(funct6) @ vm @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = NITYPE(funct6, vm, vs2, simm, vd)                                          if extensionEnabled(Ext_V)
+  <-> encdec_nifunct6(funct6) @ vm @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(NITYPE(funct6, vm, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -990,7 +990,7 @@ function clause execute(NITYPE(funct6, vm, vs2, simm, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let imm_val : bits('m)             = sign_extend(simm);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -1032,7 +1032,7 @@ mapping clause assembly = NITYPE(funct6, vm, vs2, simm, vd)
 
 /* ***************** OPIVI (Vector Slide & Gather Instructions) ****************** */
 /* Slide and gather instructions extend rs1/imm to XLEN intead of SEW bits */
-union clause ast = VISG : (visgfunct6, bits(1), regidx, bits(5), regidx)
+union clause ast = VISG : (visgfunct6, bits(1), vregidx, bits(5), vregidx)
 
 mapping encdec_visgfunct6 : visgfunct6 <-> bits(6) = {
   VI_VSLIDEUP     <-> 0b001110,
@@ -1040,8 +1040,8 @@ mapping encdec_visgfunct6 : visgfunct6 <-> bits(6) = {
   VI_VRGATHER     <-> 0b001100
 }
 
-mapping clause encdec = VISG(funct6, vm, vs2, simm, vd)                                            if extensionEnabled(Ext_V)
-  <-> encdec_visgfunct6(funct6) @ vm @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VISG(funct6, vm, vs2, simm, vd)                                              if extensionEnabled(Ext_V)
+  <-> encdec_visgfunct6(funct6) @ vm @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let SEW_pow  = get_sew_pow();
@@ -1055,7 +1055,7 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let imm_val : nat                  = unsigned(zero_extend(xlen, simm));
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -1100,10 +1100,10 @@ mapping clause assembly = VISG(funct6, vm, vs2, simm, vd)
   <-> visg_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ maybe_vmask(vm)
 
 /* ********************** OPIVI (Integer Merge Instruction) ********************** */
-union clause ast = MASKTYPEI : (regidx, bits(5), regidx)
+union clause ast = MASKTYPEI : (vregidx, bits(5), vregidx)
 
-mapping clause encdec = MASKTYPEI(vs2, simm, vd)                                   if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b0 @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MASKTYPEI(vs2, simm, vd)                                     if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MASKTYPEI(vs2, simm, vd)) = {
   let start_element = get_start_element();
@@ -1118,7 +1118,7 @@ function clause execute(MASKTYPEI(vs2, simm, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b0, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b0, zvreg);
   let imm_val : bits('m)             = sign_extend(simm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -1148,10 +1148,10 @@ mapping clause assembly = MASKTYPEI(vs2, simm, vd)
   <-> "vmerge.vim" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ sep() ^ "v0"
 
 /* ********************** OPIVI (Integer Move Instruction) *********************** */
-union clause ast = MOVETYPEI : (regidx, bits(5))
+union clause ast = MOVETYPEI : (vregidx, bits(5))
 
-mapping clause encdec = MOVETYPEI (vd, simm)                               if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b1 @ 0b00000 @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MOVETYPEI (vd, simm)                                if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b1 @ 0b00000 @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MOVETYPEI(vd, simm)) = {
   let SEW      = get_sew();
@@ -1163,7 +1163,7 @@ function clause execute(MOVETYPEI(vd, simm)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zvreg);
   let imm_val : bits('m)             = sign_extend(simm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
@@ -1183,10 +1183,10 @@ mapping clause assembly = MOVETYPEI(vd, simm)
   <-> "vmv.v.i" ^ spc() ^ vreg_name(vd) ^ sep() ^ hex_bits_5(simm)
 
 /* ********************* OPIVI (Whole Vector Register Move) ********************** */
-union clause ast = VMVRTYPE : (regidx, bits(5), regidx)
+union clause ast = VMVRTYPE : (vregidx, bits(5), vregidx)
 
-mapping clause encdec = VMVRTYPE(vs2, simm, vd)                                    if extensionEnabled(Ext_V)
-  <-> 0b100111 @ 0b1 @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VMVRTYPE(vs2, simm, vd)                                      if extensionEnabled(Ext_V)
+  <-> 0b100111 @ 0b1 @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VMVRTYPE(vs2, simm, vd)) = {
   let start_element = get_start_element();
@@ -1201,7 +1201,7 @@ function clause execute(VMVRTYPE(vs2, simm, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zvreg);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, EMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, EMUL_pow, vd);
   var result  : vector('n, bits('m)) = vector_init(zeros());
@@ -1226,7 +1226,7 @@ mapping clause assembly = VMVRTYPE(vs2, simm, vd)
   <-> "vmv" ^ simm_string(simm) ^ "r.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)
 
 /* ******************************* OPMVV (VVTYPE) ******************************** */
-union clause ast = MVVTYPE : (mvvfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = MVVTYPE : (mvvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_mvvfunct6 : mvvfunct6 <-> bits(6) = {
   MVV_VAADDU      <-> 0b001000,
@@ -1243,8 +1243,8 @@ mapping encdec_mvvfunct6 : mvvfunct6 <-> bits(6) = {
   MVV_VREM        <-> 0b100011
 }
 
-mapping clause encdec = MVVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_mvvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MVVTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_mvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -1256,7 +1256,7 @@ function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -1342,7 +1342,7 @@ mapping clause assembly = MVVTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ************************* OPMVV (VVtype Multiply-Add) ************************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast = MVVMATYPE : (mvvmafunct6, bits(1), regidx, regidx, regidx)
+union clause ast = MVVMATYPE : (mvvmafunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_mvvmafunct6 : mvvmafunct6 <-> bits(6) = {
   MVV_VMACC       <-> 0b101101,
@@ -1351,8 +1351,8 @@ mapping encdec_mvvmafunct6 : mvvmafunct6 <-> bits(6) = {
   MVV_VNMSUB      <-> 0b101011
 }
 
-mapping clause encdec = MVVMATYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_mvvmafunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MVVMATYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_mvvmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -1364,7 +1364,7 @@ function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -1399,7 +1399,7 @@ mapping clause assembly = MVVMATYPE(funct6, vm, vs2, vs1, vd)
   <-> mvvmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* *************************** OPMVV (VVTYPE Widening) *************************** */
-union clause ast = WVVTYPE : (wvvfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = WVVTYPE : (wvvfunct6, bits(1), vregidx, vregidx, vregidx)
 mapping encdec_wvvfunct6 : wvvfunct6 <-> bits(6) = {
   WVV_VADD       <-> 0b110001,
   WVV_VSUB       <-> 0b110011,
@@ -1410,8 +1410,8 @@ mapping encdec_wvvfunct6 : wvvfunct6 <-> bits(6) = {
   WVV_VWMULSU    <-> 0b111010
 }
 
-mapping clause encdec = WVVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_wvvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = WVVTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_wvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -1429,7 +1429,7 @@ function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
@@ -1470,7 +1470,7 @@ mapping clause assembly = WVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> wvvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
 /* *************************** OPMVV (WVTYPE Widening) *************************** */
-union clause ast = WVTYPE : (wvfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = WVTYPE : (wvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_wvfunct6 : wvfunct6 <-> bits(6) = {
   WV_VADD       <-> 0b110101,
@@ -1479,8 +1479,8 @@ mapping encdec_wvfunct6 : wvfunct6 <-> bits(6) = {
   WV_VSUBU      <-> 0b110110
 }
 
-mapping clause encdec = WVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_wvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = WVTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_wvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(WVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -1497,7 +1497,7 @@ function clause execute(WVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -1533,7 +1533,7 @@ mapping clause assembly = WVTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ******************** OPMVV (VVtype Widening Multiply-Add) ********************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast = WMVVTYPE : (wmvvfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = WMVVTYPE : (wmvvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_wmvvfunct6 : wmvvfunct6 <-> bits(6) = {
   WMVV_VWMACCU   <-> 0b111100,
@@ -1541,8 +1541,8 @@ mapping encdec_wmvvfunct6 : wmvvfunct6 <-> bits(6) = {
   WMVV_VWMACCSU  <-> 0b111111
 }
 
-mapping clause encdec =  WMVVTYPE(funct6, vm, vs2, vs1, vd)                                                   if extensionEnabled(Ext_V)
-  <-> encdec_wmvvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec =  WMVVTYPE(funct6, vm, vs2, vs1, vd)                                                      if extensionEnabled(Ext_V)
+  <-> encdec_wmvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -1560,7 +1560,7 @@ function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
@@ -1594,15 +1594,15 @@ mapping clause assembly = WMVVTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ****************************** OPMVV (VXUNARY0) ******************************* */
 /* ******************* Vector Integer Extension (SEW/2 source) ******************* */
-union clause ast = VEXT2TYPE : (vext2funct6, bits(1), regidx, regidx)
+union clause ast = VEXT2TYPE : (vext2funct6, bits(1), vregidx, vregidx)
 
 mapping vext2_vs1 : vext2funct6 <-> bits(5) = {
   VEXT2_ZVF2  <-> 0b00110,
   VEXT2_SVF2  <-> 0b00111
 }
 
-mapping clause encdec = VEXT2TYPE(funct6, vm, vs2, vd)                                         if extensionEnabled(Ext_V)
-  <-> 0b010010 @ vm @ encdec_reg(vs2) @ vext2_vs1(funct6) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VEXT2TYPE(funct6, vm, vs2, vd)                                           if extensionEnabled(Ext_V)
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ vext2_vs1(funct6) @ 0b010 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VEXT2TYPE(funct6, vm, vs2, vd)) = {
   let SEW = get_sew();
@@ -1619,7 +1619,7 @@ function clause execute(VEXT2TYPE(funct6, vm, vs2, vd)) = {
   let 'm = SEW;
   let 'o = SEW_half;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_half, LMUL_pow_half, vs2);
 
@@ -1650,15 +1650,15 @@ mapping clause assembly = VEXT2TYPE(funct6, vm, vs2, vd)
 
 /* ****************************** OPMVV (VXUNARY0) ******************************* */
 /* ******************* Vector Integer Extension (SEW/4 source) ******************* */
-union clause ast = VEXT4TYPE : (vext4funct6, bits(1), regidx, regidx)
+union clause ast = VEXT4TYPE : (vext4funct6, bits(1), vregidx, vregidx)
 
 mapping vext4_vs1 : vext4funct6 <-> bits(5) = {
   VEXT4_ZVF4  <-> 0b00100,
   VEXT4_SVF4  <-> 0b00101
 }
 
-mapping clause encdec = VEXT4TYPE(funct6, vm, vs2, vd)                                         if extensionEnabled(Ext_V)
-  <-> 0b010010 @ vm @ encdec_reg(vs2) @ vext4_vs1(funct6) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VEXT4TYPE(funct6, vm, vs2, vd)                                           if extensionEnabled(Ext_V)
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ vext4_vs1(funct6) @ 0b010 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VEXT4TYPE(funct6, vm, vs2, vd)) = {
   let SEW = get_sew();
@@ -1675,7 +1675,7 @@ function clause execute(VEXT4TYPE(funct6, vm, vs2, vd)) = {
   let 'm = SEW;
   let 'o = SEW_quart;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_quart, LMUL_pow_quart, vs2);
 
@@ -1706,15 +1706,15 @@ mapping clause assembly = VEXT4TYPE(funct6, vm, vs2, vd)
 
 /* ****************************** OPMVV (VXUNARY0) ******************************* */
 /* ******************* Vector Integer Extension (SEW/8 source) ******************* */
-union clause ast = VEXT8TYPE : (vext8funct6, bits(1), regidx, regidx)
+union clause ast = VEXT8TYPE : (vext8funct6, bits(1), vregidx, vregidx)
 
 mapping vext8_vs1 : vext8funct6 <-> bits(5) = {
   VEXT8_ZVF8  <-> 0b00010,
   VEXT8_SVF8  <-> 0b00011
 }
 
-mapping clause encdec = VEXT8TYPE(funct6, vm, vs2, vd)                                         if extensionEnabled(Ext_V)
-  <-> 0b010010 @ vm @ encdec_reg(vs2) @ vext8_vs1(funct6) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VEXT8TYPE(funct6, vm, vs2, vd)                                           if extensionEnabled(Ext_V)
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ vext8_vs1(funct6) @ 0b010 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VEXT8TYPE(funct6, vm, vs2, vd)) = {
   let SEW = get_sew();
@@ -1731,7 +1731,7 @@ function clause execute(VEXT8TYPE(funct6, vm, vs2, vd)) = {
   let 'm = SEW;
   let 'o = SEW_eighth;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_eighth, LMUL_pow_eighth, vs2);
 
@@ -1762,10 +1762,10 @@ mapping clause assembly = VEXT8TYPE(funct6, vm, vs2, vd)
   <-> vext8type_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************ OPMVV (vmv.x.s in VWXUNARY0) ************************* */
-union clause ast = VMVXS : (regidx, regidx)
+union clause ast = VMVXS : (vregidx, regidx)
 
-mapping clause encdec = VMVXS(vs2, rd)                                                if extensionEnabled(Ext_V)
-  <-> 0b010000 @ 0b1 @ encdec_reg(vs2) @ 0b00000 @ 0b010 @ encdec_reg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VMVXS(vs2, rd)                                                 if extensionEnabled(Ext_V)
+  <-> 0b010000 @ 0b1 @ encdec_vreg(vs2) @ 0b00000 @ 0b010 @ encdec_reg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VMVXS(vs2, rd)) = {
   let SEW      = get_sew();
@@ -1790,10 +1790,10 @@ mapping clause assembly = VMVXS(vs2, rd)
   <-> "vmv.x.s" ^ spc() ^ reg_name(rd) ^ sep() ^ vreg_name(vs2)
 
 /* ********************* OPMVV (Vector Compress Instruction) ********************* */
-union clause ast = MVVCOMPRESS : (regidx, regidx, regidx)
+union clause ast = MVVCOMPRESS : (vregidx, vregidx, vregidx)
 
-mapping clause encdec = MVVCOMPRESS(vs2, vs1, vd)                                             if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b1 @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MVVCOMPRESS(vs2, vs1, vd)                                                if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b1 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MVVCOMPRESS(vs2, vs1, vd)) = {
   let start_element = get_start_element();
@@ -1847,7 +1847,7 @@ mapping clause assembly = MVVCOMPRESS(vs2, vs1, vd)
   <-> "vcompress.vm" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1)
 
 /* ******************************* OPMVX (VXTYPE) ******************************** */
-union clause ast = MVXTYPE : (mvxfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = MVXTYPE : (mvxfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_mvxfunct6 : mvxfunct6 <-> bits(6) = {
   MVX_VAADDU        <-> 0b001000,
@@ -1866,8 +1866,8 @@ mapping encdec_mvxfunct6 : mvxfunct6 <-> bits(6) = {
   MVX_VREM          <-> 0b100011
 }
 
-mapping clause encdec = MVXTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_mvxfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MVXTYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
+  <-> encdec_mvxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -1879,7 +1879,7 @@ function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -1976,7 +1976,7 @@ mapping clause assembly = MVXTYPE(funct6, vm, vs2, rs1, vd)
 
 /* ************************* OPMVX (VXtype Multiply-Add) ************************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast = MVXMATYPE : (mvxmafunct6, bits(1), regidx, regidx, regidx)
+union clause ast = MVXMATYPE : (mvxmafunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_mvxmafunct6 : mvxmafunct6 <-> bits(6) = {
   MVX_VMACC         <-> 0b101101,
@@ -1985,8 +1985,8 @@ mapping encdec_mvxmafunct6 : mvxmafunct6 <-> bits(6) = {
   MVX_VNMSUB        <-> 0b101011
 }
 
-mapping clause encdec = MVXMATYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_mvxmafunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MVXMATYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
+  <-> encdec_mvxmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -1998,7 +1998,7 @@ function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -2033,7 +2033,7 @@ mapping clause assembly = MVXMATYPE(funct6, vm, vs2, rs1, vd)
   <-> mvxmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* *************************** OPMVX (VXTYPE Widening) *************************** */
-union clause ast = WVXTYPE : (wvxfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = WVXTYPE : (wvxfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_wvxfunct6 : wvxfunct6 <-> bits(6) = {
   WVX_VADD       <-> 0b110001,
@@ -2045,8 +2045,8 @@ mapping encdec_wvxfunct6 : wvxfunct6 <-> bits(6) = {
   WVX_VWMULSU    <-> 0b111010
 }
 
-mapping clause encdec = WVXTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_wvxfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = WVXTYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
+  <-> encdec_wvxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(WVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -2063,7 +2063,7 @@ function clause execute(WVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
@@ -2104,7 +2104,7 @@ mapping clause assembly = WVXTYPE(funct6, vm, vs2, rs1, vd)
   <-> wvxtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
 
 /* *************************** OPMVX (WXTYPE Widening) *************************** */
-union clause ast = WXTYPE : (wxfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = WXTYPE : (wxfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_wxfunct6 : wxfunct6 <-> bits(6) = {
   WX_VADD       <-> 0b110101,
@@ -2113,8 +2113,8 @@ mapping encdec_wxfunct6 : wxfunct6 <-> bits(6) = {
   WX_VSUBU      <-> 0b110110
 }
 
-mapping clause encdec = WXTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_wxfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = WXTYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
+  <-> encdec_wxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(WXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -2130,7 +2130,7 @@ function clause execute(WXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -2166,7 +2166,7 @@ mapping clause assembly = WXTYPE(funct6, vm, vs2, rs1, vd)
 
 /* ******************** OPMVX (VXtype Widening Multiply-Add) ********************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast =  WMVXTYPE : (wmvxfunct6, bits(1), regidx, regidx, regidx)
+union clause ast =  WMVXTYPE : (wmvxfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_wmvxfunct6 : wmvxfunct6 <-> bits(6) = {
   WMVX_VWMACCU    <-> 0b111100,
@@ -2175,8 +2175,8 @@ mapping encdec_wmvxfunct6 : wmvxfunct6 <-> bits(6) = {
   WMVX_VWMACCSU   <-> 0b111111
 }
 
-mapping clause encdec = WMVXTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_wmvxfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = WMVXTYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
+  <-> encdec_wmvxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(WMVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -2193,7 +2193,7 @@ function clause execute(WMVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
@@ -2228,10 +2228,10 @@ mapping clause assembly = WMVXTYPE(funct6, vm, vs2, rs1, vd)
   <-> wmvxtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ****************************** OPMVX (VRXUNARY0) ****************************** */
-union clause ast = VMVSX : (regidx, regidx)
+union clause ast = VMVSX : (regidx, vregidx)
 
-mapping clause encdec = VMVSX(rs1, vd)                                                if extensionEnabled(Ext_V)
-  <-> 0b010000 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b110 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VMVSX(rs1, vd)                                                 if extensionEnabled(Ext_V)
+  <-> 0b010000 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VMVSX(rs1, vd)) = {
   let SEW      = get_sew();
@@ -2243,7 +2243,7 @@ function clause execute(VMVSX(rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zvreg);
   let rs1_val : bits('m)             = get_scalar(rs1, 'm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
 

--- a/model/riscv_insts_vext_fp.sail
+++ b/model/riscv_insts_vext_fp.sail
@@ -27,8 +27,8 @@ mapping encdec_fvvfunct6 : fvvfunct6 <-> bits(6) = {
   FVV_VMUL       <-> 0b100100
 }
 
-mapping clause encdec = FVVTYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_fvvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b001 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_fvvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -42,7 +42,7 @@ function clause execute(FVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)            = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)            = read_vmask(num_elem, vm, zreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -101,8 +101,8 @@ mapping encdec_fvvmafunct6 : fvvmafunct6 <-> bits(6) = {
   FVV_VNMSAC     <-> 0b101111
 }
 
-mapping clause encdec = FVVMATYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_fvvmafunct6(funct6) @ vm @ vs2 @ vs1 @ 0b001 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVVMATYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_fvvmafunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -116,7 +116,7 @@ function clause execute(FVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -167,8 +167,8 @@ mapping encdec_fwvvfunct6 : fwvvfunct6 <-> bits(6) = {
   FWVV_VMUL       <-> 0b111000
 }
 
-mapping clause encdec = FWVVTYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_fwvvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b001 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_fwvvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FWVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -188,7 +188,7 @@ function clause execute(FWVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
@@ -231,8 +231,8 @@ mapping encdec_fwvvmafunct6 : fwvvmafunct6 <-> bits(6) = {
   FWVV_VNMSAC     <-> 0b111111
 }
 
-mapping clause encdec = FWVVMATYPE(funct6, vm, vs1, vs2, vd) if extensionEnabled(Ext_V)
-  <-> encdec_fwvvmafunct6(funct6) @ vm @ vs1 @ vs2 @ 0b001 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVVMATYPE(funct6, vm, vs1, vs2, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_fwvvmafunct6(funct6) @ vm @ encdec_reg(vs1) @ encdec_reg(vs2) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FWVVMATYPE(funct6, vm, vs1, vs2, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -252,7 +252,7 @@ function clause execute(FWVVMATYPE(funct6, vm, vs1, vs2, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
@@ -294,8 +294,8 @@ mapping encdec_fwvfunct6 : fwvfunct6 <-> bits(6) = {
   FWV_VSUB       <-> 0b110110
 }
 
-mapping clause encdec = FWVTYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_fwvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b001 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_fwvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FWVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -314,7 +314,7 @@ function clause execute(FWVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -356,8 +356,8 @@ mapping encdec_vfunary0_vs1 : vfunary0 <-> bits(5) = {
   FV_CVT_RTZ_X_F    <-> 0b00111
 }
 
-mapping clause encdec = VFUNARY0(vm, vs2, vfunary0, vd) if extensionEnabled(Ext_V)
-  <-> 0b010010 @ vm @ vs2 @ encdec_vfunary0_vs1(vfunary0) @ 0b001 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFUNARY0(vm, vs2, vfunary0, vd)                                                    if extensionEnabled(Ext_V)
+  <-> 0b010010 @ vm @ encdec_reg(vs2) @ encdec_vfunary0_vs1(vfunary0) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -371,7 +371,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
@@ -469,8 +469,8 @@ mapping encdec_vfwunary0_vs1 : vfwunary0 <-> bits(5) = {
   FWV_CVT_RTZ_X_F   <-> 0b01111
 }
 
-mapping clause encdec = VFWUNARY0(vm, vs2, vfwunary0, vd) if extensionEnabled(Ext_V)
-  <-> 0b010010 @ vm @ vs2 @ encdec_vfwunary0_vs1(vfwunary0) @ 0b001 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFWUNARY0(vm, vs2, vfwunary0, vd)                                                    if extensionEnabled(Ext_V)
+  <-> 0b010010 @ vm @ encdec_reg(vs2) @ encdec_vfwunary0_vs1(vfwunary0) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -489,7 +489,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
 
@@ -598,8 +598,8 @@ mapping encdec_vfnunary0_vs1 : vfnunary0 <-> bits(5) = {
   FNV_CVT_RTZ_X_F   <-> 0b10111
 }
 
-mapping clause encdec = VFNUNARY0(vm, vs2, vfnunary0, vd) if extensionEnabled(Ext_V)
-  <-> 0b010010 @ vm @ vs2 @ encdec_vfnunary0_vs1(vfnunary0) @ 0b001 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFNUNARY0(vm, vs2, vfnunary0, vd)                                                    if extensionEnabled(Ext_V)
+  <-> 0b010010 @ vm @ encdec_reg(vs2) @ encdec_vfnunary0_vs1(vfnunary0) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -618,7 +618,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
@@ -733,8 +733,8 @@ mapping encdec_vfunary1_vs1 : vfunary1 <-> bits(5) = {
   FVV_VCLASS      <-> 0b10000
 }
 
-mapping clause encdec = VFUNARY1(vm, vs2, vfunary1, vd) if extensionEnabled(Ext_V)
-  <-> 0b010011 @ vm @ vs2 @ encdec_vfunary1_vs1(vfunary1) @ 0b001 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFUNARY1(vm, vs2, vfunary1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> 0b010011 @ vm @ encdec_reg(vs2) @ encdec_vfunary1_vs1(vfunary1) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -748,7 +748,7 @@ function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
@@ -808,8 +808,8 @@ mapping clause assembly = VFUNARY1(vm, vs2, vfunary1, vd)
 /* ****************************** OPFVV (VWFUNARY0) ****************************** */
 union clause ast = VFMVFS : (regidx, regidx)
 
-mapping clause encdec = VFMVFS(vs2, rd) if extensionEnabled(Ext_V)
-  <-> 0b010000 @ 0b1 @ vs2 @ 0b00000 @ 0b001 @ rd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFMVFS(vs2, rd)                                               if extensionEnabled(Ext_V)
+  <-> 0b010000 @ 0b1 @ encdec_reg(vs2) @ 0b00000 @ 0b001 @ encdec_reg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFMVFS(vs2, rd)) = {
   let rm_3b    = fcsr[FRM];
@@ -856,8 +856,8 @@ mapping encdec_fvffunct6 : fvffunct6 <-> bits(6) = {
   VF_VRSUB         <-> 0b100111
 }
 
-mapping clause encdec = FVFTYPE(funct6, vm, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_fvffunct6(funct6) @ vm @ vs2 @ rs1 @ 0b101 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVFTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_fvffunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -871,7 +871,7 @@ function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -945,8 +945,8 @@ mapping encdec_fvfmafunct6 : fvfmafunct6 <-> bits(6) = {
   VF_VNMSAC     <-> 0b101111
 }
 
-mapping clause encdec = FVFMATYPE(funct6, vm, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_fvfmafunct6(funct6) @ vm @ vs2 @ rs1 @ 0b101 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVFMATYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_fvfmafunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FVFMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -960,7 +960,7 @@ function clause execute(FVFMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -1011,8 +1011,8 @@ mapping encdec_fwvffunct6 : fwvffunct6 <-> bits(6) = {
   FWVF_VMUL       <-> 0b111000
 }
 
-mapping clause encdec = FWVFTYPE(funct6, vm, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_fwvffunct6(funct6) @ vm @ vs2 @ rs1 @ 0b101 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVFTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_fwvffunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FWVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1031,7 +1031,7 @@ function clause execute(FWVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
@@ -1074,8 +1074,8 @@ mapping encdec_fwvfmafunct6 : fwvfmafunct6 <-> bits(6) = {
   FWVF_VNMSAC     <-> 0b111111
 }
 
-mapping clause encdec = FWVFMATYPE(funct6, vm, rs1, vs2, vd) if extensionEnabled(Ext_V)
-  <-> encdec_fwvfmafunct6(funct6) @ vm @ vs2 @ rs1 @ 0b101 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVFMATYPE(funct6, vm, rs1, vs2, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_fwvfmafunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FWVFMATYPE(funct6, vm, rs1, vs2, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1094,7 +1094,7 @@ function clause execute(FWVFMATYPE(funct6, vm, rs1, vs2, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
@@ -1136,8 +1136,8 @@ mapping encdec_fwffunct6 : fwffunct6 <-> bits(6) = {
   FWF_VSUB       <-> 0b110110
 }
 
-mapping clause encdec = FWFTYPE(funct6, vm, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_fwffunct6(funct6) @ vm @ vs2 @ rs1 @ 0b101 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWFTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_fwffunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FWFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1155,7 +1155,7 @@ function clause execute(FWFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -1189,8 +1189,8 @@ mapping clause assembly = FWFTYPE(funct6, vm, vs2, rs1, vd)
 /* This instruction operates on all body elements regardless of mask value */
 union clause ast = VFMERGE : (regidx, regidx, regidx)
 
-mapping clause encdec = VFMERGE(vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b0 @ vs2 @ rs1 @ 0b101 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFMERGE(vs2, rs1, vd)                                                 if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b0 @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFMERGE(vs2, rs1, vd)) = {
   let rm_3b         = fcsr[FRM];
@@ -1207,7 +1207,7 @@ function clause execute(VFMERGE(vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b0, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b0, zreg);
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -1240,8 +1240,8 @@ mapping clause assembly = VFMERGE(vs2, rs1, vd)
 /* This instruction shares the encoding with vfmerge.vfm, but with vm=1 and vs2=v0 */
 union clause ast = VFMV : (regidx, regidx)
 
-mapping clause encdec = VFMV(rs1, vd) if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b1 @ 0b00000 @ rs1 @ 0b101 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFMV(rs1, vd)                                                 if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFMV(rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1256,7 +1256,7 @@ function clause execute(VFMV(rs1, vd)) = {
   let 'm = SEW;
 
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
@@ -1277,8 +1277,8 @@ mapping clause assembly = VFMV(rs1, vd)
 /* ****************************** OPFVF (VRFUNARY0) ****************************** */
 union clause ast = VFMVSF : (regidx, regidx)
 
-mapping clause encdec = VFMVSF(rs1, vd) if extensionEnabled(Ext_V)
-  <-> 0b010000 @ 0b1 @ 0b00000 @ rs1 @ 0b101 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFMVSF(rs1, vd)                                               if extensionEnabled(Ext_V)
+  <-> 0b010000 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFMVSF(rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1291,7 +1291,7 @@ function clause execute(VFMVSF(rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, 0b00000);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zreg);
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
 

--- a/model/riscv_insts_vext_fp.sail
+++ b/model/riscv_insts_vext_fp.sail
@@ -13,7 +13,7 @@
 /* ******************************************************************************* */
 
 /* ******************************* OPFVV (VVTYPE) ******************************** */
-union clause ast = FVVTYPE : (fvvfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = FVVTYPE : (fvvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_fvvfunct6 : fvvfunct6 <-> bits(6) = {
   FVV_VADD       <-> 0b000000,
@@ -27,8 +27,8 @@ mapping encdec_fvvfunct6 : fvvfunct6 <-> bits(6) = {
   FVV_VMUL       <-> 0b100100
 }
 
-mapping clause encdec = FVVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_fvvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVVTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_fvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -42,7 +42,7 @@ function clause execute(FVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)            = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)            = read_vmask(num_elem, vm, zvreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -88,7 +88,7 @@ mapping clause assembly = FVVTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ************************* OPFVV (VVtype Multiply-Add) ************************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast = FVVMATYPE : (fvvmafunct6, bits(1), regidx, regidx, regidx)
+union clause ast = FVVMATYPE : (fvvmafunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_fvvmafunct6 : fvvmafunct6 <-> bits(6) = {
   FVV_VMADD      <-> 0b101000,
@@ -101,8 +101,8 @@ mapping encdec_fvvmafunct6 : fvvmafunct6 <-> bits(6) = {
   FVV_VNMSAC     <-> 0b101111
 }
 
-mapping clause encdec = FVVMATYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_fvvmafunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVVMATYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_fvvmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -116,7 +116,7 @@ function clause execute(FVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -159,7 +159,7 @@ mapping clause assembly = FVVMATYPE(funct6, vm, vs2, vs1, vd)
   <-> fvvmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* *************************** OPFVV (VVTYPE Widening) *************************** */
-union clause ast = FWVVTYPE : (fwvvfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = FWVVTYPE : (fwvvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_fwvvfunct6 : fwvvfunct6 <-> bits(6) = {
   FWVV_VADD       <-> 0b110000,
@@ -167,8 +167,8 @@ mapping encdec_fwvvfunct6 : fwvvfunct6 <-> bits(6) = {
   FWVV_VMUL       <-> 0b111000
 }
 
-mapping clause encdec = FWVVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_fwvvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVVTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_fwvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FWVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -188,7 +188,7 @@ function clause execute(FWVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
@@ -222,7 +222,7 @@ mapping clause assembly = FWVVTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ******************** OPFVV (VVtype Widening Multiply-Add) ********************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast = FWVVMATYPE : (fwvvmafunct6, bits(1), regidx, regidx, regidx)
+union clause ast = FWVVMATYPE : (fwvvmafunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_fwvvmafunct6 : fwvvmafunct6 <-> bits(6) = {
   FWVV_VMACC      <-> 0b111100,
@@ -231,8 +231,8 @@ mapping encdec_fwvvmafunct6 : fwvvmafunct6 <-> bits(6) = {
   FWVV_VNMSAC     <-> 0b111111
 }
 
-mapping clause encdec = FWVVMATYPE(funct6, vm, vs1, vs2, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_fwvvmafunct6(funct6) @ vm @ encdec_reg(vs1) @ encdec_reg(vs2) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVVMATYPE(funct6, vm, vs1, vs2, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_fwvvmafunct6(funct6) @ vm @ encdec_vreg(vs1) @ encdec_vreg(vs2) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FWVVMATYPE(funct6, vm, vs1, vs2, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -252,7 +252,7 @@ function clause execute(FWVVMATYPE(funct6, vm, vs1, vs2, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
@@ -287,15 +287,15 @@ mapping clause assembly = FWVVMATYPE(funct6, vm, vs1, vs2, vd)
   <-> fwvvmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* *************************** OPFVV (WVTYPE Widening) *************************** */
-union clause ast = FWVTYPE : (fwvfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = FWVTYPE : (fwvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_fwvfunct6 : fwvfunct6 <-> bits(6) = {
   FWV_VADD       <-> 0b110100,
   FWV_VSUB       <-> 0b110110
 }
 
-mapping clause encdec = FWVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_fwvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_fwvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FWVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -314,7 +314,7 @@ function clause execute(FWVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -345,7 +345,7 @@ mapping clause assembly = FWVTYPE(funct6, vm, vs2, vs1, vd)
   <-> fwvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
 /* ****************************** OPFVV (VFUNARY0) ******************************* */
-union clause ast = VFUNARY0 : (bits(1), regidx, vfunary0, regidx)
+union clause ast = VFUNARY0 : (bits(1), vregidx, vfunary0, vregidx)
 
 mapping encdec_vfunary0_vs1 : vfunary0 <-> bits(5) = {
   FV_CVT_XU_F       <-> 0b00000,
@@ -356,8 +356,8 @@ mapping encdec_vfunary0_vs1 : vfunary0 <-> bits(5) = {
   FV_CVT_RTZ_X_F    <-> 0b00111
 }
 
-mapping clause encdec = VFUNARY0(vm, vs2, vfunary0, vd)                                                    if extensionEnabled(Ext_V)
-  <-> 0b010010 @ vm @ encdec_reg(vs2) @ encdec_vfunary0_vs1(vfunary0) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFUNARY0(vm, vs2, vfunary0, vd)                                                      if extensionEnabled(Ext_V)
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ encdec_vfunary0_vs1(vfunary0) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -371,7 +371,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
@@ -457,7 +457,7 @@ mapping clause assembly = VFUNARY0(vm, vs2, vfunary0, vd)
   <-> vfunary0_mnemonic(vfunary0) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************** OPFVV (VFUNARY0 Widening) ************************** */
-union clause ast = VFWUNARY0 : (bits(1), regidx, vfwunary0, regidx)
+union clause ast = VFWUNARY0 : (bits(1), vregidx, vfwunary0, vregidx)
 
 mapping encdec_vfwunary0_vs1 : vfwunary0 <-> bits(5) = {
   FWV_CVT_XU_F      <-> 0b01000,
@@ -469,8 +469,8 @@ mapping encdec_vfwunary0_vs1 : vfwunary0 <-> bits(5) = {
   FWV_CVT_RTZ_X_F   <-> 0b01111
 }
 
-mapping clause encdec = VFWUNARY0(vm, vs2, vfwunary0, vd)                                                    if extensionEnabled(Ext_V)
-  <-> 0b010010 @ vm @ encdec_reg(vs2) @ encdec_vfwunary0_vs1(vfwunary0) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFWUNARY0(vm, vs2, vfwunary0, vd)                                                      if extensionEnabled(Ext_V)
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ encdec_vfwunary0_vs1(vfwunary0) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -489,7 +489,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
 
@@ -585,7 +585,7 @@ mapping clause assembly = VFWUNARY0(vm, vs2, vfwunary0, vd)
   <-> vfwunary0_mnemonic(vfwunary0) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************* OPFVV (VFUNARY0 Narrowing) ************************** */
-union clause ast = VFNUNARY0 : (bits(1), regidx, vfnunary0, regidx)
+union clause ast = VFNUNARY0 : (bits(1), vregidx, vfnunary0, vregidx)
 
 mapping encdec_vfnunary0_vs1 : vfnunary0 <-> bits(5) = {
   FNV_CVT_XU_F      <-> 0b10000,
@@ -598,8 +598,8 @@ mapping encdec_vfnunary0_vs1 : vfnunary0 <-> bits(5) = {
   FNV_CVT_RTZ_X_F   <-> 0b10111
 }
 
-mapping clause encdec = VFNUNARY0(vm, vs2, vfnunary0, vd)                                                    if extensionEnabled(Ext_V)
-  <-> 0b010010 @ vm @ encdec_reg(vs2) @ encdec_vfnunary0_vs1(vfnunary0) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFNUNARY0(vm, vs2, vfnunary0, vd)                                                      if extensionEnabled(Ext_V)
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ encdec_vfnunary0_vs1(vfnunary0) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -618,7 +618,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
@@ -724,7 +724,7 @@ mapping clause assembly = VFNUNARY0(vm, vs2, vfnunary0, vd)
   <-> vfnunary0_mnemonic(vfnunary0) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ****************************** OPFVV (VFUNARY1) ******************************* */
-union clause ast = VFUNARY1 : (bits(1), regidx, vfunary1, regidx)
+union clause ast = VFUNARY1 : (bits(1), vregidx, vfunary1, vregidx)
 
 mapping encdec_vfunary1_vs1 : vfunary1 <-> bits(5) = {
   FVV_VSQRT       <-> 0b00000,
@@ -733,8 +733,8 @@ mapping encdec_vfunary1_vs1 : vfunary1 <-> bits(5) = {
   FVV_VCLASS      <-> 0b10000
 }
 
-mapping clause encdec = VFUNARY1(vm, vs2, vfunary1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> 0b010011 @ vm @ encdec_reg(vs2) @ encdec_vfunary1_vs1(vfunary1) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFUNARY1(vm, vs2, vfunary1, vd)                                                      if extensionEnabled(Ext_V)
+  <-> 0b010011 @ vm @ encdec_vreg(vs2) @ encdec_vfunary1_vs1(vfunary1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -748,7 +748,7 @@ function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
@@ -806,10 +806,10 @@ mapping clause assembly = VFUNARY1(vm, vs2, vfunary1, vd)
   <-> vfunary1_mnemonic(vfunary1) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ****************************** OPFVV (VWFUNARY0) ****************************** */
-union clause ast = VFMVFS : (regidx, regidx)
+union clause ast = VFMVFS : (vregidx, regidx)
 
-mapping clause encdec = VFMVFS(vs2, rd)                                               if extensionEnabled(Ext_V)
-  <-> 0b010000 @ 0b1 @ encdec_reg(vs2) @ 0b00000 @ 0b001 @ encdec_reg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFMVFS(vs2, rd)                                                if extensionEnabled(Ext_V)
+  <-> 0b010000 @ 0b1 @ encdec_vreg(vs2) @ 0b00000 @ 0b001 @ encdec_reg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFMVFS(vs2, rd)) = {
   let rm_3b    = fcsr[FRM];
@@ -838,7 +838,7 @@ mapping clause assembly = VFMVFS(vs2, rd)
   <-> "vfmv.f.s" ^ spc() ^ freg_name(rd) ^ sep() ^ vreg_name(vs2)
 
 /* ******************************* OPFVF (VFtype) ******************************** */
-union clause ast = FVFTYPE : (fvffunct6, bits(1), regidx, regidx, regidx)
+union clause ast = FVFTYPE : (fvffunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_fvffunct6 : fvffunct6 <-> bits(6) = {
   VF_VADD          <-> 0b000000,
@@ -856,8 +856,8 @@ mapping encdec_fvffunct6 : fvffunct6 <-> bits(6) = {
   VF_VRSUB         <-> 0b100111
 }
 
-mapping clause encdec = FVFTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_fvffunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVFTYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
+  <-> encdec_fvffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -871,7 +871,7 @@ function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -932,7 +932,7 @@ mapping clause assembly = FVFTYPE(funct6, vm, vs2, rs1, vd)
 
 /* ************************* OPFVF (VFtype Multiply-Add) ************************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast = FVFMATYPE : (fvfmafunct6, bits(1), regidx, regidx, regidx)
+union clause ast = FVFMATYPE : (fvfmafunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_fvfmafunct6 : fvfmafunct6 <-> bits(6) = {
   VF_VMADD      <-> 0b101000,
@@ -945,8 +945,8 @@ mapping encdec_fvfmafunct6 : fvfmafunct6 <-> bits(6) = {
   VF_VNMSAC     <-> 0b101111
 }
 
-mapping clause encdec = FVFMATYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_fvfmafunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVFMATYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
+  <-> encdec_fvfmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FVFMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -960,7 +960,7 @@ function clause execute(FVFMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -1003,7 +1003,7 @@ mapping clause assembly = FVFMATYPE(funct6, vm, vs2, rs1, vd)
   <-> fvfmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* *************************** OPFVF (VFTYPE Widening) *************************** */
-union clause ast = FWVFTYPE : (fwvffunct6, bits(1), regidx, regidx, regidx)
+union clause ast = FWVFTYPE : (fwvffunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_fwvffunct6 : fwvffunct6 <-> bits(6) = {
   FWVF_VADD       <-> 0b110000,
@@ -1011,8 +1011,8 @@ mapping encdec_fwvffunct6 : fwvffunct6 <-> bits(6) = {
   FWVF_VMUL       <-> 0b111000
 }
 
-mapping clause encdec = FWVFTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_fwvffunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVFTYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
+  <-> encdec_fwvffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FWVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1031,7 +1031,7 @@ function clause execute(FWVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
@@ -1065,7 +1065,7 @@ mapping clause assembly = FWVFTYPE(funct6, vm, vs2, rs1, vd)
 
 /* ******************** OPFVF (VFtype Widening Multiply-Add) ********************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast = FWVFMATYPE : (fwvfmafunct6, bits(1), regidx, regidx, regidx)
+union clause ast = FWVFMATYPE : (fwvfmafunct6, bits(1), regidx, vregidx, vregidx)
 
 mapping encdec_fwvfmafunct6 : fwvfmafunct6 <-> bits(6) = {
   FWVF_VMACC      <-> 0b111100,
@@ -1074,8 +1074,8 @@ mapping encdec_fwvfmafunct6 : fwvfmafunct6 <-> bits(6) = {
   FWVF_VNMSAC     <-> 0b111111
 }
 
-mapping clause encdec = FWVFMATYPE(funct6, vm, rs1, vs2, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_fwvfmafunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVFMATYPE(funct6, vm, rs1, vs2, vd)                                                      if extensionEnabled(Ext_V)
+  <-> encdec_fwvfmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FWVFMATYPE(funct6, vm, rs1, vs2, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1094,7 +1094,7 @@ function clause execute(FWVFMATYPE(funct6, vm, rs1, vs2, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
@@ -1129,15 +1129,15 @@ mapping clause assembly = FWVFMATYPE(funct6, vm, rs1, vs2, vd)
   <-> fwvfmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* *************************** OPFVF (WFTYPE Widening) *************************** */
-union clause ast = FWFTYPE : (fwffunct6, bits(1), regidx, regidx, regidx)
+union clause ast = FWFTYPE : (fwffunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_fwffunct6 : fwffunct6 <-> bits(6) = {
   FWF_VADD       <-> 0b110100,
   FWF_VSUB       <-> 0b110110
 }
 
-mapping clause encdec = FWFTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_fwffunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWFTYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
+  <-> encdec_fwffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FWFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1155,7 +1155,7 @@ function clause execute(FWFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
@@ -1187,10 +1187,10 @@ mapping clause assembly = FWFTYPE(funct6, vm, vs2, rs1, vd)
 
 /* ************************** OPFVF (Merge Instruction) ************************** */
 /* This instruction operates on all body elements regardless of mask value */
-union clause ast = VFMERGE : (regidx, regidx, regidx)
+union clause ast = VFMERGE : (vregidx, regidx, vregidx)
 
-mapping clause encdec = VFMERGE(vs2, rs1, vd)                                                 if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b0 @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFMERGE(vs2, rs1, vd)                                                   if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFMERGE(vs2, rs1, vd)) = {
   let rm_3b         = fcsr[FRM];
@@ -1207,7 +1207,7 @@ function clause execute(VFMERGE(vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b0, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b0, zvreg);
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -1238,10 +1238,10 @@ mapping clause assembly = VFMERGE(vs2, rs1, vd)
 
 /* ************************** OPFVF (Move Instruction) *************************** */
 /* This instruction shares the encoding with vfmerge.vfm, but with vm=1 and vs2=v0 */
-union clause ast = VFMV : (regidx, regidx)
+union clause ast = VFMV : (regidx, vregidx)
 
-mapping clause encdec = VFMV(rs1, vd)                                                 if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFMV(rs1, vd)                                                  if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFMV(rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1256,7 +1256,7 @@ function clause execute(VFMV(rs1, vd)) = {
   let 'm = SEW;
 
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zvreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
@@ -1275,10 +1275,10 @@ mapping clause assembly = VFMV(rs1, vd)
   <-> "vfmv.v.f" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)
 
 /* ****************************** OPFVF (VRFUNARY0) ****************************** */
-union clause ast = VFMVSF : (regidx, regidx)
+union clause ast = VFMVSF : (regidx, vregidx)
 
-mapping clause encdec = VFMVSF(rs1, vd)                                               if extensionEnabled(Ext_V)
-  <-> 0b010000 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFMVSF(rs1, vd)                                                if extensionEnabled(Ext_V)
+  <-> 0b010000 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFMVSF(rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1291,7 +1291,7 @@ function clause execute(VFMVSF(rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zreg);
+  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zvreg);
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
 

--- a/model/riscv_insts_vext_fp.sail
+++ b/model/riscv_insts_vext_fp.sail
@@ -806,10 +806,10 @@ mapping clause assembly = VFUNARY1(vm, vs2, vfunary1, vd)
   <-> vfunary1_mnemonic(vfunary1) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ****************************** OPFVV (VWFUNARY0) ****************************** */
-union clause ast = VFMVFS : (vregidx, regidx)
+union clause ast = VFMVFS : (vregidx, fregidx)
 
-mapping clause encdec = VFMVFS(vs2, rd)                                                if extensionEnabled(Ext_V)
-  <-> 0b010000 @ 0b1 @ encdec_vreg(vs2) @ 0b00000 @ 0b001 @ encdec_reg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFMVFS(vs2, rd)                                                 if extensionEnabled(Ext_V)
+  <-> 0b010000 @ 0b1 @ encdec_vreg(vs2) @ 0b00000 @ 0b001 @ encdec_freg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFMVFS(vs2, rd)) = {
   let rm_3b    = fcsr[FRM];
@@ -838,7 +838,7 @@ mapping clause assembly = VFMVFS(vs2, rd)
   <-> "vfmv.f.s" ^ spc() ^ freg_name(rd) ^ sep() ^ vreg_name(vs2)
 
 /* ******************************* OPFVF (VFtype) ******************************** */
-union clause ast = FVFTYPE : (fvffunct6, bits(1), vregidx, regidx, vregidx)
+union clause ast = FVFTYPE : (fvffunct6, bits(1), vregidx, fregidx, vregidx)
 
 mapping encdec_fvffunct6 : fvffunct6 <-> bits(6) = {
   VF_VADD          <-> 0b000000,
@@ -856,8 +856,8 @@ mapping encdec_fvffunct6 : fvffunct6 <-> bits(6) = {
   VF_VRSUB         <-> 0b100111
 }
 
-mapping clause encdec = FVFTYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
-  <-> encdec_fvffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVFTYPE(funct6, vm, vs2, rs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_fvffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -928,11 +928,11 @@ mapping fvftype_mnemonic : fvffunct6 <-> string = {
 }
 
 mapping clause assembly = FVFTYPE(funct6, vm, vs2, rs1, vd)
-  <-> fvftype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+  <-> fvftype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ freg_name(rs1) ^ maybe_vmask(vm)
 
 /* ************************* OPFVF (VFtype Multiply-Add) ************************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast = FVFMATYPE : (fvfmafunct6, bits(1), vregidx, regidx, vregidx)
+union clause ast = FVFMATYPE : (fvfmafunct6, bits(1), vregidx, fregidx, vregidx)
 
 mapping encdec_fvfmafunct6 : fvfmafunct6 <-> bits(6) = {
   VF_VMADD      <-> 0b101000,
@@ -945,8 +945,8 @@ mapping encdec_fvfmafunct6 : fvfmafunct6 <-> bits(6) = {
   VF_VNMSAC     <-> 0b101111
 }
 
-mapping clause encdec = FVFMATYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
-  <-> encdec_fvfmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVFMATYPE(funct6, vm, vs2, rs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_fvfmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FVFMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1000,10 +1000,10 @@ mapping fvfmatype_mnemonic : fvfmafunct6 <-> string = {
 }
 
 mapping clause assembly = FVFMATYPE(funct6, vm, vs2, rs1, vd)
-  <-> fvfmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+  <-> fvfmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ freg_name(rs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* *************************** OPFVF (VFTYPE Widening) *************************** */
-union clause ast = FWVFTYPE : (fwvffunct6, bits(1), vregidx, regidx, vregidx)
+union clause ast = FWVFTYPE : (fwvffunct6, bits(1), vregidx, fregidx, vregidx)
 
 mapping encdec_fwvffunct6 : fwvffunct6 <-> bits(6) = {
   FWVF_VADD       <-> 0b110000,
@@ -1011,8 +1011,8 @@ mapping encdec_fwvffunct6 : fwvffunct6 <-> bits(6) = {
   FWVF_VMUL       <-> 0b111000
 }
 
-mapping clause encdec = FWVFTYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
-  <-> encdec_fwvffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVFTYPE(funct6, vm, vs2, rs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_fwvffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FWVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1061,11 +1061,11 @@ mapping fwvftype_mnemonic : fwvffunct6 <-> string = {
 }
 
 mapping clause assembly = FWVFTYPE(funct6, vm, vs2, rs1, vd)
-  <-> fwvftype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+  <-> fwvftype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ freg_name(rs1) ^ maybe_vmask(vm)
 
 /* ******************** OPFVF (VFtype Widening Multiply-Add) ********************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast = FWVFMATYPE : (fwvfmafunct6, bits(1), regidx, vregidx, vregidx)
+union clause ast = FWVFMATYPE : (fwvfmafunct6, bits(1), fregidx, vregidx, vregidx)
 
 mapping encdec_fwvfmafunct6 : fwvfmafunct6 <-> bits(6) = {
   FWVF_VMACC      <-> 0b111100,
@@ -1074,8 +1074,8 @@ mapping encdec_fwvfmafunct6 : fwvfmafunct6 <-> bits(6) = {
   FWVF_VNMSAC     <-> 0b111111
 }
 
-mapping clause encdec = FWVFMATYPE(funct6, vm, rs1, vs2, vd)                                                      if extensionEnabled(Ext_V)
-  <-> encdec_fwvfmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVFMATYPE(funct6, vm, rs1, vs2, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_fwvfmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FWVFMATYPE(funct6, vm, rs1, vs2, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1126,18 +1126,18 @@ mapping fwvfmatype_mnemonic : fwvfmafunct6 <-> string = {
 }
 
 mapping clause assembly = FWVFMATYPE(funct6, vm, rs1, vs2, vd)
-  <-> fwvfmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+  <-> fwvfmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ freg_name(rs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* *************************** OPFVF (WFTYPE Widening) *************************** */
-union clause ast = FWFTYPE : (fwffunct6, bits(1), vregidx, regidx, vregidx)
+union clause ast = FWFTYPE : (fwffunct6, bits(1), vregidx, fregidx, vregidx)
 
 mapping encdec_fwffunct6 : fwffunct6 <-> bits(6) = {
   FWF_VADD       <-> 0b110100,
   FWF_VSUB       <-> 0b110110
 }
 
-mapping clause encdec = FWFTYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
-  <-> encdec_fwffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWFTYPE(funct6, vm, vs2, rs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_fwffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FWFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1183,14 +1183,14 @@ mapping fwftype_mnemonic : fwffunct6 <-> string = {
 }
 
 mapping clause assembly = FWFTYPE(funct6, vm, vs2, rs1, vd)
-  <-> fwftype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+  <-> fwftype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ freg_name(rs1) ^ maybe_vmask(vm)
 
 /* ************************** OPFVF (Merge Instruction) ************************** */
 /* This instruction operates on all body elements regardless of mask value */
-union clause ast = VFMERGE : (vregidx, regidx, vregidx)
+union clause ast = VFMERGE : (vregidx, fregidx, vregidx)
 
-mapping clause encdec = VFMERGE(vs2, rs1, vd)                                                   if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFMERGE(vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFMERGE(vs2, rs1, vd)) = {
   let rm_3b         = fcsr[FRM];
@@ -1234,14 +1234,14 @@ function clause execute(VFMERGE(vs2, rs1, vd)) = {
 }
 
 mapping clause assembly = VFMERGE(vs2, rs1, vd)
-  <-> "vfmerge.vfm" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ sep() ^ "v0"
+  <-> "vfmerge.vfm" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ freg_name(rs1) ^ sep() ^ "v0"
 
 /* ************************** OPFVF (Move Instruction) *************************** */
 /* This instruction shares the encoding with vfmerge.vfm, but with vm=1 and vs2=v0 */
-union clause ast = VFMV : (regidx, vregidx)
+union clause ast = VFMV : (fregidx, vregidx)
 
-mapping clause encdec = VFMV(rs1, vd)                                                  if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFMV(rs1, vd)                                                   if extensionEnabled(Ext_V)
+  <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFMV(rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1272,13 +1272,13 @@ function clause execute(VFMV(rs1, vd)) = {
 }
 
 mapping clause assembly = VFMV(rs1, vd)
-  <-> "vfmv.v.f" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)
+  <-> "vfmv.v.f" ^ spc() ^ vreg_name(vd) ^ sep() ^ freg_name(rs1)
 
 /* ****************************** OPFVF (VRFUNARY0) ****************************** */
-union clause ast = VFMVSF : (regidx, vregidx)
+union clause ast = VFMVSF : (fregidx, vregidx)
 
-mapping clause encdec = VFMVSF(rs1, vd)                                                if extensionEnabled(Ext_V)
-  <-> 0b010000 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFMVSF(rs1, vd)                                                 if extensionEnabled(Ext_V)
+  <-> 0b010000 @ 0b1 @ 0b00000 @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFMVSF(rs1, vd)) = {
   let rm_3b    = fcsr[FRM];

--- a/model/riscv_insts_vext_fp_red.sail
+++ b/model/riscv_insts_vext_fp_red.sail
@@ -12,7 +12,7 @@
 /* ******************************************************************************* */
 
 /* ********************** OPFVV (Floating-Point Reduction) *********************** */
-union clause ast = RFVVTYPE : (rfvvfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = RFVVTYPE : (rfvvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_rfvvfunct6 : rfvvfunct6 <-> bits(6) = {
   FVV_VFREDOSUM   <-> 0b000011,
@@ -23,10 +23,10 @@ mapping encdec_rfvvfunct6 : rfvvfunct6 <-> bits(6) = {
   FVV_VFWREDUSUM  <-> 0b110001
 }
 
-mapping clause encdec = RFVVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_rfvvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = RFVVTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_rfvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
-val process_rfvv_single: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), regidx, regidx, regidx, int('n), int('m), int('p)) -> Retired
+val process_rfvv_single: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, int('n), int('m), int('p)) -> Retired
 function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {
   let rm_3b = fcsr[FRM];
   let num_elem_vd = get_num_elem(0, SEW); /* vd regardless of LMUL setting */
@@ -40,7 +40,7 @@ function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_po
   let 'd = num_elem_vd;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zvreg);
   let vd_val  : vector('d, bits('m)) = read_vreg(num_elem_vd, SEW, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
   let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
@@ -66,7 +66,7 @@ function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_po
   RETIRE_SUCCESS
 }
 
-val process_rfvv_widen: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), regidx, regidx, regidx, int('n), int('m), int('p)) -> Retired
+val process_rfvv_widen: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, int('n), int('m), int('p)) -> Retired
 function process_rfvv_widen(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {
   let rm_3b          = fcsr[FRM];
   let SEW_widen      = SEW * 2;
@@ -83,7 +83,7 @@ function process_rfvv_widen(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zvreg);
   let vd_val  : vector('d, bits('o)) = read_vreg(num_elem_vd, SEW_widen, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
   let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);

--- a/model/riscv_insts_vext_fp_red.sail
+++ b/model/riscv_insts_vext_fp_red.sail
@@ -23,8 +23,8 @@ mapping encdec_rfvvfunct6 : rfvvfunct6 <-> bits(6) = {
   FVV_VFWREDUSUM  <-> 0b110001
 }
 
-mapping clause encdec = RFVVTYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_rfvvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b001 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = RFVVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_rfvvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 val process_rfvv_single: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), regidx, regidx, regidx, int('n), int('m), int('p)) -> Retired
 function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {
@@ -40,7 +40,7 @@ function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_po
   let 'd = num_elem_vd;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zreg);
   let vd_val  : vector('d, bits('m)) = read_vreg(num_elem_vd, SEW, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
   let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
@@ -83,7 +83,7 @@ function process_rfvv_widen(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zreg);
   let vd_val  : vector('d, bits('o)) = read_vreg(num_elem_vd, SEW_widen, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
   let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);

--- a/model/riscv_insts_vext_fp_utils.sail
+++ b/model/riscv_insts_vext_fp_utils.sail
@@ -31,7 +31,7 @@ function illegal_fp_normal(vd, vm, SEW, rm_3b) = {
 /* b. Masked check for floating-point instructions encoded with vm = 0 */
 val illegal_fp_vd_masked : (regidx, {8, 16, 32, 64}, bits(3)) -> bool
 function illegal_fp_vd_masked(vd, SEW, rm_3b) = {
-  not(valid_vtype()) | vd == 0b00000 | not(valid_fp_op(SEW, rm_3b))
+  not(valid_vtype()) | vd == zreg | not(valid_fp_op(SEW, rm_3b))
 }
 
 /* c. Unmasked check for floating-point instructions encoded with vm = 1 */

--- a/model/riscv_insts_vext_fp_utils.sail
+++ b/model/riscv_insts_vext_fp_utils.sail
@@ -161,7 +161,7 @@ function f_is_NaN(xf) = {
 }
 
 /* Scalar register shaping for floating point operations */
-val get_scalar_fp : forall 'n, 'n in {16, 32, 64}. (regidx, int('n)) -> bits('n)
+val get_scalar_fp : forall 'n, 'n in {16, 32, 64}. (fregidx, int('n)) -> bits('n)
 function get_scalar_fp(rs1, SEW) = {
   assert(flen >= SEW, "invalid vector floating-point type width: FLEN < SEW");
   match SEW {

--- a/model/riscv_insts_vext_fp_utils.sail
+++ b/model/riscv_insts_vext_fp_utils.sail
@@ -23,15 +23,15 @@ function valid_fp_op(SEW, rm_3b) = {
 }
 
 /* a. Normal check for floating-point instructions */
-val illegal_fp_normal : (regidx, bits(1), {8, 16, 32, 64}, bits(3)) -> bool
+val illegal_fp_normal : (vregidx, bits(1), {8, 16, 32, 64}, bits(3)) -> bool
 function illegal_fp_normal(vd, vm, SEW, rm_3b) = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b))
 }
 
 /* b. Masked check for floating-point instructions encoded with vm = 0 */
-val illegal_fp_vd_masked : (regidx, {8, 16, 32, 64}, bits(3)) -> bool
+val illegal_fp_vd_masked : (vregidx, {8, 16, 32, 64}, bits(3)) -> bool
 function illegal_fp_vd_masked(vd, SEW, rm_3b) = {
-  not(valid_vtype()) | vd == zreg | not(valid_fp_op(SEW, rm_3b))
+  not(valid_vtype()) | vd == zvreg | not(valid_fp_op(SEW, rm_3b))
 }
 
 /* c. Unmasked check for floating-point instructions encoded with vm = 1 */
@@ -41,7 +41,7 @@ function illegal_fp_vd_unmasked(SEW, rm_3b) = {
 }
 
 /* d. Variable width check for floating-point widening/narrowing instructions */
-val illegal_fp_variable_width : (regidx, bits(1), {8, 16, 32, 64}, bits(3), int, int) -> bool
+val illegal_fp_variable_width : (vregidx, bits(1), {8, 16, 32, 64}, bits(3), int, int) -> bool
 function illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_new, LMUL_pow_new) = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) |
   not(valid_eew_emul(SEW_new, LMUL_pow_new))

--- a/model/riscv_insts_vext_fp_vm.sail
+++ b/model/riscv_insts_vext_fp_vm.sail
@@ -13,7 +13,7 @@
 
 /* ******************************* OPFVV (VVMTYPE) ******************************* */
 /* FVVM instructions' destination is a mask register */
-union clause ast = FVVMTYPE : (fvvmfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = FVVMTYPE : (fvvmfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_fvvmfunct6 : fvvmfunct6 <-> bits(6) = {
   FVVM_VMFEQ      <-> 0b011000,
@@ -22,8 +22,8 @@ mapping encdec_fvvmfunct6 : fvvmfunct6 <-> bits(6) = {
   FVVM_VMFNE      <-> 0b011100
 }
 
-mapping clause encdec = FVVMTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_fvvmfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVVMTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_fvvmfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FVVMTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -37,7 +37,7 @@ function clause execute(FVVMTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
@@ -74,7 +74,7 @@ mapping clause assembly = FVVMTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ******************************* OPFVF (VFMTYPE) ******************************* */
 /* VFM instructions' destination is a mask register */
-union clause ast = FVFMTYPE : (fvfmfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = FVFMTYPE : (fvfmfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_fvfmfunct6 : fvfmfunct6 <-> bits(6) = {
   VFM_VMFEQ      <-> 0b011000,
@@ -85,8 +85,8 @@ mapping encdec_fvfmfunct6 : fvfmfunct6 <-> bits(6) = {
   VFM_VMFGE      <-> 0b011111
 }
 
-mapping clause encdec = FVFMTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_fvfmfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVFMTYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
+  <-> encdec_fvfmfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FVFMTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -100,7 +100,7 @@ function clause execute(FVFMTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
   let rs1_val : bits('m)                  = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);

--- a/model/riscv_insts_vext_fp_vm.sail
+++ b/model/riscv_insts_vext_fp_vm.sail
@@ -74,7 +74,7 @@ mapping clause assembly = FVVMTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ******************************* OPFVF (VFMTYPE) ******************************* */
 /* VFM instructions' destination is a mask register */
-union clause ast = FVFMTYPE : (fvfmfunct6, bits(1), vregidx, regidx, vregidx)
+union clause ast = FVFMTYPE : (fvfmfunct6, bits(1), vregidx, fregidx, vregidx)
 
 mapping encdec_fvfmfunct6 : fvfmfunct6 <-> bits(6) = {
   VFM_VMFEQ      <-> 0b011000,
@@ -85,8 +85,8 @@ mapping encdec_fvfmfunct6 : fvfmfunct6 <-> bits(6) = {
   VFM_VMFGE      <-> 0b011111
 }
 
-mapping clause encdec = FVFMTYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
-  <-> encdec_fvfmfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVFMTYPE(funct6, vm, vs2, rs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_fvfmfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FVFMTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -137,4 +137,4 @@ mapping fvfmtype_mnemonic : fvfmfunct6 <-> string = {
 }
 
 mapping clause assembly = FVFMTYPE(funct6, vm, vs2, rs1, vd)
-  <-> fvfmtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+  <-> fvfmtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ freg_name(rs1) ^ maybe_vmask(vm)

--- a/model/riscv_insts_vext_fp_vm.sail
+++ b/model/riscv_insts_vext_fp_vm.sail
@@ -22,8 +22,8 @@ mapping encdec_fvvmfunct6 : fvvmfunct6 <-> bits(6) = {
   FVVM_VMFNE      <-> 0b011100
 }
 
-mapping clause encdec = FVVMTYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_fvvmfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b001 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVVMTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_fvvmfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b001 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FVVMTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -37,7 +37,7 @@ function clause execute(FVVMTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
@@ -85,8 +85,8 @@ mapping encdec_fvfmfunct6 : fvfmfunct6 <-> bits(6) = {
   VFM_VMFGE      <-> 0b011111
 }
 
-mapping clause encdec = FVFMTYPE(funct6, vm, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_fvfmfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b101 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVFMTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_fvfmfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(FVFMTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -100,7 +100,7 @@ function clause execute(FVFMTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
   let rs1_val : bits('m)                  = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);

--- a/model/riscv_insts_vext_mask.sail
+++ b/model/riscv_insts_vext_mask.sail
@@ -25,8 +25,8 @@ mapping encdec_mmfunct6 : mmfunct6 <-> bits(6) = {
   MM_VMXNOR    <-> 0b011111
 }
 
-mapping clause encdec = MMTYPE(funct6, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_mmfunct6(funct6) @ 0b1 @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MMTYPE(funct6, vs2, vs1, vd)                                                         if extensionEnabled(Ext_V)
+  <-> encdec_mmfunct6(funct6) @ 0b1 @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MMTYPE(funct6, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -82,8 +82,8 @@ mapping clause assembly = MMTYPE(funct6, vs2, vs1, vd)
 /* ************************* OPMVV (vpopc in VWXUNARY0) ************************** */
 union clause ast = VCPOP_M : (bits(1), regidx, regidx)
 
-mapping clause encdec = VCPOP_M(vm, vs2, rd) if extensionEnabled(Ext_V)
-  <-> 0b010000 @ vm @ vs2 @ 0b10000 @ 0b010 @ rd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VCPOP_M(vm, vs2, rd)                                         if extensionEnabled(Ext_V)
+  <-> 0b010000 @ vm @ encdec_reg(vs2) @ 0b10000 @ 0b010 @ encdec_reg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VCPOP_M(vm, vs2, rd)) = {
   let SEW      = get_sew();
@@ -95,7 +95,7 @@ function clause execute(VCPOP_M(vm, vs2, rd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
 
   let (_, mask) = init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val);
@@ -116,8 +116,8 @@ mapping clause assembly = VCPOP_M(vm, vs2, rd)
 /* ************************* OPMVV (vfirst in VWXUNARY0) ************************* */
 union clause ast = VFIRST_M : (bits(1), regidx, regidx)
 
-mapping clause encdec = VFIRST_M(vm, vs2, rd) if extensionEnabled(Ext_V)
-  <-> 0b010000 @ vm @ vs2 @ 0b10001 @ 0b010 @ rd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFIRST_M(vm, vs2, rd)                                        if extensionEnabled(Ext_V)
+  <-> 0b010000 @ vm @ encdec_reg(vs2) @ 0b10001 @ 0b010 @ encdec_reg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFIRST_M(vm, vs2, rd)) = {
   let SEW      = get_sew();
@@ -129,7 +129,7 @@ function clause execute(VFIRST_M(vm, vs2, rd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
 
   let (_, mask) = init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val);
@@ -152,8 +152,8 @@ mapping clause assembly = VFIRST_M(vm, vs2, rd)
 /* ************************** OPMVV (vmsbf in VMUNARY0) ************************** */
 union clause ast = VMSBF_M : (bits(1), regidx, regidx)
 
-mapping clause encdec = VMSBF_M(vm, vs2, vd) if extensionEnabled(Ext_V)
-  <-> 0b010100 @ vm @ vs2 @ 0b00001 @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VMSBF_M(vm, vs2, vd)                                         if extensionEnabled(Ext_V)
+  <-> 0b010100 @ vm @ encdec_reg(vs2) @ 0b00001 @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VMSBF_M(vm, vs2, vd)) = {
   let SEW      = get_sew();
@@ -166,7 +166,7 @@ function clause execute(VMSBF_M(vm, vs2, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
@@ -192,8 +192,8 @@ mapping clause assembly = VMSBF_M(vm, vs2, vd)
 /* ************************** OPMVV (vmsif in VMUNARY0) ************************** */
 union clause ast = VMSIF_M : (bits(1), regidx, regidx)
 
-mapping clause encdec = VMSIF_M(vm, vs2, vd) if extensionEnabled(Ext_V)
-  <-> 0b010100 @ vm @ vs2 @ 0b00011 @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VMSIF_M(vm, vs2, vd)                                         if extensionEnabled(Ext_V)
+  <-> 0b010100 @ vm @ encdec_reg(vs2) @ 0b00011 @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VMSIF_M(vm, vs2, vd)) = {
   let SEW      = get_sew();
@@ -206,7 +206,7 @@ function clause execute(VMSIF_M(vm, vs2, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
@@ -232,8 +232,8 @@ mapping clause assembly = VMSIF_M(vm, vs2, vd)
 /* ************************** OPMVV (vmsof in VMUNARY0) ************************** */
 union clause ast = VMSOF_M : (bits(1), regidx, regidx)
 
-mapping clause encdec = VMSOF_M(vm, vs2, vd) if extensionEnabled(Ext_V)
-  <-> 0b010100 @ vm @ vs2 @ 0b00010 @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VMSOF_M(vm, vs2, vd)                                         if extensionEnabled(Ext_V)
+  <-> 0b010100 @ vm @ encdec_reg(vs2) @ 0b00010 @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VMSOF_M(vm, vs2, vd)) = {
   let SEW      = get_sew();
@@ -246,7 +246,7 @@ function clause execute(VMSOF_M(vm, vs2, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
@@ -276,8 +276,8 @@ mapping clause assembly = VMSOF_M(vm, vs2, vd)
 /* ************************** OPMVV (viota in VMUNARY0) ************************** */
 union clause ast = VIOTA_M : (bits(1), regidx, regidx)
 
-mapping clause encdec = VIOTA_M(vm, vs2, vd) if extensionEnabled(Ext_V)
-  <-> 0b010100 @ vm @ vs2 @ 0b10000 @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VIOTA_M(vm, vs2, vd)                                         if extensionEnabled(Ext_V)
+  <-> 0b010100 @ vm @ encdec_reg(vs2) @ 0b10000 @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VIOTA_M(vm, vs2, vd)) = {
   let SEW      = get_sew();
@@ -290,7 +290,7 @@ function clause execute(VIOTA_M(vm, vs2, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
   let vs2_val : bits('n)     = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
@@ -316,8 +316,8 @@ mapping clause assembly = VIOTA_M(vm, vs2, vd)
 /* *************************** OPMVV (vid in VMUNARY0) *************************** */
 union clause ast = VID_V : (bits(1), regidx)
 
-mapping clause encdec = VID_V(vm, vd) if extensionEnabled(Ext_V)
-  <-> 0b010100 @ vm @ 0b00000 @ 0b10001 @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VID_V(vm, vd)                                        if extensionEnabled(Ext_V)
+  <-> 0b010100 @ vm @ 0b00000 @ 0b10001 @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VID_V(vm, vd)) = {
   let SEW      = get_sew();
@@ -329,7 +329,7 @@ function clause execute(VID_V(vm, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);

--- a/model/riscv_insts_vext_mask.sail
+++ b/model/riscv_insts_vext_mask.sail
@@ -12,7 +12,7 @@
 /* ******************************************************************************* */
 
 /* ******************************* OPMVV (MMTYPE) ******************************** */
-union clause ast = MMTYPE : (mmfunct6, regidx, regidx, regidx)
+union clause ast = MMTYPE : (mmfunct6, vregidx, vregidx, vregidx)
 
 mapping encdec_mmfunct6 : mmfunct6 <-> bits(6) = {
   MM_VMAND     <-> 0b011001,
@@ -25,8 +25,8 @@ mapping encdec_mmfunct6 : mmfunct6 <-> bits(6) = {
   MM_VMXNOR    <-> 0b011111
 }
 
-mapping clause encdec = MMTYPE(funct6, vs2, vs1, vd)                                                         if extensionEnabled(Ext_V)
-  <-> encdec_mmfunct6(funct6) @ 0b1 @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = MMTYPE(funct6, vs2, vs1, vd)                                                            if extensionEnabled(Ext_V)
+  <-> encdec_mmfunct6(funct6) @ 0b1 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MMTYPE(funct6, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -80,10 +80,10 @@ mapping clause assembly = MMTYPE(funct6, vs2, vs1, vd)
   <-> mmtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1)
 
 /* ************************* OPMVV (vpopc in VWXUNARY0) ************************** */
-union clause ast = VCPOP_M : (bits(1), regidx, regidx)
+union clause ast = VCPOP_M : (bits(1), vregidx, regidx)
 
-mapping clause encdec = VCPOP_M(vm, vs2, rd)                                         if extensionEnabled(Ext_V)
-  <-> 0b010000 @ vm @ encdec_reg(vs2) @ 0b10000 @ 0b010 @ encdec_reg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VCPOP_M(vm, vs2, rd)                                          if extensionEnabled(Ext_V)
+  <-> 0b010000 @ vm @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_reg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VCPOP_M(vm, vs2, rd)) = {
   let SEW      = get_sew();
@@ -95,7 +95,7 @@ function clause execute(VCPOP_M(vm, vs2, rd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
 
   let (_, mask) = init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val);
@@ -114,10 +114,10 @@ mapping clause assembly = VCPOP_M(vm, vs2, rd)
   <-> "vpopc.m" ^ spc() ^ reg_name(rd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************* OPMVV (vfirst in VWXUNARY0) ************************* */
-union clause ast = VFIRST_M : (bits(1), regidx, regidx)
+union clause ast = VFIRST_M : (bits(1), vregidx, regidx)
 
-mapping clause encdec = VFIRST_M(vm, vs2, rd)                                        if extensionEnabled(Ext_V)
-  <-> 0b010000 @ vm @ encdec_reg(vs2) @ 0b10001 @ 0b010 @ encdec_reg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFIRST_M(vm, vs2, rd)                                         if extensionEnabled(Ext_V)
+  <-> 0b010000 @ vm @ encdec_vreg(vs2) @ 0b10001 @ 0b010 @ encdec_reg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VFIRST_M(vm, vs2, rd)) = {
   let SEW      = get_sew();
@@ -129,7 +129,7 @@ function clause execute(VFIRST_M(vm, vs2, rd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
 
   let (_, mask) = init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val);
@@ -150,10 +150,10 @@ mapping clause assembly = VFIRST_M(vm, vs2, rd)
   <-> "vfirst.m" ^ spc() ^ reg_name(rd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************** OPMVV (vmsbf in VMUNARY0) ************************** */
-union clause ast = VMSBF_M : (bits(1), regidx, regidx)
+union clause ast = VMSBF_M : (bits(1), vregidx, vregidx)
 
-mapping clause encdec = VMSBF_M(vm, vs2, vd)                                         if extensionEnabled(Ext_V)
-  <-> 0b010100 @ vm @ encdec_reg(vs2) @ 0b00001 @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VMSBF_M(vm, vs2, vd)                                           if extensionEnabled(Ext_V)
+  <-> 0b010100 @ vm @ encdec_vreg(vs2) @ 0b00001 @ 0b010 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VMSBF_M(vm, vs2, vd)) = {
   let SEW      = get_sew();
@@ -166,7 +166,7 @@ function clause execute(VMSBF_M(vm, vs2, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
@@ -190,10 +190,10 @@ mapping clause assembly = VMSBF_M(vm, vs2, vd)
   <-> "vmsbf.m" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************** OPMVV (vmsif in VMUNARY0) ************************** */
-union clause ast = VMSIF_M : (bits(1), regidx, regidx)
+union clause ast = VMSIF_M : (bits(1), vregidx, vregidx)
 
-mapping clause encdec = VMSIF_M(vm, vs2, vd)                                         if extensionEnabled(Ext_V)
-  <-> 0b010100 @ vm @ encdec_reg(vs2) @ 0b00011 @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VMSIF_M(vm, vs2, vd)                                           if extensionEnabled(Ext_V)
+  <-> 0b010100 @ vm @ encdec_vreg(vs2) @ 0b00011 @ 0b010 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VMSIF_M(vm, vs2, vd)) = {
   let SEW      = get_sew();
@@ -206,7 +206,7 @@ function clause execute(VMSIF_M(vm, vs2, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
@@ -230,10 +230,10 @@ mapping clause assembly = VMSIF_M(vm, vs2, vd)
   <-> "vmsif.m" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************** OPMVV (vmsof in VMUNARY0) ************************** */
-union clause ast = VMSOF_M : (bits(1), regidx, regidx)
+union clause ast = VMSOF_M : (bits(1), vregidx, vregidx)
 
-mapping clause encdec = VMSOF_M(vm, vs2, vd)                                         if extensionEnabled(Ext_V)
-  <-> 0b010100 @ vm @ encdec_reg(vs2) @ 0b00010 @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VMSOF_M(vm, vs2, vd)                                           if extensionEnabled(Ext_V)
+  <-> 0b010100 @ vm @ encdec_vreg(vs2) @ 0b00010 @ 0b010 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VMSOF_M(vm, vs2, vd)) = {
   let SEW      = get_sew();
@@ -246,7 +246,7 @@ function clause execute(VMSOF_M(vm, vs2, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
@@ -274,10 +274,10 @@ mapping clause assembly = VMSOF_M(vm, vs2, vd)
   <-> "vmsof.m" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************** OPMVV (viota in VMUNARY0) ************************** */
-union clause ast = VIOTA_M : (bits(1), regidx, regidx)
+union clause ast = VIOTA_M : (bits(1), vregidx, vregidx)
 
-mapping clause encdec = VIOTA_M(vm, vs2, vd)                                         if extensionEnabled(Ext_V)
-  <-> 0b010100 @ vm @ encdec_reg(vs2) @ 0b10000 @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VIOTA_M(vm, vs2, vd)                                           if extensionEnabled(Ext_V)
+  <-> 0b010100 @ vm @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VIOTA_M(vm, vs2, vd)) = {
   let SEW      = get_sew();
@@ -290,7 +290,7 @@ function clause execute(VIOTA_M(vm, vs2, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
   let vs2_val : bits('n)     = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
@@ -314,10 +314,10 @@ mapping clause assembly = VIOTA_M(vm, vs2, vd)
   <-> "viota.m" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* *************************** OPMVV (vid in VMUNARY0) *************************** */
-union clause ast = VID_V : (bits(1), regidx)
+union clause ast = VID_V : (bits(1), vregidx)
 
-mapping clause encdec = VID_V(vm, vd)                                        if extensionEnabled(Ext_V)
-  <-> 0b010100 @ vm @ 0b00000 @ 0b10001 @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VID_V(vm, vd)                                         if extensionEnabled(Ext_V)
+  <-> 0b010100 @ vm @ 0b00000 @ 0b10001 @ 0b010 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VID_V(vm, vd)) = {
   let SEW      = get_sew();
@@ -329,7 +329,7 @@ function clause execute(VID_V(vm, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -62,16 +62,16 @@ mapping vlewidth_pow : vlewidth <-> {3, 4, 5, 6} = {
 }
 
 /* ******************** Vector Load Unit-Stride Normal & Segment (mop=0b00, lumop=0b00000) ********************* */
-union clause ast = VLSEGTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
+union clause ast = VLSEGTYPE : (bits(3), bits(1), regidx, vlewidth, vregidx)
 
-mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd)                                                    if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
+mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd)                                                     if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
 
-val process_vlseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired
+val process_vlseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> Retired
 function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
-  let vm_val : bits('n) = read_vmask(num_elem, vm, zreg);
+  let vm_val : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vd_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
 
   let (result, mask) = init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val);
@@ -90,7 +90,7 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
                 TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                 TR_Address(paddr, _) => {
                   match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                    Ok(elem) => write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
+                    Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
                     Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                   }
                 }
@@ -100,7 +100,7 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
     } else { /* prestart, masked or tail segments */
       foreach (j from 0 to (nf - 1)) {
         let skipped_elem = (result[i] >> (j * load_width_bytes * 8))[(load_width_bytes * 8 - 1) .. 0];
-        write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_reg)), skipped_elem)
+        write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), skipped_elem)
       }
     }
   };
@@ -130,16 +130,16 @@ mapping clause assembly = VLSEGTYPE(nf, vm, rs1, width, vd)
   <-> "vl" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ maybe_vmask(vm)
 
 /* ************ Vector Load Unit-Stride Normal & Segment Fault-Only-First (mop=0b00, lumop=0b10000) ************ */
-union clause ast = VLSEGFFTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
+union clause ast = VLSEGFFTYPE : (bits(3), bits(1), regidx, vlewidth, vregidx)
 
-mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd)                                                  if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b00 @ vm @ 0b10000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
+mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd)                                                   if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b00 @ vm @ 0b10000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
 
-val process_vlsegff : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired
+val process_vlsegff : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> Retired
 function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
-  let vm_val : bits('n) = read_vmask(num_elem, vm, zreg);
+  let vm_val : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vd_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
   let tail_ag : agtype = get_vtype_vta();
 
@@ -179,7 +179,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
                 },
                 TR_Address(paddr, _) => {
                   match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                    Ok(elem) => write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
+                    Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
                     Err(e)   => {
                       if i == 0 then { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                       else {
@@ -197,7 +197,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
       } else { /* prestart, masked or tail segments */
         foreach (j from 0 to (nf - 1)) {
           let skipped_elem = (result[i] >> (j * load_width_bytes * 8))[(load_width_bytes * 8 - 1) .. 0];
-          write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_reg)), skipped_elem)
+          write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), skipped_elem)
         }
       }
     } else {
@@ -205,7 +205,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
       if tail_ag == AGNOSTIC then {
         foreach (j from 0 to (nf - 1)) {
           let skipped_elem = (vd_seg[i] >> (j * load_width_bytes * 8))[(load_width_bytes * 8 - 1) .. 0];
-          write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_reg)), skipped_elem)
+          write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), skipped_elem)
         }
         /* TODO: configuration support for agnostic behavior */
       }
@@ -237,16 +237,16 @@ mapping clause assembly = VLSEGFFTYPE(nf, vm, rs1, width, vd)
   <-> "vl" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ "ff.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ maybe_vmask(vm)
 
 /* ******************** Vector Store Unit-Stride Normal & Segment (mop=0b00, sumop=0b00000) ******************** */
-union clause ast = VSSEGTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
+union clause ast = VSSEGTYPE : (bits(3), bits(1), regidx, vlewidth, vregidx)
 
-mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3)                                                    if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vs3) @ 0b0100111 if extensionEnabled(Ext_V)
+mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3)                                                     if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111 if extensionEnabled(Ext_V)
 
-val process_vsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired
+val process_vsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> Retired
 function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs3_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
   let mask    : bits('n) = init_masked_source(num_elem, EMUL_pow, vm_val);
 
@@ -267,7 +267,7 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
                 match (eares) {
                   Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                   Ok(_)  => {
-                    let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, regidx_offset(vs3, to_bits(5, j * EMUL_reg)));
+                    let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(5, j * EMUL_reg)));
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, elem_val, false, false, false);
                     match (res) {
                       Ok(true)  => (),
@@ -308,16 +308,16 @@ mapping clause assembly = VSSEGTYPE(nf, vm, rs1, width, vs3)
   <-> "vs" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ maybe_vmask(vm)
 
 /* ****************************** Vector Load Strided Normal & Segment (mop=0b10) ****************************** */
-union clause ast = VLSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
+union clause ast = VLSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, vregidx)
 
-mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)                                                      if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b10 @ vm @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
+mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)                                                       if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b10 @ vm @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
 
-val process_vlsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired
+val process_vlsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, regidx, int('p), int('n)) -> Retired
 function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vd_seg  : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
   let rs2_val : int = unsigned(get_scalar(rs2, xlen));
 
@@ -337,7 +337,7 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                  Ok(elem) => write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
+                  Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
                   Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                 }
               }
@@ -347,7 +347,7 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
     } else { /* prestart, masked or tail segments */
       foreach (j from 0 to (nf - 1)) {
         let skipped_elem = (result[i] >> (j * load_width_bytes * 8))[(load_width_bytes * 8 - 1) .. 0];
-        write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_reg)), skipped_elem)
+        write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), skipped_elem)
       }
     }
   };
@@ -377,16 +377,16 @@ mapping clause assembly = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
   <-> "vls" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(rs2) ^ maybe_vmask(vm)
 
 /* ***************************** Vector Store Strided Normal & Segment (mop=0b10) ****************************** */
-union clause ast = VSSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
+union clause ast = VSSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, vregidx)
 
-mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)                                                      if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b10 @ vm @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vs3) @ 0b0100111 if extensionEnabled(Ext_V)
+mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)                                                       if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b10 @ vm @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111 if extensionEnabled(Ext_V)
 
-val process_vssseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired
+val process_vssseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, regidx, int('p), int('n)) -> Retired
 function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs3_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
   let rs2_val : int = unsigned(get_scalar(rs2, xlen));
   let mask    : bits('n) = init_masked_source(num_elem, EMUL_pow, vm_val);
@@ -408,7 +408,7 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
                 match (eares) {
                   Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                   Ok(_)  => {
-                    let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, regidx_offset(vs3, to_bits(5, j * EMUL_reg)));
+                    let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(5, j * EMUL_reg)));
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, elem_val, false, false, false);
                     match (res) {
                       Ok(true)  => (),
@@ -449,16 +449,16 @@ mapping clause assembly = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
   <-> "vss" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(rs2) ^ maybe_vmask(vm)
 
 /* ************************* Vector Load Indexed Unordered Normal & Segment (mop=0b01) ************************* */
-union clause ast = VLUXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
+union clause ast = VLUXSEGTYPE : (bits(3), bits(1), vregidx, regidx, vlewidth, vregidx)
 
-mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)                                                     if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b01 @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
+mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)                                                       if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b01 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
 
-val process_vlxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired
+val process_vlxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('ib), int('db), int('ip), int('dp), regidx, vregidx, int('n), int) -> Retired
 function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
   let width_type : word_width = size_bytes(EEW_data_bytes);
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vd_seg  : vector('n, bits('f * 'db * 8)) = read_vreg_seg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, nf, vd);
   let vs2_val : vector('n, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
 
@@ -479,7 +479,7 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, EEW_data_bytes, false, false, false) {
-                  Ok(elem) => write_single_element(EEW_data_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_data_reg)), elem),
+                  Ok(elem) => write_single_element(EEW_data_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_data_reg)), elem),
                   Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                 }
               }
@@ -489,7 +489,7 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
     } else { /* prestart, masked or tail segments */
       foreach (j from 0 to (nf - 1)) {
         let skipped_elem = (result[i] >> (j * EEW_data_bytes * 8))[(EEW_data_bytes * 8 - 1) .. 0];
-        write_single_element(EEW_data_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_data_reg)), skipped_elem)
+        write_single_element(EEW_data_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_data_reg)), skipped_elem)
       }
     }
   };
@@ -516,13 +516,13 @@ function clause execute(VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
 }
 
 mapping clause assembly = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
-  <-> "vlux" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(vs2) ^ maybe_vmask(vm)
+  <-> "vlux" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************** Vector Load Indexed Ordered Normal & Segment (mop=0b11) ************************** */
-union clause ast = VLOXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
+union clause ast = VLOXSEGTYPE : (bits(3), bits(1), vregidx, regidx, vlewidth, vregidx)
 
-mapping clause encdec = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)                                                     if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b11 @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
+mapping clause encdec = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)                                                       if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b11 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
 
 function clause execute(VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
   let EEW_index_pow = vlewidth_pow(width);
@@ -542,19 +542,19 @@ function clause execute(VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
 }
 
 mapping clause assembly = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)
-  <-> "vlox" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(vs2) ^ maybe_vmask(vm)
+  <-> "vlox" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************ Vector Store Indexed Unordered Normal & Segment (mop=0b01) ************************* */
-union clause ast = VSUXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
+union clause ast = VSUXSEGTYPE : (bits(3), bits(1), vregidx, regidx, vlewidth, vregidx)
 
-mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)                                                     if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b01 @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vs3) @ 0b0100111 if extensionEnabled(Ext_V)
+mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)                                                       if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b01 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111 if extensionEnabled(Ext_V)
 
-val process_vsxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired
+val process_vsxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('ib), int('db), int('ip), int('dp), regidx, vregidx, int('n), int) -> Retired
 function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
   let width_type : word_width = size_bytes(EEW_data_bytes);
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs3_seg : vector('n, bits('f * 'db * 8)) = read_vreg_seg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, nf, vs3);
   let vs2_val : vector('n, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
   let mask    : bits('n) = init_masked_source(num_elem, EMUL_data_pow, vm_val);
@@ -577,7 +577,7 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
                 match (eares) {
                   Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                   Ok(_)  => {
-                    let elem_val : bits('db * 8) = read_single_element(EEW_data_bytes * 8, i, regidx_offset(vs3, to_bits(5, j * EMUL_data_reg)));
+                    let elem_val : bits('db * 8) = read_single_element(EEW_data_bytes * 8, i, vregidx_offset(vs3, to_bits(5, j * EMUL_data_reg)));
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, EEW_data_bytes, elem_val, false, false, false);
                     match (res) {
                       Ok(true)  => (),
@@ -615,13 +615,13 @@ function clause execute(VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
 }
 
 mapping clause assembly = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
-  <-> "vsux" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(vs2) ^ maybe_vmask(vm)
+  <-> "vsux" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************* Vector Store Indexed Ordered Normal & Segment (mop=0b11) ************************** */
-union clause ast = VSOXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
+union clause ast = VSOXSEGTYPE : (bits(3), bits(1), vregidx, regidx, vlewidth, vregidx)
 
-mapping clause encdec = VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)                                                     if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b11 @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vs3) @ 0b0100111 if extensionEnabled(Ext_V)
+mapping clause encdec = VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)                                                       if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b11 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111 if extensionEnabled(Ext_V)
 
 function clause execute(VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
   let EEW_index_pow = vlewidth_pow(width);
@@ -641,15 +641,15 @@ function clause execute(VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
 }
 
 mapping clause assembly = VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
-  <-> "vsox" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(vs2) ^ maybe_vmask(vm)
+  <-> "vsox" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ***************** Vector Load Unit-Stride Whole Register (vm=0b1, mop=0b00, lumop=0b01000) ****************** */
-union clause ast = VLRETYPE : (bits(3), regidx, vlewidth, regidx)
+union clause ast = VLRETYPE : (bits(3), regidx, vlewidth, vregidx)
 
-mapping clause encdec = VLRETYPE(nf, rs1, width, vd)                                                          if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
+mapping clause encdec = VLRETYPE(nf, rs1, width, vd)                                                           if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
 
-val process_vlre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), regidx, int('b), regidx, int('n)) -> Retired
+val process_vlre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), vregidx, int('b), regidx, int('n)) -> Retired
 function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
   let width_type : word_width = size_bytes(load_width_bytes);
   let start_element = get_start_element();
@@ -671,7 +671,7 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
             TR_Address(paddr, _) => {
               match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                Ok(elem) => write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, cur_field)), elem),
+                Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, cur_field)), elem),
                 Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
               }
             }
@@ -695,7 +695,7 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
             TR_Address(paddr, _) => {
               match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                Ok(elem) => write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, j)), elem),
+                Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j)), elem),
                 Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
               }
             }
@@ -725,12 +725,12 @@ mapping clause assembly = VLRETYPE(nf, rs1, width, vd)
   <-> "vl" ^ nfields_string(nf) ^ "re" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
 
 /* ***************** Vector Store Unit-Stride Whole Register (vm=0b1, mop=0b00, lumop=0b01000) ***************** */
-union clause ast = VSRETYPE : (bits(3), regidx, regidx)
+union clause ast = VSRETYPE : (bits(3), regidx, vregidx)
 
-mapping clause encdec = VSRETYPE(nf, rs1, vs3)                                                if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(vs3) @ 0b0100111 if extensionEnabled(Ext_V)
+mapping clause encdec = VSRETYPE(nf, rs1, vs3)                                                 if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ encdec_reg(rs1) @ 0b000 @ encdec_vreg(vs3) @ 0b0100111 if extensionEnabled(Ext_V)
 
-val process_vsre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), int('b), regidx, regidx, int('n)) -> Retired
+val process_vsre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), int('b), regidx, vregidx, int('n)) -> Retired
 function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
   let width_type : word_width = BYTE;
   let start_element = get_start_element();
@@ -755,7 +755,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
               match (eares) {
                 Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                 Ok(_)  => {
-                  let elem : bits('b * 8) = read_single_element(load_width_bytes * 8, i, regidx_offset(vs3, to_bits(5, cur_field)));
+                  let elem : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(5, cur_field)));
                   let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, elem, false, false, false);
                   match (res) {
                     Ok(true)  => (),
@@ -773,7 +773,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
   };
 
   foreach (j from cur_field to (nf - 1)) {
-    let vs3_val : vector('n, bits('b * 8)) = read_vreg(elem_per_reg, load_width_bytes * 8, 0, regidx_offset(vs3, to_bits(5, j)));
+    let vs3_val : vector('n, bits('b * 8)) = read_vreg(elem_per_reg, load_width_bytes * 8, 0, vregidx_offset(vs3, to_bits(5, j)));
     foreach (i from 0 to (elem_per_reg - 1)) {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
@@ -824,17 +824,17 @@ mapping clause assembly = VSRETYPE(nf, rs1, vs3)
   <-> "vs" ^ nfields_string(nf) ^ "r.v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
 
 /* ************** Vector Mask Load/Store Unit-Stride (nf=0b000, mop=0b00, lumop or sumop=0b01011) ************** */
-union clause ast = VMTYPE : (regidx, regidx, vmlsop)
+union clause ast = VMTYPE : (regidx, vregidx, vmlsop)
 
 mapping encdec_lsop : vmlsop <-> bits(7) = {
   VLM      <-> 0b0000111,
   VSM      <-> 0b0100111
 }
 
-mapping clause encdec = VMTYPE(rs1, vd_or_vs3, op)                                                           if extensionEnabled(Ext_V)
-  <-> 0b000 @ 0b0 @ 0b00 @ 0b1 @ 0b01011 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(vd_or_vs3) @ encdec_lsop(op) if extensionEnabled(Ext_V)
+mapping clause encdec = VMTYPE(rs1, vd_or_vs3, op)                                                            if extensionEnabled(Ext_V)
+  <-> 0b000 @ 0b0 @ 0b00 @ 0b1 @ 0b01011 @ encdec_reg(rs1) @ 0b000 @ encdec_vreg(vd_or_vs3) @ encdec_lsop(op) if extensionEnabled(Ext_V)
 
-val process_vm : forall 'n 'l, ('n >= 0 & 'l >= 0). (regidx, regidx, int('n), int('l), vmlsop) -> Retired
+val process_vm : forall 'n 'l, ('n >= 0 & 'l >= 0). (vregidx, regidx, int('n), int('l), vmlsop) -> Retired
 function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
   let width_type : word_width = BYTE;
   let start_element = get_start_element();

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -64,14 +64,14 @@ mapping vlewidth_pow : vlewidth <-> {3, 4, 5, 6} = {
 /* ******************** Vector Load Unit-Stride Normal & Segment (mop=0b00, lumop=0b00000) ********************* */
 union clause ast = VLSEGTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
 
-mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd) if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if extensionEnabled(Ext_V)
+mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd)                                                    if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
 
 val process_vlseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired
 function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
-  let vm_val : bits('n) = read_vmask(num_elem, vm, 0b00000);
+  let vm_val : bits('n) = read_vmask(num_elem, vm, zreg);
   let vd_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
 
   let (result, mask) = init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val);
@@ -90,7 +90,7 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
                 TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                 TR_Address(paddr, _) => {
                   match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                    Ok(elem) => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j * EMUL_reg), elem),
+                    Ok(elem) => write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
                     Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                   }
                 }
@@ -100,7 +100,7 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
     } else { /* prestart, masked or tail segments */
       foreach (j from 0 to (nf - 1)) {
         let skipped_elem = (result[i] >> (j * load_width_bytes * 8))[(load_width_bytes * 8 - 1) .. 0];
-        write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j * EMUL_reg), skipped_elem)
+        write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_reg)), skipped_elem)
       }
     }
   };
@@ -132,14 +132,14 @@ mapping clause assembly = VLSEGTYPE(nf, vm, rs1, width, vd)
 /* ************ Vector Load Unit-Stride Normal & Segment Fault-Only-First (mop=0b00, lumop=0b10000) ************ */
 union clause ast = VLSEGFFTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
 
-mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd) if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b00 @ vm @ 0b10000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if extensionEnabled(Ext_V)
+mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd)                                                  if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b00 @ vm @ 0b10000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
 
 val process_vlsegff : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired
 function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
-  let vm_val : bits('n) = read_vmask(num_elem, vm, 0b00000);
+  let vm_val : bits('n) = read_vmask(num_elem, vm, zreg);
   let vd_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
   let tail_ag : agtype = get_vtype_vta();
 
@@ -179,7 +179,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
                 },
                 TR_Address(paddr, _) => {
                   match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                    Ok(elem) => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j * EMUL_reg), elem),
+                    Ok(elem) => write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
                     Err(e)   => {
                       if i == 0 then { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                       else {
@@ -197,7 +197,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
       } else { /* prestart, masked or tail segments */
         foreach (j from 0 to (nf - 1)) {
           let skipped_elem = (result[i] >> (j * load_width_bytes * 8))[(load_width_bytes * 8 - 1) .. 0];
-          write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j * EMUL_reg), skipped_elem)
+          write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_reg)), skipped_elem)
         }
       }
     } else {
@@ -205,7 +205,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
       if tail_ag == AGNOSTIC then {
         foreach (j from 0 to (nf - 1)) {
           let skipped_elem = (vd_seg[i] >> (j * load_width_bytes * 8))[(load_width_bytes * 8 - 1) .. 0];
-          write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j * EMUL_reg), skipped_elem)
+          write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_reg)), skipped_elem)
         }
         /* TODO: configuration support for agnostic behavior */
       }
@@ -239,14 +239,14 @@ mapping clause assembly = VLSEGFFTYPE(nf, vm, rs1, width, vd)
 /* ******************** Vector Store Unit-Stride Normal & Segment (mop=0b00, sumop=0b00000) ******************** */
 union clause ast = VSSEGTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
 
-mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3) if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111 if extensionEnabled(Ext_V)
+mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3)                                                    if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vs3) @ 0b0100111 if extensionEnabled(Ext_V)
 
 val process_vsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired
 function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
   let vs3_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
   let mask    : bits('n) = init_masked_source(num_elem, EMUL_pow, vm_val);
 
@@ -267,7 +267,7 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
                 match (eares) {
                   Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                   Ok(_)  => {
-                    let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vs3 + to_bits(5, j * EMUL_reg));
+                    let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, regidx_offset(vs3, to_bits(5, j * EMUL_reg)));
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, elem_val, false, false, false);
                     match (res) {
                       Ok(true)  => (),
@@ -310,14 +310,14 @@ mapping clause assembly = VSSEGTYPE(nf, vm, rs1, width, vs3)
 /* ****************************** Vector Load Strided Normal & Segment (mop=0b10) ****************************** */
 union clause ast = VLSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd) if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if extensionEnabled(Ext_V)
+mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)                                                      if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b10 @ vm @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
 
 val process_vlsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired
 function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
   let vd_seg  : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
   let rs2_val : int = unsigned(get_scalar(rs2, xlen));
 
@@ -337,7 +337,7 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                  Ok(elem) => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j * EMUL_reg), elem),
+                  Ok(elem) => write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
                   Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                 }
               }
@@ -347,7 +347,7 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
     } else { /* prestart, masked or tail segments */
       foreach (j from 0 to (nf - 1)) {
         let skipped_elem = (result[i] >> (j * load_width_bytes * 8))[(load_width_bytes * 8 - 1) .. 0];
-        write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j * EMUL_reg), skipped_elem)
+        write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_reg)), skipped_elem)
       }
     }
   };
@@ -379,14 +379,14 @@ mapping clause assembly = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
 /* ***************************** Vector Store Strided Normal & Segment (mop=0b10) ****************************** */
 union clause ast = VSSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3) if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111 if extensionEnabled(Ext_V)
+mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)                                                      if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b10 @ vm @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vs3) @ 0b0100111 if extensionEnabled(Ext_V)
 
 val process_vssseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired
 function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
   let vs3_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
   let rs2_val : int = unsigned(get_scalar(rs2, xlen));
   let mask    : bits('n) = init_masked_source(num_elem, EMUL_pow, vm_val);
@@ -408,7 +408,7 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
                 match (eares) {
                   Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                   Ok(_)  => {
-                    let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vs3 + to_bits(5, j * EMUL_reg));
+                    let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, regidx_offset(vs3, to_bits(5, j * EMUL_reg)));
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, elem_val, false, false, false);
                     match (res) {
                       Ok(true)  => (),
@@ -451,14 +451,14 @@ mapping clause assembly = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
 /* ************************* Vector Load Indexed Unordered Normal & Segment (mop=0b01) ************************* */
 union clause ast = VLUXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd) if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if extensionEnabled(Ext_V)
+mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)                                                     if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b01 @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
 
 val process_vlxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired
 function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
   let width_type : word_width = size_bytes(EEW_data_bytes);
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
   let vd_seg  : vector('n, bits('f * 'db * 8)) = read_vreg_seg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, nf, vd);
   let vs2_val : vector('n, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
 
@@ -479,7 +479,7 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, EEW_data_bytes, false, false, false) {
-                  Ok(elem) => write_single_element(EEW_data_bytes * 8, i, vd + to_bits(5, j * EMUL_data_reg), elem),
+                  Ok(elem) => write_single_element(EEW_data_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_data_reg)), elem),
                   Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                 }
               }
@@ -489,7 +489,7 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
     } else { /* prestart, masked or tail segments */
       foreach (j from 0 to (nf - 1)) {
         let skipped_elem = (result[i] >> (j * EEW_data_bytes * 8))[(EEW_data_bytes * 8 - 1) .. 0];
-        write_single_element(EEW_data_bytes * 8, i, vd + to_bits(5, j * EMUL_data_reg), skipped_elem)
+        write_single_element(EEW_data_bytes * 8, i, regidx_offset(vd, to_bits(5, j * EMUL_data_reg)), skipped_elem)
       }
     }
   };
@@ -521,8 +521,8 @@ mapping clause assembly = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
 /* ************************** Vector Load Indexed Ordered Normal & Segment (mop=0b11) ************************** */
 union clause ast = VLOXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd) if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if extensionEnabled(Ext_V)
+mapping clause encdec = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)                                                     if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b11 @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
 
 function clause execute(VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
   let EEW_index_pow = vlewidth_pow(width);
@@ -547,14 +547,14 @@ mapping clause assembly = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)
 /* ************************ Vector Store Indexed Unordered Normal & Segment (mop=0b01) ************************* */
 union clause ast = VSUXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3) if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111 if extensionEnabled(Ext_V)
+mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)                                                     if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b01 @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vs3) @ 0b0100111 if extensionEnabled(Ext_V)
 
 val process_vsxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired
 function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
   let width_type : word_width = size_bytes(EEW_data_bytes);
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zreg);
   let vs3_seg : vector('n, bits('f * 'db * 8)) = read_vreg_seg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, nf, vs3);
   let vs2_val : vector('n, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
   let mask    : bits('n) = init_masked_source(num_elem, EMUL_data_pow, vm_val);
@@ -577,7 +577,7 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
                 match (eares) {
                   Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                   Ok(_)  => {
-                    let elem_val : bits('db * 8) = read_single_element(EEW_data_bytes * 8, i, vs3 + to_bits(5, j * EMUL_data_reg));
+                    let elem_val : bits('db * 8) = read_single_element(EEW_data_bytes * 8, i, regidx_offset(vs3, to_bits(5, j * EMUL_data_reg)));
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, EEW_data_bytes, elem_val, false, false, false);
                     match (res) {
                       Ok(true)  => (),
@@ -620,8 +620,8 @@ mapping clause assembly = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
 /* ************************* Vector Store Indexed Ordered Normal & Segment (mop=0b11) ************************** */
 union clause ast = VSOXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, regidx)
 
-mapping clause encdec = VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3) if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b11 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111 if extensionEnabled(Ext_V)
+mapping clause encdec = VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)                                                     if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b11 @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vs3) @ 0b0100111 if extensionEnabled(Ext_V)
 
 function clause execute(VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
   let EEW_index_pow = vlewidth_pow(width);
@@ -646,8 +646,8 @@ mapping clause assembly = VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
 /* ***************** Vector Load Unit-Stride Whole Register (vm=0b1, mop=0b00, lumop=0b01000) ****************** */
 union clause ast = VLRETYPE : (bits(3), regidx, vlewidth, regidx)
 
-mapping clause encdec = VLRETYPE(nf, rs1, width, vd) if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if extensionEnabled(Ext_V)
+mapping clause encdec = VLRETYPE(nf, rs1, width, vd)                                                          if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_reg(vd) @ 0b0000111 if extensionEnabled(Ext_V)
 
 val process_vlre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), regidx, int('b), regidx, int('n)) -> Retired
 function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
@@ -671,7 +671,7 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
             TR_Address(paddr, _) => {
               match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                Ok(elem) => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, cur_field), elem),
+                Ok(elem) => write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, cur_field)), elem),
                 Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
               }
             }
@@ -695,7 +695,7 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
             TR_Address(paddr, _) => {
               match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                Ok(elem) => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j), elem),
+                Ok(elem) => write_single_element(load_width_bytes * 8, i, regidx_offset(vd, to_bits(5, j)), elem),
                 Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
               }
             }
@@ -727,8 +727,8 @@ mapping clause assembly = VLRETYPE(nf, rs1, width, vd)
 /* ***************** Vector Store Unit-Stride Whole Register (vm=0b1, mop=0b00, lumop=0b01000) ***************** */
 union clause ast = VSRETYPE : (bits(3), regidx, regidx)
 
-mapping clause encdec = VSRETYPE(nf, rs1, vs3) if extensionEnabled(Ext_V)
-  <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ rs1 @ 0b000 @ vs3 @ 0b0100111 if extensionEnabled(Ext_V)
+mapping clause encdec = VSRETYPE(nf, rs1, vs3)                                                if extensionEnabled(Ext_V)
+  <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(vs3) @ 0b0100111 if extensionEnabled(Ext_V)
 
 val process_vsre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), int('b), regidx, regidx, int('n)) -> Retired
 function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
@@ -755,7 +755,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
               match (eares) {
                 Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                 Ok(_)  => {
-                  let elem : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vs3 + to_bits(5, cur_field));
+                  let elem : bits('b * 8) = read_single_element(load_width_bytes * 8, i, regidx_offset(vs3, to_bits(5, cur_field)));
                   let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, elem, false, false, false);
                   match (res) {
                     Ok(true)  => (),
@@ -773,7 +773,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
   };
 
   foreach (j from cur_field to (nf - 1)) {
-    let vs3_val : vector('n, bits('b * 8)) = read_vreg(elem_per_reg, load_width_bytes * 8, 0, vs3 + to_bits(5, j));
+    let vs3_val : vector('n, bits('b * 8)) = read_vreg(elem_per_reg, load_width_bytes * 8, 0, regidx_offset(vs3, to_bits(5, j)));
     foreach (i from 0 to (elem_per_reg - 1)) {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
@@ -831,8 +831,8 @@ mapping encdec_lsop : vmlsop <-> bits(7) = {
   VSM      <-> 0b0100111
 }
 
-mapping clause encdec = VMTYPE(rs1, vd_or_vs3, op) if extensionEnabled(Ext_V)
-  <-> 0b000 @ 0b0 @ 0b00 @ 0b1 @ 0b01011 @ rs1 @ 0b000 @ vd_or_vs3 @ encdec_lsop(op) if extensionEnabled(Ext_V)
+mapping clause encdec = VMTYPE(rs1, vd_or_vs3, op)                                                           if extensionEnabled(Ext_V)
+  <-> 0b000 @ 0b0 @ 0b00 @ 0b1 @ 0b01011 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(vd_or_vs3) @ encdec_lsop(op) if extensionEnabled(Ext_V)
 
 val process_vm : forall 'n 'l, ('n >= 0 & 'l >= 0). (regidx, regidx, int('n), int('l), vmlsop) -> Retired
 function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {

--- a/model/riscv_insts_vext_red.sail
+++ b/model/riscv_insts_vext_red.sail
@@ -19,8 +19,8 @@ mapping encdec_rivvfunct6 : rivvfunct6 <-> bits(6) = {
   IVV_VWREDSUM    <-> 0b110001
 }
 
-mapping clause encdec = RIVVTYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_rivvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = RIVVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_rivvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(RIVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -39,7 +39,7 @@ function clause execute(RIVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zreg);
   let vd_val  : vector('d, bits('o)) = read_vreg(num_elem_vd, SEW_widen, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
   let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
@@ -84,8 +84,8 @@ mapping encdec_rmvvfunct6 : rmvvfunct6 <-> bits(6) = {
   MVV_VREDMAX     <-> 0b000111
 }
 
-mapping clause encdec = RMVVTYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_rmvvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = RMVVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_rmvvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(RMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -101,7 +101,7 @@ function clause execute(RMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'd = num_elem_vd;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zreg);
   let vd_val  : vector('d, bits('m)) = read_vreg(num_elem_vd, SEW, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
   let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);

--- a/model/riscv_insts_vext_red.sail
+++ b/model/riscv_insts_vext_red.sail
@@ -12,15 +12,15 @@
 /* ******************************************************************************* */
 
 /* ********************* OPIVV (Widening Integer Reduction) ********************** */
-union clause ast = RIVVTYPE : (rivvfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = RIVVTYPE : (rivvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_rivvfunct6 : rivvfunct6 <-> bits(6) = {
   IVV_VWREDSUMU   <-> 0b110000,
   IVV_VWREDSUM    <-> 0b110001
 }
 
-mapping clause encdec = RIVVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_rivvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = RIVVTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_rivvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(RIVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -39,7 +39,7 @@ function clause execute(RIVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'm = SEW;
   let 'o = SEW_widen;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zvreg);
   let vd_val  : vector('d, bits('o)) = read_vreg(num_elem_vd, SEW_widen, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
   let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
@@ -71,7 +71,7 @@ mapping clause assembly = RIVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> rivvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
 /* ******************* OPMVV (Single-Width Integer Reduction) ******************** */
-union clause ast = RMVVTYPE : (rmvvfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = RMVVTYPE : (rmvvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_rmvvfunct6 : rmvvfunct6 <-> bits(6) = {
   MVV_VREDSUM     <-> 0b000000,
@@ -84,8 +84,8 @@ mapping encdec_rmvvfunct6 : rmvvfunct6 <-> bits(6) = {
   MVV_VREDMAX     <-> 0b000111
 }
 
-mapping clause encdec = RMVVTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_rmvvfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b010 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = RMVVTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_rmvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(RMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -101,7 +101,7 @@ function clause execute(RMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'd = num_elem_vd;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zvreg);
   let vd_val  : vector('d, bits('m)) = read_vreg(num_elem_vd, SEW, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
   let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -49,7 +49,7 @@ function assert_vstart(i) = {
  */
 val valid_rd_mask : (regidx, bits(1)) -> bool
 function valid_rd_mask(rd, vm) = {
-  vm != 0b0 | rd != 0b00000
+  vm != 0b0 | rd != zreg
 }
 
 /* Check for valid register overlap in vector widening/narrowing instructions:
@@ -62,8 +62,8 @@ val valid_reg_overlap : (regidx, regidx, int, int) -> bool
 function valid_reg_overlap(rs, rd, EMUL_pow_rs, EMUL_pow_rd) = {
   let rs_group = if EMUL_pow_rs > 0 then 2 ^ EMUL_pow_rs else 1;
   let rd_group = if EMUL_pow_rd > 0 then 2 ^ EMUL_pow_rd else 1;
-  let rs_int = unsigned(rs);
-  let rd_int = unsigned(rd);
+  let rs_int = unsigned(regidx_bits(rs));
+  let rd_int = unsigned(regidx_bits(rd));
   if EMUL_pow_rs < EMUL_pow_rd then {
     (rs_int + rs_group <= rd_int) | (rs_int >= rd_int + rd_group) |
     ((rs_int + rs_group == rd_int + rd_group) & (EMUL_pow_rs >= 0))
@@ -95,7 +95,7 @@ function illegal_normal(vd, vm) = {
 /* b. Masked check for instructions encoded with vm = 0 */
 val illegal_vd_masked : regidx -> bool
 function illegal_vd_masked(vd) = {
-  not(valid_vtype()) | vd == 0b00000
+  not(valid_vtype()) | vd == zreg
 }
 
 /* c. Unmasked check for:
@@ -375,7 +375,7 @@ function read_vreg_seg(num_elem, SEW, LMUL_pow, nf, vrid) = {
   var vreg_list : vector('q, vector('n, bits('m))) = vector_init(vector_init(zeros()));
   var result : vector('n, bits('q * 'm)) = vector_init(zeros());
   foreach (j from 0 to (nf - 1)) {
-    vreg_list[j] = read_vreg(num_elem, SEW, LMUL_pow, vrid + to_bits(5, j * LMUL_reg));
+    vreg_list[j] = read_vreg(num_elem, SEW, LMUL_pow, regidx_offset(vrid, to_bits(5, j * LMUL_reg)));
   };
   foreach (i from 0 to (num_elem - 1)) {
     result[i] = zeros('q * 'm);

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -47,9 +47,9 @@ function assert_vstart(i) = {
  *  unless the destination vector register is being written with a mask value (e.g., compares)
  *  or the scalar result of a reduction.
  */
-val valid_rd_mask : (regidx, bits(1)) -> bool
+val valid_rd_mask : (vregidx, bits(1)) -> bool
 function valid_rd_mask(rd, vm) = {
-  vm != 0b0 | rd != zreg
+  vm != 0b0 | rd != zvreg
 }
 
 /* Check for valid register overlap in vector widening/narrowing instructions:
@@ -58,12 +58,12 @@ function valid_rd_mask(rd, vm) = {
  *  In a narrowing instruction, the overlap is valid only in the lowest-numbered part
  *  of the source register group.
  */
-val valid_reg_overlap : (regidx, regidx, int, int) -> bool
+val valid_reg_overlap : (vregidx, vregidx, int, int) -> bool
 function valid_reg_overlap(rs, rd, EMUL_pow_rs, EMUL_pow_rd) = {
   let rs_group = if EMUL_pow_rs > 0 then 2 ^ EMUL_pow_rs else 1;
   let rd_group = if EMUL_pow_rd > 0 then 2 ^ EMUL_pow_rd else 1;
-  let rs_int = unsigned(regidx_bits(rs));
-  let rd_int = unsigned(regidx_bits(rd));
+  let rs_int = unsigned(vregidx_bits(rs));
+  let rd_int = unsigned(vregidx_bits(rd));
   if EMUL_pow_rs < EMUL_pow_rd then {
     (rs_int + rs_group <= rd_int) | (rs_int >= rd_int + rd_group) |
     ((rs_int + rs_group == rd_int + rd_group) & (EMUL_pow_rs >= 0))
@@ -87,15 +87,15 @@ function valid_segment(nf, EMUL_pow) = {
 /* ******************************************************************************* */
 
 /* a. Normal check including vtype.vill field and vd/v0 overlap if vm = 0 */
-val illegal_normal : (regidx, bits(1)) -> bool
+val illegal_normal : (vregidx, bits(1)) -> bool
 function illegal_normal(vd, vm) = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm))
 }
 
 /* b. Masked check for instructions encoded with vm = 0 */
-val illegal_vd_masked : regidx -> bool
+val illegal_vd_masked : vregidx -> bool
 function illegal_vd_masked(vd) = {
-  not(valid_vtype()) | vd == zreg
+  not(valid_vtype()) | vd == zvreg
 }
 
 /* c. Unmasked check for:
@@ -113,7 +113,7 @@ function illegal_vd_unmasked() = {
  *  1. integer/fixed-point widening/narrowing instructions
  *  2. vector integer extension: vzext, vsext
  */
-val illegal_variable_width : (regidx, bits(1), int, int) -> bool
+val illegal_variable_width : (vregidx, bits(1), int, int) -> bool
 function illegal_variable_width(vd, vm, SEW_new, LMUL_pow_new) = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm)) | not(valid_eew_emul(SEW_new, LMUL_pow_new))
 }
@@ -134,7 +134,7 @@ function illegal_reduction_widen(SEW_widen, LMUL_pow_widen) = {
 }
 
 /* g. Non-indexed load instruction check */
-val illegal_load : (regidx, bits(1), int, int, int) -> bool
+val illegal_load : (vregidx, bits(1), int, int, int) -> bool
 function illegal_load(vd, vm, nf, EEW, EMUL_pow) = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm)) |
   not(valid_eew_emul(EEW, EMUL_pow)) | not(valid_segment(nf, EMUL_pow))
@@ -147,7 +147,7 @@ function illegal_store(nf, EEW, EMUL_pow) = {
 }
 
 /* i. Indexed load instruction check */
-val illegal_indexed_load : (regidx, bits(1), int, int, int, int) -> bool
+val illegal_indexed_load : (vregidx, bits(1), int, int, int, int) -> bool
 function illegal_indexed_load(vd, vm, nf, EEW_index, EMUL_pow_index, EMUL_pow_data) = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm)) |
   not(valid_eew_emul(EEW_index, EMUL_pow_index)) | not(valid_segment(nf, EMUL_pow_data))
@@ -369,13 +369,13 @@ function init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
  *   Read multiple register groups and concatenate them in parallel
  *   The whole segments with the same element index are combined together
  */
-val read_vreg_seg : forall 'n 'm 'p 'q, 'n >= 0 & 'm >= 0 & 'q >= 0. (int('n), int('m), int('p), int('q), regidx) -> vector('n, bits('q * 'm))
+val read_vreg_seg : forall 'n 'm 'p 'q, 'n >= 0 & 'm >= 0 & 'q >= 0. (int('n), int('m), int('p), int('q), vregidx) -> vector('n, bits('q * 'm))
 function read_vreg_seg(num_elem, SEW, LMUL_pow, nf, vrid) = {
   let LMUL_reg : int = if LMUL_pow <= 0 then 1 else 2 ^ LMUL_pow;
   var vreg_list : vector('q, vector('n, bits('m))) = vector_init(vector_init(zeros()));
   var result : vector('n, bits('q * 'm)) = vector_init(zeros());
   foreach (j from 0 to (nf - 1)) {
-    vreg_list[j] = read_vreg(num_elem, SEW, LMUL_pow, regidx_offset(vrid, to_bits(5, j * LMUL_reg)));
+    vreg_list[j] = read_vreg(num_elem, SEW, LMUL_pow, vregidx_offset(vrid, to_bits(5, j * LMUL_reg)));
   };
   foreach (i from 0 to (num_elem - 1)) {
     result[i] = zeros('q * 'm);

--- a/model/riscv_insts_vext_vm.sail
+++ b/model/riscv_insts_vext_vm.sail
@@ -15,15 +15,15 @@
 /* VVM instructions' destination is a mask register (e.g. carry out) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VVMTYPE : (vvmfunct6, regidx, regidx, regidx)
+union clause ast = VVMTYPE : (vvmfunct6, vregidx, vregidx, vregidx)
 
 mapping encdec_vvmfunct6 : vvmfunct6 <-> bits(6) = {
   VVM_VMADC    <-> 0b010001, /* carry in, carry out */
   VVM_VMSBC    <-> 0b010011
 }
 
-mapping clause encdec = VVMTYPE(funct6, vs2, vs1, vd)                                                         if extensionEnabled(Ext_V)
-  <-> encdec_vvmfunct6(funct6) @ 0b0 @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VVMTYPE(funct6, vs2, vs1, vd)                                                            if extensionEnabled(Ext_V)
+  <-> encdec_vvmfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VVMTYPE(funct6, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -35,7 +35,7 @@ function clause execute(VVMTYPE(funct6, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zreg);
+  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zvreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
@@ -70,15 +70,15 @@ mapping clause assembly = VVMTYPE(funct6, vs2, vs1, vd)
 /* VVMC instructions' destination is a mask register (e.g. carry out) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VVMCTYPE : (vvmcfunct6, regidx, regidx, regidx)
+union clause ast = VVMCTYPE : (vvmcfunct6, vregidx, vregidx, vregidx)
 
 mapping encdec_vvmcfunct6 : vvmcfunct6 <-> bits(6) = {
   VVMC_VMADC    <-> 0b010001, /* no carry in, carry out */
   VVMC_VMSBC    <-> 0b010011
 }
 
-mapping clause encdec = VVMCTYPE(funct6, vs2, vs1, vd)                                                         if extensionEnabled(Ext_V)
-  <-> encdec_vvmcfunct6(funct6) @ 0b1 @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VVMCTYPE(funct6, vs2, vs1, vd)                                                            if extensionEnabled(Ext_V)
+  <-> encdec_vvmcfunct6(funct6) @ 0b1 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VVMCTYPE(funct6, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -124,15 +124,15 @@ mapping clause assembly = VVMCTYPE(funct6, vs2, vs1, vd)
 /* VVMS instructions' destination is a vector register (e.g. actual sum) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VVMSTYPE : (vvmsfunct6, regidx, regidx, regidx)
+union clause ast = VVMSTYPE : (vvmsfunct6, vregidx, vregidx, vregidx)
 
 mapping encdec_vvmsfunct6 : vvmsfunct6 <-> bits(6) = {
   VVMS_VADC     <-> 0b010000, /* carry in, no carry out */
   VVMS_VSBC     <-> 0b010010
 }
 
-mapping clause encdec = VVMSTYPE(funct6, vs2, vs1, vd)                                                         if extensionEnabled(Ext_V)
-  <-> encdec_vvmsfunct6(funct6) @ 0b0 @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VVMSTYPE(funct6, vs2, vs1, vd)                                                            if extensionEnabled(Ext_V)
+  <-> encdec_vvmsfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VVMSTYPE(funct6, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -147,7 +147,7 @@ function clause execute(VVMSTYPE(funct6, vs2, vs1, vd)) = {
   /* for bypassing normal masking in init_masked_result */
   let vec_trues : bits('n) = ones();
 
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zreg);
+  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zvreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -179,7 +179,7 @@ mapping clause assembly = VVMSTYPE(funct6, vs2, vs1, vd)
 
 /* ***************** OPIVV (Vector Integer Compare Instructions) ***************** */
 /* VVCMP instructions' destination is a mask register */
-union clause ast = VVCMPTYPE : (vvcmpfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = VVCMPTYPE : (vvcmpfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_vvcmpfunct6 : vvcmpfunct6 <-> bits(6) = {
   VVCMP_VMSEQ    <-> 0b011000,
@@ -190,8 +190,8 @@ mapping encdec_vvcmpfunct6 : vvcmpfunct6 <-> bits(6) = {
   VVCMP_VMSLE    <-> 0b011101
 }
 
-mapping clause encdec = VVCMPTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_vvcmpfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VVCMPTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
+  <-> encdec_vvcmpfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VVCMPTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -203,7 +203,7 @@ function clause execute(VVCMPTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
@@ -246,15 +246,15 @@ mapping clause assembly = VVCMPTYPE(funct6, vm, vs2, vs1, vd)
 /* VXM instructions' destination is a mask register (e.g. carry out) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VXMTYPE : (vxmfunct6, regidx, regidx, regidx)
+union clause ast = VXMTYPE : (vxmfunct6, vregidx, regidx, vregidx)
 
 mapping encdec_vxmfunct6 : vxmfunct6 <-> bits(6) = {
   VXM_VMADC    <-> 0b010001, /* carry in, carry out */
   VXM_VMSBC    <-> 0b010011
 }
 
-mapping clause encdec = VXMTYPE(funct6, vs2, rs1, vd)                                                         if extensionEnabled(Ext_V)
-  <-> encdec_vxmfunct6(funct6) @ 0b0 @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VXMTYPE(funct6, vs2, rs1, vd)                                                           if extensionEnabled(Ext_V)
+  <-> encdec_vxmfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VXMTYPE(funct6, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -266,7 +266,7 @@ function clause execute(VXMTYPE(funct6, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zreg);
+  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zvreg);
   let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
@@ -301,15 +301,15 @@ mapping clause assembly = VXMTYPE(funct6, vs2, rs1, vd)
 /* VXMC instructions' destination is a mask register (e.g. carry out) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VXMCTYPE : (vxmcfunct6, regidx, regidx, regidx)
+union clause ast = VXMCTYPE : (vxmcfunct6, vregidx, regidx, vregidx)
 
 mapping encdec_vxmcfunct6 : vxmcfunct6 <-> bits(6) = {
   VXMC_VMADC    <-> 0b010001, /* carry in, carry out */
   VXMC_VMSBC    <-> 0b010011
 }
 
-mapping clause encdec = VXMCTYPE(funct6, vs2, rs1, vd)                                                         if extensionEnabled(Ext_V)
-  <-> encdec_vxmcfunct6(funct6) @ 0b1 @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VXMCTYPE(funct6, vs2, rs1, vd)                                                           if extensionEnabled(Ext_V)
+  <-> encdec_vxmcfunct6(funct6) @ 0b1 @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VXMCTYPE(funct6, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -355,15 +355,15 @@ mapping clause assembly = VXMCTYPE(funct6, vs2, rs1, vd)
 /* VXMS instructions' destination is a vector register (e.g. actual sum) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VXMSTYPE : (vxmsfunct6, regidx, regidx, regidx)
+union clause ast = VXMSTYPE : (vxmsfunct6, vregidx, regidx, vregidx)
 
 mapping encdec_vxmsfunct6 : vxmsfunct6 <-> bits(6) = {
   VXMS_VADC     <-> 0b010000, /* carry in, no carry out */
   VXMS_VSBC     <-> 0b010010
 }
 
-mapping clause encdec = VXMSTYPE(funct6, vs2, rs1, vd)                                                         if extensionEnabled(Ext_V)
-  <-> encdec_vxmsfunct6(funct6) @ 0b0 @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VXMSTYPE(funct6, vs2, rs1, vd)                                                           if extensionEnabled(Ext_V)
+  <-> encdec_vxmsfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VXMSTYPE(funct6, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -378,7 +378,7 @@ function clause execute(VXMSTYPE(funct6, vs2, rs1, vd)) = {
   /* for bypassing normal masking in init_masked_result */
   let vec_trues : bits('n) = ones();
 
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zreg);
+  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zvreg);
   let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -410,7 +410,7 @@ mapping clause assembly = VXMSTYPE(funct6, vs2, rs1, vd)
 
 /* ***************** OPIVX (Vector Integer Compare Instructions) ***************** */
 /* VXCMP instructions' destination is a mask register */
-union clause ast = VXCMPTYPE : (vxcmpfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = VXCMPTYPE : (vxcmpfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_vxcmpfunct6 : vxcmpfunct6 <-> bits(6) = {
   VXCMP_VMSEQ    <-> 0b011000,
@@ -423,8 +423,8 @@ mapping encdec_vxcmpfunct6 : vxcmpfunct6 <-> bits(6) = {
   VXCMP_VMSGT    <-> 0b011111
 }
 
-mapping clause encdec = VXCMPTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> encdec_vxcmpfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VXCMPTYPE(funct6, vm, vs2, rs1, vd)                                                      if extensionEnabled(Ext_V)
+  <-> encdec_vxcmpfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VXCMPTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -436,7 +436,7 @@ function clause execute(VXCMPTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
   let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
@@ -483,14 +483,14 @@ mapping clause assembly = VXCMPTYPE(funct6, vm, vs2, rs1, vd)
 /* VIM instructions' destination is a mask register (e.g. carry out) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VIMTYPE : (vimfunct6, regidx, bits(5), regidx)
+union clause ast = VIMTYPE : (vimfunct6, vregidx, bits(5), vregidx)
 
 mapping encdec_vimfunct6 : vimfunct6 <-> bits(6) = {
   VIM_VMADC    <-> 0b010001 /* carry in, carry out */
 }
 
-mapping clause encdec = VIMTYPE(funct6, vs2, simm, vd)                                             if extensionEnabled(Ext_V)
-  <-> encdec_vimfunct6(funct6) @ 0b0 @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VIMTYPE(funct6, vs2, simm, vd)                                               if extensionEnabled(Ext_V)
+  <-> encdec_vimfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VIMTYPE(funct6, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -502,7 +502,7 @@ function clause execute(VIMTYPE(funct6, vs2, simm, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zreg);
+  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zvreg);
   let imm_val : bits('m)                  = sign_extend(simm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
@@ -535,14 +535,14 @@ mapping clause assembly = VIMTYPE(funct6, vs2, simm, vd)
 /* VIMC instructions' destination is a mask register (e.g. carry out) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VIMCTYPE : (vimcfunct6, regidx, bits(5), regidx)
+union clause ast = VIMCTYPE : (vimcfunct6, vregidx, bits(5), vregidx)
 
 mapping encdec_vimcfunct6 : vimcfunct6 <-> bits(6) = {
   VIMC_VMADC    <-> 0b010001 /* carry in, carry out */
 }
 
-mapping clause encdec = VIMCTYPE(funct6, vs2, simm, vd)                                             if extensionEnabled(Ext_V)
-  <-> encdec_vimcfunct6(funct6) @ 0b1 @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VIMCTYPE(funct6, vs2, simm, vd)                                               if extensionEnabled(Ext_V)
+  <-> encdec_vimcfunct6(funct6) @ 0b1 @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VIMCTYPE(funct6, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -586,14 +586,14 @@ mapping clause assembly = VIMCTYPE(funct6, vs2, simm, vd)
 /* VIMS instructions' destination is a vector register (e.g. actual sum) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VIMSTYPE : (vimsfunct6, regidx, bits(5), regidx)
+union clause ast = VIMSTYPE : (vimsfunct6, vregidx, bits(5), vregidx)
 
 mapping encdec_vimsfunct6 : vimsfunct6 <-> bits(6) = {
   VIMS_VADC     <-> 0b010000 /* Carry in, no carry out */
 }
 
-mapping clause encdec = VIMSTYPE(funct6, vs2, simm, vd)                                             if extensionEnabled(Ext_V)
-  <-> encdec_vimsfunct6(funct6) @ 0b0 @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VIMSTYPE(funct6, vs2, simm, vd)                                               if extensionEnabled(Ext_V)
+  <-> encdec_vimsfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VIMSTYPE(funct6, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -608,7 +608,7 @@ function clause execute(VIMSTYPE(funct6, vs2, simm, vd)) = {
   /* for bypassing normal masking in init_masked_result */
   let vec_trues : bits('n) = ones();
 
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zreg);
+  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zvreg);
   let imm_val : bits('m)                  = sign_extend(simm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -638,7 +638,7 @@ mapping clause assembly = VIMSTYPE(funct6, vs2, simm, vd)
 
 /* ***************** OPIVI (Vector Integer Compare Instructions) ***************** */
 /* VICMP instructions' destination is a mask register */
-union clause ast = VICMPTYPE : (vicmpfunct6, bits(1), regidx, bits(5), regidx)
+union clause ast = VICMPTYPE : (vicmpfunct6, bits(1), vregidx, bits(5), vregidx)
 
 mapping encdec_vicmpfunct6 : vicmpfunct6 <-> bits(6) = {
   VICMP_VMSEQ    <-> 0b011000,
@@ -649,8 +649,8 @@ mapping encdec_vicmpfunct6 : vicmpfunct6 <-> bits(6) = {
   VICMP_VMSGT    <-> 0b011111
 }
 
-mapping clause encdec = VICMPTYPE(funct6, vm, vs2, simm, vd)                                        if extensionEnabled(Ext_V)
-  <-> encdec_vicmpfunct6(funct6) @ vm @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VICMPTYPE(funct6, vm, vs2, simm, vd)                                          if extensionEnabled(Ext_V)
+  <-> encdec_vicmpfunct6(funct6) @ vm @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VICMPTYPE(funct6, vm, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -662,7 +662,7 @@ function clause execute(VICMPTYPE(funct6, vm, vs2, simm, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
   let imm_val : bits('m)                  = sign_extend(simm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);

--- a/model/riscv_insts_vext_vm.sail
+++ b/model/riscv_insts_vext_vm.sail
@@ -22,8 +22,8 @@ mapping encdec_vvmfunct6 : vvmfunct6 <-> bits(6) = {
   VVM_VMSBC    <-> 0b010011
 }
 
-mapping clause encdec = VVMTYPE(funct6, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_vvmfunct6(funct6) @ 0b0 @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VVMTYPE(funct6, vs2, vs1, vd)                                                         if extensionEnabled(Ext_V)
+  <-> encdec_vvmfunct6(funct6) @ 0b0 @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VVMTYPE(funct6, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -35,7 +35,7 @@ function clause execute(VVMTYPE(funct6, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, 0b00000);
+  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
@@ -77,8 +77,8 @@ mapping encdec_vvmcfunct6 : vvmcfunct6 <-> bits(6) = {
   VVMC_VMSBC    <-> 0b010011
 }
 
-mapping clause encdec = VVMCTYPE(funct6, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_vvmcfunct6(funct6) @ 0b1 @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VVMCTYPE(funct6, vs2, vs1, vd)                                                         if extensionEnabled(Ext_V)
+  <-> encdec_vvmcfunct6(funct6) @ 0b1 @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VVMCTYPE(funct6, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -131,8 +131,8 @@ mapping encdec_vvmsfunct6 : vvmsfunct6 <-> bits(6) = {
   VVMS_VSBC     <-> 0b010010
 }
 
-mapping clause encdec = VVMSTYPE(funct6, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_vvmsfunct6(funct6) @ 0b0 @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VVMSTYPE(funct6, vs2, vs1, vd)                                                         if extensionEnabled(Ext_V)
+  <-> encdec_vvmsfunct6(funct6) @ 0b0 @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VVMSTYPE(funct6, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -147,7 +147,7 @@ function clause execute(VVMSTYPE(funct6, vs2, vs1, vd)) = {
   /* for bypassing normal masking in init_masked_result */
   let vec_trues : bits('n) = ones();
 
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, 0b00000);
+  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -190,8 +190,8 @@ mapping encdec_vvcmpfunct6 : vvcmpfunct6 <-> bits(6) = {
   VVCMP_VMSLE    <-> 0b011101
 }
 
-mapping clause encdec = VVCMPTYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_vvcmpfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VVCMPTYPE(funct6, vm, vs2, vs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_vvcmpfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(vs1) @ 0b000 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VVCMPTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -203,7 +203,7 @@ function clause execute(VVCMPTYPE(funct6, vm, vs2, vs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
@@ -253,8 +253,8 @@ mapping encdec_vxmfunct6 : vxmfunct6 <-> bits(6) = {
   VXM_VMSBC    <-> 0b010011
 }
 
-mapping clause encdec = VXMTYPE(funct6, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_vxmfunct6(funct6) @ 0b0 @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VXMTYPE(funct6, vs2, rs1, vd)                                                         if extensionEnabled(Ext_V)
+  <-> encdec_vxmfunct6(funct6) @ 0b0 @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VXMTYPE(funct6, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -266,7 +266,7 @@ function clause execute(VXMTYPE(funct6, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, 0b00000);
+  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zreg);
   let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
@@ -308,8 +308,8 @@ mapping encdec_vxmcfunct6 : vxmcfunct6 <-> bits(6) = {
   VXMC_VMSBC    <-> 0b010011
 }
 
-mapping clause encdec = VXMCTYPE(funct6, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_vxmcfunct6(funct6) @ 0b1 @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VXMCTYPE(funct6, vs2, rs1, vd)                                                         if extensionEnabled(Ext_V)
+  <-> encdec_vxmcfunct6(funct6) @ 0b1 @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VXMCTYPE(funct6, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -321,7 +321,7 @@ function clause execute(VXMCTYPE(funct6, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
+  let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
@@ -362,8 +362,8 @@ mapping encdec_vxmsfunct6 : vxmsfunct6 <-> bits(6) = {
   VXMS_VSBC     <-> 0b010010
 }
 
-mapping clause encdec = VXMSTYPE(funct6, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_vxmsfunct6(funct6) @ 0b0 @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VXMSTYPE(funct6, vs2, rs1, vd)                                                         if extensionEnabled(Ext_V)
+  <-> encdec_vxmsfunct6(funct6) @ 0b0 @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VXMSTYPE(funct6, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -378,7 +378,7 @@ function clause execute(VXMSTYPE(funct6, vs2, rs1, vd)) = {
   /* for bypassing normal masking in init_masked_result */
   let vec_trues : bits('n) = ones();
 
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, 0b00000);
+  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zreg);
   let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -423,8 +423,8 @@ mapping encdec_vxcmpfunct6 : vxcmpfunct6 <-> bits(6) = {
   VXCMP_VMSGT    <-> 0b011111
 }
 
-mapping clause encdec = VXCMPTYPE(funct6, vm, vs2, rs1, vd) if extensionEnabled(Ext_V)
-  <-> encdec_vxcmpfunct6(funct6) @ vm @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VXCMPTYPE(funct6, vm, vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
+  <-> encdec_vxcmpfunct6(funct6) @ vm @ encdec_reg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VXCMPTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -436,7 +436,7 @@ function clause execute(VXCMPTYPE(funct6, vm, vs2, rs1, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
   let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
@@ -483,14 +483,14 @@ mapping clause assembly = VXCMPTYPE(funct6, vm, vs2, rs1, vd)
 /* VIM instructions' destination is a mask register (e.g. carry out) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VIMTYPE : (vimfunct6, regidx, regidx, regidx)
+union clause ast = VIMTYPE : (vimfunct6, regidx, bits(5), regidx)
 
 mapping encdec_vimfunct6 : vimfunct6 <-> bits(6) = {
   VIM_VMADC    <-> 0b010001 /* carry in, carry out */
 }
 
-mapping clause encdec = VIMTYPE(funct6, vs2, simm, vd) if extensionEnabled(Ext_V)
-  <-> encdec_vimfunct6(funct6) @ 0b0 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VIMTYPE(funct6, vs2, simm, vd)                                             if extensionEnabled(Ext_V)
+  <-> encdec_vimfunct6(funct6) @ 0b0 @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VIMTYPE(funct6, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -502,7 +502,7 @@ function clause execute(VIMTYPE(funct6, vs2, simm, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, 0b00000);
+  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zreg);
   let imm_val : bits('m)                  = sign_extend(simm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
@@ -535,14 +535,14 @@ mapping clause assembly = VIMTYPE(funct6, vs2, simm, vd)
 /* VIMC instructions' destination is a mask register (e.g. carry out) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VIMCTYPE : (vimcfunct6, regidx, regidx, regidx)
+union clause ast = VIMCTYPE : (vimcfunct6, regidx, bits(5), regidx)
 
 mapping encdec_vimcfunct6 : vimcfunct6 <-> bits(6) = {
   VIMC_VMADC    <-> 0b010001 /* carry in, carry out */
 }
 
-mapping clause encdec = VIMCTYPE(funct6, vs2, simm, vd) if extensionEnabled(Ext_V)
-  <-> encdec_vimcfunct6(funct6) @ 0b1 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VIMCTYPE(funct6, vs2, simm, vd)                                             if extensionEnabled(Ext_V)
+  <-> encdec_vimcfunct6(funct6) @ 0b1 @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VIMCTYPE(funct6, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -554,7 +554,7 @@ function clause execute(VIMCTYPE(funct6, vs2, simm, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let imm_val : bits('m)                  = sign_extend(simm);
+  let imm_val : bits('m)             = sign_extend(simm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
@@ -586,14 +586,14 @@ mapping clause assembly = VIMCTYPE(funct6, vs2, simm, vd)
 /* VIMS instructions' destination is a vector register (e.g. actual sum) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VIMSTYPE : (vimsfunct6, regidx, regidx, regidx)
+union clause ast = VIMSTYPE : (vimsfunct6, regidx, bits(5), regidx)
 
 mapping encdec_vimsfunct6 : vimsfunct6 <-> bits(6) = {
   VIMS_VADC     <-> 0b010000 /* Carry in, no carry out */
 }
 
-mapping clause encdec = VIMSTYPE(funct6, vs2, simm, vd) if extensionEnabled(Ext_V)
-  <-> encdec_vimsfunct6(funct6) @ 0b0 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VIMSTYPE(funct6, vs2, simm, vd)                                             if extensionEnabled(Ext_V)
+  <-> encdec_vimsfunct6(funct6) @ 0b0 @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VIMSTYPE(funct6, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -608,7 +608,7 @@ function clause execute(VIMSTYPE(funct6, vs2, simm, vd)) = {
   /* for bypassing normal masking in init_masked_result */
   let vec_trues : bits('n) = ones();
 
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, 0b00000);
+  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zreg);
   let imm_val : bits('m)                  = sign_extend(simm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
@@ -638,7 +638,7 @@ mapping clause assembly = VIMSTYPE(funct6, vs2, simm, vd)
 
 /* ***************** OPIVI (Vector Integer Compare Instructions) ***************** */
 /* VICMP instructions' destination is a mask register */
-union clause ast = VICMPTYPE : (vicmpfunct6, bits(1), regidx, regidx, regidx)
+union clause ast = VICMPTYPE : (vicmpfunct6, bits(1), regidx, bits(5), regidx)
 
 mapping encdec_vicmpfunct6 : vicmpfunct6 <-> bits(6) = {
   VICMP_VMSEQ    <-> 0b011000,
@@ -649,8 +649,8 @@ mapping encdec_vicmpfunct6 : vicmpfunct6 <-> bits(6) = {
   VICMP_VMSGT    <-> 0b011111
 }
 
-mapping clause encdec = VICMPTYPE(funct6, vm, vs2, simm, vd) if extensionEnabled(Ext_V)
-  <-> encdec_vicmpfunct6(funct6) @ vm @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VICMPTYPE(funct6, vm, vs2, simm, vd)                                        if extensionEnabled(Ext_V)
+  <-> encdec_vicmpfunct6(funct6) @ vm @ encdec_reg(vs2) @ simm @ 0b011 @ encdec_reg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VICMPTYPE(funct6, vm, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -662,7 +662,7 @@ function clause execute(VICMPTYPE(funct6, vm, vs2, simm, vd)) = {
   let 'n = num_elem;
   let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, 0b00000);
+  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zreg);
   let imm_val : bits('m)                  = sign_extend(simm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -73,8 +73,8 @@ function calculate_new_vl(AVL : int, VLMAX : int) -> xlenbits = {
 /* *********************************** vsetvli *********************************** */
 union clause ast = VSETVLI : (bits(1), bits(1), bits(3), bits(3), regidx, regidx)
 
-mapping clause encdec = VSETVLI(ma, ta, sew, lmul, rs1, rd) if extensionEnabled(Ext_V)
-  <-> 0b0000 @ ma @ ta @ sew @ lmul @ rs1 @ 0b111 @ rd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VSETVLI(ma, ta, sew, lmul, rs1, rd)                                if extensionEnabled(Ext_V)
+  <-> 0b0000 @ ma @ ta @ sew @ lmul @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute VSETVLI(ma, ta, sew, lmul, rs1, rd) = {
   let LMUL_pow_ori  = get_lmul_pow();
@@ -93,12 +93,12 @@ function clause execute VSETVLI(ma, ta, sew, lmul, rs1, rd) = {
   let VLMAX = 2 ^ (VLEN_pow + LMUL_pow_new - SEW_pow_new);
 
   /* set vl according to VLMAX and AVL */
-  if (rs1 != 0b00000) then { /* normal stripmining */
+  if (rs1 != zreg) then { /* normal stripmining */
     let rs1_val = X(rs1);
     let AVL = unsigned(rs1_val);
     vl = calculate_new_vl(AVL, VLMAX);
     X(rd) = vl;
-  } else if (rd != 0b00000) then { /* set vl to VLMAX */
+  } else if (rd != zreg) then { /* set vl to VLMAX */
     let AVL = unsigned(ones(xlen));
     vl = to_bits(xlen, VLMAX);
     X(rd) = vl;
@@ -124,8 +124,8 @@ mapping clause assembly = VSETVLI(ma, ta, sew, lmul, rs1, rd)
 /* *********************************** vsetvl ************************************ */
 union clause ast = VSETVL : (regidx, regidx, regidx)
 
-mapping clause encdec = VSETVL(rs2, rs1, rd) if extensionEnabled(Ext_V)
-  <-> 0b1000000 @ rs2 @ rs1 @ 0b111 @ rd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VSETVL(rs2, rs1, rd)                                             if extensionEnabled(Ext_V)
+  <-> 0b1000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute VSETVL(rs2, rs1, rd) = {
   let LMUL_pow_ori  = get_lmul_pow();
@@ -144,12 +144,12 @@ function clause execute VSETVL(rs2, rs1, rd) = {
   let VLMAX = 2 ^ (VLEN_pow + LMUL_pow_new - SEW_pow_new);
 
   /* set vl according to VLMAX and AVL */
-  if (rs1 != 0b00000) then { /* normal stripmining */
+  if (rs1 != zreg) then { /* normal stripmining */
     let rs1_val = X(rs1);
     let AVL = unsigned(rs1_val);
     vl = calculate_new_vl(AVL, VLMAX);
     X(rd) = vl;
-  } else if (rd != 0b00000) then { /* set vl to VLMAX */
+  } else if (rd != zreg) then { /* set vl to VLMAX */
     let AVL = unsigned(ones(xlen));
     vl = to_bits(xlen, VLMAX);
     X(rd) = vl;
@@ -173,10 +173,10 @@ mapping clause assembly = VSETVL(rs2, rs1, rd)
   <-> "vsetvl" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
 /* ********************************** vsetivli *********************************** */
-union clause ast = VSETIVLI : ( bits(1), bits(1), bits(3), bits(3), regidx, regidx)
+union clause ast = VSETIVLI : ( bits(1), bits(1), bits(3), bits(3), bits(5), regidx)
 
-mapping clause encdec = VSETIVLI(ma, ta, sew, lmul, uimm, rd) if extensionEnabled(Ext_V)
-  <-> 0b1100 @ ma @ ta @ sew @ lmul @ uimm @ 0b111 @ rd @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VSETIVLI(ma, ta, sew, lmul, uimm, rd)                   if extensionEnabled(Ext_V)
+  <-> 0b1100 @ ma @ ta @ sew @ lmul @ uimm @ 0b111 @ encdec_reg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute VSETIVLI(ma, ta, sew, lmul, uimm, rd) = {
   /* set vtype */

--- a/model/riscv_insts_zba.sail
+++ b/model/riscv_insts_zba.sail
@@ -12,8 +12,8 @@ function clause extensionEnabled(Ext_Zba) = true | extensionEnabled(Ext_B)
 /* ****************************************************************** */
 union clause ast = RISCV_SLLIUW : (bits(6), regidx, regidx)
 
-mapping clause encdec = RISCV_SLLIUW(shamt, rs1, rd) if extensionEnabled(Ext_Zba) & xlen == 64
-  <-> 0b000010 @ shamt @ rs1 @ 0b001 @ rd @ 0b0011011 if extensionEnabled(Ext_Zba) & xlen == 64
+mapping clause encdec = RISCV_SLLIUW(shamt, rs1, rd)                          if extensionEnabled(Ext_Zba) & xlen == 64
+  <-> 0b000010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011 if extensionEnabled(Ext_Zba) & xlen == 64
 
 mapping clause assembly = RISCV_SLLIUW(shamt, rs1, rd)
   <-> "slli.uw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_6(shamt)
@@ -28,17 +28,17 @@ function clause execute (RISCV_SLLIUW(shamt, rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = ZBA_RTYPEUW : (regidx, regidx, regidx, bropw_zba)
 
-mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, RISCV_ADDUW) if extensionEnabled(Ext_Zba) & xlen == 64
-  <-> 0b0000100 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0111011 if extensionEnabled(Ext_Zba) & xlen == 64
+mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, RISCV_ADDUW)                           if extensionEnabled(Ext_Zba) & xlen == 64
+  <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0111011 if extensionEnabled(Ext_Zba) & xlen == 64
 
-mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, RISCV_SH1ADDUW) if extensionEnabled(Ext_Zba) & xlen == 64
-  <-> 0b0010000 @ rs2 @ rs1 @ 0b010 @ rd @ 0b0111011 if extensionEnabled(Ext_Zba) & xlen == 64
+mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, RISCV_SH1ADDUW)                        if extensionEnabled(Ext_Zba) & xlen == 64
+  <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0111011 if extensionEnabled(Ext_Zba) & xlen == 64
 
-mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, RISCV_SH2ADDUW) if extensionEnabled(Ext_Zba) & xlen == 64
-  <-> 0b0010000 @ rs2 @ rs1 @ 0b100 @ rd @ 0b0111011 if extensionEnabled(Ext_Zba) & xlen == 64
+mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, RISCV_SH2ADDUW)                        if extensionEnabled(Ext_Zba) & xlen == 64
+  <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0111011 if extensionEnabled(Ext_Zba) & xlen == 64
 
-mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, RISCV_SH3ADDUW) if extensionEnabled(Ext_Zba) & xlen == 64
-  <-> 0b0010000 @ rs2 @ rs1 @ 0b110 @ rd @ 0b0111011 if extensionEnabled(Ext_Zba) & xlen == 64
+mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, RISCV_SH3ADDUW)                        if extensionEnabled(Ext_Zba) & xlen == 64
+  <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0111011 if extensionEnabled(Ext_Zba) & xlen == 64
 
 mapping zba_rtypeuw_mnemonic : bropw_zba <-> string = {
   RISCV_ADDUW    <-> "add.uw",
@@ -67,12 +67,12 @@ function clause execute (ZBA_RTYPEUW(rs2, rs1, rd, op)) = {
 /* ****************************************************************** */
 union clause ast = ZBA_RTYPE : (regidx, regidx, regidx, brop_zba)
 
-mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, RISCV_SH1ADD) if extensionEnabled(Ext_Zba)
-  <-> 0b0010000 @ rs2 @ rs1 @ 0b010 @ rd @ 0b0110011 if extensionEnabled(Ext_Zba)
-mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, RISCV_SH2ADD) if extensionEnabled(Ext_Zba)
-  <-> 0b0010000 @ rs2 @ rs1 @ 0b100 @ rd @ 0b0110011 if extensionEnabled(Ext_Zba)
-mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, RISCV_SH3ADD) if extensionEnabled(Ext_Zba)
-  <-> 0b0010000 @ rs2 @ rs1 @ 0b110 @ rd @ 0b0110011 if extensionEnabled(Ext_Zba)
+mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, RISCV_SH1ADD)                            if extensionEnabled(Ext_Zba)
+  <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zba)
+mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, RISCV_SH2ADD)                            if extensionEnabled(Ext_Zba)
+  <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zba)
+mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, RISCV_SH3ADD)                            if extensionEnabled(Ext_Zba)
+  <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zba)
 
 mapping zba_rtype_mnemonic : brop_zba <-> string = {
   RISCV_SH1ADD <-> "sh1add",

--- a/model/riscv_insts_zbb.sail
+++ b/model/riscv_insts_zbb.sail
@@ -12,8 +12,8 @@ function clause extensionEnabled(Ext_Zbkb) = true
 /* ****************************************************************** */
 union clause ast = RISCV_RORIW : (bits(5), regidx, regidx)
 
-mapping clause encdec = RISCV_RORIW(shamt, rs1, rd) if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
-  <-> 0b0110000 @ shamt @ rs1 @ 0b101 @ rd @ 0b0011011 if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
+mapping clause encdec = RISCV_RORIW(shamt, rs1, rd)                            if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
+  <-> 0b0110000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0011011 if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
 
 mapping clause assembly = RISCV_RORIW(shamt, rs1, rd)
   <-> "roriw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_5(shamt)
@@ -28,8 +28,8 @@ function clause execute (RISCV_RORIW(shamt, rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = RISCV_RORI : (bits(6), regidx, regidx)
 
-mapping clause encdec = RISCV_RORI(shamt, rs1, rd) if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & (xlen == 64 | shamt[5] == bitzero)
-  <-> 0b011000 @ shamt @ rs1 @ 0b101 @ rd @ 0b0010011 if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & (xlen == 64 | shamt[5] == bitzero)
+mapping clause encdec = RISCV_RORI(shamt, rs1, rd)                            if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & (xlen == 64 | shamt[5] == bitzero)
+  <-> 0b011000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011 if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & (xlen == 64 | shamt[5] == bitzero)
 
 mapping clause assembly = RISCV_RORI(shamt, rs1, rd)
   <-> "rori" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_6(shamt)
@@ -46,11 +46,11 @@ function clause execute (RISCV_RORI(shamt, rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = ZBB_RTYPEW : (regidx, regidx, regidx, bropw_zbb)
 
-mapping clause encdec = ZBB_RTYPEW(rs2, rs1, rd, RISCV_ROLW) if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
-  <-> 0b0110000 @ rs2 @ rs1 @ 0b001 @ rd @ 0b0111011 if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
+mapping clause encdec = ZBB_RTYPEW(rs2, rs1, rd, RISCV_ROLW)                             if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
+  <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0111011 if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
 
-mapping clause encdec = ZBB_RTYPEW(rs2, rs1, rd, RISCV_RORW) if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
-  <-> 0b0110000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0111011 if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
+mapping clause encdec = ZBB_RTYPEW(rs2, rs1, rd, RISCV_RORW)                             if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
+  <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0111011 if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
 
 mapping zbb_rtypew_mnemonic : bropw_zbb <-> string = {
   RISCV_ROLW <-> "rolw",
@@ -74,32 +74,32 @@ function clause execute (ZBB_RTYPEW(rs2, rs1, rd, op)) = {
 /* ****************************************************************** */
 union clause ast = ZBB_RTYPE : (regidx, regidx, regidx, brop_zbb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ANDN) if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
-  <-> 0b0100000 @ rs2 @ rs1 @ 0b111 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ANDN)                              if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
+  <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ORN) if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
-  <-> 0b0100000 @ rs2 @ rs1 @ 0b110 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ORN)                               if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
+  <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_XNOR) if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
-  <-> 0b0100000 @ rs2 @ rs1 @ 0b100 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_XNOR)                              if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
+  <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MAX) if extensionEnabled(Ext_Zbb)
-  <-> 0b0000101 @ rs2 @ rs1 @ 0b110 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbb)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MAX)                               if extensionEnabled(Ext_Zbb)
+  <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MAXU) if extensionEnabled(Ext_Zbb)
-  <-> 0b0000101 @ rs2 @ rs1 @ 0b111 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbb)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MAXU)                              if extensionEnabled(Ext_Zbb)
+  <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MIN) if extensionEnabled(Ext_Zbb)
-  <-> 0b0000101 @ rs2 @ rs1 @ 0b100 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbb)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MIN)                               if extensionEnabled(Ext_Zbb)
+  <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MINU) if extensionEnabled(Ext_Zbb)
-  <-> 0b0000101 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbb)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MINU)                              if extensionEnabled(Ext_Zbb)
+  <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ROL) if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
-  <-> 0b0110000 @ rs2 @ rs1 @ 0b001 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ROL)                               if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
+  <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ROR) if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
-  <-> 0b0110000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ROR)                               if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
+  <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
 
 mapping zbb_rtype_mnemonic : brop_zbb <-> string = {
   RISCV_ANDN <-> "andn",
@@ -141,17 +141,17 @@ function clause execute (ZBB_RTYPE(rs2, rs1, rd, op)) = {
 /* ****************************************************************** */
 union clause ast = ZBB_EXTOP : (regidx, regidx, extop_zbb)
 
-mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_SEXTB) if extensionEnabled(Ext_Zbb)
-  <-> 0b0110000 @ 0b00100 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zbb)
+mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_SEXTB)                          if extensionEnabled(Ext_Zbb)
+  <-> 0b0110000 @ 0b00100 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zbb)
 
-mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_SEXTH) if extensionEnabled(Ext_Zbb)
-  <-> 0b0110000 @ 0b00101 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zbb)
+mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_SEXTH)                          if extensionEnabled(Ext_Zbb)
+  <-> 0b0110000 @ 0b00101 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zbb)
 
-mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_ZEXTH) if extensionEnabled(Ext_Zbb) & xlen == 32
-  <-> 0b0000100 @ 0b00000 @ rs1 @ 0b100 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbb) & xlen == 32
+mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_ZEXTH)                          if extensionEnabled(Ext_Zbb) & xlen == 32
+  <-> 0b0000100 @ 0b00000 @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbb) & xlen == 32
 
-mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_ZEXTH) if extensionEnabled(Ext_Zbb) & xlen == 64
-  <-> 0b0000100 @ 0b00000 @ rs1 @ 0b100 @ rd @ 0b0111011 if extensionEnabled(Ext_Zbb) & xlen == 64
+mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_ZEXTH)                          if extensionEnabled(Ext_Zbb) & xlen == 64
+  <-> 0b0000100 @ 0b00000 @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0111011 if extensionEnabled(Ext_Zbb) & xlen == 64
 
 mapping zbb_extop_mnemonic : extop_zbb <-> string = {
   RISCV_SEXTB <-> "sext.b",
@@ -176,11 +176,11 @@ function clause execute (ZBB_EXTOP(rs1, rd, op)) = {
 /* ****************************************************************** */
 union clause ast = RISCV_REV8 : (regidx, regidx)
 
-mapping clause encdec = RISCV_REV8(rs1, rd) if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 32
-  <-> 0b011010011000 @ rs1 @ 0b101 @ rd @ 0b0010011 if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 32
+mapping clause encdec = RISCV_REV8(rs1, rd)                                 if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 32
+  <-> 0b011010011000 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011 if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 32
 
-mapping clause encdec = RISCV_REV8(rs1, rd) if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
-  <-> 0b011010111000 @ rs1 @ 0b101 @ rd @ 0b0010011 if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
+mapping clause encdec = RISCV_REV8(rs1, rd)                                 if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
+  <-> 0b011010111000 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011 if (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
 
 mapping clause assembly = RISCV_REV8(rs1, rd)
   <-> "rev8" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -197,8 +197,8 @@ function clause execute (RISCV_REV8(rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = RISCV_ORCB : (regidx, regidx)
 
-mapping clause encdec = RISCV_ORCB(rs1, rd) if extensionEnabled(Ext_Zbb)
-  <-> 0b001010000111 @ rs1 @ 0b101 @ rd @ 0b0010011 if extensionEnabled(Ext_Zbb)
+mapping clause encdec = RISCV_ORCB(rs1, rd)                                 if extensionEnabled(Ext_Zbb)
+  <-> 0b001010000111 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zbb)
 
 mapping clause assembly = RISCV_ORCB(rs1, rd)
   <-> "orc.b" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -217,8 +217,8 @@ function clause execute (RISCV_ORCB(rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = RISCV_CPOP : (regidx, regidx)
 
-mapping clause encdec = RISCV_CPOP(rs1, rd) if extensionEnabled(Ext_Zbb)
-  <-> 0b011000000010 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zbb)
+mapping clause encdec = RISCV_CPOP(rs1, rd)                                 if extensionEnabled(Ext_Zbb)
+  <-> 0b011000000010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zbb)
 
 mapping clause assembly = RISCV_CPOP(rs1, rd)
   <-> "cpop" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -235,8 +235,8 @@ function clause execute (RISCV_CPOP(rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = RISCV_CPOPW : (regidx, regidx)
 
-mapping clause encdec = RISCV_CPOPW(rs1, rd) if extensionEnabled(Ext_Zbb) & xlen == 64
-  <-> 0b011000000010 @ rs1 @ 0b001 @ rd @ 0b0011011 if extensionEnabled(Ext_Zbb) & xlen == 64
+mapping clause encdec = RISCV_CPOPW(rs1, rd)                                if extensionEnabled(Ext_Zbb) & xlen == 64
+  <-> 0b011000000010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011 if extensionEnabled(Ext_Zbb) & xlen == 64
 
 mapping clause assembly = RISCV_CPOPW(rs1, rd)
   <-> "cpopw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -253,8 +253,8 @@ function clause execute (RISCV_CPOPW(rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = RISCV_CLZ : (regidx, regidx)
 
-mapping clause encdec = RISCV_CLZ(rs1, rd) if extensionEnabled(Ext_Zbb)
-  <-> 0b011000000000 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zbb)
+mapping clause encdec = RISCV_CLZ(rs1, rd)                                  if extensionEnabled(Ext_Zbb)
+  <-> 0b011000000000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zbb)
 
 mapping clause assembly = RISCV_CLZ(rs1, rd)
   <-> "clz" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -274,8 +274,8 @@ function clause execute (RISCV_CLZ(rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = RISCV_CLZW : (regidx, regidx)
 
-mapping clause encdec = RISCV_CLZW(rs1, rd) if extensionEnabled(Ext_Zbb) & xlen == 64
-  <-> 0b011000000000 @ rs1 @ 0b001 @ rd @ 0b0011011 if extensionEnabled(Ext_Zbb) & xlen == 64
+mapping clause encdec = RISCV_CLZW(rs1, rd)                                 if extensionEnabled(Ext_Zbb) & xlen == 64
+  <-> 0b011000000000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011 if extensionEnabled(Ext_Zbb) & xlen == 64
 
 mapping clause assembly = RISCV_CLZW(rs1, rd)
   <-> "clzw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -295,8 +295,8 @@ function clause execute (RISCV_CLZW(rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = RISCV_CTZ : (regidx, regidx)
 
-mapping clause encdec = RISCV_CTZ(rs1, rd) if extensionEnabled(Ext_Zbb)
-  <-> 0b011000000001 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zbb)
+mapping clause encdec = RISCV_CTZ(rs1, rd)                                  if extensionEnabled(Ext_Zbb)
+  <-> 0b011000000001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zbb)
 
 mapping clause assembly = RISCV_CTZ(rs1, rd)
   <-> "ctz" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -316,8 +316,8 @@ function clause execute (RISCV_CTZ(rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = RISCV_CTZW : (regidx, regidx)
 
-mapping clause encdec = RISCV_CTZW(rs1, rd) if extensionEnabled(Ext_Zbb) & xlen == 64
-  <-> 0b011000000001 @ rs1 @ 0b001 @ rd @ 0b0011011 if extensionEnabled(Ext_Zbb) & xlen == 64
+mapping clause encdec = RISCV_CTZW(rs1, rd)                                 if extensionEnabled(Ext_Zbb) & xlen == 64
+  <-> 0b011000000001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011 if extensionEnabled(Ext_Zbb) & xlen == 64
 
 mapping clause assembly = RISCV_CTZW(rs1, rd)
   <-> "ctzw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)

--- a/model/riscv_insts_zbc.sail
+++ b/model/riscv_insts_zbc.sail
@@ -12,8 +12,8 @@ function clause extensionEnabled(Ext_Zbkc) = true
 /* ****************************************************************** */
 union clause ast = RISCV_CLMUL : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_CLMUL(rs2, rs1, rd) if extensionEnabled(Ext_Zbc) | extensionEnabled(Ext_Zbkc)
-  <-> 0b0000101 @ rs2 @ rs1 @ 0b001 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbc) | extensionEnabled(Ext_Zbkc)
+mapping clause encdec = RISCV_CLMUL(rs2, rs1, rd)                                        if extensionEnabled(Ext_Zbc) | extensionEnabled(Ext_Zbkc)
+  <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbc) | extensionEnabled(Ext_Zbkc)
 
 mapping clause assembly = RISCV_CLMUL(rs2, rs1, rd)
   <-> "clmul" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
@@ -31,8 +31,8 @@ function clause execute (RISCV_CLMUL(rs2, rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = RISCV_CLMULH : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_CLMULH(rs2, rs1, rd) if extensionEnabled(Ext_Zbc) | extensionEnabled(Ext_Zbkc)
-  <-> 0b0000101 @ rs2 @ rs1 @ 0b011 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbc) | extensionEnabled(Ext_Zbkc)
+mapping clause encdec = RISCV_CLMULH(rs2, rs1, rd)                                       if extensionEnabled(Ext_Zbc) | extensionEnabled(Ext_Zbkc)
+  <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b011 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbc) | extensionEnabled(Ext_Zbkc)
 
 mapping clause assembly = RISCV_CLMULH(rs2, rs1, rd)
   <-> "clmulh" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
@@ -50,8 +50,8 @@ function clause execute (RISCV_CLMULH(rs2, rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = RISCV_CLMULR : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_CLMULR(rs2, rs1, rd) if extensionEnabled(Ext_Zbc)
-  <-> 0b0000101 @ rs2 @ rs1 @ 0b010 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbc)
+mapping clause encdec = RISCV_CLMULR(rs2, rs1, rd)                                       if extensionEnabled(Ext_Zbc)
+  <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbc)
 
 mapping clause assembly = RISCV_CLMULR(rs2, rs1, rd)
   <-> "clmulr" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)

--- a/model/riscv_insts_zbkb.sail
+++ b/model/riscv_insts_zbkb.sail
@@ -9,11 +9,11 @@
 /* ****************************************************************** */
 union clause ast = ZBKB_RTYPE : (regidx, regidx, regidx, brop_zbkb)
 
-mapping clause encdec = ZBKB_RTYPE(rs2, rs1, rd, RISCV_PACK) if extensionEnabled(Ext_Zbkb)
-  <-> 0b0000100 @ rs2 @ rs1 @ 0b100 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbkb)
+mapping clause encdec = ZBKB_RTYPE(rs2, rs1, rd, RISCV_PACK)                             if extensionEnabled(Ext_Zbkb)
+  <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbkb)
 
-mapping clause encdec = ZBKB_RTYPE(rs2, rs1, rd, RISCV_PACKH) if extensionEnabled(Ext_Zbkb)
-  <-> 0b0000100 @ rs2 @ rs1 @ 0b111 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbkb)
+mapping clause encdec = ZBKB_RTYPE(rs2, rs1, rd, RISCV_PACKH)                            if extensionEnabled(Ext_Zbkb)
+  <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbkb)
 
 mapping zbkb_rtype_mnemonic : brop_zbkb <-> string = {
   RISCV_PACK  <-> "pack",
@@ -37,8 +37,8 @@ function clause execute (ZBKB_RTYPE(rs2, rs1, rd, op)) = {
 /* ****************************************************************** */
 union clause ast = ZBKB_PACKW : (regidx, regidx, regidx)
 
-mapping clause encdec = ZBKB_PACKW(rs2, rs1, rd) if extensionEnabled(Ext_Zbkb) & xlen == 64
-  <-> 0b0000100 @ rs2 @ rs1 @ 0b100 @ rd @ 0b0111011 if extensionEnabled(Ext_Zbkb) & xlen == 64
+mapping clause encdec = ZBKB_PACKW(rs2, rs1, rd)                                         if extensionEnabled(Ext_Zbkb) & xlen == 64
+  <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0111011 if extensionEnabled(Ext_Zbkb) & xlen == 64
 
 mapping clause assembly = ZBKB_PACKW(rs2, rs1, rd)
   <-> "packw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
@@ -55,8 +55,8 @@ function clause execute (ZBKB_PACKW(rs2, rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = RISCV_ZIP : (regidx, regidx)
 
-mapping clause encdec = RISCV_ZIP(rs1, rd) if extensionEnabled(Ext_Zbkb) & xlen == 32
-  <-> 0b000010001111 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zbkb) & xlen == 32
+mapping clause encdec = RISCV_ZIP(rs1, rd)                                  if extensionEnabled(Ext_Zbkb) & xlen == 32
+  <-> 0b000010001111 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zbkb) & xlen == 32
 
 mapping clause assembly = RISCV_ZIP(rs1, rd)
   <-> "zip" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -76,8 +76,8 @@ function clause execute (RISCV_ZIP(rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = RISCV_UNZIP : (regidx, regidx)
 
-mapping clause encdec = RISCV_UNZIP(rs1, rd) if extensionEnabled(Ext_Zbkb) & xlen == 32
-  <-> 0b000010001111 @ rs1 @ 0b101 @ rd @ 0b0010011 if extensionEnabled(Ext_Zbkb) & xlen == 32
+mapping clause encdec = RISCV_UNZIP(rs1, rd)                                if extensionEnabled(Ext_Zbkb) & xlen == 32
+  <-> 0b000010001111 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zbkb) & xlen == 32
 
 mapping clause assembly = RISCV_UNZIP(rs1, rd)
   <-> "unzip" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -97,8 +97,8 @@ function clause execute (RISCV_UNZIP(rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = RISCV_BREV8 : (regidx, regidx)
 
-mapping clause encdec = RISCV_BREV8(rs1, rd) if extensionEnabled(Ext_Zbkb)
-  <-> 0b011010000111 @ rs1 @ 0b101 @ rd @ 0b0010011 if extensionEnabled(Ext_Zbkb)
+mapping clause encdec = RISCV_BREV8(rs1, rd)                                if extensionEnabled(Ext_Zbkb)
+  <-> 0b011010000111 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zbkb)
 
 mapping clause assembly = RISCV_BREV8(rs1, rd)
   <-> "brev8" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)

--- a/model/riscv_insts_zbkx.sail
+++ b/model/riscv_insts_zbkx.sail
@@ -11,8 +11,8 @@ function clause extensionEnabled(Ext_Zbkx) = true
 /* ****************************************************************** */
 union clause ast = RISCV_XPERM8 : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_XPERM8(rs2, rs1, rd) if extensionEnabled(Ext_Zbkx)
-  <-> 0b0010100 @ rs2 @ rs1 @ 0b100 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbkx)
+mapping clause encdec = RISCV_XPERM8(rs2, rs1, rd)                                       if extensionEnabled(Ext_Zbkx)
+  <-> 0b0010100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbkx)
 
 mapping clause assembly = RISCV_XPERM8(rs2, rs1, rd)
   <-> "xperm8" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
@@ -34,8 +34,8 @@ function clause execute (RISCV_XPERM8(rs2, rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = RISCV_XPERM4 : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_XPERM4(rs2, rs1, rd) if extensionEnabled(Ext_Zbkx)
-  <-> 0b0010100 @ rs2 @ rs1 @ 0b010 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbkx)
+mapping clause encdec = RISCV_XPERM4(rs2, rs1, rd)                                       if extensionEnabled(Ext_Zbkx)
+  <-> 0b0010100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbkx)
 
 mapping clause assembly = RISCV_XPERM4(rs2, rs1, rd)
   <-> "xperm4" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)

--- a/model/riscv_insts_zbs.sail
+++ b/model/riscv_insts_zbs.sail
@@ -11,17 +11,17 @@ function clause extensionEnabled(Ext_Zbs) = true | extensionEnabled(Ext_B)
 /* ****************************************************************** */
 union clause ast = ZBS_IOP : (bits(6), regidx, regidx, biop_zbs)
 
-mapping clause encdec = ZBS_IOP(shamt, rs1, rd, RISCV_BCLRI) if extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
-  <-> 0b010010 @ shamt @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
+mapping clause encdec = ZBS_IOP(shamt, rs1, rd, RISCV_BCLRI)                  if extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
+  <-> 0b010010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
 
-mapping clause encdec = ZBS_IOP(shamt, rs1, rd, RISCV_BEXTI) if extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
-  <-> 0b010010 @ shamt @ rs1 @ 0b101 @ rd @ 0b0010011 if extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
+mapping clause encdec = ZBS_IOP(shamt, rs1, rd, RISCV_BEXTI)                  if extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
+  <-> 0b010010 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
 
-mapping clause encdec = ZBS_IOP(shamt, rs1, rd, RISCV_BINVI) if extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
-  <-> 0b011010 @ shamt @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
+mapping clause encdec = ZBS_IOP(shamt, rs1, rd, RISCV_BINVI)                  if extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
+  <-> 0b011010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
 
-mapping clause encdec = ZBS_IOP(shamt, rs1, rd, RISCV_BSETI) if extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
-  <-> 0b001010 @ shamt @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
+mapping clause encdec = ZBS_IOP(shamt, rs1, rd, RISCV_BSETI)                  if extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
+  <-> 0b001010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
 
 mapping zbs_iop_mnemonic : biop_zbs <-> string = {
   RISCV_BCLRI <-> "bclri",
@@ -51,17 +51,17 @@ function clause execute (ZBS_IOP(shamt, rs1, rd, op)) = {
 /* ****************************************************************** */
 union clause ast = ZBS_RTYPE : (regidx, regidx, regidx, brop_zbs)
 
-mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, RISCV_BCLR) if extensionEnabled(Ext_Zbs)
-  <-> 0b0100100 @ rs2 @ rs1 @ 0b001 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbs)
+mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, RISCV_BCLR)                              if extensionEnabled(Ext_Zbs)
+  <-> 0b0100100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbs)
 
-mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, RISCV_BEXT) if extensionEnabled(Ext_Zbs)
-  <-> 0b0100100 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbs)
+mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, RISCV_BEXT)                              if extensionEnabled(Ext_Zbs)
+  <-> 0b0100100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbs)
 
-mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, RISCV_BINV) if extensionEnabled(Ext_Zbs)
-  <-> 0b0110100 @ rs2 @ rs1 @ 0b001 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbs)
+mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, RISCV_BINV)                              if extensionEnabled(Ext_Zbs)
+  <-> 0b0110100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbs)
 
-mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, RISCV_BSET) if extensionEnabled(Ext_Zbs)
-  <-> 0b0010100 @ rs2 @ rs1 @ 0b001 @ rd @ 0b0110011 if extensionEnabled(Ext_Zbs)
+mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, RISCV_BSET)                              if extensionEnabled(Ext_Zbs)
+  <-> 0b0010100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zbs)
 
 mapping zbs_rtype_mnemonic : brop_zbs <-> string = {
   RISCV_BCLR    <-> "bclr",

--- a/model/riscv_insts_zca.sail
+++ b/model/riscv_insts_zca.sail
@@ -16,7 +16,7 @@
 /* ****************************************************************** */
 union clause ast = C_NOP : unit
 
-mapping clause encdec_compressed = C_NOP() if extensionEnabled(Ext_Zca)
+mapping clause encdec_compressed = C_NOP()   if extensionEnabled(Ext_Zca)
   <-> 0b000 @ 0b0 @ 0b00000 @ 0b00000 @ 0b01 if extensionEnabled(Ext_Zca)
 
 function clause execute C_NOP() = RETIRE_SUCCESS
@@ -29,7 +29,7 @@ union clause ast = C_ADDI4SPN : (cregidx, bits(8))
 
 mapping clause encdec_compressed = C_ADDI4SPN(rd, nz96 @ nz54 @ nz3 @ nz2)
       if nz96 @ nz54 @ nz3 @ nz2 != 0b00000000 & extensionEnabled(Ext_Zca)
-  <-> 0b000 @ nz54 : bits(2) @ nz96 : bits(4) @ nz2 : bits(1) @ nz3 : bits(1) @ rd : cregidx @ 0b00
+  <-> 0b000 @ nz54 : bits(2) @ nz96 : bits(4) @ nz2 : bits(1) @ nz3 : bits(1) @ encdec_creg(rd) @ 0b00
       if nz96 @ nz54 @ nz3 @ nz2 != 0b00000000 & extensionEnabled(Ext_Zca)
 
 function clause execute (C_ADDI4SPN(rdc, nzimm)) = {
@@ -46,8 +46,8 @@ mapping clause assembly = C_ADDI4SPN(rdc, nzimm)
 /* ****************************************************************** */
 union clause ast = C_LW : (bits(5), cregidx, cregidx)
 
-mapping clause encdec_compressed = C_LW(ui6 @ ui53 @ ui2, rs1, rd) if extensionEnabled(Ext_Zca)
-  <-> 0b010 @ ui53 : bits(3) @ rs1 : cregidx @ ui2 : bits(1) @ ui6 : bits(1) @ rd : cregidx @ 0b00 if extensionEnabled(Ext_Zca)
+mapping clause encdec_compressed = C_LW(ui6 @ ui53 @ ui2, rs1, rd)                                       if extensionEnabled(Ext_Zca)
+  <-> 0b010 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_creg(rd) @ 0b00 if extensionEnabled(Ext_Zca)
 
 function clause execute (C_LW(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
@@ -64,7 +64,7 @@ union clause ast = C_LD : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_LD(ui76 @ ui53, rs1, rd)
       if xlen == 64 & extensionEnabled(Ext_Zca)
-  <-> 0b011 @ ui53 : bits(3) @ rs1 : cregidx @ ui76 : bits(2) @ rd : cregidx @ 0b00
+  <-> 0b011 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_creg(rd) @ 0b00
       if xlen == 64 & extensionEnabled(Ext_Zca)
 
 function clause execute (C_LD(uimm, rsc, rdc)) = {
@@ -82,8 +82,8 @@ mapping clause assembly = C_LD(uimm, rsc, rdc)
 /* ****************************************************************** */
 union clause ast = C_SW : (bits(5), cregidx, cregidx)
 
-mapping clause encdec_compressed = C_SW(ui6 @ ui53 @ ui2, rs1, rs2) if extensionEnabled(Ext_Zca)
-  <-> 0b110 @ ui53 : bits(3) @ rs1 : cregidx @ ui2 : bits(1) @ ui6 : bits(1) @ rs2 : cregidx @ 0b00 if extensionEnabled(Ext_Zca)
+mapping clause encdec_compressed = C_SW(ui6 @ ui53 @ ui2, rs1, rs2)                                       if extensionEnabled(Ext_Zca)
+  <-> 0b110 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_creg(rs2) @ 0b00 if extensionEnabled(Ext_Zca)
 
 function clause execute (C_SW(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
@@ -100,7 +100,7 @@ union clause ast = C_SD : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SD(ui76 @ ui53, rs1, rs2)
       if xlen == 64 & extensionEnabled(Ext_Zca)
-  <-> 0b111 @ ui53 : bits(3) @ rs1 : bits(3) @ ui76 : bits(2) @ rs2 : bits(3) @ 0b00
+  <-> 0b111 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_creg(rs2) @ 0b00
       if xlen == 64 & extensionEnabled(Ext_Zca)
 
 function clause execute (C_SD(uimm, rsc1, rsc2)) = {
@@ -120,7 +120,7 @@ union clause ast = C_ADDI : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_ADDI(nzi5 @ nzi40, rsd)
       if nzi5 @ nzi40 != 0b000000 & rsd != zreg & extensionEnabled(Ext_Zca)
-  <-> 0b000 @ nzi5 : bits(1) @ rsd : regidx @ nzi40 : bits(5) @ 0b01
+  <-> 0b000 @ nzi5 : bits(1) @ encdec_reg(rsd) @ nzi40 : bits(5) @ 0b01
       if nzi5 @ nzi40 != 0b000000 & rsd != zreg & extensionEnabled(Ext_Zca)
 
 function clause execute (C_ADDI(nzi, rsd)) = {
@@ -154,7 +154,7 @@ union clause ast = C_ADDIW : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_ADDIW(imm5 @ imm40, rsd)
       if rsd != zreg & xlen == 64 & extensionEnabled(Ext_Zca)
-  <-> 0b001 @ imm5 : bits(1) @ rsd : regidx @ imm40 : bits(5) @ 0b01
+  <-> 0b001 @ imm5 : bits(1) @ encdec_reg(rsd) @ imm40 : bits(5) @ 0b01
       if rsd != zreg & xlen == 64 & extensionEnabled(Ext_Zca)
 
 function clause execute (C_ADDIW(imm, rsd)) =
@@ -170,7 +170,7 @@ union clause ast = C_LI : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_LI(imm5 @ imm40, rd)
       if rd != zreg & extensionEnabled(Ext_Zca)
-  <-> 0b010 @ imm5 : bits(1) @ rd : regidx @ imm40 : bits(5) @ 0b01
+  <-> 0b010 @ imm5 : bits(1) @ encdec_reg(rd) @ imm40 : bits(5) @ 0b01
       if rd != zreg & extensionEnabled(Ext_Zca)
 
 function clause execute (C_LI(imm, rd)) = {
@@ -206,7 +206,7 @@ union clause ast = C_LUI : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_LUI(imm17 @ imm1612, rd)
       if rd != zreg & rd != sp & imm17 @ imm1612 != 0b000000 & extensionEnabled(Ext_Zca)
-  <-> 0b011 @ imm17 : bits(1) @ rd : regidx @ imm1612 : bits(5) @ 0b01
+  <-> 0b011 @ imm17 : bits(1) @ encdec_reg(rd) @ imm1612 : bits(5) @ 0b01
       if rd != zreg & rd != sp & imm17 @ imm1612 != 0b000000 & extensionEnabled(Ext_Zca)
 
 function clause execute (C_LUI(imm, rd)) = {
@@ -224,7 +224,7 @@ union clause ast = C_SRLI : (bits(6), cregidx)
 
 mapping clause encdec_compressed = C_SRLI(nzui5 @ nzui40, rsd)
       if nzui5 @ nzui40 != 0b000000 & (xlen == 64 | nzui5 == 0b0) & extensionEnabled(Ext_Zca)
-  <-> 0b100 @ nzui5 : bits(1) @ 0b00 @ rsd : cregidx @ nzui40 : bits(5) @ 0b01
+  <-> 0b100 @ nzui5 : bits(1) @ 0b00 @ encdec_creg(rsd) @ nzui40 : bits(5) @ 0b01
       if nzui5 @ nzui40 != 0b000000 & (xlen == 64 | nzui5 == 0b0) & extensionEnabled(Ext_Zca)
 
 function clause execute (C_SRLI(shamt, rsd)) = {
@@ -242,7 +242,7 @@ union clause ast = C_SRAI : (bits(6), cregidx)
 
 mapping clause encdec_compressed = C_SRAI(nzui5 @ nzui40, rsd)
       if nzui5 @ nzui40 != 0b000000 & (xlen == 64 | nzui5 == 0b0) & extensionEnabled(Ext_Zca)
-  <-> 0b100 @ nzui5 : bits(1) @ 0b01 @ rsd : cregidx @ nzui40 : bits(5) @ 0b01
+  <-> 0b100 @ nzui5 : bits(1) @ 0b01 @ encdec_creg(rsd) @ nzui40 : bits(5) @ 0b01
       if nzui5 @ nzui40 != 0b000000 & (xlen == 64 | nzui5 == 0b0) & extensionEnabled(Ext_Zca)
 
 function clause execute (C_SRAI(shamt, rsd)) = {
@@ -258,8 +258,8 @@ mapping clause assembly = C_SRAI(shamt, rsd)
 /* ****************************************************************** */
 union clause ast = C_ANDI : (bits(6), cregidx)
 
-mapping clause encdec_compressed = C_ANDI(i5 @ i40, rsd) if extensionEnabled(Ext_Zca)
-  <-> 0b100 @ i5 : bits(1) @ 0b10 @ rsd : cregidx @ i40 : bits(5) @ 0b01 if extensionEnabled(Ext_Zca)
+mapping clause encdec_compressed = C_ANDI(i5 @ i40, rsd)                    if extensionEnabled(Ext_Zca)
+  <-> 0b100 @ i5 : bits(1) @ 0b10 @ encdec_creg(rsd) @ i40 : bits(5) @ 0b01 if extensionEnabled(Ext_Zca)
 
 function clause execute (C_ANDI(imm, rsd)) = {
   let rsd = creg2reg_idx(rsd);
@@ -272,8 +272,8 @@ mapping clause assembly = C_ANDI(imm, rsd)
 /* ****************************************************************** */
 union clause ast = C_SUB : (cregidx, cregidx)
 
-mapping clause encdec_compressed = C_SUB(rsd, rs2) if extensionEnabled(Ext_Zca)
-  <-> 0b100 @ 0b0 @ 0b11 @ rsd : cregidx @ 0b00 @ rs2 : cregidx @ 0b01 if extensionEnabled(Ext_Zca)
+mapping clause encdec_compressed = C_SUB(rsd, rs2)                           if extensionEnabled(Ext_Zca)
+  <-> 0b100 @ 0b0 @ 0b11 @ encdec_creg(rsd) @ 0b00 @ encdec_creg(rs2) @ 0b01 if extensionEnabled(Ext_Zca)
 
 function clause execute (C_SUB(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
@@ -287,8 +287,8 @@ mapping clause assembly = C_SUB(rsd, rs2)
 /* ****************************************************************** */
 union clause ast = C_XOR : (cregidx, cregidx)
 
-mapping clause encdec_compressed = C_XOR(rsd, rs2) if extensionEnabled(Ext_Zca)
-  <-> 0b100 @ 0b0 @ 0b11 @ rsd : cregidx @ 0b01 @ rs2 : cregidx @ 0b01 if extensionEnabled(Ext_Zca)
+mapping clause encdec_compressed = C_XOR(rsd, rs2)                           if extensionEnabled(Ext_Zca)
+  <-> 0b100 @ 0b0 @ 0b11 @ encdec_creg(rsd) @ 0b01 @ encdec_creg(rs2) @ 0b01 if extensionEnabled(Ext_Zca)
 
 function clause execute (C_XOR(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
@@ -302,8 +302,8 @@ mapping clause assembly = C_XOR(rsd, rs2)
 /* ****************************************************************** */
 union clause ast = C_OR : (cregidx, cregidx)
 
-mapping clause encdec_compressed = C_OR(rsd, rs2) if extensionEnabled(Ext_Zca)
-  <-> 0b100 @ 0b0 @ 0b11 @ rsd : cregidx @ 0b10 @ rs2 : cregidx @ 0b01 if extensionEnabled(Ext_Zca)
+mapping clause encdec_compressed = C_OR(rsd, rs2)                            if extensionEnabled(Ext_Zca)
+  <-> 0b100 @ 0b0 @ 0b11 @ encdec_creg(rsd) @ 0b10 @ encdec_creg(rs2) @ 0b01 if extensionEnabled(Ext_Zca)
 
 function clause execute (C_OR(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
@@ -317,8 +317,8 @@ mapping clause assembly = C_OR(rsd, rs2)
 /* ****************************************************************** */
 union clause ast = C_AND : (cregidx, cregidx)
 
-mapping clause encdec_compressed = C_AND(rsd, rs2) if extensionEnabled(Ext_Zca)
-  <-> 0b100 @ 0b0 @ 0b11 @ rsd : cregidx @ 0b11 @ rs2 : cregidx @ 0b01 if extensionEnabled(Ext_Zca)
+mapping clause encdec_compressed = C_AND(rsd, rs2)                           if extensionEnabled(Ext_Zca)
+  <-> 0b100 @ 0b0 @ 0b11 @ encdec_creg(rsd) @ 0b11 @ encdec_creg(rs2) @ 0b01 if extensionEnabled(Ext_Zca)
 
 function clause execute (C_AND(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
@@ -334,7 +334,7 @@ union clause ast = C_SUBW : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SUBW(rsd, rs2)
       if xlen == 64 & extensionEnabled(Ext_Zca)
-  <-> 0b100 @ 0b1 @ 0b11 @ rsd : cregidx @ 0b00 @ rs2 : cregidx @ 0b01
+  <-> 0b100 @ 0b1 @ 0b11 @ encdec_creg(rsd) @ 0b00 @ encdec_creg(rs2) @ 0b01
       if xlen == 64 & extensionEnabled(Ext_Zca)
 
 function clause execute (C_SUBW(rsd, rs2)) = {
@@ -353,7 +353,7 @@ union clause ast = C_ADDW : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_ADDW(rsd, rs2)
       if xlen == 64 & extensionEnabled(Ext_Zca)
-  <-> 0b100 @ 0b1 @ 0b11 @ rsd : cregidx @ 0b01 @ rs2 : cregidx @ 0b01
+  <-> 0b100 @ 0b1 @ 0b11 @ encdec_creg(rsd) @ 0b01 @ encdec_creg(rs2) @ 0b01
       if xlen == 64 & extensionEnabled(Ext_Zca)
 
 function clause execute (C_ADDW(rsd, rs2)) = {
@@ -370,7 +370,7 @@ mapping clause assembly = C_ADDW(rsd, rs2)
 /* ****************************************************************** */
 union clause ast = C_J : (bits(11))
 
-mapping clause encdec_compressed = C_J(i11 @ i10 @ i98 @ i7 @ i6 @ i5 @ i4 @ i31) if extensionEnabled(Ext_Zca)
+mapping clause encdec_compressed = C_J(i11 @ i10 @ i98 @ i7 @ i6 @ i5 @ i4 @ i31)                                                              if extensionEnabled(Ext_Zca)
   <-> 0b101 @ i11 : bits(1) @ i4 : bits(1) @ i98 : bits(2) @ i10 : bits(1) @ i6 : bits(1) @ i7 : bits(1) @ i31 : bits(3) @ i5 : bits(1) @ 0b01 if extensionEnabled(Ext_Zca)
 
 function clause execute (C_J(imm)) =
@@ -382,8 +382,8 @@ mapping clause assembly = C_J(imm)
 /* ****************************************************************** */
 union clause ast = C_BEQZ : (bits(8), cregidx)
 
-mapping clause encdec_compressed = C_BEQZ(i8 @ i76 @ i5 @ i43 @ i21, rs) if extensionEnabled(Ext_Zca)
-  <-> 0b110 @ i8 : bits(1) @ i43 : bits(2) @ rs : cregidx @ i76 : bits(2) @ i21 : bits(2) @ i5 : bits(1) @ 0b01 if extensionEnabled(Ext_Zca)
+mapping clause encdec_compressed = C_BEQZ(i8 @ i76 @ i5 @ i43 @ i21, rs)                                           if extensionEnabled(Ext_Zca)
+  <-> 0b110 @ i8 : bits(1) @ i43 : bits(2) @ encdec_creg(rs) @ i76 : bits(2) @ i21 : bits(2) @ i5 : bits(1) @ 0b01 if extensionEnabled(Ext_Zca)
 
 function clause execute (C_BEQZ(imm, rs)) =
   execute(BTYPE(sign_extend(imm @ 0b0), zreg, creg2reg_idx(rs), RISCV_BEQ))
@@ -394,8 +394,8 @@ mapping clause assembly = C_BEQZ(imm, rs)
 /* ****************************************************************** */
 union clause ast = C_BNEZ : (bits(8), cregidx)
 
-mapping clause encdec_compressed = C_BNEZ(i8 @ i76 @ i5 @ i43 @ i21, rs) if extensionEnabled(Ext_Zca)
-  <-> 0b111 @ i8 : bits(1) @ i43 : bits(2) @ rs : cregidx @ i76 : bits(2) @ i21 : bits(2) @ i5 : bits(1) @ 0b01 if extensionEnabled(Ext_Zca)
+mapping clause encdec_compressed = C_BNEZ(i8 @ i76 @ i5 @ i43 @ i21, rs)                                           if extensionEnabled(Ext_Zca)
+  <-> 0b111 @ i8 : bits(1) @ i43 : bits(2) @ encdec_creg(rs) @ i76 : bits(2) @ i21 : bits(2) @ i5 : bits(1) @ 0b01 if extensionEnabled(Ext_Zca)
 
 function clause execute (C_BNEZ(imm, rs)) =
   execute(BTYPE(sign_extend(imm @ 0b0), zreg, creg2reg_idx(rs), RISCV_BNE))
@@ -408,7 +408,7 @@ union clause ast = C_SLLI : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_SLLI(nzui5 @ nzui40, rsd)
       if nzui5 @ nzui40 != 0b000000 & rsd != zreg & (xlen == 64 | nzui5 == 0b0) & extensionEnabled(Ext_Zca)
-  <-> 0b000 @ nzui5 : bits(1) @ rsd : regidx @ nzui40 : bits(5) @ 0b10
+  <-> 0b000 @ nzui5 : bits(1) @ encdec_reg(rsd) @ nzui40 : bits(5) @ 0b10
       if nzui5 @ nzui40 != 0b000000 & rsd != zreg & (xlen == 64 | nzui5 == 0b0) & extensionEnabled(Ext_Zca)
 
 function clause execute (C_SLLI(shamt, rsd)) =
@@ -424,7 +424,7 @@ union clause ast = C_LWSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_LWSP(ui76 @ ui5 @ ui42, rd)
       if rd != zreg & extensionEnabled(Ext_Zca)
-  <-> 0b010 @ ui5 : bits(1) @ rd : regidx @ ui42 : bits(3) @ ui76 : bits(2) @ 0b10
+  <-> 0b010 @ ui5 : bits(1) @ encdec_reg(rd) @ ui42 : bits(3) @ ui76 : bits(2) @ 0b10
       if rd != zreg & extensionEnabled(Ext_Zca)
 
 function clause execute (C_LWSP(uimm, rd)) = {
@@ -442,7 +442,7 @@ union clause ast = C_LDSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_LDSP(ui86 @ ui5 @ ui43, rd)
       if rd != zreg & xlen == 64 & extensionEnabled(Ext_Zca)
-  <-> 0b011 @ ui5 : bits(1) @ rd : regidx @ ui43 : bits(2) @ ui86 : bits(3) @ 0b10
+  <-> 0b011 @ ui5 : bits(1) @ encdec_reg(rd) @ ui43 : bits(2) @ ui86 : bits(3) @ 0b10
       if rd != zreg & xlen == 64 & extensionEnabled(Ext_Zca)
 
 function clause execute (C_LDSP(uimm, rd)) = {
@@ -460,7 +460,7 @@ union clause ast = C_SWSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_SWSP(ui76 @ ui52, rs2)
       if extensionEnabled(Ext_Zca)
-  <-> 0b110 @ ui52 : bits(4) @ ui76 : bits(2) @ rs2 : regidx @ 0b10
+  <-> 0b110 @ ui52 : bits(4) @ ui76 : bits(2) @ encdec_reg(rs2) @ 0b10
       if extensionEnabled(Ext_Zca)
 
 function clause execute (C_SWSP(uimm, rs2)) = {
@@ -476,7 +476,7 @@ union clause ast = C_SDSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_SDSP(ui86 @ ui53, rs2)
       if xlen == 64 & extensionEnabled(Ext_Zca)
-  <-> 0b111 @ ui53 : bits(3) @ ui86 : bits(3) @ rs2 : regidx @ 0b10
+  <-> 0b111 @ ui53 : bits(3) @ ui86 : bits(3) @ encdec_reg(rs2) @ 0b10
       if xlen == 64 & extensionEnabled(Ext_Zca)
 
 function clause execute (C_SDSP(uimm, rs2)) = {
@@ -494,7 +494,7 @@ union clause ast = C_JR : (regidx)
 
 mapping clause encdec_compressed = C_JR(rs1)
       if rs1 != zreg & extensionEnabled(Ext_Zca)
-  <-> 0b100 @ 0b0 @ rs1 : regidx @ 0b00000 @ 0b10
+  <-> 0b100 @ 0b0 @ encdec_reg(rs1) @ 0b00000 @ 0b10
       if rs1 != zreg & extensionEnabled(Ext_Zca)
 
 function clause execute (C_JR(rs1)) =
@@ -510,7 +510,7 @@ union clause ast = C_JALR : (regidx)
 
 mapping clause encdec_compressed = C_JALR(rs1)
       if rs1 != zreg & extensionEnabled(Ext_Zca)
-  <-> 0b100 @ 0b1 @ rs1 : regidx @ 0b00000 @ 0b10
+  <-> 0b100 @ 0b1 @ encdec_reg(rs1) @ 0b00000 @ 0b10
       if rs1 != zreg & extensionEnabled(Ext_Zca)
 
 function clause execute (C_JALR(rs1)) =
@@ -526,7 +526,7 @@ union clause ast = C_MV : (regidx, regidx)
 
 mapping clause encdec_compressed = C_MV(rd, rs2)
       if rd != zreg & rs2 != zreg & extensionEnabled(Ext_Zca)
-  <-> 0b100 @ 0b0 @ rd : regidx @ rs2 : regidx @ 0b10
+  <-> 0b100 @ 0b0 @ encdec_reg(rd) @ encdec_reg(rs2) @ 0b10
       if rd != zreg & rs2 != zreg & extensionEnabled(Ext_Zca)
 
 function clause execute (C_MV(rd, rs2)) =
@@ -541,7 +541,7 @@ mapping clause assembly = C_MV(rd, rs2)
 union clause ast = C_EBREAK : unit
 
 mapping clause encdec_compressed = C_EBREAK() if extensionEnabled(Ext_Zca)
-  <-> 0b100 @ 0b1 @ 0b00000 @ 0b00000 @ 0b10 if extensionEnabled(Ext_Zca)
+  <-> 0b100 @ 0b1 @ 0b00000 @ 0b00000 @ 0b10  if extensionEnabled(Ext_Zca)
 
 function clause execute C_EBREAK() =
   execute(EBREAK())
@@ -553,7 +553,7 @@ union clause ast = C_ADD : (regidx, regidx)
 
 mapping clause encdec_compressed = C_ADD(rsd, rs2)
       if rsd != zreg & rs2 != zreg & extensionEnabled(Ext_Zca)
-  <-> 0b100 @ 0b1 @ rsd : regidx @ rs2 : regidx @ 0b10
+  <-> 0b100 @ 0b1 @ encdec_reg(rsd) @ encdec_reg(rs2) @ 0b10
       if rsd != zreg & rs2 != zreg & extensionEnabled(Ext_Zca)
 
 function clause execute (C_ADD(rsd, rs2)) =

--- a/model/riscv_insts_zcb.sail
+++ b/model/riscv_insts_zcb.sail
@@ -11,8 +11,8 @@ function clause extensionEnabled(Ext_Zcb) = sys_enable_zcb() & extensionEnabled(
 union clause ast = C_LBU : (bits(2), cregidx, cregidx)
 
 mapping clause encdec_compressed =
-      C_LBU(uimm1 @ uimm0, rdc, rs1c)                                                           if extensionEnabled(Ext_Zcb)
-  <-> 0b100 @ 0b000 @ rs1c : cregidx @ uimm0 : bits(1) @ uimm1 : bits(1) @ rdc : cregidx @ 0b00 if extensionEnabled(Ext_Zcb)
+      C_LBU(uimm1 @ uimm0, rdc, rs1c)                                                                 if extensionEnabled(Ext_Zcb)
+  <-> 0b100 @ 0b000 @ encdec_creg(rs1c) @ uimm0 : bits(1) @ uimm1 : bits(1) @ encdec_creg(rdc) @ 0b00 if extensionEnabled(Ext_Zcb)
 
 mapping clause assembly = C_LBU(uimm, rdc, rs1c) <->
   "c.lbu" ^ spc() ^ creg_name(rdc) ^ sep() ^ hex_bits_2(uimm) ^ opt_spc() ^ "(" ^ opt_spc() ^ creg_name(rs1c) ^ opt_spc() ^ ")"
@@ -29,8 +29,8 @@ function clause execute C_LBU(uimm, rdc, rs1c) = {
 union clause ast = C_LHU : (bits(2), cregidx, cregidx)
 
 mapping clause encdec_compressed =
-      C_LHU(uimm1 @ 0b0, rdc, rs1c)                                                 if extensionEnabled(Ext_Zcb)
-  <-> 0b100 @ 0b001 @ rs1c : cregidx @ 0b0 @ uimm1 : bits(1) @ rdc : cregidx @ 0b00 if extensionEnabled(Ext_Zcb)
+      C_LHU(uimm1 @ 0b0, rdc, rs1c)                                                       if extensionEnabled(Ext_Zcb)
+  <-> 0b100 @ 0b001 @ encdec_creg(rs1c) @ 0b0 @ uimm1 : bits(1) @ encdec_creg(rdc) @ 0b00 if extensionEnabled(Ext_Zcb)
 
 mapping clause assembly = C_LHU(uimm, rdc, rs1c) <->
   "c.lhu" ^ spc() ^ creg_name(rdc) ^ sep() ^ hex_bits_2(uimm) ^ opt_spc() ^ "(" ^ opt_spc() ^ creg_name(rs1c) ^ opt_spc() ^ ")"
@@ -47,8 +47,8 @@ function clause execute C_LHU(uimm, rdc, rs1c) = {
 union clause ast = C_LH : (bits(2), cregidx, cregidx)
 
 mapping clause encdec_compressed =
-      C_LH(uimm1 @ 0b0, rdc, rs1c)                                                  if extensionEnabled(Ext_Zcb)
-  <-> 0b100 @ 0b001 @ rs1c : cregidx @ 0b1 @ uimm1 : bits(1) @ rdc : cregidx @ 0b00 if extensionEnabled(Ext_Zcb)
+      C_LH(uimm1 @ 0b0, rdc, rs1c)                                                        if extensionEnabled(Ext_Zcb)
+  <-> 0b100 @ 0b001 @ encdec_creg(rs1c) @ 0b1 @ uimm1 : bits(1) @ encdec_creg(rdc) @ 0b00 if extensionEnabled(Ext_Zcb)
 
 mapping clause assembly = C_LH(uimm, rdc, rs1c) <->
   "c.lh" ^ spc() ^ creg_name(rdc) ^ sep() ^ hex_bits_2(uimm) ^ opt_spc() ^ "(" ^ opt_spc() ^ creg_name(rs1c) ^ opt_spc() ^ ")"
@@ -65,8 +65,8 @@ function clause execute C_LH(uimm, rdc, rs1c) = {
 union clause ast = C_SB : (bits(2), cregidx, cregidx)
 
 mapping clause encdec_compressed =
-      C_SB(uimm1 @ uimm0, rs1c, rs2c)                                                  if extensionEnabled(Ext_Zcb)
-  <-> 0b100 @ 0b010 @ rs1c : cregidx @ uimm0 : bits(1) @ uimm1 : bits(1) @ rs2c @ 0b00 if extensionEnabled(Ext_Zcb)
+      C_SB(uimm1 @ uimm0, rs1c, rs2c)                                                                  if extensionEnabled(Ext_Zcb)
+  <-> 0b100 @ 0b010 @ encdec_creg(rs1c) @ uimm0 : bits(1) @ uimm1 : bits(1) @ encdec_creg(rs2c) @ 0b00 if extensionEnabled(Ext_Zcb)
 
 mapping clause assembly = C_SB(uimm, rs1c, rs2c) <->
   "c.sb" ^ spc() ^ creg_name(rs2c) ^ sep() ^ hex_bits_2(uimm) ^ opt_spc() ^ "(" ^ opt_spc() ^ creg_name(rs1c) ^ opt_spc() ^ ")"
@@ -83,8 +83,8 @@ function clause execute C_SB(uimm, rs1c, rs2c) = {
 union clause ast = C_SH : (bits(2), cregidx, cregidx)
 
 mapping clause encdec_compressed =
-      C_SH(uimm1 @ 0b0, rs1c, rs2c)                                                  if extensionEnabled(Ext_Zcb)
-  <-> 0b100 @ 0b011 @ rs1c : cregidx @ 0b0 @ uimm1 : bits(1) @ rs2c : cregidx @ 0b00 if extensionEnabled(Ext_Zcb)
+      C_SH(uimm1 @ 0b0, rs1c, rs2c)                                                        if extensionEnabled(Ext_Zcb)
+  <-> 0b100 @ 0b011 @ encdec_creg(rs1c) @ 0b0 @ uimm1 : bits(1) @ encdec_creg(rs2c) @ 0b00 if extensionEnabled(Ext_Zcb)
 
 mapping clause assembly = C_SH(uimm, rs1c, rs2c) <->
   "c.sh" ^ spc() ^ creg_name(rs1c) ^ sep() ^ hex_bits_2(uimm) ^ opt_spc() ^ "(" ^ opt_spc() ^ creg_name(rs2c) ^ opt_spc() ^ ")"
@@ -101,8 +101,8 @@ function clause execute C_SH(uimm, rs1c, rs2c) = {
 union clause ast = C_ZEXT_B : (cregidx)
 
 mapping clause encdec_compressed =
-      C_ZEXT_B(rsdc)                                       if extensionEnabled(Ext_Zcb)
-  <-> 0b100 @ 0b111 @ rsdc : cregidx @ 0b11 @ 0b000 @ 0b01 if extensionEnabled(Ext_Zcb)
+      C_ZEXT_B(rsdc)                                          if extensionEnabled(Ext_Zcb)
+  <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b000 @ 0b01 if extensionEnabled(Ext_Zcb)
 
 mapping clause assembly = C_ZEXT_B(rsdc) <->
   "c.zext.b" ^ spc() ^ creg_name(rsdc)
@@ -118,8 +118,8 @@ function clause execute C_ZEXT_B(rsdc) = {
 union clause ast = C_SEXT_B : (cregidx)
 
 mapping clause encdec_compressed =
-      C_SEXT_B(rsdc)                                       if extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zbb)
-  <-> 0b100 @ 0b111 @ rsdc : cregidx @ 0b11 @ 0b001 @ 0b01 if extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zbb)
+      C_SEXT_B(rsdc)                                          if extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zbb)
+  <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b001 @ 0b01 if extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zbb)
 
 mapping clause assembly = C_SEXT_B(rsdc) <->
   "c.sext.b" ^ spc() ^ creg_name(rsdc)
@@ -134,8 +134,8 @@ function clause execute C_SEXT_B(rsdc) = {
 union clause ast = C_ZEXT_H : (cregidx)
 
 mapping clause encdec_compressed =
-      C_ZEXT_H(rsdc)                                       if extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zbb)
-  <-> 0b100 @ 0b111 @ rsdc : cregidx @ 0b11 @ 0b010 @ 0b01 if extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zbb)
+      C_ZEXT_H(rsdc)                                          if extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zbb)
+  <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b010 @ 0b01 if extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zbb)
 
 mapping clause assembly = C_ZEXT_H(rsdc) <->
   "c.zext.h" ^ spc() ^ creg_name(rsdc)
@@ -150,8 +150,8 @@ function clause execute C_ZEXT_H(rsdc) = {
 union clause ast = C_SEXT_H : (cregidx)
 
 mapping clause encdec_compressed =
-      C_SEXT_H(rsdc)                                       if extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zbb)
-  <-> 0b100 @ 0b111 @ rsdc : cregidx @ 0b11 @ 0b011 @ 0b01 if extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zbb)
+      C_SEXT_H(rsdc)                                          if extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zbb)
+  <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b011 @ 0b01 if extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zbb)
 
 mapping clause assembly = C_SEXT_H(rsdc) <->
   "c.sext.h" ^ spc() ^ creg_name(rsdc)
@@ -166,15 +166,15 @@ function clause execute C_SEXT_H(rsdc) = {
 union clause ast = C_ZEXT_W : (cregidx)
 
 mapping clause encdec_compressed =
-      C_ZEXT_W(rsdc)                                       if extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zba) & xlen == 64
-  <-> 0b100 @ 0b111 @ rsdc : cregidx @ 0b11 @ 0b100 @ 0b01 if extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zba) & xlen == 64
+      C_ZEXT_W(rsdc)                                          if extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zba) & xlen == 64
+  <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b100 @ 0b01 if extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zba) & xlen == 64
 
 mapping clause assembly = C_ZEXT_W(rsdc) <->
   "c.zext.w" ^ spc() ^ creg_name(rsdc)
 
 function clause execute C_ZEXT_W(rsdc) = {
   let rsd = creg2reg_idx(rsdc);
-  execute (ZBA_RTYPEUW(0b00000, rsd, rsd, RISCV_ADDUW)) // Note 0b00000 is the regidx of the zero register
+  execute (ZBA_RTYPEUW(zreg, rsd, rsd, RISCV_ADDUW))
 }
 
 /* ****************************************************************** */
@@ -182,8 +182,8 @@ function clause execute C_ZEXT_W(rsdc) = {
 union clause ast = C_NOT : (cregidx)
 
 mapping clause encdec_compressed =
-      C_NOT(rsdc)                                          if extensionEnabled(Ext_Zcb)
-  <-> 0b100 @ 0b111 @ rsdc : cregidx @ 0b11 @ 0b101 @ 0b01 if extensionEnabled(Ext_Zcb)
+      C_NOT(rsdc)                                             if extensionEnabled(Ext_Zcb)
+  <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b101 @ 0b01 if extensionEnabled(Ext_Zcb)
 
 mapping clause assembly = C_NOT(rsdc) <->
   "c.not" ^ spc() ^ creg_name(rsdc)
@@ -199,8 +199,8 @@ function clause execute C_NOT(rsdc) = {
 union clause ast = C_MUL : (cregidx, cregidx)
 
 mapping clause encdec_compressed =
-      C_MUL(rsdc, rs2c)                                             if extensionEnabled(Ext_Zcb) & (extensionEnabled(Ext_M) | extensionEnabled(Ext_Zmmul))
-  <-> 0b100 @ 0b111 @ rsdc : cregidx @ 0b10 @ rs2c : cregidx @ 0b01 if extensionEnabled(Ext_Zcb) & (extensionEnabled(Ext_M) | extensionEnabled(Ext_Zmmul))
+      C_MUL(rsdc, rs2c)                                                   if extensionEnabled(Ext_Zcb) & (extensionEnabled(Ext_M) | extensionEnabled(Ext_Zmmul))
+  <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b10 @ encdec_creg(rs2c) @ 0b01 if extensionEnabled(Ext_Zcb) & (extensionEnabled(Ext_M) | extensionEnabled(Ext_Zmmul))
 
 mapping clause assembly = C_MUL(rsdc, rs2c) <->
   "c.mul" ^ spc() ^ creg_name(rsdc) ^ sep() ^ creg_name(rs2c)

--- a/model/riscv_insts_zcd.sail
+++ b/model/riscv_insts_zcd.sail
@@ -8,10 +8,10 @@
 
 function clause extensionEnabled(Ext_Zcd) = extensionEnabled(Ext_Zca) & extensionEnabled(Ext_D) & (xlen == 32 | xlen == 64)
 
-union clause ast = C_FLDSP : (bits(6), regidx)
+union clause ast = C_FLDSP : (bits(6), fregidx)
 
-mapping clause encdec_compressed = C_FLDSP(ui86 @ ui5 @ ui43, rd)                     if extensionEnabled(Ext_Zcd)
-  <-> 0b001 @ ui5 : bits(1) @ encdec_reg(rd) @ ui43 : bits(2) @ ui86 : bits(3) @ 0b10 if extensionEnabled(Ext_Zcd)
+mapping clause encdec_compressed = C_FLDSP(ui86 @ ui5 @ ui43, rd)                      if extensionEnabled(Ext_Zcd)
+  <-> 0b001 @ ui5 : bits(1) @ encdec_freg(rd) @ ui43 : bits(2) @ ui86 : bits(3) @ 0b10 if extensionEnabled(Ext_Zcd)
 
 function clause execute (C_FLDSP(uimm, rd)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
@@ -20,14 +20,14 @@ function clause execute (C_FLDSP(uimm, rd)) = {
 
 mapping clause assembly = C_FLDSP(uimm, rd)
       if (xlen == 32 | xlen == 64)
-  <-> "c.fldsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm)
+  <-> "c.fldsp" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_6(uimm)
       if (xlen == 32 | xlen == 64)
 
 /* ****************************************************************** */
-union clause ast = C_FSDSP : (bits(6), regidx)
+union clause ast = C_FSDSP : (bits(6), fregidx)
 
-mapping clause encdec_compressed = C_FSDSP(ui86 @ ui53, rs2)           if extensionEnabled(Ext_Zcd)
-  <-> 0b101 @ ui53 : bits(3) @ ui86 : bits(3) @ encdec_reg(rs2) @ 0b10 if extensionEnabled(Ext_Zcd)
+mapping clause encdec_compressed = C_FSDSP(ui86 @ ui53, rs2)            if extensionEnabled(Ext_Zcd)
+  <-> 0b101 @ ui53 : bits(3) @ ui86 : bits(3) @ encdec_freg(rs2) @ 0b10 if extensionEnabled(Ext_Zcd)
 
 function clause execute (C_FSDSP(uimm, rs2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
@@ -36,7 +36,7 @@ function clause execute (C_FSDSP(uimm, rs2)) = {
 
 mapping clause assembly = C_FSDSP(uimm, rs2)
       if (xlen == 32 | xlen == 64)
-  <-> "c.fsdsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm)
+  <-> "c.fsdsp" ^ spc() ^ freg_name(rs2) ^ sep() ^ hex_bits_6(uimm)
       if (xlen == 32 | xlen == 64)
 
 /* ****************************************************************** */
@@ -47,7 +47,7 @@ mapping clause encdec_compressed = C_FLD(ui76 @ ui53, rs1, rd)                  
 
 function clause execute (C_FLD(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
-  let rd = creg2reg_idx(rdc);
+  let rd = cregidx_to_fregidx(rdc);
   let rs = creg2reg_idx(rsc);
   execute(LOAD_FP(imm, rs, rd, DOUBLE))
 }
@@ -66,7 +66,7 @@ mapping clause encdec_compressed = C_FSD(ui76 @ ui53, rs1, rs2)                 
 function clause execute (C_FSD(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
   let rs1 = creg2reg_idx(rsc1);
-  let rs2 = creg2reg_idx(rsc2);
+  let rs2 = cregidx_to_fregidx(rsc2);
   execute(STORE_FP(imm, rs2, rs1, DOUBLE))
 }
 

--- a/model/riscv_insts_zcd.sail
+++ b/model/riscv_insts_zcd.sail
@@ -10,8 +10,8 @@ function clause extensionEnabled(Ext_Zcd) = extensionEnabled(Ext_Zca) & extensio
 
 union clause ast = C_FLDSP : (bits(6), regidx)
 
-mapping clause encdec_compressed = C_FLDSP(ui86 @ ui5 @ ui43, rd)                  if extensionEnabled(Ext_Zcd)
-  <-> 0b001 @ ui5 : bits(1) @ rd : regidx @ ui43 : bits(2) @ ui86 : bits(3) @ 0b10 if extensionEnabled(Ext_Zcd)
+mapping clause encdec_compressed = C_FLDSP(ui86 @ ui5 @ ui43, rd)                     if extensionEnabled(Ext_Zcd)
+  <-> 0b001 @ ui5 : bits(1) @ encdec_reg(rd) @ ui43 : bits(2) @ ui86 : bits(3) @ 0b10 if extensionEnabled(Ext_Zcd)
 
 function clause execute (C_FLDSP(uimm, rd)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
@@ -26,8 +26,8 @@ mapping clause assembly = C_FLDSP(uimm, rd)
 /* ****************************************************************** */
 union clause ast = C_FSDSP : (bits(6), regidx)
 
-mapping clause encdec_compressed = C_FSDSP(ui86 @ ui53, rs2)        if extensionEnabled(Ext_Zcd)
-  <-> 0b101 @ ui53 : bits(3) @ ui86 : bits(3) @ rs2 : regidx @ 0b10 if extensionEnabled(Ext_Zcd)
+mapping clause encdec_compressed = C_FSDSP(ui86 @ ui53, rs2)           if extensionEnabled(Ext_Zcd)
+  <-> 0b101 @ ui53 : bits(3) @ ui86 : bits(3) @ encdec_reg(rs2) @ 0b10 if extensionEnabled(Ext_Zcd)
 
 function clause execute (C_FSDSP(uimm, rs2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
@@ -42,8 +42,8 @@ mapping clause assembly = C_FSDSP(uimm, rs2)
 /* ****************************************************************** */
 union clause ast = C_FLD : (bits(5), cregidx, cregidx)
 
-mapping clause encdec_compressed = C_FLD(ui76 @ ui53, rs1, rd)                      if extensionEnabled(Ext_Zcd)
-  <-> 0b001 @ ui53 : bits(3) @ rs1 : cregidx @ ui76 : bits(2) @ rd : cregidx @ 0b00 if extensionEnabled(Ext_Zcd)
+mapping clause encdec_compressed = C_FLD(ui76 @ ui53, rs1, rd)                            if extensionEnabled(Ext_Zcd)
+  <-> 0b001 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_creg(rd) @ 0b00 if extensionEnabled(Ext_Zcd)
 
 function clause execute (C_FLD(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
@@ -60,8 +60,8 @@ mapping clause assembly = C_FLD(uimm, rsc, rdc)
 /* ****************************************************************** */
 union clause ast = C_FSD : (bits(5), cregidx, cregidx)
 
-mapping clause encdec_compressed = C_FSD(ui76 @ ui53, rs1, rs2)                      if extensionEnabled(Ext_Zcd)
-  <-> 0b101 @ ui53 : bits(3) @ rs1 : bits(3) @ ui76 : bits(2) @ rs2 : bits(3) @ 0b00 if extensionEnabled(Ext_Zcd)
+mapping clause encdec_compressed = C_FSD(ui76 @ ui53, rs1, rs2)                            if extensionEnabled(Ext_Zcd)
+  <-> 0b101 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_creg(rs2) @ 0b00 if extensionEnabled(Ext_Zcd)
 
 function clause execute (C_FSD(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);

--- a/model/riscv_insts_zcf.sail
+++ b/model/riscv_insts_zcf.sail
@@ -19,8 +19,8 @@ function clause extensionEnabled(Ext_Zcf) = extensionEnabled(Ext_Zca) & extensio
 
 union clause ast = C_FLWSP : (bits(6), regidx)
 
-mapping clause encdec_compressed = C_FLWSP(ui76 @ ui5 @ ui42, rd)                  if extensionEnabled(Ext_Zcf)
-  <-> 0b011 @ ui5 : bits(1) @ rd : regidx @ ui42 : bits(3) @ ui76 : bits(2) @ 0b10 if extensionEnabled(Ext_Zcf)
+mapping clause encdec_compressed = C_FLWSP(ui76 @ ui5 @ ui42, rd)                     if extensionEnabled(Ext_Zcf)
+  <-> 0b011 @ ui5 : bits(1) @ encdec_reg(rd) @ ui42 : bits(3) @ ui76 : bits(2) @ 0b10 if extensionEnabled(Ext_Zcf)
 
 function clause execute (C_FLWSP(imm, rd)) = {
   let imm : bits(12) = zero_extend(imm @ 0b00);
@@ -35,8 +35,8 @@ mapping clause assembly = C_FLWSP(imm, rd)
 /* ****************************************************************** */
 union clause ast = C_FSWSP : (bits(6), regidx)
 
-mapping clause encdec_compressed = C_FSWSP(ui76 @ ui52, rs2)        if extensionEnabled(Ext_Zcf)
-  <-> 0b111 @ ui52 : bits(4) @ ui76 : bits(2) @ rs2 : regidx @ 0b10 if extensionEnabled(Ext_Zcf)
+mapping clause encdec_compressed = C_FSWSP(ui76 @ ui52, rs2)           if extensionEnabled(Ext_Zcf)
+  <-> 0b111 @ ui52 : bits(4) @ ui76 : bits(2) @ encdec_reg(rs2) @ 0b10 if extensionEnabled(Ext_Zcf)
 
 function clause execute (C_FSWSP(uimm, rs2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
@@ -51,8 +51,8 @@ mapping clause assembly = C_FSWSP(uimm, rs2)
 /* ****************************************************************** */
 union clause ast = C_FLW : (bits(5), cregidx, cregidx)
 
-mapping clause encdec_compressed = C_FLW(ui6 @ ui53 @ ui2, rs1, rd)                                if extensionEnabled(Ext_Zcf)
-  <-> 0b011 @ ui53 : bits(3) @ rs1 : cregidx @ ui2 : bits(1) @ ui6 : bits(1) @ rd : cregidx @ 0b00 if extensionEnabled(Ext_Zcf)
+mapping clause encdec_compressed = C_FLW(ui6 @ ui53 @ ui2, rs1, rd)                                      if extensionEnabled(Ext_Zcf)
+  <-> 0b011 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_creg(rd) @ 0b00 if extensionEnabled(Ext_Zcf)
 
 function clause execute (C_FLW(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
@@ -69,8 +69,8 @@ mapping clause assembly = C_FLW(uimm, rsc, rdc)
 /* ****************************************************************** */
 union clause ast = C_FSW : (bits(5), cregidx, cregidx)
 
-mapping clause encdec_compressed = C_FSW(ui6 @ ui53 @ ui2, rs1, rs2)                                if extensionEnabled(Ext_Zcf)
-  <-> 0b111 @ ui53 : bits(3) @ rs1 : cregidx @ ui2 : bits(1) @ ui6 : bits(1) @ rs2 : cregidx @ 0b00 if extensionEnabled(Ext_Zcf)
+mapping clause encdec_compressed = C_FSW(ui6 @ ui53 @ ui2, rs1, rs2)                                      if extensionEnabled(Ext_Zcf)
+  <-> 0b111 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_creg(rs2) @ 0b00 if extensionEnabled(Ext_Zcf)
 
 function clause execute (C_FSW(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);

--- a/model/riscv_insts_zcf.sail
+++ b/model/riscv_insts_zcf.sail
@@ -17,10 +17,10 @@
 
 function clause extensionEnabled(Ext_Zcf) = extensionEnabled(Ext_Zca) & extensionEnabled(Ext_F) & xlen == 32
 
-union clause ast = C_FLWSP : (bits(6), regidx)
+union clause ast = C_FLWSP : (bits(6), fregidx)
 
 mapping clause encdec_compressed = C_FLWSP(ui76 @ ui5 @ ui42, rd)                     if extensionEnabled(Ext_Zcf)
-  <-> 0b011 @ ui5 : bits(1) @ encdec_reg(rd) @ ui42 : bits(3) @ ui76 : bits(2) @ 0b10 if extensionEnabled(Ext_Zcf)
+  <-> 0b011 @ ui5 : bits(1) @ encdec_freg(rd) @ ui42 : bits(3) @ ui76 : bits(2) @ 0b10 if extensionEnabled(Ext_Zcf)
 
 function clause execute (C_FLWSP(imm, rd)) = {
   let imm : bits(12) = zero_extend(imm @ 0b00);
@@ -29,14 +29,14 @@ function clause execute (C_FLWSP(imm, rd)) = {
 
 mapping clause assembly = C_FLWSP(imm, rd)
       if xlen == 32
-  <-> "c.flwsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(imm)
+  <-> "c.flwsp" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_6(imm)
       if xlen == 32
 
 /* ****************************************************************** */
-union clause ast = C_FSWSP : (bits(6), regidx)
+union clause ast = C_FSWSP : (bits(6), fregidx)
 
 mapping clause encdec_compressed = C_FSWSP(ui76 @ ui52, rs2)           if extensionEnabled(Ext_Zcf)
-  <-> 0b111 @ ui52 : bits(4) @ ui76 : bits(2) @ encdec_reg(rs2) @ 0b10 if extensionEnabled(Ext_Zcf)
+  <-> 0b111 @ ui52 : bits(4) @ ui76 : bits(2) @ encdec_freg(rs2) @ 0b10 if extensionEnabled(Ext_Zcf)
 
 function clause execute (C_FSWSP(uimm, rs2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
@@ -45,7 +45,7 @@ function clause execute (C_FSWSP(uimm, rs2)) = {
 
 mapping clause assembly = C_FSWSP(uimm, rs2)
       if xlen == 32
-  <-> "c.fswsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm)
+  <-> "c.fswsp" ^ spc() ^ freg_name(rs2) ^ sep() ^ hex_bits_6(uimm)
       if xlen == 32
 
 /* ****************************************************************** */
@@ -56,7 +56,7 @@ mapping clause encdec_compressed = C_FLW(ui6 @ ui53 @ ui2, rs1, rd)             
 
 function clause execute (C_FLW(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
-  let rd = creg2reg_idx(rdc);
+  let rd = cregidx_to_fregidx(rdc);
   let rs = creg2reg_idx(rsc);
   execute(LOAD_FP(imm, rs, rd, WORD))
 }
@@ -75,7 +75,7 @@ mapping clause encdec_compressed = C_FSW(ui6 @ ui53 @ ui2, rs1, rs2)            
 function clause execute (C_FSW(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   let rs1 = creg2reg_idx(rsc1);
-  let rs2 = creg2reg_idx(rsc2);
+  let rs2 = cregidx_to_fregidx(rsc2);
   execute(STORE_FP(imm, rs2, rs1, WORD))
 }
 

--- a/model/riscv_insts_zfa.sail
+++ b/model/riscv_insts_zfa.sail
@@ -10,10 +10,10 @@ function clause extensionEnabled(Ext_Zfa) = true
 
 /* FLI.H */
 
-union clause ast = RISCV_FLI_H : (bits(5), regidx)
+union clause ast = RISCV_FLI_H : (bits(5), fregidx)
 
-mapping clause encdec = RISCV_FLI_H(rs1, rd)                           if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
-  <-> 0b111_1010 @ 0b00001 @ rs1 @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLI_H(rs1, rd)                            if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  <-> 0b111_1010 @ 0b00001 @ rs1 @ 0b000 @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLI_H(constantidx, rd)
   <-> "fli.h" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_5(constantidx)
@@ -59,10 +59,10 @@ function clause execute (RISCV_FLI_H(constantidx, rd)) = {
 
 /* FLI.S */
 
-union clause ast = RISCV_FLI_S : (bits(5), regidx)
+union clause ast = RISCV_FLI_S : (bits(5), fregidx)
 
-mapping clause encdec = RISCV_FLI_S(rs1, rd)                           if extensionEnabled(Ext_Zfa)
-  <-> 0b111_1000 @ 0b00001 @ rs1 @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLI_S(rs1, rd)                            if extensionEnabled(Ext_Zfa)
+  <-> 0b111_1000 @ 0b00001 @ rs1 @ 0b000 @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLI_S(constantidx, rd)
   <-> "fli.s" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_5(constantidx)
@@ -108,10 +108,10 @@ function clause execute (RISCV_FLI_S(constantidx, rd)) = {
 
 /* FLI.D */
 
-union clause ast = RISCV_FLI_D : (bits(5), regidx)
+union clause ast = RISCV_FLI_D : (bits(5), fregidx)
 
-mapping clause encdec = RISCV_FLI_D(rs1, rd)                           if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
-  <-> 0b111_1001 @ 0b00001 @ rs1 @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLI_D(rs1, rd)                            if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  <-> 0b111_1001 @ 0b00001 @ rs1 @ 0b000 @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLI_D(constantidx, rd)
   <-> "fli.d" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_5(constantidx)
@@ -157,10 +157,10 @@ function clause execute (RISCV_FLI_D(constantidx, rd)) = {
 
 /* FMINM.H */
 
-union clause ast = RISCV_FMINM_H : (regidx, regidx, regidx)
+union clause ast = RISCV_FMINM_H : (fregidx, fregidx, fregidx)
 
-mapping clause encdec = RISCV_FMINM_H(rs2, rs1, rd)                                        if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
-  <-> 0b001_0110 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FMINM_H(rs2, rs1, rd)                                           if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  <-> 0b001_0110 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMINM_H(rs2, rs1, rd)
   <-> "fminm.h" ^ spc() ^ freg_name(rd)
@@ -187,10 +187,10 @@ function clause execute (RISCV_FMINM_H(rs2, rs1, rd)) = {
 
 /* FMAXM.H */
 
-union clause ast = RISCV_FMAXM_H : (regidx, regidx, regidx)
+union clause ast = RISCV_FMAXM_H : (fregidx, fregidx, fregidx)
 
-mapping clause encdec = RISCV_FMAXM_H(rs2, rs1, rd)                                        if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
-  <-> 0b001_0110 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b011 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FMAXM_H(rs2, rs1, rd)                                           if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  <-> 0b001_0110 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b011 @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMAXM_H(rs2, rs1, rd)
   <-> "fmaxm.h" ^ spc() ^ freg_name(rd)
@@ -217,10 +217,10 @@ function clause execute (RISCV_FMAXM_H(rs2, rs1, rd)) = {
 
 /* FMINM.S */
 
-union clause ast = RISCV_FMINM_S : (regidx, regidx, regidx)
+union clause ast = RISCV_FMINM_S : (fregidx, fregidx, fregidx)
 
-mapping clause encdec = RISCV_FMINM_S(rs2, rs1, rd)                                        if extensionEnabled(Ext_Zfa)
-  <-> 0b001_0100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FMINM_S(rs2, rs1, rd)                                           if extensionEnabled(Ext_Zfa)
+  <-> 0b001_0100 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMINM_S(rs2, rs1, rd)
   <-> "fminm.s" ^ spc() ^ freg_name(rd)
@@ -247,10 +247,10 @@ function clause execute (RISCV_FMINM_S(rs2, rs1, rd)) = {
 
 /* FMAXM.S */
 
-union clause ast = RISCV_FMAXM_S : (regidx, regidx, regidx)
+union clause ast = RISCV_FMAXM_S : (fregidx, fregidx, fregidx)
 
-mapping clause encdec = RISCV_FMAXM_S(rs2, rs1, rd)                                        if extensionEnabled(Ext_Zfa)
-  <-> 0b001_0100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b011 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FMAXM_S(rs2, rs1, rd)                                           if extensionEnabled(Ext_Zfa)
+  <-> 0b001_0100 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b011 @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMAXM_S(rs2, rs1, rd)
   <-> "fmaxm.s" ^ spc() ^ freg_name(rd)
@@ -277,10 +277,10 @@ function clause execute (RISCV_FMAXM_S(rs2, rs1, rd)) = {
 
 /* FMINM.D */
 
-union clause ast = RISCV_FMINM_D : (regidx, regidx, regidx)
+union clause ast = RISCV_FMINM_D : (fregidx, fregidx, fregidx)
 
-mapping clause encdec = RISCV_FMINM_D(rs2, rs1, rd)                                        if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
-  <-> 0b001_0101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FMINM_D(rs2, rs1, rd)                                           if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  <-> 0b001_0101 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMINM_D(rs2, rs1, rd)
   <-> "fminm.d" ^ spc() ^ freg_name(rd)
@@ -307,10 +307,10 @@ function clause execute (RISCV_FMINM_D(rs2, rs1, rd)) = {
 
 /* FMAXM.D */
 
-union clause ast = RISCV_FMAXM_D : (regidx, regidx, regidx)
+union clause ast = RISCV_FMAXM_D : (fregidx, fregidx, fregidx)
 
-mapping clause encdec = RISCV_FMAXM_D(rs2, rs1, rd)                                        if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
-  <-> 0b001_0101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b011 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FMAXM_D(rs2, rs1, rd)                                           if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  <-> 0b001_0101 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b011 @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMAXM_D(rs2, rs1, rd)
   <-> "fmaxm.d" ^ spc() ^ freg_name(rd)
@@ -337,10 +337,10 @@ function clause execute (RISCV_FMAXM_D(rs2, rs1, rd)) = {
 
 /* FROUND.H */
 
-union clause ast = RISCV_FROUND_H : (regidx, rounding_mode, regidx)
+union clause ast = RISCV_FROUND_H : (fregidx, rounding_mode, fregidx)
 
-mapping clause encdec = RISCV_FROUND_H(rs1, rm, rd)                                                   if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
-  <-> 0b010_0010 @ 0b00100 @ encdec_reg(rs1) @ encdec_rounding_mode(rm) @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FROUND_H(rs1, rm, rd)                                                     if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  <-> 0b010_0010 @ 0b00100 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUND_H(rs1, rm, rd)
   <-> "fround.h" ^ spc() ^ freg_name(rd)
@@ -365,10 +365,10 @@ function clause execute (RISCV_FROUND_H(rs1, rm, rd)) = {
 
 /* FROUNDNX.H */
 
-union clause ast = RISCV_FROUNDNX_H : (regidx, rounding_mode, regidx)
+union clause ast = RISCV_FROUNDNX_H : (fregidx, rounding_mode, fregidx)
 
-mapping clause encdec = RISCV_FROUNDNX_H(rs1, rm, rd)                                                 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
-  <-> 0b010_0010 @ 0b00101 @ encdec_reg(rs1) @ encdec_rounding_mode(rm) @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FROUNDNX_H(rs1, rm, rd)                                                   if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  <-> 0b010_0010 @ 0b00101 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUNDNX_H(rs1, rm, rd)
   <-> "froundnx.h" ^ spc() ^ freg_name(rd)
@@ -393,10 +393,10 @@ function clause execute (RISCV_FROUNDNX_H(rs1, rm, rd)) = {
 
 /* FROUND.S */
 
-union clause ast = RISCV_FROUND_S : (regidx, rounding_mode, regidx)
+union clause ast = RISCV_FROUND_S : (fregidx, rounding_mode, fregidx)
 
-mapping clause encdec = RISCV_FROUND_S(rs1, rm, rd)                                                   if extensionEnabled(Ext_Zfa)
-  <-> 0b010_0000 @ 0b00100 @ encdec_reg(rs1) @ encdec_rounding_mode(rm) @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FROUND_S(rs1, rm, rd)                                                     if extensionEnabled(Ext_Zfa)
+  <-> 0b010_0000 @ 0b00100 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUND_S(rs1, rm, rd)
   <-> "fround.s" ^ spc() ^ freg_name(rd)
@@ -421,10 +421,10 @@ function clause execute (RISCV_FROUND_S(rs1, rm, rd)) = {
 
 /* FROUNDNX.S */
 
-union clause ast = RISCV_FROUNDNX_S : (regidx, rounding_mode, regidx)
+union clause ast = RISCV_FROUNDNX_S : (fregidx, rounding_mode, fregidx)
 
-mapping clause encdec = RISCV_FROUNDNX_S(rs1, rm, rd)                                                 if extensionEnabled(Ext_Zfa)
-  <-> 0b010_0000 @ 0b00101 @ encdec_reg(rs1) @ encdec_rounding_mode(rm) @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FROUNDNX_S(rs1, rm, rd)                                                   if extensionEnabled(Ext_Zfa)
+  <-> 0b010_0000 @ 0b00101 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUNDNX_S(rs1, rm, rd)
   <-> "froundnx.s" ^ spc() ^ freg_name(rd)
@@ -449,10 +449,10 @@ function clause execute (RISCV_FROUNDNX_S(rs1, rm, rd)) = {
 
 /* FROUND.D */
 
-union clause ast = RISCV_FROUND_D : (regidx, rounding_mode, regidx)
+union clause ast = RISCV_FROUND_D : (fregidx, rounding_mode, fregidx)
 
-mapping clause encdec = RISCV_FROUND_D(rs1, rm, rd)                                                   if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
-  <-> 0b010_0001 @ 0b00100 @ encdec_reg(rs1) @ encdec_rounding_mode(rm) @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FROUND_D(rs1, rm, rd)                                                     if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  <-> 0b010_0001 @ 0b00100 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUND_D(rs1, rm, rd)
   <-> "fround.d" ^ spc() ^ freg_name(rd)
@@ -477,10 +477,10 @@ function clause execute (RISCV_FROUND_D(rs1, rm, rd)) = {
 
 /* FROUNDNX.D */
 
-union clause ast = RISCV_FROUNDNX_D : (regidx, rounding_mode, regidx)
+union clause ast = RISCV_FROUNDNX_D : (fregidx, rounding_mode, fregidx)
 
-mapping clause encdec = RISCV_FROUNDNX_D(rs1, rm, rd)                                                 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
-  <-> 0b010_0001 @ 0b00101 @ encdec_reg(rs1) @ encdec_rounding_mode(rm) @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FROUNDNX_D(rs1, rm, rd)                                                   if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  <-> 0b010_0001 @ 0b00101 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUNDNX_D(rs1, rm, rd)
   <-> "froundnx.d" ^ spc() ^ freg_name(rd)
@@ -505,10 +505,10 @@ function clause execute (RISCV_FROUNDNX_D(rs1, rm, rd)) = {
 
 /* FMVH.X.D */
 
-union clause ast = RISCV_FMVH_X_D : (regidx, regidx)
+union clause ast = RISCV_FMVH_X_D : (fregidx, regidx)
 
-mapping clause encdec   = RISCV_FMVH_X_D(rs1, rd)                                  if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
-  <-> 0b111_0001 @ 0b00001 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
+mapping clause encdec   = RISCV_FMVH_X_D(rs1, rd)                                   if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
+  <-> 0b111_0001 @ 0b00001 @ encdec_freg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
 
 mapping clause assembly = RISCV_FMVH_X_D(rs1, rd)
   <-> "fmvh.x.d" ^ spc() ^ reg_name(rd)
@@ -523,10 +523,10 @@ function clause execute (RISCV_FMVH_X_D(rs1, rd)) = {
 
 /* FMVP.X.D */
 
-union clause ast = RISCV_FMVP_D_X : (regidx, regidx, regidx)
+union clause ast = RISCV_FMVP_D_X : (regidx, regidx, fregidx)
 
-mapping clause encdec = RISCV_FMVP_D_X(rs2, rs1, rd)                                       if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
-  <-> 0b101_1001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
+mapping clause encdec = RISCV_FMVP_D_X(rs2, rs1, rd)                                        if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
+  <-> 0b101_1001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
 
 mapping clause assembly = RISCV_FMVP_D_X(rs2, rs1, rd)
   <-> "fmvp.d.x" ^ spc() ^ freg_name(rd)
@@ -550,13 +550,13 @@ function clause execute (RISCV_FMVP_D_X(rs2, rs1, rd)) = {
 
 /* FLEQ.H */
 
-union clause ast = RISCV_FLEQ_H : (regidx, regidx, regidx)
+union clause ast = RISCV_FLEQ_H : (fregidx, fregidx, regidx)
 
-mapping clause encdec = RISCV_FLEQ_H(rs2, rs1, rd)                                         if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
-  <-> 0b101_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLEQ_H(rs2, rs1, rd)                                           if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  <-> 0b101_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLEQ_H(rs2, rs1, rd)
-  <-> "fleq.h" ^ spc() ^ freg_name(rd)
+  <-> "fleq.h" ^ spc() ^ reg_name(rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
@@ -574,13 +574,13 @@ function clause execute(RISCV_FLEQ_H(rs2, rs1, rd)) = {
 
 /* FLTQ.H */
 
-union clause ast = RISCV_FLTQ_H : (regidx, regidx, regidx)
+union clause ast = RISCV_FLTQ_H : (fregidx, fregidx, regidx)
 
-mapping clause encdec = RISCV_FLTQ_H(rs2, rs1, rd)                                         if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
-  <-> 0b101_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLTQ_H(rs2, rs1, rd)                                           if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  <-> 0b101_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLTQ_H(rs2, rs1, rd)
-  <-> "fltq.h" ^ spc() ^ freg_name(rd)
+  <-> "fltq.h" ^ spc() ^ reg_name(rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
@@ -598,13 +598,13 @@ function clause execute(RISCV_FLTQ_H(rs2, rs1, rd)) = {
 
 /* FLEQ.S */
 
-union clause ast = RISCV_FLEQ_S : (regidx, regidx, regidx)
+union clause ast = RISCV_FLEQ_S : (fregidx, fregidx, regidx)
 
-mapping clause encdec = RISCV_FLEQ_S(rs2, rs1, rd)                                         if extensionEnabled(Ext_Zfa)
-  <-> 0b101_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLEQ_S(rs2, rs1, rd)                                           if extensionEnabled(Ext_Zfa)
+  <-> 0b101_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLEQ_S(rs2, rs1, rd)
-  <-> "fleq.s" ^ spc() ^ freg_name(rd)
+  <-> "fleq.s" ^ spc() ^ reg_name(rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
@@ -622,13 +622,13 @@ function clause execute(RISCV_FLEQ_S(rs2, rs1, rd)) = {
 
 /* FLTQ.S */
 
-union clause ast = RISCV_FLTQ_S : (regidx, regidx, regidx)
+union clause ast = RISCV_FLTQ_S : (fregidx, fregidx, regidx)
 
-mapping clause encdec = RISCV_FLTQ_S(rs2, rs1, rd)                                         if extensionEnabled(Ext_Zfa)
-  <-> 0b101_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLTQ_S(rs2, rs1, rd)                                           if extensionEnabled(Ext_Zfa)
+  <-> 0b101_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLTQ_S(rs2, rs1, rd)
-  <-> "fltq.s" ^ spc() ^ freg_name(rd)
+  <-> "fltq.s" ^ spc() ^ reg_name(rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
@@ -647,13 +647,13 @@ function clause execute(RISCV_FLTQ_S(rs2, rs1, rd)) = {
 
 /* FLEQ.D */
 
-union clause ast = RISCV_FLEQ_D : (regidx, regidx, regidx)
+union clause ast = RISCV_FLEQ_D : (fregidx, fregidx, regidx)
 
-mapping clause encdec = RISCV_FLEQ_D(rs2, rs1, rd)                                         if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
-  <-> 0b101_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLEQ_D(rs2, rs1, rd)                                           if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  <-> 0b101_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLEQ_D(rs2, rs1, rd)
-  <-> "fleq.d" ^ spc() ^ freg_name(rd)
+  <-> "fleq.d" ^ spc() ^ reg_name(rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
@@ -671,13 +671,13 @@ function clause execute(RISCV_FLEQ_D(rs2, rs1, rd)) = {
 
 /* FLTQ.D */
 
-union clause ast = RISCV_FLTQ_D : (regidx, regidx, regidx)
+union clause ast = RISCV_FLTQ_D : (fregidx, fregidx, regidx)
 
-mapping clause encdec = RISCV_FLTQ_D(rs2, rs1, rd)                                         if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
-  <-> 0b101_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLTQ_D(rs2, rs1, rd)                                           if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  <-> 0b101_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLTQ_D(rs2, rs1, rd)
-  <-> "fltq.d" ^ spc() ^ freg_name(rd)
+  <-> "fltq.d" ^ spc() ^ reg_name(rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
@@ -758,11 +758,11 @@ function fcvtmod_helper(x64) = {
   }
 }
 
-union clause ast = RISCV_FCVTMOD_W_D : (regidx, regidx)
+union clause ast = RISCV_FCVTMOD_W_D : (fregidx, regidx)
 
 /* We need rounding mode to be explicitly specified to RTZ(0b001) */
-mapping clause encdec = RISCV_FCVTMOD_W_D(rs1, rd)                                 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
-  <-> 0b110_0001 @ 0b01000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FCVTMOD_W_D(rs1, rd)                                  if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  <-> 0b110_0001 @ 0b01000 @ encdec_freg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FCVTMOD_W_D(rs1, rd)
   <-> "fcvtmod.w.d" ^ spc() ^ reg_name(rd) ^ sep() ^ freg_name(rs1)

--- a/model/riscv_insts_zfa.sail
+++ b/model/riscv_insts_zfa.sail
@@ -12,8 +12,8 @@ function clause extensionEnabled(Ext_Zfa) = true
 
 union clause ast = RISCV_FLI_H : (bits(5), regidx)
 
-mapping clause encdec = RISCV_FLI_H(rs1, rd)                if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
-  <-> 0b111_1010 @ 0b00001 @ rs1 @ 0b000 @ rd @ 0b101_0011  if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLI_H(rs1, rd)                           if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  <-> 0b111_1010 @ 0b00001 @ rs1 @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLI_H(constantidx, rd)
   <-> "fli.h" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_5(constantidx)
@@ -61,8 +61,8 @@ function clause execute (RISCV_FLI_H(constantidx, rd)) = {
 
 union clause ast = RISCV_FLI_S : (bits(5), regidx)
 
-mapping clause encdec = RISCV_FLI_S(rs1, rd)                if extensionEnabled(Ext_Zfa)
-  <-> 0b111_1000 @ 0b00001 @ rs1 @ 0b000 @ rd @ 0b101_0011  if extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLI_S(rs1, rd)                           if extensionEnabled(Ext_Zfa)
+  <-> 0b111_1000 @ 0b00001 @ rs1 @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLI_S(constantidx, rd)
   <-> "fli.s" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_5(constantidx)
@@ -110,8 +110,8 @@ function clause execute (RISCV_FLI_S(constantidx, rd)) = {
 
 union clause ast = RISCV_FLI_D : (bits(5), regidx)
 
-mapping clause encdec = RISCV_FLI_D(rs1, rd)                if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
-  <-> 0b111_1001 @ 0b00001 @ rs1 @ 0b000 @ rd @ 0b101_0011  if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLI_D(rs1, rd)                           if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  <-> 0b111_1001 @ 0b00001 @ rs1 @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLI_D(constantidx, rd)
   <-> "fli.d" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_5(constantidx)
@@ -159,8 +159,8 @@ function clause execute (RISCV_FLI_D(constantidx, rd)) = {
 
 union clause ast = RISCV_FMINM_H : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_FMINM_H(rs2, rs1, rd)     if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
-  <-> 0b001_0110 @ rs2 @ rs1 @ 0b010 @ rd @ 0b101_0011  if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FMINM_H(rs2, rs1, rd)                                        if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  <-> 0b001_0110 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMINM_H(rs2, rs1, rd)
   <-> "fminm.h" ^ spc() ^ freg_name(rd)
@@ -189,8 +189,8 @@ function clause execute (RISCV_FMINM_H(rs2, rs1, rd)) = {
 
 union clause ast = RISCV_FMAXM_H : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_FMAXM_H(rs2, rs1, rd)     if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
-  <-> 0b001_0110 @ rs2 @ rs1 @ 0b011 @ rd @ 0b101_0011  if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FMAXM_H(rs2, rs1, rd)                                        if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  <-> 0b001_0110 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b011 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMAXM_H(rs2, rs1, rd)
   <-> "fmaxm.h" ^ spc() ^ freg_name(rd)
@@ -219,8 +219,8 @@ function clause execute (RISCV_FMAXM_H(rs2, rs1, rd)) = {
 
 union clause ast = RISCV_FMINM_S : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_FMINM_S(rs2, rs1, rd)     if extensionEnabled(Ext_Zfa)
-  <-> 0b001_0100 @ rs2 @ rs1 @ 0b010 @ rd @ 0b101_0011  if extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FMINM_S(rs2, rs1, rd)                                        if extensionEnabled(Ext_Zfa)
+  <-> 0b001_0100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMINM_S(rs2, rs1, rd)
   <-> "fminm.s" ^ spc() ^ freg_name(rd)
@@ -249,8 +249,8 @@ function clause execute (RISCV_FMINM_S(rs2, rs1, rd)) = {
 
 union clause ast = RISCV_FMAXM_S : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_FMAXM_S(rs2, rs1, rd)     if extensionEnabled(Ext_Zfa)
-  <-> 0b001_0100 @ rs2 @ rs1 @ 0b011 @ rd @ 0b101_0011  if extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FMAXM_S(rs2, rs1, rd)                                        if extensionEnabled(Ext_Zfa)
+  <-> 0b001_0100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b011 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMAXM_S(rs2, rs1, rd)
   <-> "fmaxm.s" ^ spc() ^ freg_name(rd)
@@ -279,8 +279,8 @@ function clause execute (RISCV_FMAXM_S(rs2, rs1, rd)) = {
 
 union clause ast = RISCV_FMINM_D : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_FMINM_D(rs2, rs1, rd)     if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
-  <-> 0b001_0101 @ rs2 @ rs1 @ 0b010 @ rd @ 0b101_0011  if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FMINM_D(rs2, rs1, rd)                                        if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  <-> 0b001_0101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMINM_D(rs2, rs1, rd)
   <-> "fminm.d" ^ spc() ^ freg_name(rd)
@@ -309,8 +309,8 @@ function clause execute (RISCV_FMINM_D(rs2, rs1, rd)) = {
 
 union clause ast = RISCV_FMAXM_D : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_FMAXM_D(rs2, rs1, rd)     if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
-  <-> 0b001_0101 @ rs2 @ rs1 @ 0b011 @ rd @ 0b101_0011  if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FMAXM_D(rs2, rs1, rd)                                        if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  <-> 0b001_0101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b011 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMAXM_D(rs2, rs1, rd)
   <-> "fmaxm.d" ^ spc() ^ freg_name(rd)
@@ -339,8 +339,8 @@ function clause execute (RISCV_FMAXM_D(rs2, rs1, rd)) = {
 
 union clause ast = RISCV_FROUND_H : (regidx, rounding_mode, regidx)
 
-mapping clause encdec = RISCV_FROUND_H(rs1, rm, rd)                           if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
-  <-> 0b010_0010 @ 0b00100 @ rs1 @ encdec_rounding_mode(rm) @ rd @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FROUND_H(rs1, rm, rd)                                                   if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  <-> 0b010_0010 @ 0b00100 @ encdec_reg(rs1) @ encdec_rounding_mode(rm) @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUND_H(rs1, rm, rd)
   <-> "fround.h" ^ spc() ^ freg_name(rd)
@@ -367,8 +367,8 @@ function clause execute (RISCV_FROUND_H(rs1, rm, rd)) = {
 
 union clause ast = RISCV_FROUNDNX_H : (regidx, rounding_mode, regidx)
 
-mapping clause encdec = RISCV_FROUNDNX_H(rs1, rm, rd)                         if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
-  <-> 0b010_0010 @ 0b00101 @ rs1 @ encdec_rounding_mode(rm) @ rd @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FROUNDNX_H(rs1, rm, rd)                                                 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  <-> 0b010_0010 @ 0b00101 @ encdec_reg(rs1) @ encdec_rounding_mode(rm) @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUNDNX_H(rs1, rm, rd)
   <-> "froundnx.h" ^ spc() ^ freg_name(rd)
@@ -395,8 +395,8 @@ function clause execute (RISCV_FROUNDNX_H(rs1, rm, rd)) = {
 
 union clause ast = RISCV_FROUND_S : (regidx, rounding_mode, regidx)
 
-mapping clause encdec = RISCV_FROUND_S(rs1, rm, rd)                            if extensionEnabled(Ext_Zfa)
-  <-> 0b010_0000 @ 0b00100 @ rs1 @ encdec_rounding_mode(rm) @ rd @ 0b101_0011  if extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FROUND_S(rs1, rm, rd)                                                   if extensionEnabled(Ext_Zfa)
+  <-> 0b010_0000 @ 0b00100 @ encdec_reg(rs1) @ encdec_rounding_mode(rm) @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUND_S(rs1, rm, rd)
   <-> "fround.s" ^ spc() ^ freg_name(rd)
@@ -423,8 +423,8 @@ function clause execute (RISCV_FROUND_S(rs1, rm, rd)) = {
 
 union clause ast = RISCV_FROUNDNX_S : (regidx, rounding_mode, regidx)
 
-mapping clause encdec = RISCV_FROUNDNX_S(rs1, rm, rd)                         if extensionEnabled(Ext_Zfa)
-  <-> 0b010_0000 @ 0b00101 @ rs1 @ encdec_rounding_mode(rm) @ rd @ 0b101_0011 if extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FROUNDNX_S(rs1, rm, rd)                                                 if extensionEnabled(Ext_Zfa)
+  <-> 0b010_0000 @ 0b00101 @ encdec_reg(rs1) @ encdec_rounding_mode(rm) @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUNDNX_S(rs1, rm, rd)
   <-> "froundnx.s" ^ spc() ^ freg_name(rd)
@@ -451,8 +451,8 @@ function clause execute (RISCV_FROUNDNX_S(rs1, rm, rd)) = {
 
 union clause ast = RISCV_FROUND_D : (regidx, rounding_mode, regidx)
 
-mapping clause encdec = RISCV_FROUND_D(rs1, rm, rd)                            if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
-  <-> 0b010_0001 @ 0b00100 @ rs1 @ encdec_rounding_mode(rm) @ rd @ 0b101_0011  if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FROUND_D(rs1, rm, rd)                                                   if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  <-> 0b010_0001 @ 0b00100 @ encdec_reg(rs1) @ encdec_rounding_mode(rm) @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUND_D(rs1, rm, rd)
   <-> "fround.d" ^ spc() ^ freg_name(rd)
@@ -479,8 +479,8 @@ function clause execute (RISCV_FROUND_D(rs1, rm, rd)) = {
 
 union clause ast = RISCV_FROUNDNX_D : (regidx, rounding_mode, regidx)
 
-mapping clause encdec = RISCV_FROUNDNX_D(rs1, rm, rd)                         if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
-  <-> 0b010_0001 @ 0b00101 @ rs1 @ encdec_rounding_mode(rm) @ rd @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FROUNDNX_D(rs1, rm, rd)                                                 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  <-> 0b010_0001 @ 0b00101 @ encdec_reg(rs1) @ encdec_rounding_mode(rm) @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUNDNX_D(rs1, rm, rd)
   <-> "froundnx.d" ^ spc() ^ freg_name(rd)
@@ -507,8 +507,8 @@ function clause execute (RISCV_FROUNDNX_D(rs1, rm, rd)) = {
 
 union clause ast = RISCV_FMVH_X_D : (regidx, regidx)
 
-mapping clause encdec   = RISCV_FMVH_X_D(rs1, rd)           if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
-  <-> 0b111_0001 @ 0b00001 @ rs1 @ 0b000 @ rd @ 0b101_0011  if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
+mapping clause encdec   = RISCV_FMVH_X_D(rs1, rd)                                  if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
+  <-> 0b111_0001 @ 0b00001 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
 
 mapping clause assembly = RISCV_FMVH_X_D(rs1, rd)
   <-> "fmvh.x.d" ^ spc() ^ reg_name(rd)
@@ -525,8 +525,8 @@ function clause execute (RISCV_FMVH_X_D(rs1, rd)) = {
 
 union clause ast = RISCV_FMVP_D_X : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_FMVP_D_X(rs2, rs1, rd)        if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
-  <-> 0b101_1001 @ rs2 @ rs1 @ 0b000 @ rd @ 0b101_0011      if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
+mapping clause encdec = RISCV_FMVP_D_X(rs2, rs1, rd)                                       if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
+  <-> 0b101_1001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
 
 mapping clause assembly = RISCV_FMVP_D_X(rs2, rs1, rd)
   <-> "fmvp.d.x" ^ spc() ^ freg_name(rd)
@@ -552,8 +552,8 @@ function clause execute (RISCV_FMVP_D_X(rs2, rs1, rd)) = {
 
 union clause ast = RISCV_FLEQ_H : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_FLEQ_H(rs2, rs1, rd)               if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
-  <-> 0b101_0010 @ rs2 @ rs1 @ 0b100 @ rd @ 0b101_0011           if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLEQ_H(rs2, rs1, rd)                                         if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  <-> 0b101_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLEQ_H(rs2, rs1, rd)
   <-> "fleq.h" ^ spc() ^ freg_name(rd)
@@ -576,8 +576,8 @@ function clause execute(RISCV_FLEQ_H(rs2, rs1, rd)) = {
 
 union clause ast = RISCV_FLTQ_H : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_FLTQ_H(rs2, rs1, rd)               if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
-  <-> 0b101_0010 @ rs2 @ rs1 @ 0b101 @ rd @ 0b101_0011           if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLTQ_H(rs2, rs1, rd)                                         if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  <-> 0b101_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLTQ_H(rs2, rs1, rd)
   <-> "fltq.h" ^ spc() ^ freg_name(rd)
@@ -600,8 +600,8 @@ function clause execute(RISCV_FLTQ_H(rs2, rs1, rd)) = {
 
 union clause ast = RISCV_FLEQ_S : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_FLEQ_S(rs2, rs1, rd)               if extensionEnabled(Ext_Zfa)
-  <-> 0b101_0000 @ rs2 @ rs1 @ 0b100 @ rd @ 0b101_0011           if extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLEQ_S(rs2, rs1, rd)                                         if extensionEnabled(Ext_Zfa)
+  <-> 0b101_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLEQ_S(rs2, rs1, rd)
   <-> "fleq.s" ^ spc() ^ freg_name(rd)
@@ -624,8 +624,8 @@ function clause execute(RISCV_FLEQ_S(rs2, rs1, rd)) = {
 
 union clause ast = RISCV_FLTQ_S : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_FLTQ_S(rs2, rs1, rd)               if extensionEnabled(Ext_Zfa)
-  <-> 0b101_0000 @ rs2 @ rs1 @ 0b101 @ rd @ 0b101_0011           if extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLTQ_S(rs2, rs1, rd)                                         if extensionEnabled(Ext_Zfa)
+  <-> 0b101_0000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLTQ_S(rs2, rs1, rd)
   <-> "fltq.s" ^ spc() ^ freg_name(rd)
@@ -649,8 +649,8 @@ function clause execute(RISCV_FLTQ_S(rs2, rs1, rd)) = {
 
 union clause ast = RISCV_FLEQ_D : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_FLEQ_D(rs2, rs1, rd)               if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
-  <-> 0b101_0001 @ rs2 @ rs1 @ 0b100 @ rd @ 0b101_0011           if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLEQ_D(rs2, rs1, rd)                                         if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  <-> 0b101_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLEQ_D(rs2, rs1, rd)
   <-> "fleq.d" ^ spc() ^ freg_name(rd)
@@ -673,8 +673,8 @@ function clause execute(RISCV_FLEQ_D(rs2, rs1, rd)) = {
 
 union clause ast = RISCV_FLTQ_D : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_FLTQ_D(rs2, rs1, rd)               if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
-  <-> 0b101_0001 @ rs2 @ rs1 @ 0b101 @ rd @ 0b101_0011           if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FLTQ_D(rs2, rs1, rd)                                         if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  <-> 0b101_0001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLTQ_D(rs2, rs1, rd)
   <-> "fltq.d" ^ spc() ^ freg_name(rd)
@@ -761,8 +761,8 @@ function fcvtmod_helper(x64) = {
 union clause ast = RISCV_FCVTMOD_W_D : (regidx, regidx)
 
 /* We need rounding mode to be explicitly specified to RTZ(0b001) */
-mapping clause encdec = RISCV_FCVTMOD_W_D(rs1, rd)          if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
-  <-> 0b110_0001 @ 0b01000 @ rs1 @ 0b001 @ rd @ 0b101_0011  if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+mapping clause encdec = RISCV_FCVTMOD_W_D(rs1, rd)                                 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  <-> 0b110_0001 @ 0b01000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FCVTMOD_W_D(rs1, rd)
   <-> "fcvtmod.w.d" ^ spc() ^ reg_name(rd) ^ sep() ^ freg_name(rs1)

--- a/model/riscv_insts_zfh.sail
+++ b/model/riscv_insts_zfh.sail
@@ -181,25 +181,25 @@ function haveHalfMin() -> bool = haveHalfFPU() | extensionEnabled(Ext_Zfhmin)
 
 /* AST */
 
-union clause ast = F_BIN_RM_TYPE_H : (regidx, regidx, rounding_mode, regidx, f_bin_rm_op_H)
+union clause ast = F_BIN_RM_TYPE_H : (fregidx, fregidx, rounding_mode, fregidx, f_bin_rm_op_H)
 
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FADD_H)                                                                if haveHalfFPU()
-<-> 0b000_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FADD_H)                                                                   if haveHalfFPU()
+<-> 0b000_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FSUB_H)                                                                if haveHalfFPU()
-<-> 0b000_0110 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FSUB_H)                                                                   if haveHalfFPU()
+<-> 0b000_0110 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FMUL_H)                                                                if haveHalfFPU()
-<-> 0b000_1010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FMUL_H)                                                                   if haveHalfFPU()
+<-> 0b000_1010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FDIV_H)                                                                if haveHalfFPU()
-<-> 0b000_1110 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FDIV_H)                                                                   if haveHalfFPU()
+<-> 0b000_1110 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveHalfFPU()
 
 /* Execution semantics ================================ */
 
@@ -244,25 +244,25 @@ mapping clause assembly = F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, op)
 
 /* AST */
 
-union clause ast = F_MADD_TYPE_H : (regidx, regidx, regidx, rounding_mode, regidx, f_madd_op_H)
+union clause ast = F_MADD_TYPE_H : (fregidx, fregidx, fregidx, rounding_mode, fregidx, f_madd_op_H)
 
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FMADD_H)                                                                        if haveHalfFPU()
-<-> encdec_reg(rs3) @ 0b10 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_0011 if haveHalfFPU()
+    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FMADD_H)                                                                            if haveHalfFPU()
+<-> encdec_freg(rs3) @ 0b10 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b100_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FMSUB_H)                                                                        if haveHalfFPU()
-<-> encdec_reg(rs3) @ 0b10 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_0111 if haveHalfFPU()
+    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FMSUB_H)                                                                            if haveHalfFPU()
+<-> encdec_freg(rs3) @ 0b10 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b100_0111 if haveHalfFPU()
 
 mapping clause encdec =
-    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FNMSUB_H)                                                                       if haveHalfFPU()
-<-> encdec_reg(rs3) @ 0b10 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_1011 if haveHalfFPU()
+    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FNMSUB_H)                                                                           if haveHalfFPU()
+<-> encdec_freg(rs3) @ 0b10 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b100_1011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FNMADD_H)                                                                       if haveHalfFPU()
-<-> encdec_reg(rs3) @ 0b10 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_1111 if haveHalfFPU()
+    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FNMADD_H)                                                                           if haveHalfFPU()
+<-> encdec_freg(rs3) @ 0b10 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b100_1111 if haveHalfFPU()
 
 /* Execution semantics ================================ */
 
@@ -310,37 +310,38 @@ mapping clause assembly = F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, op)
 
 /* AST */
 
-union clause ast = F_BIN_TYPE_H : (regidx, regidx, regidx, f_bin_op_H)
+union clause ast = F_BIN_F_TYPE_H : (fregidx, fregidx, fregidx, f_bin_f_op_H)
+union clause ast = F_BIN_X_TYPE_H : (fregidx, fregidx, regidx, f_bin_x_op_H)
 
 /* AST <-> Binary encoding ================================ */
 
-mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJ_H)                                if haveHalfFPU()
-  <-> 0b001_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+mapping clause encdec = F_BIN_F_TYPE_H(rs2, rs1, rd, FSGNJ_H)                                 if haveHalfFPU()
+  <-> 0b001_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011 if haveHalfFPU()
 
-mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJN_H)                               if haveHalfFPU()
-  <-> 0b001_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+mapping clause encdec = F_BIN_F_TYPE_H(rs2, rs1, rd, FSGNJN_H)                                if haveHalfFPU()
+  <-> 0b001_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b001 @ encdec_freg(rd) @ 0b101_0011 if haveHalfFPU()
 
-mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJX_H)                               if haveHalfFPU()
-  <-> 0b001_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+mapping clause encdec = F_BIN_F_TYPE_H(rs2, rs1, rd, FSGNJX_H)                                if haveHalfFPU()
+  <-> 0b001_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b101_0011 if haveHalfFPU()
 
-mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FMIN_H)                                 if haveHalfFPU()
-  <-> 0b001_0110 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+mapping clause encdec = F_BIN_F_TYPE_H(rs2, rs1, rd, FMIN_H)                                  if haveHalfFPU()
+  <-> 0b001_0110 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011 if haveHalfFPU()
 
-mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FMAX_H)                                 if haveHalfFPU()
-  <-> 0b001_0110 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+mapping clause encdec = F_BIN_F_TYPE_H(rs2, rs1, rd, FMAX_H)                                  if haveHalfFPU()
+  <-> 0b001_0110 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b001 @ encdec_freg(rd) @ 0b101_0011 if haveHalfFPU()
 
-mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FEQ_H)                                  if haveHalfFPU()
-  <-> 0b101_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+mapping clause encdec = F_BIN_X_TYPE_H(rs2, rs1, rd, FEQ_H)                                  if haveHalfFPU()
+  <-> 0b101_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
-mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FLT_H)                                  if haveHalfFPU()
-  <-> 0b101_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+mapping clause encdec = F_BIN_X_TYPE_H(rs2, rs1, rd, FLT_H)                                  if haveHalfFPU()
+  <-> 0b101_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
-mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FLE_H)                                  if haveHalfFPU()
-  <-> 0b101_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+mapping clause encdec = F_BIN_X_TYPE_H(rs2, rs1, rd, FLE_H)                                  if haveHalfFPU()
+  <-> 0b101_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
 /* Execution semantics ================================ */
 
-function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FSGNJ_H)) = {
+function clause execute (F_BIN_F_TYPE_H(rs2, rs1, rd, FSGNJ_H)) = {
   let rs1_val_H    = F_or_X_H(rs1);
   let rs2_val_H    = F_or_X_H(rs2);
   let (s1, e1, m1) = fsplit_H (rs1_val_H);
@@ -351,7 +352,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FSGNJ_H)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FSGNJN_H)) = {
+function clause execute (F_BIN_F_TYPE_H(rs2, rs1, rd, FSGNJN_H)) = {
   let rs1_val_H    = F_or_X_H(rs1);
   let rs2_val_H    = F_or_X_H(rs2);
   let (s1, e1, m1) = fsplit_H (rs1_val_H);
@@ -362,7 +363,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FSGNJN_H)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FSGNJX_H)) = {
+function clause execute (F_BIN_F_TYPE_H(rs2, rs1, rd, FSGNJX_H)) = {
   let rs1_val_H    = F_or_X_H(rs1);
   let rs2_val_H    = F_or_X_H(rs2);
   let (s1, e1, m1) = fsplit_H (rs1_val_H);
@@ -373,7 +374,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FSGNJX_H)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FMIN_H)) = {
+function clause execute (F_BIN_F_TYPE_H(rs2, rs1, rd, FMIN_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   let rs2_val_H = F_or_X_H(rs2);
 
@@ -393,7 +394,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FMIN_H)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FMAX_H)) = {
+function clause execute (F_BIN_F_TYPE_H(rs2, rs1, rd, FMAX_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   let rs2_val_H = F_or_X_H(rs2);
 
@@ -413,7 +414,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FMAX_H)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FEQ_H)) = {
+function clause execute (F_BIN_X_TYPE_H(rs2, rs1, rd, FEQ_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   let rs2_val_H = F_or_X_H(rs2);
 
@@ -425,7 +426,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FEQ_H)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FLT_H)) = {
+function clause execute (F_BIN_X_TYPE_H(rs2, rs1, rd, FLT_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   let rs2_val_H = F_or_X_H(rs2);
 
@@ -437,7 +438,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FLT_H)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FLE_H)) = {
+function clause execute (F_BIN_X_TYPE_H(rs2, rs1, rd, FLE_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   let rs2_val_H = F_or_X_H(rs2);
 
@@ -451,61 +452,28 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FLE_H)) = {
 
 /* AST -> Assembly notation ================================ */
 
-mapping f_bin_type_mnemonic_H : f_bin_op_H <-> string = {
+mapping f_bin_f_type_mnemonic_H : f_bin_f_op_H <-> string = {
     FSGNJ_H  <-> "fsgnj.h",
     FSGNJN_H <-> "fsgnjn.h",
     FSGNJX_H <-> "fsgnjx.h",
     FMIN_H   <-> "fmin.h",
     FMAX_H   <-> "fmax.h",
+}
+
+mapping clause assembly = F_BIN_F_TYPE_H(rs2, rs1, rd, op)
+                      <-> f_bin_f_type_mnemonic_H(op)
+                          ^ spc() ^ freg_or_reg_name(rd)
+                          ^ sep() ^ freg_or_reg_name(rs1)
+                          ^ sep() ^ freg_or_reg_name(rs2)
+
+mapping f_bin_x_type_mnemonic_H : f_bin_x_op_H <-> string = {
     FEQ_H    <-> "feq.h",
     FLT_H    <-> "flt.h",
     FLE_H    <-> "fle.h"
 }
 
-mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJ_H)
-                      <-> f_bin_type_mnemonic_H(FSGNJ_H)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJN_H)
-                      <-> f_bin_type_mnemonic_H(FSGNJN_H)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJX_H)
-                      <-> f_bin_type_mnemonic_H(FSGNJX_H)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FMIN_H)
-                      <-> f_bin_type_mnemonic_H(FMIN_H)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FMAX_H)
-                      <-> f_bin_type_mnemonic_H(FMAX_H)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FEQ_H)
-                      <-> f_bin_type_mnemonic_H(FEQ_H)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FLT_H)
-                      <-> f_bin_type_mnemonic_H(FLT_H)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ freg_or_reg_name(rs2)
-
-mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FLE_H)
-                      <-> f_bin_type_mnemonic_H(FLE_H)
+mapping clause assembly = F_BIN_X_TYPE_H(rs2, rs1, rd, op)
+                      <-> f_bin_x_type_mnemonic_H(op)
                           ^ spc() ^ reg_name(rd)
                           ^ sep() ^ freg_or_reg_name(rs1)
                           ^ sep() ^ freg_or_reg_name(rs2)
@@ -515,45 +483,47 @@ mapping clause assembly = F_BIN_TYPE_H(rs2, rs1, rd, FLE_H)
 
 /* AST */
 
-union clause ast = F_UN_RM_TYPE_H : (regidx, rounding_mode, regidx, f_un_rm_op_H)
+union clause ast = F_UN_RM_FF_TYPE_H : (fregidx, rounding_mode, fregidx, f_un_rm_ff_op_H)
+union clause ast = F_UN_RM_FX_TYPE_H : (fregidx, rounding_mode, regidx, f_un_rm_fx_op_H)
+union clause ast = F_UN_RM_XF_TYPE_H : (regidx, rounding_mode, fregidx, f_un_rm_xf_op_H)
 
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FSQRT_H)                                                             if haveHalfFPU()
-<-> 0b010_1110 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+    F_UN_RM_FF_TYPE_H(rs1, rm, rd, FSQRT_H)                                                            if haveHalfFPU()
+<-> 0b010_1110 @ 0b00000 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_W_H)                                                            if haveHalfFPU()
-<-> 0b110_0010 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+    F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_W_H)                                                          if haveHalfFPU()
+<-> 0b110_0010 @ 0b00000 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_WU_H)                                                           if haveHalfFPU()
-<-> 0b110_0010 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+    F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_WU_H)                                                         if haveHalfFPU()
+<-> 0b110_0010 @ 0b00001 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_W)                                                            if haveHalfFPU()
-<-> 0b110_1010 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+    F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_W)                                                          if haveHalfFPU()
+<-> 0b110_1010 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_WU)                                                           if haveHalfFPU()
-<-> 0b110_1010 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+    F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_WU)                                                         if haveHalfFPU()
+<-> 0b110_1010 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_S)                                                            if haveHalfMin()
-<-> 0b010_0010 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfMin()
+    F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_H_S)                                                           if haveHalfMin()
+<-> 0b010_0010 @ 0b00000 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveHalfMin()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_D)                                                            if haveHalfMin() & (haveDoubleFPU() & validDoubleRegs([rs1]))
-<-> 0b010_0010 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfMin() & (haveDoubleFPU() & validDoubleRegs([rs1]))
+    F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_H_D)                                                           if haveHalfMin() & (haveDoubleFPU() & validDoubleRegs([rs1]))
+<-> 0b010_0010 @ 0b00001 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveHalfMin() & (haveDoubleFPU() & validDoubleRegs([rs1]))
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_S_H)                                                            if haveHalfMin()
-<-> 0b010_0000 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfMin()
+    F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_S_H)                                                           if haveHalfMin()
+<-> 0b010_0000 @ 0b00010 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveHalfMin()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_D_H)                                                            if haveHalfMin() & (haveDoubleFPU() & validDoubleRegs([rd]))
-<-> 0b010_0001 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfMin() & (haveDoubleFPU() & validDoubleRegs([rd]))
+    F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_D_H)                                                           if haveHalfMin() & (haveDoubleFPU() & validDoubleRegs([rd]))
+<-> 0b010_0001 @ 0b00010 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveHalfMin() & (haveDoubleFPU() & validDoubleRegs([rd]))
 
 // TODO:
 /* FCVT_H_Q, FCVT_Q_H : Will be added with Q Extension */
@@ -561,24 +531,24 @@ mapping clause encdec =
 /* F instructions, RV64 only */
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_L_H)                                                            if haveHalfFPU() & xlen >= 64
-<-> 0b110_0010 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU() & xlen >= 64
+    F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_L_H)                                                          if haveHalfFPU() & xlen >= 64
+<-> 0b110_0010 @ 0b00010 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_LU_H)                                                           if haveHalfFPU() & xlen >= 64
-<-> 0b110_0010 @ 0b00011 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU() & xlen >= 64
+    F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_LU_H)                                                         if haveHalfFPU() & xlen >= 64
+<-> 0b110_0010 @ 0b00011 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_L)                                                            if haveHalfFPU() & xlen >= 64
-<-> 0b110_1010 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU() & xlen >= 64
+    F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_L)                                                          if haveHalfFPU() & xlen >= 64
+<-> 0b110_1010 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveHalfFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_LU)                                                           if haveHalfFPU() & xlen >= 64
-<-> 0b110_1010 @ 0b00011 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU() & xlen >= 64
+    F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_LU)                                                         if haveHalfFPU() & xlen >= 64
+<-> 0b110_1010 @ 0b00011 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011 if haveHalfFPU() & xlen >= 64
 
 /* Execution semantics ================================ */
 
-function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FSQRT_H)) = {
+function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FSQRT_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -593,7 +563,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FSQRT_H)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_W_H)) = {
+function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_W_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -608,7 +578,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_W_H)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_WU_H)) = {
+function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_WU_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -623,7 +593,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_WU_H)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_W)) = {
+function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_W)) = {
   let rs1_val_W = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -638,7 +608,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_W)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_WU)) = {
+function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_WU)) = {
   let rs1_val_WU = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -653,7 +623,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_WU)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_S)) = {
+function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_H_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -668,7 +638,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_S)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_D)) = {
+function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_H_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -683,7 +653,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_D)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_S_H)) = {
+function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_S_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -698,8 +668,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_S_H)) = {
   }
 }
 
-
-function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_D_H)) = {
+function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_D_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => { handle_illegal(); RETIRE_FAIL },
@@ -714,7 +683,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_D_H)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_L_H)) = {
+function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_L_H)) = {
   assert(xlen >= 64);
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
@@ -730,7 +699,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_L_H)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_LU_H)) = {
+function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_LU_H)) = {
   assert(xlen >= 64);
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
@@ -746,7 +715,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_LU_H)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_L)) = {
+function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_L)) = {
   assert(xlen >= 64);
   let rs1_val_L = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
@@ -762,7 +731,7 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_L)) = {
   }
 }
 
-function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_LU)) = {
+function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_LU)) = {
   assert(xlen >= 64);
   let rs1_val_LU = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
@@ -780,121 +749,66 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_LU)) = {
 
 /* AST -> Assembly notation ================================ */
 
-mapping f_un_rm_type_mnemonic_H : f_un_rm_op_H <-> string = {
+mapping f_un_rm_ff_type_mnemonic_H : f_un_rm_ff_op_H <-> string = {
     FSQRT_H   <-> "fsqrt.h",
-    FCVT_W_H  <-> "fcvt.w.h",
-    FCVT_WU_H <-> "fcvt.wu.h",
-    FCVT_H_W  <-> "fcvt.h.w",
-    FCVT_H_WU <-> "fcvt.h.wu",
-
     FCVT_H_S  <-> "fcvt.h.s",
     FCVT_H_D  <-> "fcvt.h.d",
     FCVT_S_H  <-> "fcvt.s.h",
     FCVT_D_H  <-> "fcvt.d.h",
+}
 
+mapping clause assembly = F_UN_RM_FF_TYPE_H(rs1, rm, rd, op)
+                      <-> f_un_rm_ff_type_mnemonic_H(op)
+                          ^ spc() ^ freg_or_reg_name(rd)
+                          ^ sep() ^ freg_or_reg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+mapping f_un_rm_fx_type_mnemonic_H : f_un_rm_fx_op_H <-> string = {
+    FCVT_W_H  <-> "fcvt.w.h",
+    FCVT_WU_H <-> "fcvt.wu.h",
     FCVT_L_H  <-> "fcvt.l.h",
     FCVT_LU_H <-> "fcvt.lu.h",
+}
+
+mapping clause assembly = F_UN_RM_FX_TYPE_H(rs1, rm, rd, op)
+                      <-> f_un_rm_fx_type_mnemonic_H(op)
+                          ^ spc() ^ reg_name(rd)
+                          ^ sep() ^ freg_or_reg_name(rs1)
+                          ^ sep() ^ frm_mnemonic(rm)
+
+mapping f_un_rm_xf_type_mnemonic_H : f_un_rm_xf_op_H <-> string = {
+    FCVT_H_W  <-> "fcvt.h.w",
+    FCVT_H_WU <-> "fcvt.h.wu",
     FCVT_H_L  <-> "fcvt.h.l",
     FCVT_H_LU <-> "fcvt.h.lu"
 }
 
-mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FSQRT_H)
-                      <-> f_un_rm_type_mnemonic_H(FSQRT_H)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_W_H)
-                      <-> f_un_rm_type_mnemonic_H(FCVT_W_H)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_WU_H)
-                      <-> f_un_rm_type_mnemonic_H(FCVT_WU_H)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_W)
-                      <-> f_un_rm_type_mnemonic_H(FCVT_H_W)
+mapping clause assembly = F_UN_RM_XF_TYPE_H(rs1, rm, rd, op)
+                      <-> f_un_rm_xf_type_mnemonic_H(op)
                           ^ spc() ^ freg_or_reg_name(rd)
                           ^ sep() ^ reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_WU)
-                      <-> f_un_rm_type_mnemonic_H(FCVT_H_WU)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_L_H)
-                      <-> f_un_rm_type_mnemonic_H(FCVT_L_H)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_LU_H)
-                      <-> f_un_rm_type_mnemonic_H(FCVT_LU_H)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_L)
-                      <-> f_un_rm_type_mnemonic_H(FCVT_H_L)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_LU)
-                      <-> f_un_rm_type_mnemonic_H(FCVT_H_LU)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_S)
-                      <-> f_un_rm_type_mnemonic_H(FCVT_H_S)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_D)
-                      <-> f_un_rm_type_mnemonic_H(FCVT_H_D)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_S_H)
-                      <-> f_un_rm_type_mnemonic_H(FCVT_S_H)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
-                          ^ sep() ^ frm_mnemonic(rm)
-
-mapping clause assembly = F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_D_H)
-                      <-> f_un_rm_type_mnemonic_H(FCVT_D_H)
-                          ^ spc() ^ freg_or_reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
                           ^ sep() ^ frm_mnemonic(rm)
 
 /* ****************************************************************** */
 /* Unary, no rounding mode */
 
-union clause ast = F_UN_TYPE_H : (regidx, regidx, f_un_op_H)
+union clause ast = F_UN_F_TYPE_H : (regidx, fregidx, f_un_f_op_H)
+union clause ast = F_UN_X_TYPE_H : (fregidx, regidx, f_un_x_op_H)
 
 /* AST <-> Binary encoding ================================ */
 
-mapping clause encdec = F_UN_TYPE_H(rs1, rd, FCLASS_H)                             if haveHalfFPU()
-  <-> 0b111_0010 @ 0b00000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
+mapping clause encdec = F_UN_X_TYPE_H(rs1, rd, FCLASS_H)                            if haveHalfFPU()
+  <-> 0b111_0010 @ 0b00000 @ encdec_freg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
-mapping clause encdec = F_UN_TYPE_H(rs1, rd, FMV_X_H)                              if extensionEnabled(Ext_Zfhmin)
-  <-> 0b111_0010 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfhmin)
+mapping clause encdec = F_UN_X_TYPE_H(rs1, rd, FMV_X_H)                             if extensionEnabled(Ext_Zfhmin)
+  <-> 0b111_0010 @ 0b00000 @ encdec_freg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfhmin)
 
-mapping clause encdec = F_UN_TYPE_H(rs1, rd, FMV_H_X)                              if extensionEnabled(Ext_Zfhmin)
-  <-> 0b111_1010 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfhmin)
+mapping clause encdec = F_UN_F_TYPE_H(rs1, rd, FMV_H_X)                             if extensionEnabled(Ext_Zfhmin)
+  <-> 0b111_1010 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfhmin)
 
 /* Execution semantics ================================ */
 
-function clause execute (F_UN_TYPE_H(rs1, rd, FCLASS_H)) = {
+function clause execute (F_UN_X_TYPE_H(rs1, rd, FCLASS_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
 
   let rd_val_10b : bits (10) =
@@ -914,14 +828,14 @@ function clause execute (F_UN_TYPE_H(rs1, rd, FCLASS_H)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_UN_TYPE_H(rs1, rd, FMV_X_H)) = {
+function clause execute (F_UN_X_TYPE_H(rs1, rd, FMV_X_H)) = {
   let rs1_val_H            = F(rs1)[15..0];
   let rd_val_X  : xlenbits = sign_extend(rs1_val_H);
   X(rd) = rd_val_X;
   RETIRE_SUCCESS
 }
 
-function clause execute (F_UN_TYPE_H(rs1, rd, FMV_H_X)) = {
+function clause execute (F_UN_F_TYPE_H(rs1, rd, FMV_H_X)) = {
   let rs1_val_X            = X(rs1);
   let rd_val_H             = rs1_val_X [15..0];
   F(rd) = nan_box (rd_val_H);
@@ -930,23 +844,21 @@ function clause execute (F_UN_TYPE_H(rs1, rd, FMV_H_X)) = {
 
 /* AST -> Assembly notation ================================ */
 
-mapping f_un_type_mnemonic_H : f_un_op_H <-> string = {
-    FMV_X_H  <-> "fmv.x.h",
-    FCLASS_H <-> "fclass.h",
+mapping f_un_f_type_mnemonic_H : f_un_f_op_H <-> string = {
     FMV_H_X  <-> "fmv.h.x"
 }
 
-mapping clause assembly = F_UN_TYPE_H(rs1, rd, FMV_X_H)
-                      <-> f_un_type_mnemonic_H(FMV_X_H)
-                          ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_name(rs1)
-
-mapping clause assembly = F_UN_TYPE_H(rs1, rd, FMV_H_X)
-                      <-> f_un_type_mnemonic_H(FMV_H_X)
+mapping clause assembly = F_UN_F_TYPE_H(rs1, rd, op)
+                      <-> f_un_f_type_mnemonic_H(op)
                           ^ spc() ^ freg_name(rd)
                           ^ sep() ^ reg_name(rs1)
 
-mapping clause assembly = F_UN_TYPE_H(rs1, rd, FCLASS_H)
-                      <-> f_un_type_mnemonic_H(FCLASS_H)
+mapping f_un_x_type_mnemonic_H : f_un_x_op_H <-> string = {
+    FMV_X_H  <-> "fmv.x.h",
+    FCLASS_H <-> "fclass.h",
+}
+
+mapping clause assembly = F_UN_X_TYPE_H(rs1, rd, op)
+                      <-> f_un_x_type_mnemonic_H(op)
                           ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_or_reg_name(rs1)
+                          ^ sep() ^ freg_name(rs1)

--- a/model/riscv_insts_zfh.sail
+++ b/model/riscv_insts_zfh.sail
@@ -186,20 +186,20 @@ union clause ast = F_BIN_RM_TYPE_H : (regidx, regidx, rounding_mode, regidx, f_b
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FADD_H)                             if haveHalfFPU()
-<-> 0b000_0010 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfFPU()
+    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FADD_H)                                                                if haveHalfFPU()
+<-> 0b000_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FSUB_H)                             if haveHalfFPU()
-<-> 0b000_0110 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfFPU()
+    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FSUB_H)                                                                if haveHalfFPU()
+<-> 0b000_0110 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FMUL_H)                             if haveHalfFPU()
-<-> 0b000_1010 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfFPU()
+    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FMUL_H)                                                                if haveHalfFPU()
+<-> 0b000_1010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FDIV_H)                             if haveHalfFPU()
-<-> 0b000_1110 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfFPU()
+    F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FDIV_H)                                                                if haveHalfFPU()
+<-> 0b000_1110 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
 /* Execution semantics ================================ */
 
@@ -249,20 +249,20 @@ union clause ast = F_MADD_TYPE_H : (regidx, regidx, regidx, rounding_mode, regid
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FMADD_H)                         if haveHalfFPU()
-<-> rs3 @ 0b10 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b100_0011  if haveHalfFPU()
+    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FMADD_H)                                                                        if haveHalfFPU()
+<-> encdec_reg(rs3) @ 0b10 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FMSUB_H)                         if haveHalfFPU()
-<-> rs3 @ 0b10 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b100_0111  if haveHalfFPU()
+    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FMSUB_H)                                                                        if haveHalfFPU()
+<-> encdec_reg(rs3) @ 0b10 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_0111 if haveHalfFPU()
 
 mapping clause encdec =
-    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FNMSUB_H)                        if haveHalfFPU()
-<-> rs3 @ 0b10 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b100_1011  if haveHalfFPU()
+    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FNMSUB_H)                                                                       if haveHalfFPU()
+<-> encdec_reg(rs3) @ 0b10 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_1011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FNMADD_H)                        if haveHalfFPU()
-<-> rs3 @ 0b10 @ rs2 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b100_1111  if haveHalfFPU()
+    F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FNMADD_H)                                                                       if haveHalfFPU()
+<-> encdec_reg(rs3) @ 0b10 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b100_1111 if haveHalfFPU()
 
 /* Execution semantics ================================ */
 
@@ -314,29 +314,29 @@ union clause ast = F_BIN_TYPE_H : (regidx, regidx, regidx, f_bin_op_H)
 
 /* AST <-> Binary encoding ================================ */
 
-mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJ_H)               if haveHalfFPU()
-                    <-> 0b001_0010 @ rs2 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveHalfFPU()
+mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJ_H)                                if haveHalfFPU()
+  <-> 0b001_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
-mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJN_H)              if haveHalfFPU()
-                    <-> 0b001_0010 @ rs2 @ rs1 @ 0b001 @ rd @ 0b101_0011  if haveHalfFPU()
+mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJN_H)                               if haveHalfFPU()
+  <-> 0b001_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
-mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJX_H)              if haveHalfFPU()
-                    <-> 0b001_0010 @ rs2 @ rs1 @ 0b010 @ rd @ 0b101_0011  if haveHalfFPU()
+mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FSGNJX_H)                               if haveHalfFPU()
+  <-> 0b001_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
-mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FMIN_H)                if haveHalfFPU()
-                    <-> 0b001_0110 @ rs2 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveHalfFPU()
+mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FMIN_H)                                 if haveHalfFPU()
+  <-> 0b001_0110 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
-mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FMAX_H)                if haveHalfFPU()
-                    <-> 0b001_0110 @ rs2 @ rs1 @ 0b001 @ rd @ 0b101_0011  if haveHalfFPU()
+mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FMAX_H)                                 if haveHalfFPU()
+  <-> 0b001_0110 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
-mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FEQ_H)                 if haveHalfFPU()
-                    <-> 0b101_0010 @ rs2 @ rs1 @ 0b010 @ rd @ 0b101_0011  if haveHalfFPU()
+mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FEQ_H)                                  if haveHalfFPU()
+  <-> 0b101_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
-mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FLT_H)                 if haveHalfFPU()
-                    <-> 0b101_0010 @ rs2 @ rs1 @ 0b001 @ rd @ 0b101_0011  if haveHalfFPU()
+mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FLT_H)                                  if haveHalfFPU()
+  <-> 0b101_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
-mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FLE_H)                 if haveHalfFPU()
-                    <-> 0b101_0010 @ rs2 @ rs1 @ 0b000 @ rd @ 0b101_0011  if haveHalfFPU()
+mapping clause encdec = F_BIN_TYPE_H(rs2, rs1, rd, FLE_H)                                  if haveHalfFPU()
+  <-> 0b101_0010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
 /* Execution semantics ================================ */
 
@@ -520,40 +520,40 @@ union clause ast = F_UN_RM_TYPE_H : (regidx, rounding_mode, regidx, f_un_rm_op_H
 /* AST <-> Binary encoding ================================ */
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FSQRT_H)                                      if haveHalfFPU()
-<-> 0b010_1110 @ 0b00000 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfFPU()
+    F_UN_RM_TYPE_H(rs1, rm, rd, FSQRT_H)                                                             if haveHalfFPU()
+<-> 0b010_1110 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_W_H)                                     if haveHalfFPU()
-<-> 0b110_0010 @ 0b00000 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfFPU()
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_W_H)                                                            if haveHalfFPU()
+<-> 0b110_0010 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_WU_H)                                    if haveHalfFPU()
-<-> 0b110_0010 @ 0b00001 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfFPU()
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_WU_H)                                                           if haveHalfFPU()
+<-> 0b110_0010 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_W)                                     if haveHalfFPU()
-<-> 0b110_1010 @ 0b00000 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfFPU()
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_W)                                                            if haveHalfFPU()
+<-> 0b110_1010 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_WU)                                    if haveHalfFPU()
-<-> 0b110_1010 @ 0b00001 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfFPU()
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_WU)                                                           if haveHalfFPU()
+<-> 0b110_1010 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_S)                                     if haveHalfMin()
-<-> 0b010_0010 @ 0b00000 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfMin()
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_S)                                                            if haveHalfMin()
+<-> 0b010_0010 @ 0b00000 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfMin()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_D)                                     if haveHalfMin() & (haveDoubleFPU() & validDoubleRegs([rs1]))
-<-> 0b010_0010 @ 0b00001 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfMin() & (haveDoubleFPU() & validDoubleRegs([rs1]))
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_D)                                                            if haveHalfMin() & (haveDoubleFPU() & validDoubleRegs([rs1]))
+<-> 0b010_0010 @ 0b00001 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfMin() & (haveDoubleFPU() & validDoubleRegs([rs1]))
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_S_H)                                     if haveHalfMin()
-<-> 0b010_0000 @ 0b00010 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfMin()
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_S_H)                                                            if haveHalfMin()
+<-> 0b010_0000 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfMin()
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_D_H)                                     if haveHalfMin() & (haveDoubleFPU() & validDoubleRegs([rd]))
-<-> 0b010_0001 @ 0b00010 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfMin() & (haveDoubleFPU() & validDoubleRegs([rd]))
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_D_H)                                                            if haveHalfMin() & (haveDoubleFPU() & validDoubleRegs([rd]))
+<-> 0b010_0001 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfMin() & (haveDoubleFPU() & validDoubleRegs([rd]))
 
 // TODO:
 /* FCVT_H_Q, FCVT_Q_H : Will be added with Q Extension */
@@ -561,20 +561,20 @@ mapping clause encdec =
 /* F instructions, RV64 only */
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_L_H)                                     if haveHalfFPU() & xlen >= 64
-<-> 0b110_0010 @ 0b00010 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfFPU() & xlen >= 64
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_L_H)                                                            if haveHalfFPU() & xlen >= 64
+<-> 0b110_0010 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_LU_H)                                    if haveHalfFPU() & xlen >= 64
-<-> 0b110_0010 @ 0b00011 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfFPU() & xlen >= 64
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_LU_H)                                                           if haveHalfFPU() & xlen >= 64
+<-> 0b110_0010 @ 0b00011 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_L)                                     if haveHalfFPU() & xlen >= 64
-<-> 0b110_1010 @ 0b00010 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfFPU() & xlen >= 64
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_L)                                                            if haveHalfFPU() & xlen >= 64
+<-> 0b110_1010 @ 0b00010 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU() & xlen >= 64
 
 mapping clause encdec =
-    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_LU)                                    if haveHalfFPU() & xlen >= 64
-<-> 0b110_1010 @ 0b00011 @ rs1 @ encdec_rounding_mode (rm) @ rd @ 0b101_0011  if haveHalfFPU() & xlen >= 64
+    F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_LU)                                                           if haveHalfFPU() & xlen >= 64
+<-> 0b110_1010 @ 0b00011 @ encdec_reg(rs1) @ encdec_rounding_mode (rm) @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU() & xlen >= 64
 
 /* Execution semantics ================================ */
 
@@ -883,14 +883,14 @@ union clause ast = F_UN_TYPE_H : (regidx, regidx, f_un_op_H)
 
 /* AST <-> Binary encoding ================================ */
 
-mapping clause encdec = F_UN_TYPE_H(rs1, rd, FCLASS_H)                        if haveHalfFPU()
-                    <-> 0b111_0010 @ 0b00000 @ rs1 @ 0b001 @ rd @ 0b101_0011  if haveHalfFPU()
+mapping clause encdec = F_UN_TYPE_H(rs1, rd, FCLASS_H)                             if haveHalfFPU()
+  <-> 0b111_0010 @ 0b00000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011 if haveHalfFPU()
 
-mapping clause encdec = F_UN_TYPE_H(rs1, rd, FMV_X_H)                         if extensionEnabled(Ext_Zfhmin)
-                    <-> 0b111_0010 @ 0b00000 @ rs1 @ 0b000 @ rd @ 0b101_0011  if extensionEnabled(Ext_Zfhmin)
+mapping clause encdec = F_UN_TYPE_H(rs1, rd, FMV_X_H)                              if extensionEnabled(Ext_Zfhmin)
+  <-> 0b111_0010 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfhmin)
 
-mapping clause encdec = F_UN_TYPE_H(rs1, rd, FMV_H_X)                         if extensionEnabled(Ext_Zfhmin)
-                    <-> 0b111_1010 @ 0b00000 @ rs1 @ 0b000 @ rd @ 0b101_0011  if extensionEnabled(Ext_Zfhmin)
+mapping clause encdec = F_UN_TYPE_H(rs1, rd, FMV_H_X)                              if extensionEnabled(Ext_Zfhmin)
+  <-> 0b111_1010 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011 if extensionEnabled(Ext_Zfhmin)
 
 /* Execution semantics ================================ */
 

--- a/model/riscv_insts_zicbom.sail
+++ b/model/riscv_insts_zicbom.sail
@@ -23,8 +23,8 @@ mapping encdec_cbop : cbop_zicbom <-> bits(12) = {
   CBO_INVAL <-> 0b000000000000,
 }
 
-mapping clause encdec = RISCV_ZICBOM(cbop, rs1)             if extensionEnabled(Ext_Zicbom)
-  <-> encdec_cbop(cbop) @ rs1 @ 0b010 @ 0b00000 @ 0b0001111 if extensionEnabled(Ext_Zicbom)
+mapping clause encdec = RISCV_ZICBOM(cbop, rs1)                         if extensionEnabled(Ext_Zicbom)
+  <-> encdec_cbop(cbop) @ encdec_reg(rs1) @ 0b010 @ 0b00000 @ 0b0001111 if extensionEnabled(Ext_Zicbom)
 
 mapping cbop_mnemonic : cbop_zicbom <-> string = {
   CBO_CLEAN <-> "cbo.clean",

--- a/model/riscv_insts_zicboz.sail
+++ b/model/riscv_insts_zicboz.sail
@@ -15,8 +15,8 @@ function cbo_zero_enabled(p : Privilege) -> bool = feature_enabled_for_priv(p, m
 /* ****************************************************************** */
 union clause ast = RISCV_ZICBOZ : (regidx)
 
-mapping clause encdec = RISCV_ZICBOZ(rs1)                if extensionEnabled(Ext_Zicboz)
-  <-> 0b000000000100 @ rs1 @ 0b010 @ 0b00000 @ 0b0001111 if extensionEnabled(Ext_Zicboz)
+mapping clause encdec = RISCV_ZICBOZ(rs1)                            if extensionEnabled(Ext_Zicboz)
+  <-> 0b000000000100 @ encdec_reg(rs1) @ 0b010 @ 0b00000 @ 0b0001111 if extensionEnabled(Ext_Zicboz)
 
 mapping clause assembly = RISCV_ZICBOZ(rs1)
   <-> "cbo.zero" ^ spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"

--- a/model/riscv_insts_zicond.sail
+++ b/model/riscv_insts_zicond.sail
@@ -10,10 +10,10 @@ function clause extensionEnabled(Ext_Zicond) = true
 
 union clause ast = ZICOND_RTYPE : (regidx, regidx, regidx, zicondop)
 
-mapping clause encdec = ZICOND_RTYPE(rs2, rs1, rd, RISCV_CZERO_EQZ) if extensionEnabled(Ext_Zicond)
-  <-> 0b0000111 @ rs2 @ rs1 @ 0b101 @ rd @ 0b0110011 if extensionEnabled(Ext_Zicond)
-mapping clause encdec = ZICOND_RTYPE(rs2, rs1, rd, RISCV_CZERO_NEZ) if extensionEnabled(Ext_Zicond)
-  <-> 0b0000111 @ rs2 @ rs1 @ 0b111 @ rd @ 0b0110011 if extensionEnabled(Ext_Zicond)
+mapping clause encdec = ZICOND_RTYPE(rs2, rs1, rd, RISCV_CZERO_EQZ)                      if extensionEnabled(Ext_Zicond)
+  <-> 0b0000111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zicond)
+mapping clause encdec = ZICOND_RTYPE(rs2, rs1, rd, RISCV_CZERO_NEZ)                      if extensionEnabled(Ext_Zicond)
+  <-> 0b0000111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zicond)
 
 mapping zicond_mnemonic : zicondop <-> string = {
   RISCV_CZERO_EQZ <-> "czero.eqz",

--- a/model/riscv_insts_zicsr.sail
+++ b/model/riscv_insts_zicsr.sail
@@ -18,18 +18,18 @@ mapping encdec_csrop : csrop <-> bits(2) = {
 }
 
 mapping clause encdec = CSR(csr, rs1, rd, is_imm, op)
-  <-> csr @ rs1 @ bool_bits(is_imm) @ encdec_csrop(op) @ rd @ 0b1110011
+  <-> csr @ encdec_reg(rs1) @ bool_bits(is_imm) @ encdec_csrop(op) @ encdec_reg(rd) @ 0b1110011
 
 function clause execute CSR(csr, rs1, rd, is_imm, op) = {
-  let rs1_val : xlenbits = if is_imm then zero_extend(rs1) else X(rs1);
-  let is_CSR_Write = op == CSRRW | rs1 != zeros();
+  let rs1_val : xlenbits =  if is_imm then zero_extend(regidx_bits(rs1)) else X(rs1);
+  let is_CSR_Write = op == CSRRW | rs1 != zreg;
   if not(check_CSR(csr, cur_privilege, is_CSR_Write))
   then { handle_illegal(); RETIRE_FAIL }
   else if not(ext_check_CSR(csr, cur_privilege, is_CSR_Write))
   then { ext_check_CSR_fail(); RETIRE_FAIL }
   else {
     /* CSRRW should not generate read side-effects if rd == 0 */
-    let is_CSR_Read = not(op == CSRRW & rd == zeros());
+    let is_CSR_Read = not(op == CSRRW & rd == zreg);
     let csr_val : xlenbits = if is_CSR_Read then read_CSR(csr) else zeros();
     if is_CSR_Write then {
       let new_val : xlenbits = match op {
@@ -55,7 +55,7 @@ mapping csr_mnemonic : csrop <-> string = {
   CSRRC <-> "csrrc"
 }
 
-mapping clause assembly = CSR(csr, rs1, rd, true, op)
-  <-> csr_mnemonic(op) ^ "i" ^ spc() ^ reg_name(rd)  ^ sep() ^ csr_name_map(csr) ^ sep() ^ hex_bits_5(rs1)
+mapping clause assembly = CSR(csr, Regidx(rs1_bits), rd, true, op)
+  <-> csr_mnemonic(op) ^ "i" ^ spc() ^ reg_name(rd)  ^ sep() ^ csr_name_map(csr) ^ sep() ^ hex_bits_5(rs1_bits)
 mapping clause assembly = CSR(csr, rs1, rd, false, op)
   <-> csr_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ csr_name_map(csr) ^ sep() ^ reg_name(rs1)

--- a/model/riscv_insts_zkn.sail
+++ b/model/riscv_insts_zkn.sail
@@ -18,17 +18,17 @@ union clause ast = SHA256SIG1 : (regidx, regidx)
 union clause ast = SHA256SUM0 : (regidx, regidx)
 union clause ast = SHA256SUM1 : (regidx, regidx)
 
-mapping clause encdec = SHA256SUM0 (rs1, rd) if extensionEnabled(Ext_Zknh)
-  <-> 0b00 @ 0b01000 @ 0b00000 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zknh)
+mapping clause encdec = SHA256SUM0 (rs1, rd)                                          if extensionEnabled(Ext_Zknh)
+  <-> 0b00 @ 0b01000 @ 0b00000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zknh)
 
-mapping clause encdec = SHA256SUM1 (rs1, rd) if extensionEnabled(Ext_Zknh)
-  <-> 0b00 @ 0b01000 @ 0b00001 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zknh)
+mapping clause encdec = SHA256SUM1 (rs1, rd)                                          if extensionEnabled(Ext_Zknh)
+  <-> 0b00 @ 0b01000 @ 0b00001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zknh)
 
-mapping clause encdec = SHA256SIG0 (rs1, rd) if extensionEnabled(Ext_Zknh)
-  <-> 0b00 @ 0b01000 @ 0b00010 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zknh)
+mapping clause encdec = SHA256SIG0 (rs1, rd)                                          if extensionEnabled(Ext_Zknh)
+  <-> 0b00 @ 0b01000 @ 0b00010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zknh)
 
-mapping clause encdec = SHA256SIG1 (rs1, rd) if extensionEnabled(Ext_Zknh)
-  <-> 0b00 @ 0b01000 @ 0b00011 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zknh)
+mapping clause encdec = SHA256SIG1 (rs1, rd)                                          if extensionEnabled(Ext_Zknh)
+  <-> 0b00 @ 0b01000 @ 0b00011 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zknh)
 
 mapping clause assembly = SHA256SIG0 (rs1, rd)
   <-> "sha256sig0" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -79,8 +79,8 @@ function clause extensionEnabled(Ext_Zkne) = true
 
 union clause ast = AES32ESMI : (bits(2), regidx, regidx, regidx)
 
-mapping clause encdec = AES32ESMI (bs, rs2, rs1, rd) if extensionEnabled(Ext_Zkne) & xlen == 32
-  <-> bs @ 0b10011 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if extensionEnabled(Ext_Zkne) & xlen == 32
+mapping clause encdec = AES32ESMI (bs, rs2, rs1, rd)                                        if extensionEnabled(Ext_Zkne) & xlen == 32
+  <-> bs @ 0b10011 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zkne) & xlen == 32
 
 mapping clause assembly = AES32ESMI (bs, rs2, rs1, rd) <->
     "aes32esmi" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_2(bs)
@@ -97,8 +97,8 @@ function clause execute (AES32ESMI (bs, rs2, rs1, rd)) = {
 
 union clause ast = AES32ESI : (bits(2), regidx, regidx, regidx)
 
-mapping clause encdec = AES32ESI (bs, rs2, rs1, rd) if extensionEnabled(Ext_Zkne) & xlen == 32
-  <-> bs @ 0b10001 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if extensionEnabled(Ext_Zkne) & xlen == 32
+mapping clause encdec = AES32ESI (bs, rs2, rs1, rd)                                         if extensionEnabled(Ext_Zkne) & xlen == 32
+  <-> bs @ 0b10001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zkne) & xlen == 32
 
 mapping clause assembly = AES32ESI (bs, rs2, rs1, rd) <->
     "aes32esi" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_2(bs)
@@ -121,8 +121,8 @@ function clause extensionEnabled(Ext_Zknd) = true
 
 union clause ast = AES32DSMI : (bits(2), regidx, regidx, regidx)
 
-mapping clause encdec = AES32DSMI (bs, rs2, rs1, rd) if extensionEnabled(Ext_Zknd) & xlen == 32
-  <-> bs @ 0b10111 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if extensionEnabled(Ext_Zknd) & xlen == 32
+mapping clause encdec = AES32DSMI (bs, rs2, rs1, rd)                                        if extensionEnabled(Ext_Zknd) & xlen == 32
+  <-> bs @ 0b10111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zknd) & xlen == 32
 
 mapping clause assembly = AES32DSMI (bs, rs2, rs1, rd) <->
     "aes32dsmi" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_2(bs)
@@ -139,8 +139,8 @@ function clause execute (AES32DSMI (bs, rs2, rs1, rd)) = {
 
 union clause ast = AES32DSI  : (bits(2), regidx, regidx, regidx)
 
-mapping clause encdec = AES32DSI (bs, rs2, rs1, rd) if extensionEnabled(Ext_Zknd) & xlen == 32
-  <-> bs @ 0b10101 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if extensionEnabled(Ext_Zknd) & xlen == 32
+mapping clause encdec = AES32DSI (bs, rs2, rs1, rd)                                         if extensionEnabled(Ext_Zknd) & xlen == 32
+  <-> bs @ 0b10101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zknd) & xlen == 32
 
 mapping clause assembly = AES32DSI (bs, rs2, rs1, rd) <->
     "aes32dsi" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_2(bs)
@@ -166,23 +166,23 @@ union clause ast = SHA512SIG1H : (regidx, regidx, regidx)
 union clause ast = SHA512SUM0R : (regidx, regidx, regidx)
 union clause ast = SHA512SUM1R : (regidx, regidx, regidx)
 
-mapping clause encdec = SHA512SUM0R (rs2, rs1, rd) if extensionEnabled(Ext_Zknh) & xlen == 32
-  <-> 0b01 @ 0b01000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if extensionEnabled(Ext_Zknh) & xlen == 32
+mapping clause encdec = SHA512SUM0R (rs2, rs1, rd)                                            if extensionEnabled(Ext_Zknh) & xlen == 32
+  <-> 0b01 @ 0b01000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zknh) & xlen == 32
 
-mapping clause encdec = SHA512SUM1R (rs2, rs1, rd) if extensionEnabled(Ext_Zknh) & xlen == 32
-  <-> 0b01 @ 0b01001 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if extensionEnabled(Ext_Zknh) & xlen == 32
+mapping clause encdec = SHA512SUM1R (rs2, rs1, rd)                                            if extensionEnabled(Ext_Zknh) & xlen == 32
+  <-> 0b01 @ 0b01001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zknh) & xlen == 32
 
-mapping clause encdec = SHA512SIG0L (rs2, rs1, rd) if extensionEnabled(Ext_Zknh) & xlen == 32
-  <-> 0b01 @ 0b01010 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if extensionEnabled(Ext_Zknh) & xlen == 32
+mapping clause encdec = SHA512SIG0L (rs2, rs1, rd)                                            if extensionEnabled(Ext_Zknh) & xlen == 32
+  <-> 0b01 @ 0b01010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zknh) & xlen == 32
 
-mapping clause encdec = SHA512SIG0H (rs2, rs1, rd) if extensionEnabled(Ext_Zknh) & xlen == 32
-  <-> 0b01 @ 0b01110 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if extensionEnabled(Ext_Zknh) & xlen == 32
+mapping clause encdec = SHA512SIG0H (rs2, rs1, rd)                                            if extensionEnabled(Ext_Zknh) & xlen == 32
+  <-> 0b01 @ 0b01110 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zknh) & xlen == 32
 
-mapping clause encdec = SHA512SIG1L (rs2, rs1, rd) if extensionEnabled(Ext_Zknh) & xlen == 32
-  <-> 0b01 @ 0b01011 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if extensionEnabled(Ext_Zknh) & xlen == 32
+mapping clause encdec = SHA512SIG1L (rs2, rs1, rd)                                            if extensionEnabled(Ext_Zknh) & xlen == 32
+  <-> 0b01 @ 0b01011 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zknh) & xlen == 32
 
-mapping clause encdec = SHA512SIG1H (rs2, rs1, rd) if extensionEnabled(Ext_Zknh) & xlen == 32
-  <-> 0b01 @ 0b01111 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if extensionEnabled(Ext_Zknh) & xlen == 32
+mapping clause encdec = SHA512SIG1H (rs2, rs1, rd)                                            if extensionEnabled(Ext_Zknh) & xlen == 32
+  <-> 0b01 @ 0b01111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zknh) & xlen == 32
 
 mapping clause assembly = SHA512SIG0L (rs2, rs1, rd)
   <-> "sha512sig0l" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
@@ -251,26 +251,26 @@ union clause ast = AES64ES   : (regidx, regidx, regidx)
 union clause ast = AES64DSM  : (regidx, regidx, regidx)
 union clause ast = AES64DS   : (regidx, regidx, regidx)
 
-mapping clause encdec = AES64KS1I (rnum, rs1, rd) if (extensionEnabled(Ext_Zkne) | extensionEnabled(Ext_Zknd)) & (xlen == 64) & (rnum <_u 0xB)
-  <-> 0b00 @ 0b11000 @ 0b1 @ rnum @ rs1 @ 0b001 @ rd @ 0b0010011 if (extensionEnabled(Ext_Zkne) | extensionEnabled(Ext_Zknd)) & (xlen == 64) & (rnum <_u 0xB)
+mapping clause encdec = AES64KS1I (rnum, rs1, rd)                                        if (extensionEnabled(Ext_Zkne) | extensionEnabled(Ext_Zknd)) & (xlen == 64) & (rnum <_u 0xB)
+  <-> 0b00 @ 0b11000 @ 0b1 @ rnum @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if (extensionEnabled(Ext_Zkne) | extensionEnabled(Ext_Zknd)) & (xlen == 64) & (rnum <_u 0xB)
 
-mapping clause encdec = AES64IM (rs1, rd) if extensionEnabled(Ext_Zknd) & xlen == 64
-  <-> 0b00 @ 0b11000 @ 0b00000 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zknd) & xlen == 64
+mapping clause encdec = AES64IM (rs1, rd)                                             if extensionEnabled(Ext_Zknd) & xlen == 64
+  <-> 0b00 @ 0b11000 @ 0b00000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zknd) & xlen == 64
 
-mapping clause encdec = AES64KS2 (rs2, rs1, rd) if (extensionEnabled(Ext_Zkne) | extensionEnabled(Ext_Zknd)) & xlen == 64
-  <-> 0b01 @ 0b11111 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if (extensionEnabled(Ext_Zkne) | extensionEnabled(Ext_Zknd)) & xlen == 64
+mapping clause encdec = AES64KS2 (rs2, rs1, rd)                                               if (extensionEnabled(Ext_Zkne) | extensionEnabled(Ext_Zknd)) & xlen == 64
+  <-> 0b01 @ 0b11111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if (extensionEnabled(Ext_Zkne) | extensionEnabled(Ext_Zknd)) & xlen == 64
 
-mapping clause encdec = AES64ESM (rs2, rs1, rd) if extensionEnabled(Ext_Zkne) & xlen == 64
-  <-> 0b00 @ 0b11011 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if extensionEnabled(Ext_Zkne) & xlen == 64
+mapping clause encdec = AES64ESM (rs2, rs1, rd)                                               if extensionEnabled(Ext_Zkne) & xlen == 64
+  <-> 0b00 @ 0b11011 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zkne) & xlen == 64
 
-mapping clause encdec = AES64ES (rs2, rs1, rd) if extensionEnabled(Ext_Zkne) & xlen == 64
-  <-> 0b00 @ 0b11001 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if extensionEnabled(Ext_Zkne) & xlen == 64
+mapping clause encdec = AES64ES (rs2, rs1, rd)                                                if extensionEnabled(Ext_Zkne) & xlen == 64
+  <-> 0b00 @ 0b11001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zkne) & xlen == 64
 
-mapping clause encdec = AES64DSM (rs2, rs1, rd) if extensionEnabled(Ext_Zknd) & xlen == 64
-  <-> 0b00 @ 0b11111 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if extensionEnabled(Ext_Zknd) & xlen == 64
+mapping clause encdec = AES64DSM (rs2, rs1, rd)                                               if extensionEnabled(Ext_Zknd) & xlen == 64
+  <-> 0b00 @ 0b11111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zknd) & xlen == 64
 
-mapping clause encdec = AES64DS (rs2, rs1, rd) if extensionEnabled(Ext_Zknd) & xlen == 64
-  <-> 0b00 @ 0b11101 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if extensionEnabled(Ext_Zknd) & xlen == 64
+mapping clause encdec = AES64DS (rs2, rs1, rd)                                                if extensionEnabled(Ext_Zknd) & xlen == 64
+  <-> 0b00 @ 0b11101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zknd) & xlen == 64
 
 mapping clause assembly = AES64KS1I (rnum, rs1, rd)
   <-> "aes64ks1i" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_4(rnum)
@@ -366,17 +366,17 @@ union clause ast = SHA512SIG1 : (regidx, regidx)
 union clause ast = SHA512SUM0 : (regidx, regidx)
 union clause ast = SHA512SUM1 : (regidx, regidx)
 
-mapping clause encdec = SHA512SUM0 (rs1, rd) if extensionEnabled(Ext_Zknh) & xlen == 64
-  <-> 0b00 @ 0b01000 @ 0b00100 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zknh) & xlen == 64
+mapping clause encdec = SHA512SUM0 (rs1, rd)                                          if extensionEnabled(Ext_Zknh) & xlen == 64
+  <-> 0b00 @ 0b01000 @ 0b00100 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zknh) & xlen == 64
 
-mapping clause encdec = SHA512SUM1 (rs1, rd) if extensionEnabled(Ext_Zknh) & xlen == 64
-  <-> 0b00 @ 0b01000 @ 0b00101 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zknh) & xlen == 64
+mapping clause encdec = SHA512SUM1 (rs1, rd)                                          if extensionEnabled(Ext_Zknh) & xlen == 64
+  <-> 0b00 @ 0b01000 @ 0b00101 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zknh) & xlen == 64
 
-mapping clause encdec = SHA512SIG0 (rs1, rd) if extensionEnabled(Ext_Zknh) & xlen == 64
-  <-> 0b00 @ 0b01000 @ 0b00110 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zknh) & xlen == 64
+mapping clause encdec = SHA512SIG0 (rs1, rd)                                          if extensionEnabled(Ext_Zknh) & xlen == 64
+  <-> 0b00 @ 0b01000 @ 0b00110 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zknh) & xlen == 64
 
-mapping clause encdec = SHA512SIG1 (rs1, rd) if extensionEnabled(Ext_Zknh) & xlen == 64
-  <-> 0b00 @ 0b01000 @ 0b00111 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zknh) & xlen == 64
+mapping clause encdec = SHA512SIG1 (rs1, rd)                                          if extensionEnabled(Ext_Zknh) & xlen == 64
+  <-> 0b00 @ 0b01000 @ 0b00111 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zknh) & xlen == 64
 
 mapping clause assembly = SHA512SIG0 (rs1, rd)
   <-> "sha512sig0" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)

--- a/model/riscv_insts_zks.sail
+++ b/model/riscv_insts_zks.sail
@@ -16,11 +16,11 @@ function clause extensionEnabled(Ext_Zksh) = true
 union clause ast = SM3P0 : (regidx, regidx)
 union clause ast = SM3P1 : (regidx, regidx)
 
-mapping clause encdec = SM3P0 (rs1, rd) if extensionEnabled(Ext_Zksh)
-  <-> 0b00 @ 0b01000 @ 0b01000 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zksh)
+mapping clause encdec = SM3P0 (rs1, rd)                                               if extensionEnabled(Ext_Zksh)
+  <-> 0b00 @ 0b01000 @ 0b01000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zksh)
 
-mapping clause encdec = SM3P1 (rs1, rd) if extensionEnabled(Ext_Zksh)
-  <-> 0b00 @ 0b01000 @ 0b01001 @ rs1 @ 0b001 @ rd @ 0b0010011 if extensionEnabled(Ext_Zksh)
+mapping clause encdec = SM3P1 (rs1, rd)                                               if extensionEnabled(Ext_Zksh)
+  <-> 0b00 @ 0b01000 @ 0b01001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011 if extensionEnabled(Ext_Zksh)
 
 mapping clause assembly = SM3P0 (rs1, rd) <->
   "sm3p0" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -52,11 +52,11 @@ function clause extensionEnabled(Ext_Zksed) = true
 union clause ast = SM4ED : (bits(2), regidx, regidx, regidx)
 union clause ast = SM4KS : (bits(2), regidx, regidx, regidx)
 
-mapping clause encdec = SM4ED (bs, rs2, rs1, rd) if extensionEnabled(Ext_Zksed)
-  <-> bs @ 0b11000 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if extensionEnabled(Ext_Zksed)
+mapping clause encdec = SM4ED (bs, rs2, rs1, rd)                                            if extensionEnabled(Ext_Zksed)
+  <-> bs @ 0b11000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zksed)
 
-mapping clause encdec = SM4KS (bs, rs2, rs1, rd) if extensionEnabled(Ext_Zksed)
-  <-> bs @ 0b11010 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0110011 if extensionEnabled(Ext_Zksed)
+mapping clause encdec = SM4KS (bs, rs2, rs1, rd)                                            if extensionEnabled(Ext_Zksed)
+  <-> bs @ 0b11010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011 if extensionEnabled(Ext_Zksed)
 
 mapping clause assembly = SM4ED (bs, rs2, rs1, rd) <->
     "sm4ed" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_2(bs)

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -48,7 +48,7 @@ register x29 : regtype
 register x30 : regtype
 register x31 : regtype
 
-function rX (r : regno) -> xlenbits = {
+function rX (Regno(r) : regno) -> xlenbits = {
   let v : regtype =
     match r {
       0 => zero_reg,
@@ -89,7 +89,7 @@ function rX (r : regno) -> xlenbits = {
 }
 
 $ifdef RVFI_DII
-function rvfi_wX (r : regno, v : xlenbits) -> unit = {
+function rvfi_wX (Regno(r) : regno, v : xlenbits) -> unit = {
   rvfi_int_data[rvfi_rd_wdata] = zero_extend(v);
   rvfi_int_data[rvfi_rd_addr] = to_bits(8,r);
   rvfi_int_data_present = true;
@@ -98,7 +98,7 @@ $else
 function rvfi_wX (r : regno, v : xlenbits) -> unit = ()
 $endif
 
-function wX (r : regno, in_v : xlenbits) -> unit = {
+function wX (Regno(r) : regno, in_v : xlenbits) -> unit = {
   let v = regval_into_reg(in_v);
   match r {
     0  => (),
@@ -136,24 +136,23 @@ function wX (r : regno, in_v : xlenbits) -> unit = {
     _  => assert(false, "invalid register number")
   };
   if (r != 0) then {
-     rvfi_wX(r, in_v);
+     rvfi_wX(Regno(r), in_v);
      if   get_config_print_reg()
      then print_reg("x" ^ dec_str(r) ^ " <- " ^ RegStr(v));
   }
 }
 
-function rX_bits(i: regidx) -> xlenbits = rX(unsigned(i))
+function rX_bits(i: regidx) -> xlenbits = rX(regidx_to_regno(i))
 
 function wX_bits(i: regidx, data: xlenbits) -> unit = {
-  wX(unsigned(i)) = data
+  wX(regidx_to_regno(i)) = data
 }
 
 overload X = {rX_bits, wX_bits, rX, wX}
 
 /* mappings for assembly */
 
-val reg_name : regidx <-> string
-mapping reg_name = {
+mapping reg_name_raw : bits(5) <-> string = {
     0b00000 <-> "zero",
     0b00001 <-> "ra",
     0b00010 <-> "sp",
@@ -188,7 +187,9 @@ mapping reg_name = {
     0b11111 <-> "t6"
 }
 
-mapping creg_name : cregidx <-> string = {
+mapping reg_name : regidx <-> string = { Regidx(i) <-> reg_name_raw(i) }
+
+mapping creg_name_raw : bits(3) <-> string = {
   0b000 <-> "s0",
   0b001 <-> "s1",
   0b010 <-> "a0",
@@ -198,3 +199,11 @@ mapping creg_name : cregidx <-> string = {
   0b110 <-> "a4",
   0b111 <-> "a5"
 }
+
+mapping creg_name : cregidx <-> string = { Cregidx(i) <-> creg_name_raw(i) }
+
+/* Mappings for encoding */
+
+mapping encdec_reg : regidx <-> bits(5) = { Regidx(r) <-> r }
+
+mapping encdec_creg : cregidx <-> bits(3) = { Cregidx(r) <-> r }

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -33,24 +33,27 @@ let  pagesize_bits = sizeof(pagesize_bits)
 
 /* register identifiers */
 
-type regidx  = bits(5)
-type cregidx = bits(3)    /* identifiers in RVC instructions */
-type csreg   = bits(12)   /* CSR addressing */
+newtype regidx = Regidx : bits(5)  /* uncompressed register identifiers */
+newtype cregidx = Cregidx : bits(3) /* identifiers in RVC instructions */
+type csreg = bits(12)  /* CSR addressing */
+
+function regidx_offset(Regidx(r) : regidx, o : bits(5)) -> regidx = Regidx(r + o)
+function regidx_bits (Regidx(b) : regidx) -> bits(5) = b
 
 /* register file indexing */
 
-type regno = range(0, 31)
+newtype regno = Regno : range(0, 31)
 
-function regidx_to_regno (b : regidx) -> regno = unsigned(b)
+function regidx_to_regno (Regidx(b) : regidx) -> regno = Regno(unsigned(b))
 
 /* mapping RVC register indices into normal indices */
 val creg2reg_idx : cregidx -> regidx
-function creg2reg_idx(creg) = 0b01 @ creg
+function creg2reg_idx(Cregidx(i)) = Regidx(0b01 @ i)
 
 /* some architecture and ABI relevant register identifiers */
-let zreg : regidx = 0b00000  /* x0, zero register  */
-let ra   : regidx = 0b00001  /* x1, return address */
-let sp   : regidx = 0b00010  /* x2, stack pointer  */
+let zreg : regidx = Regidx(0b00000) /* x0, zero register  */
+let ra   : regidx = Regidx(0b00001) /* x1, return address */
+let sp   : regidx = Regidx(0b00010) /* x2, stack pointer  */
 
 /* instruction fields */
 

--- a/model/riscv_vext_regs.sail
+++ b/model/riscv_vext_regs.sail
@@ -40,8 +40,7 @@ register vr29 : vregtype
 register vr30 : vregtype
 register vr31 : vregtype
 
-val vreg_name : regidx <-> string
-mapping vreg_name = {
+mapping vreg_name_raw : bits(5) <-> string = {
     0b00000 <-> "v0",
     0b00001 <-> "v1",
     0b00010 <-> "v2",
@@ -76,13 +75,15 @@ mapping vreg_name = {
     0b11111 <-> "v31"
 }
 
+mapping vreg_name : regidx <-> string = { Regidx(i) <-> vreg_name_raw(i) }
+
 function dirty_v_context() -> unit = {
   assert(sys_enable_vext());
   mstatus[VS] = extStatus_to_bits(Dirty);
   mstatus[SD] = 0b1;
 }
 
-function rV (r : regno) -> vregtype = {
+function rV (Regno(r) : regno) -> vregtype = {
   match r {
     0 => vr0,
     1 => vr1,
@@ -119,7 +120,7 @@ function rV (r : regno) -> vregtype = {
   }
 }
 
-function wV (r : regno, v : vregtype) -> unit = {
+function wV (Regno(r) : regno, v : vregtype) -> unit = {
   match r {
     0 => vr0 = v,
     1 => vr1 = v,
@@ -162,10 +163,10 @@ function wV (r : regno, v : vregtype) -> unit = {
   then print_reg("v" ^ dec_str(r) ^ " <- " ^ BitStr(v[VLEN - 1 .. 0]));
 }
 
-function rV_bits(i: regidx) -> vregtype = rV(unsigned(i))
+function rV_bits(i: regidx) -> vregtype = rV(regidx_to_regno(i))
 
 function wV_bits(i: regidx, data: vregtype) -> unit = {
-  wV(unsigned(i)) = data
+  wV(regidx_to_regno(i)) = data
 }
 
 overload V = {rV_bits, wV_bits, rV, wV}
@@ -264,14 +265,15 @@ function write_single_vreg(num_elem, SEW, vrid, v) = {
 /* The general vreg reading operation with num_elem as max(VLMAX,VLEN/SEW)) */
 val read_vreg : forall 'n 'm 'p, 'n >= 0 & 'm >= 0. (int('n), int('m), int('p), regidx) -> vector('n, bits('m))
 function read_vreg(num_elem, SEW, LMUL_pow, vrid) = {
+  let vrid_val = unsigned(regidx_bits(vrid));
   var result : vector('n, bits('m)) = vector_init(zeros());
   let LMUL_pow_reg = if LMUL_pow < 0 then 0 else LMUL_pow;
 
   /* Check for valid vrid */
-  if unsigned(vrid) + 2 ^ LMUL_pow_reg > 32 then {
+  if vrid_val + 2 ^ LMUL_pow_reg > 32 then {
     /* vrid would read past largest vreg (v31) */
     assert(false, "invalid register group: vrid overflow the largest number")
-  } else if unsigned(vrid) % (2 ^ LMUL_pow_reg) != 0 then {
+  } else if vrid_val % (2 ^ LMUL_pow_reg) != 0 then {
     /* vrid must be a multiple of emul */
     assert(false, "invalid register group: vrid is not a multiple of EMUL")
   } else {
@@ -283,7 +285,7 @@ function read_vreg(num_elem, SEW, LMUL_pow, vrid) = {
       foreach (i_lmul from 0 to (2 ^ LMUL_pow_reg - 1)) {
         let r_start_i : int = i_lmul * 'num_elem_single;
         let r_end_i   : int = r_start_i + 'num_elem_single - 1;
-        let vrid_lmul     : regidx = vrid + to_bits(5, i_lmul);
+        let vrid_lmul     : regidx = regidx_offset(vrid, to_bits(5, i_lmul));
         let single_result : vector('num_elem_single, bits('m)) = read_single_vreg('num_elem_single, SEW, vrid_lmul);
         foreach (r_i from r_start_i to r_end_i) {
           let s_i : int = r_i - r_start_i;
@@ -304,7 +306,7 @@ function read_single_element(EEW, index, vrid) = {
   assert(VLEN >= EEW);
   let 'elem_per_reg : int = VLEN / EEW;
   assert('elem_per_reg >= 0);
-  let real_vrid  : regidx = vrid + to_bits(5, index / 'elem_per_reg);
+  let real_vrid  : regidx = regidx_offset(vrid, to_bits(5, index / 'elem_per_reg));
   let real_index : int    = index % 'elem_per_reg;
   let vrid_val : vector('elem_per_reg, bits('m)) = read_single_vreg('elem_per_reg, EEW, real_vrid);
   assert(0 <= real_index & real_index < 'elem_per_reg);
@@ -320,7 +322,7 @@ function write_vreg(num_elem, SEW, LMUL_pow, vrid, vec) = {
   assert('num_elem_single >= 0);
   foreach (i_lmul from 0 to (2 ^ LMUL_pow_reg - 1)) {
     var single_vec : vector('num_elem_single, bits('m)) = vector_init(zeros());
-    let vrid_lmul  : regidx = vrid + to_bits(5, i_lmul);
+    let vrid_lmul  : regidx = regidx_offset(vrid, to_bits(5, i_lmul));
     let r_start_i  : int = i_lmul * 'num_elem_single;
     let r_end_i    : int = r_start_i + 'num_elem_single - 1;
     foreach (r_i from r_start_i to r_end_i) {
@@ -338,7 +340,7 @@ val write_single_element : forall 'm 'x, 8 <= 'm <= 128. (int('m), int('x), regi
 function write_single_element(EEW, index, vrid, value) = {
   let 'elem_per_reg : int = VLEN / EEW;
   assert('elem_per_reg >= 0);
-  let real_vrid  : regidx = vrid + to_bits(5, index / 'elem_per_reg);
+  let real_vrid  : regidx = regidx_offset(vrid, to_bits(5, index / 'elem_per_reg));
   let real_index : int    = index % 'elem_per_reg;
 
   let vrid_val : vector('elem_per_reg, bits('m)) = read_single_vreg('elem_per_reg, EEW, real_vrid);

--- a/model/riscv_vext_regs.sail
+++ b/model/riscv_vext_regs.sail
@@ -6,6 +6,16 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
+newtype vregidx = Vregidx : bits(5)
+newtype vregno = Vregno : range(0, 31)
+function vregidx_to_vregno (Vregidx(b) : vregidx) -> vregno = Vregno(unsigned(b))
+function vregidx_offset(Vregidx(r) : vregidx, o : bits(5)) -> vregidx = Vregidx(r + o)
+function vregidx_bits (Vregidx(b) : vregidx) -> bits(5) = b
+
+mapping encdec_vreg : vregidx <-> bits(5) = { Vregidx(r) <-> r }
+
+let zvreg : vregidx = Vregidx(0b00000) /* v0, zero register  */
+
 /* vector registers */
 register vr0 : vregtype
 register vr1 : vregtype
@@ -75,7 +85,7 @@ mapping vreg_name_raw : bits(5) <-> string = {
     0b11111 <-> "v31"
 }
 
-mapping vreg_name : regidx <-> string = { Regidx(i) <-> vreg_name_raw(i) }
+mapping vreg_name : vregidx <-> string = { Vregidx(i) <-> vreg_name_raw(i) }
 
 function dirty_v_context() -> unit = {
   assert(sys_enable_vext());
@@ -83,7 +93,7 @@ function dirty_v_context() -> unit = {
   mstatus[SD] = 0b1;
 }
 
-function rV (Regno(r) : regno) -> vregtype = {
+function rV (Vregno(r) : vregno) -> vregtype = {
   match r {
     0 => vr0,
     1 => vr1,
@@ -120,7 +130,7 @@ function rV (Regno(r) : regno) -> vregtype = {
   }
 }
 
-function wV (Regno(r) : regno, v : vregtype) -> unit = {
+function wV (Vregno(r) : vregno, v : vregtype) -> unit = {
   match r {
     0 => vr0 = v,
     1 => vr1 = v,
@@ -163,10 +173,10 @@ function wV (Regno(r) : regno, v : vregtype) -> unit = {
   then print_reg("v" ^ dec_str(r) ^ " <- " ^ BitStr(v[VLEN - 1 .. 0]));
 }
 
-function rV_bits(i: regidx) -> vregtype = rV(regidx_to_regno(i))
+function rV_bits(i: vregidx) -> vregtype = rV(vregidx_to_vregno(i))
 
-function wV_bits(i: regidx, data: vregtype) -> unit = {
-  wV(regidx_to_regno(i)) = data
+function wV_bits(i: vregidx, data: vregtype) -> unit = {
+  wV(vregidx_to_vregno(i)) = data
 }
 
 overload V = {rV_bits, wV_bits, rV, wV}
@@ -234,7 +244,7 @@ function get_num_elem(LMUL_pow, SEW) = {
 }
 
 /* Reads a single vreg into multiple elements */
-val read_single_vreg : forall 'n 'm, 'n >= 0 & 'm >= 0. (int('n), int('m), regidx) -> vector('n, bits('m))
+val read_single_vreg : forall 'n 'm, 'n >= 0 & 'm >= 0. (int('n), int('m), vregidx) -> vector('n, bits('m))
 function read_single_vreg(num_elem, SEW, vrid) = {
   let bv     : vregtype                  = V(vrid);
   var result : vector('n, bits('m)) = vector_init(zeros());
@@ -249,7 +259,7 @@ function read_single_vreg(num_elem, SEW, vrid) = {
 }
 
 /* Writes multiple elements into a single vreg */
-val write_single_vreg : forall 'n 'm, 'n >= 0. (int('n), int('m), regidx, vector('n, bits('m))) -> unit
+val write_single_vreg : forall 'n 'm, 'n >= 0. (int('n), int('m), vregidx, vector('n, bits('m))) -> unit
 function write_single_vreg(num_elem, SEW, vrid, v) = {
   var r : vregtype = zeros();
 
@@ -263,9 +273,9 @@ function write_single_vreg(num_elem, SEW, vrid, v) = {
 }
 
 /* The general vreg reading operation with num_elem as max(VLMAX,VLEN/SEW)) */
-val read_vreg : forall 'n 'm 'p, 'n >= 0 & 'm >= 0. (int('n), int('m), int('p), regidx) -> vector('n, bits('m))
+val read_vreg : forall 'n 'm 'p, 'n >= 0 & 'm >= 0. (int('n), int('m), int('p), vregidx) -> vector('n, bits('m))
 function read_vreg(num_elem, SEW, LMUL_pow, vrid) = {
-  let vrid_val = unsigned(regidx_bits(vrid));
+  let vrid_val = unsigned(vregidx_bits(vrid));
   var result : vector('n, bits('m)) = vector_init(zeros());
   let LMUL_pow_reg = if LMUL_pow < 0 then 0 else LMUL_pow;
 
@@ -285,7 +295,7 @@ function read_vreg(num_elem, SEW, LMUL_pow, vrid) = {
       foreach (i_lmul from 0 to (2 ^ LMUL_pow_reg - 1)) {
         let r_start_i : int = i_lmul * 'num_elem_single;
         let r_end_i   : int = r_start_i + 'num_elem_single - 1;
-        let vrid_lmul     : regidx = regidx_offset(vrid, to_bits(5, i_lmul));
+        let vrid_lmul     : vregidx = vregidx_offset(vrid, to_bits(5, i_lmul));
         let single_result : vector('num_elem_single, bits('m)) = read_single_vreg('num_elem_single, SEW, vrid_lmul);
         foreach (r_i from r_start_i to r_end_i) {
           let s_i : int = r_i - r_start_i;
@@ -301,12 +311,12 @@ function read_vreg(num_elem, SEW, LMUL_pow, vrid) = {
 }
 
 /* Single element reading operation */
-val read_single_element : forall 'm 'x, 8 <= 'm <= 128. (int('m), int('x), regidx) -> bits('m)
+val read_single_element : forall 'm 'x, 8 <= 'm <= 128. (int('m), int('x), vregidx) -> bits('m)
 function read_single_element(EEW, index, vrid) = {
   assert(VLEN >= EEW);
   let 'elem_per_reg : int = VLEN / EEW;
   assert('elem_per_reg >= 0);
-  let real_vrid  : regidx = regidx_offset(vrid, to_bits(5, index / 'elem_per_reg));
+  let real_vrid  : vregidx = vregidx_offset(vrid, to_bits(5, index / 'elem_per_reg));
   let real_index : int    = index % 'elem_per_reg;
   let vrid_val : vector('elem_per_reg, bits('m)) = read_single_vreg('elem_per_reg, EEW, real_vrid);
   assert(0 <= real_index & real_index < 'elem_per_reg);
@@ -314,7 +324,7 @@ function read_single_element(EEW, index, vrid) = {
 }
 
 /* The general vreg writing operation with num_elem as max(VLMAX,VLEN/SEW)) */
-val write_vreg : forall 'n 'm 'p, 'n >= 0 & 'm >= 0. (int('n), int('m), int('p), regidx, vector('n, bits('m))) -> unit
+val write_vreg : forall 'n 'm 'p, 'n >= 0 & 'm >= 0. (int('n), int('m), int('p), vregidx, vector('n, bits('m))) -> unit
 function write_vreg(num_elem, SEW, LMUL_pow, vrid, vec) = {
   let LMUL_pow_reg = if LMUL_pow < 0 then 0 else LMUL_pow;
 
@@ -322,7 +332,7 @@ function write_vreg(num_elem, SEW, LMUL_pow, vrid, vec) = {
   assert('num_elem_single >= 0);
   foreach (i_lmul from 0 to (2 ^ LMUL_pow_reg - 1)) {
     var single_vec : vector('num_elem_single, bits('m)) = vector_init(zeros());
-    let vrid_lmul  : regidx = regidx_offset(vrid, to_bits(5, i_lmul));
+    let vrid_lmul  : vregidx = vregidx_offset(vrid, to_bits(5, i_lmul));
     let r_start_i  : int = i_lmul * 'num_elem_single;
     let r_end_i    : int = r_start_i + 'num_elem_single - 1;
     foreach (r_i from r_start_i to r_end_i) {
@@ -336,11 +346,11 @@ function write_vreg(num_elem, SEW, LMUL_pow, vrid, vec) = {
 }
 
 /* Single element writing operation */
-val write_single_element : forall 'm 'x, 8 <= 'm <= 128. (int('m), int('x), regidx, bits('m)) -> unit
+val write_single_element : forall 'm 'x, 8 <= 'm <= 128. (int('m), int('x), vregidx, bits('m)) -> unit
 function write_single_element(EEW, index, vrid, value) = {
   let 'elem_per_reg : int = VLEN / EEW;
   assert('elem_per_reg >= 0);
-  let real_vrid  : regidx = regidx_offset(vrid, to_bits(5, index / 'elem_per_reg));
+  let real_vrid  : vregidx = vregidx_offset(vrid, to_bits(5, index / 'elem_per_reg));
   let real_index : int    = index % 'elem_per_reg;
 
   let vrid_val : vector('elem_per_reg, bits('m)) = read_single_vreg('elem_per_reg, EEW, real_vrid);
@@ -357,7 +367,7 @@ function write_single_element(EEW, index, vrid, value) = {
 }
 
 /* Mask register reading operation with num_elem as max(VLMAX,VLEN/SEW)) */
-val read_vmask : forall 'n, 'n > 0. (int('n), bits(1), regidx) -> bits('n)
+val read_vmask : forall 'n, 'n > 0. (int('n), bits(1), vregidx) -> bits('n)
 function read_vmask(num_elem, vm, vrid) = {
   assert(num_elem <= sizeof(vlenmax));
   let vreg_val : vregtype = V(vrid);
@@ -375,7 +385,7 @@ function read_vmask(num_elem, vm, vrid) = {
 }
 
 /* This is a special version of read_vmask for carry/borrow instructions, where vm=1 means no carry */
-val read_vmask_carry : forall 'n, 'n > 0. (int('n), bits(1), regidx) -> bits('n)
+val read_vmask_carry : forall 'n, 'n > 0. (int('n), bits(1), vregidx) -> bits('n)
 function read_vmask_carry(num_elem, vm, vrid) = {
   assert(num_elem <= sizeof(vlenmax));
   let vreg_val : vregtype = V(vrid);
@@ -393,7 +403,7 @@ function read_vmask_carry(num_elem, vm, vrid) = {
 }
 
 /* Mask register writing operation with num_elem as max(VLMAX,VLEN/SEW)) */
-val write_vmask : forall 'n, 'n > 0. (int('n), regidx, bits('n)) -> unit
+val write_vmask : forall 'n, 'n > 0. (int('n), vregidx, bits('n)) -> unit
 function write_vmask(num_elem, vrid, v) = {
   assert(0 < VLEN & VLEN <= sizeof(vlenmax));
   assert(0 < num_elem & num_elem <= VLEN);


### PR DESCRIPTION
In preparation for more seriously tackling #523.  This PR...

1. Changes the definition of `regidx` and `regno` to be `newtypes` and updates all use sites appropriately.
2. Splits `vregidx` from `regidx` (and friends) for Vector (vext) registers, which, AFAIK, are a completely separate set of 32 registers.
3. Splits `fregidx` from `regidx` (and friends) for F/D/Zcd/Zcf/Zfa/Zfh and V (again) extensions.  There's a little muss and fuss around the definition to do with `Zfinx`, but otherwise it's also pretty rote.
4. Stops some punning in Zicsr and splits the `CSR` `ast` ctor into `CSRImm` and `CSRReg`.

This was a slog.  Most of the changes can be described as "type-directed" and "mechanical" but were all done... er, artisanally, so some more careful review is probably merited.  Perhaps best viewed with word diff, not line diff.

The curious are welcome to look at https://github.com/nwf/sail-riscv/tree/202411-eext to see how I think we can properly support E atop this base, and indeed, most of these changes were motivated or directed by that work, but I would like to get this reviewed independently of that shuffling and further refactoring.