### PR TITLE
insts_base: ignore architecture in SFENCE_VMA

### DIFF
--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -714,9 +714,9 @@ function clause execute SFENCE_VMA(rs1, rs2) = {
   let asid = if rs2 != zreg then Some(X(rs2)[asidlen - 1 .. 0]) else None();
   match cur_privilege {
     User       => { handle_illegal(); RETIRE_FAIL },
-    Supervisor => match (architecture(get_mstatus_SXL(mstatus)), mstatus[TVM]) {
-                    (_, 0b1)  => { handle_illegal(); RETIRE_FAIL },
-                    (_, 0b0) => { flush_TLB(asid, addr); RETIRE_SUCCESS },
+    Supervisor => match mstatus[TVM] {
+                    0b1 => { handle_illegal(); RETIRE_FAIL },
+                    0b0 => { flush_TLB(asid, addr); RETIRE_SUCCESS },
                   },
     Machine    => { flush_TLB(asid, addr); RETIRE_SUCCESS }
   }


### PR DESCRIPTION
Another patch from the mstatus cleanup,  https://github.com/riscv/sail-riscv/pull/683#issuecomment-2621133329.