### PR TITLE
Support static compilation of the emulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ ifneq (,$(STATIC))
         GMP_LIBS = $(shell pkg-config --variable=libdir gmp)/libgmp.a
         C_LIBS_WRAPPED = $(C_LIBS)
     else
-        C_LIBS_WRAPPED = -Wl,--push-state,-Bstatic $(C_LIBS) -Wl,--pop-state
+        C_LIBS_WRAPPED = -Wl,--push-state -Wl,-Bstatic $(C_LIBS) -Wl,--pop-state
     endif
 else
     C_LIBS_WRAPPED = $(C_LIBS)

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ SAIL_FLAGS += -c_coverage $(ALL_BRANCHES) -c_include sail_coverage.h
 C_LIBS += $(SAIL_LIB_DIR)/coverage/libsail_coverage.a -lm -lpthread -ldl
 endif
 
-# Optional link C_LIBS statically. Unlike -static this will not
+# Optionally link C_LIBS statically. Unlike -static this will not
 # link glibc statically which is generally a bad idea.
 ifneq (,$(STATIC))
     UNAME_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,8 @@ SOFTFLOAT_SPECIALIZE_TYPE = RISCV
 GMP_FLAGS = $(shell pkg-config --cflags gmp)
 # N.B. GMP does not have pkg-config metadata on Ubuntu 18.04 so default to -lgmp
 GMP_LIBS = $(shell pkg-config --libs gmp || echo -lgmp)
+
+# TODO: Remove Zlib when upgrading to Sail 0.19; it is no longer a requirement.
 ZLIB_FLAGS = $(shell pkg-config --cflags zlib)
 ZLIB_LIBS = $(shell pkg-config --libs zlib)
 
@@ -189,6 +191,21 @@ ALL_BRANCHES = generated_definitions/c/all_branches
 C_FLAGS += -DSAILCOV
 SAIL_FLAGS += -c_coverage $(ALL_BRANCHES) -c_include sail_coverage.h
 C_LIBS += $(SAIL_LIB_DIR)/coverage/libsail_coverage.a -lm -lpthread -ldl
+endif
+
+# Optional link C_LIBS statically. Unlike -static this will not
+# link glibc statically which is generally a bad idea.
+ifneq (,$(STATIC))
+    UNAME_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+    ifeq ($(UNAME_S),Darwin)
+        # Unfortunately the Mac linker does not support -Bstatic.
+        GMP_LIBS = $(shell pkg-config --variable=libdir gmp)/libgmp.a
+        C_LIBS_WRAPPED = $(C_LIBS)
+    else
+        C_LIBS_WRAPPED = -Wl,--push-state,-Bstatic $(C_LIBS) -Wl,--pop-state
+    endif
+else
+    C_LIBS_WRAPPED = $(C_LIBS)
 endif
 
 RISCV_EXTRAS_LEM_FILES = riscv_extras.lem mem_metadata.lem riscv_extras_fdext.lem
@@ -244,7 +261,7 @@ csim: c_emulator/riscv_sim_$(ARCH)
 rvfi: c_emulator/riscv_rvfi_$(ARCH)
 
 c_emulator/riscv_sim_$(ARCH): generated_definitions/c/riscv_model_$(ARCH).c $(C_INCS) $(C_SRCS) $(SOFTFLOAT_LIBS) Makefile
-	$(CC) -g $(C_WARNINGS) $(C_FLAGS) $< $(C_SRCS) $(SAIL_LIB_DIR)/*.c $(C_LIBS) -o $@
+	$(CC) -g $(C_WARNINGS) $(C_FLAGS) $< $(C_SRCS) $(SAIL_LIB_DIR)/*.c $(C_LIBS_WRAPPED) -o $@
 
 # Note: We have to add -c_preserve since the functions might be optimized out otherwise
 rvfi_preserve_fns=-c_preserve rvfi_set_instr_packet \
@@ -269,7 +286,7 @@ generated_definitions/c/riscv_rvfi_model_$(ARCH).c: $(SAIL_RVFI_SRCS) model/main
 	mv $@.new $@
 
 c_emulator/riscv_rvfi_$(ARCH): generated_definitions/c/riscv_rvfi_model_$(ARCH).c $(C_INCS) $(C_SRCS) $(SOFTFLOAT_LIBS) Makefile
-	$(CC) -g $(C_WARNINGS) $(C_FLAGS) $< -DRVFI_DII $(C_SRCS) $(SAIL_LIB_DIR)/*.c $(C_LIBS) -o $@
+	$(CC) -g $(C_WARNINGS) $(C_FLAGS) $< -DRVFI_DII $(C_SRCS) $(SAIL_LIB_DIR)/*.c $(C_LIBS_WRAPPED) -o $@
 
 latex: $(SAIL_SRCS) Makefile
 	mkdir -p generated_definitions/latex


### PR DESCRIPTION
Optionally wrap the libs with `-Wl,-Bstatic`, `-Wl,-Bdynamic` which will enable static compilation for those libs. We don't really want to use `-static` because it statically links glibc, which is a bad idea, and also increases the binary size. Linking with a sufficiently old version of glibc is a better option.