### PR TITLE
Factor out common parts of flen files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ endif
 
 SAIL_XLEN += riscv_xlen.sail
 SAIL_FLEN := riscv_flen_D.sail
+SAIL_FLEN += riscv_flen.sail
 SAIL_VLEN := riscv_vlen.sail
 
 # Instruction sources, depending on target

--- a/model/riscv_flen.sail
+++ b/model/riscv_flen.sail
@@ -6,6 +6,9 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-/* Define the FLEN value for the 'D' extension. */
+type flenbits = bits(flen)
 
-type flen : Int = 64
+// Variable versions of the above types. Variables and types
+// are disjoint in Sail so they are allowed to have the same name.
+// This saves typing `sizeof()` everywhere.
+let flen = sizeof(flen)

--- a/model/riscv_flen_F.sail
+++ b/model/riscv_flen_F.sail
@@ -8,10 +8,4 @@
 
 /* Define the FLEN value for the 'F' extension. */
 
-type flen       : Int = 32
-type flenbits         = bits(flen)
-
-// Variable versions of the above types. Variables and types
-// are disjoint in Sail so they are allowed to have the same name.
-// This saves typing `sizeof()` everywhere.
-let flen = sizeof(flen)
+type flen : Int = 32


### PR DESCRIPTION
Similar to what was done to XLEN already, place the the types/variables that are derived from FLEN into a separate file that is always included and only leave the value of FLEN itself in the F/D specific files.