### PR TITLE
Remove unused attempt at a platform memory map.

### DIFF
--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -63,12 +63,6 @@ val plat_htif_tohost = pure {c: "plat_htif_tohost", lem: "plat_htif_tohost"} : u
 function plat_htif_tohost () = to_bits(physaddrbits_len, elf_tohost ())
 // todo: fromhost
 
-val phys_mem_segments : unit -> list((physaddrbits, physaddrbits))
-function phys_mem_segments() =
-  (plat_rom_base (), plat_rom_size ()) ::
-  (plat_ram_base (), plat_ram_size ()) ::
-  [||]
-
 /* Physical memory map predicates */
 
 function within_phys_mem forall 'n, 'n <= max_mem_access. (physaddr(addr) : physaddr, width : int('n)) -> bool = {


### PR DESCRIPTION
The memory segments are hard-coded into `within_phys_mem` anyway and its log messages.  A more general map would need a better API to the C emulator.