### PR TITLE
Fix building the model when the sail binary is not in $PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ find_program(SAIL_BIN "sail")
 if (NOT SAIL_BIN)
     message(FATAL_ERROR "Sail not found. See README.md for installation instructions.")
 endif()
+message(STATUS "Found sail: ${SAIL_BIN}")
 
 set(DEFAULT_ARCHITECTURES "rv32d;rv64d" CACHE STRING "Architectures to build by default (rv32f|rv64f|rv32d|rv64d)(_rvfi)? " )
 

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -218,7 +218,7 @@ foreach (xlen IN ITEMS 32 64)
                     COMMENT "Building C code from Sail model (${arch})"
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     COMMAND
-                        sail
+                        ${SAIL_BIN}
                         # Output file (without extension).
                         -o ${c_model_no_ext}
                         # Generate a file containing information about all possible branches.


### PR DESCRIPTION
In my build sail is installed to a custom prefix that I pass to CMake via `CMAKE_PREFIX_PATH` instead of by overriding `$PATH`. Fix the one place in the build where we were using a bare sail instead of `${SAIL_BIN}`.