### PR TITLE
Fix mstatus legalisation of SD bit

### DIFF
--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -254,17 +254,20 @@ function legalize_mstatus(o : Mstatus, v : xlenbits) -> Mstatus = {
    * but only if Zfinx isn't enabled.
    * FIXME: This should be made a platform parameter.
    */
-  let dirty = extStatus_of_bits(m[FS]) == Dirty | extStatus_of_bits(m[XS]) == Dirty |
-              extStatus_of_bits(m[VS]) == Dirty;
-
-  /* Legalize MPP */
   let m = [m with
+    /* Legalize MPP */
     MPP = if have_privLevel(m[MPP]) then m[MPP] else privLevel_to_bits(lowest_supported_privLevel()),
     /* We don't have any extension context yet. */
     XS = extStatus_to_bits(Off),
-    SD = bool_to_bits(dirty),
     FS = if sys_enable_zfinx() then extStatus_to_bits(Off) else m[FS],
     MPRV = if extensionEnabled(Ext_U) then m[MPRV] else 0b0,
+  ];
+
+  // Set dirty bit to OR of other status bits.
+  let m = [m with
+    SD = bool_to_bits(extStatus_of_bits(m[FS]) == Dirty |
+                      extStatus_of_bits(m[XS]) == Dirty |
+                      extStatus_of_bits(m[VS]) == Dirty),
   ];
 
   /* We don't support dynamic changes to SXL and UXL. */


### PR DESCRIPTION
Unfortunately ded340f268e3ca46ac35e0d7ec11bec3c318c9ea subtly broke the mstatus legalisation. It needs to calculate FS/XS bits before it calculates SD as it's the OR of the others.