### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ exclude: '^(prover_snapshots)|(generated_definitions)|(dependencies/[^/]+/)'
 minimum_pre_commit_version: 3.2.0
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     -   id: trailing-whitespace
         # Do not strip trailing whitespace from patches or SVG images.
@@ -17,7 +17,7 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: 'v15.0.7'
+    rev: 'v19.1.7'
     hooks:
     -   id: clang-format
         types_or: [c, c++]  # Don't try running clang-format on .json files


### PR DESCRIPTION
Update pre-commit hook versions to avoid the deprecation warning we've been getting in CI with the current version.

<img width="1006" alt="Screenshot 2025-02-07 at 11 11 45 PM" src="https://github.com/user-attachments/assets/9221b348-6704-4cfc-8e90-5542160b422a" />
