### PR TITLE
Simplify float load/store

### DIFF
--- a/model/riscv_flen.sail
+++ b/model/riscv_flen.sail
@@ -6,9 +6,11 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-type flenbits = bits(flen)
+type flen       : Int = flen_bytes * 8
+type flenbits         = bits(flen)
 
 // Variable versions of the above types. Variables and types
 // are disjoint in Sail so they are allowed to have the same name.
 // This saves typing `sizeof()` everywhere.
+let flen_bytes = sizeof(flen_bytes)
 let flen = sizeof(flen)

--- a/model/riscv_flen_D.sail
+++ b/model/riscv_flen_D.sail
@@ -8,4 +8,4 @@
 
 /* Define the FLEN value for the 'D' extension. */
 
-type flen : Int = 64
+type flen_bytes : Int = 8

--- a/model/riscv_flen_F.sail
+++ b/model/riscv_flen_F.sail
@@ -8,4 +8,4 @@
 
 /* Define the FLEN value for the 'F' extension. */
 
-type flen : Int = 32
+type flen_bytes : Int = 4

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -288,60 +288,31 @@ mapping clause encdec = LOAD_FP(imm, rs1, rd, DOUBLE)        if extensionEnabled
 
 /* Execution semantics ================================ */
 
-val process_fload64 : (regidx, virtaddr, MemoryOpResult(bits(64)))
-                      -> Retired
-function process_fload64(rd, addr, value) =
-  if   flen == 64
-  then match value {
-         MemValue(result) => { F(rd) = result; RETIRE_SUCCESS },
-         MemException(e)  => { handle_mem_exception(addr, e); RETIRE_FAIL }
-       }
-  else {
-    /* should not get here */
-    RETIRE_FAIL
-  }
-
-val process_fload32 : (regidx, virtaddr, MemoryOpResult(bits(32)))
-                      -> Retired
-function process_fload32(rd, addr, value) =
-  match value {
-    MemValue(result) => { F(rd) = nan_box(result); RETIRE_SUCCESS },
-    MemException(e)  => { handle_mem_exception(addr, e); RETIRE_FAIL }
-  }
-
-val process_fload16 : (regidx, virtaddr, MemoryOpResult(bits(16)))
-                      -> Retired
-function process_fload16(rd, addr, value) =
-  match value {
-    MemValue(result) => { F(rd) = nan_box(result); RETIRE_SUCCESS },
-    MemException(e)  => { handle_mem_exception(addr, e); RETIRE_FAIL }
-  }
-
 function clause execute(LOAD_FP(imm, rs1, rd, width)) = {
+  let width_bytes = size_bytes(width);
+
+  // This is checked during decoding.
+  assert(width_bytes <= flen_bytes);
+
   let offset : xlenbits = sign_extend(imm);
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
-  match ext_data_get_addr(rs1, offset, Read(Data), size_bytes(width)) {
+  match ext_data_get_addr(rs1, offset, Read(Data), width_bytes) {
     Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
-    Ext_DataAddr_OK(vaddr) =>
+    Ext_DataAddr_OK(vaddr) => {
       if   check_misaligned(vaddr, width)
       then { handle_mem_exception(vaddr, E_Load_Addr_Align()); RETIRE_FAIL }
       else match translateAddr(vaddr, Read(Data)) {
         TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
         TR_Address(addr, _) => {
           let (aq, rl, res) = (false, false, false);
-          match (width) {
-            BYTE => { handle_illegal(); RETIRE_FAIL },
-            HALF =>
-               process_fload16(rd, vaddr, mem_read(Read(Data), addr, 2, aq, rl, res)),
-            WORD =>
-               process_fload32(rd, vaddr, mem_read(Read(Data), addr, 4, aq, rl, res)),
-            DOUBLE if flen >= 64 =>
-               process_fload64(rd, vaddr, mem_read(Read(Data), addr, 8, aq, rl, res)),
-            _ => report_invalid_width(__FILE__, __LINE__, width, "floating point load"),
+          match mem_read(Read(Data), addr, width_bytes, aq, rl, res) {
+            MemValue(result) => { F(rd) = nan_box(result); RETIRE_SUCCESS },
+            MemException(e)  => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
           }
-        }
+        },
       }
+    }
   }
 }
 
@@ -374,49 +345,38 @@ mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, DOUBLE)                 
 
 /* Execution semantics ================================ */
 
-val process_fstore : (virtaddr, MemoryOpResult(bool)) -> Retired
-function process_fstore(vaddr, value) =
-  match value {
-    MemValue(true)  => { RETIRE_SUCCESS },
-    MemValue(false) => { internal_error(__FILE__, __LINE__, "store got false from mem_write_value") },
-    MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
-  }
-
 function clause execute (STORE_FP(imm, rs2, rs1, width)) = {
+  let width_bytes = size_bytes(width);
+
+  // This is checked during decoding.
+  assert(width_bytes <= flen_bytes);
+
   let offset : xlenbits = sign_extend(imm);
   let (aq, rl, con) = (false, false, false);
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
-  match ext_data_get_addr(rs1, offset, Write(Data), size_bytes(width)) {
+  match ext_data_get_addr(rs1, offset, Write(Data), width_bytes) {
     Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
-    Ext_DataAddr_OK(vaddr) =>
+    Ext_DataAddr_OK(vaddr) => {
       if   check_misaligned(vaddr, width)
       then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); RETIRE_FAIL }
       else match translateAddr(vaddr, Write(Data)) {
         TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
         TR_Address(addr, _) => {
-          let eares : MemoryOpResult(unit) = match width {
-            BYTE   => MemValue () /* bogus placeholder for illegal size */,
-            HALF   => mem_write_ea(addr, 2, aq, rl, false),
-            WORD   => mem_write_ea(addr, 4, aq, rl, false),
-            DOUBLE => mem_write_ea(addr, 8, aq, rl, false)
-          };
-          match (eares) {
+          match mem_write_ea(addr, width_bytes, aq, rl, false) {
             MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
             MemValue(_) => {
               let rs2_val = F(rs2);
-              match (width) {
-                BYTE => { handle_illegal(); RETIRE_FAIL },
-                HALF => process_fstore (vaddr, mem_write_value(addr, 2, rs2_val[15..0], aq, rl, con)),
-                WORD => process_fstore (vaddr, mem_write_value(addr, 4, rs2_val[31..0], aq, rl, con)),
-                DOUBLE if flen >= 64 =>
-                  process_fstore (vaddr, mem_write_value(addr, 8, rs2_val, aq, rl, con)),
-                _ => report_invalid_width(__FILE__, __LINE__, width, "floating point store"),
-              };
-            }
+              match mem_write_value(addr, width_bytes, rs2_val[width_bytes * 8 - 1 .. 0], aq, rl, con) {
+                MemValue(true)  => { RETIRE_SUCCESS },
+                MemValue(false) => { internal_error(__FILE__, __LINE__, "store got false from mem_write_value") },
+                MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+              }
+            },
           }
         }
       }
+    }
   }
 }
 


### PR DESCRIPTION
Use Sail's fancy dependent types instead of separate functions for each float load/store size. Functionality is unchanged.