### PR TITLE
Implement Sscofpmf (counter overflow and privilege mode filtering)

### DIFF
--- a/Makefile.old
+++ b/Makefile.old
@@ -81,6 +81,7 @@ SAIL_SYS_SRCS += riscv_vext_control.sail    # helpers for the 'V' extension
 SAIL_SYS_SRCS += riscv_sys_exceptions.sail  # default basic helpers for exception handling
 SAIL_SYS_SRCS += riscv_sync_exception.sail  # define the exception structure used in the model
 SAIL_SYS_SRCS += riscv_zihpm.sail
+SAIL_SYS_SRCS += riscv_sscofpmf.sail
 SAIL_SYS_SRCS += riscv_zkr_control.sail
 SAIL_SYS_SRCS += riscv_zicntr_control.sail
 SAIL_SYS_SRCS += riscv_softfloat_interface.sail riscv_fdext_regs.sail riscv_fdext_control.sail

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Supported RISC-V ISA features
 - Zkr extension for entropy source, v1.0
 - V extension for vector operations, v1.0
 - Machine, Supervisor, and User modes
+- Sscofpmf extension for Count Overflow and Mode-Based Filtering, v1.0
 - Sstc extension for Supervisor-mode Timer Interrupts, v1.0
 - Svinval extension for fine-grained address-translation cache invalidation, v1.0
 - Sv32, Sv39, Sv48 and Sv57 page-based virtual-memory systems

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -105,6 +105,7 @@ foreach (xlen IN ITEMS 32 64)
                 "riscv_sys_exceptions.sail"
                 "riscv_sync_exception.sail"
                 "riscv_zihpm.sail"
+                "riscv_sscofpmf.sail"
                 "riscv_zkr_control.sail"
                 "riscv_zicntr_control.sail"
                 "riscv_softfloat_interface.sail"

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -103,6 +103,8 @@ enum clause extension = Ext_Zksh
 // Floating-Point in Integer Registers (half precision)
 enum clause extension = Ext_Zhinx
 
+// Count Overflow and Mode-Based Filtering
+enum clause extension = Ext_Sscofpmf
 // Supervisor-mode Timer Interrupts
 enum clause extension = Ext_Sstc
 // Fine-Grained Address-Translation Cache Invalidation

--- a/model/riscv_sscofpmf.sail
+++ b/model/riscv_sscofpmf.sail
@@ -1,0 +1,84 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+// TODO: Make configurable.
+function sys_enable_sscofpmf() -> bool = true
+
+/* Counter OverFlow and Privilege Mode Filtering */
+function clause extensionEnabled(Ext_Sscofpmf) = sys_enable_sscofpmf() & extensionEnabled(Ext_Zihpm)
+
+mapping clause csr_name_map = 0xB83  <-> "mhpmcounter3h"
+mapping clause csr_name_map = 0xB84  <-> "mhpmcounter4h"
+mapping clause csr_name_map = 0xB85  <-> "mhpmcounter5h"
+mapping clause csr_name_map = 0xB86  <-> "mhpmcounter6h"
+mapping clause csr_name_map = 0xB87  <-> "mhpmcounter7h"
+mapping clause csr_name_map = 0xB88  <-> "mhpmcounter8h"
+mapping clause csr_name_map = 0xB89  <-> "mhpmcounter9h"
+mapping clause csr_name_map = 0xB8A  <-> "mhpmcounter10h"
+mapping clause csr_name_map = 0xB8B  <-> "mhpmcounter11h"
+mapping clause csr_name_map = 0xB8C  <-> "mhpmcounter12h"
+mapping clause csr_name_map = 0xB8D  <-> "mhpmcounter13h"
+mapping clause csr_name_map = 0xB8E  <-> "mhpmcounter14h"
+mapping clause csr_name_map = 0xB8F  <-> "mhpmcounter15h"
+mapping clause csr_name_map = 0xB90  <-> "mhpmcounter16h"
+mapping clause csr_name_map = 0xB91  <-> "mhpmcounter17h"
+mapping clause csr_name_map = 0xB92  <-> "mhpmcounter18h"
+mapping clause csr_name_map = 0xB93  <-> "mhpmcounter19h"
+mapping clause csr_name_map = 0xB94  <-> "mhpmcounter20h"
+mapping clause csr_name_map = 0xB95  <-> "mhpmcounter21h"
+mapping clause csr_name_map = 0xB96  <-> "mhpmcounter22h"
+mapping clause csr_name_map = 0xB97  <-> "mhpmcounter23h"
+mapping clause csr_name_map = 0xB98  <-> "mhpmcounter24h"
+mapping clause csr_name_map = 0xB99  <-> "mhpmcounter25h"
+mapping clause csr_name_map = 0xB9A  <-> "mhpmcounter26h"
+mapping clause csr_name_map = 0xB9B  <-> "mhpmcounter27h"
+mapping clause csr_name_map = 0xB9C  <-> "mhpmcounter28h"
+mapping clause csr_name_map = 0xB9D  <-> "mhpmcounter29h"
+mapping clause csr_name_map = 0xB9E  <-> "mhpmcounter30h"
+mapping clause csr_name_map = 0xB9F  <-> "mhpmcounter31h"
+
+mapping clause csr_name_map = 0xDA0  <-> "scountovf"
+
+function read_mhpmeventh(index : hpmidx) -> bits(32) = mhpmevent[index].bits[63 .. 32]
+
+function write_mhpmeventh(index : hpmidx, value : bits(32)) -> unit =
+  if sys_writable_hpm_counters()[index] == bitone then
+  mhpmevent[index] = legalize_hpmevent(Mk_HpmEvent(value @ mhpmevent[index].bits[31 .. 0]))
+
+// mhpmevent3..31h
+function clause is_CSR_defined(0b0111001 /* 0x720 */ @ index : bits(5) if unsigned(index) >= 3) = extensionEnabled(Ext_Sscofpmf) & (xlen == 32)
+function clause read_CSR(0b0111001 /* 0x720 */ @ index : bits(5) if xlen == 32 & unsigned(index) >= 3) = read_mhpmeventh(hpmidx_from_bits(index))
+function clause write_CSR((0b0111001 /* 0x720 */ @ index : bits(5), value) if xlen == 32 & unsigned(index) >= 3) = {
+  let index = hpmidx_from_bits(index);
+  write_mhpmeventh(index, value);
+  read_mhpmeventh(index)
+}
+
+// scountovf collates the OF (overflow) bit for each event.
+function get_scountovf(priv : Privilege) -> bits(32) = {
+  let overflow =
+    mhpmevent[31][OF] @ mhpmevent[30][OF] @ mhpmevent[29][OF] @ mhpmevent[28][OF] @
+    mhpmevent[27][OF] @ mhpmevent[26][OF] @ mhpmevent[25][OF] @ mhpmevent[24][OF] @
+    mhpmevent[23][OF] @ mhpmevent[22][OF] @ mhpmevent[21][OF] @ mhpmevent[20][OF] @
+    mhpmevent[19][OF] @ mhpmevent[18][OF] @ mhpmevent[17][OF] @ mhpmevent[16][OF] @
+    mhpmevent[15][OF] @ mhpmevent[14][OF] @ mhpmevent[13][OF] @ mhpmevent[12][OF] @
+    mhpmevent[11][OF] @ mhpmevent[10][OF] @ mhpmevent[ 9][OF] @ mhpmevent[ 8][OF] @
+    mhpmevent[ 7][OF] @ mhpmevent[ 6][OF] @ mhpmevent[ 5][OF] @ mhpmevent[ 4][OF] @
+    mhpmevent[ 3][OF] @ 0b000;
+
+  match priv {
+    Machine => overflow,
+    Supervisor => overflow & mcounteren.bits,
+    User => internal_error(__FILE__, __LINE__, "scountovf not readable from User mode"),
+  }
+}
+
+// scountovf
+function clause is_CSR_defined(0xDA0) = extensionEnabled(Ext_Sscofpmf) & extensionEnabled(Ext_S)
+function clause read_CSR(0xDA0) = zero_extend(get_scountovf(cur_privilege))
+// scountovf is read-only.

--- a/model/riscv_zihpm.sail
+++ b/model/riscv_zihpm.sail
@@ -162,13 +162,25 @@ mapping clause csr_name_map = 0xB9D  <-> "mhpmcounter29h"
 mapping clause csr_name_map = 0xB9E  <-> "mhpmcounter30h"
 mapping clause csr_name_map = 0xB9F  <-> "mhpmcounter31h"
 
-// HPM (Hardware Performance Monitoring) counters. The lowest three values are
-// not used but they are defined for simplicity.
-register mhpmcounter : vector(32, bits(64))
+bitfield HpmEvent : bits(64) = {
+  // Sscofpmf fields.
+  OF    : 63,
+  MINH  : 62,
+  SINH  : 61,
+  UINH  : 60,
+  VSINH : 59,
+  VUINH : 58,
+
+  event : 31 .. 0,
+}
 
 // HPM events selector. These control what the HPM counters measure. The lowest
 // three values are not used but they are defined for simplicity.
-register mhpmevent : vector(32, xlenbits)
+register mhpmevent : vector(32, HpmEvent)
+
+// HPM (Hardware Performance Monitoring) counters. The lowest three values are
+// not used but they are defined for simplicity.
+register mhpmcounter : vector(32, bits(64))
 
 // Valid HPM counter indices. The lowest three are used for mcycle, mtime and minstret.
 type hpmidx = range(3, 31)
@@ -180,9 +192,21 @@ function hpmidx_from_bits(b : bits(5)) -> hpmidx = {
   index
 }
 
+function legalize_hpmevent(v : HpmEvent) -> HpmEvent = {
+  [ Mk_HpmEvent(zeros()) with
+    OF = if extensionEnabled(Ext_Sscofpmf) then v[OF] else 0b0,
+    MINH  = if extensionEnabled(Ext_Sscofpmf) then v[MINH] else 0b0,
+    SINH  = if extensionEnabled(Ext_Sscofpmf) & extensionEnabled(Ext_S) then v[SINH] else 0b0,
+    UINH  = if extensionEnabled(Ext_Sscofpmf) & extensionEnabled(Ext_U) then v[UINH] else 0b0,
+    VSINH = 0b0, // Hypervisor not supported
+    VUINH = 0b0, // Hypervisor not supported
+    event = v[event],
+  ]
+}
+
 function read_mhpmcounter(index : hpmidx) -> xlenbits = mhpmcounter[index][(xlen - 1) .. 0]
 function read_mhpmcounterh(index : hpmidx) -> bits(32) = mhpmcounter[index][63 .. 32]
-function read_mhpmevent(index : hpmidx) -> xlenbits = mhpmevent[index]
+function read_mhpmevent(index : hpmidx) -> xlenbits = mhpmevent[index].bits[(xlen - 1) .. 0]
 
 // Write the HPM CSRs. These return the new value of the CSR, for use in writeCSR.
 function write_mhpmcounter(index : hpmidx, value : xlenbits) -> unit =
@@ -192,7 +216,12 @@ function write_mhpmcounterh(index : hpmidx, value : bits(32)) -> unit =
   if sys_writable_hpm_counters()[index] == bitone then mhpmcounter[index][63 .. 32] = value
 
 function write_mhpmevent(index : hpmidx, value : xlenbits) -> unit =
-  if sys_writable_hpm_counters()[index] == bitone then mhpmevent[index] = value
+  if sys_writable_hpm_counters()[index] == bitone then
+  mhpmevent[index] = legalize_hpmevent(Mk_HpmEvent(match xlen {
+    32 => mhpmevent[index].bits[63 .. 32] @ value,
+    64 => value,
+    _ => internal_error(__FILE__, __LINE__, "Unsupported xlen"),
+  }))
 
 /* Hardware Performance Monitoring event selection */
 function clause is_CSR_defined(0b0011001 /* 0x320 */ @ index : bits(5) if unsigned(index) >= 3) = extensionEnabled(Ext_Zihpm) // mhpmevent3..31


### PR DESCRIPTION
This adds the `mhpmeventNh` and `scountovf` CSRs. It also fixes `mhpmevent` to be 64 bits instead of `xlenbits` (though this mistake is unobservable without Sscofpmf).

Since the model doesn't ever actually increment any of the HPM counters yet, there is no need to actually implement the filtering logic or the overflow interrupt. If/when we add some example HPM sources we will need to do that.