### PR TITLE
Add Svadu/Svade extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Supported RISC-V ISA features
 - Svinval extension for fine-grained address-translation cache invalidation, v1.0
 - Sv32, Sv39, Sv48 and Sv57 page-based virtual-memory systems
 - Physical Memory Protection (PMP)
+- Svadu and Svade Extension for Hardware Updating of A/D Bits, v1.0
 
 **For a list of unsupported extensions and features, see the [Extension Roadmap](https://github.com/riscv/sail-riscv/wiki/Extension-Roadmap).**
 

--- a/c_emulator/riscv_platform.cpp
+++ b/c_emulator/riscv_platform.cpp
@@ -78,6 +78,16 @@ bool sys_enable_sstc(unit)
   return rv_enable_sstc;
 }
 
+bool sys_enable_svadu(unit)
+{
+  return rv_enable_svadu;
+}
+
+bool sys_enable_svade(unit)
+{
+  return rv_enable_svadu;
+}
+
 uint64_t sys_pmp_count(unit)
 {
   return rv_pmp_count;

--- a/c_emulator/riscv_platform.h
+++ b/c_emulator/riscv_platform.h
@@ -18,6 +18,8 @@ bool sys_enable_zicbom(unit);
 bool sys_enable_zicboz(unit);
 bool sys_enable_zvkb(unit);
 bool sys_enable_sstc(unit);
+bool sys_enable_svadu(unit u);
+bool sys_enable_svade(unit u);
 
 uint64_t sys_pmp_count(unit);
 uint64_t sys_pmp_grain(unit);

--- a/c_emulator/riscv_platform_impl.cpp
+++ b/c_emulator/riscv_platform_impl.cpp
@@ -21,6 +21,7 @@ bool rv_enable_zicbom = false;
 bool rv_enable_zicboz = false;
 bool rv_enable_zvkb = false;
 bool rv_enable_sstc = false;
+bool rv_enable_svadu = false;
 
 bool rv_enable_dirty_update = false;
 bool rv_enable_misaligned = false;

--- a/c_emulator/riscv_platform_impl.h
+++ b/c_emulator/riscv_platform_impl.h
@@ -25,6 +25,7 @@ extern bool rv_enable_zicbom;
 extern bool rv_enable_zicboz;
 extern bool rv_enable_zvkb;
 extern bool rv_enable_sstc;
+extern bool rv_enable_svadu;
 extern bool rv_enable_writable_misa;
 extern bool rv_enable_dirty_update;
 extern bool rv_enable_misaligned;

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -53,6 +53,7 @@ enum {
   OPT_ENABLE_ZICBOZ,
   OPT_ENABLE_ZVKB,
   OPT_ENABLE_SSTC,
+  OPT_ENABLE_SVADU,
   OPT_CACHE_BLOCK_SIZE,
 };
 
@@ -407,6 +408,10 @@ static int process_args(int argc, char **argv)
     case OPT_ENABLE_SSTC:
       fprintf(stderr, "enabling Sstc extension.\n");
       rv_enable_sstc = true;
+      break;
+    case OPT_ENABLE_SVADU:
+      fprintf(stderr, "enabling Svadu extension.\n");
+      rv_enable_svadu = true;
       break;
     case OPT_CACHE_BLOCK_SIZE:
       block_size_exp = ilog2(atol(optarg));

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -112,6 +112,9 @@ enum clause extension = Ext_Zvkb
 enum clause extension = Ext_Sscofpmf
 // Supervisor-mode Timer Interrupts
 enum clause extension = Ext_Sstc
+// Hardware Updating of A/D Bits
+enum clause extension = Ext_Svadu
+enum clause extension = Ext_Svade
 // Fine-Grained Address-Translation Cache Invalidation
 enum clause extension = Ext_Svinval
 // NAPOT Translation Contiguity

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -33,11 +33,6 @@ val plat_cache_block_size_exp = pure {c: "plat_cache_block_size_exp", interprete
 val plat_ram_base = pure {c: "plat_ram_base", interpreter: "Platform.dram_base", lem: "plat_ram_base"} : unit -> physaddrbits
 val plat_ram_size = pure {c: "plat_ram_size", interpreter: "Platform.dram_size", lem: "plat_ram_size"} : unit -> physaddrbits
 
-/* whether the MMU should update dirty bits in PTEs */
-val plat_enable_dirty_update = pure {interpreter: "Platform.enable_dirty_update",
-                                     c: "plat_enable_dirty_update",
-                                     lem: "plat_enable_dirty_update"} : unit -> bool
-
 /* whether the platform supports misaligned accesses without trapping to M-mode. if false,
  * misaligned loads/stores are trapped to Machine mode.
  */

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -127,6 +127,17 @@ val sys_enable_sstc = pure "sys_enable_sstc" : unit -> bool
 // Supervisor timecmp
 function clause extensionEnabled(Ext_Sstc) = sys_enable_sstc()
 
+/* whether hardware updating of A/D bits was enabled at boot */
+val plat_enable_dirty_update = pure {interpreter: "Platform.enable_dirty_update",
+                                     c: "plat_enable_dirty_update",
+                                     lem: "plat_enable_dirty_update"} : unit -> bool
+
+/* whether Svadu was enabled at boot */
+val sys_enable_svadu = pure "sys_enable_svadu" : unit -> bool
+
+/* whether Svadu was enabled at boot */
+val sys_enable_svade = pure "sys_enable_svade" : unit -> bool
+
 /* This function allows an extension to veto a write to Misa
    if it would violate an alignment restriction on
    unsetting C. If it returns true the write will have no effect. */
@@ -330,8 +341,10 @@ bitfield MEnvcfg : bits(64) = {
   STCE   : 63,
   // Page Based Memory Types Extension
   PBMTE  : 62,
+  // Svadu extension
+  ADUE   : 61,
   // Reserved WPRI bits.
-  wpri_1 : 61 .. 8,
+  wpri_1 : 60 .. 8,
   // Cache Block Zero instruction Enable
   CBZE   : 7,
   // Cache Block Clean and Flush instruction Enable
@@ -365,6 +378,7 @@ function legalize_menvcfg(o : MEnvcfg, v : bits(64)) -> MEnvcfg = {
     CBCFE = if extensionEnabled(Ext_Zicbom) then v[CBCFE] else 0b0,
     CBIE = if extensionEnabled(Ext_Zicbom) then (if v[CBIE] != 0b10 then v[CBIE] else 0b00) else 0b00,
     STCE = if extensionEnabled(Ext_Sstc) then v[STCE] else 0b0,
+    ADUE = if sys_enable_svadu() then v[ADUE] else 0b0,
     // Other extensions are not implemented yet so all other fields are read only zero.
   ]
 }
@@ -381,7 +395,10 @@ function legalize_senvcfg(o : SEnvcfg, v : xlenbits) -> SEnvcfg = {
 }
 
 // Initialised to legal values in case some bits are hard-coded to 1.
-register menvcfg : MEnvcfg = legalize_menvcfg(Mk_MEnvcfg(zeros()), zeros())
+register menvcfg : MEnvcfg = legalize_menvcfg(
+  Mk_MEnvcfg(zeros()),
+  [Mk_MEnvcfg(zeros()) with ADUE = bool_to_bits(sys_enable_svadu() & plat_enable_dirty_update())].bits
+)
 register senvcfg : SEnvcfg = legalize_senvcfg(Mk_SEnvcfg(zeros()), zeros())
 
 mapping clause csr_name_map = 0x30A  <-> "menvcfg"
@@ -400,6 +417,11 @@ function clause write_CSR((0x30A, value) if xlen == 32) = { menvcfg = legalize_m
 function clause write_CSR((0x30A, value) if xlen == 64) = { menvcfg = legalize_menvcfg(menvcfg, value); menvcfg.bits }
 function clause write_CSR((0x31A, value) if xlen == 32) = { menvcfg = legalize_menvcfg(menvcfg, value @ menvcfg.bits[31 .. 0]); menvcfg.bits[63 .. 32] }
 function clause write_CSR(0x10A, value) = { senvcfg = legalize_senvcfg(senvcfg, zero_extend(value)); senvcfg.bits[xlen - 1 .. 0] }
+
+/* whether hardware updating of A/D bits is enabled */
+function clause extensionEnabled(Ext_Svadu) = sys_enable_svadu()
+/* whether Svade takes effect */
+function clause extensionEnabled(Ext_Svade) = sys_enable_svade() & menvcfg[ADUE] == 0b0
 
 // Return whether or not FIOM is currently active, based on the current
 // privilege and the menvcfg/senvcfg settings. This means that I/O fences

--- a/model/riscv_vmem.sail
+++ b/model/riscv_vmem.sail
@@ -239,10 +239,11 @@ function translate_TLB_hit forall 'v, is_sv_mode('v) . (
       match update_PTE_Bits(pte, ac) {
         None()     => TR_Address(tlb_get_ppn(sv_width, ent, vpn), ext_ptw),
         Some(pte') =>
-          if not(plat_enable_dirty_update()) then
-            // pte needs dirty/accessed update but that is not enabled
-            TR_Failure(PTW_PTE_Update(), ext_ptw)
-          else {
+          if not(extensionEnabled(Ext_Svadu)) & not(plat_enable_dirty_update()) then {
+              TR_Failure(PTW_PTE_Update(), ext_ptw)
+          } else if extensionEnabled(Ext_Svadu) & extensionEnabled(Ext_Svade) then {
+              TR_Failure(PTW_Access(), ext_ptw)
+          } else {
             // Writeback the PTE (which has new A/D bits)
             write_TLB(tlb_index, tlb_set_pte(ent, pte'));
             match write_pte(ent.pteAddr, pte_width, pte') {
@@ -276,7 +277,7 @@ function translate_TLB_miss forall 'v, is_sv_mode('v) . (
   match ptw_result {
     PTW_Failure(f, ext_ptw) => TR_Failure(f, ext_ptw),
     PTW_Success(struct {ppn, pte, pteAddr, level, global}, ext_ptw) => {
-      let ext_pte   = ext_bits_of_PTE(pte);
+      let ext_pte = ext_bits_of_PTE(pte);
       // Without TLBs, this 'match' expression can be replaced simply
       // by: 'TR_Address(ppn, ext_ptw)'    (see TLB NOTE above)
       match update_PTE_Bits(pte, ac) {
@@ -285,11 +286,11 @@ function translate_TLB_miss forall 'v, is_sv_mode('v) . (
           TR_Address(ppn, ext_ptw)
         },
         Some(pte) =>
-          // See riscv_platform.sail
-          if not(plat_enable_dirty_update()) then
-            // pte needs dirty/accessed update but that is not enabled
-            TR_Failure(PTW_PTE_Update(), ext_ptw)
-          else {
+          if not(extensionEnabled(Ext_Svadu)) & not(plat_enable_dirty_update()) then {
+              TR_Failure(PTW_PTE_Update(), ext_ptw)
+          } else if extensionEnabled(Ext_Svadu) & extensionEnabled(Ext_Svade) then {
+              TR_Failure(PTW_Access(), ext_ptw)
+          } else {
             // Writeback the PTE (which has new A/D bits)
             match write_pte(pteAddr, pte_width, pte) {
               Ok(_) => {


### PR DESCRIPTION
Please check: https://riscv-specs.timhutt.co.uk/spec/riscv-isa-release-b5aa38c-2025-01-17/riscv-privileged.html#sec:svadu

- Add `menvcfg.ADUE` 

	> If the Svadu extension is implemented, the menvcfg.ADUE field is writable. 

- Check A/D when Svade is enabled
	
	> Two schemes to manage the A and D bits are defined:
	>	- The Svade extension: when a virtual page is accessed and the A bit is clear, or is written and the D bit is clear, a page-fault exception is raised.
