### PR TITLE
Overload operators for physaddr and virtaddr

### DIFF
--- a/model/prelude_mem_addrtype.sail
+++ b/model/prelude_mem_addrtype.sail
@@ -19,3 +19,7 @@ newtype virtaddr = virtaddr : xlenbits
 function physaddr_bits(physaddr(paddr) : physaddr) -> physaddrbits = paddr
 
 function virtaddr_bits(virtaddr(vaddr) : virtaddr) -> xlenbits = vaddr
+
+function sub_virtaddr_xlenbits(virtaddr(addr) : virtaddr, offset : xlenbits) -> virtaddr = virtaddr(addr - offset)
+
+overload operator - = { sub_virtaddr_xlenbits }

--- a/model/riscv_insts_zicbom.sail
+++ b/model/riscv_insts_zicbom.sail
@@ -92,7 +92,7 @@ function process_clean_inval(rs1, cbop) = {
           };
           // Errors report the address that was encoded in the instruction rather
           // than the address that caused the fault (i.e. the aligned address).
-          handle_mem_exception(virtaddr(virtaddr_bits(vaddr) - offset), e);
+          handle_mem_exception(vaddr - offset, e);
           RETIRE_FAIL
         }
       }

--- a/model/riscv_insts_zicboz.sail
+++ b/model/riscv_insts_zicboz.sail
@@ -52,7 +52,7 @@ function clause execute(RISCV_ZICBOZ(rs1)) = {
                   MemException(e) => {
                     // Errors report the address that was encoded in the instruction rather
                     // than the address that caused the fault (i.e. the aligned address).
-                    handle_mem_exception(virtaddr(virtaddr_bits(vaddr) - offset), e);
+                    handle_mem_exception(vaddr - offset, e);
                     RETIRE_FAIL
                   },
                 }


### PR DESCRIPTION
try resolve #668 

Added operator overloading for `physaddr` and `virtaddr`

I think we don't need to implement `==` and `!=`? 
Because `eq_anything` (I just discovered this) has already been introduced in `prelude.sail`.

https://github.com/riscv/sail-riscv/blob/c0ebea2ff14e6a39d53161c3e51dcbabe3e9a0f1/model/prelude.sail#L17
