### PR TITLE
Added the flag to disable the illegal instruction exception for undefined CSRs

### DIFF
--- a/c_emulator/riscv_platform.c
+++ b/c_emulator/riscv_platform.c
@@ -117,6 +117,11 @@ bool plat_enable_misaligned_access(unit u)
   return rv_enable_misaligned;
 }
 
+bool plat_disable_illegal_instr_exp_access(unit u)        // Added this to disable illegal instruction exception
+{
+  return rv_disable_illegal_instr_exp;
+}
+
 bool plat_mtval_has_illegal_inst_bits(unit u)
 {
   return rv_mtval_has_illegal_inst_bits;

--- a/c_emulator/riscv_platform.h
+++ b/c_emulator/riscv_platform.h
@@ -23,6 +23,7 @@ uint64_t sys_vector_elen_exp(unit);
 
 bool plat_enable_dirty_update(unit);
 bool plat_enable_misaligned_access(unit);
+bool plat_disable_illegal_instr_exp_access(unit);
 bool plat_mtval_has_illegal_inst_bits(unit);
 mach_bits sys_writable_hpm_counters(unit u);
 

--- a/c_emulator/riscv_platform_impl.c
+++ b/c_emulator/riscv_platform_impl.c
@@ -23,6 +23,7 @@ bool rv_enable_sstc = false;
 
 bool rv_enable_dirty_update = false;
 bool rv_enable_misaligned = false;
+bool rv_disable_illegal_instr_exp = false;
 bool rv_mtval_has_illegal_inst_bits = false;
 bool rv_enable_writable_fiom = true;
 uint64_t rv_writable_hpm_counters = 0xFFFFFFFF;

--- a/c_emulator/riscv_platform_impl.h
+++ b/c_emulator/riscv_platform_impl.h
@@ -27,6 +27,7 @@ extern bool rv_enable_sstc;
 extern bool rv_enable_writable_misa;
 extern bool rv_enable_dirty_update;
 extern bool rv_enable_misaligned;
+extern bool rv_disable_illegal_instr_exp;             // Added disable rv_disable_illegal_instr_exp as an extern variable to be accessible to other sides 
 extern bool rv_mtval_has_illegal_inst_bits;
 extern bool rv_enable_writable_fiom;
 extern uint64_t rv_writable_hpm_counters;

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -132,6 +132,7 @@ char *sailcov_file = NULL;
 static struct option options[] = {
     {"enable-dirty-update",         no_argument,       0, 'd'                     },
     {"enable-misaligned",           no_argument,       0, 'm'                     },
+    {"disable_trap_undef_csr",      no_argument,       0, 'k'                     },
     {"pmp-count",                   required_argument, 0, OPT_PMP_COUNT           },
     {"pmp-grain",                   required_argument, 0, OPT_PMP_GRAIN           },
     {"ram-size",                    required_argument, 0, 'z'                     },
@@ -288,6 +289,7 @@ static int process_args(int argc, char **argv)
                     "T:"
                     "g:"
                     "h"
+                    "k"
 #ifdef RVFI_DII
                     "r:"
 #endif
@@ -316,6 +318,10 @@ static int process_args(int argc, char **argv)
     case 'm':
       fprintf(stderr, "enabling misaligned access.\n");
       rv_enable_misaligned = true;
+      break;
+    case 'k':                                                         // Added for disabling illegal instruction
+      fprintf(stderr, "disabling illegal instruction exception.\n");
+      rv_disable_illegal_instr_exp = true;
       break;
     case OPT_PMP_COUNT:
       pmp_count = atol(optarg);

--- a/handwritten_support/riscv_extras.lem
+++ b/handwritten_support/riscv_extras.lem
@@ -209,6 +209,10 @@ val plat_enable_misaligned_access : unit -> bool
 let plat_enable_misaligned_access () = false
 declare ocaml target_rep function plat_enable_misaligned_access = `Platform.enable_misaligned_access`
 
+val plat_disable_illegal_instr_exp_access : unit -> bool
+let plat_disable_illegal_instr_exp_access () = false
+declare ocaml target_rep function plat_disable_illegal_instr_exp_access = `Platform.disable_illegal_instr_exp_access`
+
 val plat_mtval_has_illegal_inst_bits : unit -> bool
 let plat_mtval_has_illegal_inst_bits () = false
 declare ocaml target_rep function plat_mtval_has_illegal_inst_bits = `Platform.mtval_has_illegal_inst_bits`

--- a/handwritten_support/riscv_extras_sequential.lem
+++ b/handwritten_support/riscv_extras_sequential.lem
@@ -189,6 +189,10 @@ val plat_enable_misaligned_access : unit -> bool
 let plat_enable_misaligned_access () = false
 declare ocaml target_rep function plat_enable_misaligned_access = `Platform.enable_misaligned_access`
 
+val plat_disable_illegal_instr_exp_access : unit -> bool
+let plat_disable_illegal_instr_exp_access () = false
+declare ocaml target_rep function plat_disable_illegal_instr_exp_access = `Platform.disable_illegal_instr_exp_access`
+
 val plat_mtval_has_illegal_inst_bits : unit -> bool
 let plat_mtval_has_illegal_inst_bits () = false
 declare ocaml target_rep function plat_mtval_has_illegal_inst_bits = `Platform.mtval_has_illegal_inst_bits`

--- a/model/riscv_insts_zicsr.sail
+++ b/model/riscv_insts_zicsr.sail
@@ -26,8 +26,17 @@ function clause execute CSR(csr, rs1, rd, is_imm, op) = {
     CSRRW  => true,
     _      => if is_imm then unsigned(rs1_val) != 0 else unsigned(rs1) != 0
   };
-  if not(check_CSR(csr, cur_privilege, isWrite))
-  then { handle_illegal(); RETIRE_FAIL }
+  
+  if not(check_CSR(csr, cur_privilege, isWrite)) then {
+    /* Only handle illegal instruction if not disabled by platform */
+    if not(is_CSR_defined(csr)) & plat_disable_illegal_instr_exp_access() then {
+        /* Skip the illegal instruction handling */
+        RETIRE_SUCCESS
+    } else {
+        handle_illegal();
+        RETIRE_FAIL
+    }
+} 
   else if not(ext_check_CSR(csr, cur_privilege, isWrite))
   then { ext_check_CSR_fail(); RETIRE_FAIL }
   else {

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -44,6 +44,15 @@ val plat_enable_dirty_update = pure {interpreter: "Platform.enable_dirty_update"
 val plat_enable_misaligned_access = pure {interpreter: "Platform.enable_misaligned_access",
                                           c: "plat_enable_misaligned_access",
                                           lem: "plat_enable_misaligned_access"} : unit -> bool
+                                          
+                                          
+                                          
+/* illegal instruction disable
+ */
+val plat_disable_illegal_instr_exp_access = pure {interpreter: "Platform.disable_illegal_instr_exp_access",
+                                          c: "plat_disable_illegal_instr_exp_access",
+                                          lem: "plat_disable_illegal_instr_exp_access"} : unit -> bool                                       
+                                          
 
 /* whether mtval stores the bits of a faulting instruction on illegal instruction exceptions */
 val plat_mtval_has_illegal_inst_bits = pure {interpreter: "Platform.mtval_has_illegal_inst_bits",

--- a/prover_snapshots/hol4/RV32/riscv_extrasScript.sml
+++ b/prover_snapshots/hol4/RV32/riscv_extrasScript.sml
@@ -218,7 +218,10 @@ val _ = Define `
 val _ = Define `
  ((plat_enable_misaligned_access:unit -> bool) () =  F)`;
 
-
+(*val plat_disable_illegal_instr_exp_access : unit -> bool*)
+val _ = Define `
+ ((plat_disable_illegal_instr_exp_access:unit -> bool) () =  F)`;
+ 
 (*val plat_enable_pmp : unit -> bool*)
 val _ = Define `
  ((plat_enable_pmp:unit -> bool) () =  F)`;

--- a/prover_snapshots/hol4/RV64/riscv_extrasScript.sml
+++ b/prover_snapshots/hol4/RV64/riscv_extrasScript.sml
@@ -218,6 +218,10 @@ val _ = Define `
 val _ = Define `
  ((plat_enable_misaligned_access:unit -> bool) () =  F)`;
 
+ (*val plat_disable_illegal_instr_exp_access : unit -> bool*)
+val _ = Define `
+ ((plat_disable_illegal_instr_exp_access:unit -> bool) () =  F)`;
+
 
 (*val plat_enable_pmp : unit -> bool*)
 val _ = Define `

--- a/prover_snapshots/isabelle/RV32/Riscv_extras.thy
+++ b/prover_snapshots/isabelle/RV32/Riscv_extras.thy
@@ -293,6 +293,10 @@ definition plat_enable_misaligned_access  :: \<open> unit \<Rightarrow> bool \<c
      \<open> plat_enable_misaligned_access _ = ( False )\<close>
 
 
+\<comment> \<open>\<open>val plat_disable_illegal_instr_exp_access : unit -> bool\<close>\<close>
+definition plat_disable_illegal_instr_exp_access  :: \<open> unit \<Rightarrow> bool \<close>  where 
+     \<open> plat_disable_illegal_instr_exp_access _ = ( False )\<close>
+
 \<comment> \<open>\<open>val plat_enable_pmp : unit -> bool\<close>\<close>
 definition plat_enable_pmp  :: \<open> unit \<Rightarrow> bool \<close>  where 
      \<open> plat_enable_pmp _ = ( False )\<close>

--- a/prover_snapshots/isabelle/RV64/Riscv_extras.thy
+++ b/prover_snapshots/isabelle/RV64/Riscv_extras.thy
@@ -292,6 +292,9 @@ definition plat_enable_dirty_update  :: \<open> unit \<Rightarrow> bool \<close>
 definition plat_enable_misaligned_access  :: \<open> unit \<Rightarrow> bool \<close>  where 
      \<open> plat_enable_misaligned_access _ = ( False )\<close>
 
+\<comment> \<open>\<open>val plat_disable_illegal_instr_exp_access : unit -> bool\<close>\<close>
+definition plat_disable_illegal_instr_exp_access  :: \<open> unit \<Rightarrow> bool \<close>  where 
+     \<open> plat_disable_illegal_instr_exp_access _ = ( False )\<close>
 
 \<comment> \<open>\<open>val plat_enable_pmp : unit -> bool\<close>\<close>
 definition plat_enable_pmp  :: \<open> unit \<Rightarrow> bool \<close>  where 


### PR DESCRIPTION
If the CSRs (Control and Status Registers) are not defined by the RISC-V ISA and are also not implemented, their behavior on access can vary, it’s implementation-dependent. Some systems may raise an illegal instruction exception, while others might not. 

To handle this variability, I’ve added a new flag, disable_trap_undef_csr, to the Sail tool. When this flag is enabled, the tool will not generate an exception for undefined or unimplemented CSR accesses. However, if the flag is not set, the tool will generate an illegal instruction exception for such accesses.