### PR TITLE
PTEs are invalid if reserved bits are non-zero

### DIFF
--- a/model/core/isa_version.sail
+++ b/model/core/isa_version.sail
@@ -53,7 +53,6 @@ let priv_isa_version : Privileged_ISA_Version = config base.privileged_isa_versi
 
 // In this version, a new requirement was added that reserved bits
 // in PTEs must be zero otherwise the PTE is invalid.
-// TODO: This is not used yet; this is an example that will be implemented in a future commit.
 let pte_reserved_bits_must_be_zero = priv_isa_version >= Privileged_ISA_1_12
 
 

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -419,7 +419,7 @@ private function legalize_menvcfg(o : MEnvcfg, v : bits(64)) -> MEnvcfg = {
     STCE = if currentlyEnabled(Ext_Sstc) then v[STCE] else 0b0,
     PMM = if currentlyEnabled(Ext_Smnpm) & is_supported_pmm(PM_SMNPM, pmm_mode(v[PMM])) then v[PMM] else o[PMM],
     ADUE = if currentlyEnabled(Ext_Svadu) then v[ADUE] else 0b0,
-    PBMTE = if hartSupports(Ext_Svpbmt) then v[PBMTE] else 0b0,
+    PBMTE = if currentlyEnabled(Ext_Svpbmt) then v[PBMTE] else 0b0,
     // Other extensions are not implemented yet so all other fields are read only zero.
   ]
 }

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -419,7 +419,7 @@ private function legalize_menvcfg(o : MEnvcfg, v : bits(64)) -> MEnvcfg = {
     STCE = if currentlyEnabled(Ext_Sstc) then v[STCE] else 0b0,
     PMM = if currentlyEnabled(Ext_Smnpm) & is_supported_pmm(PM_SMNPM, pmm_mode(v[PMM])) then v[PMM] else o[PMM],
     ADUE = if currentlyEnabled(Ext_Svadu) then v[ADUE] else 0b0,
-    PBMTE = if currentlyEnabled(Ext_Svpbmt) then v[PBMTE] else 0b0,
+    PBMTE = if hartSupports(Ext_Svpbmt) then v[PBMTE] else 0b0,
     // Other extensions are not implemented yet so all other fields are read only zero.
   ]
 }

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -180,7 +180,8 @@ function pt_walk(
             PTE_Check_Success(ext_ptw) => {
               let ppn = if level > 0 then {
                 // NAPOT PTEs are currently reserved for level > 0.
-                if pte_ext[N] == 0b1 then return Err(PTW_Invalid_PTE(), ext_ptw);
+                if pte_ext[N] == 0b1 & pte_reserved_bits_must_be_zero
+                then return Err(PTW_Invalid_PTE(), ext_ptw);
 
                 // Compose final PA in superpage:
                 // Superpage PPN @ lower VPNs @ page-offset

--- a/model/sys/vmem_pte.sail
+++ b/model/sys/vmem_pte.sail
@@ -74,7 +74,7 @@ private function pte_is_non_leaf(pte_flags : PTE_Flags) -> bool =
 // NAPOT Translation Contiguity
 function clause currentlyEnabled(Ext_Svnapot) = hartSupports(Ext_Svnapot) & currentlyEnabled(Ext_Sv39)
 // Page-Based Memory Types
-function clause currentlyEnabled(Ext_Svpbmt) = menvcfg[PBMTE] == 0b1
+function clause currentlyEnabled(Ext_Svpbmt) = hartSupports(Ext_Svpbmt) & currentlyEnabled(Ext_Sv39)
 // Svrsw60t59b: PTE Reserved for software bits 60-59
 function clause currentlyEnabled(Ext_Svrsw60t59b) = hartSupports(Ext_Svrsw60t59b) & currentlyEnabled(Ext_Sv39)
 // Obviating Memory-management Instructions after Marking PTEs valid

--- a/model/sys/vmem_pte.sail
+++ b/model/sys/vmem_pte.sail
@@ -74,7 +74,7 @@ private function pte_is_non_leaf(pte_flags : PTE_Flags) -> bool =
 // NAPOT Translation Contiguity
 function clause currentlyEnabled(Ext_Svnapot) = hartSupports(Ext_Svnapot) & currentlyEnabled(Ext_Sv39)
 // Page-Based Memory Types
-function clause currentlyEnabled(Ext_Svpbmt) =  hartSupports(Ext_Svpbmt) & currentlyEnabled(Ext_Sv39)
+function clause currentlyEnabled(Ext_Svpbmt) = menvcfg[PBMTE] == 0b1
 // Svrsw60t59b: PTE Reserved for software bits 60-59
 function clause currentlyEnabled(Ext_Svrsw60t59b) = hartSupports(Ext_Svrsw60t59b) & currentlyEnabled(Ext_Sv39)
 // Obviating Memory-management Instructions after Marking PTEs valid
@@ -93,14 +93,19 @@ private function pte_is_invalid(pte_flags : PTE_Flags, pte_ext : PTE_Ext) -> boo
   // TODO: handle V=1 and henvcfg.SSE=0 at VS/VU levels
   | (pte_flags[R] == 0b0 & pte_flags[W] == 0b1 & pte_flags[X] == 0b0 & menvcfg[SSE] == 0b0)
   | (pte_flags[R] == 0b0 & pte_flags[W] == 0b1 & pte_flags[X] == 0b1)
-  // Note, the following requirements depend on the privileged spec version.
-  // Early versions do not require this check. This will need to be behind
-  // a flag when the Sail model allows specifying the spec version.
-  | (pte_is_non_leaf(pte_flags) & (pte_flags[A] == 0b1 | pte_flags[D] == 0b1 | pte_flags[U] == 0b1 | pte_ext.bits != zeros()))
-  | (pte_ext[N] != 0b0 & not(currentlyEnabled(Ext_Svnapot)))
-  | (pte_ext[PBMT] != zeros() & (menvcfg[PBMTE] == 0b0 | not(page_based_mem_type_forwards_matches(pte_ext[PBMT]))))
-  | (pte_ext[RSW_60t59b] != zeros() & not(currentlyEnabled(Ext_Svrsw60t59b)))
-  | pte_ext[reserved] != zeros()
+  // Reserved encodings mean the PTE is invalid.
+  | not(page_based_mem_type_forwards_matches(pte_ext[PBMT])) & currentlyEnabled(Ext_Svpbmt)
+  // Early versions of the spec did not require reserved bits to be zero.
+  | pte_reserved_bits_must_be_zero & (
+    // A/D/U and all ext bits are currently reserved for non-leaf PTEs.
+      pte_is_non_leaf(pte_flags) & (pte_flags[A] == 0b1 | pte_flags[D] == 0b1 | pte_flags[U] == 0b1 | pte_ext.bits != zeros())
+    // N/PBMT/60t59b are reserved if not implemented.
+    | pte_ext[N]          != zeros() & not(currentlyEnabled(Ext_Svnapot))
+    | pte_ext[PBMT]       != zeros() & not(currentlyEnabled(Ext_Svpbmt))
+    | pte_ext[RSW_60t59b] != zeros() & not(currentlyEnabled(Ext_Svrsw60t59b))
+    // Reserved bits are reserved even for leaf PTEs.
+    | pte_ext[reserved] != zeros()
+  )
 
 // ----------------
 // Check access permissions in PTE
@@ -112,7 +117,7 @@ union pte_check_failure = {
 }
 
 // For (non-standard) extensions: this function gets the extension-available bits
-// of the PTE in extPte, and the accumulated information of the page-table-walk
+// of the PTE in PTE_Ext, and the accumulated information of the page-table-walk
 // in ext_ptw. It should return the updated ext_ptw in both success and failure cases.
 
 union PTE_Check = {

--- a/model/sys/vmem_pte.sail
+++ b/model/sys/vmem_pte.sail
@@ -101,7 +101,7 @@ private function pte_is_invalid(pte_flags : PTE_Flags, pte_ext : PTE_Ext) -> boo
       pte_is_non_leaf(pte_flags) & (pte_flags[A] == 0b1 | pte_flags[D] == 0b1 | pte_flags[U] == 0b1 | pte_ext.bits != zeros())
     // N/PBMT/60t59b are reserved if not implemented.
     | pte_ext[N]          != zeros() & not(currentlyEnabled(Ext_Svnapot))
-    | pte_ext[PBMT]       != zeros() & not(currentlyEnabled(Ext_Svpbmt))
+    | pte_ext[PBMT]       != zeros() & (menvcfg[PBMTE] == 0b0 | not(page_based_mem_type_forwards_matches(pte_ext[PBMT])))
     | pte_ext[RSW_60t59b] != zeros() & not(currentlyEnabled(Ext_Svrsw60t59b))
     // Reserved bits are reserved even for leaf PTEs.
     | pte_ext[reserved] != zeros()


### PR DESCRIPTION
This has only been the case since version 1.12 of the spec.