### PR TITLE
Implement Zimop and Zcmop Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Supported RISC-V ISA features
 - Zicntr and Zihpm extensions for counters, v2.0
 - Zicond extension for integer conditional operations, v1.0
 - Zicbom and Zicboz extensions for cache-block management (Zicbop not currently supported), v1.0
+- Zimop extension for May-Be-Operations, v1.0
 - M extension for integer multiplication and division, v2.0
 - Zmmul extension for integer multiplication only, v1.0
 - A extension for atomic instructions, v2.1
@@ -106,6 +107,7 @@ Supported RISC-V ISA features
 - Zfinx, Zdinx, and Zhinx extensions for floating-point in integer registers, v1.0
 - C extension for compressed instructions, v2.0
 - Zca, Zcf, Zcd, and Zcb extensions for code size reduction, v1.0
+- Zcmop extension for compressed May-Be-Operations, v1.0
 - B (Zba, Zbb, Zbs) and Zbc extensions for bit manipulation, v1.0
 - Zbkb, Zbkc, and Zbkx extensions for bit manipulation for cryptography, v1.0
 - Zkn (Zknd, Zkne, Zknh) and Zks (Zksed, Zksh) extensions for scalar cryptography, v1.0.1

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -79,6 +79,9 @@ foreach (xlen IN ITEMS 32 64)
                 "riscv_insts_zicbom.sail"
                 "riscv_insts_zicboz.sail"
                 "riscv_insts_zvbb.sail"
+                # Zimop and Zcmop should be at the end so they can be overridden by earlier extensions
+                "riscv_insts_zimop.sail"
+                "riscv_insts_zcmop.sail"
             )
 
             if (variant STREQUAL "rmem")

--- a/model/prelude.sail
+++ b/model/prelude.sail
@@ -17,6 +17,7 @@ $include <vector_dec.sail>
 $include <generic_equality.sail>
 $include <hex_bits.sail>
 $include <hex_bits_signed.sail>
+$include <dec_bits.sail>
 
 val not_bit : bit -> bit
 function not_bit(b) = if b == bitone then bitzero else bitone

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -40,6 +40,8 @@ enum clause extension = Ext_Zicond
 enum clause extension = Ext_Zifencei
 // Hardware Performance Counters
 enum clause extension = Ext_Zihpm
+// May-Be-Operations
+enum clause extension = Ext_Zimop
 
 // Multiplication and Division: Multiplication only
 enum clause extension = Ext_Zmmul
@@ -71,6 +73,8 @@ enum clause extension = Ext_Zcb
 enum clause extension = Ext_Zcd
 // Code Size Reduction: compressed single precision floating point loads and stores
 enum clause extension = Ext_Zcf
+// Compressed May-Be-Operations
+enum clause extension = Ext_Zcmop
 
 // Bit Manipulation: Address generation
 enum clause extension = Ext_Zba

--- a/model/riscv_insts_zcmop.sail
+++ b/model/riscv_insts_zcmop.sail
@@ -1,0 +1,22 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+function clause extensionEnabled(Ext_Zcmop) = true & extensionEnabled(Ext_Zca) // TODO: add configuration
+
+union clause ast = ZCMOP : (bits(3))
+
+mapping clause encdec_compressed = ZCMOP(mop)
+  <-> 0b01100 @ mop : bits(3) @ 0b100000 @ 0b01
+  when extensionEnabled(Ext_Zcmop)
+
+mapping clause assembly = ZCMOP(mop)
+  <-> "c.mop." ^ dec_bits_4(mop @ 0b1)
+
+function clause execute ZCMOP(mop) = {
+  RETIRE_SUCCESS
+}

--- a/model/riscv_insts_zimop.sail
+++ b/model/riscv_insts_zimop.sail
@@ -1,0 +1,36 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+function clause extensionEnabled(Ext_Zimop) = true // TODO: add configuration
+
+union clause ast = ZIMOP_MOP_R : (bits(5), regidx, regidx)
+union clause ast = ZIMOP_MOP_RR : (bits(3), regidx, regidx, regidx)
+
+mapping clause encdec = ZIMOP_MOP_R(mop_30 @ mop_27_26 @ mop_21_20, rs1, rd)
+  <-> 0b1 @ mop_30 : bits(1) @ 0b00 @ mop_27_26 : bits(2) @ 0b0111 @ mop_21_20 : bits(2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b1110011
+  when extensionEnabled(Ext_Zimop)
+
+mapping clause encdec = ZIMOP_MOP_RR(mop_30 @ mop_27_26, rs2, rs1, rd)
+  <-> 0b1 @ mop_30 : bits(1) @ 0b00 @ mop_27_26 : bits(2) @ 0b1 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b1110011
+  when extensionEnabled(Ext_Zimop)
+
+mapping clause assembly = ZIMOP_MOP_R(mop, rs1, rd)
+  <->  "mop.r." ^ dec_bits_5(mop) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
+
+mapping clause assembly = ZIMOP_MOP_RR(mop, rs2, rs1, rd)
+  <-> "mop.rr." ^ dec_bits_3(mop) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
+
+function clause execute ZIMOP_MOP_R(mop, rs1, rd) = {
+  X(rd) = zeros();
+  RETIRE_SUCCESS
+}
+
+function clause execute ZIMOP_MOP_RR(mop, rs2, rs1, rd) = {
+  X(rd) = zeros();
+  RETIRE_SUCCESS
+}


### PR DESCRIPTION
Extracted and updated the `Zimop` and `Zcmop` extensions from #377.

One of the tricky parts with this extension is that it is designed to have its instructions overridden by other extensions (like `Zicfiss`). The implementation in #377 had a function dedicated to Zimop and Zcmop in each of their files that listed which specific instructions were overridden. I'd rather avoid the need to modify this file each time a new extension is added that reuses one of its encodings, so I added new scattered `encdec_overrides` and `encdec_compressed_overrides` mappings for this purpose. These mappings are checked first, and only if there is no match does it check the normal `encdec` mappings. This allows each new extension (like `Zicfiss` and `Zicflp`) to be self-contained. It also opens the door to properly supporting hints from extensions like `Zicbop` and `Zihintpause`. While the hints don't do anything architecturally, having the correct assembly in the log would still be beneficial.

This new mapping can be split out into a separate PR, but I'm introducing it here to clarify the motivation behind it.