### PR TITLE
Remove obsolete z_set_Misa functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,11 +242,9 @@ cloc:
 gcovr:
 	gcovr -r . --html --html-detail -o index.html
 
-c_preserve_fns=-c_preserve _set_Misa_C
-
 generated_definitions/c/riscv_model_$(ARCH).c: $(SAIL_SRCS) model/main.sail Makefile
 	mkdir -p generated_definitions/c
-	$(SAIL) $(SAIL_FLAGS) $(c_preserve_fns) -O -Oconstant_fold -memo_z3 -c -c_include riscv_prelude.h -c_include riscv_platform.h -c_no_main $(SAIL_SRCS) model/main.sail -o $(basename $@)
+	$(SAIL) $(SAIL_FLAGS) -O -Oconstant_fold -memo_z3 -c -c_include riscv_prelude.h -c_include riscv_platform.h -c_no_main $(SAIL_SRCS) model/main.sail -o $(basename $@)
 
 generated_definitions/c2/riscv_model_$(ARCH).c: $(SAIL_SRCS) model/main.sail Makefile
 	mkdir -p generated_definitions/c2
@@ -282,7 +280,7 @@ rvfi_preserve_fns=-c_preserve rvfi_set_instr_packet \
 # sed -i isn't posix compliant, unfortunately
 generated_definitions/c/riscv_rvfi_model_$(ARCH).c: $(SAIL_RVFI_SRCS) model/main.sail Makefile
 	mkdir -p generated_definitions/c
-	$(SAIL) $(c_preserve_fns) $(rvfi_preserve_fns) $(SAIL_FLAGS) -O -Oconstant_fold -memo_z3 -c -c_include riscv_prelude.h -c_include riscv_platform.h -c_no_main $(SAIL_RVFI_SRCS) model/main.sail -o $(basename $@)
+	$(SAIL) $(rvfi_preserve_fns) $(SAIL_FLAGS) -O -Oconstant_fold -memo_z3 -c -c_include riscv_prelude.h -c_include riscv_platform.h -c_no_main $(SAIL_RVFI_SRCS) model/main.sail -o $(basename $@)
 	sed -e '/^[[:space:]]*$$/d' $@ > $@.new
 	mv $@.new $@
 

--- a/c_emulator/riscv_sail.h
+++ b/c_emulator/riscv_sail.h
@@ -19,10 +19,6 @@ bool zstep(sail_int);
 unit ztick_clock(unit);
 unit ztick_platform(unit);
 
-unit z_set_Misa_C(struct zMisa *, mach_bits);
-unit z_set_Misa_D(struct zMisa *, mach_bits);
-unit z_set_Misa_F(struct zMisa *, mach_bits);
-
 #ifdef RVFI_DII
 unit zext_rvfi_init(unit);
 unit zrvfi_set_instr_packet(mach_bits);

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -680,10 +680,6 @@ void init_sail(uint64_t elf_entry)
   } else
 #endif
     init_sail_reset_vector(elf_entry);
-
-  // this is probably unnecessary now; remove
-  if (!rv_enable_rvc)
-    z_set_Misa_C(&zmisa, 0);
 }
 
 /* reinitialize to clear state and memory, typically across tests runs */


### PR DESCRIPTION
This appears to be an obsolete and unused mechanism of disabling extensions by calling into the model to modify `misa`. Now it is done by `sys_enable_` callbacks.