### PR TITLE
Move extension scattered enum to single file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,10 +106,10 @@ SAIL_REGS_SRCS += riscv_ext_regs.sail $(SAIL_CHECK_SRCS)
 SAIL_REGS_SRCS += riscv_vreg_type.sail riscv_vext_regs.sail
 
 SAIL_ARCH_SRCS = $(PRELUDE)
-SAIL_ARCH_SRCS += riscv_types_common.sail riscv_types_ext.sail riscv_types.sail
+SAIL_ARCH_SRCS += riscv_extensions.sail riscv_types_common.sail riscv_types_ext.sail riscv_types.sail
 SAIL_ARCH_SRCS += riscv_vmem_types.sail $(SAIL_REGS_SRCS) $(SAIL_SYS_SRCS) riscv_platform.sail
 SAIL_ARCH_SRCS += riscv_mem.sail $(SAIL_VM_SRCS)
-SAIL_ARCH_RVFI_SRCS = $(PRELUDE) rvfi_dii.sail riscv_types_common.sail riscv_types_ext.sail riscv_types.sail riscv_vmem_types.sail $(SAIL_REGS_SRCS) $(SAIL_SYS_SRCS) riscv_platform.sail riscv_mem.sail $(SAIL_VM_SRCS) riscv_types_kext.sail
+SAIL_ARCH_RVFI_SRCS = $(PRELUDE) rvfi_dii.sail riscv_extensions.sail riscv_types_common.sail riscv_types_ext.sail riscv_types.sail riscv_vmem_types.sail $(SAIL_REGS_SRCS) $(SAIL_SYS_SRCS) riscv_platform.sail riscv_mem.sail $(SAIL_VM_SRCS) riscv_types_kext.sail
 SAIL_ARCH_SRCS += riscv_types_kext.sail    # Shared/common code for the cryptography extension.
 
 SAIL_STEP_SRCS = riscv_step_common.sail riscv_step_ext.sail riscv_decode_ext.sail riscv_fetch.sail riscv_step.sail

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -1,0 +1,107 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+scattered enum extension
+
+// Note, these are sorted according to the canonical ordering vaguely described
+// in the `Subset Naming Convention` section of the unprivileged spec.
+
+// Integer Multiplication and Division; not Machine!
+enum clause extension = Ext_M
+// Single-Precision Floating-Point
+enum clause extension = Ext_F
+// Double-Precision Floating-Point
+enum clause extension = Ext_D
+// Compressed Instructions
+enum clause extension = Ext_C
+// Bit Manipulation
+enum clause extension = Ext_B
+// Vector Operations
+enum clause extension = Ext_V
+// Supervisor
+enum clause extension = Ext_S
+// User
+enum clause extension = Ext_U
+
+// Cache-Block Management Instructions
+enum clause extension = Ext_Zicbom
+// Cache-Block Zero Instructions
+enum clause extension = Ext_Zicboz
+// Integer Conditional Operations
+enum clause extension = Ext_Zicond
+// Instruction-Fetch Fence
+enum clause extension = Ext_Zifencei
+// Hardware Performance Counters
+enum clause extension = Ext_Zihpm
+
+// Multiplication and Division: Multiplication only
+enum clause extension = Ext_Zmmul
+// Atomic Memory Operations
+
+enum clause extension = Ext_Zaamo
+// Byte and Halfword Atomic Memory Operations
+enum clause extension = Ext_Zabha
+// Load-Reserved/Store-Conditional Instructions
+enum clause extension = Ext_Zalrsc
+
+// Additional Floating-Point Instructions
+enum clause extension = Ext_Zfa
+// Half-Precision Floating-Point
+enum clause extension = Ext_Zfh
+// Minimal Half-Precision Floating-Point
+enum clause extension = Ext_Zfhmin
+// Floating-Point in Integer Registers (single precision)
+enum clause extension = Ext_Zfinx
+
+// Floating-Point in Integer Registers (double precision)
+enum clause extension = Ext_Zdinx
+
+// Code Size Reduction: compressed instructions excluding floating point loads and stores
+enum clause extension = Ext_Zca
+// Code Size Reduction: additional 16-bit aliases
+enum clause extension = Ext_Zcb
+// Code Size Reduction: compressed double precision floating point loads and stores
+enum clause extension = Ext_Zcd
+// Code Size Reduction: compressed single precision floating point loads and stores
+enum clause extension = Ext_Zcf
+
+// Bit Manipulation: Address generation
+enum clause extension = Ext_Zba
+// Bit Manipulation: Basic bit-manipulation
+enum clause extension = Ext_Zbb
+// Bit Manipulation: Carry-less multiplication
+enum clause extension = Ext_Zbc
+// Bit Manipulation: Bit-manipulation for Cryptography
+enum clause extension = Ext_Zbkb
+// Bit Manipulation: Carry-less multiplication for Cryptography
+enum clause extension = Ext_Zbkc
+// Bit Manipulation: Crossbar permutations
+enum clause extension = Ext_Zbkx
+// Bit Manipulation: Single-bit instructions
+enum clause extension = Ext_Zbs
+
+// Scalar & Entropy Source Instructions: NIST Suite: AES Decryption
+enum clause extension = Ext_Zknd
+// Scalar & Entropy Source Instructions: NIST Suite: AES Encryption
+enum clause extension = Ext_Zkne
+// Scalar & Entropy Source Instructions: NIST Suite: Hash Function Instructions
+enum clause extension = Ext_Zknh
+// Scalar & Entropy Source Instructions: Entropy Source Extension
+enum clause extension = Ext_Zkr
+// Scalar & Entropy Source Instructions: ShangMi Suite: SM4 Block Cipher Instructions
+enum clause extension = Ext_Zksed
+// Scalar & Entropy Source Instructions: ShangMi Suite: SM3 Hash Cipher Instructions
+enum clause extension = Ext_Zksh
+
+// Floating-Point in Integer Registers (half precision)
+enum clause extension = Ext_Zhinx
+
+// Supervisor-mode Timer Interrupts
+enum clause extension = Ext_Sstc
+// Fine-Grained Address-Translation Cache Invalidation
+enum clause extension = Ext_Svinval

--- a/model/riscv_fdext_control.sail
+++ b/model/riscv_fdext_control.sail
@@ -15,13 +15,8 @@
 
 /* **************************************************************** */
 
-enum clause extension = Ext_F
 function clause extensionEnabled(Ext_F) = (misa[F] == 0b1) & (mstatus[FS] != 0b00)
-
-enum clause extension = Ext_D
 function clause extensionEnabled(Ext_D) = (misa[D] == 0b1) & (mstatus[FS] != 0b00) & flen >= 64
-
-enum clause extension = Ext_Zfinx
 function clause extensionEnabled(Ext_Zfinx) = sys_enable_zfinx()
 
 /* Floating Point CSRs */

--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -10,7 +10,7 @@
 /* This file specifies the atomic instructions in the 'A' extension.  */
 
 /* ****************************************************************** */
-enum clause extension = Ext_Zabha
+
 function clause extensionEnabled(Ext_Zabha) = true
 
 // Some print utils for lr/sc.
@@ -53,7 +53,6 @@ function amo_width_valid(size : word_width) -> bool = {
 }
 
 /* ****************************************************************** */
-enum clause extension = Ext_Zalrsc
 function clause extensionEnabled(Ext_Zalrsc) = misa[A] == 0b1
 
 union clause ast = LOADRES : (bool, bool, regidx, word_width, regidx)
@@ -168,7 +167,6 @@ mapping clause assembly = STORECON(aq, rl, rs2, rs1, size, rd)
   <-> "sc." ^ size_mnemonic(size) ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs2) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
 
 /* ****************************************************************** */
-enum clause extension = Ext_Zaamo
 function clause extensionEnabled(Ext_Zaamo) = misa[A] == 0b1
 
 union clause ast = AMO : (amoop, bool, bool, regidx, regidx, word_width, regidx)

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -9,10 +9,7 @@
 /* ****************************************************************** */
 /* This file specifies the instructions in the base integer set.      */
 
-enum clause extension = Ext_C
 function clause extensionEnabled(Ext_C) = misa[C] == 0b1
-
-enum clause extension = Ext_Zca
 function clause extensionEnabled(Ext_Zca) = extensionEnabled(Ext_C)
 
 /* ****************************************************************** */

--- a/model/riscv_insts_dext.sail
+++ b/model/riscv_insts_dext.sail
@@ -224,7 +224,6 @@ function fle_D   (v1,       v2,        is_quiet) = {
 /* **************************************************************** */
 /* Helper functions for 'encdec()'                                  */
 
-enum clause extension = Ext_Zdinx
 function clause extensionEnabled(Ext_Zdinx) = sys_enable_zfinx() & flen >= 64
 
 function haveDoubleFPU() -> bool = extensionEnabled(Ext_D) | extensionEnabled(Ext_Zdinx)

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -26,10 +26,8 @@
 /* **************************************************************** */
 
 // TODO: Add config flags to control Zfh and Zfhmin
-enum clause extension = Ext_Zfh
 function clause extensionEnabled(Ext_Zfh) = (misa[F] == 0b1) & (mstatus[FS] != 0b00)
 
-enum clause extension = Ext_Zfhmin
 // Zfhmin is a subset of Zfh. This can be changed to extensionEnabled(Ext_Zfh) | sys_enable_zfhmin() when more configuration is implemented.
 function clause extensionEnabled(Ext_Zfhmin) = extensionEnabled(Ext_Zfh)
 

--- a/model/riscv_insts_mext.sail
+++ b/model/riscv_insts_mext.sail
@@ -11,9 +11,7 @@
 
 /* ****************************************************************** */
 
-enum clause extension = Ext_M
 function clause extensionEnabled(Ext_M) = misa[M] == 0b1
-enum clause extension = Ext_Zmmul
 function clause extensionEnabled(Ext_Zmmul) = true
 
 

--- a/model/riscv_insts_svinval.sail
+++ b/model/riscv_insts_svinval.sail
@@ -6,7 +6,6 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-enum clause extension = Ext_Svinval
 function clause extensionEnabled(Ext_Svinval) = sys_enable_svinval()
 
 union clause ast = SINVAL_VMA : (regidx, regidx)

--- a/model/riscv_insts_zba.sail
+++ b/model/riscv_insts_zba.sail
@@ -6,10 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-enum clause extension = Ext_B
 function clause extensionEnabled(Ext_B) = misa[B] == 0b1
-
-enum clause extension = Ext_Zba
 function clause extensionEnabled(Ext_Zba) = true | extensionEnabled(Ext_B)
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zbb.sail
+++ b/model/riscv_insts_zbb.sail
@@ -6,10 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-enum clause extension = Ext_Zbb
 function clause extensionEnabled(Ext_Zbb) = true | extensionEnabled(Ext_B)
-
-enum clause extension = Ext_Zbkb
 function clause extensionEnabled(Ext_Zbkb) = true
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zbc.sail
+++ b/model/riscv_insts_zbc.sail
@@ -6,10 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-enum clause extension = Ext_Zbc
 function clause extensionEnabled(Ext_Zbc) = true
-
-enum clause extension = Ext_Zbkc
 function clause extensionEnabled(Ext_Zbkc) = true
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zbkx.sail
+++ b/model/riscv_insts_zbkx.sail
@@ -6,7 +6,6 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-enum clause extension = Ext_Zbkx
 function clause extensionEnabled(Ext_Zbkx) = true
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zbs.sail
+++ b/model/riscv_insts_zbs.sail
@@ -6,7 +6,6 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-enum clause extension = Ext_Zbs
 function clause extensionEnabled(Ext_Zbs) = true | extensionEnabled(Ext_B)
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zcb.sail
+++ b/model/riscv_insts_zcb.sail
@@ -6,7 +6,6 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-enum clause extension = Ext_Zcb
 function clause extensionEnabled(Ext_Zcb) = sys_enable_zcb() & extensionEnabled(Ext_Zca)
 
 union clause ast = C_LBU : (bits(2), cregidx, cregidx)

--- a/model/riscv_insts_zcd.sail
+++ b/model/riscv_insts_zcd.sail
@@ -6,7 +6,6 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-enum clause extension = Ext_Zcd
 function clause extensionEnabled(Ext_Zcd) = extensionEnabled(Ext_Zca) & extensionEnabled(Ext_D) & (xlen == 32 | xlen == 64)
 
 union clause ast = C_FLDSP : (bits(6), regidx)

--- a/model/riscv_insts_zcf.sail
+++ b/model/riscv_insts_zcf.sail
@@ -15,7 +15,6 @@
 
 /* ****************************************************************** */
 
-enum clause extension = Ext_Zcf
 function clause extensionEnabled(Ext_Zcf) = extensionEnabled(Ext_Zca) & extensionEnabled(Ext_F) & xlen == 32
 
 union clause ast = C_FLWSP : (bits(6), regidx)

--- a/model/riscv_insts_zfa.sail
+++ b/model/riscv_insts_zfa.sail
@@ -6,7 +6,6 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-enum clause extension = Ext_Zfa
 function clause extensionEnabled(Ext_Zfa) = true
 
 /* FLI.H */

--- a/model/riscv_insts_zfh.sail
+++ b/model/riscv_insts_zfh.sail
@@ -6,7 +6,6 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-enum clause extension = Ext_Zhinx
 function clause extensionEnabled(Ext_Zhinx) = sys_enable_zfinx()
 
 /* **************************************************************** */

--- a/model/riscv_insts_zicbom.sail
+++ b/model/riscv_insts_zicbom.sail
@@ -8,7 +8,6 @@
 
 // Cache Block Operations - Management
 
-enum clause extension = Ext_Zicbom
 function clause extensionEnabled(Ext_Zicbom) = sys_enable_zicbom()
 
 function cbo_clean_flush_enabled(p : Privilege) -> bool = feature_enabled_for_priv(p, menvcfg[CBCFE][0], senvcfg[CBCFE][0])

--- a/model/riscv_insts_zicboz.sail
+++ b/model/riscv_insts_zicboz.sail
@@ -8,7 +8,6 @@
 
 // Cache Block Operations - Zero
 
-enum clause extension = Ext_Zicboz
 function clause extensionEnabled(Ext_Zicboz) = sys_enable_zicboz()
 
 function cbo_zero_enabled(p : Privilege) -> bool = feature_enabled_for_priv(p, menvcfg[CBZE][0], senvcfg[CBZE][0])

--- a/model/riscv_insts_zicond.sail
+++ b/model/riscv_insts_zicond.sail
@@ -6,7 +6,6 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-enum clause extension = Ext_Zicond
 function clause extensionEnabled(Ext_Zicond) = true
 
 union clause ast = ZICOND_RTYPE : (regidx, regidx, regidx, zicondop)

--- a/model/riscv_insts_zifencei.sail
+++ b/model/riscv_insts_zifencei.sail
@@ -10,7 +10,7 @@
 /* This file specifies the instructions in the 'Zifencei' extension.     */
 
 /* ****************************************************************** */
-enum clause extension = Ext_Zifencei
+
 function clause extensionEnabled(Ext_Zifencei) = true
 
 union clause ast = FENCEI : unit

--- a/model/riscv_insts_zkn.sail
+++ b/model/riscv_insts_zkn.sail
@@ -10,7 +10,7 @@
  * Scalar Cryptography Extension - Scalar SHA256 instructions (RV32/RV64)
  * ----------------------------------------------------------------------
  */
-enum clause extension = Ext_Zknh
+
 function clause extensionEnabled(Ext_Zknh) = true
 
 union clause ast = SHA256SIG0 : (regidx, regidx)
@@ -75,7 +75,6 @@ function clause execute (SHA256SUM1(rs1, rd)) = {
  * ----------------------------------------------------------------------
  */
 
-enum clause extension = Ext_Zkne
 function clause extensionEnabled(Ext_Zkne) = true
 
 union clause ast = AES32ESMI : (bits(2), regidx, regidx, regidx)
@@ -118,7 +117,6 @@ function clause execute (AES32ESI (bs, rs2, rs1, rd)) = {
  * ----------------------------------------------------------------------
  */
 
-enum clause extension = Ext_Zknd
 function clause extensionEnabled(Ext_Zknd) = true
 
 union clause ast = AES32DSMI : (bits(2), regidx, regidx, regidx)

--- a/model/riscv_insts_zks.sail
+++ b/model/riscv_insts_zks.sail
@@ -11,7 +11,6 @@
  * ----------------------------------------------------------------------
  */
 
-enum clause extension = Ext_Zksh
 function clause extensionEnabled(Ext_Zksh) = true
 
 union clause ast = SM3P0 : (regidx, regidx)
@@ -48,7 +47,6 @@ function clause execute (SM3P1(rs1, rd)) = {
  * ----------------------------------------------------------------------
  */
 
-enum clause extension = Ext_Zksed
 function clause extensionEnabled(Ext_Zksed) = true
 
 union clause ast = SM4ED : (bits(2), regidx, regidx, regidx)

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -118,7 +118,6 @@ val sys_enable_zicboz = pure "sys_enable_zicboz" : unit -> bool
 val sys_enable_sstc = pure "sys_enable_sstc" : unit -> bool
 
 // Supervisor timecmp
-enum clause extension = Ext_Sstc
 function clause extensionEnabled(Ext_Sstc) = sys_enable_sstc()
 
 /* This function allows an extension to veto a write to Misa
@@ -146,10 +145,8 @@ function clause is_CSR_defined(0x301) = true // misa
 function clause read_CSR(0x301) = misa.bits
 function clause write_CSR(0x301, value) = { misa = legalize_misa(misa, value); misa.bits }
 
-enum clause extension = Ext_U
 function clause extensionEnabled(Ext_U) = misa[U] == 0b1
 
-enum clause extension = Ext_S
 function clause extensionEnabled(Ext_S) = misa[S] == 0b1
 
 /*

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -8,9 +8,6 @@
 
 /* Basic type and function definitions used pervasively in the model. */
 
-/* ISA extension names as enums */
-scattered enum extension
-
 // Function used to determine if an extension is enabled in the current configuration.
 // This means an extension is implemented & supported, *and* any necessary bits
 // are set in the relevant CSRs (misa, mstatus, etc.) to enable its use. It is possible

--- a/model/riscv_vext_control.sail
+++ b/model/riscv_vext_control.sail
@@ -6,7 +6,6 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-enum clause extension = Ext_V
 function clause extensionEnabled(Ext_V) = (misa[V] == 0b1) & (mstatus[VS] != 0b00)
 
 mapping clause csr_name_map = 0x008  <-> "vstart"

--- a/model/riscv_zihpm.sail
+++ b/model/riscv_zihpm.sail
@@ -7,7 +7,6 @@
 /*=======================================================================================*/
 
 /* Hardware Performance Monitoring counters */
-enum clause extension = Ext_Zihpm
 function clause extensionEnabled(Ext_Zihpm) = true
 
 /* Hardware performance monitoring counters */

--- a/model/riscv_zkr_control.sail
+++ b/model/riscv_zkr_control.sail
@@ -7,7 +7,6 @@
 /*=======================================================================================*/
 
 /* Zkr entropy seed source */
-enum clause extension = Ext_Zkr
 function clause extensionEnabled(Ext_Zkr) = true
 
 /* Valid return states for reading the seed CSR. */


### PR DESCRIPTION
Having this distributed through the code can lead to slightly awkward dependency order issues. We need to keep it scattered though so e.g. CHERI can add its extensions.

Fixes #633 