### PR TITLE
Report the correct address for CBO errors

### DIFF
--- a/model/riscv_insts_zicbom.sail
+++ b/model/riscv_insts_zicbom.sail
@@ -90,7 +90,9 @@ function process_clean_inval(rs1, cbop) = {
             // for fetch access and it's can't be misaligned.
             _ => internal_error(__FILE__, __LINE__, "unexpected exception for cmo.clean/inval"),
           };
-          handle_mem_exception(vaddr, e);
+          // Errors report the address that was encoded in the instruction rather
+          // than the address that caused the fault (i.e. the aligned address).
+          handle_mem_exception(virtaddr(virtaddr_bits(vaddr) - offset), e);
           RETIRE_FAIL
         }
       }

--- a/model/riscv_insts_zicboz.sail
+++ b/model/riscv_insts_zicboz.sail
@@ -49,7 +49,12 @@ function clause execute(RISCV_ZICBOZ(rs1)) = {
                 match (res) {
                   MemValue(true) => RETIRE_SUCCESS,
                   MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                  MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+                  MemException(e) => {
+                    // Errors report the address that was encoded in the instruction rather
+                    // than the address that caused the fault (i.e. the aligned address).
+                    handle_mem_exception(virtaddr(virtaddr_bits(vaddr) - offset), e);
+                    RETIRE_FAIL
+                  },
                 }
               }
             }


### PR DESCRIPTION
CBO faults report the address in rs1, not the cache block address.

The spec is not explicit about this yet but I have a pending PR to clarify that: https://github.com/riscv/riscv-isa-manual/pull/1433