### PR TITLE
Add a DOWNLOAD_GMP option to build against a local GMP build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,14 +63,35 @@ if (NOT ZLIB_FOUND)
     endif()
 endif()
 
-find_package(GMP)
-if (NOT GMP_FOUND)
-    if (APPLE)
-        message(FATAL_ERROR "GMP not found. Try 'brew install gmp'.")
-    elseif (UNIX)
-        message(FATAL_ERROR "GMP not found. Try 'sudo apt install libgmp-dev' or 'sudo dnf install gmp-devel'.")
-    else()
-        message(FATAL_ERROR "GMP not found.")
+option(DOWNLOAD_GMP "Download libgmp and build the library locally instead of using a system installation" OFF)
+if (DOWNLOAD_GMP)
+    include(ExternalProject)
+    ExternalProject_Add(
+        gmp
+        URL https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz
+        INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/gmp
+        CONFIGURE_COMMAND "<SOURCE_DIR>/configure" "--prefix=<INSTALL_DIR>" --disable-shared --enable-static
+    )
+    ExternalProject_Get_property(gmp INSTALL_DIR)
+    add_library(GMP::GMP STATIC IMPORTED GLOBAL)
+    # Work around `Imported target "GMP::GMP" includes non-existent path`.
+    # See https://gitlab.kitware.com/cmake/cmake/-/issues/15052
+    file(MAKE_DIRECTORY ${INSTALL_DIR}/include)
+    set_target_properties(GMP::GMP PROPERTIES
+            IMPORTED_LOCATION "${INSTALL_DIR}/lib/libgmp.a"
+            INTERFACE_INCLUDE_DIRECTORIES "${INSTALL_DIR}/include")
+    add_dependencies(GMP::GMP gmp)
+else()
+    find_package(GMP)
+    if (NOT GMP_FOUND)
+        set(download_gmp "setting -DDOWNLOAD_GMP=TRUE to use a local build of GMP instead of a system library")
+        if (APPLE)
+            message(FATAL_ERROR "GMP not found. Try 'brew install gmp' or ${download_gmp}.")
+        elseif (UNIX)
+            message(FATAL_ERROR "GMP not found. Try 'sudo apt install libgmp-dev' or 'sudo dnf install gmp-devel' or ${download_gmp}.")
+        else()
+            message(FATAL_ERROR "GMP not found. Try ${download_gmp}")
+        endif()
     endif()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ build directory, then e.g.
 $ make -C build riscv_sim_rv64f_rvfi
 ```
 
+By default `build_simulators.sh` will download and build [libgmp](https://gmplib.org/).
+To use a system installation of libgmp, run `env DOWNLOAD_GMP=FALSE ./build_simulators.sh` instead.
+
 ### Executing test binaries
 
 The simulator can be used to execute small test binaries.

--- a/build_simulators.sh
+++ b/build_simulators.sh
@@ -3,4 +3,5 @@
 set -e
 : "${DOWNLOAD_GMP:=TRUE}"
 cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDOWNLOAD_GMP="${DOWNLOAD_GMP}"
-cmake --build build -j2
+jobs=$( (nproc || sysctl -n hw.ncpu || echo 2) 2>/dev/null)
+cmake --build build -j${jobs}

--- a/build_simulators.sh
+++ b/build_simulators.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 set -e
-
-cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+: "${DOWNLOAD_GMP:=TRUE}"
+cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDOWNLOAD_GMP="${DOWNLOAD_GMP}"
 cmake --build build -j2


### PR DESCRIPTION
This downloads the latest release of GMP and builds it as part of the overall emulator build. This should make it easier to build sail without having to install system dependencies.

See https://github.com/riscv/sail-riscv/issues/215