### PR TITLE
Draft: refactor the instruction stepper to better support waiting instructions like WFI, WRS.{NTO, STO}

### DIFF
--- a/Makefile.old
+++ b/Makefile.old
@@ -106,8 +106,9 @@ SAIL_ARCH_SRCS += riscv_extensions.sail riscv_types_common.sail riscv_types_ext.
 SAIL_ARCH_SRCS += riscv_vmem_types.sail $(SAIL_REGS_SRCS) $(SAIL_SYS_SRCS) riscv_platform.sail
 SAIL_ARCH_SRCS += riscv_sstc.sail
 SAIL_ARCH_SRCS += riscv_mem.sail $(SAIL_VM_SRCS)
-SAIL_ARCH_RVFI_SRCS = $(PRELUDE) rvfi_dii.sail riscv_extensions.sail riscv_types_common.sail riscv_types_ext.sail riscv_types.sail riscv_vmem_types.sail $(SAIL_REGS_SRCS) $(SAIL_SYS_SRCS) riscv_platform.sail riscv_mem.sail $(SAIL_VM_SRCS) riscv_types_kext.sail
+SAIL_ARCH_RVFI_SRCS = $(PRELUDE) rvfi_dii.sail riscv_extensions.sail riscv_types_common.sail riscv_types_ext.sail riscv_types.sail riscv_vmem_types.sail $(SAIL_REGS_SRCS) $(SAIL_SYS_SRCS) riscv_platform.sail riscv_mem.sail $(SAIL_VM_SRCS) riscv_types_kext.sail riscv_inst_retire.sail
 SAIL_ARCH_SRCS += riscv_types_kext.sail    # Shared/common code for the cryptography extension.
+SAIL_ARCH_SRCS += riscv_inst_retire.sail
 
 SAIL_STEP_SRCS = riscv_step_common.sail riscv_step_ext.sail riscv_decode_ext.sail riscv_fetch.sail riscv_step.sail
 RVFI_STEP_SRCS = riscv_step_common.sail riscv_step_rvfi.sail riscv_decode_ext.sail riscv_fetch_rvfi.sail riscv_step.sail

--- a/c_emulator/riscv_sail.h
+++ b/c_emulator/riscv_sail.h
@@ -14,8 +14,14 @@ extern struct zMisa zmisa;
 void model_init(void);
 void model_fini(void);
 
+enum zStepState { zSTEP_ACTIVE, zSTEP_WAIT };
+struct zstep_result {
+  enum zStepState zstate;
+  bool zstepped;
+};
+
 unit zinit_model(unit);
-bool zstep(sail_int);
+struct zstep_result zstep(sail_int, bool exit_wait);
 unit ztick_clock(unit);
 unit ztick_platform(unit);
 

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -692,7 +692,8 @@ void rvfi_send_trace(unsigned version)
 
 void run_sail(void)
 {
-  bool stepped;
+  struct zstep_result step_result;
+  bool exit_wait = true;
   bool diverged = false;
 
   /* initialize the step number */
@@ -800,7 +801,7 @@ void run_sail(void)
       sail_int sail_step;
       CREATE(sail_int)(&sail_step);
       CONVERT_OF(sail_int, mach_int)(&sail_step, step_no);
-      stepped = zstep(sail_step);
+      step_result = zstep(sail_step, exit_wait);
       if (have_exception)
         goto step_exception;
       flush_logs();
@@ -812,13 +813,13 @@ void run_sail(void)
       sail_int sail_step;
       CREATE(sail_int)(&sail_step);
       CONVERT_OF(sail_int, mach_int)(&sail_step, step_no);
-      stepped = zstep(sail_step);
+      step_result = zstep(sail_step, exit_wait);
       if (have_exception)
         goto step_exception;
       flush_logs();
       KILL(sail_int)(&sail_step);
     }
-    if (stepped) {
+    if (step_result.zstepped) {
       if (config_print_step) {
         fprintf(trace_log, "\n");
       }

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -166,6 +166,7 @@ foreach (xlen IN ITEMS 32 64)
                 ${sail_vm_srcs}
                 # Shared/common code for the cryptography extension.
                 "riscv_types_kext.sail"
+                "riscv_inst_retire.sail"
             )
 
             if (variant STREQUAL "rvfi")

--- a/model/riscv_inst_retire.sail
+++ b/model/riscv_inst_retire.sail
@@ -1,0 +1,28 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+/* Reasons an instruction retire might fail or be incomplete. */
+
+union Retire_Failure = {
+  // standard reasons
+  Illegal_Instruction            : unit,
+  Wait_For_Interrupt             : unit,
+  Trap                           : (Privilege, ctl_result, xlenbits),
+  Memory_Exception               : (virtaddr, ExceptionType),
+
+  // reasons from external extensions
+  Ext_Fetch_Check_Failure        : ext_fetch_addr_error,
+  Ext_CSR_Check_Failure          : unit,
+  Ext_ControlAddr_Check_Failure  : ext_control_addr_error,
+  Ext_DataAddr_Check_Failure     : ext_data_addr_error,
+  Ext_XRET_Priv_Failure          : unit,
+
+  // model-internal reasons
+  Waiting                        : unit,
+  Pending_Interrupt              : (InterruptType, Privilege)
+}

--- a/model/riscv_inst_retire.sail
+++ b/model/riscv_inst_retire.sail
@@ -16,13 +16,9 @@ union Retire_Failure = {
   Memory_Exception               : (virtaddr, ExceptionType),
 
   // reasons from external extensions
-  Ext_Fetch_Check_Failure        : ext_fetch_addr_error,
   Ext_CSR_Check_Failure          : unit,
   Ext_ControlAddr_Check_Failure  : ext_control_addr_error,
   Ext_DataAddr_Check_Failure     : ext_data_addr_error,
   Ext_XRET_Priv_Failure          : unit,
 
-  // model-internal reasons
-  Waiting                        : unit,
-  Pending_Interrupt              : (InterruptType, Privilege)
 }

--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -80,19 +80,19 @@ function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
     * Extensions might perform additional checks on address validity.
     */
   match ext_data_get_addr(rs1, zeros(), Read(Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_Error(e)  => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
     Ext_DataAddr_OK(vaddr) => {
       /* "LR faults like a normal load, even though it's in the AMO major opcode space."
         * - Andrew Waterman, isa-dev, 10 Jul 2018.
         */
       if not(is_aligned(virtaddr_bits(vaddr), width))
-      then { handle_mem_exception(vaddr, E_Load_Addr_Align()); RETIRE_FAIL }
+      then RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
       else match translateAddr(vaddr, Read(Data)) {
-        TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+        TR_Failure(e, _)    => RETIRE_FAIL(Memory_Exception(vaddr, e)),
         TR_Address(addr, _) =>
           match mem_read(Read(Data), addr, width_bytes, aq, aq & rl, true) {
-            Ok(result) => { load_reservation(physaddr_bits(addr)); X(rd) = sign_extend(result); RETIRE_SUCCESS },
-            Err(e)     => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+            Ok(result) => { load_reservation(physaddr_bits(addr)); X(rd) = sign_extend(result); RETIRE_SUCCESS() },
+            Err(e)     => RETIRE_FAIL(Memory_Exception(vaddr, e)),
           },
       }
     }
@@ -119,7 +119,7 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
     /* should only happen in rmem
      * rmem: allow SC to fail very early
      */
-    X(rd) = zero_extend(0b1); RETIRE_SUCCESS
+    X(rd) = zero_extend(0b1); RETIRE_SUCCESS()
   } else {
     /* normal non-rmem case
       * rmem: SC is allowed to succeed (but might fail later)
@@ -128,29 +128,29 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
       * Extensions might perform additional checks on address validity.
       */
     match ext_data_get_addr(rs1, zeros(), Write(Data), width_bytes) {
-      Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
+      Ext_DataAddr_Error(e)  => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
       Ext_DataAddr_OK(vaddr) => {
         if not(is_aligned(virtaddr_bits(vaddr), width))
-        then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); RETIRE_FAIL }
+        then RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
         else {
           match translateAddr(vaddr, Write(Data)) {  /* Write and ReadWrite are equivalent here:
                                                       * both result in a SAMO exception */
-            TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            TR_Failure(e, _) => RETIRE_FAIL(Memory_Exception(vaddr, e)),
             TR_Address(addr, _) => {
               // Check reservation with physical address.
               if not(match_reservation(physaddr_bits(addr))) then {
                 /* cannot happen in rmem */
-                X(rd) = zero_extend(0b1); cancel_reservation(); RETIRE_SUCCESS
+                X(rd) = zero_extend(0b1); cancel_reservation(); RETIRE_SUCCESS()
               } else {
                 let eares = mem_write_ea(addr, width_bytes, aq & rl, rl, true);
                 match eares {
-                  Err(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+                  Err(e) => RETIRE_FAIL(Memory_Exception(vaddr, e)),
                   Ok(_)  => {
                     let rs2_val = X(rs2);
                     match mem_write_value(addr, width_bytes, rs2_val[width_bytes * 8 - 1 .. 0], aq & rl, rl, true) {
-                      Ok(true)  => { X(rd) = zero_extend(0b0); cancel_reservation(); RETIRE_SUCCESS },
-                      Ok(false) => { X(rd) = zero_extend(0b1); cancel_reservation(); RETIRE_SUCCESS },
-                      Err(e)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+                      Ok(true)  => { X(rd) = zero_extend(0b0); cancel_reservation(); RETIRE_SUCCESS() },
+                      Ok(false) => { X(rd) = zero_extend(0b1); cancel_reservation(); RETIRE_SUCCESS() },
+                      Err(e)    => RETIRE_FAIL(Memory_Exception(vaddr, e)),
                     }
                   }
                 }
@@ -198,20 +198,20 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
     * Some extensions perform additional checks on address validity.
     */
   match ext_data_get_addr(rs1, zeros(), ReadWrite(Data, Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_Error(e)  => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
     Ext_DataAddr_OK(vaddr) => {
       if not(is_aligned(virtaddr_bits(vaddr), width))
-      then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); RETIRE_FAIL }
+      then RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
       else match translateAddr(vaddr, ReadWrite(Data, Data)) {
-        TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+        TR_Failure(e, _) => RETIRE_FAIL(Memory_Exception(vaddr, e)),
         TR_Address(addr, _) => {
           let eares = mem_write_ea(addr, width_bytes, aq & rl, rl, true);
           let rs2_val = X(rs2)[width_bytes * 8 - 1 .. 0];
           match eares {
-            Err(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            Err(e) => RETIRE_FAIL(Memory_Exception(vaddr, e)),
             Ok(_) => {
               match mem_read(ReadWrite(Data, Data), addr, width_bytes, aq, aq & rl, true) {
-                Err(e)     => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+                Err(e)     => RETIRE_FAIL(Memory_Exception(vaddr, e)),
                 Ok(loaded) => {
                   let result : bits('width_bytes * 8) =
                     match op {
@@ -226,9 +226,9 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
                       AMOMAXU => if rs2_val >_u loaded then rs2_val else loaded,
                     };
                   match mem_write_value(addr, width_bytes, sign_extend(result), aq & rl, rl, true) {
-                    Ok(true)  => { X(rd) = sign_extend(loaded); RETIRE_SUCCESS },
+                    Ok(true)  => { X(rd) = sign_extend(loaded); RETIRE_SUCCESS() },
                     Ok(false) => { internal_error(__FILE__, __LINE__, "AMO got false from mem_write_value") },
-                    Err(e)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+                    Err(e)    => RETIRE_FAIL(Memory_Exception(vaddr, e)),
                   }
                 }
               }

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -29,7 +29,7 @@ function clause execute (UTYPE(imm, rd, op)) = {
     RISCV_LUI   => off,
     RISCV_AUIPC => get_arch_pc() + off
   };
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping utype_mnemonic : uop <-> string = {
@@ -62,20 +62,16 @@ function clause execute (RISCV_JAL(imm, rd)) = {
   let target = PC + sign_extend(imm);
   /* Extensions get the first checks on the prospective target address. */
   match ext_control_check_pc(target) {
-    Ext_ControlAddr_Error(e) => {
-      ext_handle_control_check_error(e);
-      RETIRE_FAIL
-    },
+    Ext_ControlAddr_Error(e) => RETIRE_FAIL(Ext_ControlAddr_Check_Failure(e)),
     Ext_ControlAddr_OK(target) => {
       /* Perform standard alignment check */
       let target_bits = virtaddr_bits(target);
       if bit_to_bool(target_bits[1]) & not(extensionEnabled(Ext_Zca)) then {
-        handle_mem_exception(target, E_Fetch_Addr_Align());
-        RETIRE_FAIL
+        RETIRE_FAIL(Memory_Exception(target, E_Fetch_Addr_Align()))
       } else {
         X(rd) = get_next_pc();
         set_next_pc(target_bits);
-        RETIRE_SUCCESS
+        RETIRE_SUCCESS()
       }
     }
   }
@@ -125,22 +121,18 @@ function clause execute (BTYPE(imm, rs2, rs1, op)) = {
     let target = PC + sign_extend(imm);
     /* Extensions get the first checks on the prospective target address. */
     match ext_control_check_pc(target) {
-      Ext_ControlAddr_Error(e) => {
-        ext_handle_control_check_error(e);
-        RETIRE_FAIL
-      },
+      Ext_ControlAddr_Error(e) => RETIRE_FAIL(Ext_ControlAddr_Check_Failure(e)),
       Ext_ControlAddr_OK(target) => {
         let target_bits = virtaddr_bits(target);
         if bit_to_bool(target_bits[1]) & not(extensionEnabled(Ext_Zca)) then {
-          handle_mem_exception(target, E_Fetch_Addr_Align());
-          RETIRE_FAIL
+          RETIRE_FAIL(Memory_Exception(target, E_Fetch_Addr_Align()))
         } else {
           set_next_pc(target_bits);
-          RETIRE_SUCCESS
+          RETIRE_SUCCESS()
         }
       }
     }
-  } else RETIRE_SUCCESS
+  } else RETIRE_SUCCESS()
 }
 
 mapping btype_mnemonic : bop <-> string = {
@@ -180,7 +172,7 @@ function clause execute (ITYPE (imm, rs1, rd, op)) = {
     RISCV_ORI   => X(rs1) | immext,
     RISCV_XORI  => X(rs1) ^ immext
   };
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping itype_mnemonic : iop <-> string = {
@@ -215,7 +207,7 @@ function clause execute (SHIFTIOP(shamt, rs1, rd, op)) = {
     RISCV_SRLI => X(rs1) >> shamt,
     RISCV_SRAI => shift_bits_right_arith(X(rs1), shamt),
   };
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping shiftiop_mnemonic : sop <-> string = {
@@ -254,7 +246,7 @@ function clause execute (RTYPE(rs2, rs1, rd, op)) = {
     RISCV_SUB  => X(rs1) - X(rs2),
     RISCV_SRA  => shift_bits_right_arith(X(rs1), X(rs2)[log2_xlen - 1 .. 0]),
   };
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping rtype_mnemonic : rop <-> string = {
@@ -306,17 +298,16 @@ function clause execute (LOAD(imm, rs1, rd, is_unsigned, width, aq, rl)) = {
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
   match ext_data_get_addr(rs1, offset, Read(Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_Error(e)  => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
     Ext_DataAddr_OK(vaddr) => {
       if   check_misaligned(vaddr, width)
-      then { handle_mem_exception(vaddr, E_Load_Addr_Align()); RETIRE_FAIL }
+      then RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
       else match translateAddr(vaddr, Read(Data)) {
-        TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+        TR_Failure(e, _) => RETIRE_FAIL(Memory_Exception(vaddr, e)),
         TR_Address(paddr, _) =>
-
           match mem_read(Read(Data), paddr, width_bytes, aq, rl, false) {
-            Ok(result) => { X(rd) = extend_value(is_unsigned, result); RETIRE_SUCCESS },
-            Err(e)     => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            Ok(result) => { X(rd) = extend_value(is_unsigned, result); RETIRE_SUCCESS() },
+            Err(e)     => RETIRE_FAIL(Memory_Exception(vaddr, e)),
           },
       }
     },
@@ -362,22 +353,22 @@ function clause execute (STORE(imm, rs2, rs1, width, aq, rl)) = {
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
   match ext_data_get_addr(rs1, offset, Write(Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_Error(e)  => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
     Ext_DataAddr_OK(vaddr) =>
       if   check_misaligned(vaddr, width)
-      then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); RETIRE_FAIL }
+      then RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
       else match translateAddr(vaddr, Write(Data)) {
-        TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+        TR_Failure(e, _)    => RETIRE_FAIL(Memory_Exception(vaddr, e)),
         TR_Address(paddr, _) => {
           let eares = mem_write_ea(paddr, width_bytes, aq, rl, false);
           match (eares) {
-            Err(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            Err(e) => RETIRE_FAIL(Memory_Exception(vaddr, e)),
             Ok(_)  => {
               let rs2_val = X(rs2);
               match mem_write_value(paddr, width_bytes, rs2_val[width_bytes * 8 - 1 .. 0], aq, rl, false) {
-                Ok(true)  => RETIRE_SUCCESS,
+                Ok(true)  => RETIRE_SUCCESS(),
                 Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                Err(e)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+                Err(e)    => RETIRE_FAIL(Memory_Exception(vaddr, e))
               }
             }
           }
@@ -400,7 +391,7 @@ mapping clause encdec = ADDIW(imm, rs1, rd)
 function clause execute (ADDIW(imm, rs1, rd)) = {
   let result = X(rs1) + sign_extend(imm);
   X(rd) = sign_extend(result[31..0]);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = ADDIW(imm, rs1, rd)
@@ -443,7 +434,7 @@ function clause execute (RTYPEW(rs2, rs1, rd, op)) = {
     RISCV_SRAW => shift_bits_right_arith(rs1_val, rs2_val[4..0]),
   };
   X(rd) = sign_extend(result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping rtypew_mnemonic : ropw <-> string = {
@@ -483,7 +474,7 @@ function clause execute (SHIFTIWOP(shamt, rs1, rd, op)) = {
     RISCV_SRAIW => shift_bits_right_arith(rs1_val, shamt),
   };
   X(rd) = sign_extend(result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping shiftiwop_mnemonic : sopw <-> string = {
@@ -533,7 +524,7 @@ function clause execute (FENCE(pred, succ)) = {
     _ => { print("FIXME: unsupported fence");
            () }
   };
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping bit_maybe_r : bits(1) <-> string = {
@@ -577,7 +568,7 @@ function clause execute (FENCE_TSO(pred, succ)) = {
     _ => { print("FIXME: unsupported fence");
            () }
   };
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = FENCE_TSO(pred, succ)
@@ -598,8 +589,7 @@ function clause execute ECALL() = {
                     },
              excinfo = (None() : option(xlenbits)),
              ext     = None() };
-  set_next_pc(exception_handler(cur_privilege, CTL_TRAP(t), PC));
-  RETIRE_FAIL
+  RETIRE_FAIL(Trap(cur_privilege, CTL_TRAP(t), PC))
 }
 
 mapping clause assembly = ECALL() <-> "ecall"
@@ -612,12 +602,12 @@ mapping clause encdec = MRET()
 
 function clause execute MRET() = {
   if   cur_privilege != Machine
-  then { handle_illegal(); RETIRE_FAIL }
-  else if not(ext_check_xret_priv (Machine))
-  then { ext_fail_xret_priv(); RETIRE_FAIL }
+  then RETIRE_FAIL(Illegal_Instruction())
+  else if not(ext_check_xret_priv(Machine))
+  then RETIRE_FAIL(Ext_XRET_Priv_Failure())
   else {
     set_next_pc(exception_handler(cur_privilege, CTL_MRET(), PC));
-    RETIRE_SUCCESS
+    RETIRE_SUCCESS()
   }
 }
 
@@ -636,12 +626,12 @@ function clause execute SRET() = {
     Machine    => not(extensionEnabled(Ext_S))
   };
   if   sret_illegal
-  then { handle_illegal(); RETIRE_FAIL }
+  then RETIRE_FAIL(Illegal_Instruction())
   else if not(ext_check_xret_priv (Supervisor))
-  then { ext_fail_xret_priv(); RETIRE_FAIL }
+  then RETIRE_FAIL(Ext_XRET_Priv_Failure())
   else {
     set_next_pc(exception_handler(cur_privilege, CTL_SRET(), PC));
-    RETIRE_SUCCESS
+    RETIRE_SUCCESS()
   }
 }
 
@@ -653,10 +643,8 @@ union clause ast = EBREAK : unit
 mapping clause encdec = EBREAK()
   <-> 0b000000000001 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
 
-function clause execute EBREAK() = {
-  handle_mem_exception(virtaddr(PC), E_Breakpoint());
-  RETIRE_FAIL
-}
+function clause execute EBREAK() =
+  RETIRE_FAIL(Memory_Exception(virtaddr(PC), E_Breakpoint()))
 
 mapping clause assembly = EBREAK() <-> "ebreak"
 
@@ -668,11 +656,11 @@ mapping clause encdec = WFI()
 
 function clause execute WFI() =
   match cur_privilege {
-    Machine    => { platform_wfi(); RETIRE_SUCCESS },
+    Machine    => RETIRE_FAIL(Wait_For_Interrupt()),
     Supervisor => if   mstatus[TW] == 0b1
-                  then { handle_illegal(); RETIRE_FAIL }
-                  else { platform_wfi(); RETIRE_SUCCESS },
-    User       => { handle_illegal(); RETIRE_FAIL }
+                  then RETIRE_FAIL(Illegal_Instruction())
+                  else RETIRE_FAIL(Wait_For_Interrupt()),
+    User       => RETIRE_FAIL(Illegal_Instruction())
   }
 
 mapping clause assembly = WFI() <-> "wfi"
@@ -690,12 +678,12 @@ function clause execute SFENCE_VMA(rs1, rs2) = {
   // is 9 but we always set it to 16 for RV64.
   let asid = if rs2 != zreg then Some(X(rs2)[asidlen - 1 .. 0]) else None();
   match cur_privilege {
-    User       => { handle_illegal(); RETIRE_FAIL },
+    User       => RETIRE_FAIL(Illegal_Instruction()),
     Supervisor => match mstatus[TVM] {
-                    0b1 => { handle_illegal(); RETIRE_FAIL },
-                    0b0 => { flush_TLB(asid, addr); RETIRE_SUCCESS },
+                    0b1 => RETIRE_FAIL(Illegal_Instruction()),
+                    0b0 => { flush_TLB(asid, addr); RETIRE_SUCCESS() },
                   },
-    Machine    => { flush_TLB(asid, addr); RETIRE_SUCCESS }
+    Machine    => { flush_TLB(asid, addr); RETIRE_SUCCESS() }
   }
 }
 

--- a/model/riscv_insts_begin.sail
+++ b/model/riscv_insts_begin.sail
@@ -14,7 +14,7 @@
 scattered union ast
 
 /* returns whether an instruction was retired, used for computing minstret */
-val execute : ast -> Retired
+val execute : ast -> Retired(Retire_Failure)
 scattered function execute
 
 val assembly : ast <-> string

--- a/model/riscv_insts_dext.sail
+++ b/model/riscv_insts_dext.sail
@@ -279,7 +279,7 @@ function clause execute (F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, op)) = {
   let rs3_val_64b = F_or_X_D(rs3);
 
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_64b) : (bits(5), bits(64)) =
@@ -291,7 +291,7 @@ function clause execute (F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, op)) = {
         };
       accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_64b;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -344,7 +344,7 @@ function clause execute (F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, op)) = {
   let rs1_val_64b = F_or_X_D(rs1);
   let rs2_val_64b = F_or_X_D(rs2);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_64b) : (bits(5), bits(64)) = match op {
@@ -355,7 +355,7 @@ function clause execute (F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, op)) = {
       };
       accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_64b;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -436,14 +436,14 @@ mapping clause encdec =
 function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FSQRT_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_f64Sqrt   (rm_3b, rs1_val_D);
 
       accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_D;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -451,14 +451,14 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FSQRT_D)) = {
 function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_W_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_W) = riscv_f64ToI32 (rm_3b, rs1_val_D);
 
       accrue_fflags(fflags);
       X(rd) = sign_extend (rd_val_W);
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -466,14 +466,14 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_W_D)) = {
 function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_WU_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_WU) = riscv_f64ToUi32 (rm_3b, rs1_val_D);
 
       accrue_fflags(fflags);
       X(rd) = sign_extend (rd_val_WU);
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -481,14 +481,14 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_WU_D)) = {
 function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_W)) = {
   let rs1_val_W = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_i32ToF64 (rm_3b, rs1_val_W);
 
       accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_D;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -496,14 +496,14 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_W)) = {
 function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_WU)) = {
   let rs1_val_WU = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_ui32ToF64 (rm_3b, rs1_val_WU);
 
       accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_D;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -511,14 +511,14 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_WU)) = {
 function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_S_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_f64ToF32 (rm_3b, rs1_val_D);
 
       accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_S;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -526,14 +526,14 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_S_D)) = {
 function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_f32ToF64 (rm_3b, rs1_val_S);
 
       accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_D;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -542,14 +542,14 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_L_D)) = {
   assert(xlen >= 64);
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_L) = riscv_f64ToI64 (rm_3b, rs1_val_D);
 
       accrue_fflags(fflags);
       X(rd) = sign_extend(rd_val_L);
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -558,14 +558,14 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_LU_D)) = {
   assert(xlen >= 64);
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_LU) = riscv_f64ToUi64 (rm_3b, rs1_val_D);
 
       accrue_fflags(fflags);
       X(rd) = sign_extend(rd_val_LU);
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -574,14 +574,14 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_L)) = {
   assert(xlen >= 64);
   let rs1_val_L = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_i64ToF64 (rm_3b, rs1_val_L);
 
       accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_D;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -590,14 +590,14 @@ function clause execute (F_UN_RM_TYPE_D(rs1, rm, rd, FCVT_D_LU)) = {
   assert(xlen >= 64);
   let rs1_val_LU = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_ui64ToF64 (rm_3b, rs1_val_LU);
 
       accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_D;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -730,7 +730,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FSGNJ_D)) = {
   let rd_val_D     = fmake_D (s2, e1, m1);
 
   F_or_X_D(rd) = rd_val_D;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FSGNJN_D)) = {
@@ -741,7 +741,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FSGNJN_D)) = {
   let rd_val_D     = fmake_D (0b1 ^ s2, e1, m1);
 
   F_or_X_D(rd) = rd_val_D;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FSGNJX_D)) = {
@@ -752,7 +752,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FSGNJX_D)) = {
   let rd_val_D     = fmake_D (s1 ^ s2, e1, m1);
 
   F_or_X_D(rd) = rd_val_D;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FMIN_D)) = {
@@ -772,7 +772,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FMIN_D)) = {
 
   accrue_fflags(fflags);
   F_or_X_D(rd) = rd_val_D;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FMAX_D)) = {
@@ -792,7 +792,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FMAX_D)) = {
 
   accrue_fflags(fflags);
   F_or_X_D(rd) = rd_val_D;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FEQ_D)) = {
@@ -804,7 +804,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FEQ_D)) = {
 
   accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FLT_D)) = {
@@ -816,7 +816,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FLT_D)) = {
 
   accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FLE_D)) = {
@@ -828,7 +828,7 @@ function clause execute (F_BIN_TYPE_D(rs2, rs1, rd, FLE_D)) = {
 
   accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* AST -> Assembly notation ================================ */
@@ -929,19 +929,19 @@ function clause execute (F_UN_TYPE_D(rs1, rd, FCLASS_D)) = {
     else zeros();
 
   X(rd) = zero_extend (rd_val_10b);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_UN_TYPE_D(rs1, rd, FMV_X_D)) = {
   assert(xlen >= 64 & flen >= 64);
   X(rd) = sign_extend(F(rs1)[63..0]);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_UN_TYPE_D(rs1, rd, FMV_D_X)) = {
   assert(xlen >= 64 & flen >= 64);
   F(rd) = nan_box(X(rs1)[63..0]);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* AST -> Assembly notation ================================ */

--- a/model/riscv_insts_end.sail
+++ b/model/riscv_insts_end.sail
@@ -12,7 +12,7 @@
 
 mapping clause encdec = ILLEGAL(s) <-> s
 
-function clause execute (ILLEGAL(s)) = { handle_illegal(); RETIRE_FAIL }
+function clause execute (ILLEGAL(s)) = RETIRE_FAIL(Illegal_Instruction())
 
 mapping clause assembly = ILLEGAL(s) <-> "illegal" ^ spc() ^ hex_bits_32(s)
 
@@ -20,7 +20,7 @@ mapping clause assembly = ILLEGAL(s) <-> "illegal" ^ spc() ^ hex_bits_32(s)
 
 mapping clause encdec_compressed = C_ILLEGAL(s) <-> s
 
-function clause execute C_ILLEGAL(s) = { handle_illegal(); RETIRE_FAIL }
+function clause execute C_ILLEGAL(s) = RETIRE_FAIL(Illegal_Instruction())
 
 mapping clause assembly = C_ILLEGAL(s) <-> "c.illegal" ^ spc() ^ hex_bits_16(s)
 

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -298,17 +298,17 @@ function clause execute(LOAD_FP(imm, rs1, rd, width)) = {
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
   match ext_data_get_addr(rs1, offset, Read(Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_Error(e)  => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
     Ext_DataAddr_OK(vaddr) => {
       if   check_misaligned(vaddr, width)
-      then { handle_mem_exception(vaddr, E_Load_Addr_Align()); RETIRE_FAIL }
+      then RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
       else match translateAddr(vaddr, Read(Data)) {
-        TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+        TR_Failure(e, _)    => RETIRE_FAIL(Memory_Exception(vaddr, e)),
         TR_Address(addr, _) => {
           let (aq, rl, res) = (false, false, false);
           match mem_read(Read(Data), addr, width_bytes, aq, rl, res) {
-            Ok(result) => { F(rd) = nan_box(result); RETIRE_SUCCESS },
-            Err(e)     => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            Ok(result) => { F(rd) = nan_box(result); RETIRE_SUCCESS() },
+            Err(e)     => RETIRE_FAIL(Memory_Exception(vaddr, e)),
           }
         },
       }
@@ -356,21 +356,21 @@ function clause execute (STORE_FP(imm, rs2, rs1, width)) = {
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
   match ext_data_get_addr(rs1, offset, Write(Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_Error(e)  => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
     Ext_DataAddr_OK(vaddr) => {
       if   check_misaligned(vaddr, width)
-      then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); RETIRE_FAIL }
+      then RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
       else match translateAddr(vaddr, Write(Data)) {
-        TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+        TR_Failure(e, _)    => RETIRE_FAIL(Memory_Exception(vaddr, e)),
         TR_Address(addr, _) => {
           match mem_write_ea(addr, width_bytes, aq, rl, false) {
-            Err(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            Err(e) => RETIRE_FAIL(Memory_Exception(vaddr, e)),
             Ok(_)  => {
               let rs2_val = F(rs2);
               match mem_write_value(addr, width_bytes, rs2_val[width_bytes * 8 - 1 .. 0], aq, rl, con) {
-                Ok(true)  => { RETIRE_SUCCESS },
+                Ok(true)  => RETIRE_SUCCESS(),
                 Ok(false) => { internal_error(__FILE__, __LINE__, "store got false from mem_write_value") },
-                Err(e)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+                Err(e)    => RETIRE_FAIL(Memory_Exception(vaddr, e))
               }
             },
           }
@@ -420,7 +420,7 @@ function clause execute (F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, op)) = {
   let rs2_val_32b = F_or_X_S(rs2);
   let rs3_val_32b = F_or_X_S(rs3);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_32b) : (bits(5), bits(32)) =
@@ -432,7 +432,7 @@ function clause execute (F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, op)) = {
         };
       accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_32b;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -485,7 +485,7 @@ function clause execute (F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, op)) = {
   let rs1_val_32b = F_or_X_S(rs1);
   let rs2_val_32b = F_or_X_S(rs2);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_32b) : (bits(5), bits(32)) = match op {
@@ -496,7 +496,7 @@ function clause execute (F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, op)) = {
       };
       accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_32b;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -569,14 +569,14 @@ mapping clause encdec =
 function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FSQRT_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_f32Sqrt   (rm_3b, rs1_val_S);
 
       accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_S;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -584,14 +584,14 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FSQRT_S)) = {
 function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_W_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_W) = riscv_f32ToI32 (rm_3b, rs1_val_S);
 
       accrue_fflags(fflags);
       X(rd) = sign_extend (rd_val_W);
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -599,14 +599,14 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_W_S)) = {
 function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_WU_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_WU) = riscv_f32ToUi32 (rm_3b, rs1_val_S);
 
       accrue_fflags(fflags);
       X(rd) = sign_extend (rd_val_WU);
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -614,14 +614,14 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_WU_S)) = {
 function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_W)) = {
   let rs1_val_W = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_i32ToF32 (rm_3b, rs1_val_W);
 
       accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_S;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -629,14 +629,14 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_W)) = {
 function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_WU)) = {
   let rs1_val_WU = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_ui32ToF32 (rm_3b, rs1_val_WU);
 
       accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_S;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -645,14 +645,14 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_L_S)) = {
   assert(xlen >= 64);
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_L) = riscv_f32ToI64 (rm_3b, rs1_val_S);
 
       accrue_fflags(fflags);
       X(rd) = sign_extend(rd_val_L);
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -661,14 +661,14 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_LU_S)) = {
   assert(xlen >= 64);
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_LU) = riscv_f32ToUi64 (rm_3b, rs1_val_S);
 
       accrue_fflags(fflags);
       X(rd) = sign_extend(rd_val_LU);
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -677,14 +677,14 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_L)) = {
   assert(xlen >= 64);
   let rs1_val_L = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_i64ToF32 (rm_3b, rs1_val_L);
 
       accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_S;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -693,14 +693,14 @@ function clause execute (F_UN_RM_TYPE_S(rs1, rm, rd, FCVT_S_LU)) = {
   assert(xlen >= 64);
   let rs1_val_LU = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_ui64ToF32 (rm_3b, rs1_val_LU);
 
       accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_S;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -818,7 +818,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FSGNJ_S)) = {
   let rd_val_S     = fmake_S (s2, e1, m1);
 
   F_or_X_S(rd) = rd_val_S;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FSGNJN_S)) = {
@@ -829,7 +829,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FSGNJN_S)) = {
   let rd_val_S     = fmake_S (0b1 ^ s2, e1, m1);
 
   F_or_X_S(rd) = rd_val_S;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FSGNJX_S)) = {
@@ -840,7 +840,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FSGNJX_S)) = {
   let rd_val_S     = fmake_S (s1 ^ s2, e1, m1);
 
   F_or_X_S(rd) = rd_val_S;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FMIN_S)) = {
@@ -860,7 +860,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FMIN_S)) = {
 
   accrue_fflags(fflags);
   F_or_X_S(rd) = rd_val_S;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FMAX_S)) = {
@@ -880,7 +880,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FMAX_S)) = {
 
   accrue_fflags(fflags);
   F_or_X_S(rd) = rd_val_S;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FEQ_S)) = {
@@ -892,7 +892,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FEQ_S)) = {
 
   accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FLT_S)) = {
@@ -904,7 +904,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FLT_S)) = {
 
   accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FLE_S)) = {
@@ -916,7 +916,7 @@ function clause execute (F_BIN_TYPE_S(rs2, rs1, rd, FLE_S)) = {
 
   accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* AST -> Assembly notation ================================ */
@@ -1015,17 +1015,17 @@ function clause execute (F_UN_TYPE_S(rs1, rd, FCLASS_S)) = {
     else zeros();
 
   X(rd) = zero_extend (rd_val_10b);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_UN_TYPE_S(rs1, rd, FMV_X_W)) = {
   X(rd) = sign_extend(F(rs1)[31..0]);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_UN_TYPE_S(rs1, rd, FMV_W_X)) = {
   F(rd) = nan_box(X(rs1)[31..0]);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* AST -> Assembly notation ================================ */

--- a/model/riscv_insts_hints.sail
+++ b/model/riscv_insts_hints.sail
@@ -18,7 +18,7 @@ mapping clause encdec_compressed = C_NOP_HINT(im5 @ im40)
   <-> 0b000 @ im5 : bits(1) @ 0b00000 @ im40 : bits(5) @ 0b01
       if im5 @ im40 != 0b000000
 
-function clause execute C_NOP_HINT(imm) = RETIRE_SUCCESS
+function clause execute C_NOP_HINT(imm) = RETIRE_SUCCESS()
 
 mapping clause assembly = C_NOP_HINT(imm) <-> "c.nop.hint." ^ hex_bits_6(imm)
 
@@ -30,7 +30,7 @@ mapping clause encdec_compressed = C_ADDI_HINT(rsd)
   <-> 0b000 @ 0b0 @ rsd : regidx @ 0b00000 @ 0b01
       if rsd != zreg
 
-function clause execute (C_ADDI_HINT(rsd)) = RETIRE_SUCCESS
+function clause execute (C_ADDI_HINT(rsd)) = RETIRE_SUCCESS()
 
 mapping clause assembly = C_ADDI_HINT(rsd)
       if rsd != zreg
@@ -43,7 +43,7 @@ union clause ast = C_LI_HINT : (bits(6))
 mapping clause encdec_compressed = C_LI_HINT(imm5 @ imm40)
   <-> 0b010 @ imm5 : bits(1) @ 0b00000 @ imm40 : bits(5) @ 0b01
 
-function clause execute (C_LI_HINT(imm)) = RETIRE_SUCCESS
+function clause execute (C_LI_HINT(imm)) = RETIRE_SUCCESS()
 
 mapping clause assembly = C_LI_HINT(imm)
   <-> "c.li.hint." ^ hex_bits_6(imm)
@@ -56,7 +56,7 @@ mapping clause encdec_compressed = C_LUI_HINT(imm17 @ imm1612)
   <-> 0b011 @ imm17 : bits(1) @ 0b00000 @ imm1612 : bits(5) @ 0b01
       if imm17 @ imm1612 != 0b000000
 
-function clause execute (C_LUI_HINT(imm)) = RETIRE_SUCCESS
+function clause execute (C_LUI_HINT(imm)) = RETIRE_SUCCESS()
 
 mapping clause assembly = C_LUI_HINT(imm)
       if imm != 0b000000
@@ -71,7 +71,7 @@ mapping clause encdec_compressed = C_MV_HINT(rs2)
   <-> 0b100 @ 0b0 @ 0b00000 @ rs2 : regidx @ 0b10
       if rs2 != zreg
 
-function clause execute (C_MV_HINT(rs2)) = RETIRE_SUCCESS
+function clause execute (C_MV_HINT(rs2)) = RETIRE_SUCCESS()
 
 mapping clause assembly = C_MV_HINT(rs2)
       if rs2 != zreg
@@ -86,7 +86,7 @@ mapping clause encdec_compressed = C_ADD_HINT(rs2)
   <-> 0b100 @ 0b1 @ 0b00000 @ rs2 : regidx @ 0b10
       if rs2 != zreg
 
-function clause execute (C_ADD_HINT(rs2)) = RETIRE_SUCCESS
+function clause execute (C_ADD_HINT(rs2)) = RETIRE_SUCCESS()
 
 mapping clause assembly = C_ADD_HINT(rs2)
       if rs2 != zreg
@@ -101,7 +101,7 @@ mapping clause encdec_compressed = C_SLLI_HINT(nzui5 @ nzui40, rsd)
   <-> 0b000 @ nzui5 : bits(1) @ rsd : regidx @ nzui40 : bits(5) @ 0b10
       if (nzui5 @ nzui40 == 0b000000 | rsd == zreg) & (xlen == 64 | nzui5 == 0b0)
 
-function clause execute (C_SLLI_HINT(shamt, rsd)) = RETIRE_SUCCESS
+function clause execute (C_SLLI_HINT(shamt, rsd)) = RETIRE_SUCCESS()
 
 mapping clause assembly = C_SLLI_HINT(shamt, rsd)
       if shamt == 0b000000 | rsd == zreg
@@ -114,7 +114,7 @@ union clause ast = C_SRLI_HINT : (cregidx)
 mapping clause encdec_compressed = C_SRLI_HINT(rsd)
   <-> 0b100 @ 0b0 @ 0b00 @ rsd : cregidx @ 0b00000 @ 0b01
 
-function clause execute (C_SRLI_HINT(rsd)) = RETIRE_SUCCESS
+function clause execute (C_SRLI_HINT(rsd)) = RETIRE_SUCCESS()
 
 mapping clause assembly = C_SRLI_HINT(rsd)
   <-> "c.srli.hint." ^ creg_name(rsd)
@@ -125,7 +125,7 @@ union clause ast = C_SRAI_HINT : (cregidx)
 mapping clause encdec_compressed = C_SRAI_HINT(rsd)
   <-> 0b100 @ 0b0 @ 0b01 @ rsd : cregidx @ 0b00000 @ 0b01
 
-function clause execute (C_SRAI_HINT(rsd)) = RETIRE_SUCCESS
+function clause execute (C_SRAI_HINT(rsd)) = RETIRE_SUCCESS()
 
 mapping clause assembly = C_SRAI_HINT(rsd)
   <-> "c.srai.hint." ^ creg_name(rsd)
@@ -142,7 +142,7 @@ mapping clause encdec = FENCE_RESERVED(fm, pred, succ, rs, rd)
   <-> fm : bits(4) @ pred : bits(4) @ succ : bits(4) @ rs : regidx @ 0b000 @ rd : regidx @ 0b0001111
       if (fm != 0b0000 & fm != 0b1000) | rs != 0b00000 | rd != 0b00000
 
-function clause execute (FENCE_RESERVED(fm, pred, succ, rs, rd)) = RETIRE_SUCCESS
+function clause execute (FENCE_RESERVED(fm, pred, succ, rs, rd)) = RETIRE_SUCCESS()
 
 mapping clause assembly = FENCE_RESERVED(fm, pred, succ, rs, rd)
       if (fm != 0b0000 & fm != 0b1000) | rs != 0b00000 | rd != 0b00000
@@ -158,7 +158,7 @@ mapping clause encdec = FENCEI_RESERVED(imm, rs, rd)
   <-> imm : bits(12) @ rs : regidx @ 0b001 @ rd : regidx @ 0b0001111
       if imm != 0b000000000000 | rs != zreg | rd != zreg
 
-function clause execute FENCEI_RESERVED(imm, rs, rd) = RETIRE_SUCCESS
+function clause execute FENCEI_RESERVED(imm, rs, rd) = RETIRE_SUCCESS()
 
 mapping clause assembly = FENCEI_RESERVED(imm, rs, rd)
       if imm != 0b000000000000 | rs != zreg | rd != zreg

--- a/model/riscv_insts_mext.sail
+++ b/model/riscv_insts_mext.sail
@@ -14,7 +14,6 @@
 function clause extensionEnabled(Ext_M) = misa[M] == 0b1
 function clause extensionEnabled(Ext_Zmmul) = true
 
-
 union clause ast = MUL : (regidx, regidx, regidx, mul_op)
 
 mapping encdec_mul_op : mul_op <-> bits(3) = {
@@ -37,7 +36,7 @@ function clause execute (MUL(rs2, rs1, rd, mul_op)) = {
                then result_wide[(2 * xlen - 1) .. xlen]
                else result_wide[(xlen - 1) .. 0];
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping mul_mnemonic : mul_op <-> string = {
@@ -65,7 +64,7 @@ function clause execute (DIV(rs2, rs1, rd, s)) = {
   /* check for signed overflow */
   let q': int = if s & q > xlen_max_signed then xlen_min_signed else q;
   X(rd) = to_bits(xlen, q');
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping maybe_not_u : bool <-> string = {
@@ -90,7 +89,7 @@ function clause execute (REM(rs2, rs1, rd, s)) = {
   let r : int = if rs2_int == 0 then rs1_int else rem_round_zero(rs1_int, rs2_int);
   /* signed overflow case returns zero naturally as required due to -1 divisor */
   X(rd) = to_bits(xlen, r);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = REM(rs2, rs1, rd, s)
@@ -113,7 +112,7 @@ function clause execute (MULW(rs2, rs1, rd)) = {
   let result32 = to_bits(64, rs1_int * rs2_int)[31..0];
   let result : xlenbits = sign_extend(result32);
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = MULW(rs2, rs1, rd)
@@ -138,7 +137,7 @@ function clause execute (DIVW(rs2, rs1, rd, s)) = {
   /* check for signed overflow */
   let q': int = if s & q > (2 ^ 31 - 1) then  (0 - (2 ^ 31)) else q;
   X(rd) = sign_extend(to_bits(32, q'));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = DIVW(rs2, rs1, rd, s)
@@ -162,7 +161,7 @@ function clause execute (REMW(rs2, rs1, rd, s)) = {
   let r : int = if rs2_int == 0 then rs1_int else rem_round_zero(rs1_int, rs2_int);
   /* signed overflow case returns zero naturally as required due to -1 divisor */
   X(rd) = sign_extend(to_bits(32, r));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = REMW(rs2, rs1, rd, s)

--- a/model/riscv_insts_svinval.sail
+++ b/model/riscv_insts_svinval.sail
@@ -31,8 +31,8 @@ mapping clause encdec =
 
 function clause execute SFENCE_W_INVAL() = {
   if cur_privilege == User
-  then { handle_illegal(); RETIRE_FAIL }
-  else { RETIRE_SUCCESS } // Implemented as no-op as all memory operations are visible immediately the current Sail model
+  then RETIRE_FAIL(Illegal_Instruction())
+  else RETIRE_SUCCESS() // Implemented as no-op as all memory operations are visible immediately the current Sail model
 }
 
 mapping clause assembly = SFENCE_W_INVAL() <-> "sfence.w.inval"
@@ -47,8 +47,8 @@ mapping clause encdec =
 
 function clause execute SFENCE_INVAL_IR() = {
   if cur_privilege == User
-  then { handle_illegal(); RETIRE_FAIL }
-  else { RETIRE_SUCCESS } // Implemented as no-op as all memory operations are visible immediately in current Sail model
+  then RETIRE_FAIL(Illegal_Instruction())
+  else RETIRE_SUCCESS() // Implemented as no-op as all memory operations are visible immediately in current Sail model
 }
 
 mapping clause assembly = SFENCE_INVAL_IR() <-> "sfence.inval.ir"

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -50,7 +50,7 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -60,7 +60,10 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -113,14 +116,14 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
         VV_VMAXU         => to_bits(SEW, max(unsigned(vs2_val[i]), unsigned(vs1_val[i]))),
         VV_VMAX          => to_bits(SEW, max(signed(vs2_val[i]), signed(vs1_val[i]))),
         VV_VRGATHER      => {
-                              if (vs1 == vd | vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
+                              if (vs1 == vd | vs2 == vd) then return RETIRE_FAIL(Illegal_Instruction());
                               let idx = unsigned(vs1_val[i]);
                               let VLMAX = 2 ^ (LMUL_pow + VLEN_pow - SEW_pow);
                               assert(VLMAX <= 'n);
                               if idx < VLMAX then vs2_val[idx] else zeros()
                             },
         VV_VRGATHEREI16  => {
-                              if (vs1 == vd | vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
+                              if (vs1 == vd | vs2 == vd) then return RETIRE_FAIL(Illegal_Instruction());
                               /* vrgatherei16.vv uses SEW/LMUL for the data in vs2 but EEW=16 and EMUL = (16/SEW)*LMUL for the indices in vs1 */
                               let vs1_new : vector('n, bits(16)) = read_vreg(num_elem, 16, 4 + LMUL_pow - SEW_pow, vs1);
                               let idx = unsigned(vs1_new[i]);
@@ -134,7 +137,7 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vvtype_mnemonic : vvfunct6 <-> string = {
@@ -185,7 +188,7 @@ function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -196,7 +199,10 @@ function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   assert(SEW_widen <= 64);
@@ -219,7 +225,7 @@ function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping nvstype_mnemonic : nvsfunct6 <-> string = {
@@ -251,7 +257,7 @@ function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -262,7 +268,10 @@ function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   assert(SEW_widen <= 64);
@@ -286,7 +295,7 @@ function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping nvtype_mnemonic : nvfunct6 <-> string = {
@@ -304,14 +313,17 @@ mapping clause encdec = MASKTYPEV (vs2, vs1,  vd) if extensionEnabled(Ext_V)
   <-> 0b010111 @ 0b0 @ vs2 @ vs1 @ 0b000 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MASKTYPEV(vs2, vs1, vd)) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   let end_element   = get_end_element();
   let SEW           = get_sew();
   let LMUL_pow      = get_lmul_pow();
   let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
 
-  if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_masked(vd) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -339,7 +351,7 @@ function clause execute(MASKTYPEV(vs2, vs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = MASKTYPEV(vs2, vs1, vd)
@@ -356,7 +368,7 @@ function clause execute(MOVETYPEV(vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -365,7 +377,10 @@ function clause execute(MOVETYPEV(vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -374,7 +389,7 @@ function clause execute(MOVETYPEV(vs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = MOVETYPEV(vs1, vd)
@@ -414,7 +429,7 @@ function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -424,7 +439,10 @@ function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -483,7 +501,7 @@ function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vxtype_mnemonic : vxfunct6 <-> string = {
@@ -533,7 +551,7 @@ function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -544,7 +562,10 @@ function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   assert(SEW_widen <= 64);
@@ -567,7 +588,7 @@ function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping nxstype_mnemonic : nxsfunct6 <-> string = {
@@ -599,7 +620,7 @@ function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -610,7 +631,10 @@ function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   assert(SEW_widen <= 64);
@@ -634,7 +658,7 @@ function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping nxtype_mnemonic : nxfunct6 <-> string = {
@@ -665,7 +689,7 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -675,14 +699,17 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
       result[i] = match funct6 {
         VX_VSLIDEUP    => {
-                            if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
+                            if (vs2 == vd) then return RETIRE_FAIL(Illegal_Instruction());
                             if i >= rs1_val then vs2_val[i - rs1_val] else vd_val[i]
                           },
         VX_VSLIDEDOWN  => {
@@ -691,7 +718,7 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
                             if i + rs1_val < VLMAX then vs2_val[i + rs1_val] else zeros()
                           },
         VX_VRGATHER    => {
-                            if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
+                            if (vs2 == vd) then return RETIRE_FAIL(Illegal_Instruction());
                             let VLMAX = 2 ^ (LMUL_pow + VLEN_pow - SEW_pow);
                             assert(VLMAX > 0 & VLMAX <= 'n);
                             if rs1_val < VLMAX then vs2_val[rs1_val] else zeros()
@@ -702,7 +729,7 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vxsg_mnemonic : vxsgfunct6 <-> string = {
@@ -721,14 +748,17 @@ mapping clause encdec = MASKTYPEX(vs2, rs1, vd) if extensionEnabled(Ext_V)
   <-> 0b010111 @ 0b0 @ vs2 @ rs1 @ 0b100 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MASKTYPEX(vs2, rs1, vd)) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   let end_element   = get_end_element();
   let SEW           = get_sew();
   let LMUL_pow      = get_lmul_pow();
   let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
 
-  if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_masked(vd) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -756,7 +786,7 @@ function clause execute(MASKTYPEX(vs2, rs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = MASKTYPEX(vs2, rs1, vd)
@@ -773,7 +803,7 @@ function clause execute(MOVETYPEX(rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -782,7 +812,10 @@ function clause execute(MOVETYPEX(rs1, vd)) = {
   let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, 0b00000);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -791,7 +824,7 @@ function clause execute(MOVETYPEX(rs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = MOVETYPEX(rs1, vd)
@@ -823,7 +856,7 @@ function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -833,7 +866,10 @@ function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -876,7 +912,7 @@ function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vitype_mnemonic : vifunct6 <-> string = {
@@ -918,7 +954,7 @@ function clause execute(NISTYPE(funct6, vm, vs2, simm, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -929,7 +965,10 @@ function clause execute(NISTYPE(funct6, vm, vs2, simm, vd)) = {
   let imm_val : bits('m)             = sign_extend(simm);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   assert(SEW_widen <= 64);
@@ -952,7 +991,7 @@ function clause execute(NISTYPE(funct6, vm, vs2, simm, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping nistype_mnemonic : nisfunct6 <-> string = {
@@ -984,7 +1023,7 @@ function clause execute(NITYPE(funct6, vm, vs2, simm, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -995,7 +1034,10 @@ function clause execute(NITYPE(funct6, vm, vs2, simm, vd)) = {
   let imm_val : bits('m)             = sign_extend(simm);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   assert(SEW_widen <= 64);
@@ -1019,7 +1061,7 @@ function clause execute(NITYPE(funct6, vm, vs2, simm, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping nitype_mnemonic : nifunct6 <-> string = {
@@ -1050,7 +1092,7 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1060,14 +1102,17 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
       result[i] = match funct6 {
         VI_VSLIDEUP    => {
-                            if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
+                            if (vs2 == vd) then return RETIRE_FAIL(Illegal_Instruction());
                             if i >= imm_val then vs2_val[i - imm_val] else vd_val[i]
                           },
         VI_VSLIDEDOWN  => {
@@ -1076,7 +1121,7 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
                             if i + imm_val < VLMAX then vs2_val[i + imm_val] else zeros()
                           },
         VI_VRGATHER    => {
-                            if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
+                            if (vs2 == vd) then return RETIRE_FAIL(Illegal_Instruction());
                             let VLMAX = 2 ^ (LMUL_pow + VLEN_pow - SEW_pow);
                             assert(VLMAX > 0 & VLMAX <= 'n);
                             if imm_val < VLMAX then vs2_val[imm_val] else zeros()
@@ -1087,7 +1132,7 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping visg_mnemonic : visgfunct6 <-> string = {
@@ -1106,14 +1151,17 @@ mapping clause encdec = MASKTYPEI(vs2, simm, vd) if extensionEnabled(Ext_V)
   <-> 0b010111 @ 0b0 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MASKTYPEI(vs2, simm, vd)) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   let end_element   = get_end_element();
   let SEW           = get_sew();
   let LMUL_pow      = get_lmul_pow();
   let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
 
-  if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_masked(vd) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1141,7 +1189,7 @@ function clause execute(MASKTYPEI(vs2, simm, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = MASKTYPEI(vs2, simm, vd)
@@ -1158,7 +1206,7 @@ function clause execute(MOVETYPEI(vd, simm)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1167,7 +1215,10 @@ function clause execute(MOVETYPEI(vd, simm)) = {
   let imm_val : bits('m)             = sign_extend(simm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1176,7 +1227,7 @@ function clause execute(MOVETYPEI(vd, simm)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = MOVETYPEI(vd, simm)
@@ -1189,12 +1240,15 @@ mapping clause encdec = VMVRTYPE(vs2, simm, vd) if extensionEnabled(Ext_V)
   <-> 0b100111 @ 0b1 @ vs2 @ simm @ 0b011 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(VMVRTYPE(vs2, simm, vd)) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   let SEW     = get_sew();
   let imm_val = unsigned(zero_extend(xlen, simm));
   let EMUL    = imm_val + 1;
 
-  if not(EMUL == 1 | EMUL == 2 | EMUL == 4 | EMUL == 8) then { handle_illegal(); return RETIRE_FAIL };
+  if not(EMUL == 1 | EMUL == 2 | EMUL == 4 | EMUL == 8) then return RETIRE_FAIL(Illegal_Instruction());
 
   let EMUL_pow = log2(EMUL);
   let num_elem = get_num_elem(EMUL_pow, SEW);
@@ -1212,7 +1266,7 @@ function clause execute(VMVRTYPE(vs2, simm, vd)) = {
 
   write_vreg(num_elem, SEW, EMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping simm_string : bits(5) <-> string = {
@@ -1251,7 +1305,7 @@ function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1261,7 +1315,10 @@ function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1319,7 +1376,7 @@ function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping mvvtype_mnemonic : mvvfunct6 <-> string = {
@@ -1359,7 +1416,7 @@ function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1369,7 +1426,10 @@ function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1385,7 +1445,7 @@ function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping mvvmatype_mnemonic : mvvmafunct6 <-> string = {
@@ -1423,7 +1483,7 @@ function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1434,7 +1494,10 @@ function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1453,7 +1516,7 @@ function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping wvvtype_mnemonic : wvvfunct6 <-> string = {
@@ -1491,7 +1554,7 @@ function clause execute(WVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1502,7 +1565,10 @@ function clause execute(WVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1518,7 +1584,7 @@ function clause execute(WVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping wvtype_mnemonic : wvfunct6 <-> string = {
@@ -1554,7 +1620,7 @@ function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1565,7 +1631,10 @@ function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1580,7 +1649,7 @@ function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping wmvvtype_mnemonic : wmvvfunct6 <-> string = {
@@ -1613,7 +1682,7 @@ function clause execute(VEXT2TYPE(funct6, vm, vs2, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_half, LMUL_pow_half) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_half, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1623,7 +1692,10 @@ function clause execute(VEXT2TYPE(funct6, vm, vs2, vd)) = {
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_half, LMUL_pow_half, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1637,7 +1709,7 @@ function clause execute(VEXT2TYPE(funct6, vm, vs2, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vext2type_mnemonic : vext2funct6 <-> string = {
@@ -1669,7 +1741,7 @@ function clause execute(VEXT4TYPE(funct6, vm, vs2, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_quart, LMUL_pow_quart) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_quart, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1679,7 +1751,10 @@ function clause execute(VEXT4TYPE(funct6, vm, vs2, vd)) = {
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_quart, LMUL_pow_quart, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1693,7 +1768,7 @@ function clause execute(VEXT4TYPE(funct6, vm, vs2, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vext4type_mnemonic : vext4funct6 <-> string = {
@@ -1725,7 +1800,7 @@ function clause execute(VEXT8TYPE(funct6, vm, vs2, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_eighth, LMUL_pow_eighth) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_eighth, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1735,7 +1810,10 @@ function clause execute(VEXT8TYPE(funct6, vm, vs2, vd)) = {
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_eighth, LMUL_pow_eighth, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   assert(SEW > SEW_eighth);
@@ -1750,7 +1828,7 @@ function clause execute(VEXT8TYPE(funct6, vm, vs2, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vext8type_mnemonic : vext8funct6 <-> string = {
@@ -1771,7 +1849,7 @@ function clause execute(VMVXS(vs2, rd)) = {
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   assert(num_elem > 0);
   let 'n = num_elem;
@@ -1783,7 +1861,7 @@ function clause execute(VMVXS(vs2, rd)) = {
           else vs2_val[0];
   set_vstart(zeros());
 
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = VMVXS(vs2, rd)
@@ -1796,7 +1874,10 @@ mapping clause encdec = MVVCOMPRESS(vs2, vs1, vd) if extensionEnabled(Ext_V)
   <-> 0b010111 @ 0b1 @ vs2 @ vs1 @ 0b010 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
 
 function clause execute(MVVCOMPRESS(vs2, vs1, vd)) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   let end_element = get_end_element();
   let SEW = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -1804,7 +1885,7 @@ function clause execute(MVVCOMPRESS(vs2, vs1, vd)) = {
 
   /* vcompress should always be executed with a vstart of 0 */
   if start_element != 0 | vs1 == vd | vs2 == vd | illegal_vd_unmasked()
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1840,7 +1921,7 @@ function clause execute(MVVCOMPRESS(vs2, vs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = MVVCOMPRESS(vs2, vs1, vd)
@@ -1874,7 +1955,7 @@ function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1884,7 +1965,10 @@ function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1911,7 +1995,7 @@ function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
                               slice(result_sub >> 1, 0, 'm) + zero_extend('m, rounding_incr)
                             },
         MVX_VSLIDE1UP    => {
-                              if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
+                              if (vs2 == vd) then return RETIRE_FAIL(Illegal_Instruction());
                               if i == 0 then rs1_val else vs2_val[i - 1]
                             },
         MVX_VSLIDE1DOWN  => {
@@ -1951,7 +2035,7 @@ function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping mvxtype_mnemonic : mvxfunct6 <-> string = {
@@ -1993,7 +2077,7 @@ function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -2003,7 +2087,10 @@ function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -2019,7 +2106,7 @@ function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping mvxmatype_mnemonic : mvxmafunct6 <-> string = {
@@ -2057,7 +2144,7 @@ function clause execute(WVXTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -2068,7 +2155,10 @@ function clause execute(WVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -2087,7 +2177,7 @@ function clause execute(WVXTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping wvxtype_mnemonic : wvxfunct6 <-> string = {
@@ -2124,7 +2214,7 @@ function clause execute(WXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen)
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -2135,7 +2225,10 @@ function clause execute(WXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -2151,7 +2244,7 @@ function clause execute(WXTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping wxtype_mnemonic : wxfunct6 <-> string = {
@@ -2187,7 +2280,7 @@ function clause execute(WMVXTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -2198,7 +2291,10 @@ function clause execute(WMVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -2214,7 +2310,7 @@ function clause execute(WMVXTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping wmvxtype_mnemonic : wmvxfunct6 <-> string = {
@@ -2237,7 +2333,7 @@ function clause execute(VMVSX(rs1, vd)) = {
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   assert(num_elem > 0);
   let 'n = num_elem;
@@ -2247,7 +2343,10 @@ function clause execute(VMVSX(rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar(rs1, 'm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, 0, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, 0, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   /* one body element */
@@ -2264,7 +2363,7 @@ function clause execute(VMVSX(rs1, vd)) = {
 
   write_vreg(num_elem, SEW, 0, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = VMVSX(rs1, vd)

--- a/model/riscv_insts_vext_fp.sail
+++ b/model/riscv_insts_vext_fp.sail
@@ -36,7 +36,7 @@ function clause execute(FVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_normal(vd, vm, SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -47,7 +47,10 @@ function clause execute(FVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -68,7 +71,7 @@ function clause execute(FVVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping fvvtype_mnemonic : fvvfunct6 <-> string = {
@@ -110,7 +113,7 @@ function clause execute(FVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_normal(vd, vm, SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -121,7 +124,10 @@ function clause execute(FVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -141,7 +147,7 @@ function clause execute(FVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping fvvmatype_mnemonic : fvvmafunct6 <-> string = {
@@ -181,7 +187,7 @@ function clause execute(FWVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW >= 16 & SEW_widen <= 64);
 
   let 'n = num_elem;
@@ -193,7 +199,10 @@ function clause execute(FWVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -208,7 +217,7 @@ function clause execute(FWVVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping fwvvtype_mnemonic : fwvvfunct6 <-> string = {
@@ -245,7 +254,7 @@ function clause execute(FWVVMATYPE(funct6, vm, vs1, vs2, vd)) = {
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW >= 16 & SEW_widen <= 64);
 
   let 'n = num_elem;
@@ -257,7 +266,10 @@ function clause execute(FWVVMATYPE(funct6, vm, vs1, vs2, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -273,7 +285,7 @@ function clause execute(FWVVMATYPE(funct6, vm, vs1, vs2, vd)) = {
 
   write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping fwvvmatype_mnemonic : fwvvmafunct6 <-> string = {
@@ -307,7 +319,7 @@ function clause execute(FWVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW >= 16 & SEW_widen <= 64);
 
   let 'n = num_elem;
@@ -319,7 +331,10 @@ function clause execute(FWVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -333,7 +348,7 @@ function clause execute(FWVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping fwvtype_mnemonic : fwvfunct6 <-> string = {
@@ -365,7 +380,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_normal(vd, vm, SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -375,7 +390,10 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -441,7 +459,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vfunary0_mnemonic : vfunary0 <-> string = {
@@ -482,7 +500,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
 
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW >= 8 & SEW_widen <= 64);
 
   let 'n = num_elem;
@@ -493,7 +511,10 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -501,7 +522,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
       result[i] = match vfwunary0 {
         FWV_CVT_XU_F     => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_f16ToUi32(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToUi64(rm_3b, vs2_val[i])
                               };
@@ -510,7 +531,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                             },
         FWV_CVT_X_F      => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_f16ToI32(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToI64(rm_3b, vs2_val[i])
                               };
@@ -537,7 +558,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                             },
         FWV_CVT_F_F      => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_f16ToF32(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToF64(rm_3b, vs2_val[i])
                               };
@@ -546,7 +567,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                             },
         FWV_CVT_RTZ_XU_F => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_f16ToUi32(0b001, vs2_val[i]),
                                 32 => riscv_f32ToUi64(0b001, vs2_val[i])
                               };
@@ -555,7 +576,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                             },
         FWV_CVT_RTZ_X_F  => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_f16ToI32(0b001, vs2_val[i]),
                                 32 => riscv_f32ToI64(0b001, vs2_val[i])
                               };
@@ -568,7 +589,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
 
   write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vfwunary0_mnemonic : vfwunary0 <-> string = {
@@ -611,7 +632,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
 
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 64);
 
   let 'n = num_elem;
@@ -622,7 +643,10 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -648,7 +672,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                             },
         FNV_CVT_F_XU     => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_ui32ToF16(rm_3b, vs2_val[i]),
                                 32 => riscv_ui64ToF32(rm_3b, vs2_val[i])
                               };
@@ -657,7 +681,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                             },
         FNV_CVT_F_X      => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_i32ToF16(rm_3b, vs2_val[i]),
                                 32 => riscv_i64ToF32(rm_3b, vs2_val[i])
                               };
@@ -666,7 +690,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                             },
         FNV_CVT_F_F      => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_f32ToF16(rm_3b, vs2_val[i]),
                                 32 => riscv_f64ToF32(rm_3b, vs2_val[i])
                               };
@@ -675,7 +699,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                             },
         FNV_CVT_ROD_F_F  => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_f32ToF16(0b110, vs2_val[i]),
                                 32 => riscv_f64ToF32(0b110, vs2_val[i])
                               };
@@ -706,7 +730,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vfnunary0_mnemonic : vfnunary0 <-> string = {
@@ -742,7 +766,7 @@ function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_normal(vd, vm, SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -752,7 +776,10 @@ function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -792,7 +819,7 @@ function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vfunary1_mnemonic : vfunary1 <-> string = {
@@ -817,7 +844,7 @@ function clause execute(VFMVFS(vs2, rd)) = {
   let num_elem = get_num_elem(0, SEW);
 
   if illegal_fp_vd_unmasked(SEW, rm_3b) | SEW > flen
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(num_elem > 0 & SEW != 8);
 
   let 'n = num_elem;
@@ -831,7 +858,7 @@ function clause execute(VFMVFS(vs2, rd)) = {
   };
   set_vstart(zeros());
 
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = VFMVFS(vs2, rd)
@@ -865,7 +892,7 @@ function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_normal(vd, vm, SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -876,7 +903,10 @@ function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -894,7 +924,7 @@ function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
         VF_VSGNJN        => (0b1 ^ [rs1_val['m - 1]]) @ vs2_val[i][('m - 2)..0],
         VF_VSGNJX        => ([vs2_val[i]['m - 1]] ^ [rs1_val['m - 1]]) @ vs2_val[i][('m - 2)..0],
         VF_VSLIDE1UP     => {
-                              if vs2 == vd then { handle_illegal(); return RETIRE_FAIL };
+                              if vs2 == vd then return RETIRE_FAIL(Illegal_Instruction());
                               if i == 0 then rs1_val else vs2_val[i - 1]
                             },
         VF_VSLIDE1DOWN   => {
@@ -908,7 +938,7 @@ function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping fvftype_mnemonic : fvffunct6 <-> string = {
@@ -954,7 +984,7 @@ function clause execute(FVFMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_normal(vd, vm, SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -965,7 +995,10 @@ function clause execute(FVFMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -985,7 +1018,7 @@ function clause execute(FVFMATYPE(funct6, vm, vs2, rs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping fvfmatype_mnemonic : fvfmafunct6 <-> string = {
@@ -1024,7 +1057,7 @@ function clause execute(FWVFTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW >= 16 & SEW_widen <= 64);
 
   let 'n = num_elem;
@@ -1036,7 +1069,10 @@ function clause execute(FWVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1051,7 +1087,7 @@ function clause execute(FWVFTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping fwvftype_mnemonic : fwvffunct6 <-> string = {
@@ -1087,7 +1123,7 @@ function clause execute(FWVFMATYPE(funct6, vm, rs1, vs2, vd)) = {
 
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW >= 16 & SEW_widen <= 64);
 
   let 'n = num_elem;
@@ -1099,7 +1135,10 @@ function clause execute(FWVFMATYPE(funct6, vm, rs1, vs2, vd)) = {
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1115,7 +1154,7 @@ function clause execute(FWVFMATYPE(funct6, vm, rs1, vs2, vd)) = {
 
   write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping fwvfmatype_mnemonic : fwvfmafunct6 <-> string = {
@@ -1148,7 +1187,7 @@ function clause execute(FWFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen)
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW >= 16 & SEW_widen <= 64);
 
   let 'n = num_elem;
@@ -1160,7 +1199,10 @@ function clause execute(FWFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1174,7 +1216,7 @@ function clause execute(FWFTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping fwftype_mnemonic : fwffunct6 <-> string = {
@@ -1194,14 +1236,17 @@ mapping clause encdec = VFMERGE(vs2, rs1, vd) if extensionEnabled(Ext_V)
 
 function clause execute(VFMERGE(vs2, rs1, vd)) = {
   let rm_3b         = fcsr[FRM];
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   let end_element   = get_end_element();
   let SEW           = get_sew();
   let LMUL_pow      = get_lmul_pow();
   let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
 
-  if illegal_fp_vd_masked(vd, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_vd_masked(vd, SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -1230,7 +1275,7 @@ function clause execute(VFMERGE(vs2, rs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = VFMERGE(vs2, rs1, vd)
@@ -1249,7 +1294,7 @@ function clause execute(VFMV(rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_vd_unmasked(SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_vd_unmasked(SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -1259,7 +1304,10 @@ function clause execute(VFMV(rs1, vd)) = {
   let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, 0b00000);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1268,7 +1316,7 @@ function clause execute(VFMV(rs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = VFMV(rs1, vd)
@@ -1285,7 +1333,7 @@ function clause execute(VFMVSF(rs1, vd)) = {
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
-  if illegal_fp_vd_unmasked(SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_vd_unmasked(SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(num_elem > 0 & SEW != 8);
 
   let 'n = num_elem;
@@ -1295,7 +1343,10 @@ function clause execute(VFMVSF(rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, 0, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, 0, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   /* one body element */
@@ -1312,7 +1363,7 @@ function clause execute(VFMVSF(rs1, vd)) = {
 
   write_vreg(num_elem, SEW, 0, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = VFMVSF(rs1, vd)

--- a/model/riscv_insts_vext_fp_red.sail
+++ b/model/riscv_insts_vext_fp_red.sail
@@ -26,15 +26,15 @@ mapping encdec_rfvvfunct6 : rfvvfunct6 <-> bits(6) = {
 mapping clause encdec = RFVVTYPE(funct6, vm, vs2, vs1, vd) if extensionEnabled(Ext_V)
   <-> encdec_rfvvfunct6(funct6) @ vm @ vs2 @ vs1 @ 0b001 @ vd @ 0b1010111 if extensionEnabled(Ext_V)
 
-val process_rfvv_single: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), regidx, regidx, regidx, int('n), int('m), int('p)) -> Retired
+val process_rfvv_single: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), regidx, regidx, regidx, int('n), int('m), int('p)) -> Retired(Retire_Failure)
 function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {
   let rm_3b = fcsr[FRM];
   let num_elem_vd = get_num_elem(0, SEW); /* vd regardless of LMUL setting */
 
-  if illegal_fp_reduction(SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_reduction(SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
-  if unsigned(vl) == 0 then return RETIRE_SUCCESS; /* if vl=0, no operation is performed */
+  if unsigned(vl) == 0 then return RETIRE_SUCCESS(); /* if vl=0, no operation is performed */
 
   let 'n = num_elem_vs;
   let 'd = num_elem_vd;
@@ -43,7 +43,10 @@ function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_po
   let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, 0b00000);
   let vd_val  : vector('d, bits('m)) = read_vreg(num_elem_vd, SEW, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
-  let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
+  let mask    : bits('n)     = match init_masked_source(num_elem_vs, LMUL_pow, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   var sum : bits('m) = read_single_element(SEW, 0, vs1); /* vs1 regardless of LMUL setting */
   foreach (i from 0 to (num_elem_vs - 1)) {
@@ -63,20 +66,20 @@ function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_po
   /* other elements in vd are treated as tail elements, currently remain unchanged */
   /* TODO: configuration support for agnostic behavior */
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
-val process_rfvv_widen: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), regidx, regidx, regidx, int('n), int('m), int('p)) -> Retired
+val process_rfvv_widen: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), regidx, regidx, regidx, int('n), int('m), int('p)) -> Retired(Retire_Failure)
 function process_rfvv_widen(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {
   let rm_3b          = fcsr[FRM];
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
   let num_elem_vd = get_num_elem(0, SEW_widen); /* vd regardless of LMUL setting */
 
-  if illegal_fp_reduction_widen(SEW, rm_3b, SEW_widen, LMUL_pow_widen) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_reduction_widen(SEW, rm_3b, SEW_widen, LMUL_pow_widen) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW >= 16 & SEW_widen <= 64);
 
-  if unsigned(vl) == 0 then return RETIRE_SUCCESS; /* if vl=0, no operation is performed */
+  if unsigned(vl) == 0 then return RETIRE_SUCCESS(); /* if vl=0, no operation is performed */
 
   let 'n = num_elem_vs;
   let 'd = num_elem_vd;
@@ -86,7 +89,10 @@ function process_rfvv_widen(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow
   let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, 0b00000);
   let vd_val  : vector('d, bits('o)) = read_vreg(num_elem_vd, SEW_widen, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
-  let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
+  let mask    : bits('n)     = match init_masked_source(num_elem_vs, LMUL_pow, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   var sum : bits('o) = read_single_element(SEW_widen, 0, vs1); /* vs1 regardless of LMUL setting */
   foreach (i from 0 to (num_elem_vs - 1)) {
@@ -100,7 +106,7 @@ function process_rfvv_widen(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow
   /* other elements in vd are treated as tail elements, currently remain unchanged */
   /* TODO: configuration support for agnostic behavior */
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute(RFVVTYPE(funct6, vm, vs2, vs1, vd)) = {

--- a/model/riscv_insts_vext_fp_vm.sail
+++ b/model/riscv_insts_vext_fp_vm.sail
@@ -31,7 +31,7 @@ function clause execute(FVVMTYPE(funct6, vm, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_vd_unmasked(SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_vd_unmasked(SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -42,7 +42,10 @@ function clause execute(FVVMTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -59,7 +62,7 @@ function clause execute(FVVMTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   write_vmask(num_elem, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping fvvmtype_mnemonic : fvvmfunct6 <-> string = {
@@ -94,7 +97,7 @@ function clause execute(FVFMTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_vd_unmasked(SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_vd_unmasked(SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -105,7 +108,10 @@ function clause execute(FVFMTYPE(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -124,7 +130,7 @@ function clause execute(FVFMTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   write_vmask(num_elem, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping fvfmtype_mnemonic : fvfmfunct6 <-> string = {

--- a/model/riscv_insts_vext_mask.sail
+++ b/model/riscv_insts_vext_mask.sail
@@ -33,7 +33,7 @@ function clause execute(MMTYPE(funct6, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = VLEN;
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -42,7 +42,10 @@ function clause execute(MMTYPE(funct6, vs2, vs1, vd)) = {
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, 0, vd_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, 0, vd_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -62,7 +65,7 @@ function clause execute(MMTYPE(funct6, vs2, vs1, vd)) = {
 
   write_vmask(num_elem, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping mmtype_mnemonic : mmfunct6 <-> string = {
@@ -90,7 +93,7 @@ function clause execute(VCPOP_M(vm, vs2, rd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = VLEN;
 
-  if illegal_vd_unmasked() | not(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() | not(assert_vstart(0)) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -98,7 +101,10 @@ function clause execute(VCPOP_M(vm, vs2, rd)) = {
   let vm_val  : bits('n) = read_vmask(num_elem, vm, 0b00000);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
 
-  let (_, mask) = init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val);
+  let (_, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   var count : nat = 0;
   foreach (i from 0 to (num_elem - 1)) {
@@ -107,7 +113,7 @@ function clause execute(VCPOP_M(vm, vs2, rd)) = {
 
   X(rd) = to_bits(xlen, count);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = VCPOP_M(vm, vs2, rd)
@@ -124,7 +130,7 @@ function clause execute(VFIRST_M(vm, vs2, rd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = VLEN;
 
-  if illegal_vd_unmasked() | not(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() | not(assert_vstart(0)) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -132,7 +138,10 @@ function clause execute(VFIRST_M(vm, vs2, rd)) = {
   let vm_val  : bits('n) = read_vmask(num_elem, vm, 0b00000);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
 
-  let (_, mask) = init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val);
+  let (_, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   var index : int = -1;
   foreach (i from 0 to (num_elem - 1)) {
@@ -143,7 +152,7 @@ function clause execute(VFIRST_M(vm, vs2, rd)) = {
 
   X(rd) = to_bits(xlen, index);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = VFIRST_M(vm, vs2, rd)
@@ -161,7 +170,7 @@ function clause execute(VMSBF_M(vm, vs2, vd)) = {
   let num_elem = VLEN;
 
   if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -170,7 +179,10 @@ function clause execute(VMSBF_M(vm, vs2, vd)) = {
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   var found_elem : bool = false;
@@ -183,7 +195,7 @@ function clause execute(VMSBF_M(vm, vs2, vd)) = {
 
   write_vmask(num_elem, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = VMSBF_M(vm, vs2, vd)
@@ -201,7 +213,7 @@ function clause execute(VMSIF_M(vm, vs2, vd)) = {
   let num_elem = VLEN;
 
   if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -210,7 +222,10 @@ function clause execute(VMSIF_M(vm, vs2, vd)) = {
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   var found_elem : bool = false;
@@ -223,7 +238,7 @@ function clause execute(VMSIF_M(vm, vs2, vd)) = {
 
   write_vmask(num_elem, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = VMSIF_M(vm, vs2, vd)
@@ -241,7 +256,7 @@ function clause execute(VMSOF_M(vm, vs2, vd)) = {
   let num_elem = VLEN;
 
   if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -250,7 +265,10 @@ function clause execute(VMSOF_M(vm, vs2, vd)) = {
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   var found_elem : bool = false;
@@ -267,7 +285,7 @@ function clause execute(VMSOF_M(vm, vs2, vd)) = {
 
   write_vmask(num_elem, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = VMSOF_M(vm, vs2, vd)
@@ -285,7 +303,7 @@ function clause execute(VIOTA_M(vm, vs2, vd)) = {
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -294,7 +312,10 @@ function clause execute(VIOTA_M(vm, vs2, vd)) = {
   let vs2_val : bits('n)     = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   var sum : int = 0;
@@ -307,7 +328,7 @@ function clause execute(VIOTA_M(vm, vs2, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = VIOTA_M(vm, vs2, vd)
@@ -324,7 +345,7 @@ function clause execute(VID_V(vm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -332,7 +353,10 @@ function clause execute(VID_V(vm, vd)) = {
   let vm_val  : bits('n)     = read_vmask(num_elem, vm, 0b00000);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)    => v,
+    Err(())  => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -341,7 +365,7 @@ function clause execute(VID_V(vm, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = VID_V(vm, vd)

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -67,14 +67,19 @@ union clause ast = VLSEGTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
 mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd) if extensionEnabled(Ext_V)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if extensionEnabled(Ext_V)
 
-val process_vlseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired
+val process_vlseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired(Retire_Failure)
 function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val : bits('n) = read_vmask(num_elem, vm, 0b00000);
   let vd_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
 
-  let (result, mask) = init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val);
+  let 'n = num_elem;
+  let 'm = nf * load_width_bytes * 8;
+  let (result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then { /* active segments */
@@ -82,16 +87,16 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = (i * nf + j) * load_width_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+          Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
               if check_misaligned(vaddr, width_type)
-              then { handle_mem_exception(vaddr, E_Load_Addr_Align()); return RETIRE_FAIL }
+              then return RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
               else match translateAddr(vaddr, Read(Data)) {
-                TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                 TR_Address(paddr, _) => {
                   match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
                     Ok(elem) => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j * EMUL_reg), elem),
-                    Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                    Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                   }
                 }
               }
@@ -106,7 +111,7 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
   };
 
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute(VLSEGTYPE(nf, vm, rs1, width, vd)) = {
@@ -121,7 +126,7 @@ function clause execute(VLSEGTYPE(nf, vm, rs1, width, vd)) = {
 
   assert(num_elem > 0);
 
-  if illegal_load(vd, vm, nf_int, EEW, EMUL_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_load(vd, vm, nf_int, EEW, EMUL_pow) then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vlseg(nf_int, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -135,7 +140,7 @@ union clause ast = VLSEGFFTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
 mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd) if extensionEnabled(Ext_V)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b10000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if extensionEnabled(Ext_V)
 
-val process_vlsegff : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired
+val process_vlsegff : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired(Retire_Failure)
 function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
@@ -143,7 +148,12 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
   let vd_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
   let tail_ag : agtype = get_vtype_vta();
 
-  let (result, mask) = init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val);
+  let 'n = num_elem;
+  let 'm = nf * load_width_bytes * 8;
+  let (result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   var trimmed : bool = false;
   foreach (i from 0 to (num_elem - 1)) {
@@ -153,7 +163,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
           let elem_offset = (i * nf + j) * load_width_bytes;
           match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
             Ext_DataAddr_Error(e)  => {
-              if i == 0 then { ext_handle_data_check_error(e); return RETIRE_FAIL }
+              if i == 0 then return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e))
               else {
                 vl = to_bits(xlen, i);
                 print_reg("CSR vl <- " ^ BitStr(vl));
@@ -162,7 +172,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
             },
             Ext_DataAddr_OK(vaddr) => {
               if check_misaligned(vaddr, width_type) then {
-                if i == 0 then { handle_mem_exception(vaddr, E_Load_Addr_Align()); return RETIRE_FAIL }
+                if i == 0 then return RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
                 else {
                   vl = to_bits(xlen, i);
                   print_reg("CSR vl <- " ^ BitStr(vl));
@@ -170,7 +180,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
                 }
               } else match translateAddr(vaddr, Read(Data)) {
                 TR_Failure(e, _)     => {
-                  if i == 0 then { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                  if i == 0 then return RETIRE_FAIL(Memory_Exception(vaddr, e))
                   else {
                     vl = to_bits(xlen, i);
                     print_reg("CSR vl <- " ^ BitStr(vl));
@@ -181,7 +191,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
                   match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
                     Ok(elem) => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j * EMUL_reg), elem),
                     Err(e)   => {
-                      if i == 0 then { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                      if i == 0 then return RETIRE_FAIL(Memory_Exception(vaddr, e))
                       else {
                         vl = to_bits(xlen, i);
                         print_reg("CSR vl <- " ^ BitStr(vl));
@@ -213,7 +223,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
   };
 
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute(VLSEGFFTYPE(nf, vm, rs1, width, vd)) = {
@@ -228,7 +238,7 @@ function clause execute(VLSEGFFTYPE(nf, vm, rs1, width, vd)) = {
 
   assert(num_elem > 0);
 
-  if illegal_load(vd, vm, nf_int, EEW, EMUL_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_load(vd, vm, nf_int, EEW, EMUL_pow) then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vlsegff(nf_int, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -242,13 +252,18 @@ union clause ast = VSSEGTYPE : (bits(3), bits(1), regidx, vlewidth, regidx)
 mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3) if extensionEnabled(Ext_V)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111 if extensionEnabled(Ext_V)
 
-val process_vsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired
+val process_vsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, int('p), int('n)) -> Retired(Retire_Failure)
 function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val  : bits('n) = read_vmask(num_elem, vm, 0b00000);
   let vs3_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
-  let mask    : bits('n) = init_masked_source(num_elem, EMUL_pow, vm_val);
+
+  let 'n = num_elem;
+  let mask : bits('n) = match init_masked_source(num_elem, EMUL_pow, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then { /* active segments */
@@ -256,23 +271,23 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = (i * nf + j) * load_width_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), load_width_bytes) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+          Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); return RETIRE_FAIL }
+            then return RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
             else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+              TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
               TR_Address(paddr, _) => {
                 let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
                 match (eares) {
-                  Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                  Err(e) => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                   Ok(_)  => {
                     let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vs3 + to_bits(5, j * EMUL_reg));
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, elem_val, false, false, false);
                     match (res) {
                       Ok(true)  => (),
                       Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                      Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                      Err(e)    => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                     }
                   }
                 }
@@ -284,7 +299,7 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
   };
 
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute(VSSEGTYPE(nf, vm, rs1, width, vs3)) = {
@@ -299,7 +314,7 @@ function clause execute(VSSEGTYPE(nf, vm, rs1, width, vs3)) = {
 
   assert(num_elem > 0);
 
-  if illegal_store(nf_int, EEW, EMUL_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_store(nf_int, EEW, EMUL_pow) then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vsseg(nf_int, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -313,7 +328,7 @@ union clause ast = VLSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, reg
 mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd) if extensionEnabled(Ext_V)
   <-> nf @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if extensionEnabled(Ext_V)
 
-val process_vlsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired
+val process_vlsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired(Retire_Failure)
 function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
@@ -321,7 +336,12 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
   let vd_seg  : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
   let rs2_val : int = unsigned(get_scalar(rs2, xlen));
 
-  let (result, mask) = init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val);
+  let 'n = num_elem;
+  let 'm = nf * load_width_bytes * 8;
+  let (result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then { /* active segments */
@@ -329,16 +349,16 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = i * rs2_val + j * load_width_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+          Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); return RETIRE_FAIL }
+            then return RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
             else match translateAddr(vaddr, Read(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+              TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
                   Ok(elem) => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j * EMUL_reg), elem),
-                  Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                  Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                 }
               }
             }
@@ -353,7 +373,7 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
   };
 
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute(VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)) = {
@@ -368,7 +388,7 @@ function clause execute(VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)) = {
 
   assert(num_elem > 0);
 
-  if illegal_load(vd, vm, nf_int, EEW, EMUL_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_load(vd, vm, nf_int, EEW, EMUL_pow) then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vlsseg(nf_int, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
@@ -382,14 +402,19 @@ union clause ast = VSSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, reg
 mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3) if extensionEnabled(Ext_V)
   <-> nf @ 0b0 @ 0b10 @ vm @ rs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111 if extensionEnabled(Ext_V)
 
-val process_vssseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired
+val process_vssseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('b), regidx, regidx, int('p), int('n)) -> Retired(Retire_Failure)
 function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val  : bits('n) = read_vmask(num_elem, vm, 0b00000);
   let vs3_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
   let rs2_val : int = unsigned(get_scalar(rs2, xlen));
-  let mask    : bits('n) = init_masked_source(num_elem, EMUL_pow, vm_val);
+
+  let 'n = num_elem;
+  let mask : bits('n) = match init_masked_source(num_elem, EMUL_pow, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then { /* active segments */
@@ -397,23 +422,23 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = i * rs2_val + j * load_width_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), load_width_bytes) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+          Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); return RETIRE_FAIL }
+            then return RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
             else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+              TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
               TR_Address(paddr, _) => {
                 let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
                 match (eares) {
-                  Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                  Err(e) => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                   Ok(_)  => {
                     let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vs3 + to_bits(5, j * EMUL_reg));
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, elem_val, false, false, false);
                     match (res) {
                       Ok(true)  => (),
                       Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                      Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                      Err(e)    => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                     }
                   }
                 }
@@ -425,7 +450,7 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
   };
 
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute(VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)) = {
@@ -440,7 +465,7 @@ function clause execute(VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)) = {
 
   assert(num_elem > 0);
 
-  if illegal_store(nf_int, EEW, EMUL_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_store(nf_int, EEW, EMUL_pow) then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vssseg(nf_int, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
@@ -454,7 +479,7 @@ union clause ast = VLUXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, re
 mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd) if extensionEnabled(Ext_V)
   <-> nf @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if extensionEnabled(Ext_V)
 
-val process_vlxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired
+val process_vlxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired(Retire_Failure)
 function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
   let width_type : word_width = size_bytes(EEW_data_bytes);
@@ -462,7 +487,12 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
   let vd_seg  : vector('n, bits('f * 'db * 8)) = read_vreg_seg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, nf, vd);
   let vs2_val : vector('n, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
 
-  let (result, mask) = init_masked_result(num_elem, nf * EEW_data_bytes * 8, EMUL_data_pow, vd_seg, vm_val);
+  let 'n = num_elem;
+  let 'm = nf * EEW_data_bytes * 8;
+  let (result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, nf * EEW_data_bytes * 8, EMUL_data_pow, vd_seg, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   /* currently mop = 1 (unordered) or 3 (ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
@@ -471,16 +501,16 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
       foreach (j from 0 to (nf - 1)) {
         let elem_offset : int = unsigned(vs2_val[i]) + j * EEW_data_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), EEW_data_bytes) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+          Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); return RETIRE_FAIL }
+            then return RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
             else match translateAddr(vaddr, Read(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+              TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, EEW_data_bytes, false, false, false) {
                   Ok(elem) => write_single_element(EEW_data_bytes * 8, i, vd + to_bits(5, j * EMUL_data_reg), elem),
-                  Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                  Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                 }
               }
             }
@@ -495,7 +525,7 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
   };
 
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute(VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
@@ -510,7 +540,8 @@ function clause execute(VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
 
   assert(num_elem > 0);
 
-  if illegal_indexed_load(vd, vm, nf_int, EEW_index_bytes * 8, EMUL_index_pow, EMUL_data_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_indexed_load(vd, vm, nf_int, EEW_index_bytes * 8, EMUL_index_pow, EMUL_data_pow)
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vlxseg(nf_int, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
@@ -536,7 +567,8 @@ function clause execute(VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
 
   assert(num_elem > 0);
 
-  if illegal_indexed_load(vd, vm, nf_int, EEW_index_bytes * 8, EMUL_index_pow, EMUL_data_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_indexed_load(vd, vm, nf_int, EEW_index_bytes * 8, EMUL_index_pow, EMUL_data_pow)
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vlxseg(nf_int, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
@@ -550,14 +582,19 @@ union clause ast = VSUXSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, re
 mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3) if extensionEnabled(Ext_V)
   <-> nf @ 0b0 @ 0b01 @ vm @ vs2 @ rs1 @ encdec_vlewidth(width) @ vs3 @ 0b0100111 if extensionEnabled(Ext_V)
 
-val process_vsxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired
+val process_vsxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), regidx, int('ib), int('db), int('ip), int('dp), regidx, regidx, int('n), int) -> Retired(Retire_Failure)
 function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
   let width_type : word_width = size_bytes(EEW_data_bytes);
   let vm_val  : bits('n) = read_vmask(num_elem, vm, 0b00000);
   let vs3_seg : vector('n, bits('f * 'db * 8)) = read_vreg_seg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, nf, vs3);
   let vs2_val : vector('n, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
-  let mask    : bits('n) = init_masked_source(num_elem, EMUL_data_pow, vm_val);
+
+  let 'n = num_elem;
+  let mask : bits('n) = match init_masked_source(num_elem, EMUL_data_pow, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   /* currently mop = 1 (unordered) or 3 (ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
@@ -566,23 +603,23 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
       foreach (j from 0 to (nf - 1)) {
         let elem_offset : int = unsigned(vs2_val[i]) + j * EEW_data_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), EEW_data_bytes) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+          Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); return RETIRE_FAIL }
+            then return RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
             else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+              TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
               TR_Address(paddr, _) => {
                 let eares : MemoryOpResult(unit) = mem_write_ea(paddr, EEW_data_bytes, false, false, false);
                 match (eares) {
-                  Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                  Err(e) => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                   Ok(_)  => {
                     let elem_val : bits('db * 8) = read_single_element(EEW_data_bytes * 8, i, vs3 + to_bits(5, j * EMUL_data_reg));
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, EEW_data_bytes, elem_val, false, false, false);
                     match (res) {
                       Ok(true)  => (),
                       Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                      Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                      Err(e)    => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                     }
                   }
                 }
@@ -594,7 +631,7 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
   };
 
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute(VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
@@ -609,7 +646,8 @@ function clause execute(VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
 
   assert(num_elem > 0);
 
-  if illegal_indexed_store(nf_int, EEW_index_bytes * 8, EMUL_index_pow, EMUL_data_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_indexed_store(nf_int, EEW_index_bytes * 8, EMUL_index_pow, EMUL_data_pow)
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vsxseg(nf_int, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
@@ -635,7 +673,8 @@ function clause execute(VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
 
   assert(num_elem > 0);
 
-  if illegal_indexed_store(nf_int, EEW_index_bytes * 8, EMUL_index_pow, EMUL_data_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_indexed_store(nf_int, EEW_index_bytes * 8, EMUL_index_pow, EMUL_data_pow)
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vsxseg(nf_int, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
@@ -649,11 +688,14 @@ union clause ast = VLRETYPE : (bits(3), regidx, vlewidth, regidx)
 mapping clause encdec = VLRETYPE(nf, rs1, width, vd) if extensionEnabled(Ext_V)
   <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ rs1 @ encdec_vlewidth(width) @ vd @ 0b0000111 if extensionEnabled(Ext_V)
 
-val process_vlre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), regidx, int('b), regidx, int('n)) -> Retired
+val process_vlre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), regidx, int('b), regidx, int('n)) -> Retired(Retire_Failure)
 function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
   let width_type : word_width = size_bytes(load_width_bytes);
-  let start_element = get_start_element();
-  if start_element >= nf * elem_per_reg then return RETIRE_SUCCESS; /* no elements are written if vstart >= evl */
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
+  if start_element >= nf * elem_per_reg then return RETIRE_SUCCESS(); /* no elements are written if vstart >= evl */
   let elem_to_align : int = start_element % elem_per_reg;
   var cur_field : int = start_element / elem_per_reg;
   var cur_elem  : int = start_element;
@@ -663,16 +705,16 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+        Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
         Ext_DataAddr_OK(vaddr) =>
           if check_misaligned(vaddr, width_type)
-          then { handle_mem_exception(vaddr, E_Load_Addr_Align()); return RETIRE_FAIL }
+          then return RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
           else match translateAddr(vaddr, Read(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+            TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
             TR_Address(paddr, _) => {
               match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
                 Ok(elem) => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, cur_field), elem),
-                Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
               }
             }
           }
@@ -687,16 +729,16 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+        Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
         Ext_DataAddr_OK(vaddr) =>
           if check_misaligned(vaddr, width_type)
-          then { handle_mem_exception(vaddr, E_Load_Addr_Align()); return RETIRE_FAIL }
+          then return RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
           else match translateAddr(vaddr, Read(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+            TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
             TR_Address(paddr, _) => {
               match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
                 Ok(elem) => write_single_element(load_width_bytes * 8, i, vd + to_bits(5, j), elem),
-                Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
               }
             }
           }
@@ -706,7 +748,7 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
   };
 
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute(VLRETYPE(nf, rs1, width, vd)) = {
@@ -716,7 +758,7 @@ function clause execute(VLRETYPE(nf, rs1, width, vd)) = {
   let nf_int = nfields_int(nf);
 
   assert(elem_per_reg >= 0);
-  if not(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then { handle_illegal(); return RETIRE_FAIL };
+  if not(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vlre(nf_int, vd, load_width_bytes, rs1, elem_per_reg)
 }
@@ -730,11 +772,14 @@ union clause ast = VSRETYPE : (bits(3), regidx, regidx)
 mapping clause encdec = VSRETYPE(nf, rs1, vs3) if extensionEnabled(Ext_V)
   <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ rs1 @ 0b000 @ vs3 @ 0b0100111 if extensionEnabled(Ext_V)
 
-val process_vsre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), int('b), regidx, regidx, int('n)) -> Retired
+val process_vsre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), int('b), regidx, regidx, int('n)) -> Retired(Retire_Failure)
 function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
   let width_type : word_width = BYTE;
-  let start_element = get_start_element();
-  if start_element >= nf * elem_per_reg then return RETIRE_SUCCESS; /* no elements are written if vstart >= evl */
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
+  if start_element >= nf * elem_per_reg then return RETIRE_SUCCESS(); /* no elements are written if vstart >= evl */
   let elem_to_align : int = start_element % elem_per_reg;
   var cur_field : int = start_element / elem_per_reg;
   var cur_elem  : int = start_element;
@@ -744,23 +789,23 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset : int = cur_elem * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), load_width_bytes) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+        Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
         Ext_DataAddr_OK(vaddr) =>
           if check_misaligned(vaddr, width_type)
-          then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); return RETIRE_FAIL }
+          then return RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
           else match translateAddr(vaddr, Write(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+            TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
             TR_Address(paddr, _) => {
               let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
               match (eares) {
-                Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                Err(e) => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                 Ok(_)  => {
                   let elem : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vs3 + to_bits(5, cur_field));
                   let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, elem, false, false, false);
                   match (res) {
                     Ok(true)  => (),
                     Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                    Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                    Err(e)    => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                   }
                 }
               }
@@ -778,22 +823,22 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), load_width_bytes) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+        Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
         Ext_DataAddr_OK(vaddr) =>
           if check_misaligned(vaddr, width_type)
-          then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); return RETIRE_FAIL }
+          then return RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
           else match translateAddr(vaddr, Write(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+            TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
             TR_Address(paddr, _) => {
               let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
               match (eares) {
-                Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                Err(e) => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                 Ok(_)  => {
                   let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, vs3_val[i], false, false, false);
                   match (res) {
                     Ok(true)  => (),
                     Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                    Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                    Err(e)    => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                   }
                 }
               }
@@ -805,7 +850,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
   };
 
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute(VSRETYPE(nf, rs1, vs3)) = {
@@ -815,7 +860,7 @@ function clause execute(VSRETYPE(nf, rs1, vs3)) = {
   let nf_int = nfields_int(nf);
 
   assert(elem_per_reg >= 0);
-  if not(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then { handle_illegal(); return RETIRE_FAIL };
+  if not(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vsre(nf_int, load_width_bytes, rs1, vs3, elem_per_reg)
 }
@@ -834,10 +879,13 @@ mapping encdec_lsop : vmlsop <-> bits(7) = {
 mapping clause encdec = VMTYPE(rs1, vd_or_vs3, op) if extensionEnabled(Ext_V)
   <-> 0b000 @ 0b0 @ 0b00 @ 0b1 @ 0b01011 @ rs1 @ 0b000 @ vd_or_vs3 @ encdec_lsop(op) if extensionEnabled(Ext_V)
 
-val process_vm : forall 'n 'l, ('n >= 0 & 'l >= 0). (regidx, regidx, int('n), int('l), vmlsop) -> Retired
+val process_vm : forall 'n 'l, ('n >= 0 & 'l >= 0). (regidx, regidx, int('n), int('l), vmlsop) -> Retired(Retire_Failure)
 function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
   let width_type : word_width = BYTE;
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   let vd_or_vs3_val : vector('n, bits(8)) = read_vreg(num_elem, 8, 0, vd_or_vs3);
 
   foreach (i from start_element to (num_elem - 1)) {
@@ -845,38 +893,38 @@ function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
       set_vstart(to_bits(16, i));
       if op == VLM then { /* load */
         match ext_data_get_addr(rs1, to_bits(xlen, i), Read(Data), 1) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+          Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); return RETIRE_FAIL }
+            then return RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
             else match translateAddr(vaddr, Read(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+              TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, 1, false, false, false) {
                   Ok(elem) => write_single_element(8, i, vd_or_vs3, elem),
-                  Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                  Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                 }
               }
             }
         }
       } else if op == VSM then { /* store */
         match ext_data_get_addr(rs1, to_bits(xlen, i), Write(Data), 1) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+          Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); return RETIRE_FAIL }
+            then return RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
             else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+              TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
               TR_Address(paddr, _) => {
                 let eares : MemoryOpResult(unit) = mem_write_ea(paddr, 1, false, false, false);
                 match (eares) {
-                  Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                  Err(e) => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                   Ok(_)  => {
                     let res : MemoryOpResult(bool) = mem_write_value(paddr, 1, vd_or_vs3_val[i], false, false, false);
                     match (res) {
                       Ok(true)  => (),
                       Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                      Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                      Err(e)    => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                     }
                   }
                 }
@@ -893,7 +941,7 @@ function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
   };
 
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute(VMTYPE(rs1, vd_or_vs3, op)) = {
@@ -903,7 +951,7 @@ function clause execute(VMTYPE(rs1, vd_or_vs3, op)) = {
   let evl : int = if vl_val % 8 == 0 then vl_val / 8 else vl_val / 8 + 1; /* the effective vector length is evl=ceil(vl/8) */
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   assert(evl >= 0);
   process_vm(vd_or_vs3, rs1, num_elem, evl, op)

--- a/model/riscv_insts_vext_red.sail
+++ b/model/riscv_insts_vext_red.sail
@@ -30,9 +30,9 @@ function clause execute(RIVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let num_elem_vs = get_num_elem(LMUL_pow, SEW);
   let num_elem_vd = get_num_elem(0, SEW_widen); /* vd regardless of LMUL setting */
 
-  if illegal_reduction_widen(SEW_widen, LMUL_pow_widen) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_reduction_widen(SEW_widen, LMUL_pow_widen) then return RETIRE_FAIL(Illegal_Instruction());
 
-  if unsigned(vl) == 0 then return RETIRE_SUCCESS; /* if vl=0, no operation is performed */
+  if unsigned(vl) == 0 then return RETIRE_SUCCESS(); /* if vl=0, no operation is performed */
 
   let 'n = num_elem_vs;
   let 'd = num_elem_vd;
@@ -42,7 +42,10 @@ function clause execute(RIVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, 0b00000);
   let vd_val  : vector('d, bits('o)) = read_vreg(num_elem_vd, SEW_widen, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
-  let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
+  let mask    : bits('n)     = match init_masked_source(num_elem_vs, LMUL_pow, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   var sum : bits('o) = read_single_element(SEW_widen, 0, vs1); /* vs1 regardless of LMUL setting */
   foreach (i from 0 to (num_elem_vs - 1)) {
@@ -59,7 +62,7 @@ function clause execute(RIVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   /* other elements in vd are treated as tail elements, currently remain unchanged */
   /* TODO: configuration support for agnostic behavior */
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping rivvtype_mnemonic : rivvfunct6 <-> string = {
@@ -93,9 +96,9 @@ function clause execute(RMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let num_elem_vs = get_num_elem(LMUL_pow, SEW);
   let num_elem_vd = get_num_elem(0, SEW); /* vd regardless of LMUL setting */
 
-  if illegal_reduction() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_reduction() then return RETIRE_FAIL(Illegal_Instruction());
 
-  if unsigned(vl) == 0 then return RETIRE_SUCCESS; /* if vl=0, no operation is performed */
+  if unsigned(vl) == 0 then return RETIRE_SUCCESS(); /* if vl=0, no operation is performed */
 
   let 'n = num_elem_vs;
   let 'd = num_elem_vd;
@@ -104,7 +107,10 @@ function clause execute(RMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, 0b00000);
   let vd_val  : vector('d, bits('m)) = read_vreg(num_elem_vd, SEW, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
-  let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
+  let mask    : bits('n)     = match init_masked_source(num_elem_vs, LMUL_pow, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   var sum : bits('m) = read_single_element(SEW, 0, vs1); /* vs1 regardless of LMUL setting */
   foreach (i from 0 to (num_elem_vs - 1)) {
@@ -126,7 +132,7 @@ function clause execute(RMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   /* other elements in vd are treated as tail elements, currently remain unchanged */
   /* TODO: configuration support for agnostic behavior */
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping rmvvtype_mnemonic : rmvvfunct6 <-> string = {

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -173,7 +173,7 @@ function get_scalar(rs1, SEW) = {
 }
 
 /* Get the starting element index from csr vtype */
-val get_start_element : unit -> nat
+val get_start_element : unit -> result(nat, unit)
 function get_start_element() = {
   let start_element = unsigned(vstart);
   let VLEN_pow = get_vlen_pow();
@@ -183,8 +183,9 @@ function get_start_element() = {
     It is recommended that implementations trap if vstart is out of bounds.
     It is not required to trap, as a possible future use of upper vstart bits
     is to store imprecise trap information. */
-  if start_element > (2 ^ (3 + VLEN_pow - SEW_pow) - 1) then handle_illegal();
-  start_element
+  if start_element > (2 ^ (3 + VLEN_pow - SEW_pow) - 1)
+  then Err(())
+  else Ok(start_element)
 }
 
 /* Get the ending element index from csr vl */
@@ -199,9 +200,12 @@ function get_end_element() = unsigned(vl) - 1
  *   vector2 is a "mask" vector that is true for an element if the corresponding element
  *     in the result vector should be updated by the calling instruction
  */
-val init_masked_result : forall 'n 'm 'p, 'n >= 0 & 'm >= 0. (int('n), int('m), int('p), vector('n, bits('m)), bits('n)) -> (vector('n, bits('m)), bits('n))
+val init_masked_result : forall 'n 'm 'p, 'n >= 0 & 'm >= 0. (int('n), int('m), int('p), vector('n, bits('m)), bits('n)) -> result((vector('n, bits('m)), bits('n)), unit)
 function init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return Err(())
+  };
   let end_element   = get_end_element();
   let tail_ag : agtype = get_vtype_vta();
   let mask_ag : agtype = get_vtype_vma();
@@ -244,7 +248,7 @@ function init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
     }
   };
 
-  (result, mask)
+  Ok((result, mask))
 }
 
 /* For instructions like vector reduction and vector store,
@@ -252,9 +256,12 @@ function init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
  * (vs3 for store and vs2 for reduction). There's no destination register to be masked.
  * In these cases, this function can be called to simply get the mask vector for vs (without the prepared vd result vector).
  */
-val init_masked_source : forall 'n 'p, 'n > 0. (int('n), int('p), bits('n)) -> bits('n)
+val init_masked_source : forall 'n 'p, 'n > 0. (int('n), int('p), bits('n)) -> result(bits('n), unit)
 function init_masked_source(num_elem, LMUL_pow, vm_val) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return Err(())
+  };
   let end_element   = get_end_element();
   var mask : bits('n) = undefined;
 
@@ -281,14 +288,17 @@ function init_masked_source(num_elem, LMUL_pow, vm_val) = {
     }
   };
 
-  mask
+  Ok(mask)
 }
 
 /* Mask handling for carry functions that use masks as input/output */
 /* Only prestart and tail elements are masked in a mask value */
-val init_masked_result_carry : forall 'n 'm 'p, 'n >= 0. (int('n), int('m), int('p), bits('n)) -> (bits('n), bits('n))
+val init_masked_result_carry : forall 'n 'm 'p, 'n >= 0. (int('n), int('m), int('p), bits('n)) -> result((bits('n), bits('n)), unit)
 function init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return Err(())
+  };
   let end_element   = get_end_element();
   var mask : bits('n) = undefined;
   var result : bits('n) = undefined;
@@ -318,13 +328,16 @@ function init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) = {
     }
   };
 
-  (result, mask)
+  Ok(result, mask)
 }
 
 /* Mask handling for cmp functions that use masks as output */
-val init_masked_result_cmp : forall 'n 'm 'p, 'n >= 0. (int('n), int('m), int('p), bits('n), bits('n)) -> (bits('n), bits('n))
+val init_masked_result_cmp : forall 'n 'm 'p, 'n >= 0. (int('n), int('m), int('p), bits('n), bits('n)) -> result((bits('n), bits('n)), unit)
 function init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return Err(())
+  };
   let end_element   = get_end_element();
   let mask_ag : agtype = get_vtype_vma();
   var mask : bits('n) = undefined;
@@ -362,7 +375,7 @@ function init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
     }
   };
 
-  (result, mask)
+  Ok(result, mask)
 }
 
 /* For vector load/store segment instructions:

--- a/model/riscv_insts_vext_vm.sail
+++ b/model/riscv_insts_vext_vm.sail
@@ -30,7 +30,7 @@ function clause execute(VVMTYPE(funct6, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -40,7 +40,10 @@ function clause execute(VVMTYPE(funct6, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -55,7 +58,7 @@ function clause execute(VVMTYPE(funct6, vs2, vs1, vd)) = {
 
   write_vmask(num_elem, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vvmtype_mnemonic : vvmfunct6 <-> string = {
@@ -85,7 +88,7 @@ function clause execute(VVMCTYPE(funct6, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -94,7 +97,10 @@ function clause execute(VVMCTYPE(funct6, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -109,7 +115,7 @@ function clause execute(VVMCTYPE(funct6, vs2, vs1, vd)) = {
 
   write_vmask(num_elem, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vvmctype_mnemonic : vvmcfunct6 <-> string = {
@@ -139,7 +145,7 @@ function clause execute(VVMSTYPE(funct6, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_masked(vd) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -152,7 +158,10 @@ function clause execute(VVMSTYPE(funct6, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -166,7 +175,7 @@ function clause execute(VVMSTYPE(funct6, vs2, vs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vvmstype_mnemonic : vvmsfunct6 <-> string = {
@@ -198,7 +207,7 @@ function clause execute(VVCMPTYPE(funct6, vm, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -208,7 +217,10 @@ function clause execute(VVCMPTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -227,7 +239,7 @@ function clause execute(VVCMPTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   write_vmask(num_elem, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vvcmptype_mnemonic : vvcmpfunct6 <-> string = {
@@ -261,7 +273,7 @@ function clause execute(VXMTYPE(funct6, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -271,7 +283,10 @@ function clause execute(VXMTYPE(funct6, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -286,7 +301,7 @@ function clause execute(VXMTYPE(funct6, vs2, rs1, vd)) = {
 
   write_vmask(num_elem, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vxmtype_mnemonic : vxmfunct6 <-> string = {
@@ -316,7 +331,7 @@ function clause execute(VXMCTYPE(funct6, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -325,7 +340,10 @@ function clause execute(VXMCTYPE(funct6, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -340,7 +358,7 @@ function clause execute(VXMCTYPE(funct6, vs2, rs1, vd)) = {
 
   write_vmask(num_elem, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vxmctype_mnemonic : vxmcfunct6 <-> string = {
@@ -370,7 +388,7 @@ function clause execute(VXMSTYPE(funct6, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_masked(vd) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -383,7 +401,10 @@ function clause execute(VXMSTYPE(funct6, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -397,7 +418,7 @@ function clause execute(VXMSTYPE(funct6, vs2, rs1, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vxmstype_mnemonic : vxmsfunct6 <-> string = {
@@ -431,7 +452,7 @@ function clause execute(VXCMPTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -441,7 +462,10 @@ function clause execute(VXCMPTYPE(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -462,7 +486,7 @@ function clause execute(VXCMPTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   write_vmask(num_elem, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vxcmptype_mnemonic : vxcmpfunct6 <-> string = {
@@ -497,7 +521,7 @@ function clause execute(VIMTYPE(funct6, vs2, simm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -507,7 +531,10 @@ function clause execute(VIMTYPE(funct6, vs2, simm, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -521,7 +548,7 @@ function clause execute(VIMTYPE(funct6, vs2, simm, vd)) = {
 
   write_vmask(num_elem, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vimtype_mnemonic : vimfunct6 <-> string = {
@@ -549,7 +576,7 @@ function clause execute(VIMCTYPE(funct6, vs2, simm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -558,7 +585,10 @@ function clause execute(VIMCTYPE(funct6, vs2, simm, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -572,7 +602,7 @@ function clause execute(VIMCTYPE(funct6, vs2, simm, vd)) = {
 
   write_vmask(num_elem, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vimctype_mnemonic : vimcfunct6 <-> string = {
@@ -600,7 +630,7 @@ function clause execute(VIMSTYPE(funct6, vs2, simm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_masked(vd) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -613,7 +643,10 @@ function clause execute(VIMSTYPE(funct6, vs2, simm, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -626,7 +659,7 @@ function clause execute(VIMSTYPE(funct6, vs2, simm, vd)) = {
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vimstype_mnemonic : vimsfunct6 <-> string = {
@@ -657,7 +690,7 @@ function clause execute(VICMPTYPE(funct6, vm, vs2, simm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -667,7 +700,10 @@ function clause execute(VICMPTYPE(funct6, vm, vs2, simm, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -686,7 +722,7 @@ function clause execute(VICMPTYPE(funct6, vm, vs2, simm, vd)) = {
 
   write_vmask(num_elem, vd, result);
   set_vstart(zeros());
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping vicmptype_mnemonic : vicmpfunct6 <-> string = {

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -89,7 +89,7 @@ function clause execute VSETVLI(ma, ta, sew, lmul, rs1, rd) = {
   let ELEN_pow     = get_elen_pow();
   let LMUL_pow_new = get_lmul_pow();
   let SEW_pow_new  = get_sew_pow();
-  if SEW_pow_new > (LMUL_pow_new + ELEN_pow) then { handle_illegal_vtype(); return RETIRE_SUCCESS };
+  if SEW_pow_new > (LMUL_pow_new + ELEN_pow) then { handle_illegal_vtype(); return RETIRE_SUCCESS() };
   let VLMAX = 2 ^ (VLEN_pow + LMUL_pow_new - SEW_pow_new);
 
   /* set vl according to VLMAX and AVL */
@@ -105,7 +105,7 @@ function clause execute VSETVLI(ma, ta, sew, lmul, rs1, rd) = {
   } else { /* keep existing vl */
     let AVL = unsigned(vl);
     let ratio_pow_new = SEW_pow_new - LMUL_pow_new;
-    if (ratio_pow_new != ratio_pow_ori) then { handle_illegal_vtype(); return RETIRE_SUCCESS }
+    if (ratio_pow_new != ratio_pow_ori) then { handle_illegal_vtype(); return RETIRE_SUCCESS() }
   };
 
   /* reset vstart to 0 */
@@ -115,7 +115,7 @@ function clause execute VSETVLI(ma, ta, sew, lmul, rs1, rd) = {
   print_reg("CSR vl <- " ^ BitStr(vl));
   print_reg("CSR vstart <- " ^ BitStr(vstart));
 
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = VSETVLI(ma, ta, sew, lmul, rs1, rd)
@@ -140,7 +140,7 @@ function clause execute VSETVL(rs2, rs1, rd) = {
   let ELEN_pow     = get_elen_pow();
   let LMUL_pow_new = get_lmul_pow();
   let SEW_pow_new  = get_sew_pow();
-  if SEW_pow_new > (LMUL_pow_new + ELEN_pow) then { handle_illegal_vtype(); return RETIRE_SUCCESS };
+  if SEW_pow_new > (LMUL_pow_new + ELEN_pow) then { handle_illegal_vtype(); return RETIRE_SUCCESS() };
   let VLMAX = 2 ^ (VLEN_pow + LMUL_pow_new - SEW_pow_new);
 
   /* set vl according to VLMAX and AVL */
@@ -156,7 +156,7 @@ function clause execute VSETVL(rs2, rs1, rd) = {
   } else { /* keep existing vl */
     let AVL = unsigned(vl);
     let ratio_pow_new = SEW_pow_new - LMUL_pow_new;
-    if (ratio_pow_new != ratio_pow_ori) then { handle_illegal_vtype(); return RETIRE_SUCCESS }
+    if (ratio_pow_new != ratio_pow_ori) then { handle_illegal_vtype(); return RETIRE_SUCCESS() }
   };
 
   /* reset vstart to 0 */
@@ -166,7 +166,7 @@ function clause execute VSETVL(rs2, rs1, rd) = {
   print_reg("CSR vl <- " ^ BitStr(vl));
   print_reg("CSR vstart <- " ^ BitStr(vstart));
 
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = VSETVL(rs2, rs1, rd)
@@ -187,7 +187,7 @@ function clause execute VSETIVLI(ma, ta, sew, lmul, uimm, rd) = {
   let ELEN_pow     = get_elen_pow();
   let LMUL_pow_new = get_lmul_pow();
   let SEW_pow_new  = get_sew_pow();
-  if SEW_pow_new > (LMUL_pow_new + ELEN_pow) then { handle_illegal_vtype(); return RETIRE_SUCCESS };
+  if SEW_pow_new > (LMUL_pow_new + ELEN_pow) then { handle_illegal_vtype(); return RETIRE_SUCCESS() };
   let VLMAX = 2 ^ (VLEN_pow + LMUL_pow_new - SEW_pow_new);
 
   /* set vl according to VLMAX and AVL */
@@ -202,7 +202,7 @@ function clause execute VSETIVLI(ma, ta, sew, lmul, uimm, rd) = {
   print_reg("CSR vl <- " ^ BitStr(vl));
   print_reg("CSR vstart <- " ^ BitStr(vstart));
 
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 mapping clause assembly = VSETIVLI(ma, ta, sew, lmul, uimm, rd)

--- a/model/riscv_insts_zba.sail
+++ b/model/riscv_insts_zba.sail
@@ -22,7 +22,7 @@ function clause execute (RISCV_SLLIUW(shamt, rs1, rd)) = {
   let rs1_val = X(rs1);
   let result : xlenbits = zero_extend(rs1_val[31..0]) << shamt;
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -61,7 +61,7 @@ function clause execute (ZBA_RTYPEUW(rs2, rs1, rd, op)) = {
   };
   let result : xlenbits = (zero_extend(rs1_val[31..0]) << shamt) + rs2_val;
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -93,5 +93,5 @@ function clause execute (ZBA_RTYPE(rs2, rs1, rd, op)) = {
   };
   let result : xlenbits = (rs1_val << shamt) + rs2_val;
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }

--- a/model/riscv_insts_zbb.sail
+++ b/model/riscv_insts_zbb.sail
@@ -22,7 +22,7 @@ function clause execute (RISCV_RORIW(shamt, rs1, rd)) = {
   let rs1_val = (X(rs1))[31..0];
   let result : xlenbits = sign_extend(rs1_val >>> shamt);
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -40,7 +40,7 @@ function clause execute (RISCV_RORI(shamt, rs1, rd)) = {
                           then rs1_val >>> shamt[4..0]
                           else rs1_val >>> shamt;
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -68,7 +68,7 @@ function clause execute (ZBB_RTYPEW(rs2, rs1, rd, op)) = {
     RISCV_RORW => rs1_val >>> shamt
   };
   X(rd) = sign_extend(result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -135,7 +135,7 @@ function clause execute (ZBB_RTYPE(rs2, rs1, rd, op)) = {
                   else rs1_val >>> rs2_val[5..0]
   };
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -170,7 +170,7 @@ function clause execute (ZBB_EXTOP(rs1, rd, op)) = {
     RISCV_ZEXTH => zero_extend(rs1_val[15..0])
   };
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -191,7 +191,7 @@ function clause execute (RISCV_REV8(rs1, rd)) = {
   foreach (i from 0 to (xlen - 8) by 8)
     result[(i + 7) .. i] = rs1_val[(xlen - i - 1) .. (xlen - i - 8)];
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -211,7 +211,7 @@ function clause execute (RISCV_ORCB(rs1, rd)) = {
                            then 0x00
                            else 0xFF;
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -229,7 +229,7 @@ function clause execute (RISCV_CPOP(rs1, rd)) = {
   foreach (i from 0 to (xlen_val - 1))
     if rs1_val[i] == bitone then result = result + 1;
   X(rd) = to_bits(xlen, result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -247,7 +247,7 @@ function clause execute (RISCV_CPOPW(rs1, rd)) = {
   foreach (i from 0 to 31)
     if rs1_val[i] == bitone then result = result + 1;
   X(rd) = to_bits(xlen, result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -268,7 +268,7 @@ function clause execute (RISCV_CLZ(rs1, rd)) = {
                     then result = result + 1
                     else done = true;
   X(rd) = to_bits(xlen, result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -289,7 +289,7 @@ function clause execute (RISCV_CLZW(rs1, rd)) = {
                     then result = result + 1
                     else done = true;
   X(rd) = to_bits(xlen, result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -310,7 +310,7 @@ function clause execute (RISCV_CTZ(rs1, rd)) = {
                     then result = result + 1
                     else done = true;
   X(rd) = to_bits(xlen, result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -331,5 +331,5 @@ function clause execute (RISCV_CTZW(rs1, rd)) = {
                     then result = result + 1
                     else done = true;
   X(rd) = to_bits(xlen, result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }

--- a/model/riscv_insts_zbc.sail
+++ b/model/riscv_insts_zbc.sail
@@ -25,7 +25,7 @@ function clause execute (RISCV_CLMUL(rs2, rs1, rd)) = {
   foreach (i from 0 to (xlen_val - 1))
     if rs2_val[i] == bitone then result = result ^ (rs1_val << i);
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -44,7 +44,7 @@ function clause execute (RISCV_CLMULH(rs2, rs1, rd)) = {
   foreach (i from 0 to (xlen_val - 1))
     if rs2_val[i] == bitone then result = result ^ (rs1_val >> (xlen_val - i));
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -63,5 +63,5 @@ function clause execute (RISCV_CLMULR(rs2, rs1, rd)) = {
   foreach (i from 0 to (xlen_val - 1))
     if rs2_val[i] == bitone then result = result ^ (rs1_val >> (xlen_val - i - 1));
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }

--- a/model/riscv_insts_zbkb.sail
+++ b/model/riscv_insts_zbkb.sail
@@ -31,7 +31,7 @@ function clause execute (ZBKB_RTYPE(rs2, rs1, rd, op)) = {
     RISCV_PACKH => zero_extend(rs2_val[7..0] @ rs1_val[7..0])
   };
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -49,7 +49,7 @@ function clause execute (ZBKB_PACKW(rs2, rs1, rd)) = {
   let rs2_val = X(rs2);
   let result : bits(32) = rs2_val[15..0] @ rs1_val[15..0];
   X(rd) = sign_extend(result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -70,7 +70,7 @@ function clause execute (RISCV_ZIP(rs1, rd)) = {
     result[i*2 + 1] = rs1_val[i + xlen_bytes*4];
   };
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -91,7 +91,7 @@ function clause execute (RISCV_UNZIP(rs1, rd)) = {
     result[i + xlen_bytes*4] = rs1_val[i*2 + 1];
   };
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -109,5 +109,5 @@ function clause execute (RISCV_BREV8(rs1, rd)) = {
   foreach (i from 0 to (xlen - 8) by 8)
     result[i+7..i] = reverse(rs1_val[i+7..i]);
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }

--- a/model/riscv_insts_zbkx.sail
+++ b/model/riscv_insts_zbkx.sail
@@ -28,7 +28,7 @@ function clause execute (RISCV_XPERM8(rs2, rs1, rd)) = {
                      else zeros()
   };
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -51,5 +51,5 @@ function clause execute (RISCV_XPERM4(rs2, rs1, rd)) = {
                      else zeros()
   };
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }

--- a/model/riscv_insts_zbs.sail
+++ b/model/riscv_insts_zbs.sail
@@ -45,7 +45,7 @@ function clause execute (ZBS_IOP(shamt, rs1, rd, op)) = {
     RISCV_BSETI => rs1_val | mask
   };
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -86,5 +86,5 @@ function clause execute (ZBS_RTYPE(rs2, rs1, rd, op)) = {
     RISCV_BSET => rs1_val | mask
   };
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }

--- a/model/riscv_insts_zca.sail
+++ b/model/riscv_insts_zca.sail
@@ -19,7 +19,7 @@ union clause ast = C_NOP : unit
 mapping clause encdec_compressed = C_NOP() if extensionEnabled(Ext_Zca)
   <-> 0b000 @ 0b0 @ 0b00000 @ 0b00000 @ 0b01 if extensionEnabled(Ext_Zca)
 
-function clause execute C_NOP() = RETIRE_SUCCESS
+function clause execute C_NOP() = RETIRE_SUCCESS()
 
 mapping clause assembly = C_NOP() <-> "c.nop"
 

--- a/model/riscv_insts_zcb.sail
+++ b/model/riscv_insts_zcb.sail
@@ -110,7 +110,7 @@ mapping clause assembly = C_ZEXT_B(rsdc) <->
 function clause execute C_ZEXT_B(rsdc) = {
   let rsd = creg2reg_idx(rsdc);
   X(rsd) = zero_extend(X(rsd)[7..0]);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */
@@ -191,7 +191,7 @@ mapping clause assembly = C_NOT(rsdc) <->
 function clause execute C_NOT(rsdc) = {
   let r = creg2reg_idx(rsdc);
   X(r) = ~(X(r));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zfa.sail
+++ b/model/riscv_insts_zfa.sail
@@ -54,7 +54,7 @@ function clause execute (RISCV_FLI_H(constantidx, rd)) = {
     0b11111 => { canonical_NaN_H() },
   };
   F_H(rd) = bits;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* FLI.S */
@@ -103,7 +103,7 @@ function clause execute (RISCV_FLI_S(constantidx, rd)) = {
     0b11111 => { canonical_NaN_S() },
   };
   F_S(rd) = bits;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* FLI.D */
@@ -152,7 +152,7 @@ function clause execute (RISCV_FLI_D(constantidx, rd)) = {
     0b11111 => { canonical_NaN_D() },
   };
   F_D(rd) = bits;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* FMINM.H */
@@ -182,7 +182,7 @@ function clause execute (RISCV_FMINM_H(rs2, rs1, rd)) = {
 
   accrue_fflags(fflags);
   F_H(rd) = rd_val_H;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* FMAXM.H */
@@ -212,7 +212,7 @@ function clause execute (RISCV_FMAXM_H(rs2, rs1, rd)) = {
 
   accrue_fflags(fflags);
   F_H(rd) = rd_val_H;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* FMINM.S */
@@ -242,7 +242,7 @@ function clause execute (RISCV_FMINM_S(rs2, rs1, rd)) = {
 
   accrue_fflags(fflags);
   F_S(rd) = rd_val_S;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* FMAXM.S */
@@ -272,7 +272,7 @@ function clause execute (RISCV_FMAXM_S(rs2, rs1, rd)) = {
 
   accrue_fflags(fflags);
   F_S(rd) = rd_val_S;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* FMINM.D */
@@ -302,7 +302,7 @@ function clause execute (RISCV_FMINM_D(rs2, rs1, rd)) = {
 
   accrue_fflags(fflags);
   F_D(rd) = rd_val_D;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* FMAXM.D */
@@ -332,7 +332,7 @@ function clause execute (RISCV_FMAXM_D(rs2, rs1, rd)) = {
 
   accrue_fflags(fflags);
   F_D(rd) = rd_val_D;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* FROUND.H */
@@ -351,14 +351,14 @@ function clause execute (RISCV_FROUND_H(rs1, rm, rd)) = {
   let rs1_val_H = F_H(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_f16roundToInt(rm_3b, rs1_val_H, false);
 
       accrue_fflags(fflags);
       F_H(rd) = rd_val_H;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -379,14 +379,14 @@ function clause execute (RISCV_FROUNDNX_H(rs1, rm, rd)) = {
   let rs1_val_H = F_H(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_f16roundToInt(rm_3b, rs1_val_H, true);
 
       accrue_fflags(fflags);
       F_H(rd) = rd_val_H;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -407,14 +407,14 @@ function clause execute (RISCV_FROUND_S(rs1, rm, rd)) = {
   let rs1_val_S = F_S(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_f32roundToInt(rm_3b, rs1_val_S, false);
 
       accrue_fflags(fflags);
       F_S(rd) = rd_val_S;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -435,14 +435,14 @@ function clause execute (RISCV_FROUNDNX_S(rs1, rm, rd)) = {
   let rs1_val_S = F_S(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_f32roundToInt(rm_3b, rs1_val_S, true);
 
       accrue_fflags(fflags);
       F_S(rd) = rd_val_S;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -463,14 +463,14 @@ function clause execute (RISCV_FROUND_D(rs1, rm, rd)) = {
   let rs1_val_D = F_D(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_f64roundToInt(rm_3b, rs1_val_D, false);
 
       accrue_fflags(fflags);
       F_D(rd) = rd_val_D;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -491,14 +491,14 @@ function clause execute (RISCV_FROUNDNX_D(rs1, rm, rd)) = {
   let rs1_val_D = F_D(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_f64roundToInt(rm_3b, rs1_val_D, true);
 
       accrue_fflags(fflags);
       F_D(rd) = rd_val_D;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -518,7 +518,7 @@ function clause execute (RISCV_FMVH_X_D(rs1, rd)) = {
   let rs1_val_D           = F_D(rs1)[63..32];
   let rd_val_X : xlenbits = sign_extend(rs1_val_D);
   X(rd)                   = rd_val_X;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* FMVP.X.D */
@@ -545,7 +545,7 @@ function clause execute (RISCV_FMVP_D_X(rs2, rs1, rd)) = {
   let rd_val_D      = rs2_val_X @ rs1_val_X;
 
   F_D(rd)           = rd_val_D;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* FLEQ.H */
@@ -569,7 +569,7 @@ function clause execute(RISCV_FLEQ_H(rs2, rs1, rd)) = {
 
   accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* FLTQ.H */
@@ -593,7 +593,7 @@ function clause execute(RISCV_FLTQ_H(rs2, rs1, rd)) = {
 
   accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* FLEQ.S */
@@ -617,7 +617,7 @@ function clause execute(RISCV_FLEQ_S(rs2, rs1, rd)) = {
 
   accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* FLTQ.S */
@@ -641,7 +641,7 @@ function clause execute(RISCV_FLTQ_S(rs2, rs1, rd)) = {
 
   accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 
@@ -666,7 +666,7 @@ function clause execute(RISCV_FLEQ_D(rs2, rs1, rd)) = {
 
   accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* FLTQ.D */
@@ -690,7 +690,7 @@ function clause execute(RISCV_FLTQ_D(rs2, rs1, rd)) = {
 
   accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* FCVTMOD.W.D */
@@ -772,5 +772,5 @@ function clause execute(RISCV_FCVTMOD_W_D(rs1, rd)) = {
   let (fflags, rd_val) = fcvtmod_helper(rs1_val_D);
   accrue_fflags(fflags);
   X(rd) = sign_extend(rd_val);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }

--- a/model/riscv_insts_zfh.sail
+++ b/model/riscv_insts_zfh.sail
@@ -207,7 +207,7 @@ function clause execute (F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, op)) = {
   let rs1_val_16b = F_or_X_H(rs1);
   let rs2_val_16b = F_or_X_H(rs2);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => return RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_16b) : (bits(5), bits(16)) = match op {
@@ -218,7 +218,7 @@ function clause execute (F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, op)) = {
       };
       accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_16b;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -271,7 +271,7 @@ function clause execute (F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, op)) = {
   let rs2_val_16b = F_or_X_H(rs2);
   let rs3_val_16b = F_or_X_H(rs3);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_16b) : (bits(5), bits(16)) =
@@ -283,7 +283,7 @@ function clause execute (F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, op)) = {
         };
       accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_16b;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -348,7 +348,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FSGNJ_H)) = {
   let rd_val_H     = fmake_H (s2, e1, m1);
 
   F_or_X_H(rd) = rd_val_H;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FSGNJN_H)) = {
@@ -359,7 +359,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FSGNJN_H)) = {
   let rd_val_H     = fmake_H (0b1 ^ s2, e1, m1);
 
   F_or_X_H(rd) = rd_val_H;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FSGNJX_H)) = {
@@ -370,7 +370,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FSGNJX_H)) = {
   let rd_val_H     = fmake_H (s1 ^ s2, e1, m1);
 
   F_or_X_H(rd) = rd_val_H;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FMIN_H)) = {
@@ -390,7 +390,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FMIN_H)) = {
 
   accrue_fflags(fflags);
   F_or_X_H(rd) = rd_val_H;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FMAX_H)) = {
@@ -410,7 +410,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FMAX_H)) = {
 
   accrue_fflags(fflags);
   F_or_X_H(rd) = rd_val_H;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FEQ_H)) = {
@@ -422,7 +422,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FEQ_H)) = {
 
   accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FLT_H)) = {
@@ -434,7 +434,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FLT_H)) = {
 
   accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FLE_H)) = {
@@ -446,7 +446,7 @@ function clause execute (F_BIN_TYPE_H(rs2, rs1, rd, FLE_H)) = {
 
   accrue_fflags(fflags);
   X(rd) = zero_extend(bool_to_bits(rd_val));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* AST -> Assembly notation ================================ */
@@ -581,14 +581,14 @@ mapping clause encdec =
 function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FSQRT_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_f16Sqrt   (rm_3b, rs1_val_H);
 
       accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_H;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -596,14 +596,14 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FSQRT_H)) = {
 function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_W_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_W) = riscv_f16ToI32 (rm_3b, rs1_val_H);
 
       accrue_fflags(fflags);
       X(rd) = sign_extend (rd_val_W);
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -611,14 +611,14 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_W_H)) = {
 function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_WU_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_WU) = riscv_f16ToUi32 (rm_3b, rs1_val_H);
 
       accrue_fflags(fflags);
       X(rd) = sign_extend (rd_val_WU);
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -626,14 +626,14 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_WU_H)) = {
 function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_W)) = {
   let rs1_val_W = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_i32ToF16 (rm_3b, rs1_val_W);
 
       accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_H;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -641,14 +641,14 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_W)) = {
 function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_WU)) = {
   let rs1_val_WU = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_ui32ToF16 (rm_3b, rs1_val_WU);
 
       accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_H;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -656,14 +656,14 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_WU)) = {
 function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_f32ToF16 (rm_3b, rs1_val_S);
 
       accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_H;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -671,14 +671,14 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_S)) = {
 function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_f64ToF16 (rm_3b, rs1_val_D);
 
       accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_H;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -686,14 +686,14 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_D)) = {
 function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_S_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_f16ToF32 (rm_3b, rs1_val_H);
 
       accrue_fflags(fflags);
       F_or_X_S(rd) = rd_val_S;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -702,14 +702,14 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_S_H)) = {
 function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_D_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_f16ToF64 (rm_3b, rs1_val_H);
 
       accrue_fflags(fflags);
       F_or_X_D(rd) = rd_val_D;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -718,14 +718,14 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_L_H)) = {
   assert(xlen >= 64);
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_L) = riscv_f16ToI64 (rm_3b, rs1_val_H);
 
       accrue_fflags(fflags);
       X(rd) = sign_extend(rd_val_L);
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -734,14 +734,14 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_LU_H)) = {
   assert(xlen >= 64);
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_LU) = riscv_f16ToUi64 (rm_3b, rs1_val_H);
 
       accrue_fflags(fflags);
       X(rd) = sign_extend(rd_val_LU);
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -750,14 +750,14 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_L)) = {
   assert(xlen >= 64);
   let rs1_val_L = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_i64ToF16 (rm_3b, rs1_val_L);
 
       accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_H;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -766,14 +766,14 @@ function clause execute (F_UN_RM_TYPE_H(rs1, rm, rd, FCVT_H_LU)) = {
   assert(xlen >= 64);
   let rs1_val_LU = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_ui64ToF16 (rm_3b, rs1_val_LU);
 
       accrue_fflags(fflags);
       F_or_X_H(rd) = rd_val_H;
-      RETIRE_SUCCESS
+      RETIRE_SUCCESS()
     }
   }
 }
@@ -911,21 +911,21 @@ function clause execute (F_UN_TYPE_H(rs1, rd, FCLASS_H)) = {
     else zeros();
 
   X(rd) = zero_extend (rd_val_10b);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_UN_TYPE_H(rs1, rd, FMV_X_H)) = {
   let rs1_val_H            = F(rs1)[15..0];
   let rd_val_X  : xlenbits = sign_extend(rs1_val_H);
   X(rd) = rd_val_X;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (F_UN_TYPE_H(rs1, rd, FMV_H_X)) = {
   let rs1_val_X            = X(rs1);
   let rd_val_H             = rs1_val_X [15..0];
   F(rd) = nan_box (rd_val_H);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /* AST -> Assembly notation ================================ */

--- a/model/riscv_insts_zicbom.sail
+++ b/model/riscv_insts_zicbom.sail
@@ -35,7 +35,7 @@ mapping cbop_mnemonic : cbop_zicbom <-> string = {
 mapping clause assembly = RISCV_ZICBOM(cbop, rs1)
   <-> cbop_mnemonic(cbop) ^ spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
 
-val process_clean_inval : (regidx, cbop_zicbom) -> Retired
+val process_clean_inval : (regidx, cbop_zicbom) -> Retired(Retire_Failure)
 function process_clean_inval(rs1, cbop) = {
   let rs1_val = X(rs1);
   let cache_block_size_exp = plat_cache_block_size_exp();
@@ -49,7 +49,7 @@ function process_clean_inval(rs1, cbop) = {
   // to be in bounds here, whereas `ext_data_get_addr()` checks that all bytes
   // are in bounds. We will need to add a new function, parameter or access type.
   match ext_data_get_addr(rs1, negative_offset, Read(Data), cache_block_size) {
-    Ext_DataAddr_Error(e) => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_Error(e) => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
     Ext_DataAddr_OK(vaddr) => {
       let res : option(ExceptionType) = match translateAddr(vaddr, Read(Data)) {
         TR_Address(paddr, _) => {
@@ -79,7 +79,7 @@ function process_clean_inval(rs1, cbop) = {
       //  fault exception otherwise."
       match res {
         // The model has no caches so there's no action required.
-        None() => RETIRE_SUCCESS,
+        None() => RETIRE_SUCCESS(),
         Some(e) => {
           let e : ExceptionType = match e {
             E_Load_Access_Fault() => E_SAMO_Access_Fault(),
@@ -94,8 +94,7 @@ function process_clean_inval(rs1, cbop) = {
           // was encoded in the instruction. We subtract the negative offset
           // (add the positive offset) to get it. Normally this will be
           // equal to rs1, but pointer masking can change that.
-          handle_mem_exception(vaddr - negative_offset, e);
-          RETIRE_FAIL
+          RETIRE_FAIL(Memory_Exception(vaddr - negative_offset, e))
         }
       }
     }
@@ -110,8 +109,6 @@ function clause execute(RISCV_ZICBOM(cbop, rs1)) =
       process_clean_inval(rs1, cbop),
     CBO_INVAL if cbo_inval_enabled(cur_privilege) =>
       process_clean_inval(rs1, if cbo_inval_as_inval(cur_privilege) then CBO_INVAL else CBO_FLUSH),
-    _ => {
-      handle_illegal();
-      RETIRE_FAIL
-    },
+    _ =>
+      RETIRE_FAIL(Illegal_Instruction())
   }

--- a/model/riscv_insts_zicboz.sail
+++ b/model/riscv_insts_zicboz.sail
@@ -32,7 +32,7 @@ function clause execute(RISCV_ZICBOZ(rs1)) = {
     let negative_offset = (rs1_val & ~(zero_extend(ones(cache_block_size_exp)))) - rs1_val;
 
     match ext_data_get_addr(rs1, negative_offset, Write(Data), cache_block_size) {
-      Ext_DataAddr_Error(e) => { ext_handle_data_check_error(e); RETIRE_FAIL },
+      Ext_DataAddr_Error(e) => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
       Ext_DataAddr_OK(vaddr) => {
         // "An implementation may update the bytes in any order and with any granularity
         //  and atomicity, including individual bytes."
@@ -43,15 +43,15 @@ function clause execute(RISCV_ZICBOZ(rs1)) = {
           // was encoded in the instruction. We subtract the negative offset
           // (add the positive offset) to get it. Normally this will be
           // equal to rs1, but pointer masking can change that.
-          TR_Failure(e, _) => { handle_mem_exception(vaddr - negative_offset, e); RETIRE_FAIL },
+          TR_Failure(e, _) => RETIRE_FAIL(Memory_Exception(vaddr - negative_offset, e)),
           TR_Address(paddr, _) => {
             match mem_write_ea(paddr, cache_block_size, false, false, false) {
-              Err(e) => { handle_mem_exception(vaddr - negative_offset, e); RETIRE_FAIL },
+              Err(e) => RETIRE_FAIL(Memory_Exception(vaddr - negative_offset, e)),
               Ok(_)  => {
                 match mem_write_value(paddr, cache_block_size, zeros(), false, false, false) {
-                  Ok(true)  => RETIRE_SUCCESS,
+                  Ok(true)  => RETIRE_SUCCESS(),
                   Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                  Err(e)    => { handle_mem_exception(vaddr - negative_offset, e); RETIRE_FAIL },
+                  Err(e)    => RETIRE_FAIL(Memory_Exception(vaddr - negative_offset, e))
                 }
               }
             }
@@ -60,7 +60,6 @@ function clause execute(RISCV_ZICBOZ(rs1)) = {
       },
     }
   } else {
-    handle_illegal();
-    RETIRE_FAIL
+    RETIRE_FAIL(Illegal_Instruction())
   }
 }

--- a/model/riscv_insts_zicond.sail
+++ b/model/riscv_insts_zicond.sail
@@ -28,7 +28,7 @@ function clause execute (ZICOND_RTYPE(rs2, rs1, rd, RISCV_CZERO_EQZ)) = {
   let condition = X(rs2);
   let result : xlenbits = if condition == zeros() then zeros() else value;
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (ZICOND_RTYPE(rs2, rs1, rd, RISCV_CZERO_NEZ)) = {
@@ -36,5 +36,5 @@ function clause execute (ZICOND_RTYPE(rs2, rs1, rd, RISCV_CZERO_NEZ)) = {
   let condition = X(rs2);
   let result : xlenbits = if condition != zeros() then zeros() else value;
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }

--- a/model/riscv_insts_zicsr.sail
+++ b/model/riscv_insts_zicsr.sail
@@ -24,9 +24,9 @@ function clause execute CSR(csr, rs1, rd, is_imm, op) = {
   let rs1_val : xlenbits = if is_imm then zero_extend(rs1) else X(rs1);
   let is_CSR_Write = op == CSRRW | rs1 != zeros();
   if not(check_CSR(csr, cur_privilege, is_CSR_Write))
-  then { handle_illegal(); RETIRE_FAIL }
+  then RETIRE_FAIL(Illegal_Instruction())
   else if not(ext_check_CSR(csr, cur_privilege, is_CSR_Write))
-  then { ext_check_CSR_fail(); RETIRE_FAIL }
+  then RETIRE_FAIL(Ext_CSR_Check_Failure())
   else {
     /* CSRRW should not generate read side-effects if rd == 0 */
     let is_CSR_Read = not(op == CSRRW & rd == zeros());
@@ -45,7 +45,7 @@ function clause execute CSR(csr, rs1, rd, is_imm, op) = {
       then print_reg("CSR " ^ to_str(csr) ^ " -> " ^ bits_str(csr_val));
     };
     X(rd) = csr_val;
-    RETIRE_SUCCESS
+    RETIRE_SUCCESS()
   }
 }
 

--- a/model/riscv_insts_zifencei.sail
+++ b/model/riscv_insts_zifencei.sail
@@ -19,6 +19,6 @@ mapping clause encdec = FENCEI() if extensionEnabled(Ext_Zifencei)
   <-> 0b000000000000 @ 0b00000 @ 0b001 @ 0b00000 @ 0b0001111 if extensionEnabled(Ext_Zifencei)
 
 /* fence.i is a nop for the memory model */
-function clause execute FENCEI() = { /* __barrier(Barrier_RISCV_i); */ RETIRE_SUCCESS }
+function clause execute FENCEI() = { /* __barrier(Barrier_RISCV_i); */ RETIRE_SUCCESS() }
 
 mapping clause assembly = FENCEI() <-> "fence.i"

--- a/model/riscv_insts_zkn.sail
+++ b/model/riscv_insts_zkn.sail
@@ -46,28 +46,28 @@ function clause execute (SHA256SIG0(rs1, rd)) = {
   let inb    : bits(32) = X(rs1)[31..0];
   let result : bits(32) = (inb >>> 7) ^ (inb >>> 18) ^ (inb >>  3);
   X(rd)      = sign_extend(result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (SHA256SIG1(rs1, rd)) = {
   let inb    : bits(32) = X(rs1)[31..0];
   let result : bits(32) = (inb >>> 17) ^ (inb >>> 19) ^ (inb >> 10);
   X(rd)      = sign_extend(result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (SHA256SUM0(rs1, rd)) = {
   let inb    : bits(32) = X(rs1)[31..0];
   let result : bits(32) = (inb >>> 2) ^ (inb >>> 13) ^ (inb >>> 22);
   X(rd)      = sign_extend(result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (SHA256SUM1(rs1, rd)) = {
   let inb    : bits(32) = X(rs1)[31..0];
   let result : bits(32) = (inb >>> 6) ^ (inb >>> 11) ^ (inb >>> 25);
   X(rd)      = sign_extend(result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /*
@@ -92,7 +92,7 @@ function clause execute (AES32ESMI (bs, rs2, rs1, rd)) = {
   let mixed   : bits(32) = aes_mixcolumn_byte_fwd(so);
   let result  : bits(32) = X(rs1)[31..0] ^ (mixed <<< shamt);
   X(rd) = sign_extend(result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 union clause ast = AES32ESI : (bits(2), regidx, regidx, regidx)
@@ -109,7 +109,7 @@ function clause execute (AES32ESI (bs, rs2, rs1, rd)) = {
   let so      : bits(32) = 0x000000 @ aes_sbox_fwd(si);
   let result  : bits(32) = X(rs1)[31..0] ^ (so <<< shamt);
   X(rd) = sign_extend(result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /*
@@ -134,7 +134,7 @@ function clause execute (AES32DSMI (bs, rs2, rs1, rd)) = {
   let mixed   : bits(32) = aes_mixcolumn_byte_inv(so);
   let result  : bits(32) = X(rs1)[31..0] ^ (mixed <<< shamt);
   X(rd) = sign_extend(result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 union clause ast = AES32DSI  : (bits(2), regidx, regidx, regidx)
@@ -151,7 +151,7 @@ function clause execute (AES32DSI (bs, rs2, rs1, rd)) = {
   let so      : bits(32) = 0x000000 @ aes_sbox_inv(si);
   let result  : bits(32) = X(rs1)[31..0] ^ (so <<< shamt);
   X(rd) = sign_extend(result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /*
@@ -205,37 +205,37 @@ mapping clause assembly = SHA512SUM1R (rs2, rs1, rd)
 function clause execute (SHA512SIG0H(rs2, rs1, rd)) = {
   X(rd) = sign_extend((X(rs1) >>  1) ^ (X(rs1) >>  7) ^ (X(rs1) >>  8) ^
                (X(rs2) << 31)                  ^ (X(rs2) << 24));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (SHA512SIG0L(rs2, rs1, rd)) = {
   X(rd) = sign_extend((X(rs1) >>  1) ^ (X(rs1) >>  7) ^ (X(rs1) >>  8) ^
                (X(rs2) << 31) ^ (X(rs2) << 25) ^ (X(rs2) << 24));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (SHA512SIG1H(rs2, rs1, rd)) = {
   X(rd) = sign_extend((X(rs1) <<  3) ^ (X(rs1) >>  6) ^ (X(rs1) >> 19) ^
                (X(rs2) >> 29)                  ^ (X(rs2) << 13));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (SHA512SIG1L(rs2, rs1, rd)) = {
   X(rd) = sign_extend((X(rs1) <<  3) ^ (X(rs1) >>  6) ^ (X(rs1) >> 19) ^
                (X(rs2) >> 29) ^ (X(rs2) << 26) ^ (X(rs2) << 13));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (SHA512SUM0R(rs2, rs1, rd)) = {
   X(rd) = sign_extend((X(rs1) << 25) ^ (X(rs1) << 30) ^ (X(rs1) >> 28) ^
                (X(rs2) >>  7) ^ (X(rs2) >>  2) ^ (X(rs2) <<  4));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (SHA512SUM1R(rs2, rs1, rd)) = {
   X(rd) = sign_extend((X(rs1) << 23) ^ (X(rs1) >> 14) ^ (X(rs1) >> 18) ^
                (X(rs2) >>  9) ^ (X(rs2) << 18) ^ (X(rs2) << 14));
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /*
@@ -303,7 +303,7 @@ function clause execute (AES64KS1I(rnum, rs1, rd)) = {
   let result   : bits(32) = if (rnum == 0xA) then subwords
                             else (subwords >>> 8) ^ aes_decode_rcon(rnum);
   X(rd) = result @ result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (AES64KS2(rs2, rs1, rd)) = {
@@ -311,7 +311,7 @@ function clause execute (AES64KS2(rs2, rs1, rd)) = {
   let w0 : bits(32) = X(rs1)[63..32] ^ X(rs2)[31..0];
   let w1 : bits(32) = X(rs1)[63..32] ^ X(rs2)[31..0] ^ X(rs2)[63..32];
   X(rd)  = w1 @ w0;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (AES64IM(rs1, rd)) = {
@@ -319,7 +319,7 @@ function clause execute (AES64IM(rs1, rd)) = {
   let w0 : bits(32) = aes_mixcolumn_inv(X(rs1)[31.. 0]);
   let w1 : bits(32) = aes_mixcolumn_inv(X(rs1)[63..32]);
   X(rd)  = w1 @ w0;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (AES64ESM(rs2, rs1, rd)) = {
@@ -328,7 +328,7 @@ function clause execute (AES64ESM(rs2, rs1, rd)) = {
   let wd : bits(64) = sr[63..0];
   let sb : bits(64) = aes_apply_fwd_sbox_to_each_byte(wd);
   X(rd)  = aes_mixcolumn_fwd(sb[63..32]) @ aes_mixcolumn_fwd(sb[31..0]);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (AES64ES(rs2, rs1, rd)) = {
@@ -336,7 +336,7 @@ function clause execute (AES64ES(rs2, rs1, rd)) = {
   let sr : bits(64) = aes_rv64_shiftrows_fwd(X(rs2), X(rs1));
   let wd : bits(64) = sr[63..0];
   X(rd) = aes_apply_fwd_sbox_to_each_byte(wd);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (AES64DSM(rs2, rs1, rd)) = {
@@ -345,7 +345,7 @@ function clause execute (AES64DSM(rs2, rs1, rd)) = {
   let wd : bits(64) = sr[63..0];
   let sb : bits(64) = aes_apply_inv_sbox_to_each_byte(wd);
   X(rd) = aes_mixcolumn_inv(sb[63..32]) @ aes_mixcolumn_inv(sb[31..0]);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (AES64DS(rs2, rs1, rd)) = {
@@ -353,7 +353,7 @@ function clause execute (AES64DS(rs2, rs1, rd)) = {
   let sr : bits(64) = aes_rv64_shiftrows_inv(X(rs2), X(rs1));
   let wd : bits(64) = sr[63..0];
   X(rd) = aes_apply_inv_sbox_to_each_byte(wd);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /*
@@ -397,7 +397,7 @@ function clause execute (SHA512SIG0(rs1, rd)) = {
   let input  : bits(64) = X(rs1);
   let result : bits(64) = (input >>>  1) ^ (input >>>  8) ^ (input >> 7);
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (SHA512SIG1(rs1, rd)) = {
@@ -405,7 +405,7 @@ function clause execute (SHA512SIG1(rs1, rd)) = {
   let input  : bits(64) = X(rs1);
   let result : bits(64) = (input >>> 19) ^ (input >>> 61) ^ (input >> 6);
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (SHA512SUM0(rs1, rd)) = {
@@ -413,7 +413,7 @@ function clause execute (SHA512SUM0(rs1, rd)) = {
   let input  : bits(64) = X(rs1);
   let result : bits(64) = (input >>> 28) ^ (input >>> 34) ^ (input >>> 39);
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (SHA512SUM1(rs1, rd)) = {
@@ -421,5 +421,5 @@ function clause execute (SHA512SUM1(rs1, rd)) = {
   let input  : bits(64) = X(rs1);
   let result : bits(64) = (input >>> 14) ^ (input >>> 18) ^ (input >>> 41);
   X(rd) = result;
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }

--- a/model/riscv_insts_zks.sail
+++ b/model/riscv_insts_zks.sail
@@ -32,14 +32,14 @@ function clause execute (SM3P0(rs1, rd)) = {
   let r1     : bits(32) = X(rs1)[31..0];
   let result : bits(32) =  r1 ^ (r1 <<< 9) ^ (r1 <<< 17);
   X(rd) = sign_extend(result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (SM3P1(rs1, rd)) = {
   let r1     : bits(32) = X(rs1)[31..0];
   let result : bits(32) =  r1 ^ (r1 <<< 15) ^ (r1 <<< 23);
   X(rd) = sign_extend(result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 /*
@@ -74,7 +74,7 @@ function clause execute (SM4ED (bs, rs2, rs1, rd)) = {
   let z     : bits(32) = (y <<< shamt);
   let result : bits(32) = z ^ X(rs1)[31..0];
   X(rd)                = sign_extend(result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }
 
 function clause execute (SM4KS (bs, rs2, rs1, rd)) = {
@@ -86,5 +86,5 @@ function clause execute (SM4KS (bs, rs2, rs1, rd)) = {
   let z     : bits(32) = (y <<< shamt);
   let result : bits(32) = z ^ X(rs1)[31..0];
   X(rd) = sign_extend(result);
-  RETIRE_SUCCESS
+  RETIRE_SUCCESS()
 }

--- a/model/riscv_jalr_seq.sail
+++ b/model/riscv_jalr_seq.sail
@@ -18,19 +18,16 @@ function clause execute (RISCV_JALR(imm, rs1, rd)) = {
   let t : xlenbits = X(rs1) + sign_extend(imm);
   /* Extensions get the first checks on the prospective target address. */
   match ext_control_check_addr(t) {
-    Ext_ControlAddr_Error(e) => {
-      ext_handle_control_check_error(e);
-      RETIRE_FAIL
-    },
+    Ext_ControlAddr_Error(e) =>
+      RETIRE_FAIL(Ext_ControlAddr_Check_Failure(e)),
     Ext_ControlAddr_OK(addr) => {
       let target = [virtaddr_bits(addr) with 0 = bitzero];  /* clear addr[0] */
       if bit_to_bool(target[1]) & not(extensionEnabled(Ext_Zca)) then {
-        handle_mem_exception(addr, E_Fetch_Addr_Align());
-        RETIRE_FAIL
+        RETIRE_FAIL(Memory_Exception(addr, E_Fetch_Addr_Align()))
       } else {
         X(rd) = get_next_pc();
         set_next_pc(target);
-        RETIRE_SUCCESS
+        RETIRE_SUCCESS()
       }
     }
   }

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -446,7 +446,7 @@ function tick_platform() -> unit = {
 
 /* Platform-specific handling of instruction faults */
 
-function handle_illegal() -> unit = {
+function handle_illegal(instbits: xlenbits) -> unit = {
   let info = if plat_mtval_has_illegal_inst_bits ()
              then Some(instbits)
              else None();

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -11,9 +11,6 @@
 register PC       : xlenbits
 register nextPC   : xlenbits
 
-/* internal state to hold instruction bits for faulting instructions */
-register instbits : xlenbits
-
 /* register file and accessors */
 
 register x1  : regtype

--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -23,31 +23,23 @@ function step(step_no : int) -> bool = {
    */
   minstret_increment = should_inc_minstret(cur_privilege);
 
-  let (retired, stepped) : (Retired, bool) =
+  /* instruction bits for faulting instructions */
+  var instbits : option(xlenbits) = None();
+
+  let (retired, stepped) : (Retired(Retire_Failure), bool) =
     match dispatchInterrupt(cur_privilege) {
-      Some(intr, priv) => {
-        if   get_config_print_instr()
-        then print_bits("Handling interrupt: ", interruptType_to_bits(intr));
-        handle_interrupt(intr, priv);
-        (RETIRE_FAIL, false)
-      },
+      Some(intr, priv) => (RETIRE_FAIL(Pending_Interrupt(intr, priv)), false),
       None() => {
         /* the extension hook interposes on the fetch result */
         match ext_fetch_hook(fetch()) {
           /* extension error */
-          F_Ext_Error(e)   => {
-            ext_handle_fetch_check_error(e);
-            (RETIRE_FAIL, false)
-          },
+          F_Ext_Error(e)   => (RETIRE_FAIL(Ext_Fetch_Check_Failure(e)), false),
           /* standard error */
-          F_Error(e, addr) => {
-            handle_mem_exception(virtaddr(addr), e);
-            (RETIRE_FAIL, false)
-          },
+          F_Error(e, addr) => (RETIRE_FAIL(Memory_Exception(virtaddr(addr), e)), false),
           /* non-error cases: */
           F_RVC(h) => {
             sail_instr_announce(h);
-            instbits = zero_extend(h);
+            instbits = Some(zero_extend(h));
             let ast = ext_decode_compressed(h);
             if   get_config_print_instr()
             then {
@@ -58,13 +50,12 @@ function step(step_no : int) -> bool = {
               nextPC = PC + 2;
               (execute(ast), true)
             } else {
-              handle_illegal();
-              (RETIRE_FAIL, true)
+              (RETIRE_FAIL(Illegal_Instruction()), true)
             }
           },
           F_Base(w) => {
             sail_instr_announce(w);
-            instbits = zero_extend(w);
+            instbits = Some(zero_extend(w));
             let ast = ext_decode(w);
             if   get_config_print_instr()
             then {
@@ -77,13 +68,38 @@ function step(step_no : int) -> bool = {
       }
     };
 
-  tick_pc();
-
-  /* update minstret */
   match retired {
-    RETIRE_SUCCESS => retire_instruction(),
-    RETIRE_FAIL    => ()
+    RETIRE_SUCCESS()  => retire_instruction(), // update minstret
+    RETIRE_FAIL(fail) => match fail {
+      // standard failures
+      Trap(priv, ctl, pc)           => set_next_pc(exception_handler(priv, ctl, pc)),
+      Memory_Exception(vaddr, exc)  => handle_mem_exception(vaddr, exc),
+      Pending_Interrupt(intr, priv) => {
+        if   get_config_print_instr()
+        then print_bits("Handling interrupt: ", interruptType_to_bits(intr));
+        handle_interrupt(intr, priv)
+      },
+      Illegal_Instruction() => match instbits {
+          None()         => internal_error(__FILE__, __LINE__, "no instruction bits for illegal instruction"),
+          Some(instbits) => handle_illegal(instbits)
+        },
+      Wait_For_Interrupt() => {
+        // This is currently treated as a nop that retires
+        // successfully.
+        platform_wfi();
+        retire_instruction()
+      },
+
+      // failures from extensions
+      Ext_Fetch_Check_Failure(e)       => ext_handle_fetch_check_error(e),
+      Ext_CSR_Check_Failure()          => ext_check_CSR_fail(),
+      Ext_ControlAddr_Check_Failure(e) => ext_handle_control_check_error(e),
+      Ext_DataAddr_Check_Failure(e)    => ext_handle_data_check_error(e),
+      Ext_XRET_Priv_Failure()          => ext_fail_xret_priv ()
+    }
   };
+
+  tick_pc();
 
   /* for step extensions */
   ext_post_step_hook();

--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -15,30 +15,23 @@ function init_stepper() -> unit = {
 }
 
 // Checks if the retire returned by the execution of an instruction
-// counts as a step.  It should not be called on other retires.
+// counts as a step.
 function does_executed_retire_step(r : Retired(Retire_Failure)) -> bool =
   match r {
+    // do not step if a wait instruction executed.
+    RETIRE_FAIL(Wait_For_Interrupt())  => false,
+
+    // other standard retires
     RETIRE_SUCCESS()                   => true,
     RETIRE_FAIL(Illegal_Instruction()) => true,
     RETIRE_FAIL(Memory_Exception(_))   => true,
     RETIRE_FAIL(Trap(_))               => true,
-
-    // do not step if a wait instruction executed.
-    RETIRE_FAIL(Wait_For_Interrupt())  => false,
 
     // retires from extensions
     RETIRE_FAIL(Ext_ControlAddr_Check_Failure(_)) => true,
     RETIRE_FAIL(Ext_DataAddr_Check_Failure(_))    => true,
     RETIRE_FAIL(Ext_CSR_Check_Failure())          => true,
     RETIRE_FAIL(Ext_XRET_Priv_Failure(_))         => true,
-
-    // illegal retires for instruction execution
-    RETIRE_FAIL(Waiting()) =>
-      internal_error(__FILE__, __LINE__, "execute returned invalid Waiting retire"),
-    RETIRE_FAIL(Pending_Interrupt(_)) =>
-      internal_error(__FILE__, __LINE__, "execute returned invalid Pending-Interrupt retire"),
-    RETIRE_FAIL(Ext_Fetch_Check_Failure(_)) =>
-      internal_error(__FILE__, __LINE__, "execute returned invalid Ext-Fetch-Check-Failure retire")
   }
 
 // The `step` function is the main interface to the non-Sail
@@ -46,6 +39,13 @@ function does_executed_retire_step(r : Retired(Retire_Failure)) -> bool =
 // active or wait step), and whether it should exit a wait state.
 // It returns whether the Sail emulator executed a step, and the
 // stepper state at the end of the step.
+
+union Step = {
+  Exec                     : Retired(Retire_Failure),
+  Ext_Fetch_Check_Failure  : ext_fetch_addr_error,
+  Waiting                  : unit,
+  Pending_Interrupt        : (InterruptType, Privilege)
+}
 
 function step(step_no : int, exit_wait : bool) -> step_result = {
   /* for step extensions */
@@ -64,7 +64,7 @@ function step(step_no : int, exit_wait : bool) -> step_result = {
   /* instruction bits for faulting instructions */
   var instbits : option(xlenbits) = None();
 
-  let (retired, stepped) : (Retired(Retire_Failure), bool) =
+  let (step_val, stepped) : (Step, bool) =
     match (dispatchInterrupt(cur_privilege), step_state) {
       (Some(_, _), STEP_WAIT) => {
         if   get_config_print_instr()
@@ -74,10 +74,10 @@ function step(step_no : int, exit_wait : bool) -> step_result = {
         // The waiting instruction retires successfully.  The
         // pending interrupts will be handled in the next step, which
         // will match the next clause.
-        (RETIRE_SUCCESS(), true)
+        (Exec(RETIRE_SUCCESS()), true)
       },
       (Some(intr, priv), STEP_ACTIVE) =>
-        (RETIRE_FAIL(Pending_Interrupt(intr, priv)), false),
+        (Pending_Interrupt(intr, priv), false),
       (None(), STEP_WAIT) => {
         // There are no pending interrupts; transition out of the Wait
         // if instructed.
@@ -91,21 +91,21 @@ function step(step_no : int, exit_wait : bool) -> step_result = {
           // implementation-specific, bounded time limit, the WFI
           // instruction causes an illegal-instruction exception."
           if   (cur_privilege == Machine | mstatus[TW] == 0b0)
-          then (RETIRE_SUCCESS(), true)
-          else (RETIRE_FAIL(Illegal_Instruction()), true)
+          then (Exec(RETIRE_SUCCESS()), true)
+          else (Exec(RETIRE_FAIL(Illegal_Instruction())), true)
         } else {
           if   get_config_print_instr()
           then print_instr("remaining in WAIT state at PC " ^ BitStr(PC));
-          (RETIRE_FAIL(Waiting()), false)
+          (Waiting(), false)
         }
       },
       (None(), STEP_ACTIVE) => {
         /* the extension hook interposes on the fetch result */
         match ext_fetch_hook(fetch()) {
           /* extension error */
-          F_Ext_Error(e)   => (RETIRE_FAIL(Ext_Fetch_Check_Failure(e)), false),
+          F_Ext_Error(e)   => (Ext_Fetch_Check_Failure(e), false),
           /* standard error */
-          F_Error(e, addr) => (RETIRE_FAIL(Memory_Exception(virtaddr(addr), e)), false),
+          F_Error(e, addr) => (Exec(RETIRE_FAIL(Memory_Exception(virtaddr(addr), e))), false),
           /* non-error cases: */
           F_RVC(h) => {
             sail_instr_announce(h);
@@ -119,9 +119,9 @@ function step(step_no : int, exit_wait : bool) -> step_result = {
             if extensionEnabled(Ext_Zca) then {
               nextPC = PC + 2;
               let r = execute(ast);
-              (r, does_executed_retire_step(r))
+              (Exec(r), does_executed_retire_step(r))
             } else {
-              (RETIRE_FAIL(Illegal_Instruction()), true)
+              (Exec(RETIRE_FAIL(Illegal_Instruction())), true)
             }
           },
           F_Base(w) => {
@@ -134,46 +134,50 @@ function step(step_no : int, exit_wait : bool) -> step_result = {
             };
             nextPC = PC + 4;
             let r = execute(ast);
-            (r, does_executed_retire_step(r))
+            (Exec(r), does_executed_retire_step(r))
           }
         }
       }
     };
 
-  match retired {
-    RETIRE_SUCCESS()  => {
-      assert(step_state == STEP_ACTIVE);
-      retire_instruction() // update minstret
+  match step_val {
+    Pending_Interrupt(intr, priv) => {
+      if   get_config_print_instr()
+      then print_bits("Handling interrupt: ", interruptType_to_bits(intr));
+      handle_interrupt(intr, priv)
     },
-    RETIRE_FAIL(fail) => match fail {
-      // standard failures
-      Trap(priv, ctl, pc)           => set_next_pc(exception_handler(priv, ctl, pc)),
-      Memory_Exception(vaddr, exc)  => handle_mem_exception(vaddr, exc),
-      Pending_Interrupt(intr, priv) => {
-        if   get_config_print_instr()
-        then print_bits("Handling interrupt: ", interruptType_to_bits(intr));
-        handle_interrupt(intr, priv)
+    Waiting() => {
+      assert(step_state == STEP_WAIT, "cannot be Waiting in a non-wait state.")
+    },
+    Ext_Fetch_Check_Failure(e) => {
+      ext_handle_fetch_check_error(e)
+    },
+    Exec(r) => match r {
+      RETIRE_SUCCESS()  => {
+        assert(step_state == STEP_ACTIVE);
+        retire_instruction() // update minstret
       },
-      Illegal_Instruction() => match instbits {
-          None()         => internal_error(__FILE__, __LINE__, "no instruction bits for illegal instruction"),
-          Some(instbits) => handle_illegal(instbits)
+      RETIRE_FAIL(fail) => match fail {
+        // standard failures
+        Trap(priv, ctl, pc)           => set_next_pc(exception_handler(priv, ctl, pc)),
+        Memory_Exception(vaddr, exc)  => handle_mem_exception(vaddr, exc),
+        Illegal_Instruction() => match instbits {
+            None()         => internal_error(__FILE__, __LINE__, "no instruction bits for illegal instruction"),
+            Some(instbits) => handle_illegal(instbits)
         },
-      Wait_For_Interrupt() => {
-        // Transition into the wait state.
-        if   get_config_print_instr()
-        then print_instr("entering WAIT state at PC " ^ BitStr(PC));
-        step_state = STEP_WAIT
-      },
-      Waiting() => {
-        assert(step_state == STEP_WAIT, "cannot be Waiting in a non-wait state.")
-      },
+        Wait_For_Interrupt() => {
+          // Transition into the wait state.
+          if   get_config_print_instr()
+          then print_instr("entering WAIT state at PC " ^ BitStr(PC));
+          step_state = STEP_WAIT
+        },
 
-      // failures from extensions
-      Ext_Fetch_Check_Failure(e)       => ext_handle_fetch_check_error(e),
-      Ext_CSR_Check_Failure()          => ext_check_CSR_fail(),
-      Ext_ControlAddr_Check_Failure(e) => ext_handle_control_check_error(e),
-      Ext_DataAddr_Check_Failure(e)    => ext_handle_data_check_error(e),
-      Ext_XRET_Priv_Failure()          => ext_fail_xret_priv()
+        // failures from extensions
+        Ext_CSR_Check_Failure()          => ext_check_CSR_fail(),
+        Ext_ControlAddr_Check_Failure(e) => ext_handle_control_check_error(e),
+        Ext_DataAddr_Check_Failure(e)    => ext_handle_data_check_error(e),
+        Ext_XRET_Priv_Failure()          => ext_fail_xret_priv()
+      }
     }
   };
 

--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -8,8 +8,46 @@
 
 /* The emulator fetch-execute-interrupt dispatch loop. */
 
-/* returns whether to increment the step count in the trace */
-function step(step_no : int) -> bool = {
+register step_state : StepState
+
+function init_stepper() -> unit = {
+  step_state = STEP_ACTIVE;
+}
+
+// Checks if the retire returned by the execution of an instruction
+// counts as a step.  It should not be called on other retires.
+function does_executed_retire_step(r : Retired(Retire_Failure)) -> bool =
+  match r {
+    RETIRE_SUCCESS()                   => true,
+    RETIRE_FAIL(Illegal_Instruction()) => true,
+    RETIRE_FAIL(Memory_Exception(_))   => true,
+    RETIRE_FAIL(Trap(_))               => true,
+
+    // do not step if a wait instruction executed.
+    RETIRE_FAIL(Wait_For_Interrupt())  => false,
+
+    // retires from extensions
+    RETIRE_FAIL(Ext_ControlAddr_Check_Failure(_)) => true,
+    RETIRE_FAIL(Ext_DataAddr_Check_Failure(_))    => true,
+    RETIRE_FAIL(Ext_CSR_Check_Failure())          => true,
+    RETIRE_FAIL(Ext_XRET_Priv_Failure(_))         => true,
+
+    // illegal retires for instruction execution
+    RETIRE_FAIL(Waiting()) =>
+      internal_error(__FILE__, __LINE__, "execute returned invalid Waiting retire"),
+    RETIRE_FAIL(Pending_Interrupt(_)) =>
+      internal_error(__FILE__, __LINE__, "execute returned invalid Pending-Interrupt retire"),
+    RETIRE_FAIL(Ext_Fetch_Check_Failure(_)) =>
+      internal_error(__FILE__, __LINE__, "execute returned invalid Ext-Fetch-Check-Failure retire")
+  }
+
+// The `step` function is the main interface to the non-Sail
+// harness.  It receives the current step number (which numbers the
+// active or wait step), and whether it should exit a wait state.
+// It returns whether the Sail emulator executed a step, and the
+// stepper state at the end of the step.
+
+function step(step_no : int, exit_wait : bool) -> step_result = {
   /* for step extensions */
   ext_pre_step_hook();
 
@@ -27,9 +65,41 @@ function step(step_no : int) -> bool = {
   var instbits : option(xlenbits) = None();
 
   let (retired, stepped) : (Retired(Retire_Failure), bool) =
-    match dispatchInterrupt(cur_privilege) {
-      Some(intr, priv) => (RETIRE_FAIL(Pending_Interrupt(intr, priv)), false),
-      None() => {
+    match (dispatchInterrupt(cur_privilege), step_state) {
+      (Some(_, _), STEP_WAIT) => {
+        if   get_config_print_instr()
+        then print_instr("interrupt exit from WAIT state at PC " ^ BitStr(PC));
+
+        step_state = STEP_ACTIVE;
+        // The waiting instruction retires successfully.  The
+        // pending interrupts will be handled in the next step, which
+        // will match the next clause.
+        (RETIRE_SUCCESS(), true)
+      },
+      (Some(intr, priv), STEP_ACTIVE) =>
+        (RETIRE_FAIL(Pending_Interrupt(intr, priv)), false),
+      (None(), STEP_WAIT) => {
+        // There are no pending interrupts; transition out of the Wait
+        // if instructed.
+        if exit_wait then {
+          if   get_config_print_instr()
+          then print_instr("forced exit from WAIT state at PC " ^ BitStr(PC));
+
+          step_state = STEP_ACTIVE;
+          // "When TW=1, then if WFI is executed in any
+          // less-privileged mode, and it does not complete within an
+          // implementation-specific, bounded time limit, the WFI
+          // instruction causes an illegal-instruction exception."
+          if   (cur_privilege == Machine | mstatus[TW] == 0b0)
+          then (RETIRE_SUCCESS(), true)
+          else (RETIRE_FAIL(Illegal_Instruction()), true)
+        } else {
+          if   get_config_print_instr()
+          then print_instr("remaining in WAIT state at PC " ^ BitStr(PC));
+          (RETIRE_FAIL(Waiting()), false)
+        }
+      },
+      (None(), STEP_ACTIVE) => {
         /* the extension hook interposes on the fetch result */
         match ext_fetch_hook(fetch()) {
           /* extension error */
@@ -48,7 +118,8 @@ function step(step_no : int) -> bool = {
             /* check for RVC once here instead of every RVC execute clause. */
             if extensionEnabled(Ext_Zca) then {
               nextPC = PC + 2;
-              (execute(ast), true)
+              let r = execute(ast);
+              (r, does_executed_retire_step(r))
             } else {
               (RETIRE_FAIL(Illegal_Instruction()), true)
             }
@@ -62,14 +133,18 @@ function step(step_no : int) -> bool = {
               print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ BitStr(PC) ^ " (" ^ BitStr(w) ^ ") " ^ to_str(ast));
             };
             nextPC = PC + 4;
-            (execute(ast), true)
+            let r = execute(ast);
+            (r, does_executed_retire_step(r))
           }
         }
       }
     };
 
   match retired {
-    RETIRE_SUCCESS()  => retire_instruction(), // update minstret
+    RETIRE_SUCCESS()  => {
+      assert(step_state == STEP_ACTIVE);
+      retire_instruction() // update minstret
+    },
     RETIRE_FAIL(fail) => match fail {
       // standard failures
       Trap(priv, ctl, pc)           => set_next_pc(exception_handler(priv, ctl, pc)),
@@ -84,10 +159,13 @@ function step(step_no : int) -> bool = {
           Some(instbits) => handle_illegal(instbits)
         },
       Wait_For_Interrupt() => {
-        // This is currently treated as a nop that retires
-        // successfully.
-        platform_wfi();
-        retire_instruction()
+        // Transition into the wait state.
+        if   get_config_print_instr()
+        then print_instr("entering WAIT state at PC " ^ BitStr(PC));
+        step_state = STEP_WAIT
+      },
+      Waiting() => {
+        assert(step_state == STEP_WAIT, "cannot be Waiting in a non-wait state.")
       },
 
       // failures from extensions
@@ -95,16 +173,17 @@ function step(step_no : int) -> bool = {
       Ext_CSR_Check_Failure()          => ext_check_CSR_fail(),
       Ext_ControlAddr_Check_Failure(e) => ext_handle_control_check_error(e),
       Ext_DataAddr_Check_Failure(e)    => ext_handle_data_check_error(e),
-      Ext_XRET_Priv_Failure()          => ext_fail_xret_priv ()
+      Ext_XRET_Priv_Failure()          => ext_fail_xret_priv()
     }
   };
 
-  tick_pc();
+  if step_state != STEP_WAIT then {
+    tick_pc();
 
-  /* for step extensions */
-  ext_post_step_hook();
-
-  stepped
+    /* for step extensions */
+    ext_post_step_hook();
+  };
+  struct { state = step_state, stepped }
 }
 
 function loop () : unit -> unit = {
@@ -112,8 +191,10 @@ function loop () : unit -> unit = {
   var i : int = 0;
   var step_no : int = 0;
   while not(htif_done) do {
-    let stepped = step(step_no);
-    if stepped then {
+    // This standalone loop always exits immediately out of waiting
+    // states.
+    let step_result = step(step_no, true);
+    if step_result.stepped then {
       step_no = step_no + 1;
       if get_config_print_instr() then {
         print_step()
@@ -151,5 +232,6 @@ function reset() -> unit = {
 // Initialize model state. This is only called once; not for every chip reset.
 function init_model() -> unit = {
   init_platform();
+  init_stepper();
   reset();
 }

--- a/model/riscv_step_common.sail
+++ b/model/riscv_step_common.sail
@@ -6,6 +6,24 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
+// The current state of the emulator.
+//
+// The RISC-V hart could either be active (fetching and executing
+// instructions) or waiting (e.g. for an interrupt).  The transition
+// from `active` to `wait` occurs on instructions like WFI.  The
+// transition from `wait` to `active` can occur if (i) the hart
+// detects an interrupt, or (ii) if the external non-Sail emulator
+// harness indicates that the waiting instruction should be retired
+// (as a nop).
+
+enum StepState = {STEP_ACTIVE, STEP_WAIT}
+
+// The return type of the `step` function.
+struct step_result = {
+  state   : StepState,
+  stepped : bool
+}
+
 /* The result of a fetch, which includes any possible error
  * from an extension that interposes on the fetch operation.
  */

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -107,9 +107,15 @@ function privLevel_to_str (p) =
 
 overload to_str = {privLevel_to_str}
 
-/* enum denoting whether an executed instruction retires */
+/* Type denoting whether an executed instruction retires
+ * that is generic over the reasons why a retire might
+ * fail or be incomplete.
+ */
 
-enum Retired = {RETIRE_SUCCESS, RETIRE_FAIL}
+union Retired ('a : Type) = {
+  RETIRE_SUCCESS : unit,
+  RETIRE_FAIL    : 'a
+}
 
 /* memory access types */
 


### PR DESCRIPTION
This tries to address the issues raised in #398 and implements some ideas discussed in #412.

The first commit refactors the stepper and instruction retirement, and addresses #412.
The second adds a Wait state to the stepper and exposes it to the C emulator.
The third adds a configuration option for the max number of wait states before the Wait (for WFI) expires.  This should provide a better foundation for #398.

This is an invasive and backwards-incompatible change, and so mainly submitted for discussion.

I am unsure of the effects on RVFI.  Is it still being used?