### PR TITLE
Increase RAM size

### DIFF
--- a/c_emulator/riscv_platform_impl.c
+++ b/c_emulator/riscv_platform_impl.c
@@ -28,7 +28,7 @@ bool rv_enable_writable_fiom = true;
 uint64_t rv_writable_hpm_counters = 0xFFFFFFFF;
 
 uint64_t rv_ram_base = UINT64_C(0x80000000);
-uint64_t rv_ram_size = UINT64_C(0x4000000);
+uint64_t rv_ram_size = UINT64_C(0x80000000);
 
 uint64_t rv_rom_base = UINT64_C(0x1000);
 uint64_t rv_rom_size = UINT64_C(0x100);


### PR DESCRIPTION
This matches Spike, and means a default Linux build has enough RAM to boot properly.

I'm not exactly sure why the old value was not sufficient but it didn't work when I tried and this did, and I think consistency with Spike is valuable anyway.