### PR TITLE
Remove obsolete comments about effect annotations

### DIFF
--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -235,7 +235,6 @@ function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
 /* Memory write with an explicit metadata value.  Metadata writes are
  * currently assumed to have the same alignment constraints as their
  * data.
- * NOTE: The wreg effect is due to MMIO, the rreg is due to checking mtime.
  */
 val mem_write_value_priv_meta : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), AccessType(ext_access_type), Privilege, mem_meta, bool, bool, bool) -> MemoryOpResult(bool)
 function mem_write_value_priv_meta (paddr, width, value, typ, priv, meta, aq, rl, con) = {

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -213,7 +213,6 @@ function clint_dispatch() -> unit = {
     (if extensionEnabled(Ext_Sstc) then ", mip.STI <- " ^ BitStr(mip[STI]) else "") ^ ")");
 }
 
-/* The rreg effect is due to checking mtime. */
 val clint_store: forall 'n, 'n > 0. (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
 function clint_store(physaddr(addr), width, data) = {
   let addr = addr - plat_clint_base ();
@@ -333,7 +332,6 @@ function htif_load(t, physaddr(paddr), width) = {
   }
 }
 
-/* The rreg,wreg effects are an artifact of using 'register' to implement device state. */
 val htif_store: forall 'n, 0 < 'n <= 8. (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
 function htif_store(physaddr(paddr), width, data) = {
   if   get_config_print_platform()

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -902,9 +902,6 @@ function clause write_CSR(0x7a0, value) = { tselect = value; tselect }
 
 /*
  * Entropy Source - Platform access to random bits.
- * WARNING: This function currently lacks a proper side-effect annotation.
- *          If you are using theorem prover tool flows, you
- *          may need to modify or stub out this function for now.
  * NOTE: This would be better placed in riscv_platform.sail, but that file
  *       appears _after_ this one in the compile order meaning the valspec
  *       for this function is unavailable when it's first encountered in


### PR DESCRIPTION
These were missed when we removed the deprecated effects annotations.