### PR TITLE
Use result type instead of MemoryOpResult

### DIFF
--- a/model/riscv_fetch.sail
+++ b/model/riscv_fetch.sail
@@ -30,8 +30,8 @@ function fetch() -> FetchResult =
            * exceptions.
            */
           match mem_read(Execute(), ppclo, 2, false, false, false) {
-            MemException(e) => F_Error(e, PC),
-            MemValue(ilo)   => {
+            Err(e)  => F_Error(e, PC),
+            Ok(ilo) => {
               if   isRVC(ilo)
               then F_RVC(ilo)
               else {
@@ -44,8 +44,8 @@ function fetch() -> FetchResult =
                       TR_Failure(e, _)     => F_Error(e, PC_hi),
                       TR_Address(ppchi, _) => {
                         match mem_read(Execute(), ppchi, 2, false, false, false) {
-                          MemException(e) => F_Error(e, PC_hi),
-                          MemValue(ihi)   => F_Base(append(ihi, ilo))
+                          Err(e)  => F_Error(e, PC_hi),
+                          Ok(ihi) => F_Base(append(ihi, ilo))
                         }
                       }
                     }

--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -91,8 +91,8 @@ function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
         TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
         TR_Address(addr, _) =>
           match mem_read(Read(Data), addr, width_bytes, aq, aq & rl, true) {
-            MemValue(result) => { load_reservation(physaddr_bits(addr)); X(rd) = sign_extend(result); RETIRE_SUCCESS },
-            MemException(e)  => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+            Ok(result) => { load_reservation(physaddr_bits(addr)); X(rd) = sign_extend(result); RETIRE_SUCCESS },
+            Err(e)     => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
           },
       }
     }
@@ -144,13 +144,13 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
               } else {
                 let eares = mem_write_ea(addr, width_bytes, aq & rl, rl, true);
                 match eares {
-                  MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
-                  MemValue(_) => {
+                  Err(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+                  Ok(_)  => {
                     let rs2_val = X(rs2);
                     match mem_write_value(addr, width_bytes, rs2_val[width_bytes * 8 - 1 .. 0], aq & rl, rl, true) {
-                      MemValue(true)  => { X(rd) = zero_extend(0b0); cancel_reservation(); RETIRE_SUCCESS },
-                      MemValue(false) => { X(rd) = zero_extend(0b1); cancel_reservation(); RETIRE_SUCCESS },
-                      MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+                      Ok(true)  => { X(rd) = zero_extend(0b0); cancel_reservation(); RETIRE_SUCCESS },
+                      Ok(false) => { X(rd) = zero_extend(0b1); cancel_reservation(); RETIRE_SUCCESS },
+                      Err(e)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
                     }
                   }
                 }
@@ -208,11 +208,11 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
           let eares = mem_write_ea(addr, width_bytes, aq & rl, rl, true);
           let rs2_val = X(rs2)[width_bytes * 8 - 1 .. 0];
           match eares {
-            MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
-            MemValue(_) => {
+            Err(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            Ok(_) => {
               match mem_read(ReadWrite(Data, Data), addr, width_bytes, aq, aq & rl, true) {
-                MemException(e)  => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
-                MemValue(loaded) => {
+                Err(e)     => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+                Ok(loaded) => {
                   let result : bits('width_bytes * 8) =
                     match op {
                       AMOSWAP => rs2_val,
@@ -226,9 +226,9 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
                       AMOMAXU => if rs2_val >_u loaded then rs2_val else loaded,
                     };
                   match mem_write_value(addr, width_bytes, sign_extend(result), aq & rl, rl, true) {
-                    MemValue(true)  => { X(rd) = sign_extend(loaded); RETIRE_SUCCESS },
-                    MemValue(false) => { internal_error(__FILE__, __LINE__, "AMO got false from mem_write_value") },
-                    MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+                    Ok(true)  => { X(rd) = sign_extend(loaded); RETIRE_SUCCESS },
+                    Ok(false) => { internal_error(__FILE__, __LINE__, "AMO got false from mem_write_value") },
+                    Err(e)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
                   }
                 }
               }

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -338,8 +338,8 @@ function clause execute(LOAD(imm, rs1, rd, is_unsigned, width, aq, rl)) = {
         TR_Address(paddr, _) =>
 
           match mem_read(Read(Data), paddr, width_bytes, aq, rl, false) {
-            MemValue(result) => { X(rd) = extend_value(is_unsigned, result); RETIRE_SUCCESS },
-            MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            Ok(result) => { X(rd) = extend_value(is_unsigned, result); RETIRE_SUCCESS },
+            Err(e)     => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
           },
       }
     },
@@ -394,13 +394,13 @@ function clause execute (STORE(imm, rs2, rs1, width, aq, rl)) = {
         TR_Address(paddr, _) => {
           let eares = mem_write_ea(paddr, width_bytes, aq, rl, false);
           match (eares) {
-            MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
-            MemValue(_) => {
+            Err(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            Ok(_)  => {
               let rs2_val = X(rs2);
               match mem_write_value(paddr, width_bytes, rs2_val[width_bytes * 8 - 1 .. 0], aq, rl, false) {
-                MemValue(true)  => RETIRE_SUCCESS,
-                MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+                Ok(true)  => RETIRE_SUCCESS,
+                Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
+                Err(e)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
               }
             }
           }

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -303,12 +303,12 @@ function clause execute(LOAD_FP(imm, rs1, rd, width)) = {
       if   check_misaligned(vaddr, width)
       then { handle_mem_exception(vaddr, E_Load_Addr_Align()); RETIRE_FAIL }
       else match translateAddr(vaddr, Read(Data)) {
-        TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+        TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
         TR_Address(addr, _) => {
           let (aq, rl, res) = (false, false, false);
           match mem_read(Read(Data), addr, width_bytes, aq, rl, res) {
-            MemValue(result) => { F(rd) = nan_box(result); RETIRE_SUCCESS },
-            MemException(e)  => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            Ok(result) => { F(rd) = nan_box(result); RETIRE_SUCCESS },
+            Err(e)     => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
           }
         },
       }
@@ -364,13 +364,13 @@ function clause execute (STORE_FP(imm, rs2, rs1, width)) = {
         TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
         TR_Address(addr, _) => {
           match mem_write_ea(addr, width_bytes, aq, rl, false) {
-            MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
-            MemValue(_) => {
+            Err(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            Ok(_)  => {
               let rs2_val = F(rs2);
               match mem_write_value(addr, width_bytes, rs2_val[width_bytes * 8 - 1 .. 0], aq, rl, con) {
-                MemValue(true)  => { RETIRE_SUCCESS },
-                MemValue(false) => { internal_error(__FILE__, __LINE__, "store got false from mem_write_value") },
-                MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+                Ok(true)  => { RETIRE_SUCCESS },
+                Ok(false) => { internal_error(__FILE__, __LINE__, "store got false from mem_write_value") },
+                Err(e)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
               }
             },
           }

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -90,8 +90,8 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
                 TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                 TR_Address(paddr, _) => {
                   match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                    MemValue(elem)   => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j * EMUL_reg), elem),
-                    MemException(e)  => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                    Ok(elem) => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j * EMUL_reg), elem),
+                    Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                   }
                 }
               }
@@ -179,8 +179,8 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
                 },
                 TR_Address(paddr, _) => {
                   match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                    MemValue(elem)   => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j * EMUL_reg), elem),
-                    MemException(e)  => {
+                    Ok(elem) => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j * EMUL_reg), elem),
+                    Err(e)   => {
                       if i == 0 then { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                       else {
                         vl = to_bits(xlen, i);
@@ -265,14 +265,14 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
               TR_Address(paddr, _) => {
                 let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
                 match (eares) {
-                  MemException(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
-                  MemValue(_) => {
+                  Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                  Ok(_)  => {
                     let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vs3 + to_bits(5, j * EMUL_reg));
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, elem_val, false, false, false);
                     match (res) {
-                      MemValue(true)  => (),
-                      MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                      MemException(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                      Ok(true)  => (),
+                      Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
+                      Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                     }
                   }
                 }
@@ -337,8 +337,8 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                  MemValue(elem)   => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j * EMUL_reg), elem),
-                  MemException(e)  => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                  Ok(elem) => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j * EMUL_reg), elem),
+                  Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                 }
               }
             }
@@ -406,14 +406,14 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
               TR_Address(paddr, _) => {
                 let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
                 match (eares) {
-                  MemException(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
-                  MemValue(_) => {
+                  Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                  Ok(_)  => {
                     let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vs3 + to_bits(5, j * EMUL_reg));
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, elem_val, false, false, false);
                     match (res) {
-                      MemValue(true)  => (),
-                      MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                      MemException(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                      Ok(true)  => (),
+                      Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
+                      Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                     }
                   }
                 }
@@ -479,8 +479,8 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, EEW_data_bytes, false, false, false) {
-                  MemValue(elem)   => write_single_element(EEW_data_bytes * 8, i, vd + to_bits(5, j * EMUL_data_reg), elem),
-                  MemException(e)  => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                  Ok(elem) => write_single_element(EEW_data_bytes * 8, i, vd + to_bits(5, j * EMUL_data_reg), elem),
+                  Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                 }
               }
             }
@@ -575,14 +575,14 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
               TR_Address(paddr, _) => {
                 let eares : MemoryOpResult(unit) = mem_write_ea(paddr, EEW_data_bytes, false, false, false);
                 match (eares) {
-                  MemException(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
-                  MemValue(_) => {
+                  Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                  Ok(_)  => {
                     let elem_val : bits('db * 8) = read_single_element(EEW_data_bytes * 8, i, vs3 + to_bits(5, j * EMUL_data_reg));
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, EEW_data_bytes, elem_val, false, false, false);
                     match (res) {
-                      MemValue(true)  => (),
-                      MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                      MemException(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                      Ok(true)  => (),
+                      Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
+                      Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                     }
                   }
                 }
@@ -671,8 +671,8 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
             TR_Address(paddr, _) => {
               match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                MemValue(elem)   => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, cur_field), elem),
-                MemException(e)  => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                Ok(elem) => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, cur_field), elem),
+                Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
               }
             }
           }
@@ -695,8 +695,8 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
             TR_Address(paddr, _) => {
               match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                MemValue(elem)   => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j), elem),
-                MemException(e)  => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                Ok(elem) => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j), elem),
+                Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
               }
             }
           }
@@ -753,14 +753,14 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
             TR_Address(paddr, _) => {
               let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
               match (eares) {
-                MemException(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
-                MemValue(_) => {
+                Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                Ok(_)  => {
                   let elem : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vs3 + to_bits(5, cur_field));
                   let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, elem, false, false, false);
                   match (res) {
-                    MemValue(true)  => (),
-                    MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                    MemException(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                    Ok(true)  => (),
+                    Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
+                    Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                   }
                 }
               }
@@ -787,13 +787,13 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
             TR_Address(paddr, _) => {
               let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
               match (eares) {
-                MemException(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
-                MemValue(_) => {
+                Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                Ok(_)  => {
                   let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, vs3_val[i], false, false, false);
                   match (res) {
-                    MemValue(true)  => (),
-                    MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                    MemException(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                    Ok(true)  => (),
+                    Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
+                    Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                   }
                 }
               }
@@ -853,8 +853,8 @@ function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, 1, false, false, false) {
-                  MemValue(elem)   => write_single_element(8, i, vd_or_vs3, elem),
-                  MemException(e)  => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                  Ok(elem) => write_single_element(8, i, vd_or_vs3, elem),
+                  Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                 }
               }
             }
@@ -870,13 +870,13 @@ function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
               TR_Address(paddr, _) => {
                 let eares : MemoryOpResult(unit) = mem_write_ea(paddr, 1, false, false, false);
                 match (eares) {
-                  MemException(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
-                  MemValue(_) => {
+                  Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                  Ok(_)  => {
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, 1, vd_or_vs3_val[i], false, false, false);
                     match (res) {
-                      MemValue(true)  => (),
-                      MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                      MemException(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                      Ok(true)  => (),
+                      Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
+                      Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
                     }
                   }
                 }

--- a/model/riscv_insts_zicboz.sail
+++ b/model/riscv_insts_zicboz.sail
@@ -43,13 +43,13 @@ function clause execute(RISCV_ZICBOZ(rs1)) = {
           TR_Address(paddr, _) => {
             let eares : MemoryOpResult(unit) = mem_write_ea(paddr, cache_block_size, false, false, false);
             match (eares) {
-              MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
-              MemValue(_) => {
+              Err(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+              Ok(_)  => {
                 let res : MemoryOpResult(bool) = mem_write_value(paddr, cache_block_size, zeros(), false, false, false);
                 match (res) {
-                  MemValue(true) => RETIRE_SUCCESS,
-                  MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                  MemException(e) => {
+                  Ok(true)  => RETIRE_SUCCESS,
+                  Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
+                  Err(e)    => {
                     // Errors report the address that was encoded in the instruction rather
                     // than the address that caused the fault (i.e. the aligned address).
                     handle_mem_exception(vaddr - offset, e);

--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -70,12 +70,12 @@ function phys_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext
     None()   => None()
   }) : option((bits(8 * 'n), mem_meta));
   match (t, result) {
-    (Execute(),  None()) => MemException(E_Fetch_Access_Fault()),
-    (Read(Data), None()) => MemException(E_Load_Access_Fault()),
-    (_,          None()) => MemException(E_SAMO_Access_Fault()),
+    (Execute(),  None()) => Err(E_Fetch_Access_Fault()),
+    (Read(Data), None()) => Err(E_Load_Access_Fault()),
+    (_,          None()) => Err(E_SAMO_Access_Fault()),
     (_,      Some(v, m)) => { if   get_config_print_mem()
                               then print_mem("mem[" ^ to_str(t) ^ "," ^ BitStr(physaddr_bits(paddr)) ^ "] -> " ^ BitStr(v));
-                              MemValue(v, m) }
+                              Ok(v, m) }
   }
 }
 
@@ -99,18 +99,18 @@ function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (
   meta : bool,
 ) -> MemoryOpResult((bits(8 * 'n), mem_meta)) =
   match phys_access_check(t, priv, paddr, width) {
-    Some(e) => MemException(e),
+    Some(e) => Err(e),
     None() => {
       if   within_mmio_readable(paddr, width)
       then MemoryOpResult_add_meta(mmio_read(t, paddr, width), default_meta)
       else if within_phys_mem(paddr, width)
       then match ext_check_phys_mem_read(t, paddr, width, aq, rl, res, meta) {
         Ext_PhysAddr_OK()     => phys_mem_read(t, paddr, width, aq, rl, res, meta),
-        Ext_PhysAddr_Error(e) => MemException(e)
+        Ext_PhysAddr_Error(e) => Err(e)
       } else match t {
-        Execute()  => MemException(E_Fetch_Access_Fault()),
-        Read(Data) => MemException(E_Load_Access_Fault()),
-        _          => MemException(E_SAMO_Access_Fault())
+        Execute()  => Err(E_Fetch_Access_Fault()),
+        Read(Data) => Err(E_Load_Access_Fault()),
+        _          => Err(E_SAMO_Access_Fault())
       }
     }
   }
@@ -124,11 +124,11 @@ function rvfi_read (physaddr(addr), width, result) = {
   rvfi_mem_data_present = true;
   match result {
     /* TODO: report tag bit for capability writes and extend mask by one bit. */
-    MemValue(v, _) => if width <= 16
+    Ok(v, _) => if width <= 16
                        then { rvfi_mem_data[rvfi_mem_rdata] = sail_zero_extend(v, 256);
                               rvfi_mem_data[rvfi_mem_rmask] = rvfi_encode_width_mask(width) }
                        else { internal_error(__FILE__, __LINE__, "Expected at most 16 bytes here!") },
-    MemException(_) => ()
+    Err(_)   => ()
   };
 }
 $else
@@ -145,7 +145,7 @@ val mem_read_priv_meta : forall 'n, 0 < 'n <= max_mem_access . (AccessType(ext_a
 function mem_read_priv_meta (typ, priv, paddr, width, aq, rl, res, meta) = {
   let result : MemoryOpResult((bits(8 * 'n), mem_meta)) =
     if (aq | res) & not(is_aligned_addr(paddr, width))
-    then MemException(E_Load_Addr_Align())
+    then Err(E_Load_Addr_Align())
     else match (aq, rl, res) {
       (false, true,  false) => throw(Error_not_implemented("load.rl")),
       (false, true,  true)  => throw(Error_not_implemented("lr.rl")),
@@ -169,8 +169,8 @@ function mem_read (typ, paddr, width, aq, rel, res) =
 val mem_write_ea : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bool, bool, bool) -> MemoryOpResult(unit)
 function mem_write_ea (addr, width, aq, rl, con) =
   if (rl | con) & not(is_aligned_addr(addr, width))
-  then MemException(E_SAMO_Addr_Align())
-  else MemValue(write_ram_ea(write_kind_of_flags(aq, rl, con), addr, width))
+  then Err(E_SAMO_Addr_Align())
+  else Ok(write_ram_ea(write_kind_of_flags(aq, rl, con), addr, width))
 
 $ifdef RVFI_DII
 val rvfi_write : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), mem_meta, MemoryOpResult(bool)) -> unit
@@ -179,14 +179,14 @@ function rvfi_write (physaddr(addr), width, value, meta, result) = {
   rvfi_mem_data_present = true;
   match result {
     /* Log only the memory address (without the value) if the write fails. */
-    MemValue(_) => if width <= 16 then {
+    Ok(_) => if width <= 16 then {
         /* TODO: report tag bit for capability writes and extend mask by one bit. */
         rvfi_mem_data[rvfi_mem_wdata] = sail_zero_extend(value,256);
         rvfi_mem_data[rvfi_mem_wmask] = rvfi_encode_width_mask(width);
       } else {
         internal_error(__FILE__, __LINE__, "Expected at most 16 bytes here!");
       },
-    MemException(_) => ()
+    Err(_) => ()
   }
 }
 $else
@@ -196,10 +196,10 @@ $endif
 
 // only used for actual memory regions, to avoid MMIO effects
 function phys_mem_write forall 'n, 0 < 'n <= max_mem_access . (wk : write_kind, paddr : physaddr, width : int('n), data : bits(8 * 'n), meta : mem_meta) -> MemoryOpResult(bool) = {
-  let result = MemValue(write_ram(wk, paddr, width, data, meta));
+  let result = write_ram(wk, paddr, width, data, meta);
   if   get_config_print_mem()
   then print_mem("mem[" ^ BitStr(physaddr_bits(paddr)) ^ "] <- " ^ BitStr(data));
-  result
+  Ok(result)
 }
 
 /* dispatches to MMIO regions or physical memory regions depending on physical memory map */
@@ -215,7 +215,7 @@ function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
   con : bool,
 ) -> MemoryOpResult(bool) =
   match phys_access_check(typ, priv, paddr, width) {
-    Some(e) => MemException(e),
+    Some(e) => Err(e),
     None() => {
       if   within_mmio_writable(paddr, width)
       then mmio_write(paddr, width, data)
@@ -224,9 +224,9 @@ function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
         let wk = write_kind_of_flags(aq, rl, con);
         match ext_check_phys_mem_write (wk, paddr, width, data, meta) {
           Ext_PhysAddr_OK() => phys_mem_write(wk, paddr, width, data, meta),
-          Ext_PhysAddr_Error(e)  => MemException(e),
+          Ext_PhysAddr_Error(e)  => Err(e),
         }
-      } else MemException(E_SAMO_Access_Fault())
+      } else Err(E_SAMO_Access_Fault())
     }
   }
 
@@ -240,7 +240,7 @@ function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
 val mem_write_value_priv_meta : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), AccessType(ext_access_type), Privilege, mem_meta, bool, bool, bool) -> MemoryOpResult(bool)
 function mem_write_value_priv_meta (paddr, width, value, typ, priv, meta, aq, rl, con) = {
   if (rl | con) & not(is_aligned_addr(paddr, width))
-  then MemException(E_SAMO_Addr_Align())
+  then Err(E_SAMO_Addr_Align())
   else {
     let result = checked_mem_write(paddr, width, value, typ, priv, meta, aq, rl, con);
     rvfi_write(paddr, width, value, meta, result);

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -157,54 +157,54 @@ function clint_load(t, physaddr(addr), width) = {
   then {
     if   get_config_print_platform()
     then print_platform("clint[" ^ BitStr(addr) ^ "] -> " ^ BitStr(mip[MSI]));
-    MemValue(sail_zero_extend(mip[MSI], sizeof(8 * 'n)))
+    Ok(sail_zero_extend(mip[MSI], sizeof(8 * 'n)))
   }
   else if addr == MTIMECMP_BASE & ('n == 4)
   then {
     if   get_config_print_platform()
     then print_platform("clint<4>[" ^ BitStr(addr) ^ "] -> " ^ BitStr(mtimecmp[31..0]));
     /* FIXME: Redundant zero_extend currently required by Lem backend */
-    MemValue(sail_zero_extend(mtimecmp[31..0], 32))
+    Ok(sail_zero_extend(mtimecmp[31..0], 32))
   }
   else if addr == MTIMECMP_BASE & ('n == 8)
   then {
     if   get_config_print_platform()
     then print_platform("clint<8>[" ^ BitStr(addr) ^ "] -> " ^ BitStr(mtimecmp));
     /* FIXME: Redundant zero_extend currently required by Lem backend */
-    MemValue(sail_zero_extend(mtimecmp, 64))
+    Ok(sail_zero_extend(mtimecmp, 64))
   }
   else if addr == MTIMECMP_BASE_HI & ('n == 4)
   then {
     if   get_config_print_platform()
     then print_platform("clint-hi<4>[" ^ BitStr(addr) ^ "] -> " ^ BitStr(mtimecmp[63..32]));
     /* FIXME: Redundant zero_extend currently required by Lem backend */
-    MemValue(sail_zero_extend(mtimecmp[63..32], 32))
+    Ok(sail_zero_extend(mtimecmp[63..32], 32))
   }
   else if addr == MTIME_BASE & ('n == 4)
   then {
     if   get_config_print_platform()
     then print_platform("clint[" ^ BitStr(addr) ^ "] -> " ^ BitStr(mtime));
-    MemValue(sail_zero_extend(mtime[31..0], 32))
+    Ok(sail_zero_extend(mtime[31..0], 32))
   }
   else if addr == MTIME_BASE & ('n == 8)
   then {
     if   get_config_print_platform()
     then print_platform("clint[" ^ BitStr(addr) ^ "] -> " ^ BitStr(mtime));
-    MemValue(sail_zero_extend(mtime, 64))
+    Ok(sail_zero_extend(mtime, 64))
   }
   else if addr == MTIME_BASE_HI & ('n == 4)
   then {
     if   get_config_print_platform()
     then print_platform("clint[" ^ BitStr(addr) ^ "] -> " ^ BitStr(mtime));
-    MemValue(sail_zero_extend(mtime[63..32], 32))
+    Ok(sail_zero_extend(mtime[63..32], 32))
   }
   else {
     if   get_config_print_platform()
     then print_platform("clint[" ^ BitStr(addr) ^ "] -> <not-mapped>");
     match t {
-      Execute()  => MemException(E_Fetch_Access_Fault()),
-      Read(Data) => MemException(E_Load_Access_Fault()),
-      _          => MemException(E_SAMO_Access_Fault())
+      Execute()  => Err(E_Fetch_Access_Fault()),
+      Read(Data) => Err(E_Load_Access_Fault()),
+      _          => Err(E_SAMO_Access_Fault())
     }
   }
 }
@@ -228,47 +228,47 @@ function clint_store(physaddr(addr), width, data) = {
     then print_platform("clint[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mip.MSI <- " ^ BitStr(data[0]) ^ ")");
     mip[MSI] = [data[0]];
     clint_dispatch();
-    MemValue(true)
+    Ok(true)
   } else if addr == MTIMECMP_BASE & 'n == 8 then {
     if   get_config_print_platform()
     then print_platform("clint<8>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtimecmp)");
     mtimecmp = sail_zero_extend(data, 64); /* FIXME: Redundant zero_extend currently required by Lem backend */
     clint_dispatch();
-    MemValue(true)
+    Ok(true)
   } else if addr == MTIMECMP_BASE & 'n == 4 then {
     if   get_config_print_platform()
     then print_platform("clint<4>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtimecmp)");
     mtimecmp = vector_update_subrange(mtimecmp, 31, 0, sail_zero_extend(data, 32));  /* FIXME: Redundant zero_extend currently required by Lem backend */
     clint_dispatch();
-    MemValue(true)
+    Ok(true)
   } else if addr == MTIMECMP_BASE_HI & 'n == 4 then {
     if   get_config_print_platform()
     then print_platform("clint<4>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtimecmp)");
     mtimecmp = vector_update_subrange(mtimecmp, 63, 32, sail_zero_extend(data, 32)); /* FIXME: Redundant zero_extend currently required by Lem backend */
     clint_dispatch();
-    MemValue(true)
+    Ok(true)
   } else if addr == MTIME_BASE & 'n == 8 then {
     if   get_config_print_platform()
     then print_platform("clint<8>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtime)");
     mtime = data;
     clint_dispatch();
-    MemValue(true)
+    Ok(true)
   } else if addr == MTIME_BASE & 'n == 4 then {
     if   get_config_print_platform()
     then print_platform("clint<4>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtime)");
     mtime[31 .. 0] = data;
     clint_dispatch();
-    MemValue(true)
+    Ok(true)
   } else if addr == MTIME_BASE_HI & 'n == 4 then {
     if   get_config_print_platform()
     then print_platform("clint<4>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtime)");
     mtime[63 .. 32] = data;
     clint_dispatch();
-    MemValue(true)
+    Ok(true)
   } else {
     if   get_config_print_platform()
     then print_platform("clint[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (<unmapped>)");
-    MemException(E_SAMO_Access_Fault())
+    Err(E_SAMO_Access_Fault())
   }
 }
 
@@ -327,15 +327,15 @@ function htif_load(t, physaddr(paddr), width) = {
   then print_platform("htif[" ^ BitStr(paddr) ^ "] -> " ^ BitStr(htif_tohost));
   /* FIXME: For now, only allow the expected access widths. */
   if      width == 8 & (paddr == plat_htif_tohost())
-  then    MemValue(sail_zero_extend(htif_tohost, 64))         /* FIXME: Redundant zero_extend currently required by Lem backend */
+  then    Ok(sail_zero_extend(htif_tohost, 64))         /* FIXME: Redundant zero_extend currently required by Lem backend */
   else if width == 4 & paddr == plat_htif_tohost()
-  then    MemValue(sail_zero_extend(htif_tohost[31..0], 32))  /* FIXME: Redundant zero_extend currently required by Lem backend */
+  then    Ok(sail_zero_extend(htif_tohost[31..0], 32))  /* FIXME: Redundant zero_extend currently required by Lem backend */
   else if width == 4 & paddr == plat_htif_tohost() + 4
-  then    MemValue(sail_zero_extend(htif_tohost[63..32], 32)) /* FIXME: Redundant zero_extend currently required by Lem backend */
+  then    Ok(sail_zero_extend(htif_tohost[63..32], 32)) /* FIXME: Redundant zero_extend currently required by Lem backend */
   else match t {
-    Execute()  => MemException(E_Fetch_Access_Fault()),
-    Read(Data) => MemException(E_Load_Access_Fault()),
-    _          => MemException(E_SAMO_Access_Fault())
+    Execute()  => Err(E_Fetch_Access_Fault()),
+    Read(Data) => Err(E_Load_Access_Fault()),
+    _          => Err(E_SAMO_Access_Fault())
   }
 }
 
@@ -395,7 +395,7 @@ function htif_store(physaddr(paddr), width, data) = {
       d => print("htif-???? cmd: " ^ BitStr(data))
     }
   };
-  MemValue(true)
+  Ok(true)
 }
 
 val htif_tick : unit -> unit
@@ -426,9 +426,9 @@ function mmio_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext_acc
   else if within_htif_readable(paddr, width) & (1 <= 'n)
   then htif_load(t, paddr, width)
   else match t {
-    Execute()  => MemException(E_Fetch_Access_Fault()),
-    Read(Data) => MemException(E_Load_Access_Fault()),
-    _          => MemException(E_SAMO_Access_Fault())
+    Execute()  => Err(E_Fetch_Access_Fault()),
+    Read(Data) => Err(E_Load_Access_Fault()),
+    _          => Err(E_SAMO_Access_Fault())
   }
 
 function mmio_write forall 'n, 0 <'n <= max_mem_access . (paddr : physaddr, width : int('n), data: bits(8 * 'n)) -> MemoryOpResult(bool) =
@@ -436,7 +436,7 @@ function mmio_write forall 'n, 0 <'n <= max_mem_access . (paddr : physaddr, widt
   then clint_store(paddr, width, data)
   else if within_htif_writable(paddr, width) & 'n <= 8
   then htif_store(paddr, width, data)
-  else MemException(E_SAMO_Access_Fault())
+  else Err(E_SAMO_Access_Fault())
 
 /* Platform initialization and ticking. */
 

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -387,19 +387,16 @@ function init_sys() -> unit = {
 
 /* memory access exceptions, defined here for use by the platform model. */
 
-union MemoryOpResult ('a : Type) = {
-  MemValue     : 'a,
-  MemException : ExceptionType
-}
+type MemoryOpResult('a : Type) = result('a, ExceptionType)
 
 val MemoryOpResult_add_meta : forall ('t : Type). (MemoryOpResult('t), mem_meta) -> MemoryOpResult(('t, mem_meta))
 function MemoryOpResult_add_meta(r, m) = match r {
-  MemValue(v)     => MemValue(v, m),
-  MemException(e) => MemException(e)
+  Ok(v)  => Ok(v, m),
+  Err(e) => Err(e)
 }
 
 val MemoryOpResult_drop_meta : forall ('t : Type). MemoryOpResult(('t, mem_meta)) -> MemoryOpResult('t)
 function MemoryOpResult_drop_meta(r) = match r {
-  MemValue(v, m)  => MemValue(v),
-  MemException(e) => MemException(e)
+  Ok(v, m)  => Ok(v),
+  Err(e) => Err(e)
 }

--- a/model/riscv_vmem.sail
+++ b/model/riscv_vmem.sail
@@ -109,8 +109,8 @@ function pt_walk(sv_params,
                                  false);                  // res
 
   match mem_result {
-    MemException(_) => PTW_Failure(PTW_Access(), ext_ptw),
-    MemValue(pte)   => {
+    Err(_)  => PTW_Failure(PTW_Access(), ext_ptw),
+    Ok(pte) => {
       // Extend to 64 bits even on RV32 for simplicity.
       let pte : bits(64) = zero_extend(pte);
 
@@ -319,8 +319,8 @@ function translate_TLB_hit(sv_params : SV_Params,
             let pte_phys_addr = physaddr(ent.pteAddr[(physaddrbits_len - 1) .. 0]);
 
             match write_pte(pte_phys_addr, 2 ^ sv_params.log_pte_size_bytes, pte') {
-              MemValue(_)     => (),
-              MemException(e) => internal_error(__FILE__, __LINE__,
+              Ok(_)  => (),
+              Err(e) => internal_error(__FILE__, __LINE__,
                                                 "invalid physical address in TLB")
             };
             TR_Address(ent.pAddr | (vAddr & ent.vAddrMask), ext_ptw)
@@ -365,13 +365,13 @@ function translate_TLB_miss(sv_params : SV_Params,
             let pte_phys_addr = physaddr(pteAddr[(physaddrbits_len - 1) .. 0]);
 
             match write_pte(pte_phys_addr, 2 ^ sv_params.log_pte_size_bytes, pte') {
-              MemValue(_) => {
+              Ok(_) => {
                 add_to_TLB(asid, vAddr, pAddr, pte', pteAddr, level, global,
                            sv_params.vpn_size_bits,
                            pagesize_bits);
                 TR_Address(pAddr, ext_ptw)
               },
-              MemException(e) =>
+              Err(e) =>
                 TR_Failure(PTW_Access(), ext_ptw)
             }
           }


### PR DESCRIPTION
resolve part of #433

Use `result` type instead of `MemoryOpResult`，for `MemoryOpResult`, `MemValue` is `'a`, so I think it's ok to use `type`


But `PTW_Success` has five members, I did not include it in this PR, I think we should create a struct for it?

```ocaml
union PTW_Result('paddr : Type, 'pte : Type) = {
  PTW_Success: ('paddr, 'pte, 'paddr, nat, bool, ext_ptw),
  PTW_Failure: (PTW_Error, ext_ptw)
}
```