### PR TITLE
Add support for Zic64b

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Supported RISC-V ISA features
 - Zicntr and Zihpm extensions for counters, v2.0
 - Zicond extension for integer conditional operations, v1.0
 - Zicbom and Zicboz extensions for cache-block management (Zicbop not currently supported), v1.0
+- Zic64b: Cache block size is 64 bytes, v1.0
 - Zimop extension for May-Be-Operations, v1.0
 - M extension for integer multiplication and division, v2.0
 - Zmmul extension for integer multiplication only, v1.0

--- a/config/default.json
+++ b/config/default.json
@@ -63,6 +63,9 @@
         "U" : {
             "supported" : true
         },
+        "Zic64b" : {
+            "supported" : true
+        },
         "Zicbom" : {
             "supported" : true
         },

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -49,6 +49,9 @@ function clause hartSupports(Ext_S) = config extensions.S.supported
 enum clause extension = Ext_U
 function clause hartSupports(Ext_U) = config extensions.U.supported
 
+// Cache blocks must be 64 bytes in size
+enum clause extension = Ext_Zic64b
+function clause hartSupports(Ext_Zic64b) = config extensions.Zic64b.supported
 // Cache-Block Management Instructions
 enum clause extension = Ext_Zicbom
 function clause hartSupports(Ext_Zicbom) = config extensions.Zicbom.supported

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -27,7 +27,7 @@ val elf_entry = pure {
 // Cache block size is 2^cache_block_size_exp. Max is `max_mem_access` (4096)
 // because this model performs `cbo.zero` with a single write, and the behaviour
 // with cache blocks larger than a page is not clearly defined.
-function plat_cache_block_size_exp() -> range(0, 12) = config platform.cache_block_size_exp
+function plat_cache_block_size_exp() -> range(0, 12) = if config extensions.Zic64b.supported then 6 else config platform.cache_block_size_exp
 
 /* Main memory */
 function plat_ram_base() -> physaddrbits = to_bits(physaddrbits_len, config platform.ram.base : int)


### PR DESCRIPTION
Seems not needed, if I understand correctly

> **Zic64b** Cache blocks must be 64 bytes in size, naturally aligned in the address space
>
> **Note**: This is a new extension name for this feature. While the general RISC-V specifications are agnostic to cache block size, selecting a common cache block size simplifies the specification and use of the following cache-block extensions within the application processor profile.
Software does not have to query a discovery mechanism and/or provide dynamic dispatch to the appropriate code. We choose 64 bytes at it is effectively an industry standard.
Implementations may use longer cache blocks to reduce tag cost provided they use 64-byte sub-blocks to remain compatible.
Implementations may use shorter cache blocks provided they sequence cache operations across the multiple cache blocks comprising a 64-byte block to remain compatible.

Spike added isa_parser for hints extension, but this is not even a hint? and sail doesn't have this requirement

The only thing can do is update the Wiki or explain it in README (seems not needed too)

So please feel free to close this PR