### PR TITLE
Refactor instruction retire and stepper

### DIFF
--- a/Makefile.old
+++ b/Makefile.old
@@ -111,8 +111,9 @@ SAIL_ARCH_SRCS += riscv_extensions.sail riscv_types_common.sail riscv_types_ext.
 SAIL_ARCH_SRCS += riscv_vmem_types.sail $(SAIL_REGS_SRCS) $(SAIL_SYS_SRCS) riscv_platform.sail
 SAIL_ARCH_SRCS += riscv_sstc.sail
 SAIL_ARCH_SRCS += riscv_mem.sail $(SAIL_VM_SRCS)
-SAIL_ARCH_RVFI_SRCS = $(PRELUDE) rvfi_dii.sail riscv_extensions.sail riscv_types_common.sail riscv_types_ext.sail riscv_types.sail riscv_vmem_types.sail $(SAIL_REGS_SRCS) $(SAIL_SYS_SRCS) riscv_platform.sail riscv_mem.sail $(SAIL_VM_SRCS) riscv_types_kext.sail
+SAIL_ARCH_RVFI_SRCS = $(PRELUDE) rvfi_dii.sail riscv_extensions.sail riscv_types_common.sail riscv_types_ext.sail riscv_types.sail riscv_vmem_types.sail $(SAIL_REGS_SRCS) $(SAIL_SYS_SRCS) riscv_platform.sail riscv_mem.sail $(SAIL_VM_SRCS) riscv_types_kext.sail riscv_inst_retire.sail
 SAIL_ARCH_SRCS += riscv_types_kext.sail    # Shared/common code for the cryptography extension.
+SAIL_ARCH_SRCS += riscv_inst_retire.sail
 
 SAIL_STEP_SRCS = riscv_step_common.sail riscv_step_ext.sail riscv_decode_ext.sail riscv_fetch.sail riscv_step.sail
 RVFI_STEP_SRCS = riscv_step_common.sail riscv_step_rvfi.sail riscv_decode_ext.sail riscv_fetch_rvfi.sail riscv_step.sail

--- a/c_emulator/riscv_sail.h
+++ b/c_emulator/riscv_sail.h
@@ -19,7 +19,7 @@ void model_init(void);
 void model_fini(void);
 
 unit zinit_model(unit);
-bool zstep(sail_int);
+bool ztry_step(sail_int, bool);
 unit ztick_clock(unit);
 unit ztick_platform(unit);
 

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -553,6 +553,7 @@ void flush_logs(void)
 void run_sail(void)
 {
   bool stepped;
+  bool exit_wait = true;
   bool diverged = false;
 
   /* initialize the step number */
@@ -586,7 +587,7 @@ void run_sail(void)
       sail_int sail_step;
       CREATE(sail_int)(&sail_step);
       CONVERT_OF(sail_int, mach_int)(&sail_step, step_no);
-      stepped = zstep(sail_step);
+      stepped = ztry_step(sail_step, exit_wait);
       if (have_exception)
         goto step_exception;
       flush_logs();

--- a/config/default.json
+++ b/config/default.json
@@ -35,7 +35,8 @@
             "base" : 33554432,
             "size" : 786432
         },
-        "instructions_per_tick" : 100
+        "instructions_per_tick" : 100,
+        "wfi_is_nop" : true
     },
     "extensions" : {
         "M" : {

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -182,6 +182,7 @@ foreach (xlen IN ITEMS 32 64)
                 # Shared/common code for the cryptography extension.
                 "riscv_types_kext.sail"
                 "riscv_zvk_utils.sail"
+                "riscv_inst_retire.sail"
             )
 
             if (variant STREQUAL "rvfi")

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -264,7 +264,7 @@ foreach (xlen IN ITEMS 32 64)
                         # Don't dead-code eliminate these functions. These should match the
                         # ones used from riscv_sail.h
                         --c-preserve init_model
-                        --c-preserve step
+                        --c-preserve try_step
                         --c-preserve tick_clock
                         --c-preserve tick_platform
                         # Preserve RVFI functions.

--- a/model/riscv_inst_retire.sail
+++ b/model/riscv_inst_retire.sail
@@ -1,0 +1,30 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+/* Reasons an instruction retire might fail or be incomplete. */
+
+union Retire_Failure = {
+  // standard reasons
+  Illegal_Instruction            : unit,
+  Wait_For_Interrupt             : unit,
+  Trap                           : (Privilege, ctl_result, xlenbits),
+  Memory_Exception               : (virtaddr, ExceptionType),
+
+  // reasons from external extensions
+  Ext_CSR_Check_Failure          : unit,
+  Ext_ControlAddr_Check_Failure  : ext_control_addr_error,
+  Ext_DataAddr_Check_Failure     : ext_data_addr_error,
+  Ext_XRET_Priv_Failure          : unit,
+}
+
+// To ease the introduction of `Retire_Failure`, this global
+// definition is temporarily used instead of the previous
+// RETIRE_SUCCESS enum value so that we don't have to immediately
+// update all the places RETIRE_SUCCESS was used.
+
+let RETIRE_SUCCESS : Retired(Retire_Failure) = RETIRE_OK()

--- a/model/riscv_inst_retire.sail
+++ b/model/riscv_inst_retire.sail
@@ -27,4 +27,4 @@ union Retire_Failure = {
 // RETIRE_SUCCESS enum value so that we don't have to immediately
 // update all the places RETIRE_SUCCESS was used.
 
-let RETIRE_SUCCESS : Retired(Retire_Failure) = RETIRE_OK()
+let RETIRE_SUCCESS : ExecutionResult(Retire_Failure) = RETIRE_OK()

--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -82,19 +82,19 @@ function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
     * Extensions might perform additional checks on address validity.
     */
   match ext_data_get_addr(rs1, zeros(), Read(Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_Error(e)  => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
     Ext_DataAddr_OK(vaddr) => {
       /* "LR faults like a normal load, even though it's in the AMO major opcode space."
         * - Andrew Waterman, isa-dev, 10 Jul 2018.
         */
       if not(is_aligned(virtaddr_bits(vaddr), width))
-      then { handle_mem_exception(vaddr, E_Load_Addr_Align()); RETIRE_FAIL }
+      then RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
       else match translateAddr(vaddr, Read(Data)) {
-        TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+        TR_Failure(e, _)    => RETIRE_FAIL(Memory_Exception(vaddr, e)),
         TR_Address(addr, _) =>
           match mem_read(Read(Data), addr, width_bytes, aq, aq & rl, true) {
             Ok(result) => { load_reservation(physaddr_bits(addr)); X(rd) = sign_extend(result); RETIRE_SUCCESS },
-            Err(e)     => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+            Err(e)     => RETIRE_FAIL(Memory_Exception(vaddr, e)),
           },
       }
     }
@@ -131,14 +131,14 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
       * Extensions might perform additional checks on address validity.
       */
     match ext_data_get_addr(rs1, zeros(), Write(Data), width_bytes) {
-      Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
+      Ext_DataAddr_Error(e)  => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
       Ext_DataAddr_OK(vaddr) => {
         if not(is_aligned(virtaddr_bits(vaddr), width))
-        then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); RETIRE_FAIL }
+        then RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
         else {
           match translateAddr(vaddr, Write(Data)) {  /* Write and ReadWrite are equivalent here:
                                                       * both result in a SAMO exception */
-            TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            TR_Failure(e, _) => RETIRE_FAIL(Memory_Exception(vaddr, e)),
             TR_Address(addr, _) => {
               // Check reservation with physical address.
               if not(match_reservation(physaddr_bits(addr))) then {
@@ -146,13 +146,13 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
                 X(rd) = zero_extend(0b1); cancel_reservation(); RETIRE_SUCCESS
               } else {
                 match mem_write_ea(addr, width_bytes, aq & rl, rl, true) {
-                  Err(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+                  Err(e) => RETIRE_FAIL(Memory_Exception(vaddr, e)),
                   Ok(_)  => {
                     let rs2_val = X(rs2);
                     match mem_write_value(addr, width_bytes, rs2_val[width_bytes * 8 - 1 .. 0], aq & rl, rl, true) {
                       Ok(true)  => { X(rd) = zero_extend(0b0); cancel_reservation(); RETIRE_SUCCESS },
                       Ok(false) => { X(rd) = zero_extend(0b1); cancel_reservation(); RETIRE_SUCCESS },
-                      Err(e)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+                      Err(e)    => RETIRE_FAIL(Memory_Exception(vaddr, e)),
                     }
                   }
                 }
@@ -201,19 +201,19 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
     * Some extensions perform additional checks on address validity.
     */
   match ext_data_get_addr(rs1, zeros(), ReadWrite(Data, Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_Error(e)  => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
     Ext_DataAddr_OK(vaddr) => {
       if not(is_aligned(virtaddr_bits(vaddr), width))
-      then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); RETIRE_FAIL }
+      then RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
       else match translateAddr(vaddr, ReadWrite(Data, Data)) {
-        TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+        TR_Failure(e, _) => RETIRE_FAIL(Memory_Exception(vaddr, e)),
         TR_Address(addr, _) => {
           let rs2_val = X(rs2)[width_bytes * 8 - 1 .. 0];
           match mem_write_ea(addr, width_bytes, aq & rl, rl, true) {
-            Err(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            Err(e) => RETIRE_FAIL(Memory_Exception(vaddr, e)),
             Ok(_) => {
               match mem_read(ReadWrite(Data, Data), addr, width_bytes, aq, aq & rl, true) {
-                Err(e)     => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+                Err(e)     => RETIRE_FAIL(Memory_Exception(vaddr, e)),
                 Ok(loaded) => {
                   let result : bits('width_bytes * 8) =
                     match op {
@@ -230,7 +230,7 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
                   match mem_write_value(addr, width_bytes, sign_extend(result), aq & rl, rl, true) {
                     Ok(true)  => { X(rd) = sign_extend(loaded); RETIRE_SUCCESS },
                     Ok(false) => { internal_error(__FILE__, __LINE__, "AMO got false from mem_write_value") },
-                    Err(e)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+                    Err(e)    => RETIRE_FAIL(Memory_Exception(vaddr, e)),
                   }
                 }
               }

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -62,16 +62,12 @@ function clause execute (RISCV_JAL(imm, rd)) = {
   let target = PC + sign_extend(imm);
   /* Extensions get the first checks on the prospective target address. */
   match ext_control_check_pc(target) {
-    Ext_ControlAddr_Error(e) => {
-      ext_handle_control_check_error(e);
-      RETIRE_FAIL
-    },
+    Ext_ControlAddr_Error(e) => RETIRE_FAIL(Ext_ControlAddr_Check_Failure(e)),
     Ext_ControlAddr_OK(target) => {
       /* Perform standard alignment check */
       let target_bits = virtaddr_bits(target);
       if bit_to_bool(target_bits[1]) & not(currentlyEnabled(Ext_Zca)) then {
-        handle_mem_exception(target, E_Fetch_Addr_Align());
-        RETIRE_FAIL
+        RETIRE_FAIL(Memory_Exception(target, E_Fetch_Addr_Align()))
       } else {
         X(rd) = get_next_pc();
         set_next_pc(target_bits);
@@ -125,15 +121,11 @@ function clause execute (BTYPE(imm, rs2, rs1, op)) = {
     let target = PC + sign_extend(imm);
     /* Extensions get the first checks on the prospective target address. */
     match ext_control_check_pc(target) {
-      Ext_ControlAddr_Error(e) => {
-        ext_handle_control_check_error(e);
-        RETIRE_FAIL
-      },
+      Ext_ControlAddr_Error(e) => RETIRE_FAIL(Ext_ControlAddr_Check_Failure(e)),
       Ext_ControlAddr_OK(target) => {
         let target_bits = virtaddr_bits(target);
         if bit_to_bool(target_bits[1]) & not(currentlyEnabled(Ext_Zca)) then {
-          handle_mem_exception(target, E_Fetch_Addr_Align());
-          RETIRE_FAIL
+          RETIRE_FAIL(Memory_Exception(target, E_Fetch_Addr_Align()))
         } else {
           set_next_pc(target_bits);
           RETIRE_SUCCESS
@@ -313,17 +305,16 @@ function clause execute (LOAD(imm, rs1, rd, is_unsigned, width, aq, rl)) = {
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
   match ext_data_get_addr(rs1, offset, Read(Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_Error(e)  => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
     Ext_DataAddr_OK(vaddr) => {
       if   check_misaligned(vaddr, width)
-      then { handle_mem_exception(vaddr, E_Load_Addr_Align()); RETIRE_FAIL }
+      then RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
       else match translateAddr(vaddr, Read(Data)) {
-        TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+        TR_Failure(e, _) => RETIRE_FAIL(Memory_Exception(vaddr, e)),
         TR_Address(paddr, _) =>
-
           match mem_read(Read(Data), paddr, width_bytes, aq, rl, false) {
             Ok(result) => { X(rd) = extend_value(is_unsigned, result); RETIRE_SUCCESS },
-            Err(e)     => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            Err(e)     => RETIRE_FAIL(Memory_Exception(vaddr, e)),
           },
       }
     },
@@ -370,21 +361,21 @@ function clause execute (STORE(imm, rs2, rs1, width, aq, rl)) = {
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
   match ext_data_get_addr(rs1, offset, Write(Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_Error(e)  => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
     Ext_DataAddr_OK(vaddr) =>
       if   check_misaligned(vaddr, width)
-      then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); RETIRE_FAIL }
+      then RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
       else match translateAddr(vaddr, Write(Data)) {
-        TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+        TR_Failure(e, _)    => RETIRE_FAIL(Memory_Exception(vaddr, e)),
         TR_Address(paddr, _) => {
           match mem_write_ea(paddr, width_bytes, aq, rl, false) {
-            Err(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            Err(e) => RETIRE_FAIL(Memory_Exception(vaddr, e)),
             Ok(_)  => {
               let rs2_val = X(rs2);
               match mem_write_value(paddr, width_bytes, rs2_val[width_bytes * 8 - 1 .. 0], aq, rl, false) {
                 Ok(true)  => RETIRE_SUCCESS,
                 Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                Err(e)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+                Err(e)    => RETIRE_FAIL(Memory_Exception(vaddr, e))
               }
             }
           }
@@ -593,8 +584,7 @@ function clause execute ECALL() = {
                     },
              excinfo = (None() : option(xlenbits)),
              ext     = None() };
-  set_next_pc(exception_handler(cur_privilege, CTL_TRAP(t), PC));
-  RETIRE_FAIL
+  RETIRE_FAIL(Trap(cur_privilege, CTL_TRAP(t), PC))
 }
 
 mapping clause assembly = ECALL() <-> "ecall"
@@ -607,9 +597,9 @@ mapping clause encdec = MRET()
 
 function clause execute MRET() = {
   if   cur_privilege != Machine
-  then { handle_illegal(); RETIRE_FAIL }
-  else if not(ext_check_xret_priv (Machine))
-  then { ext_fail_xret_priv(); RETIRE_FAIL }
+  then RETIRE_FAIL(Illegal_Instruction())
+  else if not(ext_check_xret_priv(Machine))
+  then RETIRE_FAIL(Ext_XRET_Priv_Failure())
   else {
     set_next_pc(exception_handler(cur_privilege, CTL_MRET(), PC));
     RETIRE_SUCCESS
@@ -631,9 +621,9 @@ function clause execute SRET() = {
     Machine    => not(currentlyEnabled(Ext_S))
   };
   if   sret_illegal
-  then { handle_illegal(); RETIRE_FAIL }
+  then RETIRE_FAIL(Illegal_Instruction())
   else if not(ext_check_xret_priv (Supervisor))
-  then { ext_fail_xret_priv(); RETIRE_FAIL }
+  then RETIRE_FAIL(Ext_XRET_Priv_Failure())
   else {
     set_next_pc(exception_handler(cur_privilege, CTL_SRET(), PC));
     RETIRE_SUCCESS
@@ -648,10 +638,8 @@ union clause ast = EBREAK : unit
 mapping clause encdec = EBREAK()
   <-> 0b000000000001 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
 
-function clause execute EBREAK() = {
-  handle_mem_exception(Virtaddr(PC), E_Breakpoint());
-  RETIRE_FAIL
-}
+function clause execute EBREAK() =
+  RETIRE_FAIL(Memory_Exception(Virtaddr(PC), E_Breakpoint()))
 
 mapping clause assembly = EBREAK() <-> "ebreak"
 
@@ -663,11 +651,11 @@ mapping clause encdec = WFI()
 
 function clause execute WFI() =
   match cur_privilege {
-    Machine    => { platform_wfi(); RETIRE_SUCCESS },
+    Machine    => RETIRE_FAIL(Wait_For_Interrupt()),
     Supervisor => if   mstatus[TW] == 0b1
-                  then { handle_illegal(); RETIRE_FAIL }
-                  else { platform_wfi(); RETIRE_SUCCESS },
-    User       => { handle_illegal(); RETIRE_FAIL }
+                  then RETIRE_FAIL(Illegal_Instruction())
+                  else RETIRE_FAIL(Wait_For_Interrupt()),
+    User       => RETIRE_FAIL(Illegal_Instruction())
   }
 
 mapping clause assembly = WFI() <-> "wfi"
@@ -685,9 +673,9 @@ function clause execute SFENCE_VMA(rs1, rs2) = {
   // is 9 but we always set it to 16 for RV64.
   let asid = if rs2 != zreg then Some(X(rs2)[asidlen - 1 .. 0]) else None();
   match cur_privilege {
-    User       => { handle_illegal(); RETIRE_FAIL },
+    User       => RETIRE_FAIL(Illegal_Instruction()),
     Supervisor => match mstatus[TVM] {
-                    0b1 => { handle_illegal(); RETIRE_FAIL },
+                    0b1 => RETIRE_FAIL(Illegal_Instruction()),
                     0b0 => { flush_TLB(asid, addr); RETIRE_SUCCESS },
                   },
     Machine    => { flush_TLB(asid, addr); RETIRE_SUCCESS }

--- a/model/riscv_insts_begin.sail
+++ b/model/riscv_insts_begin.sail
@@ -14,7 +14,7 @@
 scattered union ast
 
 /* returns whether an instruction was retired, used for computing minstret */
-val execute : ast -> Retired(Retire_Failure)
+val execute : ast -> ExecutionResult(Retire_Failure)
 scattered function execute
 
 val assembly : ast <-> string

--- a/model/riscv_insts_begin.sail
+++ b/model/riscv_insts_begin.sail
@@ -14,7 +14,7 @@
 scattered union ast
 
 /* returns whether an instruction was retired, used for computing minstret */
-val execute : ast -> Retired
+val execute : ast -> Retired(Retire_Failure)
 scattered function execute
 
 val assembly : ast <-> string

--- a/model/riscv_insts_dext.sail
+++ b/model/riscv_insts_dext.sail
@@ -281,7 +281,7 @@ function clause execute (F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, op)) = {
   let rs3_val_64b = F_or_X_D(rs3);
 
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_64b) : (bits(5), bits(64)) =
@@ -346,7 +346,7 @@ function clause execute (F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, op)) = {
   let rs1_val_64b = F_or_X_D(rs1);
   let rs2_val_64b = F_or_X_D(rs2);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_64b) : (bits(5), bits(64)) = match op {
@@ -440,7 +440,7 @@ mapping clause encdec = F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_LU)
 function clause execute (F_UN_RM_FF_TYPE_D(rs1, rm, rd, FSQRT_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_f64Sqrt   (rm_3b, rs1_val_D);
@@ -455,7 +455,7 @@ function clause execute (F_UN_RM_FF_TYPE_D(rs1, rm, rd, FSQRT_D)) = {
 function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_W_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_W) = riscv_f64ToI32 (rm_3b, rs1_val_D);
@@ -470,7 +470,7 @@ function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_W_D)) = {
 function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_WU_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_WU) = riscv_f64ToUi32 (rm_3b, rs1_val_D);
@@ -485,7 +485,7 @@ function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_WU_D)) = {
 function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_W)) = {
   let rs1_val_W = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_i32ToF64 (rm_3b, rs1_val_W);
@@ -500,7 +500,7 @@ function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_W)) = {
 function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_WU)) = {
   let rs1_val_WU = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_ui32ToF64 (rm_3b, rs1_val_WU);
@@ -515,7 +515,7 @@ function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_WU)) = {
 function clause execute (F_UN_RM_FF_TYPE_D(rs1, rm, rd, FCVT_S_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_f64ToF32 (rm_3b, rs1_val_D);
@@ -530,7 +530,7 @@ function clause execute (F_UN_RM_FF_TYPE_D(rs1, rm, rd, FCVT_S_D)) = {
 function clause execute (F_UN_RM_FF_TYPE_D(rs1, rm, rd, FCVT_D_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_f32ToF64 (rm_3b, rs1_val_S);
@@ -546,7 +546,7 @@ function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_L_D)) = {
   assert(xlen >= 64);
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_L) = riscv_f64ToI64 (rm_3b, rs1_val_D);
@@ -562,7 +562,7 @@ function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_LU_D)) = {
   assert(xlen >= 64);
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_LU) = riscv_f64ToUi64 (rm_3b, rs1_val_D);
@@ -578,7 +578,7 @@ function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_L)) = {
   assert(xlen >= 64);
   let rs1_val_L = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_i64ToF64 (rm_3b, rs1_val_L);
@@ -594,7 +594,7 @@ function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_LU)) = {
   assert(xlen >= 64);
   let rs1_val_LU = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_ui64ToF64 (rm_3b, rs1_val_LU);

--- a/model/riscv_insts_end.sail
+++ b/model/riscv_insts_end.sail
@@ -12,7 +12,7 @@
 
 mapping clause encdec = ILLEGAL(s) <-> s
 
-function clause execute (ILLEGAL(s)) = { handle_illegal(); RETIRE_FAIL }
+function clause execute (ILLEGAL(s)) = RETIRE_FAIL(Illegal_Instruction())
 
 mapping clause assembly = ILLEGAL(s) <-> "illegal" ^ spc() ^ hex_bits_32(s)
 
@@ -20,7 +20,7 @@ mapping clause assembly = ILLEGAL(s) <-> "illegal" ^ spc() ^ hex_bits_32(s)
 
 mapping clause encdec_compressed = C_ILLEGAL(s) <-> s
 
-function clause execute C_ILLEGAL(s) = { handle_illegal(); RETIRE_FAIL }
+function clause execute C_ILLEGAL(s) = RETIRE_FAIL(Illegal_Instruction())
 
 mapping clause assembly = C_ILLEGAL(s) <-> "c.illegal" ^ spc() ^ hex_bits_16(s)
 

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -298,17 +298,17 @@ function clause execute(LOAD_FP(imm, rs1, rd, width)) = {
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
   match ext_data_get_addr(rs1, offset, Read(Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_Error(e)  => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
     Ext_DataAddr_OK(vaddr) => {
       if   check_misaligned(vaddr, width)
-      then { handle_mem_exception(vaddr, E_Load_Addr_Align()); RETIRE_FAIL }
+      then RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
       else match translateAddr(vaddr, Read(Data)) {
-        TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+        TR_Failure(e, _)    => RETIRE_FAIL(Memory_Exception(vaddr, e)),
         TR_Address(addr, _) => {
           let (aq, rl, res) = (false, false, false);
           match mem_read(Read(Data), addr, width_bytes, aq, rl, res) {
             Ok(result) => { F(rd) = nan_box(result); RETIRE_SUCCESS },
-            Err(e)     => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            Err(e)     => RETIRE_FAIL(Memory_Exception(vaddr, e)),
           }
         },
       }
@@ -359,21 +359,21 @@ function clause execute (STORE_FP(imm, rs2, rs1, width)) = {
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
   match ext_data_get_addr(rs1, offset, Write(Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_Error(e)  => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
     Ext_DataAddr_OK(vaddr) => {
       if   check_misaligned(vaddr, width)
-      then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); RETIRE_FAIL }
+      then RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
       else match translateAddr(vaddr, Write(Data)) {
-        TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+        TR_Failure(e, _)    => RETIRE_FAIL(Memory_Exception(vaddr, e)),
         TR_Address(addr, _) => {
           match mem_write_ea(addr, width_bytes, aq, rl, false) {
-            Err(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
+            Err(e) => RETIRE_FAIL(Memory_Exception(vaddr, e)),
             Ok(_)  => {
               let rs2_val = F(rs2);
               match mem_write_value(addr, width_bytes, rs2_val[width_bytes * 8 - 1 .. 0], aq, rl, con) {
-                Ok(true)  => { RETIRE_SUCCESS },
+                Ok(true)  => RETIRE_SUCCESS,
                 Ok(false) => { internal_error(__FILE__, __LINE__, "store got false from mem_write_value") },
-                Err(e)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
+                Err(e)    => RETIRE_FAIL(Memory_Exception(vaddr, e))
               }
             },
           }
@@ -423,7 +423,7 @@ function clause execute (F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, op)) = {
   let rs2_val_32b = F_or_X_S(rs2);
   let rs3_val_32b = F_or_X_S(rs3);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_32b) : (bits(5), bits(32)) =
@@ -488,7 +488,7 @@ function clause execute (F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, op)) = {
   let rs1_val_32b = F_or_X_S(rs1);
   let rs2_val_32b = F_or_X_S(rs2);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_32b) : (bits(5), bits(32)) = match op {
@@ -574,7 +574,7 @@ mapping clause encdec = F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_LU)
 function clause execute (F_UN_RM_FF_TYPE_S(rs1, rm, rd, FSQRT_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_f32Sqrt   (rm_3b, rs1_val_S);
@@ -589,7 +589,7 @@ function clause execute (F_UN_RM_FF_TYPE_S(rs1, rm, rd, FSQRT_S)) = {
 function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_W_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_W) = riscv_f32ToI32 (rm_3b, rs1_val_S);
@@ -604,7 +604,7 @@ function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_W_S)) = {
 function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_WU_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_WU) = riscv_f32ToUi32 (rm_3b, rs1_val_S);
@@ -619,7 +619,7 @@ function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_WU_S)) = {
 function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_W)) = {
   let rs1_val_W = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_i32ToF32 (rm_3b, rs1_val_W);
@@ -634,7 +634,7 @@ function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_W)) = {
 function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_WU)) = {
   let rs1_val_WU = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_ui32ToF32 (rm_3b, rs1_val_WU);
@@ -650,7 +650,7 @@ function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_L_S)) = {
   assert(xlen >= 64);
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_L) = riscv_f32ToI64 (rm_3b, rs1_val_S);
@@ -666,7 +666,7 @@ function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_LU_S)) = {
   assert(xlen >= 64);
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_LU) = riscv_f32ToUi64 (rm_3b, rs1_val_S);
@@ -682,7 +682,7 @@ function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_L)) = {
   assert(xlen >= 64);
   let rs1_val_L = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_i64ToF32 (rm_3b, rs1_val_L);
@@ -698,7 +698,7 @@ function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_LU)) = {
   assert(xlen >= 64);
   let rs1_val_LU = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_ui64ToF32 (rm_3b, rs1_val_LU);

--- a/model/riscv_insts_mext.sail
+++ b/model/riscv_insts_mext.sail
@@ -14,7 +14,6 @@
 function clause currentlyEnabled(Ext_M) = hartSupports(Ext_M) & misa[M] == 0b1
 function clause currentlyEnabled(Ext_Zmmul) = hartSupports(Ext_Zmmul) | currentlyEnabled(Ext_M)
 
-
 union clause ast = MUL : (regidx, regidx, regidx, mul_op)
 
 mapping encdec_mul_op : mul_op <-> bits(3) = {

--- a/model/riscv_insts_svinval.sail
+++ b/model/riscv_insts_svinval.sail
@@ -31,8 +31,8 @@ mapping clause encdec = SFENCE_W_INVAL()
 
 function clause execute SFENCE_W_INVAL() = {
   if cur_privilege == User
-  then { handle_illegal(); RETIRE_FAIL }
-  else { RETIRE_SUCCESS } // Implemented as no-op as all memory operations are visible immediately the current Sail model
+  then RETIRE_FAIL(Illegal_Instruction())
+  else RETIRE_SUCCESS // Implemented as no-op as all memory operations are visible immediately the current Sail model
 }
 
 mapping clause assembly = SFENCE_W_INVAL() <-> "sfence.w.inval"
@@ -47,8 +47,8 @@ mapping clause encdec = SFENCE_INVAL_IR()
 
 function clause execute SFENCE_INVAL_IR() = {
   if cur_privilege == User
-  then { handle_illegal(); RETIRE_FAIL }
-  else { RETIRE_SUCCESS } // Implemented as no-op as all memory operations are visible immediately in current Sail model
+  then RETIRE_FAIL(Illegal_Instruction())
+  else RETIRE_SUCCESS // Implemented as no-op as all memory operations are visible immediately in current Sail model
 }
 
 mapping clause assembly = SFENCE_INVAL_IR() <-> "sfence.inval.ir"

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -51,7 +51,7 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -61,7 +61,10 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -114,14 +117,14 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
         VV_VMAXU         => to_bits(SEW, max(unsigned(vs2_val[i]), unsigned(vs1_val[i]))),
         VV_VMAX          => to_bits(SEW, max(signed(vs2_val[i]), signed(vs1_val[i]))),
         VV_VRGATHER      => {
-                              if (vs1 == vd | vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
+                              if (vs1 == vd | vs2 == vd) then return RETIRE_FAIL(Illegal_Instruction());
                               let idx = unsigned(vs1_val[i]);
                               let VLMAX = 2 ^ (LMUL_pow + VLEN_pow - SEW_pow);
                               assert(VLMAX <= 'n);
                               if idx < VLMAX then vs2_val[idx] else zeros()
                             },
         VV_VRGATHEREI16  => {
-                              if (vs1 == vd | vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
+                              if (vs1 == vd | vs2 == vd) then return RETIRE_FAIL(Illegal_Instruction());
                               /* vrgatherei16.vv uses SEW/LMUL for the data in vs2 but EEW=16 and EMUL = (16/SEW)*LMUL for the indices in vs1 */
                               let vs1_new : vector('n, bits(16)) = read_vreg(num_elem, 16, 4 + LMUL_pow - SEW_pow, vs1);
                               let idx = unsigned(vs1_new[i]);
@@ -187,7 +190,7 @@ function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -198,7 +201,10 @@ function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   assert(SEW_widen <= 64);
@@ -254,7 +260,7 @@ function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -265,7 +271,10 @@ function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   assert(SEW_widen <= 64);
@@ -308,14 +317,17 @@ mapping clause encdec = MASKTYPEV (vs2, vs1,  vd)
   when currentlyEnabled(Ext_V)
 
 function clause execute(MASKTYPEV(vs2, vs1, vd)) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   let end_element   = get_end_element();
   let SEW           = get_sew();
   let LMUL_pow      = get_lmul_pow();
   let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
 
-  if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_masked(vd) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -361,7 +373,7 @@ function clause execute(MOVETYPEV(vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -370,7 +382,10 @@ function clause execute(MOVETYPEV(vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -420,7 +435,7 @@ function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -430,7 +445,10 @@ function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -540,7 +558,7 @@ function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -551,7 +569,10 @@ function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   assert(SEW_widen <= 64);
@@ -607,7 +628,7 @@ function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -618,7 +639,10 @@ function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   assert(SEW_widen <= 64);
@@ -674,7 +698,7 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -684,14 +708,17 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
       result[i] = match funct6 {
         VX_VSLIDEUP    => {
-                            if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
+                            if (vs2 == vd) then return RETIRE_FAIL(Illegal_Instruction());
                             if i >= rs1_val then vs2_val[i - rs1_val] else vd_val[i]
                           },
         VX_VSLIDEDOWN  => {
@@ -700,7 +727,7 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
                             if i + rs1_val < VLMAX then vs2_val[i + rs1_val] else zeros()
                           },
         VX_VRGATHER    => {
-                            if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
+                            if (vs2 == vd) then return RETIRE_FAIL(Illegal_Instruction());
                             let VLMAX = 2 ^ (LMUL_pow + VLEN_pow - SEW_pow);
                             assert(VLMAX > 0 & VLMAX <= 'n);
                             if rs1_val < VLMAX then vs2_val[rs1_val] else zeros()
@@ -731,14 +758,17 @@ mapping clause encdec = MASKTYPEX(vs2, rs1, vd)
   when currentlyEnabled(Ext_V)
 
 function clause execute(MASKTYPEX(vs2, rs1, vd)) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   let end_element   = get_end_element();
   let SEW           = get_sew();
   let LMUL_pow      = get_lmul_pow();
   let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
 
-  if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_masked(vd) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -784,7 +814,7 @@ function clause execute(MOVETYPEX(rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -793,7 +823,10 @@ function clause execute(MOVETYPEX(rs1, vd)) = {
   let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zvreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -835,7 +868,7 @@ function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -845,7 +878,10 @@ function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -931,7 +967,7 @@ function clause execute(NISTYPE(funct6, vm, vs2, simm, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -942,7 +978,10 @@ function clause execute(NISTYPE(funct6, vm, vs2, simm, vd)) = {
   let imm_val : bits('m)             = sign_extend(simm);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   assert(SEW_widen <= 64);
@@ -998,7 +1037,7 @@ function clause execute(NITYPE(funct6, vm, vs2, simm, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1009,7 +1048,10 @@ function clause execute(NITYPE(funct6, vm, vs2, simm, vd)) = {
   let imm_val : bits('m)             = sign_extend(simm);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   assert(SEW_widen <= 64);
@@ -1065,7 +1107,7 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1075,14 +1117,17 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
       result[i] = match funct6 {
         VI_VSLIDEUP    => {
-                            if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
+                            if (vs2 == vd) then return RETIRE_FAIL(Illegal_Instruction());
                             if i >= imm_val then vs2_val[i - imm_val] else vd_val[i]
                           },
         VI_VSLIDEDOWN  => {
@@ -1091,7 +1136,7 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
                             if i + imm_val < VLMAX then vs2_val[i + imm_val] else zeros()
                           },
         VI_VRGATHER    => {
-                            if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
+                            if (vs2 == vd) then return RETIRE_FAIL(Illegal_Instruction());
                             let VLMAX = 2 ^ (LMUL_pow + VLEN_pow - SEW_pow);
                             assert(VLMAX > 0 & VLMAX <= 'n);
                             if imm_val < VLMAX then vs2_val[imm_val] else zeros()
@@ -1122,14 +1167,17 @@ mapping clause encdec = MASKTYPEI(vs2, simm, vd)
   when currentlyEnabled(Ext_V)
 
 function clause execute(MASKTYPEI(vs2, simm, vd)) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   let end_element   = get_end_element();
   let SEW           = get_sew();
   let LMUL_pow      = get_lmul_pow();
   let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
 
-  if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_masked(vd) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1175,7 +1223,7 @@ function clause execute(MOVETYPEI(vd, simm)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1184,7 +1232,10 @@ function clause execute(MOVETYPEI(vd, simm)) = {
   let imm_val : bits('m)             = sign_extend(simm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1207,12 +1258,15 @@ mapping clause encdec = VMVRTYPE(vs2, simm, vd)
   when currentlyEnabled(Ext_V)
 
 function clause execute(VMVRTYPE(vs2, simm, vd)) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   let SEW     = get_sew();
   let imm_val = unsigned(zero_extend(xlen, simm));
   let EMUL    = imm_val + 1;
 
-  if not(EMUL == 1 | EMUL == 2 | EMUL == 4 | EMUL == 8) then { handle_illegal(); return RETIRE_FAIL };
+  if not(EMUL == 1 | EMUL == 2 | EMUL == 4 | EMUL == 8) then return RETIRE_FAIL(Illegal_Instruction());
 
   let EMUL_pow = log2(EMUL);
   let num_elem = get_num_elem(EMUL_pow, SEW);
@@ -1270,7 +1324,7 @@ function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1280,7 +1334,10 @@ function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1379,7 +1436,7 @@ function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1389,7 +1446,10 @@ function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1444,7 +1504,7 @@ function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1455,7 +1515,10 @@ function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1513,7 +1576,7 @@ function clause execute(WVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1524,7 +1587,10 @@ function clause execute(WVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1577,7 +1643,7 @@ function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1588,7 +1654,10 @@ function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1637,7 +1706,7 @@ function clause execute(VEXT2TYPE(funct6, vm, vs2, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_half, LMUL_pow_half) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_half, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1647,7 +1716,10 @@ function clause execute(VEXT2TYPE(funct6, vm, vs2, vd)) = {
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_half, LMUL_pow_half, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1694,7 +1766,7 @@ function clause execute(VEXT4TYPE(funct6, vm, vs2, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_quart, LMUL_pow_quart) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_quart, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1704,7 +1776,10 @@ function clause execute(VEXT4TYPE(funct6, vm, vs2, vd)) = {
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_quart, LMUL_pow_quart, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1751,7 +1826,7 @@ function clause execute(VEXT8TYPE(funct6, vm, vs2, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_eighth, LMUL_pow_eighth) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_eighth, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1761,7 +1836,10 @@ function clause execute(VEXT8TYPE(funct6, vm, vs2, vd)) = {
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_eighth, LMUL_pow_eighth, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   assert(SEW > SEW_eighth);
@@ -1798,7 +1876,7 @@ function clause execute(VMVXS(vs2, rd)) = {
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   assert(num_elem > 0);
   let 'n = num_elem;
@@ -1824,7 +1902,10 @@ mapping clause encdec = MVVCOMPRESS(vs2, vs1, vd)
   when currentlyEnabled(Ext_V)
 
 function clause execute(MVVCOMPRESS(vs2, vs1, vd)) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   let end_element = get_end_element();
   let SEW = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -1832,7 +1913,7 @@ function clause execute(MVVCOMPRESS(vs2, vs1, vd)) = {
 
   /* vcompress should always be executed with a vstart of 0 */
   if start_element != 0 | vs1 == vd | vs2 == vd | illegal_vd_unmasked()
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1903,7 +1984,7 @@ function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1913,7 +1994,10 @@ function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1940,7 +2024,7 @@ function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
                               slice(result_sub >> 1, 0, 'm) + zero_extend('m, rounding_incr)
                             },
         MVX_VSLIDE1UP    => {
-                              if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
+                              if (vs2 == vd) then return RETIRE_FAIL(Illegal_Instruction());
                               if i == 0 then rs1_val else vs2_val[i - 1]
                             },
         MVX_VSLIDE1DOWN  => {
@@ -2023,7 +2107,7 @@ function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -2033,7 +2117,10 @@ function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -2088,7 +2175,7 @@ function clause execute(WVXTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -2099,7 +2186,10 @@ function clause execute(WVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -2156,7 +2246,7 @@ function clause execute(WXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen)
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -2167,7 +2257,10 @@ function clause execute(WXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -2220,7 +2313,7 @@ function clause execute(WMVXTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -2231,7 +2324,10 @@ function clause execute(WMVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -2271,7 +2367,7 @@ function clause execute(VMVSX(rs1, vd)) = {
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   assert(num_elem > 0);
   let 'n = num_elem;
@@ -2281,7 +2377,10 @@ function clause execute(VMVSX(rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar(rs1, 'm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, 0, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, 0, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   /* one body element */

--- a/model/riscv_insts_vext_fp.sail
+++ b/model/riscv_insts_vext_fp.sail
@@ -37,7 +37,7 @@ function clause execute(FVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_normal(vd, vm, SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -48,7 +48,10 @@ function clause execute(FVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -112,7 +115,7 @@ function clause execute(FVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_normal(vd, vm, SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -123,7 +126,10 @@ function clause execute(FVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -184,7 +190,7 @@ function clause execute(FWVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW >= 16 & SEW_widen <= 64);
 
   let 'n = num_elem;
@@ -196,7 +202,10 @@ function clause execute(FWVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -249,7 +258,7 @@ function clause execute(FWVVMATYPE(funct6, vm, vs1, vs2, vd)) = {
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW >= 16 & SEW_widen <= 64);
 
   let 'n = num_elem;
@@ -261,7 +270,10 @@ function clause execute(FWVVMATYPE(funct6, vm, vs1, vs2, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -312,7 +324,7 @@ function clause execute(FWVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW >= 16 & SEW_widen <= 64);
 
   let 'n = num_elem;
@@ -324,7 +336,10 @@ function clause execute(FWVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -371,7 +386,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_normal(vd, vm, SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -381,7 +396,10 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -489,7 +507,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
 
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW >= 8 & SEW_widen <= 64);
 
   let 'n = num_elem;
@@ -500,7 +518,10 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -508,7 +529,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
       result[i] = match vfwunary0 {
         FWV_CVT_XU_F     => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_f16ToUi32(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToUi64(rm_3b, vs2_val[i])
                               };
@@ -517,7 +538,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                             },
         FWV_CVT_X_F      => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_f16ToI32(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToI64(rm_3b, vs2_val[i])
                               };
@@ -544,7 +565,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                             },
         FWV_CVT_F_F      => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_f16ToF32(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToF64(rm_3b, vs2_val[i])
                               };
@@ -553,7 +574,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                             },
         FWV_CVT_RTZ_XU_F => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_f16ToUi32(0b001, vs2_val[i]),
                                 32 => riscv_f32ToUi64(0b001, vs2_val[i])
                               };
@@ -562,7 +583,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                             },
         FWV_CVT_RTZ_X_F  => {
                               let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_f16ToI32(0b001, vs2_val[i]),
                                 32 => riscv_f32ToI64(0b001, vs2_val[i])
                               };
@@ -619,7 +640,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
 
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 64);
 
   let 'n = num_elem;
@@ -630,7 +651,10 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -656,7 +680,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                             },
         FNV_CVT_F_XU     => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_ui32ToF16(rm_3b, vs2_val[i]),
                                 32 => riscv_ui64ToF32(rm_3b, vs2_val[i])
                               };
@@ -665,7 +689,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                             },
         FNV_CVT_F_X      => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_i32ToF16(rm_3b, vs2_val[i]),
                                 32 => riscv_i64ToF32(rm_3b, vs2_val[i])
                               };
@@ -674,7 +698,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                             },
         FNV_CVT_F_F      => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_f32ToF16(rm_3b, vs2_val[i]),
                                 32 => riscv_f64ToF32(rm_3b, vs2_val[i])
                               };
@@ -683,7 +707,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                             },
         FNV_CVT_ROD_F_F  => {
                               let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
-                                8  => { handle_illegal(); return RETIRE_FAIL },
+                                8  => return RETIRE_FAIL(Illegal_Instruction()),
                                 16 => riscv_f32ToF16(0b110, vs2_val[i]),
                                 32 => riscv_f64ToF32(0b110, vs2_val[i])
                               };
@@ -751,7 +775,7 @@ function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_normal(vd, vm, SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -761,7 +785,10 @@ function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -827,7 +854,7 @@ function clause execute(VFMVFS(vs2, rd)) = {
   let num_elem = get_num_elem(0, SEW);
 
   if illegal_fp_vd_unmasked(SEW, rm_3b) | SEW > flen
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(num_elem > 0 & SEW != 8);
 
   let 'n = num_elem;
@@ -876,7 +903,7 @@ function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_normal(vd, vm, SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -887,7 +914,10 @@ function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -905,7 +935,7 @@ function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
         VF_VSGNJN        => (0b1 ^ [rs1_val['m - 1]]) @ vs2_val[i][('m - 2)..0],
         VF_VSGNJX        => ([vs2_val[i]['m - 1]] ^ [rs1_val['m - 1]]) @ vs2_val[i][('m - 2)..0],
         VF_VSLIDE1UP     => {
-                              if vs2 == vd then { handle_illegal(); return RETIRE_FAIL };
+                              if vs2 == vd then return RETIRE_FAIL(Illegal_Instruction());
                               if i == 0 then rs1_val else vs2_val[i - 1]
                             },
         VF_VSLIDE1DOWN   => {
@@ -966,7 +996,7 @@ function clause execute(FVFMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_normal(vd, vm, SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -977,7 +1007,10 @@ function clause execute(FVFMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1037,7 +1070,7 @@ function clause execute(FWVFTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW >= 16 & SEW_widen <= 64);
 
   let 'n = num_elem;
@@ -1049,7 +1082,10 @@ function clause execute(FWVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1101,7 +1137,7 @@ function clause execute(FWVFMATYPE(funct6, vm, rs1, vs2, vd)) = {
 
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW >= 16 & SEW_widen <= 64);
 
   let 'n = num_elem;
@@ -1113,7 +1149,10 @@ function clause execute(FWVFMATYPE(funct6, vm, rs1, vs2, vd)) = {
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1163,7 +1202,7 @@ function clause execute(FWFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen)
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW >= 16 & SEW_widen <= 64);
 
   let 'n = num_elem;
@@ -1175,7 +1214,10 @@ function clause execute(FWFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1210,14 +1252,17 @@ mapping clause encdec = VFMERGE(vs2, rs1, vd)
 
 function clause execute(VFMERGE(vs2, rs1, vd)) = {
   let rm_3b         = fcsr[FRM];
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   let end_element   = get_end_element();
   let SEW           = get_sew();
   let LMUL_pow      = get_lmul_pow();
   let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
 
-  if illegal_fp_vd_masked(vd, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_vd_masked(vd, SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -1266,7 +1311,7 @@ function clause execute(VFMV(rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_vd_unmasked(SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_vd_unmasked(SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -1276,7 +1321,10 @@ function clause execute(VFMV(rs1, vd)) = {
   let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zvreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1303,7 +1351,7 @@ function clause execute(VFMVSF(rs1, vd)) = {
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
-  if illegal_fp_vd_unmasked(SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_vd_unmasked(SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(num_elem > 0 & SEW != 8);
 
   let 'n = num_elem;
@@ -1313,7 +1361,10 @@ function clause execute(VFMVSF(rs1, vd)) = {
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, 0, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, 0, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   /* one body element */

--- a/model/riscv_insts_vext_fp_red.sail
+++ b/model/riscv_insts_vext_fp_red.sail
@@ -27,12 +27,12 @@ mapping clause encdec = RFVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_rfvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_V)
 
-val process_rfvv_single: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, int('n), int('m), int('p)) -> Retired
+val process_rfvv_single: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, int('n), int('m), int('p)) -> Retired(Retire_Failure)
 function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {
   let rm_3b = fcsr[FRM];
   let num_elem_vd = get_num_elem(0, SEW); /* vd regardless of LMUL setting */
 
-  if illegal_fp_reduction(SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_reduction(SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   if unsigned(vl) == 0 then return RETIRE_SUCCESS; /* if vl=0, no operation is performed */
@@ -44,7 +44,10 @@ function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_po
   let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zvreg);
   let vd_val  : vector('d, bits('m)) = read_vreg(num_elem_vd, SEW, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
-  let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
+  let mask    : bits('n)     = match init_masked_source(num_elem_vs, LMUL_pow, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   var sum : bits('m) = read_single_element(SEW, 0, vs1); /* vs1 regardless of LMUL setting */
   foreach (i from 0 to (num_elem_vs - 1)) {
@@ -67,14 +70,14 @@ function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_po
   RETIRE_SUCCESS
 }
 
-val process_rfvv_widen: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, int('n), int('m), int('p)) -> Retired
+val process_rfvv_widen: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, int('n), int('m), int('p)) -> Retired(Retire_Failure)
 function process_rfvv_widen(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {
   let rm_3b          = fcsr[FRM];
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
   let num_elem_vd = get_num_elem(0, SEW_widen); /* vd regardless of LMUL setting */
 
-  if illegal_fp_reduction_widen(SEW, rm_3b, SEW_widen, LMUL_pow_widen) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_reduction_widen(SEW, rm_3b, SEW_widen, LMUL_pow_widen) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW >= 16 & SEW_widen <= 64);
 
   if unsigned(vl) == 0 then return RETIRE_SUCCESS; /* if vl=0, no operation is performed */
@@ -87,7 +90,10 @@ function process_rfvv_widen(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow
   let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zvreg);
   let vd_val  : vector('d, bits('o)) = read_vreg(num_elem_vd, SEW_widen, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
-  let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
+  let mask    : bits('n)     = match init_masked_source(num_elem_vs, LMUL_pow, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   var sum : bits('o) = read_single_element(SEW_widen, 0, vs1); /* vs1 regardless of LMUL setting */
   foreach (i from 0 to (num_elem_vs - 1)) {

--- a/model/riscv_insts_vext_fp_red.sail
+++ b/model/riscv_insts_vext_fp_red.sail
@@ -27,7 +27,7 @@ mapping clause encdec = RFVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_rfvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_V)
 
-val process_rfvv_single: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, int('n), int('m), int('p)) -> Retired(Retire_Failure)
+val process_rfvv_single: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, int('n), int('m), int('p)) -> ExecutionResult(Retire_Failure)
 function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {
   let rm_3b = fcsr[FRM];
   let num_elem_vd = get_num_elem(0, SEW); /* vd regardless of LMUL setting */
@@ -70,7 +70,7 @@ function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_po
   RETIRE_SUCCESS
 }
 
-val process_rfvv_widen: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, int('n), int('m), int('p)) -> Retired(Retire_Failure)
+val process_rfvv_widen: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, int('n), int('m), int('p)) -> ExecutionResult(Retire_Failure)
 function process_rfvv_widen(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {
   let rm_3b          = fcsr[FRM];
   let SEW_widen      = SEW * 2;

--- a/model/riscv_insts_vext_fp_vm.sail
+++ b/model/riscv_insts_vext_fp_vm.sail
@@ -32,7 +32,7 @@ function clause execute(FVVMTYPE(funct6, vm, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_vd_unmasked(SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_vd_unmasked(SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -43,7 +43,10 @@ function clause execute(FVVMTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -96,7 +99,7 @@ function clause execute(FVFMTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_vd_unmasked(SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_fp_vd_unmasked(SEW, rm_3b) then return RETIRE_FAIL(Illegal_Instruction());
   assert(SEW != 8);
 
   let 'n = num_elem;
@@ -107,7 +110,10 @@ function clause execute(FVFMTYPE(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {

--- a/model/riscv_insts_vext_mask.sail
+++ b/model/riscv_insts_vext_mask.sail
@@ -34,7 +34,7 @@ function clause execute(MMTYPE(funct6, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = VLEN;
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -43,7 +43,10 @@ function clause execute(MMTYPE(funct6, vs2, vs1, vd)) = {
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, 0, vd_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, 0, vd_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -92,7 +95,7 @@ function clause execute(VCPOP_M(vm, vs2, rd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = VLEN;
 
-  if illegal_vd_unmasked() | not(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() | not(assert_vstart(0)) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -100,7 +103,10 @@ function clause execute(VCPOP_M(vm, vs2, rd)) = {
   let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
 
-  let (_, mask) = init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val);
+  let (_, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   var count : nat = 0;
   foreach (i from 0 to (num_elem - 1)) {
@@ -127,7 +133,7 @@ function clause execute(VFIRST_M(vm, vs2, rd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = VLEN;
 
-  if illegal_vd_unmasked() | not(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() | not(assert_vstart(0)) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -135,7 +141,10 @@ function clause execute(VFIRST_M(vm, vs2, rd)) = {
   let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
 
-  let (_, mask) = init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val);
+  let (_, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   var index : int = -1;
   foreach (i from 0 to (num_elem - 1)) {
@@ -165,7 +174,7 @@ function clause execute(VMSBF_M(vm, vs2, vd)) = {
   let num_elem = VLEN;
 
   if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -174,7 +183,10 @@ function clause execute(VMSBF_M(vm, vs2, vd)) = {
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   var found_elem : bool = false;
@@ -206,7 +218,7 @@ function clause execute(VMSIF_M(vm, vs2, vd)) = {
   let num_elem = VLEN;
 
   if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -215,7 +227,10 @@ function clause execute(VMSIF_M(vm, vs2, vd)) = {
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   var found_elem : bool = false;
@@ -247,7 +262,7 @@ function clause execute(VMSOF_M(vm, vs2, vd)) = {
   let num_elem = VLEN;
 
   if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -256,7 +271,10 @@ function clause execute(VMSOF_M(vm, vs2, vd)) = {
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   var found_elem : bool = false;
@@ -292,7 +310,7 @@ function clause execute(VIOTA_M(vm, vs2, vd)) = {
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
-  then { handle_illegal(); return RETIRE_FAIL };
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -301,7 +319,10 @@ function clause execute(VIOTA_M(vm, vs2, vd)) = {
   let vs2_val : bits('n)     = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   var sum : int = 0;
@@ -332,7 +353,7 @@ function clause execute(VID_V(vm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_normal(vd, vm) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -340,7 +361,10 @@ function clause execute(VID_V(vm, vd)) = {
   let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)    => v,
+    Err(())  => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -68,7 +68,7 @@ mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
   when currentlyEnabled(Ext_V)
 
-val process_vlseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> Retired(Retire_Failure)
+val process_vlseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> ExecutionResult(Retire_Failure)
 function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
@@ -141,7 +141,7 @@ mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b10000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
   when currentlyEnabled(Ext_V)
 
-val process_vlsegff : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> Retired(Retire_Failure)
+val process_vlsegff : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> ExecutionResult(Retire_Failure)
 function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
@@ -253,7 +253,7 @@ mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
   when currentlyEnabled(Ext_V)
 
-val process_vsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> Retired(Retire_Failure)
+val process_vsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> ExecutionResult(Retire_Failure)
 function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
@@ -327,7 +327,7 @@ mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
   <-> nf @ 0b0 @ 0b10 @ vm @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
   when currentlyEnabled(Ext_V)
 
-val process_vlsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, regidx, int('p), int('n)) -> Retired(Retire_Failure)
+val process_vlsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, regidx, int('p), int('n)) -> ExecutionResult(Retire_Failure)
 function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
@@ -401,7 +401,7 @@ mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b10 @ vm @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
   when currentlyEnabled(Ext_V)
 
-val process_vssseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, regidx, int('p), int('n)) -> Retired(Retire_Failure)
+val process_vssseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, regidx, int('p), int('n)) -> ExecutionResult(Retire_Failure)
 function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
@@ -476,7 +476,7 @@ mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   <-> nf @ 0b0 @ 0b01 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
   when currentlyEnabled(Ext_V)
 
-val process_vlxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('ib), int('db), int('ip), int('dp), regidx, vregidx, int('n), int) -> Retired(Retire_Failure)
+val process_vlxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('ib), int('db), int('ip), int('dp), regidx, vregidx, int('n), int) -> ExecutionResult(Retire_Failure)
 function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
   let width_type : word_width = size_bytes(EEW_data_bytes);
@@ -580,7 +580,7 @@ mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b01 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
   when currentlyEnabled(Ext_V)
 
-val process_vsxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('ib), int('db), int('ip), int('dp), regidx, vregidx, int('n), int) -> Retired(Retire_Failure)
+val process_vsxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('ib), int('db), int('ip), int('dp), regidx, vregidx, int('n), int) -> ExecutionResult(Retire_Failure)
 function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
   let width_type : word_width = size_bytes(EEW_data_bytes);
@@ -685,7 +685,7 @@ mapping clause encdec = VLRETYPE(nf, rs1, width, vd)
   <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
   when currentlyEnabled(Ext_V)
 
-val process_vlre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), vregidx, int('b), regidx, int('n)) -> Retired(Retire_Failure)
+val process_vlre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), vregidx, int('b), regidx, int('n)) -> ExecutionResult(Retire_Failure)
 function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
   let width_type : word_width = size_bytes(load_width_bytes);
   let start_element : nat = match get_start_element() {
@@ -770,7 +770,7 @@ mapping clause encdec = VSRETYPE(nf, rs1, vs3)
   <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ encdec_reg(rs1) @ 0b000 @ encdec_vreg(vs3) @ 0b0100111
   when currentlyEnabled(Ext_V)
 
-val process_vsre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), int('b), regidx, vregidx, int('n)) -> Retired(Retire_Failure)
+val process_vsre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), int('b), regidx, vregidx, int('n)) -> ExecutionResult(Retire_Failure)
 function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
   let width_type : word_width = BYTE;
   let start_element : nat = match get_start_element() {
@@ -874,7 +874,7 @@ mapping clause encdec = VMTYPE(rs1, vd_or_vs3, op)
   <-> 0b000 @ 0b0 @ 0b00 @ 0b1 @ 0b01011 @ encdec_reg(rs1) @ 0b000 @ encdec_vreg(vd_or_vs3) @ encdec_lsop(op)
   when currentlyEnabled(Ext_V)
 
-val process_vm : forall 'n 'l, ('n >= 0 & 'l >= 0). (vregidx, regidx, int('n), int('l), vmlsop) -> Retired(Retire_Failure)
+val process_vm : forall 'n 'l, ('n >= 0 & 'l >= 0). (vregidx, regidx, int('n), int('l), vmlsop) -> ExecutionResult(Retire_Failure)
 function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
   let width_type : word_width = BYTE;
   let start_element : nat = match get_start_element() {

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -68,14 +68,18 @@ mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
   when currentlyEnabled(Ext_V)
 
-val process_vlseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> Retired
+val process_vlseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> Retired(Retire_Failure)
 function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vd_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
 
-  let (result, mask) = init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val);
+  let 'm = nf * load_width_bytes * 8;
+  let (result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then { /* active segments */
@@ -83,16 +87,16 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = (i * nf + j) * load_width_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+          Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
               if check_misaligned(vaddr, width_type)
-              then { handle_mem_exception(vaddr, E_Load_Addr_Align()); return RETIRE_FAIL }
+              then return RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
               else match translateAddr(vaddr, Read(Data)) {
-                TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                 TR_Address(paddr, _) => {
                   match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
                     Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
-                    Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                    Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                   }
                 }
               }
@@ -122,7 +126,7 @@ function clause execute(VLSEGTYPE(nf, vm, rs1, width, vd)) = {
 
   assert(num_elem > 0);
 
-  if illegal_load(vd, vm, nf_int, EEW, EMUL_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_load(vd, vm, nf_int, EEW, EMUL_pow) then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vlseg(nf_int, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -137,7 +141,7 @@ mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b10000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
   when currentlyEnabled(Ext_V)
 
-val process_vlsegff : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> Retired
+val process_vlsegff : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> Retired(Retire_Failure)
 function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
@@ -145,7 +149,11 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
   let vd_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
   let tail_ag : agtype = get_vtype_vta();
 
-  let (result, mask) = init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val);
+  let 'm = nf * load_width_bytes * 8;
+  let (result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   var trimmed : bool = false;
   foreach (i from 0 to (num_elem - 1)) {
@@ -155,7 +163,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
           let elem_offset = (i * nf + j) * load_width_bytes;
           match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
             Ext_DataAddr_Error(e)  => {
-              if i == 0 then { ext_handle_data_check_error(e); return RETIRE_FAIL }
+              if i == 0 then return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e))
               else {
                 vl = to_bits(xlen, i);
                 print_reg("CSR vl <- " ^ BitStr(vl));
@@ -164,7 +172,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
             },
             Ext_DataAddr_OK(vaddr) => {
               if check_misaligned(vaddr, width_type) then {
-                if i == 0 then { handle_mem_exception(vaddr, E_Load_Addr_Align()); return RETIRE_FAIL }
+                if i == 0 then return RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
                 else {
                   vl = to_bits(xlen, i);
                   print_reg("CSR vl <- " ^ BitStr(vl));
@@ -172,7 +180,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
                 }
               } else match translateAddr(vaddr, Read(Data)) {
                 TR_Failure(e, _)     => {
-                  if i == 0 then { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                  if i == 0 then return RETIRE_FAIL(Memory_Exception(vaddr, e))
                   else {
                     vl = to_bits(xlen, i);
                     print_reg("CSR vl <- " ^ BitStr(vl));
@@ -183,7 +191,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
                   match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
                     Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
                     Err(e)   => {
-                      if i == 0 then { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                      if i == 0 then return RETIRE_FAIL(Memory_Exception(vaddr, e))
                       else {
                         vl = to_bits(xlen, i);
                         print_reg("CSR vl <- " ^ BitStr(vl));
@@ -230,7 +238,7 @@ function clause execute(VLSEGFFTYPE(nf, vm, rs1, width, vd)) = {
 
   assert(num_elem > 0);
 
-  if illegal_load(vd, vm, nf_int, EEW, EMUL_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_load(vd, vm, nf_int, EEW, EMUL_pow) then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vlsegff(nf_int, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -245,13 +253,17 @@ mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
   when currentlyEnabled(Ext_V)
 
-val process_vsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> Retired
+val process_vsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> Retired(Retire_Failure)
 function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs3_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
-  let mask    : bits('n) = init_masked_source(num_elem, EMUL_pow, vm_val);
+
+  let mask : bits('n) = match init_masked_source(num_elem, EMUL_pow, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then { /* active segments */
@@ -259,21 +271,21 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = (i * nf + j) * load_width_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), load_width_bytes) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+          Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); return RETIRE_FAIL }
+            then return RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
             else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+              TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
               TR_Address(paddr, _) => {
                 match mem_write_ea(paddr, load_width_bytes, false, false, false) {
-                  Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                  Err(e) => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                   Ok(_)  => {
                     let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(5, j * EMUL_reg)));
                     match mem_write_value(paddr, load_width_bytes, elem_val, false, false, false) {
                       Ok(true)  => (),
                       Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                      Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                      Err(e)    => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                     }
                   }
                 }
@@ -300,7 +312,7 @@ function clause execute(VSSEGTYPE(nf, vm, rs1, width, vs3)) = {
 
   assert(num_elem > 0);
 
-  if illegal_store(nf_int, EEW, EMUL_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_store(nf_int, EEW, EMUL_pow) then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vsseg(nf_int, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem)
 }
@@ -315,7 +327,7 @@ mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
   <-> nf @ 0b0 @ 0b10 @ vm @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
   when currentlyEnabled(Ext_V)
 
-val process_vlsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, regidx, int('p), int('n)) -> Retired
+val process_vlsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, regidx, int('p), int('n)) -> Retired(Retire_Failure)
 function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
@@ -323,7 +335,11 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
   let vd_seg  : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
   let rs2_val : int = unsigned(get_scalar(rs2, xlen));
 
-  let (result, mask) = init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val);
+  let 'm = nf * load_width_bytes * 8;
+  let (result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then { /* active segments */
@@ -331,16 +347,16 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = i * rs2_val + j * load_width_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+          Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); return RETIRE_FAIL }
+            then return RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
             else match translateAddr(vaddr, Read(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+              TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
                   Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
-                  Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                  Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                 }
               }
             }
@@ -370,7 +386,7 @@ function clause execute(VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)) = {
 
   assert(num_elem > 0);
 
-  if illegal_load(vd, vm, nf_int, EEW, EMUL_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_load(vd, vm, nf_int, EEW, EMUL_pow) then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vlsseg(nf_int, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
@@ -385,14 +401,18 @@ mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b10 @ vm @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
   when currentlyEnabled(Ext_V)
 
-val process_vssseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, regidx, int('p), int('n)) -> Retired
+val process_vssseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, regidx, int('p), int('n)) -> Retired(Retire_Failure)
 function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs3_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
   let rs2_val : int = unsigned(get_scalar(rs2, xlen));
-  let mask    : bits('n) = init_masked_source(num_elem, EMUL_pow, vm_val);
+
+  let mask : bits('n) = match init_masked_source(num_elem, EMUL_pow, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then { /* active segments */
@@ -400,21 +420,21 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = i * rs2_val + j * load_width_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), load_width_bytes) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+          Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); return RETIRE_FAIL }
+            then return RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
             else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+              TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
               TR_Address(paddr, _) => {
                 match mem_write_ea(paddr, load_width_bytes, false, false, false) {
-                  Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                  Err(e) => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                   Ok(_)  => {
                     let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(5, j * EMUL_reg)));
                     match mem_write_value(paddr, load_width_bytes, elem_val, false, false, false) {
                       Ok(true)  => (),
                       Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                      Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                      Err(e)    => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                     }
                   }
                 }
@@ -441,7 +461,7 @@ function clause execute(VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)) = {
 
   assert(num_elem > 0);
 
-  if illegal_store(nf_int, EEW, EMUL_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_store(nf_int, EEW, EMUL_pow) then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vssseg(nf_int, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem)
 }
@@ -456,7 +476,7 @@ mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   <-> nf @ 0b0 @ 0b01 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
   when currentlyEnabled(Ext_V)
 
-val process_vlxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('ib), int('db), int('ip), int('dp), regidx, vregidx, int('n), int) -> Retired
+val process_vlxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('ib), int('db), int('ip), int('dp), regidx, vregidx, int('n), int) -> Retired(Retire_Failure)
 function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
   let width_type : word_width = size_bytes(EEW_data_bytes);
@@ -464,7 +484,11 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
   let vd_seg  : vector('n, bits('f * 'db * 8)) = read_vreg_seg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, nf, vd);
   let vs2_val : vector('n, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
 
-  let (result, mask) = init_masked_result(num_elem, nf * EEW_data_bytes * 8, EMUL_data_pow, vd_seg, vm_val);
+  let 'm = nf * EEW_data_bytes * 8;
+  let (result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, nf * EEW_data_bytes * 8, EMUL_data_pow, vd_seg, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   /* currently mop = 1 (unordered) or 3 (ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
@@ -473,16 +497,16 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
       foreach (j from 0 to (nf - 1)) {
         let elem_offset : int = unsigned(vs2_val[i]) + j * EEW_data_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), EEW_data_bytes) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+          Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); return RETIRE_FAIL }
+            then return RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
             else match translateAddr(vaddr, Read(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+              TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, EEW_data_bytes, false, false, false) {
                   Ok(elem) => write_single_element(EEW_data_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_data_reg)), elem),
-                  Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                  Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                 }
               }
             }
@@ -512,7 +536,8 @@ function clause execute(VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
 
   assert(num_elem > 0);
 
-  if illegal_indexed_load(vd, vm, nf_int, EEW_index_bytes * 8, EMUL_index_pow, EMUL_data_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_indexed_load(vd, vm, nf_int, EEW_index_bytes * 8, EMUL_index_pow, EMUL_data_pow)
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vlxseg(nf_int, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
@@ -539,7 +564,8 @@ function clause execute(VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
 
   assert(num_elem > 0);
 
-  if illegal_indexed_load(vd, vm, nf_int, EEW_index_bytes * 8, EMUL_index_pow, EMUL_data_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_indexed_load(vd, vm, nf_int, EEW_index_bytes * 8, EMUL_index_pow, EMUL_data_pow)
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vlxseg(nf_int, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
@@ -554,14 +580,18 @@ mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b01 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
   when currentlyEnabled(Ext_V)
 
-val process_vsxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('ib), int('db), int('ip), int('dp), regidx, vregidx, int('n), int) -> Retired
+val process_vsxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('ib), int('db), int('ip), int('dp), regidx, vregidx, int('n), int) -> Retired(Retire_Failure)
 function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
   let width_type : word_width = size_bytes(EEW_data_bytes);
   let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs3_seg : vector('n, bits('f * 'db * 8)) = read_vreg_seg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, nf, vs3);
   let vs2_val : vector('n, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
-  let mask    : bits('n) = init_masked_source(num_elem, EMUL_data_pow, vm_val);
+
+  let mask : bits('n) = match init_masked_source(num_elem, EMUL_data_pow, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   /* currently mop = 1 (unordered) or 3 (ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
@@ -570,21 +600,21 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
       foreach (j from 0 to (nf - 1)) {
         let elem_offset : int = unsigned(vs2_val[i]) + j * EEW_data_bytes;
         match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), EEW_data_bytes) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+          Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); return RETIRE_FAIL }
+            then return RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
             else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+              TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
               TR_Address(paddr, _) => {
                 match mem_write_ea(paddr, EEW_data_bytes, false, false, false) {
-                  Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                  Err(e) => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                   Ok(_)  => {
                     let elem_val : bits('db * 8) = read_single_element(EEW_data_bytes * 8, i, vregidx_offset(vs3, to_bits(5, j * EMUL_data_reg)));
                     match mem_write_value(paddr, EEW_data_bytes, elem_val, false, false, false) {
                       Ok(true)  => (),
                       Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                      Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                      Err(e)    => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                     }
                   }
                 }
@@ -611,7 +641,8 @@ function clause execute(VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
 
   assert(num_elem > 0);
 
-  if illegal_indexed_store(nf_int, EEW_index_bytes * 8, EMUL_index_pow, EMUL_data_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_indexed_store(nf_int, EEW_index_bytes * 8, EMUL_index_pow, EMUL_data_pow)
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vsxseg(nf_int, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 1)
 }
@@ -638,7 +669,8 @@ function clause execute(VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
 
   assert(num_elem > 0);
 
-  if illegal_indexed_store(nf_int, EEW_index_bytes * 8, EMUL_index_pow, EMUL_data_pow) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_indexed_store(nf_int, EEW_index_bytes * 8, EMUL_index_pow, EMUL_data_pow)
+  then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vsxseg(nf_int, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, 3)
 }
@@ -653,10 +685,13 @@ mapping clause encdec = VLRETYPE(nf, rs1, width, vd)
   <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
   when currentlyEnabled(Ext_V)
 
-val process_vlre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), vregidx, int('b), regidx, int('n)) -> Retired
+val process_vlre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), vregidx, int('b), regidx, int('n)) -> Retired(Retire_Failure)
 function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
   let width_type : word_width = size_bytes(load_width_bytes);
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   if start_element >= nf * elem_per_reg then return RETIRE_SUCCESS; /* no elements are written if vstart >= evl */
   let elem_to_align : int = start_element % elem_per_reg;
   var cur_field : int = start_element / elem_per_reg;
@@ -667,16 +702,16 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+        Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
         Ext_DataAddr_OK(vaddr) =>
           if check_misaligned(vaddr, width_type)
-          then { handle_mem_exception(vaddr, E_Load_Addr_Align()); return RETIRE_FAIL }
+          then return RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
           else match translateAddr(vaddr, Read(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+            TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
             TR_Address(paddr, _) => {
               match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
                 Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, cur_field)), elem),
-                Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
               }
             }
           }
@@ -691,16 +726,16 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+        Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
         Ext_DataAddr_OK(vaddr) =>
           if check_misaligned(vaddr, width_type)
-          then { handle_mem_exception(vaddr, E_Load_Addr_Align()); return RETIRE_FAIL }
+          then return RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
           else match translateAddr(vaddr, Read(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+            TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
             TR_Address(paddr, _) => {
               match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
                 Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j)), elem),
-                Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
               }
             }
           }
@@ -720,7 +755,7 @@ function clause execute(VLRETYPE(nf, rs1, width, vd)) = {
   let nf_int = nfields_int(nf);
 
   assert(elem_per_reg >= 0);
-  if not(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then { handle_illegal(); return RETIRE_FAIL };
+  if not(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vlre(nf_int, vd, load_width_bytes, rs1, elem_per_reg)
 }
@@ -735,10 +770,13 @@ mapping clause encdec = VSRETYPE(nf, rs1, vs3)
   <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ encdec_reg(rs1) @ 0b000 @ encdec_vreg(vs3) @ 0b0100111
   when currentlyEnabled(Ext_V)
 
-val process_vsre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), int('b), regidx, vregidx, int('n)) -> Retired
+val process_vsre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), int('b), regidx, vregidx, int('n)) -> Retired(Retire_Failure)
 function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
   let width_type : word_width = BYTE;
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   if start_element >= nf * elem_per_reg then return RETIRE_SUCCESS; /* no elements are written if vstart >= evl */
   let elem_to_align : int = start_element % elem_per_reg;
   var cur_field : int = start_element / elem_per_reg;
@@ -749,21 +787,21 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset : int = cur_elem * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), load_width_bytes) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+        Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
         Ext_DataAddr_OK(vaddr) =>
           if check_misaligned(vaddr, width_type)
-          then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); return RETIRE_FAIL }
+          then return RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
           else match translateAddr(vaddr, Write(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+            TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
             TR_Address(paddr, _) => {
               match mem_write_ea(paddr, load_width_bytes, false, false, false) {
-                Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                Err(e) => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                 Ok(_)  => {
                   let elem : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(5, cur_field)));
                   match mem_write_value(paddr, load_width_bytes, elem, false, false, false) {
                     Ok(true)  => (),
                     Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                    Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                    Err(e)    => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                   }
                 }
               }
@@ -781,20 +819,20 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
       match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), load_width_bytes) {
-        Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+        Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
         Ext_DataAddr_OK(vaddr) =>
           if check_misaligned(vaddr, width_type)
-          then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); return RETIRE_FAIL }
+          then return RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
           else match translateAddr(vaddr, Write(Data)) {
-            TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+            TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
             TR_Address(paddr, _) => {
               match mem_write_ea(paddr, load_width_bytes, false, false, false) {
-                Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                Err(e) => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                 Ok(_)  => {
                   match mem_write_value(paddr, load_width_bytes, vs3_val[i], false, false, false) {
                     Ok(true)  => (),
                     Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                    Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                    Err(e)    => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                   }
                 }
               }
@@ -816,7 +854,7 @@ function clause execute(VSRETYPE(nf, rs1, vs3)) = {
   let nf_int = nfields_int(nf);
 
   assert(elem_per_reg >= 0);
-  if not(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then { handle_illegal(); return RETIRE_FAIL };
+  if not(nf_int == 1 | nf_int == 2 | nf_int == 4 | nf_int == 8) then return RETIRE_FAIL(Illegal_Instruction());
 
   process_vsre(nf_int, load_width_bytes, rs1, vs3, elem_per_reg)
 }
@@ -836,10 +874,13 @@ mapping clause encdec = VMTYPE(rs1, vd_or_vs3, op)
   <-> 0b000 @ 0b0 @ 0b00 @ 0b1 @ 0b01011 @ encdec_reg(rs1) @ 0b000 @ encdec_vreg(vd_or_vs3) @ encdec_lsop(op)
   when currentlyEnabled(Ext_V)
 
-val process_vm : forall 'n 'l, ('n >= 0 & 'l >= 0). (vregidx, regidx, int('n), int('l), vmlsop) -> Retired
+val process_vm : forall 'n 'l, ('n >= 0 & 'l >= 0). (vregidx, regidx, int('n), int('l), vmlsop) -> Retired(Retire_Failure)
 function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
   let width_type : word_width = BYTE;
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   let vd_or_vs3_val : vector('n, bits(8)) = read_vreg(num_elem, 8, 0, vd_or_vs3);
 
   foreach (i from start_element to (num_elem - 1)) {
@@ -847,36 +888,36 @@ function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
       set_vstart(to_bits(16, i));
       if op == VLM then { /* load */
         match ext_data_get_addr(rs1, to_bits(xlen, i), Read(Data), 1) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+          Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_Load_Addr_Align()); return RETIRE_FAIL }
+            then return RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
             else match translateAddr(vaddr, Read(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+              TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, 1, false, false, false) {
                   Ok(elem) => write_single_element(8, i, vd_or_vs3, elem),
-                  Err(e)   => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                  Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                 }
               }
             }
         }
       } else if op == VSM then { /* store */
         match ext_data_get_addr(rs1, to_bits(xlen, i), Write(Data), 1) {
-          Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); return RETIRE_FAIL },
+          Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
-            then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); return RETIRE_FAIL }
+            then return RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
             else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+              TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
               TR_Address(paddr, _) => {
                 match mem_write_ea(paddr, 1, false, false, false) {
-                  Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
+                  Err(e) => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                   Ok(_)  => {
                     match mem_write_value(paddr, 1, vd_or_vs3_val[i], false, false, false) {
                       Ok(true)  => (),
                       Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                      Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
+                      Err(e)    => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                     }
                   }
                 }
@@ -903,7 +944,7 @@ function clause execute(VMTYPE(rs1, vd_or_vs3, op)) = {
   let evl : int = if vl_val % 8 == 0 then vl_val / 8 else vl_val / 8 + 1; /* the effective vector length is evl=ceil(vl/8) */
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   assert(evl >= 0);
   process_vm(vd_or_vs3, rs1, num_elem, evl, op)

--- a/model/riscv_insts_vext_red.sail
+++ b/model/riscv_insts_vext_red.sail
@@ -31,7 +31,7 @@ function clause execute(RIVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let num_elem_vs = get_num_elem(LMUL_pow, SEW);
   let num_elem_vd = get_num_elem(0, SEW_widen); /* vd regardless of LMUL setting */
 
-  if illegal_reduction_widen(SEW_widen, LMUL_pow_widen) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_reduction_widen(SEW_widen, LMUL_pow_widen) then return RETIRE_FAIL(Illegal_Instruction());
 
   if unsigned(vl) == 0 then return RETIRE_SUCCESS; /* if vl=0, no operation is performed */
 
@@ -43,7 +43,10 @@ function clause execute(RIVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zvreg);
   let vd_val  : vector('d, bits('o)) = read_vreg(num_elem_vd, SEW_widen, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
-  let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
+  let mask    : bits('n)     = match init_masked_source(num_elem_vs, LMUL_pow, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   var sum : bits('o) = read_single_element(SEW_widen, 0, vs1); /* vs1 regardless of LMUL setting */
   foreach (i from 0 to (num_elem_vs - 1)) {
@@ -95,7 +98,7 @@ function clause execute(RMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let num_elem_vs = get_num_elem(LMUL_pow, SEW);
   let num_elem_vd = get_num_elem(0, SEW); /* vd regardless of LMUL setting */
 
-  if illegal_reduction() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_reduction() then return RETIRE_FAIL(Illegal_Instruction());
 
   if unsigned(vl) == 0 then return RETIRE_SUCCESS; /* if vl=0, no operation is performed */
 
@@ -106,7 +109,10 @@ function clause execute(RMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zvreg);
   let vd_val  : vector('d, bits('m)) = read_vreg(num_elem_vd, SEW, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
-  let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
+  let mask    : bits('n)     = match init_masked_source(num_elem_vs, LMUL_pow, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
 
   var sum : bits('m) = read_single_element(SEW, 0, vs1); /* vs1 regardless of LMUL setting */
   foreach (i from 0 to (num_elem_vs - 1)) {

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -184,7 +184,7 @@ function write_velem_quad(vd, SEW, input, i) = {
 }
 
 /* Get the starting element index from csr vtype */
-val get_start_element : unit -> nat
+val get_start_element : unit -> result(nat, unit)
 function get_start_element() = {
   let start_element = unsigned(vstart);
   let VLEN_pow = get_vlen_pow();
@@ -194,8 +194,9 @@ function get_start_element() = {
     It is recommended that implementations trap if vstart is out of bounds.
     It is not required to trap, as a possible future use of upper vstart bits
     is to store imprecise trap information. */
-  if start_element > (2 ^ (3 + VLEN_pow - SEW_pow) - 1) then handle_illegal();
-  start_element
+  if start_element > (2 ^ (3 + VLEN_pow - SEW_pow) - 1)
+  then Err(())
+  else Ok(start_element)
 }
 
 /* Get the ending element index from csr vl */
@@ -210,9 +211,12 @@ function get_end_element() = unsigned(vl) - 1
  *   vector2 is a "mask" vector that is true for an element if the corresponding element
  *     in the result vector should be updated by the calling instruction
  */
-val init_masked_result : forall 'n 'm 'p, 'n >= 0 & 'm >= 0. (int('n), int('m), int('p), vector('n, bits('m)), bits('n)) -> (vector('n, bits('m)), bits('n))
+val init_masked_result : forall 'n 'm 'p, 'n >= 0 & 'm >= 0. (int('n), int('m), int('p), vector('n, bits('m)), bits('n)) -> result((vector('n, bits('m)), bits('n)), unit)
 function init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return Err(())
+  };
   let end_element   = get_end_element();
   let tail_ag : agtype = get_vtype_vta();
   let mask_ag : agtype = get_vtype_vma();
@@ -255,7 +259,7 @@ function init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
     }
   };
 
-  (result, mask)
+  Ok((result, mask))
 }
 
 /* For instructions like vector reduction and vector store,
@@ -263,9 +267,12 @@ function init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
  * (vs3 for store and vs2 for reduction). There's no destination register to be masked.
  * In these cases, this function can be called to simply get the mask vector for vs (without the prepared vd result vector).
  */
-val init_masked_source : forall 'n 'p, 'n > 0. (int('n), int('p), bits('n)) -> bits('n)
+val init_masked_source : forall 'n 'p, 'n > 0. (int('n), int('p), bits('n)) -> result(bits('n), unit)
 function init_masked_source(num_elem, LMUL_pow, vm_val) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return Err(())
+  };
   let end_element   = get_end_element();
   var mask : bits('n) = undefined;
 
@@ -292,14 +299,17 @@ function init_masked_source(num_elem, LMUL_pow, vm_val) = {
     }
   };
 
-  mask
+  Ok(mask)
 }
 
 /* Mask handling for carry functions that use masks as input/output */
 /* Only prestart and tail elements are masked in a mask value */
-val init_masked_result_carry : forall 'n 'm 'p, 'n >= 0. (int('n), int('m), int('p), bits('n)) -> (bits('n), bits('n))
+val init_masked_result_carry : forall 'n 'm 'p, 'n >= 0. (int('n), int('m), int('p), bits('n)) -> result((bits('n), bits('n)), unit)
 function init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return Err(())
+  };
   let end_element   = get_end_element();
   var mask : bits('n) = undefined;
   var result : bits('n) = undefined;
@@ -329,13 +339,16 @@ function init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) = {
     }
   };
 
-  (result, mask)
+  Ok(result, mask)
 }
 
 /* Mask handling for cmp functions that use masks as output */
-val init_masked_result_cmp : forall 'n 'm 'p, 'n >= 0. (int('n), int('m), int('p), bits('n), bits('n)) -> (bits('n), bits('n))
+val init_masked_result_cmp : forall 'n 'm 'p, 'n >= 0. (int('n), int('m), int('p), bits('n), bits('n)) -> result((bits('n), bits('n)), unit)
 function init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
-  let start_element = get_start_element();
+  let start_element : nat = match get_start_element() {
+    Ok(v)   => v,
+    Err(()) => return Err(())
+  };
   let end_element   = get_end_element();
   let mask_ag : agtype = get_vtype_vma();
   var mask : bits('n) = undefined;
@@ -373,7 +386,7 @@ function init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
     }
   };
 
-  (result, mask)
+  Ok(result, mask)
 }
 
 /* For vector load/store segment instructions:

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -190,10 +190,11 @@ function get_start_element() = {
   let VLEN_pow = get_vlen_pow();
   let SEW_pow = get_sew_pow();
   /* The use of vstart values greater than the largest element
-    index for the current SEW setting is reserved.
-    It is recommended that implementations trap if vstart is out of bounds.
-    It is not required to trap, as a possible future use of upper vstart bits
-    is to store imprecise trap information. */
+   * index for the current SEW setting is reserved.
+   *
+   * TODO: the bound here might be incorrect.
+   * See https://github.com/riscv/sail-riscv/pull/755#discussion_r2035095825
+   */
   if start_element > (2 ^ (3 + VLEN_pow - SEW_pow) - 1)
   then Err(())
   else Ok(start_element)

--- a/model/riscv_insts_vext_vm.sail
+++ b/model/riscv_insts_vext_vm.sail
@@ -31,7 +31,7 @@ function clause execute(VVMTYPE(funct6, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -41,7 +41,10 @@ function clause execute(VVMTYPE(funct6, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -87,7 +90,7 @@ function clause execute(VVMCTYPE(funct6, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -96,7 +99,10 @@ function clause execute(VVMCTYPE(funct6, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -142,7 +148,7 @@ function clause execute(VVMSTYPE(funct6, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_masked(vd) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -155,7 +161,10 @@ function clause execute(VVMSTYPE(funct6, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -202,7 +211,7 @@ function clause execute(VVCMPTYPE(funct6, vm, vs2, vs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -212,7 +221,10 @@ function clause execute(VVCMPTYPE(funct6, vm, vs2, vs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -266,7 +278,7 @@ function clause execute(VXMTYPE(funct6, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -276,7 +288,10 @@ function clause execute(VXMTYPE(funct6, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -322,7 +337,7 @@ function clause execute(VXMCTYPE(funct6, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -331,7 +346,10 @@ function clause execute(VXMCTYPE(funct6, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -377,7 +395,7 @@ function clause execute(VXMSTYPE(funct6, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_masked(vd) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -390,7 +408,10 @@ function clause execute(VXMSTYPE(funct6, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -439,7 +460,7 @@ function clause execute(VXCMPTYPE(funct6, vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -449,7 +470,10 @@ function clause execute(VXCMPTYPE(funct6, vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -506,7 +530,7 @@ function clause execute(VIMTYPE(funct6, vs2, simm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -516,7 +540,10 @@ function clause execute(VIMTYPE(funct6, vs2, simm, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -559,7 +586,7 @@ function clause execute(VIMCTYPE(funct6, vs2, simm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -568,7 +595,10 @@ function clause execute(VIMCTYPE(funct6, vs2, simm, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -611,7 +641,7 @@ function clause execute(VIMSTYPE(funct6, vs2, simm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_masked(vd) then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -624,7 +654,10 @@ function clause execute(VIMSTYPE(funct6, vs2, simm, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -669,7 +702,7 @@ function clause execute(VICMPTYPE(funct6, vm, vs2, simm, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
+  if illegal_vd_unmasked() then return RETIRE_FAIL(Illegal_Instruction());
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -679,7 +712,10 @@ function clause execute(VICMPTYPE(funct6, vm, vs2, simm, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {

--- a/model/riscv_insts_zfa.sail
+++ b/model/riscv_insts_zfa.sail
@@ -361,7 +361,7 @@ function clause execute (RISCV_FROUND_H(rs1, rm, rd)) = {
   let rs1_val_H = F_H(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_f16roundToInt(rm_3b, rs1_val_H, false);
@@ -390,7 +390,7 @@ function clause execute (RISCV_FROUNDNX_H(rs1, rm, rd)) = {
   let rs1_val_H = F_H(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_f16roundToInt(rm_3b, rs1_val_H, true);
@@ -419,7 +419,7 @@ function clause execute (RISCV_FROUND_S(rs1, rm, rd)) = {
   let rs1_val_S = F_S(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_f32roundToInt(rm_3b, rs1_val_S, false);
@@ -448,7 +448,7 @@ function clause execute (RISCV_FROUNDNX_S(rs1, rm, rd)) = {
   let rs1_val_S = F_S(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_f32roundToInt(rm_3b, rs1_val_S, true);
@@ -477,7 +477,7 @@ function clause execute (RISCV_FROUND_D(rs1, rm, rd)) = {
   let rs1_val_D = F_D(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_f64roundToInt(rm_3b, rs1_val_D, false);
@@ -506,7 +506,7 @@ function clause execute (RISCV_FROUNDNX_D(rs1, rm, rd)) = {
   let rs1_val_D = F_D(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b =  encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_f64roundToInt(rm_3b, rs1_val_D, true);

--- a/model/riscv_insts_zfh.sail
+++ b/model/riscv_insts_zfh.sail
@@ -207,7 +207,7 @@ function clause execute (F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, op)) = {
   let rs1_val_16b = F_or_X_H(rs1);
   let rs2_val_16b = F_or_X_H(rs2);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => return RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_16b) : (bits(5), bits(16)) = match op {
@@ -271,7 +271,7 @@ function clause execute (F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, op)) = {
   let rs2_val_16b = F_or_X_H(rs2);
   let rs3_val_16b = F_or_X_H(rs3);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_16b) : (bits(5), bits(16)) =
@@ -559,7 +559,7 @@ mapping clause encdec = F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_LU)
 function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FSQRT_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_f16Sqrt   (rm_3b, rs1_val_H);
@@ -574,7 +574,7 @@ function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FSQRT_H)) = {
 function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_W_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_W) = riscv_f16ToI32 (rm_3b, rs1_val_H);
@@ -589,7 +589,7 @@ function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_W_H)) = {
 function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_WU_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_WU) = riscv_f16ToUi32 (rm_3b, rs1_val_H);
@@ -604,7 +604,7 @@ function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_WU_H)) = {
 function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_W)) = {
   let rs1_val_W = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_i32ToF16 (rm_3b, rs1_val_W);
@@ -619,7 +619,7 @@ function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_W)) = {
 function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_WU)) = {
   let rs1_val_WU = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_ui32ToF16 (rm_3b, rs1_val_WU);
@@ -634,7 +634,7 @@ function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_WU)) = {
 function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_H_S)) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_f32ToF16 (rm_3b, rs1_val_S);
@@ -649,7 +649,7 @@ function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_H_S)) = {
 function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_H_D)) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_f64ToF16 (rm_3b, rs1_val_D);
@@ -664,7 +664,7 @@ function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_H_D)) = {
 function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_S_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_S) = riscv_f16ToF32 (rm_3b, rs1_val_H);
@@ -679,7 +679,7 @@ function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_S_H)) = {
 function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_D_H)) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_D) = riscv_f16ToF64 (rm_3b, rs1_val_H);
@@ -695,7 +695,7 @@ function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_L_H)) = {
   assert(xlen >= 64);
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_L) = riscv_f16ToI64 (rm_3b, rs1_val_H);
@@ -711,7 +711,7 @@ function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_LU_H)) = {
   assert(xlen >= 64);
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_LU) = riscv_f16ToUi64 (rm_3b, rs1_val_H);
@@ -727,7 +727,7 @@ function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_L)) = {
   assert(xlen >= 64);
   let rs1_val_L = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_i64ToF16 (rm_3b, rs1_val_L);
@@ -743,7 +743,7 @@ function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_LU)) = {
   assert(xlen >= 64);
   let rs1_val_LU = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
-    None() => { handle_illegal(); RETIRE_FAIL },
+    None() => RETIRE_FAIL(Illegal_Instruction()),
     Some(rm') => {
       let rm_3b = encdec_rounding_mode(rm');
       let (fflags, rd_val_H) = riscv_ui64ToF16 (rm_3b, rs1_val_LU);

--- a/model/riscv_insts_zicbom.sail
+++ b/model/riscv_insts_zicbom.sail
@@ -63,7 +63,7 @@ function cbop_priv_check(p: Privilege) -> checked_cbop = {
   }
 }
 
-val process_clean_inval : (regidx, cbop_zicbom) -> Retired(Retire_Failure)
+val process_clean_inval : (regidx, cbop_zicbom) -> ExecutionResult(Retire_Failure)
 function process_clean_inval(rs1, cbop) = {
   let rs1_val = X(rs1);
   let cache_block_size_exp = plat_cache_block_size_exp();

--- a/model/riscv_insts_zicbom.sail
+++ b/model/riscv_insts_zicbom.sail
@@ -63,7 +63,7 @@ function cbop_priv_check(p: Privilege) -> checked_cbop = {
   }
 }
 
-val process_clean_inval : (regidx, cbop_zicbom) -> Retired
+val process_clean_inval : (regidx, cbop_zicbom) -> Retired(Retire_Failure)
 function process_clean_inval(rs1, cbop) = {
   let rs1_val = X(rs1);
   let cache_block_size_exp = plat_cache_block_size_exp();
@@ -77,7 +77,7 @@ function process_clean_inval(rs1, cbop) = {
   // to be in bounds here, whereas `ext_data_get_addr()` checks that all bytes
   // are in bounds. We will need to add a new function, parameter or access type.
   match ext_data_get_addr(rs1, negative_offset, Read(Data), cache_block_size) {
-    Ext_DataAddr_Error(e) => { ext_handle_data_check_error(e); RETIRE_FAIL },
+    Ext_DataAddr_Error(e) => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
     Ext_DataAddr_OK(vaddr) => {
       let res : option(ExceptionType) = match translateAddr(vaddr, Read(Data)) {
         TR_Address(paddr, _) => {
@@ -128,37 +128,27 @@ function process_clean_inval(rs1, cbop) = {
           // was encoded in the instruction. We subtract the negative offset
           // (add the positive offset) to get it. Normally this will be
           // equal to rs1, but pointer masking can change that.
-          handle_mem_exception(vaddr - negative_offset, e);
-          RETIRE_FAIL
+          RETIRE_FAIL(Memory_Exception(vaddr - negative_offset, e))
         }
       }
     }
   }
 }
 
-function clause execute(RISCV_ZICBOM(CBO_CLEAN, rs1)) = {
+function clause execute(RISCV_ZICBOM(CBO_CLEAN, rs1)) =
   if   cbo_clean_flush_enabled(cur_privilege)
   then process_clean_inval(rs1, CBO_CLEAN)
-  else {
-    handle_illegal();
-    RETIRE_FAIL
-  }
-}
-function clause execute(RISCV_ZICBOM(CBO_FLUSH, rs1)) = {
+  else RETIRE_FAIL(Illegal_Instruction())
+
+function clause execute(RISCV_ZICBOM(CBO_FLUSH, rs1)) =
   if   cbo_clean_flush_enabled(cur_privilege)
   then process_clean_inval(rs1, CBO_FLUSH)
-  else {
-    handle_illegal();
-    RETIRE_FAIL
-  }
-}
+  else RETIRE_FAIL(Illegal_Instruction())
 
-function clause execute(RISCV_ZICBOM(CBO_INVAL, rs1)) = {
+function clause execute(RISCV_ZICBOM(CBO_INVAL, rs1)) =
   match cbop_priv_check(cur_privilege) {
-    CBOP_ILLEGAL         => { handle_illegal();
-                              RETIRE_FAIL },
+    CBOP_ILLEGAL         => RETIRE_FAIL(Illegal_Instruction()),
     CBOP_ILLEGAL_VIRTUAL => internal_error(__FILE__, __LINE__, "unimplemented"),
     CBOP_INVAL_INVAL     => process_clean_inval(rs1, CBO_INVAL),
     CBOP_INVAL_FLUSH     => process_clean_inval(rs1, CBO_FLUSH),
   }
-}

--- a/model/riscv_insts_zicboz.sail
+++ b/model/riscv_insts_zicboz.sail
@@ -33,7 +33,7 @@ function clause execute(RISCV_ZICBOZ(rs1)) = {
     let negative_offset = (rs1_val & ~(zero_extend(ones(cache_block_size_exp)))) - rs1_val;
 
     match ext_data_get_addr(rs1, negative_offset, Write(Data), cache_block_size) {
-      Ext_DataAddr_Error(e) => { ext_handle_data_check_error(e); RETIRE_FAIL },
+      Ext_DataAddr_Error(e) => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
       Ext_DataAddr_OK(vaddr) => {
         // "An implementation may update the bytes in any order and with any granularity
         //  and atomicity, including individual bytes."
@@ -44,15 +44,15 @@ function clause execute(RISCV_ZICBOZ(rs1)) = {
           // was encoded in the instruction. We subtract the negative offset
           // (add the positive offset) to get it. Normally this will be
           // equal to rs1, but pointer masking can change that.
-          TR_Failure(e, _) => { handle_mem_exception(vaddr - negative_offset, e); RETIRE_FAIL },
+          TR_Failure(e, _) => RETIRE_FAIL(Memory_Exception(vaddr - negative_offset, e)),
           TR_Address(paddr, _) => {
             match mem_write_ea(paddr, cache_block_size, false, false, false) {
-              Err(e) => { handle_mem_exception(vaddr - negative_offset, e); RETIRE_FAIL },
+              Err(e) => RETIRE_FAIL(Memory_Exception(vaddr - negative_offset, e)),
               Ok(_)  => {
                 match mem_write_value(paddr, cache_block_size, zeros(), false, false, false) {
                   Ok(true)  => RETIRE_SUCCESS,
                   Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                  Err(e)    => { handle_mem_exception(vaddr - negative_offset, e); RETIRE_FAIL },
+                  Err(e)    => RETIRE_FAIL(Memory_Exception(vaddr - negative_offset, e))
                 }
               }
             }
@@ -61,7 +61,6 @@ function clause execute(RISCV_ZICBOZ(rs1)) = {
       },
     }
   } else {
-    handle_illegal();
-    RETIRE_FAIL
+    RETIRE_FAIL(Illegal_Instruction())
   }
 }

--- a/model/riscv_insts_zicsr.sail
+++ b/model/riscv_insts_zicsr.sail
@@ -24,11 +24,11 @@ mapping clause encdec = CSRReg(csr, rs1, rd, op)
 mapping clause encdec = CSRImm(csr, imm, rd, op)
   <-> csr @ imm @ 0b1 @ encdec_csrop(op) @ encdec_reg(rd) @ 0b1110011
 
-function doCSR(csr : csreg, rs1_val : xlenbits, rd : regidx, op : csrop, is_CSR_Write: bool) -> Retired = {
+function doCSR(csr : csreg, rs1_val : xlenbits, rd : regidx, op : csrop, is_CSR_Write: bool) -> Retired(Retire_Failure) = {
   if not(check_CSR(csr, cur_privilege, is_CSR_Write))
-  then { handle_illegal(); RETIRE_FAIL }
+  then RETIRE_FAIL(Illegal_Instruction())
   else if not(ext_check_CSR(csr, cur_privilege, is_CSR_Write))
-  then { ext_check_CSR_fail(); RETIRE_FAIL }
+  then RETIRE_FAIL(Ext_CSR_Check_Failure())
   else {
     /* CSRRW should not generate read side-effects if rd == 0 */
     let is_CSR_Read = not(op == CSRRW & rd == zreg);

--- a/model/riscv_insts_zicsr.sail
+++ b/model/riscv_insts_zicsr.sail
@@ -24,7 +24,7 @@ mapping clause encdec = CSRReg(csr, rs1, rd, op)
 mapping clause encdec = CSRImm(csr, imm, rd, op)
   <-> csr @ imm @ 0b1 @ encdec_csrop(op) @ encdec_reg(rd) @ 0b1110011
 
-function doCSR(csr : csreg, rs1_val : xlenbits, rd : regidx, op : csrop, is_CSR_Write: bool) -> Retired(Retire_Failure) = {
+function doCSR(csr : csreg, rs1_val : xlenbits, rd : regidx, op : csrop, is_CSR_Write: bool) -> ExecutionResult(Retire_Failure) = {
   if not(check_CSR(csr, cur_privilege, is_CSR_Write))
   then RETIRE_FAIL(Illegal_Instruction())
   else if not(ext_check_CSR(csr, cur_privilege, is_CSR_Write))

--- a/model/riscv_insts_zvbb.sail
+++ b/model/riscv_insts_zvbb.sail
@@ -31,7 +31,10 @@ function clause execute (VANDN_VV(vm, vs1, vs2, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -65,7 +68,10 @@ function clause execute (VANDN_VX(vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem- 1)) {
@@ -98,7 +104,10 @@ function clause execute (VBREV_V(vm, vs2, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -135,7 +144,10 @@ function clause execute (VBREV8_V(vm, vs2, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -172,7 +184,10 @@ function clause execute (VREV8_V(vm, vs2, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -209,7 +224,10 @@ function clause execute (VCLZ_V(vm, vs2, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -244,7 +262,10 @@ function clause execute (VCTZ_V(vm, vs2, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -279,7 +300,10 @@ function clause execute (VCPOP_V(vm, vs2, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -318,7 +342,10 @@ function clause execute (VROL_VV(vm, vs1, vs2, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -352,7 +379,10 @@ function clause execute (VROL_VX(vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -386,7 +416,10 @@ function clause execute (VROR_VV(vm, vs1, vs2, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -420,7 +453,10 @@ function clause execute (VROR_VX(vm, vs2, rs1, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -454,7 +490,10 @@ function clause execute (VROR_VI(vm, vs2, uimm, vd)) = {
   let vs2_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val   : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -492,7 +531,10 @@ function clause execute (VWSLL_VV(vm, vs2, vs1, vd)) = {
   let vd_val      : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
 
   let SEW_widen_bits = to_bits(SEW_widen, 'o);
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -533,7 +575,10 @@ function clause execute (VWSLL_VX(vm, vs2, rs1, vd)) = {
   let vd_val      : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
 
   let SEW_widen_bits = to_bits(SEW_widen, 'o);
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -573,7 +618,10 @@ function clause execute (VWSLL_VI(vm, vs2, uimm, vd)) = {
   let vd_val      : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
 
   let SEW_widen_bits = to_bits(SEW_widen, 'o);
-  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {

--- a/model/riscv_insts_zvbc.sail
+++ b/model/riscv_insts_zvbc.sail
@@ -29,7 +29,10 @@ function clause execute (VCLMUL_VV(vm, vs2, vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to ('n - 1)) {
@@ -65,7 +68,10 @@ function clause execute (VCLMUL_VX(vm, vs2, rs1, vd)) = {
   let rs1_val : bits('m) = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to ('n - 1)) {
@@ -100,7 +106,10 @@ function clause execute (VCLMULH_VV(vm, vs2, vs1, vd)) = {
   let vs1_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to ('n - 1)) {
@@ -136,7 +145,10 @@ function clause execute (VCLMULH_VX(vm, vs2, rs1, vd)) = {
   let rs1_val : bits('m) = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return RETIRE_FAIL(Illegal_Instruction())
+  };
   var result = initial_result;
 
   foreach (i from 0 to ('n - 1)) {

--- a/model/riscv_jalr_seq.sail
+++ b/model/riscv_jalr_seq.sail
@@ -18,15 +18,12 @@ function clause execute (RISCV_JALR(imm, rs1, rd)) = {
   let t : xlenbits = X(rs1) + sign_extend(imm);
   /* Extensions get the first checks on the prospective target address. */
   match ext_control_check_addr(t) {
-    Ext_ControlAddr_Error(e) => {
-      ext_handle_control_check_error(e);
-      RETIRE_FAIL
-    },
+    Ext_ControlAddr_Error(e) =>
+      RETIRE_FAIL(Ext_ControlAddr_Check_Failure(e)),
     Ext_ControlAddr_OK(addr) => {
       let target = [virtaddr_bits(addr) with 0 = bitzero];  /* clear addr[0] */
       if bit_to_bool(target[1]) & not(currentlyEnabled(Ext_Zca)) then {
-        handle_mem_exception(addr, E_Fetch_Addr_Align());
-        RETIRE_FAIL
+        RETIRE_FAIL(Memory_Exception(addr, E_Fetch_Addr_Align()))
       } else {
         X(rd) = get_next_pc();
         set_next_pc(target);

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -440,7 +440,7 @@ function tick_platform() -> unit = {
 
 /* Platform-specific handling of instruction faults */
 
-function handle_illegal() -> unit = {
+function handle_illegal(instbits: xlenbits) -> unit = {
   let info = if plat_mtval_has_illegal_inst_bits ()
              then Some(instbits)
              else None();

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -11,9 +11,6 @@
 register PC       : xlenbits
 register nextPC   : xlenbits
 
-/* internal state to hold instruction bits for faulting instructions */
-register instbits : xlenbits
-
 /* register file and accessors */
 
 register x1  : regtype

--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -8,6 +8,12 @@
 
 /* The emulator fetch-execute-interrupt dispatch loop. */
 
+union Step = {
+  Step_Pending_Interrupt  : (InterruptType, Privilege),
+  Step_Ext_Fetch_Failure  : ext_fetch_addr_error,
+  Step_Execute            : Retired(Retire_Failure)
+}
+
 /* returns whether to increment the step count in the trace */
 function step(step_no : int) -> bool = {
   /* for step extensions */
@@ -23,31 +29,23 @@ function step(step_no : int) -> bool = {
    */
   minstret_increment = should_inc_minstret(cur_privilege);
 
-  let (retired, stepped) : (Retired, bool) =
+  /* instruction bits for faulting instructions */
+  var instbits : option(xlenbits) = None();
+
+  let (step_val, stepped) : (Step, bool) =
     match dispatchInterrupt(cur_privilege) {
-      Some(intr, priv) => {
-        if   get_config_print_instr()
-        then print_bits("Handling interrupt: ", interruptType_to_bits(intr));
-        handle_interrupt(intr, priv);
-        (RETIRE_FAIL, false)
-      },
+      Some(intr, priv) => (Step_Pending_Interrupt(intr, priv), false),
       None() => {
         /* the extension hook interposes on the fetch result */
         match ext_fetch_hook(fetch()) {
           /* extension error */
-          F_Ext_Error(e)   => {
-            ext_handle_fetch_check_error(e);
-            (RETIRE_FAIL, false)
-          },
+          F_Ext_Error(e)   => (Step_Ext_Fetch_Failure(e), false),
           /* standard error */
-          F_Error(e, addr) => {
-            handle_mem_exception(Virtaddr(addr), e);
-            (RETIRE_FAIL, false)
-          },
+          F_Error(e, addr) => (Step_Execute(RETIRE_FAIL(Memory_Exception(Virtaddr(addr), e))), false),
           /* non-error cases: */
           F_RVC(h) => {
             sail_instr_announce(h);
-            instbits = zero_extend(h);
+            instbits = Some(zero_extend(h));
             let ast = ext_decode_compressed(h);
             if   get_config_print_instr()
             then {
@@ -56,31 +54,72 @@ function step(step_no : int) -> bool = {
             /* check for RVC once here instead of every RVC execute clause. */
             if currentlyEnabled(Ext_Zca) then {
               nextPC = PC + 2;
-              (execute(ast), true)
+              (Step_Execute(execute(ast)), true)
             } else {
-              handle_illegal();
-              (RETIRE_FAIL, true)
+              (Step_Execute(RETIRE_FAIL(Illegal_Instruction())), true)
             }
           },
           F_Base(w) => {
             sail_instr_announce(w);
-            instbits = zero_extend(w);
+            instbits = Some(zero_extend(w));
             let ast = ext_decode(w);
             if   get_config_print_instr()
             then {
               print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ BitStr(PC) ^ " (" ^ BitStr(w) ^ ") " ^ to_str(ast));
             };
             nextPC = PC + 4;
-            (execute(ast), true)
+            (Step_Execute(execute(ast)), true)
           }
         }
       }
     };
 
-  tick_pc();
+  match step_val {
+    Step_Pending_Interrupt(intr, priv) => {
+      if   get_config_print_instr()
+      then print_bits("Handling interrupt: ", interruptType_to_bits(intr));
+      minstret_increment = false;
+      handle_interrupt(intr, priv)
+    },
+    Step_Ext_Fetch_Failure(e) => {
+      minstret_increment = false;
+      ext_handle_fetch_check_error(e)
+    },
+    Step_Execute(RETIRE_OK()) => {
+      // default handling of minstret
+      ()
+    },
+    Step_Execute(RETIRE_FAIL(failure)) => match failure {
+      // standard failures
+      Trap(priv, ctl, pc)           => {
+        minstret_increment = false;
+        set_next_pc(exception_handler(priv, ctl, pc))
+      },
+      Memory_Exception(vaddr, exc)  => {
+        minstret_increment = false;
+        handle_mem_exception(vaddr, exc)
+      },
+      Illegal_Instruction() => {
+        minstret_increment = false;
+        match instbits {
+          None()         => internal_error(__FILE__, __LINE__, "no instruction bits for illegal instruction"),
+          Some(instbits) => handle_illegal(instbits)
+        }
+      },
+      Wait_For_Interrupt() => {
+        // This is currently treated as a nop with the default handling of minstret.
+        platform_wfi();
+      },
 
-  // Only increment minstret if the instruction retired successfully.
-  if retired != RETIRE_SUCCESS then minstret_increment = false;
+      // failures from extensions
+      Ext_CSR_Check_Failure()          => { minstret_increment = false; ext_check_CSR_fail() },
+      Ext_ControlAddr_Check_Failure(e) => { minstret_increment = false; ext_handle_control_check_error(e) },
+      Ext_DataAddr_Check_Failure(e)    => { minstret_increment = false; ext_handle_data_check_error(e) },
+      Ext_XRET_Priv_Failure()          => { minstret_increment = false; ext_fail_xret_priv () }
+    }
+  };
+
+  tick_pc();
 
   update_minstret();
 

--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -8,14 +8,121 @@
 
 /* The emulator fetch-execute-interrupt dispatch loop. */
 
+register hart_state : HartState = HART_ACTIVE()
+
+// Returns whether the retire result returned by the execution of an
+// instruction counts as a step, where a step is said to occur when an
+// instruction retires successfully or it raises an exception.
+// Crucially, if an instruction returns a Wait retire result, it does
+// not step.
+function retires_or_traps(r : ExecutionResult(Retire_Failure)) -> bool =
+  match r {
+    RETIRE_OK()                        => true,
+    RETIRE_FAIL(Illegal_Instruction()) => true,
+    RETIRE_FAIL(Memory_Exception(_))   => true,
+    RETIRE_FAIL(Trap(_))               => true,
+
+    // do not step if a wait instruction executed.
+    RETIRE_FAIL(Wait_For_Interrupt())  => false,
+
+    // errors from extensions
+    RETIRE_FAIL(Ext_ControlAddr_Check_Failure(_)) => true,
+    RETIRE_FAIL(Ext_DataAddr_Check_Failure(_))    => true,
+    RETIRE_FAIL(Ext_CSR_Check_Failure())          => true,
+    RETIRE_FAIL(Ext_XRET_Priv_Failure(_))         => true,
+}
+
 union Step = {
   Step_Pending_Interrupt  : (InterruptType, Privilege),
   Step_Ext_Fetch_Failure  : ext_fetch_addr_error,
-  Step_Execute            : Retired(Retire_Failure)
+  Step_Fetch_Failure      : (virtaddr, ExceptionType),
+  Step_Execute            : (ExecutionResult(Retire_Failure), instbits),
+  Step_Waiting            : unit,
 }
 
-/* returns whether to increment the step count in the trace */
-function step(step_no : int) -> bool = {
+function run_hart_waiting(step_no : int, exit_wait : bool, instbits : instbits) -> (Step, bool) = {
+  if shouldWakeForInterrupt() then {
+    if   get_config_print_instr()
+    then print_instr("interrupt exit from WAIT state at PC " ^ BitStr(PC));
+
+    hart_state = HART_ACTIVE();
+    // The waiting instruction retires successfully.  The
+    // pending interrupts will be handled in the next step.
+    (Step_Execute(RETIRE_OK(), instbits), true)
+  } else if exit_wait then {
+    // There are no pending interrupts; transition out of the Wait
+    // as instructed.
+    if   get_config_print_instr()
+    then print_instr("forced exit from WAIT state at PC " ^ BitStr(PC));
+
+    hart_state = HART_ACTIVE();
+    // "When TW=1, then if WFI is executed in any
+    // less-privileged mode, and it does not complete within an
+    // implementation-specific, bounded time limit, the WFI
+    // instruction causes an illegal-instruction exception."
+    if   (cur_privilege == Machine | mstatus[TW] == 0b0)
+    then (Step_Execute(RETIRE_OK(), instbits), true)
+    else (Step_Execute(RETIRE_FAIL(Illegal_Instruction()), instbits), true)
+  } else {
+    if   get_config_print_instr()
+    then print_instr("remaining in WAIT state at PC " ^ BitStr(PC));
+    (Step_Waiting(), false)
+  }
+}
+
+function run_hart_active(step_no: int, exit_wait : bool) -> (Step, bool) = {
+  match dispatchInterrupt(cur_privilege) {
+    Some(intr, priv) => (Step_Pending_Interrupt(intr, priv), false),
+    None() => match ext_fetch_hook(fetch()) {
+      /* extension error */
+      F_Ext_Error(e)   => (Step_Ext_Fetch_Failure(e), false),
+      /* standard error */
+      F_Error(e, addr) => (Step_Fetch_Failure(Virtaddr(addr), e), false),
+      /* non-error cases: */
+      F_RVC(h) => {
+        sail_instr_announce(h);
+        let instbits : xlenbits = zero_extend(h);
+        let ast = ext_decode_compressed(h);
+        if   get_config_print_instr()
+        then {
+          print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ BitStr(PC) ^ " (" ^ BitStr(h) ^ ") " ^ to_str(ast));
+        };
+        /* check for RVC once here instead of every RVC execute clause. */
+        if currentlyEnabled(Ext_Zca) then {
+          nextPC = PC + 2;
+          let r = execute(ast);
+          (Step_Execute(r, instbits), retires_or_traps(r))
+        } else {
+          (Step_Execute(RETIRE_FAIL(Illegal_Instruction()), instbits), true)
+        }
+      },
+      F_Base(w) => {
+        sail_instr_announce(w);
+        let instbits : instbits = zero_extend(w);
+        let ast = ext_decode(w);
+        if   get_config_print_instr()
+        then {
+          print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ BitStr(PC) ^ " (" ^ BitStr(w) ^ ") " ^ to_str(ast));
+        };
+        nextPC = PC + 4;
+        let r = execute(ast);
+        (Step_Execute(r, instbits), retires_or_traps(r))
+      }
+    }
+  }
+}
+
+function wfi_is_nop() -> bool = config platform.wfi_is_nop
+
+// The `try_step` function is the main internal driver of the Sail
+// model. It performs the fetch-decode-execute for an instruction. It
+// is also the primary interface to the non-Sail execution harness.
+// The harness calls this function with the current step number (which
+// numbers the active or wait step), and whether it should exit a wait
+// state. The `try_step` function returns whether the Sail emulator
+// executed a step, and the stepper state at the end of the step.
+
+function try_step(step_no : int, exit_wait : bool) -> bool = {
   /* for step extensions */
   ext_pre_step_hook();
 
@@ -29,50 +136,12 @@ function step(step_no : int) -> bool = {
    */
   minstret_increment = should_inc_minstret(cur_privilege);
 
-  /* instruction bits for faulting instructions */
-  var instbits : option(xlenbits) = None();
-
-  let (step_val, stepped) : (Step, bool) =
-    match dispatchInterrupt(cur_privilege) {
-      Some(intr, priv) => (Step_Pending_Interrupt(intr, priv), false),
-      None() => {
-        /* the extension hook interposes on the fetch result */
-        match ext_fetch_hook(fetch()) {
-          /* extension error */
-          F_Ext_Error(e)   => (Step_Ext_Fetch_Failure(e), false),
-          /* standard error */
-          F_Error(e, addr) => (Step_Execute(RETIRE_FAIL(Memory_Exception(Virtaddr(addr), e))), false),
-          /* non-error cases: */
-          F_RVC(h) => {
-            sail_instr_announce(h);
-            instbits = Some(zero_extend(h));
-            let ast = ext_decode_compressed(h);
-            if   get_config_print_instr()
-            then {
-              print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ BitStr(PC) ^ " (" ^ BitStr(h) ^ ") " ^ to_str(ast));
-            };
-            /* check for RVC once here instead of every RVC execute clause. */
-            if currentlyEnabled(Ext_Zca) then {
-              nextPC = PC + 2;
-              (Step_Execute(execute(ast)), true)
-            } else {
-              (Step_Execute(RETIRE_FAIL(Illegal_Instruction())), true)
-            }
-          },
-          F_Base(w) => {
-            sail_instr_announce(w);
-            instbits = Some(zero_extend(w));
-            let ast = ext_decode(w);
-            if   get_config_print_instr()
-            then {
-              print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ BitStr(PC) ^ " (" ^ BitStr(w) ^ ") " ^ to_str(ast));
-            };
-            nextPC = PC + 4;
-            (Step_Execute(execute(ast)), true)
-          }
-        }
-      }
+  let (step_val, did_step) : (Step, bool) = match hart_state {
+      HART_WAITING(instbits) => run_hart_waiting(step_no, exit_wait, instbits),
+      HART_ACTIVE()          => run_hart_active(step_no, exit_wait),
     };
+
+  var stepped : bool = did_step;
 
   match step_val {
     Step_Pending_Interrupt(intr, priv) => {
@@ -85,46 +154,69 @@ function step(step_no : int) -> bool = {
       minstret_increment = false;
       ext_handle_fetch_check_error(e)
     },
-    Step_Execute(RETIRE_OK()) => {
-      // default handling of minstret
-      ()
+    Step_Fetch_Failure(vaddr, e) => {
+      minstret_increment = false;
+      handle_mem_exception(vaddr, e)
     },
-    Step_Execute(RETIRE_FAIL(failure)) => match failure {
-      // standard failures
-      Trap(priv, ctl, pc)           => {
-        minstret_increment = false;
-        set_next_pc(exception_handler(priv, ctl, pc))
+    Step_Waiting() => {
+      assert(hart_is_waiting(hart_state), "cannot be Waiting in a non-Wait state")
+    },
+    Step_Execute(RETIRE_OK(), _) => {
+      assert(hart_is_active(hart_state))
+    },
+    // standard errors
+    Step_Execute(RETIRE_FAIL(Trap(priv, ctl, pc)), _) => {
+      minstret_increment = false;
+      set_next_pc(exception_handler(priv, ctl, pc))
+    },
+    Step_Execute(RETIRE_FAIL(Memory_Exception(vaddr, e)), _) => {
+      minstret_increment = false;
+      handle_mem_exception(vaddr, e)
+    },
+    Step_Execute(RETIRE_FAIL(Illegal_Instruction()), instbits) => {
+      minstret_increment = false;
+      handle_illegal(instbits)
+    },
+    Step_Execute(RETIRE_FAIL(Wait_For_Interrupt()), instbits) =>
+      if wfi_is_nop() then {
+        // This is the same as the RETIRE_OK case.
+        assert(hart_is_active(hart_state));
+        // Override the default step for WFI.
+        stepped = true;
+      } else {
+        // Transition into the wait state.
+        if   get_config_print_instr()
+        then print_instr("entering WAIT state at PC " ^ BitStr(PC));
+        hart_state = HART_WAITING(instbits);
       },
-      Memory_Exception(vaddr, exc)  => {
-        minstret_increment = false;
-        handle_mem_exception(vaddr, exc)
-      },
-      Illegal_Instruction() => {
-        minstret_increment = false;
-        match instbits {
-          None()         => internal_error(__FILE__, __LINE__, "no instruction bits for illegal instruction"),
-          Some(instbits) => handle_illegal(instbits)
-        }
-      },
-      Wait_For_Interrupt() => {
-        // This is currently treated as a nop with the default handling of minstret.
-        platform_wfi();
-      },
-
-      // failures from extensions
-      Ext_CSR_Check_Failure()          => { minstret_increment = false; ext_check_CSR_fail() },
-      Ext_ControlAddr_Check_Failure(e) => { minstret_increment = false; ext_handle_control_check_error(e) },
-      Ext_DataAddr_Check_Failure(e)    => { minstret_increment = false; ext_handle_data_check_error(e) },
-      Ext_XRET_Priv_Failure()          => { minstret_increment = false; ext_fail_xret_priv () }
-    }
+    // errors from extensions
+    Step_Execute(RETIRE_FAIL(Ext_CSR_Check_Failure()), _) => {
+      minstret_increment = false;
+      ext_check_CSR_fail()
+    },
+    Step_Execute(RETIRE_FAIL(Ext_ControlAddr_Check_Failure(e)), _) => {
+      minstret_increment = false;
+      ext_handle_control_check_error(e)
+    },
+    Step_Execute(RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)), _) => {
+      minstret_increment = false;
+      ext_handle_data_check_error(e)
+    },
+    Step_Execute(RETIRE_FAIL(Ext_XRET_Priv_Failure()), _) => {
+      minstret_increment = false;
+      ext_fail_xret_priv ()
+    },
   };
 
-  tick_pc();
-
-  update_minstret();
-
-  /* for step extensions */
-  ext_post_step_hook();
+  match hart_state {
+    HART_WAITING(_) => (),
+    HART_ACTIVE() => {
+      tick_pc();
+      update_minstret();
+      /* for step extensions */
+      ext_post_step_hook();
+    }
+  };
 
   stepped
 }
@@ -134,7 +226,9 @@ function loop () : unit -> unit = {
   var i : int = 0;
   var step_no : int = 0;
   while not(htif_done) do {
-    let stepped = step(step_no);
+    // This standalone loop always exits immediately out of waiting
+    // states.
+    let stepped = try_step(step_no, true);
     if stepped then {
       step_no = step_no + 1;
       if get_config_print_instr() then {
@@ -172,6 +266,7 @@ function reset() -> unit = {
 
 // Initialize model state. This is only called once; not for every chip reset.
 function init_model() -> unit = {
+  hart_state = HART_ACTIVE();
   init_platform();
   reset();
 }

--- a/model/riscv_step_common.sail
+++ b/model/riscv_step_common.sail
@@ -6,6 +6,26 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
+// The state of the emulator.
+//
+// The RISC-V hart could either be active (fetching and executing
+// instructions) or waiting (e.g. for an interrupt).  The transition
+// from `active` to `wait` occurs on instructions such as WFI and
+// WRS.{NTO,STO}. The transition from `wait` to `active` can occur
+// if (i) the hart detects an interrupt or (in the case of
+// WRS.{NTO,STO}) a reservation set is invalidated, or (ii) if the
+// external non-Sail emulator harness indicates that the waiting
+// instruction should finish execution.  Note that in the latter
+// case, the platform can decide to end the stall for any reason,
+// even if there are no interrupts or invalidated reservation set.
+
+type instbits = xlenbits
+
+union HartState = {
+  HART_ACTIVE  : unit,
+  HART_WAITING : instbits, // the instruction that caused the wait
+}
+
 /* The result of a fetch, which includes any possible error
  * from an extension that interposes on the fetch operation.
  */
@@ -16,3 +36,17 @@ union FetchResult = {
   F_RVC       : half,                      /* Compressed ISA */
   F_Error     : (ExceptionType, xlenbits)  /* standard exception and PC */
 }
+
+// utility predicates
+
+function hart_is_active(s : HartState) -> bool =
+  match s {
+    HART_ACTIVE()   => true,
+    HART_WAITING(_) => false,
+  }
+
+function hart_is_waiting(s : HartState) -> bool =
+  match s {
+    HART_ACTIVE()   => false,
+    HART_WAITING(_) => true,
+  }

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -129,6 +129,8 @@ function findPendingInterrupt(ip : xlenbits) -> option(InterruptType) = {
  *
  * We don't use the lowered views of {xie,xip} here, since the spec
  * allows for example the M_Timer to be delegated to the S-mode.
+ *
+ * This is used when the hart is in the Active state.
  */
 function getPendingSet(priv : Privilege) -> option((xlenbits, Privilege)) = {
   // mideleg can only be non-zero if we support Supervisor mode.
@@ -143,6 +145,30 @@ function getPendingSet(priv : Privilege) -> option((xlenbits, Privilege)) = {
   if      mIE & (pending_m != zeros()) then Some((pending_m, Machine))
   else if sIE & (pending_s != zeros()) then Some((pending_s, Supervisor))
   else None()
+}
+
+/* Check if a locally enabled interrupt is pending.
+ *
+ * This does not examine the global enable bits (MIE and SIE in
+ * mstatus) and their delegation in mideleg. It does honor the
+ * local interrupt enables in mie.
+ *
+ * This is used when the hart is in the Waiting state, caused by
+ * instructions such as WFI and WRS.{NTO,STO}.
+ *
+ * The relevant detail in the privileged spec is:
+ * https://riscv.github.io/riscv-isa-manual/snapshot/privileged/#wfi
+ *
+ * "The operation of WFI must be unaffected by the global interrupt
+ * bits in mstatus (MIE and SIE) and the delegation register mideleg
+ * (i.e., the hart must resume if a locally enabled interrupt becomes
+ * pending, even if it has been delegated to a less-privileged mode),
+ * but should honor the individual interrupt enables (e.g, MTIE)
+ * (i.e., implementations should avoid resuming the hart if the
+ * interrupt is pending but not individually enabled)."
+ */
+function shouldWakeForInterrupt() -> bool = {
+  (mip.bits & mie.bits) != zeros()
 }
 
 /* Examine the current interrupt state and return an interrupt to be *

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -102,12 +102,11 @@ function privLevel_to_str (p) =
 
 overload to_str = {privLevel_to_str}
 
-/* Type denoting whether an executed instruction retires
- * that is generic over the reasons why a retire might
- * fail or be incomplete.
+/* Type denoting the result of executing an instruction that
+ * is generic over the reasons why it fails or is incomplete.
  */
 
-union Retired ('a : Type) = {
+union ExecutionResult ('a : Type) = {
   RETIRE_OK      : unit,
   RETIRE_FAIL    : 'a
 }

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -102,9 +102,15 @@ function privLevel_to_str (p) =
 
 overload to_str = {privLevel_to_str}
 
-/* enum denoting whether an executed instruction retires */
+/* Type denoting whether an executed instruction retires
+ * that is generic over the reasons why a retire might
+ * fail or be incomplete.
+ */
 
-enum Retired = {RETIRE_SUCCESS, RETIRE_FAIL}
+union Retired ('a : Type) = {
+  RETIRE_OK      : unit,
+  RETIRE_FAIL    : 'a
+}
 
 /* memory access types */
 


### PR DESCRIPTION
This is a slightly cleaner implementation of the draft proposed in #746.
The change now affects 33 files instead of 47 files, hopefully making it easier to review.

I added @Timmmm, @jrtc27 and @Alasdair as co-authors to the main commit as it's based on their discussions and suggestions in #398, #412 and #746.

If merged, I plan to port #398 to this design.
