### PR TITLE
Fix match AccessType

### DIFF
--- a/model/riscv_vmem_pte.sail
+++ b/model/riscv_vmem_pte.sail
@@ -117,7 +117,7 @@ function update_PTE_Bits(sv_params : SV_Params,
   let update_d : bool = (pte_flags[D] == 0b0)
                         & (match a {
                              Execute()       => false,
-                             Read()          => false,
+                             Read(_)         => false,
                              Write(_)        => true,
                              ReadWrite(_, _) => true
                            });


### PR DESCRIPTION
```diff
-                            Read()          => false,
+                            Read(_)         => false,
```

I don't know why the previous one could compile, it should be wrong, but after replacing `ext_access_type` with newtype, the compiler detected the error correctly.

```
union AccessType ('a : Type) = {
  Read      : 'a,
  Write     : 'a,
  ReadWrite : ('a, 'a),
  Execute   : unit
}
```
