### PR TITLE
Fix future clause warnings introduced by upcoming sail release

### DIFF
--- a/model/riscv_insts_end.sail
+++ b/model/riscv_insts_end.sail
@@ -6,34 +6,27 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-/* Put the illegal instructions last to use their wildcard match. */
+/* End scattered definitions and default to illegal instructions if no match */
 
-/* ****************************************************************** */
+end ast
+
+function clause extensionEnabled(_) = false
+end extensionEnabled
+end extension
 
 mapping clause encdec = ILLEGAL(s) <-> s
-
-function clause execute (ILLEGAL(s)) = { handle_illegal(); RETIRE_FAIL }
-
-mapping clause assembly = ILLEGAL(s) <-> "illegal" ^ spc() ^ hex_bits_32(s)
-
-/* ****************************************************************** */
+end encdec
 
 mapping clause encdec_compressed = C_ILLEGAL(s) <-> s
-
-function clause execute C_ILLEGAL(s) = { handle_illegal(); RETIRE_FAIL }
-
-mapping clause assembly = C_ILLEGAL(s) <-> "c.illegal" ^ spc() ^ hex_bits_16(s)
-
-/* ****************************************************************** */
-
-/* End definitions */
-end extension
-end extensionEnabled
-end ast
-end execute
-end assembly
-end encdec
 end encdec_compressed
+
+function clause execute ILLEGAL(s) = { handle_illegal(); RETIRE_FAIL }
+function clause execute C_ILLEGAL(s) = { handle_illegal(); RETIRE_FAIL }
+end execute
+
+mapping clause assembly = ILLEGAL(s) <-> "illegal" ^ spc() ^ hex_bits_32(s)
+mapping clause assembly = C_ILLEGAL(s) <-> "c.illegal" ^ spc() ^ hex_bits_16(s)
+end assembly
 
 val print_insn : ast -> string
 function print_insn insn = assembly(insn)


### PR DESCRIPTION
The in-development next version of Sail introduces new warnings to catch incomplete pattern matching from potential future clauses. This refactors `riscv_insts_end.sail` to avoid this by adding a new wildcard match for undefined extensions and reordering the `end` clauses.

```
Warning: Incomplete pattern match statement at model/riscv_insts_zicboz.sail:11.0-8:
11 |function clause extensionEnabled(Ext_Zicboz) = sys_enable_zicboz()
   |^------^
   | 
The following expression is unmatched: <future extension clause>

Warning: Incomplete pattern match statement at model/riscv_insts_end.sail:23.0-8:
23 |function clause execute C_ILLEGAL(s) = { handle_illegal(); RETIRE_FAIL }
   |^------^
   | 
The following expression is unmatched: <future ast clause>(undefined)
```