### PR TITLE
Move csr_name function back to desired location

### DIFF
--- a/model/riscv_csr_begin.sail
+++ b/model/riscv_csr_begin.sail
@@ -13,6 +13,7 @@ val csr_name_map : csreg <-> string
 scattered mapping csr_name_map
 
 val csr_name : csreg -> string
+function csr_name(csr) = csr_name_map(csr)
 overload to_str = {csr_name}
 
 /* returns whether a CSR exists

--- a/model/riscv_csr_end.sail
+++ b/model/riscv_csr_end.sail
@@ -9,11 +9,6 @@
 mapping clause csr_name_map = reg <-> hex_bits_12(reg)
 end csr_name_map
 
-/* XXX due to an apparent Sail bug the definition of this function must appear
-   after the last csr_name_map clause and not by the val spec as it was
-   previously. */
-function csr_name(csr) = csr_name_map(csr)
-
 function clause is_CSR_defined(_) = false
 end is_CSR_defined
 


### PR DESCRIPTION
`csr_name` had been moved because of a bug in the Sail compiler. Seems like this is no longer an issue so move it back to where it is supposed to be.