### PR TITLE
Add support for Zhinxmin extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Supported RISC-V ISA features
 - F and D extensions for single and double-precision floating-point, v2.2
 - Zfh and Zfhmin extensions for half-precision floating-point, v1.0
 - Zfa extension for additional floating-point instructions, v1.0
-- Zfinx, Zdinx, and Zhinx extensions for floating-point in integer registers, v1.0
+- Zfinx, Zdinx, Zhinx, and Zhinxmin extensions for floating-point in integer registers, v1.0
 - C extension for compressed instructions, v2.0
 - Zca, Zcf, Zcd, and Zcb extensions for code size reduction, v1.0
 - B (Zba, Zbb, Zbs) and Zbc extensions for bit manipulation, v1.0

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -102,6 +102,8 @@ enum clause extension = Ext_Zksh
 
 // Floating-Point in Integer Registers (half precision)
 enum clause extension = Ext_Zhinx
+// Floating-Point in Integer Registers (minimal half precision)
+enum clause extension = Ext_Zhinxmin
 
 // Count Overflow and Mode-Based Filtering
 enum clause extension = Ext_Sscofpmf

--- a/model/riscv_insts_zfh.sail
+++ b/model/riscv_insts_zfh.sail
@@ -8,6 +8,9 @@
 
 function clause extensionEnabled(Ext_Zhinx) = sys_enable_zfinx()
 
+// Zhinxmin is a subset of Zhinx. This can be changed to extensionEnabled(Ext_Zhinx) | sys_enable_zhinxmin() when more configuration is implemented.
+function clause extensionEnabled(Ext_Zhinxmin) = extensionEnabled(Ext_Zhinx)
+
 /* **************************************************************** */
 /* This file specifies the instructions in the Zfh extension        */
 /* (half precision floating point).                                 */
@@ -167,7 +170,7 @@ function fle_H   (v1,       v2,        is_quiet) = {
 function haveHalfFPU() -> bool = extensionEnabled(Ext_Zfh) | extensionEnabled(Ext_Zhinx)
 // Support for conversion of halves to/from single & double, but no actual
 // calculations with halves.
-function haveHalfMin() -> bool = haveHalfFPU() | extensionEnabled(Ext_Zfhmin)
+function haveHalfMin() -> bool = haveHalfFPU() | extensionEnabled(Ext_Zfhmin) | extensionEnabled(Ext_Zhinxmin)
 
 /* ****************************************************************** */
 /* Floating-point loads                                               */


### PR DESCRIPTION
Adds support for the Zhinxmin extension. Will need to be properly hooked up to the config system once that is implemented.