### PR TITLE
Support for the E base architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ For booting operating system images, see the information under the
 ### The Sail specification currently captures the following ISA extensions and features:
 
 - RV32I and RV64I base ISAs, v2.1
+- RV32E and RV64E base ISAs, v2.0
 - Zifencei extension for instruction-fetch fence, v2.0
 - Zicsr extension for CSR instructions, v2.0
 - Zicntr and Zihpm extensions for counters, v2.0

--- a/c_emulator/riscv_callbacks.cpp
+++ b/c_emulator/riscv_callbacks.cpp
@@ -43,7 +43,7 @@ unit mem_exception_callback(sbits paddr, uint64_t num_of_exception)
   return UNIT;
 }
 
-unit xreg_full_write_callback(const_sail_string abi_name, unsigned reg,
+unit xreg_full_write_callback(const_sail_string abi_name, sbits reg,
                               sbits value)
 {
   for (auto c : callbacks) {

--- a/c_emulator/riscv_callbacks.h
+++ b/c_emulator/riscv_callbacks.h
@@ -10,7 +10,7 @@ unit mem_write_callback(const char *type, sbits paddr, uint64_t width,
 unit mem_read_callback(const char *type, sbits paddr, uint64_t width,
                        lbits value);
 unit mem_exception_callback(sbits paddr, uint64_t num_of_exception);
-unit xreg_full_write_callback(const_sail_string abi_name, unsigned reg,
+unit xreg_full_write_callback(const_sail_string abi_name, sbits reg,
                               sbits value);
 unit freg_write_callback(unsigned reg, sbits value);
 // `full` indicates that the name and index of the CSR are provided.

--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -18,8 +18,8 @@ public:
       = 0;
   virtual void mem_exception_callback(sbits paddr, uint64_t num_of_exception)
       = 0;
-  virtual void xreg_full_write_callback(const_sail_string abi_name,
-                                        unsigned reg, sbits value)
+  virtual void xreg_full_write_callback(const_sail_string abi_name, sbits reg,
+                                        sbits value)
       = 0;
   virtual void freg_write_callback(unsigned reg, sbits value) = 0;
   virtual void csr_full_write_callback(const_sail_string csr_name, unsigned reg,

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -54,14 +54,14 @@ void log_callbacks::mem_read_callback(const char *type, sbits paddr,
 void log_callbacks::mem_exception_callback(sbits, uint64_t) { }
 
 void log_callbacks::xreg_full_write_callback(const_sail_string abi_name,
-                                             unsigned reg, sbits value)
+                                             sbits reg, sbits value)
 {
   if (trace_log != nullptr && config_print_reg) {
     if (config_use_abi_names) {
       fprintf(trace_log, "%s <- 0x%0*" PRIX64 "\n", abi_name,
               static_cast<int>(zxlen / 4), value.bits);
     } else {
-      fprintf(trace_log, "x%d <- 0x%0*" PRIX64 "\n", reg,
+      fprintf(trace_log, "x%lu <- 0x%0*" PRIX64 "\n", reg.bits,
               static_cast<int>(zxlen / 4), value.bits);
     }
   }

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -15,7 +15,7 @@ public:
   void mem_read_callback(const char *type, sbits paddr, uint64_t width,
                          lbits value) override;
   void mem_exception_callback(sbits paddr, uint64_t num_of_exception) override;
-  void xreg_full_write_callback(const_sail_string abi_name, unsigned reg,
+  void xreg_full_write_callback(const_sail_string abi_name, sbits reg,
                                 sbits value) override;
   void freg_write_callback(unsigned reg, sbits value) override;
   void csr_full_write_callback(const_sail_string csr_name, unsigned reg,

--- a/c_emulator/riscv_callbacks_rvfi.cpp
+++ b/c_emulator/riscv_callbacks_rvfi.cpp
@@ -33,11 +33,11 @@ void rvfi_callbacks::mem_exception_callback(sbits paddr, uint64_t)
   }
 }
 
-void rvfi_callbacks::xreg_full_write_callback(const_sail_string, unsigned reg,
+void rvfi_callbacks::xreg_full_write_callback(const_sail_string, sbits reg,
                                               sbits value)
 {
   if (config_enable_rvfi) {
-    zrvfi_wX(reg, value);
+    zrvfi_wX(reg.bits, value);
   }
 }
 

--- a/c_emulator/riscv_callbacks_rvfi.h
+++ b/c_emulator/riscv_callbacks_rvfi.h
@@ -11,7 +11,7 @@ public:
   void mem_read_callback(const char *type, sbits paddr, uint64_t width,
                          lbits value) override;
   void mem_exception_callback(sbits paddr, uint64_t num_of_exception) override;
-  void xreg_full_write_callback(const_sail_string abi_name, unsigned reg,
+  void xreg_full_write_callback(const_sail_string abi_name, sbits reg,
                                 sbits value) override;
   void freg_write_callback(unsigned reg, sbits value) override;
   void csr_full_write_callback(const_sail_string csr_name, unsigned reg,

--- a/config/rv32d.json
+++ b/config/rv32d.json
@@ -1,6 +1,7 @@
 {
   "base": {
     "xlen": 32,
+    "E": false,
     "writable_misa": true,
     "writable_fiom": true,
     "writable_hpm_counters": {

--- a/config/rv64d.json
+++ b/config/rv64d.json
@@ -1,6 +1,7 @@
 {
   "base": {
     "xlen": 64,
+    "E": false,
     "writable_misa": true,
     "writable_fiom": true,
     "writable_hpm_counters": {

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -1,3 +1,10 @@
+# Notes since the last release
+
+- Support for the RV32E and RV64E base ISAs has been added. These
+  are enabled by setting `base.E` to `true` in `config/rv32d.json`
+  and `config/rv64d.json` respectively. Dynamic switching between
+  the 'E' and 'I' base ISAs is not supported.
+
 # Release notes for the 0.8 release
 
 This is a major release with some backwards-incompatible changes.
@@ -38,8 +45,8 @@ The configuration parameters for the model are now specified in a JSON
 file. These parameters include `base.xlen` (which is set to `32` for
 RV32 or `64` for RV64), various platform settings and flags to enable
 each individual extension, and any parameters for these extensions.
-Sample configurations are provided for RV32 (`config/rv32.json`) and
-RV64 (`config/rv64.json`).
+Sample configurations are provided for RV32 (`config/rv32d.json`) and
+RV64 (`config/rv64d.json`).
 
 The `--config` option to `sail_riscv_sim` is used to specify the
 configuration file. The default configuration can be printed using

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -11,6 +11,15 @@
 register PC       : xlenbits
 register nextPC   : xlenbits
 
+/* Mappings for encoding */
+
+mapping encdec_reg : regidx <-> bits(5) = {
+  forwards Regidx(r) => zero_extend(r),
+  backwards r if not(base_E_enabled) | r[4] == bitzero => Regidx(r[regidx_bit_width - 1 .. 0]),
+}
+
+mapping encdec_creg : cregidx <-> bits(3) = { Cregidx(r) <-> r }
+
 /* mappings for assembly */
 
 mapping reg_abi_name_raw : bits(5) <-> string = {
@@ -84,9 +93,11 @@ mapping reg_arch_name_raw : bits(5) <-> string = {
     0b11111 <-> "x31",
 }
 
+// Mapping from 4/5 back to 5 bits here makes the name mapping much easier.
+// If you call `reg_name("t6")` on an E hart you'll get a mapping failure.
 mapping reg_name : regidx <-> string = {
-  Regidx(i) if get_config_use_abi_names()      <-> reg_abi_name_raw(i),
-  Regidx(i) if not(get_config_use_abi_names()) <-> reg_arch_name_raw(i),
+  encdec_reg(i) if get_config_use_abi_names()      <-> reg_abi_name_raw(i),
+  encdec_reg(i) if not(get_config_use_abi_names()) <-> reg_arch_name_raw(i),
 }
 
 // Special mapping for the sp register for use in assembly for sp-relative
@@ -96,7 +107,7 @@ mapping sp_reg_name : unit <-> string = {
   () if not(get_config_use_abi_names()) <-> "x2",
 }
 
-mapping creg_name : cregidx <-> string = { Cregidx(i) <-> reg_name(Regidx(0b01 @ i)) }
+mapping creg_name : cregidx <-> string = { Cregidx(i) <-> reg_name(encdec_reg(0b01 @ i)) }
 
 function xreg_write_callback(reg : regidx, value : xlenbits) -> unit = {
   let name = reg_name(reg);
@@ -236,10 +247,3 @@ function wX_pair_bits(i : regidx, data : bits(xlen * 2)) -> unit =
   }
 
 overload X_pair = {rX_pair_bits, wX_pair_bits}
-
-
-/* Mappings for encoding */
-
-mapping encdec_reg : regidx <-> bits(5) = { Regidx(r) <-> r }
-
-mapping encdec_creg : cregidx <-> bits(3) = { Cregidx(r) <-> r }

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -275,11 +275,14 @@ function reset_misa() -> unit = {
   misa[A]   = bool_to_bits(hartSupports(Ext_A));   /* atomics */
   misa[C]   = bool_to_bits(hartSupports(Ext_C));   /* RVC */
   misa[B]   = bool_to_bits(hartSupports(Ext_B));   /* Bit-manipulation */
-  misa[I]   = 0b1;                                 /* base integer ISA */
   misa[M]   = bool_to_bits(hartSupports(Ext_M));   /* integer multiply/divide */
   misa[U]   = bool_to_bits(hartSupports(Ext_U));   /* user-mode */
   misa[S]   = bool_to_bits(hartSupports(Ext_S));   /* supervisor-mode */
   misa[V]   = bool_to_bits(hartSupports(Ext_V));   /* vector extension */
+
+  // Base integer ISA (disabled if we only support the 16-register E base).
+  misa[E] = bool_to_bits(base_E_enabled);
+  misa[I] = ~(misa[E]);
 
   if   hartSupports(Ext_F) & hartSupports(Ext_Zfinx)
   then internal_error(__FILE__, __LINE__, "F and Zfinx cannot both be enabled!");

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -112,7 +112,9 @@ function legalize_misa(m : Misa, v : xlenbits) -> Misa = {
     D = if hartSupports(Ext_D) & v[F] == 0b1 then v[D] else 0b0,
     F = if hartSupports(Ext_F) then v[F] else 0b0,
     H = if hartSupports(Ext_H) then v[H] else 0b0, // TODO: Not fully supported yet
-    I = 0b1, // I is currently always supported
+    // Writable I is not currently supported.
+    I = bool_to_bits(not(base_E_enabled)),
+    E = bool_to_bits(base_E_enabled),
     M = if hartSupports(Ext_M) then v[M] else 0b0,
     // Q = if hartSupports(Ext_Q) then v[Q] else 0b0, TODO: Not supported yet
     S = if hartSupports(Ext_S) & v[U] == 0b1 then v[S] else 0b0,

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -17,28 +17,37 @@ type instbits = bits(32)
 type pagesize_bits : Int = 12
 let  pagesize_bits = sizeof(pagesize_bits)
 
+// RV32E and RV64E Base Integer Instruction Sets. If this enabled then
+// the model will only support E (16 integer registers). It is allowed
+// to have a design where `misa[I]` is writable to turn E on and off,
+// but this model does not support that.
+type base_E_enabled : Bool = config base.E
+let base_E_enabled = constraint(base_E_enabled)
+
 /* register identifiers */
 
-newtype regidx = Regidx : bits(5)  /* uncompressed register identifiers */
+type regidx_bit_width = if base_E_enabled then 4 else 5
+let regidx_bit_width = sizeof(regidx_bit_width)
+
+newtype regidx = Regidx : bits(regidx_bit_width)  /* uncompressed register identifiers */
 newtype cregidx = Cregidx : bits(3) /* identifiers in RVC instructions */
 type csreg = bits(12)  /* CSR addressing */
 
-function regidx_offset(Regidx(r) : regidx, o : bits(5)) -> regidx = Regidx(r + o)
+function regidx_offset(Regidx(r) : regidx, o : bits(regidx_bit_width)) -> regidx = Regidx(r + o)
 function regidx_offset_range(Regidx(r) : regidx, o : range(0, 31)) -> regidx = Regidx(r + o)
-function regidx_bits(Regidx(b) : regidx) -> bits(5) = b
+function regidx_bits(Regidx(b) : regidx) -> bits(regidx_bit_width) = b
 overload operator + = { regidx_offset, regidx_offset_range }
 /* register file indexing */
 
-newtype regno = Regno : range(0, 31)
+newtype regno = Regno : range(0, 2 ^ regidx_bit_width - 1)
 
 /* mapping RVC register indices into normal indices */
-val creg2reg_idx : cregidx -> regidx
-function creg2reg_idx(Cregidx(i)) = Regidx(0b01 @ i)
+function creg2reg_idx(Cregidx(i) : cregidx) -> regidx = Regidx(zero_extend(0b1 @ i))
 
 /* some architecture and ABI relevant register identifiers */
-let zreg : regidx = Regidx(0b00000) /* x0, zero register  */
-let ra   : regidx = Regidx(0b00001) /* x1, return address */
-let sp   : regidx = Regidx(0b00010) /* x2, stack pointer  */
+let zreg : regidx = Regidx(zero_extend(0b00)) /* x0, zero register  */
+let ra   : regidx = Regidx(zero_extend(0b01)) /* x1, return address */
+let sp   : regidx = Regidx(zero_extend(0b10)) /* x2, stack pointer  */
 
 /* base architecture definitions */
 


### PR DESCRIPTION
Allow configuring `regidx` to be 4 bits instead of 5, so only 16 `x` registers are supported. Instruction encodings to access `x16` - `x31` are reserved and will cause an illegal instruction exception if `E` is enabled.