### PR TITLE
fix: Print MTI value upon hart update for machine timer interrupt visibility

### DIFF
--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -212,7 +212,6 @@ function clint_load(t, addr, width) = {
 function clint_dispatch() -> unit = {
   if   get_config_print_platform()
   then print_platform("clint::tick mtime <- " ^ BitStr(mtime));
-<<<<<<< HEAD
   mip[MTI] = bool_to_bits(mtimecmp <=_u mtime);
   
   if get_config_print_platform()
@@ -224,15 +223,7 @@ function clint_dispatch() -> unit = {
     
   if get_config_print_platform()
   then print_platform(" clint mtime " ^ BitStr(mtime) ^ " (mip.STI <- " ^ BitStr(mip[STI]) ^ ")");
-  }; 
-=======
-  mip[MTI] = 0b0;
-  if mtimecmp <=_u mtime then {
-    mip[MTI] = 0b1;
-    if   get_config_print_platform()
-    then print_platform(" clint timer pending at mtime " ^ BitStr(mtime) ^ " (mip.MTI <- " ^ BitStr(mip[MTI]) ^ ")");
-  }
->>>>>>> 25748bd9 (remove problematic  else condition)
+  };
 }
 
 /* The rreg effect is due to checking mtime. */

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -211,14 +211,12 @@ function clint_load(t, addr, width) = {
 
 function clint_dispatch() -> unit = {
   mip[MTI] = bool_to_bits(mtimecmp <=_u mtime);
-  if get_config_print_platform()
-  then print_platform(" clint mtime " ^ BitStr(mtime) ^ " (mip.MTI <- " ^ BitStr(mip[MTI]) ^ ")");
-  /* Sstc - supervisor timer register */
   if extensionEnabled(Ext_Sstc) then {
     mip[STI] = bool_to_bits(stimecmp <=_u mtime); 
-    if get_config_print_platform()
-    then print_platform(" clint mtime " ^ BitStr(mtime) ^ " (mip.STI <- " ^ BitStr(mip[STI]) ^ ")");
   };
+  if get_config_print_platform()
+  then print_platform(" clint mtime " ^ BitStr(mtime) ^ " (mip.MTI <- " ^ BitStr(mip[MTI]) ^
+    (if extensionEnabled(Ext_Sstc) then ", mip.STI <- " ^ BitStr(mip[STI]) else "") ^ ")");
 }
 
 /* The rreg effect is due to checking mtime. */

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -209,7 +209,6 @@ function clint_load(t, addr, width) = {
   }
 }
 
-
 function clint_dispatch() -> unit = {
   mip[MTI] = bool_to_bits(mtimecmp <=_u mtime);
   if get_config_print_platform()

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -209,20 +209,16 @@ function clint_load(t, addr, width) = {
   }
 }
 
+
 function clint_dispatch() -> unit = {
-  if   get_config_print_platform()
-  then print_platform("clint::tick mtime <- " ^ BitStr(mtime));
   mip[MTI] = bool_to_bits(mtimecmp <=_u mtime);
-  
   if get_config_print_platform()
   then print_platform(" clint mtime " ^ BitStr(mtime) ^ " (mip.MTI <- " ^ BitStr(mip[MTI]) ^ ")");
-  
   /* Sstc - supervisor timer register */
   if extensionEnabled(Ext_Sstc) then {
-  mip[STI] = bool_to_bits(stimecmp <=_u mtime);
-    
-  if get_config_print_platform()
-  then print_platform(" clint mtime " ^ BitStr(mtime) ^ " (mip.STI <- " ^ BitStr(mip[STI]) ^ ")");
+    mip[STI] = bool_to_bits(stimecmp <=_u mtime); 
+    if get_config_print_platform()
+    then print_platform(" clint mtime " ^ BitStr(mtime) ^ " (mip.STI <- " ^ BitStr(mip[STI]) ^ ")");
   };
 }
 

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -215,7 +215,7 @@ function clint_dispatch() -> unit = {
     mip[STI] = bool_to_bits(stimecmp <=_u mtime); 
   };
   if get_config_print_platform()
-  then print_platform(" clint mtime " ^ BitStr(mtime) ^ " (mip.MTI <- " ^ BitStr(mip[MTI]) ^
+  then print_platform("clint mtime " ^ BitStr(mtime) ^ " (mip.MTI <- " ^ BitStr(mip[MTI]) ^
     (if extensionEnabled(Ext_Sstc) then ", mip.STI <- " ^ BitStr(mip[STI]) else "") ^ ")");
 }
 

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -212,21 +212,18 @@ function clint_load(t, addr, width) = {
 function clint_dispatch() -> unit = {
   if   get_config_print_platform()
   then print_platform("clint::tick mtime <- " ^ BitStr(mtime));
-  mip[MTI] = 0b0;
-  if mtimecmp <=_u mtime then {
-    if   get_config_print_platform()
-    then print_platform(" clint timer pending at mtime " ^ BitStr(mtime));
-    mip[MTI] = 0b1;
-  };
+  mip[MTI] = bool_to_bits(mtimecmp <=_u mtime);
+  
+  if get_config_print_platform()
+  then print_platform(" clint mtime " ^ BitStr(mtime) ^ " (mip.MTI <- " ^ BitStr(mip[MTI]) ^ ")");
+  
   /* Sstc - supervisor timer register */
   if extensionEnabled(Ext_Sstc) then {
-    mip[STI] = 0b0;
-    if stimecmp <=_u mtime then {
-      if   get_config_print_platform()
-      then print_platform(" supervisor timer pending at mtime " ^ BitStr(mtime));
-      mip[STI] = 0b1;
-    }
-  };
+  mip[STI] = bool_to_bits(stimecmp <=_u mtime);
+    
+  if get_config_print_platform()
+  then print_platform(" clint mtime " ^ BitStr(mtime) ^ " (mip.STI <- " ^ BitStr(mip[STI]) ^ ")");
+  }; 
 }
 
 /* The rreg effect is due to checking mtime. */

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -212,6 +212,7 @@ function clint_load(t, addr, width) = {
 function clint_dispatch() -> unit = {
   if   get_config_print_platform()
   then print_platform("clint::tick mtime <- " ^ BitStr(mtime));
+<<<<<<< HEAD
   mip[MTI] = bool_to_bits(mtimecmp <=_u mtime);
   
   if get_config_print_platform()
@@ -224,6 +225,14 @@ function clint_dispatch() -> unit = {
   if get_config_print_platform()
   then print_platform(" clint mtime " ^ BitStr(mtime) ^ " (mip.STI <- " ^ BitStr(mip[STI]) ^ ")");
   }; 
+=======
+  mip[MTI] = 0b0;
+  if mtimecmp <=_u mtime then {
+    mip[MTI] = 0b1;
+    if   get_config_print_platform()
+    then print_platform(" clint timer pending at mtime " ^ BitStr(mtime) ^ " (mip.MTI <- " ^ BitStr(mip[MTI]) ^ ")");
+  }
+>>>>>>> 25748bd9 (remove problematic  else condition)
 }
 
 /* The rreg effect is due to checking mtime. */

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -212,7 +212,7 @@ function clint_load(t, addr, width) = {
 function clint_dispatch() -> unit = {
   mip[MTI] = bool_to_bits(mtimecmp <=_u mtime);
   if extensionEnabled(Ext_Sstc) then {
-    mip[STI] = bool_to_bits(stimecmp <=_u mtime); 
+    mip[STI] = bool_to_bits(stimecmp <=_u mtime);
   };
   if get_config_print_platform()
   then print_platform("clint mtime " ^ BitStr(mtime) ^ " (mip.MTI <- " ^ BitStr(mip[MTI]) ^


### PR DESCRIPTION
Hi!

I have developed the ACTs (Architectural Compliance Tests) and coverage points for [RISC-V compliance verification](https://github.com/riscv-non-isa/riscv-arch-test). As part of the coverage points, I needed support for printing the MTI (Machine Timer Interrupt) value upon a hart update to improve the visibility and tracking of machine interrupts during the test execution.

To achieve this, I made a small change to one of the print functions, ensuring that the MTI value is printed whenever the hart state is updated. This change is essential for accurate compliance verification and enhances the observability of machine interrupts.

Please review and consider adding this change to the original repository for inclusion in the RISC-V architecture test suite.