### PR TITLE
Add support for Zvkned.

### DIFF
--- a/Makefile.old
+++ b/Makefile.old
@@ -77,8 +77,6 @@ SAIL_DEFAULT_INST += riscv_insts_zcmop.sail
 
 SAIL_DEFAULT_INST += riscv_insts_zvkned.sail
 
-SAIL_DEFAULT_INST += riscv_insts_zvkned.sail
-
 SAIL_SEQ_INST  = $(SAIL_DEFAULT_INST) riscv_jalr_seq.sail
 SAIL_RMEM_INST = $(SAIL_DEFAULT_INST) riscv_jalr_rmem.sail riscv_insts_rmem.sail
 

--- a/Makefile.old
+++ b/Makefile.old
@@ -75,6 +75,10 @@ SAIL_DEFAULT_INST += riscv_insts_zvksh.sail
 SAIL_DEFAULT_INST += riscv_insts_zimop.sail
 SAIL_DEFAULT_INST += riscv_insts_zcmop.sail
 
+SAIL_DEFAULT_INST += riscv_insts_zvkned.sail
+
+SAIL_DEFAULT_INST += riscv_insts_zvkned.sail
+
 SAIL_SEQ_INST  = $(SAIL_DEFAULT_INST) riscv_jalr_seq.sail
 SAIL_RMEM_INST = $(SAIL_DEFAULT_INST) riscv_jalr_rmem.sail riscv_insts_rmem.sail
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ For booting operating system images, see the information under the
 - Zvbb extension for vector basic bit-manipulation, v1.0
 - Zvbc extension for vector carryless multiplication, v1.0
 - Zvkb extension for vector cryptography bit-manipulation, v1.0
+- Zvkned extension for vector cryptography NIST Suite: Vector AES Block Cipher, v1.0
 - Zvknha and Zvknhb extensions for vector cryptography NIST Suite: Vector SHA-2 Secure Hash, v1.0
 - Zvksh extension for vector cryptography ShangMi Suite: SM3 Secure Hash, v1.0
 - Machine, Supervisor, and User modes

--- a/config/default.json
+++ b/config/default.json
@@ -190,11 +190,11 @@
     "Zvbc": {
       "supported": true
     },
-    "Zvknha": {
+    "Zvkned": {
       "supported": true
     },
-    "Zvkned" : {
-      "supported" : true
+    "Zvknha": {
+      "supported": true
     },
     "Zvknhb": {
       "supported": true

--- a/config/default.json
+++ b/config/default.json
@@ -193,6 +193,9 @@
     "Zvknha": {
       "supported": true
     },
+    "Zvkned" : {
+      "supported" : true
+    },
     "Zvknhb": {
       "supported": true
     },

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -84,11 +84,13 @@ foreach (xlen IN ITEMS 32 64)
                 "riscv_insts_zbkx.sail"
                 "riscv_insts_zicond.sail"
                 ${vext_srcs}
+                "riscv_insts_zvkned.sail"
                 "riscv_insts_zicbom.sail"
                 "riscv_insts_zicboz.sail"
                 "riscv_insts_zawrs.sail"
                 "riscv_insts_zvbb.sail"
                 "riscv_insts_zvbc.sail"
+                "riscv_insts_zvkned.sail"
                 "riscv_insts_zvknhab.sail"
                 "riscv_insts_zvksh.sail"
                 # Zimop and Zcmop should be at the end so they can be overridden by earlier extensions
@@ -186,6 +188,7 @@ foreach (xlen IN ITEMS 32 64)
                 "riscv_inst_retire.sail"
                 ${sail_vm_srcs}
                 # Shared/common code for the cryptography extension.
+                "riscv_zvk_utils.sail"
                 "riscv_types_kext.sail"
                 "riscv_zvk_utils.sail"
             )

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -84,7 +84,6 @@ foreach (xlen IN ITEMS 32 64)
                 "riscv_insts_zbkx.sail"
                 "riscv_insts_zicond.sail"
                 ${vext_srcs}
-                "riscv_insts_zvkned.sail"
                 "riscv_insts_zicbom.sail"
                 "riscv_insts_zicboz.sail"
                 "riscv_insts_zawrs.sail"
@@ -188,7 +187,6 @@ foreach (xlen IN ITEMS 32 64)
                 "riscv_inst_retire.sail"
                 ${sail_vm_srcs}
                 # Shared/common code for the cryptography extension.
-                "riscv_zvk_utils.sail"
                 "riscv_types_kext.sail"
                 "riscv_zvk_utils.sail"
             )

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -185,6 +185,9 @@ function clause hartSupports(Ext_Zvkb) = config extensions.Zvkb.supported
 // Vector Carryless Multiplication
 enum clause extension = Ext_Zvbc
 function clause hartSupports(Ext_Zvbc) = config extensions.Zvbc.supported
+// NIST Suite: Vector AES Block Cipher
+enum clause extension = Ext_Zvkned
+function clause hartSupports(Ext_Zvkned) = config extensions.Zvkned.supported
 // NIST Suite: Vector SHA-2 Secure Hash
 enum clause extension = Ext_Zvknha
 function clause hartSupports(Ext_Zvknha) = config extensions.Zvknha.supported
@@ -194,7 +197,6 @@ function clause hartSupports(Ext_Zvknhb) = config extensions.Zvknhb.supported
 // ShangMi Suite: SM3 Secure Hash
 enum clause extension = Ext_Zvksh
 function clause hartSupports(Ext_Zvksh) = config extensions.Zvksh.supported
-
 
 // Count Overflow and Mode-Based Filtering
 enum clause extension = Ext_Sscofpmf

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -204,6 +204,17 @@ function write_velem_oct_vec(vd, SEW, input, i) = {
     write_single_element(SEW, 8 * i + j, vd, input[j]);
 }
 
+/* Extracts 4 consecutive vector elements starting from index 4*i and returns a vector */
+val get_velem_quad_vec : forall 'n 'm 'p, 'n > 0 & 8 <= 'm <= 64  & 'p >= 0 & 4 * 'p + 3 < 'n. (vector('n, bits('m)), int('p)) -> vector(4, bits('m))
+function get_velem_quad_vec(v, i) = [ v[4 * i + 3], v[4 * i + 2], v[4 * i + 1], v[4 * i] ]
+
+/* Writes each of the 4 elements from the input vector to the vector register vd, starting at position 4 * i */
+val write_velem_quad_vec : forall 'p 'n, 8 <= 'n <= 64 & 'p >= 0. (vregidx, int('n), vector(4, bits('n)), int('p)) -> unit
+function write_velem_quad_vec(vd, SEW, input, i) = {
+  foreach(j from 0 to 3)
+    write_single_element(SEW, 4 * i + j, vd, input[j]);
+}
+
 /* Get the starting element index from csr vtype */
 val get_start_element : unit -> result(nat, unit)
 function get_start_element() = {

--- a/model/riscv_insts_zvkned.sail
+++ b/model/riscv_insts_zvkned.sail
@@ -1,0 +1,379 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+/*
+ * Vector Cryptography Extension - NIST Suite: Vector AES Block Cipher
+ * ----------------------------------------------------------------------
+ */
+
+function clause currentlyEnabled(Ext_Zvkned) = true
+
+val get_velem : forall 'n 'm 'p, 'n > 0 & 'm > 0 & 'p >= 0 & 4 * 'p + 3 < 'n . (vector('n, bits('m)), int('p)) -> bits(4 * 'm)
+function get_velem(v, i) = v[4 * i + 3] @ v[4 * i + 2] @ v[4 * i + 1] @ v[4 * i]
+
+val set_velem : forall 'n 'm 'p, 'n > 0 & 'm > 0 & 'p >= 0 & 4 * 'p + 3 < 'n . (vector('n, bits('m)), bits(4 * 'm), int('p)) -> vector('n, bits('m))
+function set_velem(s, v, i) = {
+  let m = length(v) / 4;
+  [s with
+    (4 * i) = v[m - 1 .. 0],
+    (4 * i + 1) = v[2 * m - 1 .. m],
+    (4 * i + 2) = v[3 * m - 1 .. 2 * m],
+    (4 * i + 3) = v[4 * m - 1 .. 3 * m],
+  ]
+}
+
+function aes_rotword(x : bits(32)) -> bits(32) = x[7.. 0] @ x[31..24] @ x[23..16] @ x[15.. 8]
+
+function zvk_check_elements(VLEN : int, num_elem : int, LMUL : int, SEW : int) -> bool = {
+  ((unsigned(vl)%num_elem) != 0) | ((unsigned(vstart)%num_elem) != 0) | (LMUL*VLEN) < (num_elem*SEW)
+}
+
+function zvk_check_encdec(EGW : int, EGS : int) -> bool = {
+  let LMUL_pow = get_lmul_pow();
+
+  (unsigned(vl) % EGS == 0) & (unsigned(vstart) % EGS == 0) & (2 ^ LMUL_pow * VLEN >= 128)
+}
+
+val vv_or_vs_index : forall 'n , 0 <= 'n . (suffix_kind , int('n)) -> range(0, 'n)
+function vv_or_vs_index(suffix, i) = {
+  match suffix {
+    Vector_Vector => i,
+    Vector_Scalar => 0,
+  }
+}
+
+mapping vv_or_vs : suffix_kind <-> bits(6) = {
+  Vector_Vector <-> 0b101000,
+  Vector_Scalar <-> 0b101001,
+}
+
+mapping vv_or_vs_mnemonic : suffix_kind <-> string = {
+  Vector_Vector <-> "vv",
+  Vector_Scalar <-> "vs",
+}
+
+/* VAESEF.[VV, VS] */
+
+union clause ast = RISCV_VAESEF : (vregidx, vregidx, suffix_kind)
+
+mapping clause encdec = RISCV_VAESEF(vs2, vd, suffix)
+  <-> vv_or_vs(suffix) @ 0b1 @ encdec_vreg(vs2) @ 0b00011 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
+
+mapping clause assembly = RISCV_VAESEF(vs2, vd, suffix)
+  <-> "vaesef." ^ vv_or_vs_mnemonic(suffix) ^ spc() ^ vreg_name(vd)
+                                            ^ spc() ^ vreg_name(vs2)
+
+function clause execute (RISCV_VAESEF(vs2, vd, suffix)) = {
+  let 'SEW = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let 'num_elem = get_num_elem(LMUL_pow, SEW);
+
+  assert(SEW == 32);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
+
+  let eg_len = (unsigned(vl) / 4);
+  let eg_start = (unsigned(vstart) / 4);
+
+  foreach (i from eg_start to (eg_len - 1)) {
+    assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < num_elem);
+
+    let vd_state = get_velem(vd_val, i);
+    let vs2_key  = get_velem(vs2_val, vv_or_vs_index(suffix, i));
+    let sb = aes_subbytes_fwd(vd_state);
+    let sr = aes_shift_rows_fwd(sb);
+    let ark = sr ^ vs2_key;
+
+    result = set_velem(result, ark, i);
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  set_vstart(zeros());
+  RETIRE_SUCCESS
+}
+
+/* VAESEM.[VV, VS] */
+
+union clause ast = RISCV_VAESEM : (vregidx, vregidx, suffix_kind)
+
+mapping clause encdec = RISCV_VAESEM(vs2, vd, suffix)
+  <-> vv_or_vs(suffix) @ 0b1 @ encdec_vreg(vs2) @ 0b00010 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
+
+mapping clause assembly = RISCV_VAESEM(vs2, vd, suffix)
+  <-> "vaesem." ^ vv_or_vs_mnemonic(suffix) ^ spc() ^ vreg_name(vd)
+                                            ^ sep() ^ vreg_name(vs2)
+
+function clause execute (RISCV_VAESEM(vs2, vd, suffix)) = {
+  let 'SEW = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let 'num_elem = get_num_elem(LMUL_pow, SEW);
+
+  assert(SEW == 32);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
+
+  let eg_len = (unsigned(vl) / 4);
+  let eg_start = (unsigned(vstart) / 4);
+
+  foreach (i from eg_start to (eg_len - 1)) {
+    assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < num_elem);
+
+    let vd_state = get_velem(vd_val, i);
+    let vs2_key  = get_velem(vs2_val, vv_or_vs_index(suffix, i));
+    let sb : bits(128) = aes_subbytes_fwd(vd_state);
+    let sr : bits(128) = aes_shift_rows_fwd(sb);
+    let mix : bits(128) = aes_mixcolumns_fwd(sr);
+    let ark : bits(128) = mix ^ vs2_key;
+
+    result = set_velem(result, ark, i);
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  set_vstart(zeros());
+  RETIRE_SUCCESS
+}
+
+/* VAESDF.VV */
+
+union clause ast = RISCV_VAESDF : (vregidx, vregidx, suffix_kind)
+
+mapping clause encdec = RISCV_VAESDF(vs2, vd, suffix)
+  <-> vv_or_vs(suffix) @ 0b1 @ encdec_vreg(vs2) @ 0b00001 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
+
+mapping clause assembly = RISCV_VAESDF(vs2, vd, suffix)
+  <-> "vaesdf." ^ vv_or_vs_mnemonic(suffix) ^ sep() ^ vreg_name(vd)
+                                            ^ sep() ^ vreg_name(vs2)
+
+function clause execute (RISCV_VAESDF(vs2, vd, suffix)) = {
+  let 'SEW = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let 'num_elem = get_num_elem(LMUL_pow, SEW);
+
+  assert(SEW == 32);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
+
+  let eg_len = (unsigned(vl) / 4);
+  let eg_start = (unsigned(vstart) / 4);
+
+  foreach (i from eg_start to (eg_len - 1)) {
+    assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < num_elem);
+
+    let vd_state = get_velem(vd_val, i);
+    let vs2_key  = get_velem(vs2_val, vv_or_vs_index(suffix, i));
+    let sr : bits(128) = aes_shift_rows_inv(vd_state);
+    let sb : bits(128) = aes_subbytes_inv(sr);
+    let ark : bits(128) = sb ^ vs2_key;
+
+    result = set_velem(result, ark, i);
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  set_vstart(zeros());
+  RETIRE_SUCCESS
+}
+
+/* VAESDM.VV */
+
+union clause ast = RISCV_VAESDM : (vregidx, vregidx, suffix_kind)
+
+mapping clause encdec = RISCV_VAESDM(vs2, vd, suffix)
+  <-> vv_or_vs(suffix) @ 0b1 @ encdec_vreg(vs2) @ 0b00000 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
+
+mapping clause assembly = RISCV_VAESDM(vs2, vd, suffix)
+  <-> "vaesdm." ^ vv_or_vs_mnemonic(suffix) ^ spc() ^ vreg_name(vd)
+                                            ^ sep() ^ vreg_name(vs2)
+
+function clause execute (RISCV_VAESDM(vs2, vd, suffix)) = {
+  let 'SEW = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let 'num_elem = get_num_elem(LMUL_pow, SEW);
+
+  assert(SEW == 32);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
+
+  let eg_len = (unsigned(vl) / 4);
+  let eg_start = (unsigned(vstart) / 4);
+
+  foreach (i from eg_start to (eg_len - 1)) {
+    assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < num_elem);
+
+    let vd_state = get_velem(vd_val, i);
+    let vs2_key  = get_velem(vs2_val, vv_or_vs_index(suffix, i));
+    let sr : bits(128) = aes_shift_rows_inv(vd_state);
+    let sb : bits(128) = aes_subbytes_inv(sr);
+    let ark : bits(128) = sb ^ vs2_key;
+    let mix : bits(128) = aes_mixcolumns_inv(ark);
+
+    result = set_velem(result, mix, i);
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  set_vstart(zeros());
+  RETIRE_SUCCESS
+}
+
+/* VAESKF1.VI */
+
+union clause ast = RISCV_VAESKF1_VI : (vregidx, bits(5), vregidx)
+
+mapping clause encdec = RISCV_VAESKF1_VI(vs2, rnd, vd)
+  <-> 0b1000101 @ encdec_vreg(vs2) @ rnd @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
+
+mapping clause assembly = RISCV_VAESKF1_VI(vs2, rnd, vd)
+  <-> "vaeskf1.vi" ^ sep() ^ vreg_name(vd)
+                   ^ sep() ^ vreg_name(vs2)
+                   ^ sep() ^ hex_bits_5(rnd)
+
+function clause execute (RISCV_VAESKF1_VI(vs2, rnd, vd)) = {
+  let 'SEW = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let 'num_elem = get_num_elem(LMUL_pow, SEW);
+
+  assert(SEW == 32);
+  var rnd_val : bits(5) = rnd;
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  if (unsigned(rnd_val[3..0]) > 10) | (unsigned(rnd_val[3..0]) == 0)
+  then rnd_val[3] = not_bit(rnd_val[3]);
+
+  let r : bits(4) = rnd_val[3..0] - 1;
+
+  var w : bits(128) = zeros();
+  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
+
+  let eg_len = (unsigned(vl) / 4);
+  let eg_start = (unsigned(vstart) / 4);
+
+  foreach (i from eg_start to (eg_len - 1)) {
+    assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < num_elem);
+    let current_round_key = get_velem(vs2_val, i);
+
+    w[31..0] = aes_subword_fwd(aes_rotword(current_round_key[127..96]))
+             ^ aes_decode_rcon(r)
+             ^ current_round_key[31..0];
+    w[63..32]  = w[31..0]  ^ current_round_key[63..32];
+    w[95..64]  = w[63..32] ^ current_round_key[95..64];
+    w[127..96] = w[95..64] ^ current_round_key[127..96];
+
+    result = set_velem(result, w, i);
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  set_vstart(zeros());
+  RETIRE_SUCCESS
+}
+
+/* VAESKF2.VI */
+
+union clause ast = RISCV_VAESKF2_VI : (vregidx, bits(5), vregidx)
+
+mapping clause encdec = RISCV_VAESKF2_VI(vs2, rnd, vd)
+  <-> 0b1010101 @ encdec_vreg(vs2) @ rnd @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
+
+mapping clause assembly = RISCV_VAESKF2_VI(vs2, rnd, vd)
+  <-> "vaeskf2.vi" ^ sep() ^ vreg_name(vd)
+                   ^ sep() ^ vreg_name(vs2)
+                   ^ sep() ^ hex_bits_5(rnd)
+
+function clause execute (RISCV_VAESKF2_VI(vs2, rnd, vd)) = {
+  let 'SEW = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let 'num_elem = get_num_elem(LMUL_pow, SEW);
+
+  assert(SEW == 32);
+  var rnd_val : bits(4) = rnd[3..0];
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  if (unsigned(rnd_val) < 2) | (unsigned(rnd_val) > 14)
+  then rnd_val[3] = not_bit(rnd_val[3]);
+
+  var w : bits(128) = zeros();
+  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
+
+  let eg_len = (unsigned(vl) / 4);
+  let eg_start = (unsigned(vstart) / 4);
+
+  foreach (i from eg_start to (eg_len - 1)) {
+    assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < num_elem);
+
+    let current_round_key = get_velem(vs2_val, i);
+
+    let round_key_b = get_velem(vd_val, i);
+
+    w[31..0] = if (rnd_val[0] == bitone)
+               then
+                 aes_subword_fwd(current_round_key[127..96]) ^ round_key_b[31..0]
+               else
+                 aes_subword_fwd(aes_rotword(current_round_key[127..96]))
+                   ^ aes_decode_rcon((rnd_val >> 1) - 1)
+                   ^ round_key_b[31..0];
+
+    w[63..32]  = w[31..0]  ^ round_key_b[63..32];
+    w[95..64]  = w[63..32] ^ round_key_b[95..64];
+    w[127..96] = w[95..64] ^ round_key_b[127..96];
+
+    result = set_velem(result, w, i);
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  set_vstart(zeros());
+  RETIRE_SUCCESS
+}
+
+/* VAESZ.VS */
+
+union clause ast = RISCV_VAESZ_VS : (vregidx, vregidx)
+
+mapping clause encdec = RISCV_VAESZ_VS(vs2, vd)
+  <-> 0b1010011 @ encdec_vreg(vs2) @ 0b00111 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
+
+mapping clause assembly = RISCV_VAESZ_VS(vs2, vd)
+  <-> "vaesz.vs" ^ sep() ^ vreg_name(vd)
+                 ^ sep() ^ vreg_name(vs2)
+
+function clause execute (RISCV_VAESZ_VS(vs2, vd)) = {
+  let 'SEW = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let 'num_elem = get_num_elem(LMUL_pow, SEW);
+
+  assert(SEW == 32);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
+
+  let eg_len = (unsigned(vl) / 4);
+  let eg_start = (unsigned(vstart) / 4);
+
+  foreach (i from eg_start to (eg_len - 1)) {
+    assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < num_elem);
+
+    let vd_state = get_velem(vd_val, i);
+    let vs2_key  = get_velem(vs2_val, 0);
+    let ark : bits(128) = vd_state ^ vs2_key;
+
+    result = set_velem(result, ark, i);
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  set_vstart(zeros());
+  RETIRE_SUCCESS
+}

--- a/model/riscv_insts_zvkned.sail
+++ b/model/riscv_insts_zvkned.sail
@@ -5,375 +5,350 @@
 /*                                                                                       */
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
-/*
- * Vector Cryptography Extension - NIST Suite: Vector AES Block Cipher
- * ----------------------------------------------------------------------
- */
 
-function clause currentlyEnabled(Ext_Zvkned) = true
+function clause currentlyEnabled(Ext_Zvkned) = hartSupports(Ext_Zvkned) & currentlyEnabled(Ext_V)
 
-val get_velem : forall 'n 'm 'p, 'n > 0 & 'm > 0 & 'p >= 0 & 4 * 'p + 3 < 'n . (vector('n, bits('m)), int('p)) -> bits(4 * 'm)
-function get_velem(v, i) = v[4 * i + 3] @ v[4 * i + 2] @ v[4 * i + 1] @ v[4 * i]
+union clause ast = VAESDF : (zvk_vaesdf_funct6, vregidx, vregidx)
 
-val set_velem : forall 'n 'm 'p, 'n > 0 & 'm > 0 & 'p >= 0 & 4 * 'p + 3 < 'n . (vector('n, bits('m)), bits(4 * 'm), int('p)) -> vector('n, bits('m))
-function set_velem(s, v, i) = {
-  let m = length(v) / 4;
-  [s with
-    (4 * i) = v[m - 1 .. 0],
-    (4 * i + 1) = v[2 * m - 1 .. m],
-    (4 * i + 2) = v[3 * m - 1 .. 2 * m],
-    (4 * i + 3) = v[4 * m - 1 .. 3 * m],
-  ]
+mapping encdec_vaesdf : zvk_vaesdf_funct6 <-> bits(6) = {
+  ZVK_VAESDF_VV <-> 0b101000,
+  ZVK_VAESDF_VS <-> 0b101001,
 }
 
-function aes_rotword(x : bits(32)) -> bits(32) = x[7.. 0] @ x[31..24] @ x[23..16] @ x[15.. 8]
+mapping clause encdec = VAESDF(funct6, vs2, vd)
+  <-> encdec_vaesdf(funct6) @ 0b1 @ encdec_vreg(vs2) @ 0b00001 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4) & (funct6 == ZVK_VAESDF_VV |
+  zvk_valid_reg_overlap(vs2, vd, get_lmul_pow()))
 
-function zvk_check_elements(VLEN : int, num_elem : int, LMUL : int, SEW : int) -> bool = {
-  ((unsigned(vl)%num_elem) != 0) | ((unsigned(vstart)%num_elem) != 0) | (LMUL*VLEN) < (num_elem*SEW)
-}
-
-function zvk_check_encdec(EGW : int, EGS : int) -> bool = {
+function clause execute (VAESDF(funct6, vs2, vd)) = {
+  let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-
-  (unsigned(vl) % EGS == 0) & (unsigned(vstart) % EGS == 0) & (2 ^ LMUL_pow * VLEN >= 128)
-}
-
-val vv_or_vs_index : forall 'n , 0 <= 'n . (suffix_kind , int('n)) -> range(0, 'n)
-function vv_or_vs_index(suffix, i) = {
-  match suffix {
-    Vector_Vector => i,
-    Vector_Scalar => 0,
-  }
-}
-
-mapping vv_or_vs : suffix_kind <-> bits(6) = {
-  Vector_Vector <-> 0b101000,
-  Vector_Scalar <-> 0b101001,
-}
-
-mapping vv_or_vs_mnemonic : suffix_kind <-> string = {
-  Vector_Vector <-> "vv",
-  Vector_Scalar <-> "vs",
-}
-
-/* VAESEF.[VV, VS] */
-
-union clause ast = RISCV_VAESEF : (vregidx, vregidx, suffix_kind)
-
-mapping clause encdec = RISCV_VAESEF(vs2, vd, suffix)
-  <-> vv_or_vs(suffix) @ 0b1 @ encdec_vreg(vs2) @ 0b00011 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
-  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
-
-mapping clause assembly = RISCV_VAESEF(vs2, vd, suffix)
-  <-> "vaesef." ^ vv_or_vs_mnemonic(suffix) ^ spc() ^ vreg_name(vd)
-                                            ^ spc() ^ vreg_name(vs2)
-
-function clause execute (RISCV_VAESEF(vs2, vd, suffix)) = {
-  let 'SEW = get_sew();
-  let LMUL_pow = get_lmul_pow();
-  let 'num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
   assert(SEW == 32);
-  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
 
-  let eg_len = (unsigned(vl) / 4);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let eg_len   = (unsigned(vl) / 4);
   let eg_start = (unsigned(vstart) / 4);
 
   foreach (i from eg_start to (eg_len - 1)) {
-    assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < num_elem);
+    assert(i * 4 + 3 < num_elem);
 
-    let vd_state = get_velem(vd_val, i);
-    let vs2_key  = get_velem(vs2_val, vv_or_vs_index(suffix, i));
-    let sb = aes_subbytes_fwd(vd_state);
-    let sr = aes_shift_rows_fwd(sb);
-    let ark = sr ^ vs2_key;
+    let state = get_velem_quad(vd_val, i);
+    let rkey : bits(128) = match funct6 {
+      ZVK_VAESDF_VV => get_velem_quad(vs2_val, i),
+      ZVK_VAESDF_VS => get_velem_quad(vs2_val, 0),
+    };
+    let sr  = aes_shift_rows_inv(state);
+    let sb  = aes_subbytes_inv(sr);
+    let ark = sb ^ rkey;
 
-    result = set_velem(result, ark, i);
+    write_velem_quad(vd, SEW, ark, i);
   };
 
-  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }
 
-/* VAESEM.[VV, VS] */
+mapping vaesdf_mnemonic : zvk_vaesdf_funct6 <-> string = {
+  ZVK_VAESDF_VV <-> "vaesdf.vv",
+  ZVK_VAESDF_VS <-> "vaesdf.vs",
+}
 
-union clause ast = RISCV_VAESEM : (vregidx, vregidx, suffix_kind)
+mapping clause assembly = VAESDF(funct6, vs2, vd)
+  <-> vaesdf_mnemonic(funct6) ^ sep() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)
 
-mapping clause encdec = RISCV_VAESEM(vs2, vd, suffix)
-  <-> vv_or_vs(suffix) @ 0b1 @ encdec_vreg(vs2) @ 0b00010 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
-  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
+union clause ast = VAESDM : (zvk_vaesdm_funct6, vregidx, vregidx)
 
-mapping clause assembly = RISCV_VAESEM(vs2, vd, suffix)
-  <-> "vaesem." ^ vv_or_vs_mnemonic(suffix) ^ spc() ^ vreg_name(vd)
-                                            ^ sep() ^ vreg_name(vs2)
+mapping encdec_vaesdm : zvk_vaesdm_funct6 <-> bits(6) = {
+  ZVK_VAESDM_VV <-> 0b101000,
+  ZVK_VAESDM_VS <-> 0b101001,
+}
 
-function clause execute (RISCV_VAESEM(vs2, vd, suffix)) = {
-  let 'SEW = get_sew();
+mapping clause encdec = VAESDM(funct6, vs2, vd)
+  <-> encdec_vaesdm(funct6) @ 0b1 @ encdec_vreg(vs2) @ 0b00000 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4) & (funct6 == ZVK_VAESDM_VV |
+  zvk_valid_reg_overlap(vs2, vd, get_lmul_pow()))
+
+function clause execute (VAESDM(funct6, vs2, vd)) = {
+  let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let 'num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
   assert(SEW == 32);
-  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
 
-  let eg_len = (unsigned(vl) / 4);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let eg_len   = (unsigned(vl) / 4);
   let eg_start = (unsigned(vstart) / 4);
 
   foreach (i from eg_start to (eg_len - 1)) {
-    assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < num_elem);
+    assert(i * 4 + 3 < num_elem);
 
-    let vd_state = get_velem(vd_val, i);
-    let vs2_key  = get_velem(vs2_val, vv_or_vs_index(suffix, i));
-    let sb : bits(128) = aes_subbytes_fwd(vd_state);
-    let sr : bits(128) = aes_shift_rows_fwd(sb);
-    let mix : bits(128) = aes_mixcolumns_fwd(sr);
-    let ark : bits(128) = mix ^ vs2_key;
+    let state = get_velem_quad(vd_val, i);
+    let rkey : bits(128) = match funct6 {
+      ZVK_VAESDM_VV => get_velem_quad(vs2_val, i),
+      ZVK_VAESDM_VS => get_velem_quad(vs2_val, 0),
+    };
+    let sr    = aes_shift_rows_inv(state);
+    let sb    = aes_subbytes_inv(sr);
+    let ark   = sb ^ rkey;
+    let mix   = aes_mixcolumns_inv(ark);
 
-    result = set_velem(result, ark, i);
+    write_velem_quad(vd, SEW, mix, i);
   };
 
-  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }
 
-/* VAESDF.VV */
+mapping vaesdm_mnemonic : zvk_vaesdm_funct6 <-> string = {
+  ZVK_VAESDM_VV <-> "vaesdm.vv",
+  ZVK_VAESDM_VS <-> "vaesdm.vs",
+}
 
-union clause ast = RISCV_VAESDF : (vregidx, vregidx, suffix_kind)
+mapping clause assembly = VAESDM(funct6, vs2, vd)
+  <-> vaesdm_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)
 
-mapping clause encdec = RISCV_VAESDF(vs2, vd, suffix)
-  <-> vv_or_vs(suffix) @ 0b1 @ encdec_vreg(vs2) @ 0b00001 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
-  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
+union clause ast = VAESEF : (zvk_vaesef_funct6, vregidx, vregidx)
 
-mapping clause assembly = RISCV_VAESDF(vs2, vd, suffix)
-  <-> "vaesdf." ^ vv_or_vs_mnemonic(suffix) ^ sep() ^ vreg_name(vd)
-                                            ^ sep() ^ vreg_name(vs2)
+mapping encdec_vaesef : zvk_vaesef_funct6 <-> bits(6) = {
+  ZVK_VAESEF_VV <-> 0b101000,
+  ZVK_VAESEF_VS <-> 0b101001,
+}
 
-function clause execute (RISCV_VAESDF(vs2, vd, suffix)) = {
-  let 'SEW = get_sew();
+mapping clause encdec = VAESEF(funct6, vs2, vd)
+  <-> encdec_vaesef(funct6) @ 0b1 @ encdec_vreg(vs2) @ 0b00011 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4) & (funct6 == ZVK_VAESEF_VV |
+  zvk_valid_reg_overlap(vs2, vd, get_lmul_pow()))
+
+function clause execute (VAESEF(funct6, vs2, vd)) = {
+  let SEW = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let 'num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
   assert(SEW == 32);
-  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
 
-  let eg_len = (unsigned(vl) / 4);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let eg_len   = (unsigned(vl) / 4);
   let eg_start = (unsigned(vstart) / 4);
 
   foreach (i from eg_start to (eg_len - 1)) {
-    assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < num_elem);
+    assert(i * 4 + 3 < num_elem);
 
-    let vd_state = get_velem(vd_val, i);
-    let vs2_key  = get_velem(vs2_val, vv_or_vs_index(suffix, i));
-    let sr : bits(128) = aes_shift_rows_inv(vd_state);
-    let sb : bits(128) = aes_subbytes_inv(sr);
-    let ark : bits(128) = sb ^ vs2_key;
+    let state = get_velem_quad(vd_val, i);
+    let rkey : bits(128) = match funct6 {
+      ZVK_VAESEF_VV => get_velem_quad(vs2_val, i),
+      ZVK_VAESEF_VS => get_velem_quad(vs2_val, 0),
+    };
+    let sb    = aes_subbytes_fwd(state);
+    let sr    = aes_shift_rows_fwd(sb);
+    let ark   = sr ^ rkey;
 
-    result = set_velem(result, ark, i);
+    write_velem_quad(vd, SEW, ark, i);
   };
 
-  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }
 
-/* VAESDM.VV */
+mapping vaesef_mnemonic : zvk_vaesef_funct6 <-> string = {
+  ZVK_VAESEF_VV <-> "vaesef.vv",
+  ZVK_VAESEF_VS <-> "vaesef.vs",
+}
 
-union clause ast = RISCV_VAESDM : (vregidx, vregidx, suffix_kind)
+mapping clause assembly = VAESEF(funct6, vs2, vd)
+  <-> vaesef_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ spc() ^ vreg_name(vs2)
 
-mapping clause encdec = RISCV_VAESDM(vs2, vd, suffix)
-  <-> vv_or_vs(suffix) @ 0b1 @ encdec_vreg(vs2) @ 0b00000 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
-  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
+union clause ast = VAESEM : (zvk_vaesem_funct6, vregidx, vregidx)
 
-mapping clause assembly = RISCV_VAESDM(vs2, vd, suffix)
-  <-> "vaesdm." ^ vv_or_vs_mnemonic(suffix) ^ spc() ^ vreg_name(vd)
-                                            ^ sep() ^ vreg_name(vs2)
+mapping encdec_vaesem : zvk_vaesem_funct6 <-> bits(6) = {
+  ZVK_VAESEM_VV <-> 0b101000,
+  ZVK_VAESEM_VS <-> 0b101001,
+}
 
-function clause execute (RISCV_VAESDM(vs2, vd, suffix)) = {
-  let 'SEW = get_sew();
+mapping clause encdec = VAESEM(funct6, vs2, vd)
+  <-> encdec_vaesem(funct6) @ 0b1 @ encdec_vreg(vs2) @ 0b00010 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4) & (funct6 == ZVK_VAESEM_VV |
+  zvk_valid_reg_overlap(vs2, vd, get_lmul_pow()))
+
+function clause execute (VAESEM(funct6, vs2, vd)) = {
+  let SEW = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let 'num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
   assert(SEW == 32);
-  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
 
-  let eg_len = (unsigned(vl) / 4);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let eg_len   = (unsigned(vl) / 4);
   let eg_start = (unsigned(vstart) / 4);
 
   foreach (i from eg_start to (eg_len - 1)) {
-    assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < num_elem);
+    assert(i * 4 + 3 < num_elem);
 
-    let vd_state = get_velem(vd_val, i);
-    let vs2_key  = get_velem(vs2_val, vv_or_vs_index(suffix, i));
-    let sr : bits(128) = aes_shift_rows_inv(vd_state);
-    let sb : bits(128) = aes_subbytes_inv(sr);
-    let ark : bits(128) = sb ^ vs2_key;
-    let mix : bits(128) = aes_mixcolumns_inv(ark);
+    let state = get_velem_quad(vd_val, i);
+    let rkey : bits(128) = match funct6 {
+      ZVK_VAESEM_VV => get_velem_quad(vs2_val, i),
+      ZVK_VAESEM_VS => get_velem_quad(vs2_val, 0),
+    };
+    let sb    = aes_subbytes_fwd(state);
+    let sr    = aes_shift_rows_fwd(sb);
+    let mix   = aes_mixcolumns_fwd(sr);
+    let ark   = mix ^ rkey;
 
-    result = set_velem(result, mix, i);
+    write_velem_quad(vd, SEW, ark, i);
   };
 
-  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }
 
-/* VAESKF1.VI */
+mapping vaesem_mnemonic : zvk_vaesem_funct6 <-> string = {
+  ZVK_VAESEM_VV <-> "vaesem.vv",
+  ZVK_VAESEM_VS <-> "vaesem.vs",
+}
 
-union clause ast = RISCV_VAESKF1_VI : (vregidx, bits(5), vregidx)
+mapping clause assembly = VAESEM(funct6, vs2, vd)
+  <-> vaesem_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)
 
-mapping clause encdec = RISCV_VAESKF1_VI(vs2, rnd, vd)
+union clause ast = VAESKF1_VI : (vregidx, bits(5), vregidx)
+
+mapping clause encdec = VAESKF1_VI(vs2, rnd, vd)
   <-> 0b1000101 @ encdec_vreg(vs2) @ rnd @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
 
-mapping clause assembly = RISCV_VAESKF1_VI(vs2, rnd, vd)
-  <-> "vaeskf1.vi" ^ sep() ^ vreg_name(vd)
-                   ^ sep() ^ vreg_name(vs2)
-                   ^ sep() ^ hex_bits_5(rnd)
-
-function clause execute (RISCV_VAESKF1_VI(vs2, rnd, vd)) = {
-  let 'SEW = get_sew();
+function clause execute (VAESKF1_VI(vs2, rnd, vd)) = {
+  let SEW = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let 'num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
   assert(SEW == 32);
-  var rnd_val : bits(5) = rnd;
+
   let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  var rnd_val : bits(5) = rnd;
 
   if (unsigned(rnd_val[3..0]) > 10) | (unsigned(rnd_val[3..0]) == 0)
   then rnd_val[3] = not_bit(rnd_val[3]);
 
   let r : bits(4) = rnd_val[3..0] - 1;
 
-  var w : bits(128) = zeros();
-  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
+  var w : vector(4, bits(32)) = vector_init(zeros());
 
-  let eg_len = (unsigned(vl) / 4);
+  let eg_len   = (unsigned(vl) / 4);
   let eg_start = (unsigned(vstart) / 4);
 
   foreach (i from eg_start to (eg_len - 1)) {
-    assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < num_elem);
-    let current_round_key = get_velem(vs2_val, i);
+    assert(i * 4 + 3 < num_elem);
 
-    w[31..0] = aes_subword_fwd(aes_rotword(current_round_key[127..96]))
-             ^ aes_decode_rcon(r)
-             ^ current_round_key[31..0];
-    w[63..32]  = w[31..0]  ^ current_round_key[63..32];
-    w[95..64]  = w[63..32] ^ current_round_key[95..64];
-    w[127..96] = w[95..64] ^ current_round_key[127..96];
+    let current_round_key = get_velem_quad_vec(vs2_val, i);
 
-    result = set_velem(result, w, i);
+    w[0] = aes_subword_fwd(current_round_key[3] >>> 8) ^
+           aes_decode_rcon(r) ^ current_round_key[0];
+    w[1] = w[0] ^ current_round_key[1];
+    w[2] = w[1] ^ current_round_key[2];
+    w[3] = w[2] ^ current_round_key[3];
+
+    write_velem_quad_vec(vd, SEW, w, i);
   };
 
-  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }
 
-/* VAESKF2.VI */
+mapping clause assembly = VAESKF1_VI(vs2, rnd, vd)
+  <-> "vaeskf1.vi" ^ sep() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(rnd)
 
-union clause ast = RISCV_VAESKF2_VI : (vregidx, bits(5), vregidx)
+union clause ast = VAESKF2_VI : (vregidx, bits(5), vregidx)
 
-mapping clause encdec = RISCV_VAESKF2_VI(vs2, rnd, vd)
+mapping clause encdec = VAESKF2_VI(vs2, rnd, vd)
   <-> 0b1010101 @ encdec_vreg(vs2) @ rnd @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
 
-mapping clause assembly = RISCV_VAESKF2_VI(vs2, rnd, vd)
-  <-> "vaeskf2.vi" ^ sep() ^ vreg_name(vd)
-                   ^ sep() ^ vreg_name(vs2)
-                   ^ sep() ^ hex_bits_5(rnd)
-
-function clause execute (RISCV_VAESKF2_VI(vs2, rnd, vd)) = {
-  let 'SEW = get_sew();
+function clause execute (VAESKF2_VI(vs2, rnd, vd)) = {
+  let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let 'num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
   assert(SEW == 32);
-  var rnd_val : bits(4) = rnd[3..0];
+
   let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  var rnd_val : bits(4) = rnd[3..0];
 
   if (unsigned(rnd_val) < 2) | (unsigned(rnd_val) > 14)
   then rnd_val[3] = not_bit(rnd_val[3]);
 
-  var w : bits(128) = zeros();
-  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
+  var w : vector(4, bits(32)) = vector_init(zeros());
 
-  let eg_len = (unsigned(vl) / 4);
+  let eg_len   = (unsigned(vl) / 4);
   let eg_start = (unsigned(vstart) / 4);
 
   foreach (i from eg_start to (eg_len - 1)) {
-    assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < num_elem);
+    assert(i * 4 + 3 < num_elem);
 
-    let current_round_key = get_velem(vs2_val, i);
+    let current_round_key = get_velem_quad_vec(vs2_val, i);
+    let round_key_b       = get_velem_quad_vec(vd_val, i);
 
-    let round_key_b = get_velem(vd_val, i);
+    w[0] = if (rnd_val[0] == bitone)
+           then aes_subword_fwd(current_round_key[3]) ^ round_key_b[0]
+           else aes_subword_fwd(current_round_key[3] >>> 8) ^
+                aes_decode_rcon((rnd_val >> 1) - 1) ^ round_key_b[0];
+    w[1] = w[0] ^ round_key_b[1];
+    w[2] = w[1] ^ round_key_b[2];
+    w[3] = w[2] ^ round_key_b[3];
 
-    w[31..0] = if (rnd_val[0] == bitone)
-               then
-                 aes_subword_fwd(current_round_key[127..96]) ^ round_key_b[31..0]
-               else
-                 aes_subword_fwd(aes_rotword(current_round_key[127..96]))
-                   ^ aes_decode_rcon((rnd_val >> 1) - 1)
-                   ^ round_key_b[31..0];
-
-    w[63..32]  = w[31..0]  ^ round_key_b[63..32];
-    w[95..64]  = w[63..32] ^ round_key_b[95..64];
-    w[127..96] = w[95..64] ^ round_key_b[127..96];
-
-    result = set_velem(result, w, i);
+    write_velem_quad_vec(vd, SEW, w, i)
   };
 
-  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }
 
-/* VAESZ.VS */
+mapping clause assembly = VAESKF2_VI(vs2, rnd, vd)
+  <-> "vaeskf2.vi" ^ sep() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(rnd)
 
-union clause ast = RISCV_VAESZ_VS : (vregidx, vregidx)
+union clause ast = VAESZ_VS : (vregidx, vregidx)
 
-mapping clause encdec = RISCV_VAESZ_VS(vs2, vd)
+mapping clause encdec = VAESZ_VS(vs2, vd)
   <-> 0b1010011 @ encdec_vreg(vs2) @ 0b00111 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
-  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
+  when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4) & zvk_valid_reg_overlap(vs2, vd, get_lmul_pow())
 
-mapping clause assembly = RISCV_VAESZ_VS(vs2, vd)
-  <-> "vaesz.vs" ^ sep() ^ vreg_name(vd)
-                 ^ sep() ^ vreg_name(vs2)
-
-function clause execute (RISCV_VAESZ_VS(vs2, vd)) = {
-  let 'SEW = get_sew();
+function clause execute (VAESZ_VS(vs2, vd)) = {
+  let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let 'num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
   assert(SEW == 32);
-  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
 
-  let eg_len = (unsigned(vl) / 4);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let eg_len   = (unsigned(vl) / 4);
   let eg_start = (unsigned(vstart) / 4);
 
   foreach (i from eg_start to (eg_len - 1)) {
-    assert(0 <= ((i * 4) + 3) & ((i * 4) + 3) < num_elem);
+    assert(i * 4 + 3 < num_elem);
 
-    let vd_state = get_velem(vd_val, i);
-    let vs2_key  = get_velem(vs2_val, 0);
-    let ark : bits(128) = vd_state ^ vs2_key;
+    let state = get_velem_quad(vd_val, i);
+    let rkey  = get_velem_quad(vs2_val, 0);
+    let ark   = state ^ rkey;
 
-    result = set_velem(result, ark, i);
+    write_velem_quad(vd, SEW, ark, i)
   };
 
-  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }
+
+mapping clause assembly = VAESZ_VS(vs2, vd)
+  <-> "vaesz.vs" ^ sep() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)

--- a/model/riscv_zvk_utils.sail
+++ b/model/riscv_zvk_utils.sail
@@ -117,3 +117,13 @@ function zvk_sm3_round(A_H : vector(8, bits(32)), w : bits(32), x : bits(32), j 
 
   [ A_H[6], G1, A_H[4], E1, A_H[2], C1, A_H[0], A1 ]
 }
+
+/*
+ * Utility functions for Zvkned
+ * ----------------------------------------------------------------------
+ */
+
+enum zvk_vaesdf_funct6 = {ZVK_VAESDF_VV, ZVK_VAESDF_VS}
+enum zvk_vaesdm_funct6 = {ZVK_VAESDM_VV, ZVK_VAESDM_VS}
+enum zvk_vaesef_funct6 = {ZVK_VAESEF_VV, ZVK_VAESEF_VS}
+enum zvk_vaesem_funct6 = {ZVK_VAESEM_VV, ZVK_VAESEM_VS}


### PR DESCRIPTION
Implements the Zvkned (NIST Suite: Vector AES Block Cipher) extension, as of version [Release 1.0.0](https://github.com/riscv/riscv-crypto/releases/tag/v1.0.0).

The following instructions are included:

- vaesef.[vv,vs]
- vaesem.[vv,vs]
- vaesdf.[vv,vs]
- vaesdm.[vv,vs]
- vaeskf1.vi
- vaeskf2.vi
- vaesz.vs

All instructions were tested with VLEN=128 and results were compared with QEMU results of each instruction.

Note
This PR was originally developed by @charmitro , and now the Vector AES Block Cipher has been released. 