### PR TITLE
Add support for Sail unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,9 @@ add_subdirectory("c_emulator")
 # Old pre-compiled riscv-tests.
 add_subdirectory("test/riscv-tests")
 
+# Sail unit tests.
+add_subdirectory("test/unit_tests")
+
 # Convenience targets.
 add_custom_target(csim DEPENDS riscv_sim_rv32d riscv_sim_rv64d)
 add_custom_target(check DEPENDS generated_model_rv32d generated_model_rv64d)

--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(EMULATOR_COMMON_SRCS
+add_library(riscv_platform
     riscv_config.h
     riscv_platform.c
     riscv_platform.h
@@ -7,9 +7,17 @@ set(EMULATOR_COMMON_SRCS
     riscv_prelude.c
     riscv_prelude.h
     riscv_sail.h
-    riscv_sim.c
     riscv_softfloat.c
     riscv_softfloat.h
+)
+
+target_include_directories(riscv_platform
+    # So the generated C can find riscv_platform/prelude.h"
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+
+target_link_libraries(riscv_platform
+    PUBLIC sail_runtime
 )
 
 foreach (xlen IN ITEMS 32 64)
@@ -27,7 +35,7 @@ foreach (xlen IN ITEMS 32 64)
 
             add_executable(riscv_sim_${arch}
                 "${CMAKE_BINARY_DIR}/riscv_model_${arch}.c"
-                ${EMULATOR_COMMON_SRCS}
+                "riscv_sim.c"
             )
 
             if (NOT arch IN_LIST DEFAULT_ARCHITECTURES)
@@ -37,12 +45,7 @@ foreach (xlen IN ITEMS 32 64)
             add_dependencies(riscv_sim_${arch} generated_model_${arch})
 
             target_link_libraries(riscv_sim_${arch}
-                PRIVATE softfloat sail_runtime GMP::GMP ZLIB::ZLIB
-            )
-
-            target_include_directories(riscv_sim_${arch}
-                # So the generated C can find riscv_platform/prelude.h"
-                PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
+                PRIVATE riscv_platform
             )
 
             if (arch MATCHES "rvfi")

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -189,12 +189,18 @@ foreach (xlen IN ITEMS 32 64)
                 )
             endif()
 
+            set(test_srcs
+                "unit_tests/test_mstatus.sail"
+                "unit_tests/test_pte_update_access_fault.sail"
+            )
+
             # Final file list.
             set(sail_srcs
                 ${sail_arch_srcs}
                 ${sail_seq_inst_srcs}
                 ${sail_step_srcs}
                 "main.sail"
+                ${test_srcs}
             )
 
             # Convert to absolute paths, so we can run

--- a/model/unit_tests/test_mstatus.sail
+++ b/model/unit_tests/test_mstatus.sail
@@ -1,0 +1,21 @@
+// Verify that the reset sxl and uxl are correct.
+$[test]
+function test_mstatus_sxl_uxl_reset_values() -> unit = {
+  let mstatush_val : bits(32) = match xlen {
+    32 => read_CSR(0x310),
+    64 => read_CSR(0x300)[63 .. 32],
+    _  => internal_error(__FILE__, __LINE__, "unsupported xlen"),
+  };
+  // 0 = 32, 1 = 64, 2 = 128, but on RV32 SXL/UXL don't actually
+  // exist (they are currently WPRI). For now we set them to 0.
+  // If those bits are used in future we may expect a different value.
+  let expected_xl : bits(2) = match xlen {
+    32 => 0b00,
+    64 => 0b10,
+    _  => internal_error(__FILE__, __LINE__, "unsupported xlen"),
+  };
+  // SXL
+  assert(mstatush_val[3 .. 2] == expected_xl);
+  // UXL
+  assert(mstatush_val[1 .. 0] == expected_xl);
+}

--- a/model/unit_tests/test_pte_update_access_fault.sail
+++ b/model/unit_tests/test_pte_update_access_fault.sail
@@ -1,0 +1,36 @@
+// This test is WIP.
+
+// // Verify that an access fault caused by making a PTE
+// // inaccessible (via PMP in this case) and then having
+// // the hardware update it works as expected.
+// $[test]
+// function test_pte_update_access_fault() -> unit = {
+//     // This test relies on hardware PTE update.
+//     assert(plat_enable_dirty_update());
+
+//     // Create a page table.
+
+
+//     // Write a PTE to memory.
+
+//     let pte_address = plat_ram_base();
+//     let pte_value = ...;
+//     X(1) = pte_address;
+//     X(2) = pte_value;
+
+//     assert(execute(STORE(zeros(), 0b0010, 0b0001, WORD, false, false)) == RETIRE_SUCCESS);
+
+//     // Set satp.
+//     write_CSR(0x180, ...);
+
+//     // Read from the mapped page to get it into the TLB.
+
+//     // Set up PMAs to prevent access to the PTE.
+
+//     // Magically switch to supervisor mode.
+//     cur_privilege = Supervisor;
+
+//     // Try to store to the mapped page. This *should* try to update the PTE and cause an access fault.
+
+
+// }

--- a/sail_runtime/CMakeLists.txt
+++ b/sail_runtime/CMakeLists.txt
@@ -22,6 +22,10 @@ target_include_directories(sail_runtime
     PUBLIC "${sail_dir}/lib"
 )
 
+target_link_libraries(sail_runtime
+    PUBLIC softfloat GMP::GMP ZLIB::ZLIB
+)
+
 if (COVERAGE)
     find_package(Threads REQUIRED)
 

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -1,0 +1,27 @@
+foreach (xlen IN ITEMS 32 64)
+    # TODO: flen=32. Will do this when the new config system is implemented.
+    foreach (flen IN ITEMS 64)
+        set(arch "rv${xlen}")
+        if (flen EQUAL 32)
+            string(APPEND arch "f")
+        else()
+            string(APPEND arch "d")
+        endif()
+
+        add_executable(unit_tests_${arch}
+            "${CMAKE_BINARY_DIR}/riscv_model_${arch}.c"
+            "main_unit_tests.c"
+        )
+
+        add_dependencies(unit_tests_${arch} generated_model_${arch})
+
+        target_link_libraries(unit_tests_${arch}
+            PRIVATE riscv_platform
+        )
+
+        add_test(
+            NAME "${arch}_unit_tests"
+            COMMAND $<TARGET_FILE:unit_tests_${arch}>
+        )
+    endforeach()
+endforeach()

--- a/test/unit_tests/main_unit_tests.c
+++ b/test/unit_tests/main_unit_tests.c
@@ -1,0 +1,21 @@
+#include <stdbool.h>
+#include <stdio.h>
+
+// Generated in the model C code. This is a simple test runner that just
+// runs the tests in series and aborts on the first failure. In future
+// we can do something fancier.
+void model_test();
+
+bool config_print_instr = false;
+bool config_print_reg = false;
+bool config_print_mem_access = false;
+bool config_print_platform = false;
+bool config_print_rvfi = false;
+bool config_print_step = false;
+FILE *trace_log = NULL;
+
+int main()
+{
+  trace_log = stdout;
+  model_test();
+}


### PR DESCRIPTION
Note: This is a draft because it relies on [this Sail compiler branch](https://github.com/rems-project/sail/pull/928) that I haven't finished yet.

----------------

This adds basic support for Sail unit tests. These have some pros and cons over C tests:

Pros:

* They don't require a RISC-V C compiler.
* They can test internal code (hence why I've called them unit tests).
* They can "cheat", e.g. to change privilege mode you can just magically `cur_privilege = Supervisor`. With C you have to implement a syscall, etc.

Cons:

* They are tied to internal code which will make refactoring more tedious because it means you are likely to need to update the tests. We can minimise that by using "high level" functions like `execute()`, `read_CSR()`, etc.
* They only run on the Sail model, so we can't e.g. verify them against SPIKE.

Given the sorry state of testing in this repo, and the fact that we don't have a way of writing C tests at all yet, I think this is probably a good medium term approach.

Currently the unit test executable reuses a load of code from the emulator, which is not ideal. When we have wrapped the model in a nice C++ library we can use that instead.