### PR TITLE
Fix simulator exit code

### DIFF
--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -842,10 +842,12 @@ void run_sail(void)
 
     if (zhtif_done) {
       /* check exit code */
-      if (zhtif_exit_code == 0)
+      if (zhtif_exit_code == 0) {
         fprintf(stdout, "SUCCESS\n");
-      else
+      } else {
         fprintf(stdout, "FAILURE: %" PRIi64 "\n", zhtif_exit_code);
+        exit(1);
+      }
     }
 
     if (insn_cnt == rv_insns_per_tick) {


### PR DESCRIPTION
The new CMake testing infrastructure assumed (one might say logically!) that `riscv_sim_..` would exit with a non-zero exit code if a test failed. That actually wasn't the case, so in fact we haven't been testing anything.

This corrects that. Fortunately all the tests still pass.