### PR TITLE
Speed up tests

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -59,17 +59,22 @@ printf "Building 32-bit RISCV specification...\n"
 if ARCH=RV32 make c_emulator/riscv_sim_RV32;
 then
     green "Building 32-bit RISCV C emulator" "ok"
+
+    for test in $DIR/riscv-tests/rv32*.elf; do
+        if timeout 5 $RISCVDIR/c_emulator/riscv_sim_RV32 -p $test > ${test%.elf}.cout 2>&1 && grep -q SUCCESS ${test%.elf}.cout
+        then
+            green "C-32 $(basename $test)" "ok"
+        else
+            red "C-32 $(basename $test)" "fail"
+        fi
+    done
 else
     red "Building 32-bit RISCV C emulator" "fail"
+
+    for test in $DIR/riscv-tests/rv32*.elf; do
+        red "C-32 $(basename $test)" "fail"
+    done
 fi
-for test in $DIR/riscv-tests/rv32*.elf; do
-    if timeout 5 $RISCVDIR/c_emulator/riscv_sim_RV32 -p $test > ${test%.elf}.cout 2>&1 && grep -q SUCCESS ${test%.elf}.cout
-    then
-	green "C-32 $(basename $test)" "ok"
-    else
-	red "C-32 $(basename $test)" "fail"
-    fi
-done
 finish_suite "32-bit RISCV C tests"
 
 # Do 'make clean' to avoid cross-arch pollution.
@@ -80,17 +85,22 @@ printf "Building 64-bit RISCV specification...\n"
 if make c_emulator/riscv_sim_RV64;
 then
     green "Building 64-bit RISCV C emulator" "ok"
+
+    for test in $DIR/riscv-tests/rv64*.elf; do
+        if timeout 5 $RISCVDIR/c_emulator/riscv_sim_RV64 -p $test > ${test%.elf}.cout 2>&1 && grep -q SUCCESS ${test%.elf}.cout
+        then
+            green "C-64 $(basename $test)" "ok"
+        else
+            red "C-64 $(basename $test)" "fail"
+        fi
+    done
 else
     red "Building 64-bit RISCV C emulator" "fail"
+
+    for test in $DIR/riscv-tests/rv64*.elf; do
+        red "C-64 $(basename $test)" "fail"
+    done
 fi
-for test in $DIR/riscv-tests/rv64*.elf; do
-    if timeout 5 $RISCVDIR/c_emulator/riscv_sim_RV64 -p $test > ${test%.elf}.cout 2>&1 && grep -q SUCCESS ${test%.elf}.cout
-    then
-	green "C-64 $(basename $test)" "ok"
-    else
-	red "C-64 $(basename $test)" "fail"
-    fi
-done
 finish_suite "64-bit RISCV C tests"
 
 # Do 'make clean' to avoid cross-arch pollution.

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -70,10 +70,6 @@ then
     done
 else
     red "Building 32-bit RISCV C emulator" "fail"
-
-    for test in $DIR/riscv-tests/rv32*.elf; do
-        red "C-32 $(basename $test)" "fail"
-    done
 fi
 finish_suite "32-bit RISCV C tests"
 
@@ -96,10 +92,6 @@ then
     done
 else
     red "Building 64-bit RISCV C emulator" "fail"
-
-    for test in $DIR/riscv-tests/rv64*.elf; do
-        red "C-64 $(basename $test)" "fail"
-    done
 fi
 finish_suite "64-bit RISCV C tests"
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -51,9 +51,6 @@ SAILLIBDIR="$DIR/../../lib/"
 
 cd $RISCVDIR
 
-# Do 'make clean' to avoid cross-arch pollution.
-make clean
-
 printf "Building 32-bit RISCV specification...\n"
 
 if ARCH=RV32 make c_emulator/riscv_sim_RV32;
@@ -72,9 +69,6 @@ else
     red "Building 32-bit RISCV C emulator" "fail"
 fi
 finish_suite "32-bit RISCV C tests"
-
-# Do 'make clean' to avoid cross-arch pollution.
-make clean
 
 printf "Building 64-bit RISCV specification...\n"
 
@@ -95,9 +89,6 @@ else
 fi
 finish_suite "64-bit RISCV C tests"
 
-# Do 'make clean' to avoid cross-arch pollution.
-make clean
-
 if ARCH=RV32 make c_emulator/riscv_rvfi_RV32;
 then
     green "Building 32-bit RISCV RVFI C emulator" "ok"
@@ -105,9 +96,6 @@ else
     red "Building 32-bit RISCV RVFI C emulator" "fail"
 fi
 finish_suite "32-bit RISCV RVFI C tests"
-
-# Do 'make clean' to avoid cross-arch pollution.
-make clean
 
 if ARCH=RV64 make c_emulator/riscv_rvfi_RV64;
 then


### PR DESCRIPTION
Tests shouldn't rebuild riscv_model_RVxx when we have already compiled it.

Detailed motivation is in the third patch.  First two make it possible.
