### PR TITLE
Refactor PTE update code & fix reachable assertion

### DIFF
--- a/model/riscv_vmem.sail
+++ b/model/riscv_vmem.sail
@@ -57,6 +57,33 @@ function read_pte forall 'n, 'n in {4, 8} . (
 ) -> MemoryOpResult(bits(8 * 'n)) =
   mem_read_priv(Read(Data), Supervisor, paddr, pte_size, false, false, false)
 
+// Update a PTE's A/D bits and write it to memory. This returns
+//
+// * Ok(Some(pte)) if a write was needed and was successful. pte is the new value.
+// * Ok(None()) if no write was needed.
+// * Err(e) if a write was needed but there was an error.
+//
+function update_pte forall 'pte_width, 'pte_width in {4, 8} . (
+  pte_width : int('pte_width),
+  pteAddr   : physaddr,
+  pte       : bits('pte_width * 8),
+  ac        : AccessType(ext_access_type),
+) -> result(option(bits('pte_width * 8)), PTW_Error) =
+  match updated_pte_bits(pte, ac) {
+    None() => Ok(None()),
+    Some(pte) =>
+      if not(plat_enable_dirty_update()) then {
+        // PTE needs dirty/accessed update but that is not enabled.
+        Err(PTW_PTE_Update())
+      } else {
+        // Writeback the PTE (which has new A/D bits).
+        match write_pte(pteAddr, pte_width, pte) {
+          Ok(_) => Ok(Some(pte)),
+          Err(_) => Err(PTW_Access()),
+        }
+      },
+  }
+
 // PRIVATE
 // 'v is the virtual address size.
 val pt_walk : forall 'v, is_sv_mode('v) . (
@@ -235,24 +262,17 @@ function translate_TLB_hit forall 'v, is_sv_mode('v) . (
   match pte_check {
     PTE_Check_Failure(ext_ptw, ext_ptw_fail) =>
       TR_Failure(ext_get_ptw_error(ext_ptw_fail), ext_ptw),
-    PTE_Check_Success(ext_ptw) =>
-      match update_PTE_Bits(pte, ac) {
-        None()     => TR_Address(tlb_get_ppn(sv_width, ent, vpn), ext_ptw),
-        Some(pte') =>
-          if not(plat_enable_dirty_update()) then
-            // pte needs dirty/accessed update but that is not enabled
-            TR_Failure(PTW_PTE_Update(), ext_ptw)
-          else {
-            // Writeback the PTE (which has new A/D bits)
-            write_TLB(tlb_index, tlb_set_pte(ent, pte'));
-            match write_pte(ent.pteAddr, pte_width, pte') {
-              Ok(_)  => (),
-              Err(e) => internal_error(__FILE__, __LINE__,
-                                                "invalid physical address in TLB")
-            };
-            TR_Address(tlb_get_ppn(sv_width, ent, vpn), ext_ptw)
-          }
+    PTE_Check_Success(ext_ptw) => {
+      let ppn = tlb_get_ppn(sv_width, ent, vpn);
+      match update_pte(pte_width, ent.pteAddr, pte, ac) {
+        Ok(Some(pte)) => {
+          write_TLB(tlb_index, tlb_set_pte(ent, pte));
+          TR_Address(ppn, ext_ptw)
+        },
+        Ok(None()) => TR_Address(ppn, ext_ptw),
+        Err(e) => TR_Failure(e, ext_ptw),
       }
+    },
   }
 }
 
@@ -276,33 +296,17 @@ function translate_TLB_miss forall 'v, is_sv_mode('v) . (
   match ptw_result {
     PTW_Failure(f, ext_ptw) => TR_Failure(f, ext_ptw),
     PTW_Success(struct {ppn, pte, pteAddr, level, global}, ext_ptw) => {
-      let ext_pte   = ext_bits_of_PTE(pte);
-      // Without TLBs, this 'match' expression can be replaced simply
-      // by: 'TR_Address(ppn, ext_ptw)'    (see TLB NOTE above)
-      match update_PTE_Bits(pte, ac) {
-        None() => {
+      let ext_pte = ext_bits_of_PTE(pte);
+      match update_pte(pte_width, pteAddr, pte, ac) {
+        Ok(Some(pte)) => {
           add_to_TLB(sv_width, asid, vpn, ppn, pte, pteAddr, level, global);
           TR_Address(ppn, ext_ptw)
         },
-        Some(pte) =>
-          // See riscv_platform.sail
-          if not(plat_enable_dirty_update()) then
-            // pte needs dirty/accessed update but that is not enabled
-            TR_Failure(PTW_PTE_Update(), ext_ptw)
-          else {
-            // Writeback the PTE (which has new A/D bits)
-            match write_pte(pteAddr, pte_width, pte) {
-              Ok(_) => {
-                add_to_TLB(sv_width, asid, vpn, ppn, pte, pteAddr, level, global);
-                TR_Address(ppn, ext_ptw)
-              },
-              Err(e) =>
-                TR_Failure(PTW_Access(), ext_ptw)
-            }
-          }
-        }
+        Ok(None()) => TR_Address(ppn, ext_ptw),
+        Err(e) => TR_Failure(e, ext_ptw),
       }
-    }
+    },
+  }
 }
 
 // Mapping the SATPMode to the width integer. Note there is also SvBare

--- a/model/riscv_vmem_pte.sail
+++ b/model/riscv_vmem_pte.sail
@@ -133,31 +133,30 @@ function check_PTE_permission(ac        : AccessType(ext_access_type),
   else            PTE_Check_Failure((), ())
 }
 
-// Update PTE bits if needed; return new PTE if updated
-// PRIVATE
-function update_PTE_Bits forall 'pte_size, 'pte_size in {32, 64} . (
+// Return the updated the PTE with A/D set, if needed.
+function updated_pte_bits forall 'pte_size, 'pte_size in {32, 64} . (
   pte : bits('pte_size),
   a   : AccessType(ext_access_type),
 ) -> option(bits('pte_size)) = {
+
+  let is_write : bool = match a {
+    Execute()       => false,
+    Read(_)         => false,
+    Write(_)        => true,
+    ReadWrite(_, _) => true,
+  };
+
   let pte_flags = Mk_PTE_Flags(pte[7 .. 0]);
 
-  // Update 'dirty' bit?
-  let update_d : bool = (pte_flags[D] == 0b0)
-                        & (match a {
-                             Execute()       => false,
-                             Read(_)         => false,
-                             Write(_)        => true,
-                             ReadWrite(_, _) => true
-                           });
-  // Update 'accessed'-bit?
-  let update_a = (pte_flags[A] == 0b0);
+  let new_pte_flags = [
+    pte_flags with
+    // Accessed
+    A = 0b1,
+    // Dirty
+    D = pte_flags[D] | bool_to_bits(is_write),
+  ];
 
-  if update_d | update_a then {
-    let pte_flags = [pte_flags with
-                      A = 0b1,
-                      D = (if update_d then 0b1 else pte_flags[D])];
-    Some([pte with 7 .. 0 = pte_flags.bits])
-  } else {
-    None()
-  }
+  let new_pte = [pte with 7 .. 0 = new_pte_flags.bits];
+
+  if new_pte != pte then Some(new_pte) else None()
 }


### PR DESCRIPTION
Deduplicate the code to write the PTE, and in the process remove the reachable (I think) assertion "invalid physical address in TLB".

It actually ended up being basically the same amount of code, so we may want to e.g. inline `update_pte_bits`. However I haven't done that because this code is going to get a bit more complex with CHERI.