### PR TITLE
c_emulator: fix cmake install with unbuilt targets

### DIFF
--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -61,7 +61,7 @@ foreach (xlen IN ITEMS 32 64)
             #     -Wno-unused-parameter
             # )
 
-            install(TARGETS riscv_sim_${arch})
+            install(TARGETS riscv_sim_${arch} OPTIONAL)
         endforeach()
     endforeach()
 endforeach()


### PR DESCRIPTION
When doing a default installation, CMake fails when it tries to install the unbuilt targets:
```
CMake Error at c_emulator/cmake_install.cmake:60 (file):
  file INSTALL cannot find "/build/source/build/c_emulator/riscv_sim_rv32f":
  No such file or directory.
```
Make all targets optional to avoid the failure;  this will install only the targets that are built.