### PR TITLE
Replace ad-hoc model configuration with Sail-native configuration

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Install packages
-      run: sudo apt install -y --no-install-recommends pkg-config libgmp-dev curl ninja-build
+      run: sudo apt install -y --no-install-recommends pkg-config libgmp-dev curl ninja-build jq
 
     - name: Install sail from binary
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,9 @@ add_subdirectory("dependencies/softfloat")
 # Sail C runtime.
 add_subdirectory("sail_runtime")
 
+# Sail configuration
+add_subdirectory("config")
+
 # Sail model generated C code.
 add_subdirectory("model")
 

--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -50,7 +50,7 @@ foreach (xlen IN ITEMS 32 64)
             add_dependencies(riscv_sim_${arch} generated_model_${arch})
 
             target_link_libraries(riscv_sim_${arch}
-                PRIVATE softfloat sail_runtime GMP::GMP
+                PRIVATE softfloat sail_runtime default_config GMP::GMP
             )
 
             target_include_directories(riscv_sim_${arch}

--- a/c_emulator/riscv_platform.cpp
+++ b/c_emulator/riscv_platform.cpp
@@ -18,155 +18,10 @@
 static mach_bits reservation = 0;
 static bool reservation_valid = false;
 
-bool sys_enable_rvc(unit)
-{
-  return rv_enable_rvc;
-}
-
-bool sys_enable_fdext(unit)
-{
-  return rv_enable_fdext;
-}
-
-bool sys_enable_svinval(unit)
-{
-  return rv_enable_svinval;
-}
-
-bool sys_enable_zcb(unit)
-{
-  return rv_enable_zcb;
-}
-
-bool sys_enable_zfinx(unit)
-{
-  return rv_enable_zfinx;
-}
-
-bool sys_enable_writable_fiom(unit)
-{
-  return rv_enable_writable_fiom;
-}
-
-bool sys_enable_vext(unit)
-{
-  return rv_enable_vext;
-}
-
-bool sys_enable_bext(unit)
-{
-  return rv_enable_bext;
-}
-
-bool sys_enable_zicbom(unit)
-{
-  return rv_enable_zicbom;
-}
-
-bool sys_enable_zicboz(unit)
-{
-  return rv_enable_zicboz;
-}
-
-bool sys_enable_zvkb(unit)
-{
-  return rv_enable_zvkb;
-}
-
-bool sys_enable_sstc(unit)
-{
-  return rv_enable_sstc;
-}
-
-uint64_t sys_pmp_count(unit)
-{
-  return rv_pmp_count;
-}
-
-uint64_t sys_pmp_grain(unit)
-{
-  return rv_pmp_grain;
-}
-
-uint64_t sys_vector_vlen_exp(unit)
-{
-  return rv_vector_vlen_exp;
-}
-
-uint64_t sys_vector_elen_exp(unit)
-{
-  return rv_vector_elen_exp;
-}
-
-bool sys_enable_writable_misa(unit)
-{
-  return rv_enable_writable_misa;
-}
-
-mach_bits sys_writable_hpm_counters(unit)
-{
-  return rv_writable_hpm_counters;
-}
-
-bool sys_vext_vl_use_ceil(unit)
-{
-  return rv_vext_vl_use_ceil;
-}
-
-bool plat_enable_dirty_update(unit)
-{
-  return rv_enable_dirty_update;
-}
-
-bool plat_enable_misaligned_access(unit)
-{
-  return rv_enable_misaligned;
-}
-
-bool plat_mtval_has_illegal_inst_bits(unit)
-{
-  return rv_mtval_has_illegal_inst_bits;
-}
-
-mach_bits plat_ram_base(unit)
-{
-  return rv_ram_base;
-}
-
-mach_bits plat_ram_size(unit)
-{
-  return rv_ram_size;
-}
-
-mach_bits plat_rom_base(unit)
-{
-  return rv_rom_base;
-}
-
-mach_bits plat_rom_size(unit)
-{
-  return rv_rom_size;
-}
-
-mach_bits plat_cache_block_size_exp(unit)
-{
-  return rv_cache_block_size_exp;
-}
-
 // Provides entropy for the scalar cryptography extension.
 mach_bits plat_get_16_random_bits(unit)
 {
   return rv_16_random_bits();
-}
-
-mach_bits plat_clint_base(unit)
-{
-  return rv_clint_base;
-}
-
-mach_bits plat_clint_size(unit)
-{
-  return rv_clint_size;
 }
 
 unit load_reservation(mach_bits addr)
@@ -210,8 +65,6 @@ unit plat_term_write(mach_bits s)
   plat_term_write_impl(c);
   return UNIT;
 }
-
-void plat_insns_per_tick(sail_int *, unit) { }
 
 mach_bits plat_htif_tohost(unit)
 {

--- a/c_emulator/riscv_platform.h
+++ b/c_emulator/riscv_platform.h
@@ -5,55 +5,16 @@
 extern "C" {
 #endif
 
-bool sys_enable_rvc(unit);
-bool sys_enable_fdext(unit);
-bool sys_enable_svinval(unit);
-bool sys_enable_zcb(unit);
-bool sys_enable_zfinx(unit);
-bool sys_enable_writable_misa(unit);
-bool sys_enable_writable_fiom(unit);
-bool sys_enable_vext(unit);
-bool sys_enable_bext(unit);
-bool sys_enable_zicbom(unit);
-bool sys_enable_zicboz(unit);
-bool sys_enable_zvkb(unit);
-bool sys_enable_sstc(unit);
-
-uint64_t sys_pmp_count(unit);
-uint64_t sys_pmp_grain(unit);
-
-bool sys_vext_vl_use_ceil(unit);
-uint64_t sys_vector_vlen_exp(unit);
-uint64_t sys_vector_elen_exp(unit);
-
-bool plat_enable_dirty_update(unit);
-bool plat_enable_misaligned_access(unit);
-bool plat_mtval_has_illegal_inst_bits(unit);
-mach_bits sys_writable_hpm_counters(unit);
-
-mach_bits plat_ram_base(unit);
-mach_bits plat_ram_size(unit);
-bool within_phys_mem(mach_bits, sail_int);
-
-mach_bits plat_rom_base(unit);
-mach_bits plat_rom_size(unit);
-
-mach_bits plat_cache_block_size_exp(unit);
-
 // Provides entropy for the scalar cryptography extension.
 mach_bits plat_get_16_random_bits(unit);
-
-mach_bits plat_clint_base(unit);
-mach_bits plat_clint_size(unit);
 
 bool speculate_conditional(unit);
 unit load_reservation(mach_bits);
 bool match_reservation(mach_bits);
 unit cancel_reservation(unit);
 
-void plat_insns_per_tick(sail_int *rop, unit);
-
 unit plat_term_write(mach_bits);
+
 mach_bits plat_htif_tohost(unit);
 
 unit memea(mach_bits, sail_int);

--- a/c_emulator/riscv_platform_impl.cpp
+++ b/c_emulator/riscv_platform_impl.cpp
@@ -2,43 +2,6 @@
 #include <unistd.h>
 #include <stdio.h>
 
-/* Settings of the platform implementation, with common defaults. */
-uint64_t rv_pmp_count = 0;
-uint64_t rv_pmp_grain = 0;
-
-uint64_t rv_vector_vlen_exp = 0x9;
-uint64_t rv_vector_elen_exp = 0x6;
-
-bool rv_enable_svinval = false;
-bool rv_enable_zcb = false;
-bool rv_enable_zfinx = false;
-bool rv_enable_rvc = true;
-bool rv_enable_writable_misa = true;
-bool rv_enable_fdext = true;
-bool rv_enable_vext = true;
-bool rv_enable_bext = false;
-bool rv_enable_zicbom = false;
-bool rv_enable_zicboz = false;
-bool rv_enable_zvkb = false;
-bool rv_enable_sstc = false;
-
-bool rv_enable_dirty_update = false;
-bool rv_enable_misaligned = false;
-bool rv_mtval_has_illegal_inst_bits = false;
-bool rv_enable_writable_fiom = true;
-uint64_t rv_writable_hpm_counters = 0xFFFFFFFF;
-
-uint64_t rv_ram_base = UINT64_C(0x80000000);
-uint64_t rv_ram_size = UINT64_C(0x80000000);
-
-uint64_t rv_rom_base = UINT64_C(0x1000);
-uint64_t rv_rom_size = UINT64_C(0x100);
-
-bool rv_vext_vl_use_ceil = false;
-
-// Default 64, which is mandated by RVA22.
-uint64_t rv_cache_block_size_exp = UINT64_C(6);
-
 // Provides entropy for the scalar cryptography extension.
 uint64_t rv_16_random_bits(void)
 {
@@ -54,11 +17,7 @@ uint64_t rv_16_random_bits(void)
   return (uint64_t)val;
 }
 
-uint64_t rv_clint_base = UINT64_C(0x2000000);
-uint64_t rv_clint_size = UINT64_C(0xc0000);
-
 uint64_t rv_htif_tohost = UINT64_C(0x80001000);
-uint64_t rv_insns_per_tick = UINT64_C(100);
 
 int term_fd = 1; // set during startup
 void plat_term_write_impl(char c)

--- a/c_emulator/riscv_platform_impl.h
+++ b/c_emulator/riscv_platform_impl.h
@@ -4,52 +4,10 @@
 #include <stdint.h>
 #include <stdio.h>
 
-/* Settings of the platform implementation. */
-
-#define DEFAULT_RSTVEC 0x00001000
-
-extern uint64_t rv_pmp_count;
-extern uint64_t rv_pmp_grain;
-
-extern uint64_t rv_vector_vlen_exp;
-extern uint64_t rv_vector_elen_exp;
-
-extern bool rv_enable_svinval;
-extern bool rv_enable_zcb;
-extern bool rv_enable_zfinx;
-extern bool rv_enable_rvc;
-extern bool rv_enable_fdext;
-extern bool rv_enable_vext;
-extern bool rv_enable_bext;
-extern bool rv_enable_zicbom;
-extern bool rv_enable_zicboz;
-extern bool rv_enable_zvkb;
-extern bool rv_enable_sstc;
-extern bool rv_enable_writable_misa;
-extern bool rv_enable_dirty_update;
-extern bool rv_enable_misaligned;
-extern bool rv_mtval_has_illegal_inst_bits;
-extern bool rv_enable_writable_fiom;
-extern uint64_t rv_writable_hpm_counters;
-
-extern uint64_t rv_ram_base;
-extern uint64_t rv_ram_size;
-
-extern uint64_t rv_rom_base;
-extern uint64_t rv_rom_size;
-
-extern uint64_t rv_cache_block_size_exp;
-
-extern bool rv_vext_vl_use_ceil;
-
 // Provides entropy for the scalar cryptography extension.
 extern uint64_t rv_16_random_bits(void);
 
-extern uint64_t rv_clint_base;
-extern uint64_t rv_clint_size;
-
 extern uint64_t rv_htif_tohost;
-extern uint64_t rv_insns_per_tick;
 
 extern FILE *trace_log;
 extern int term_fd;

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -10,9 +10,15 @@
 #include <sys/time.h>
 #include <fcntl.h>
 #include <optional>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <vector>
 
 #include "elf.h"
 #include "sail.h"
+#include "sail_config.h"
 #include "rts.h"
 #ifdef SAILCOV
 #include "sail_coverage.h"
@@ -21,6 +27,7 @@
 #include "riscv_platform_impl.h"
 #include "riscv_sail.h"
 #include "rvfi_dii.h"
+#include "default_config.h"
 
 const char *RV64ISA = "RV64IMAC";
 const char *RV32ISA = "RV32IMAC";
@@ -44,19 +51,12 @@ const char *RV32ISA = "RV32IMAC";
 
 enum {
   OPT_TRACE_OUTPUT = 1000,
-  OPT_ENABLE_WRITABLE_FIOM,
-  OPT_PMP_COUNT,
-  OPT_PMP_GRAIN,
-  OPT_ENABLE_SVINVAL,
-  OPT_ENABLE_ZCB,
-  OPT_ENABLE_ZICBOM,
-  OPT_ENABLE_ZICBOZ,
-  OPT_ENABLE_ZVKB,
-  OPT_ENABLE_SSTC,
-  OPT_CACHE_BLOCK_SIZE,
+  OPT_PRINT_CONFIG,
+  OPT_SAILCOV,
 };
 
 static bool do_show_times = false;
+bool do_report_arch = false;
 char *term_log = NULL;
 static const char *trace_log_path = NULL;
 FILE *trace_log = NULL;
@@ -112,43 +112,26 @@ char *sailcov_file = NULL;
 #endif
 
 static struct option options[] = {
-    {"enable-dirty-update",         no_argument,       0, 'd'                     },
-    {"enable-misaligned",           no_argument,       0, 'm'                     },
-    {"pmp-count",                   required_argument, 0, OPT_PMP_COUNT           },
-    {"pmp-grain",                   required_argument, 0, OPT_PMP_GRAIN           },
-    {"ram-size",                    required_argument, 0, 'z'                     },
-    {"disable-compressed",          no_argument,       0, 'C'                     },
-    {"disable-writable-misa",       no_argument,       0, 'I'                     },
-    {"disable-fdext",               no_argument,       0, 'F'                     },
-    {"disable-vector-ext",          no_argument,       0, 'W'                     },
-    {"mtval-has-illegal-inst-bits", no_argument,       0, 'i'                     },
-    {"device-tree-blob",            required_argument, 0, 'b'                     },
-    {"terminal-log",                required_argument, 0, 't'                     },
-    {"show-times",                  required_argument, 0, 'p'                     },
-    {"report-arch",                 no_argument,       0, 'a'                     },
-    {"test-signature",              required_argument, 0, 'T'                     },
-    {"signature-granularity",       required_argument, 0, 'g'                     },
+    {"device-tree-blob",      required_argument, 0, 'b'             },
+    {"terminal-log",          required_argument, 0, 't'             },
+    {"show-times",            required_argument, 0, 'p'             },
+    {"report-arch",           no_argument,       0, 'a'             },
+    {"test-signature",        required_argument, 0, 'T'             },
+    {"signature-granularity", required_argument, 0, 'g'             },
 #ifdef RVFI_DII
-    {"rvfi-dii",                    required_argument, 0, 'r'                     },
+    {"rvfi-dii",              required_argument, 0, 'r'             },
 #endif
-    {"help",                        no_argument,       0, 'h'                     },
-    {"trace",                       optional_argument, 0, 'v'                     },
-    {"no-trace",                    optional_argument, 0, 'V'                     },
-    {"trace-output",                required_argument, 0, OPT_TRACE_OUTPUT        },
-    {"inst-limit",                  required_argument, 0, 'l'                     },
-    {"enable-zfinx",                no_argument,       0, 'x'                     },
-    {"enable-bitmanip",             no_argument,       0, 'B'                     },
-    {"enable-writable-fiom",        no_argument,       0, OPT_ENABLE_WRITABLE_FIOM},
-    {"enable-svinval",              no_argument,       0, OPT_ENABLE_SVINVAL      },
-    {"enable-zcb",                  no_argument,       0, OPT_ENABLE_ZCB          },
-    {"enable-zicbom",               no_argument,       0, OPT_ENABLE_ZICBOM       },
-    {"enable-zicboz",               no_argument,       0, OPT_ENABLE_ZICBOZ       },
-    {"enable-zvkb",                 no_argument,       0, OPT_ENABLE_ZVKB         },
-    {"cache-block-size",            required_argument, 0, OPT_CACHE_BLOCK_SIZE    },
+    {"help",                  no_argument,       0, 1               },
+    {"config",                required_argument, 0, 'c'             },
+    {"print-default-config",  no_argument,       0, OPT_PRINT_CONFIG},
+    {"trace",                 optional_argument, 0, 'v'             },
+    {"no-trace",              optional_argument, 0, 'V'             },
+    {"trace-output",          required_argument, 0, OPT_TRACE_OUTPUT},
+    {"inst-limit",            required_argument, 0, 'l'             },
 #ifdef SAILCOV
-    {"sailcov-file",                required_argument, 0, 'c'                     },
+    {"sailcov-file",          required_argument, 0, OPT_SAILCOV     },
 #endif
-    {0,                             0,                 0, 0                       }
+    {0,                       0,                 0, 0               }
 };
 
 static void print_usage(const char *argv0, int ec)
@@ -209,17 +192,6 @@ static void read_dtb(const char *path)
   fprintf(stdout, "Read %zd bytes of DTB from %s.\n", dtb_len, path);
 }
 
-// Return log2(x), or -1 if x is not a power of 2.
-static int ilog2(uint64_t x)
-{
-  for (unsigned i = 0; i < sizeof(x) * 8; ++i) {
-    if (x == (UINT64_C(1) << i)) {
-      return i;
-    }
-  }
-  return -1;
-}
-
 /**
  * Parses the command line arguments and returns the argv index for the first
  * ELF file that should be loaded. As getopt transforms the argv array, all
@@ -230,20 +202,12 @@ static int ilog2(uint64_t x)
 static int process_args(int argc, char **argv)
 {
   int c;
-  uint64_t ram_size = 0;
-  uint64_t pmp_count = 0;
-  uint64_t pmp_grain = 0;
-  uint64_t block_size_exp = 0;
+  bool have_config = false;
   while (true) {
     c = getopt_long(argc, argv,
                     "a"
-                    "B"
                     "d"
                     "m"
-                    "C"
-                    "I"
-                    "F"
-                    "W"
                     "i"
                     "p"
                     "z:"
@@ -252,91 +216,23 @@ static int process_args(int argc, char **argv)
                     "T:"
                     "g:"
                     "h"
+                    "c:"
 #ifdef RVFI_DII
                     "r:"
 #endif
-#ifdef SAILCOV
-                    "c:"
-#endif
                     "V::"
                     "v::"
-                    "l:"
-                    "x",
+                    "l:",
                     options, NULL);
     if (c == -1)
       break;
     switch (c) {
     case 'a':
-      report_arch();
-      break;
-    case 'B':
-      fprintf(stderr, "enabling B extension.\n");
-      rv_enable_bext = true;
-      break;
-    case 'd':
-      fprintf(stderr, "enabling dirty update.\n");
-      rv_enable_dirty_update = true;
-      break;
-    case 'm':
-      fprintf(stderr, "enabling misaligned access.\n");
-      rv_enable_misaligned = true;
-      break;
-    case OPT_PMP_COUNT:
-      pmp_count = atol(optarg);
-      fprintf(stderr, "PMP count: %" PRIu64 "\n", pmp_count);
-      if (pmp_count != 0 && pmp_count != 16 && pmp_count != 64) {
-        fprintf(stderr, "invalid PMP count: must be 0, 16 or 64");
-        exit(1);
-      }
-      rv_pmp_count = pmp_count;
-      break;
-    case OPT_PMP_GRAIN:
-      pmp_grain = atol(optarg);
-      fprintf(stderr, "PMP grain: %" PRIu64 "\n", pmp_grain);
-      if (pmp_grain >= 64) {
-        fprintf(stderr, "invalid PMP grain: must less than 64");
-        exit(1);
-      }
-      rv_pmp_grain = pmp_grain;
-      break;
-    case 'C':
-      fprintf(stderr, "disabling RVC compressed instructions.\n");
-      rv_enable_rvc = false;
-      break;
-    case 'I':
-      fprintf(stderr, "disabling writable misa CSR.\n");
-      rv_enable_writable_misa = false;
-      break;
-    case 'F':
-      fprintf(stderr, "disabling floating point (F and D extensions).\n");
-      rv_enable_fdext = false;
-      break;
-    case 'W':
-      fprintf(stderr, "disabling RVV vector instructions.\n");
-      rv_enable_vext = false;
-      break;
-    case 'i':
-      fprintf(stderr, "enabling storing illegal instruction bits in mtval.\n");
-      rv_mtval_has_illegal_inst_bits = true;
-      break;
-    case OPT_ENABLE_WRITABLE_FIOM:
-      fprintf(stderr,
-              "enabling FIOM (Fence of I/O implies Memory) bit in menvcfg.\n");
-      rv_enable_writable_fiom = true;
+      do_report_arch = true;
       break;
     case 'p':
       fprintf(stderr, "will show execution times on completion.\n");
       do_show_times = true;
-      break;
-    case 'z':
-      ram_size = atol(optarg);
-      if (ram_size) {
-        fprintf(stderr, "setting ram-size to %" PRIu64 " MB\n", ram_size);
-        rv_ram_size = ram_size << 20;
-      } else {
-        fprintf(stderr, "invalid ram-size '%s' provided.\n", optarg);
-        exit(1);
-      }
       break;
     case 'b':
       dtb_file = strdup(optarg);
@@ -358,6 +254,19 @@ static int process_args(int argc, char **argv)
     case 'h':
       print_usage(argv[0], 0);
       break;
+    case 'c': {
+      if (access(optarg, R_OK) == 0) {
+        sail_config_set_file(optarg);
+        have_config = true;
+      } else {
+        fprintf(stderr, "configuration file '%s' does not exist.\n", optarg);
+        exit(1);
+      }
+      break;
+    }
+    case OPT_PRINT_CONFIG:
+      printf("%s", DEFAULT_JSON);
+      exit(0);
 #ifdef RVFI_DII
     case 'r': {
       int rvfi_dii_port = atoi(optarg);
@@ -384,49 +293,8 @@ static int process_args(int argc, char **argv)
       insn_limit = val;
       break;
     }
-    case OPT_ENABLE_SVINVAL:
-      fprintf(stderr, "enabling svinval extension.\n");
-      rv_enable_svinval = true;
-      break;
-    case OPT_ENABLE_ZCB:
-      fprintf(stderr, "enabling Zcb extension.\n");
-      rv_enable_zcb = true;
-      break;
-    case OPT_ENABLE_ZICBOM:
-      fprintf(stderr, "enabling Zicbom extension.\n");
-      rv_enable_zicbom = true;
-      break;
-    case OPT_ENABLE_ZICBOZ:
-      fprintf(stderr, "enabling Zicboz extension.\n");
-      rv_enable_zicboz = true;
-      break;
-    case OPT_ENABLE_ZVKB:
-      fprintf(stderr, "enabling Zvkb extension.\n");
-      rv_enable_zvkb = true;
-      break;
-    case OPT_ENABLE_SSTC:
-      fprintf(stderr, "enabling Sstc extension.\n");
-      rv_enable_sstc = true;
-      break;
-    case OPT_CACHE_BLOCK_SIZE:
-      block_size_exp = ilog2(atol(optarg));
-
-      if (block_size_exp > 12) {
-        fprintf(stderr, "invalid cache-block-size '%s' provided.\n", optarg);
-        exit(1);
-      }
-
-      fprintf(stderr, "setting cache-block-size to 2^%" PRIu64 " = %u B\n",
-              block_size_exp, 1 << block_size_exp);
-      rv_cache_block_size_exp = block_size_exp;
-      break;
-    case 'x':
-      fprintf(stderr, "enabling Zfinx support.\n");
-      rv_enable_zfinx = true;
-      rv_enable_fdext = false;
-      break;
 #ifdef SAILCOV
-    case 'c':
+    case OPT_SAILCOV:
       sailcov_file = strdup(optarg);
       break;
 #endif
@@ -439,6 +307,21 @@ static int process_args(int argc, char **argv)
       break;
     }
   }
+
+  if (!have_config) {
+    std::filesystem::path path = std::filesystem::temp_directory_path();
+    pid_t pid = getpid();
+    std::ostringstream filename;
+    filename << "default_config" << pid << ".json";
+    path = path / filename.str();
+    std::ofstream tmp(path);
+    tmp << DEFAULT_JSON;
+    tmp.close();
+
+    sail_config_set_file(path.c_str());
+    std::filesystem::remove(path);
+  }
+
 #ifdef RVFI_DII
   if (optind > argc || (optind == argc && !rvfi))
     print_usage(argv[0], 0);
@@ -451,7 +334,7 @@ static int process_args(int argc, char **argv)
   if (dtb_file)
     read_dtb(dtb_file);
 
-  if (!rvfi)
+  if (!rvfi && !do_report_arch)
     fprintf(stdout, "Running file %s.\n", argv[optind]);
   return optind;
 }
@@ -502,6 +385,38 @@ uint64_t load_sail(char *f, bool main_file)
   return entry;
 }
 
+uint64_t get_config_uint64(std::vector<const char *> keypath)
+{
+  sail_config_json json = sail_config_get(keypath.size(), keypath.data());
+
+  if (!json) {
+    std::cerr << "Failed to find configuration option '";
+    for (auto part : keypath) {
+      std::cerr << "." << part;
+    }
+    std::cerr << "'.\n";
+    exit(1);
+  }
+
+  sail_int big_n;
+  uint64_t n;
+
+  if (!sail_config_is_int(json)) {
+    std::cerr << "Configuration option '";
+    for (auto part : keypath) {
+      std::cerr << "." << part;
+    }
+    std::cerr << "' could not be parsed as an integer.\n";
+    exit(1);
+  }
+
+  CREATE(sail_int)(&big_n);
+  sail_config_unwrap_int(&big_n, json);
+  n = sail_int_get_ui(big_n);
+  KILL(sail_int)(&big_n);
+  return n;
+}
+
 void init_sail_reset_vector(uint64_t entry)
 {
 #define RST_VEC_SIZE 8
@@ -516,9 +431,10 @@ void init_sail_reset_vector(uint64_t entry)
          (uint32_t)(entry & 0xffffffff),
          (uint32_t)(entry >> 32)};
 
-  rv_rom_base = DEFAULT_RSTVEC;
-  uint64_t addr = rv_rom_base;
-  for (size_t i = 0; i < sizeof(reset_vec); i++)
+  uint64_t rom_base = get_config_uint64({"platform", "reset_vector"});
+  uint64_t addr = rom_base;
+
+  for (int i = 0; i < sizeof(reset_vec); i++)
     write_mem(addr++, (uint64_t)((char *)reset_vec)[i]);
 
   if (dtb && dtb_len) {
@@ -532,16 +448,32 @@ void init_sail_reset_vector(uint64_t entry)
   for (uint64_t i = addr; i < rom_end; i++)
     write_mem(addr++, 0);
 
-  /* set rom size */
-  rv_rom_size = rom_end - rv_rom_base;
+  /* calculate rom size */
+  uint64_t rom_size = rom_end - rom_base;
+
+  /* check calculated rom values match configuration */
+  if (rom_base != get_config_uint64({"platform", "rom", "base"})) {
+    fprintf(stderr,
+            "Configuration value platform.rom.base does not match %" PRIu64
+            ".\n",
+            rom_base);
+  }
+  if (rom_size != get_config_uint64({"platform", "rom", "size"})) {
+    fprintf(stderr,
+            "Configuration value platform.rom.size does not match %" PRIu64
+            ".\n",
+            rom_size);
+  }
+
   /* boot at reset vector */
-  zPC = rv_rom_base;
+  zPC = rom_base;
 }
 
 void init_sail(uint64_t elf_entry)
 {
   zinit_model(UNIT);
   if (rvfi) {
+    /*
     rv_ram_base = UINT64_C(0x80000000);
     rv_ram_size = UINT64_C(0x800000);
     rv_rom_base = UINT64_C(0);
@@ -549,6 +481,7 @@ void init_sail(uint64_t elf_entry)
     rv_clint_base = UINT64_C(0);
     rv_clint_size = UINT64_C(0);
     rv_htif_tohost = UINT64_C(0);
+    */
     zPC = elf_entry;
   } else
     init_sail_reset_vector(elf_entry);
@@ -641,7 +574,10 @@ void run_sail(void)
 
   /* initialize the step number */
   mach_int step_no = 0;
-  int insn_cnt = 0;
+  uint64_t insn_cnt = 0;
+
+  uint64_t insns_per_tick
+      = get_config_uint64({"platform", "instructions_per_tick"});
 
   struct timeval interval_start;
   if (gettimeofday(&interval_start, NULL) < 0) {
@@ -708,7 +644,7 @@ void run_sail(void)
       }
     }
 
-    if (insn_cnt == rv_insns_per_tick) {
+    if (insn_cnt == insns_per_tick) {
       insn_cnt = 0;
       ztick_clock(UNIT);
       ztick_platform(UNIT);
@@ -754,9 +690,14 @@ void init_logs()
 
 int main(int argc, char **argv)
 {
+  int files_start = process_args(argc, argv);
+
   model_init();
 
-  int files_start = process_args(argc, argv);
+  if (do_report_arch) {
+    report_arch();
+  }
+
   char *initial_elf_file = argv[files_start];
   init_logs();
 

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+file(READ "default.json" DEFAULT_JSON)
+configure_file("default_config.h.in" "default_config.h" @ONLY)
+# Ensure this runs again if `default.json` is changed.
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "default.json;default_config.h.in")
+
+add_library(default_config INTERFACE
+  "default_config.h"
+)
+
+target_include_directories(default_config INTERFACE "${CMAKE_BINARY_DIR}/config")

--- a/config/default.json
+++ b/config/default.json
@@ -1,0 +1,78 @@
+{
+    "base" : {
+        "writable_misa" : true,
+        "writable_fiom" : true,
+        "writable_hpm_counters" : {
+            "len" : 32,
+            "value" : "0xFFFF_FFFF"
+        },
+        "mtval_has_illegal_instruction_bits" : false
+    },
+    "memory" : {
+        "pmp" : {
+            "grain" : 0,
+            "count" : 0
+        },
+        "misaligned" : {
+            "enabled" : false
+        },
+        "translation" : {
+            "dirty_update" : false
+        }
+    },
+    "platform" : {
+        "reset_vector" : 4096,
+        "cache_block_size_exp" : 6,
+        "ram" : {
+            "base" : 2147483648,
+            "size" : 2147483648
+        },
+        "rom" : {
+            "base" : 4096,
+            "size" : 4096
+        },
+        "clint" : {
+            "base" : 33554432,
+            "size" : 786432
+        },
+        "instructions_per_tick" : 100
+    },
+    "extensions" : {
+        "C" : {
+            "enabled" : true
+        },
+        "FD" : {
+            "enabled" : true
+        },
+        "V" : {
+            "enabled" : true,
+            "vlen_exp" : 9,
+            "elen_exp" : 6,
+            "vl_use_ceil" : false
+        },
+        "B" : {
+            "enabled" : false
+        },
+        "Svinval" : {
+            "enabled" : false
+        },
+        "Zcb" : {
+            "enabled" : false
+        },
+        "Zfinx" : {
+            "enabled" : false
+        },
+        "Zicbom" : {
+            "enabled" : false
+        },
+        "Zicboz" : {
+            "enabled" : false
+        },
+        "Zvkb" : {
+            "enabled" : false
+        },
+        "Sstc" : {
+            "enabled" : false
+        }
+    }
+}

--- a/config/default_config.h.in
+++ b/config/default_config.h.in
@@ -1,0 +1,3 @@
+#pragma once
+
+const char *DEFAULT_JSON = R"##(@DEFAULT_JSON@)##";

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -328,6 +328,7 @@ foreach (xlen IN ITEMS 32 64)
                         -o "${CMAKE_CURRENT_BINARY_DIR}/model"
                         # Minimum required Sail compiler version.
                         --require-version ${SAIL_REQUIRED_VER}
+                        --config ${CMAKE_SOURCE_DIR}/config/default.json
                         # Input files.
                         ${sail_srcs}
                     COMMAND ${CMAKE_COMMAND} -E touch ${smt_stamp_file}

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -53,7 +53,7 @@ function handle_illegal_vtype() = {
   print_reg("CSR vl <- " ^ BitStr(vl))
 }
 
-val sys_vext_vl_use_ceil = pure "sys_vext_vl_use_ceil" : unit -> bool
+function vl_use_ceil() -> bool = config extensions.V.vl_use_ceil
 
 function calculate_new_vl(AVL : int, VLMAX : int) -> xlenbits = {
   // See "Constraints on Setting vl" in the vector spec.
@@ -63,7 +63,7 @@ function calculate_new_vl(AVL : int, VLMAX : int) -> xlenbits = {
       // If VLMAX < AVL < 2 * VLMAX then we can use any value
       // such that ceil(AVL / 2) <= vl <= VLMAX. Here we provide
       // two options: ceil(AVL / 2) or VLMAX.
-      if sys_vext_vl_use_ceil() then (AVL + 1) / 2 else VLMAX
+      if vl_use_ceil() then (AVL + 1) / 2 else VLMAX
     }
     else VLMAX;
 

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -27,36 +27,30 @@ val elf_entry = pure {
 // Cache block size is 2^cache_block_size_exp. Max is `max_mem_access` (4096)
 // because this model performs `cbo.zero` with a single write, and the behaviour
 // with cache blocks larger than a page is not clearly defined.
-val plat_cache_block_size_exp = pure {c: "plat_cache_block_size_exp", interpreter: "Platform.cache_block_size_exp", lem: "plat_cache_block_size_exp"} : unit -> range(0, 12)
+function plat_cache_block_size_exp() -> range(0, 12) = config platform.cache_block_size_exp
 
 /* Main memory */
-val plat_ram_base = pure {c: "plat_ram_base", interpreter: "Platform.dram_base", lem: "plat_ram_base"} : unit -> physaddrbits
-val plat_ram_size = pure {c: "plat_ram_size", interpreter: "Platform.dram_size", lem: "plat_ram_size"} : unit -> physaddrbits
+function plat_ram_base() -> physaddrbits = to_bits(physaddrbits_len, config platform.ram.base : int)
+function plat_ram_size() -> physaddrbits = to_bits(physaddrbits_len, config platform.ram.size : int)
 
 /* whether the MMU should update dirty bits in PTEs */
-val plat_enable_dirty_update = pure {interpreter: "Platform.enable_dirty_update",
-                                     c: "plat_enable_dirty_update",
-                                     lem: "plat_enable_dirty_update"} : unit -> bool
+function plat_enable_dirty_update() -> bool = config memory.translation.dirty_update
 
 /* whether the platform supports misaligned accesses without trapping to M-mode. if false,
  * misaligned loads/stores are trapped to Machine mode.
  */
-val plat_enable_misaligned_access = pure {interpreter: "Platform.enable_misaligned_access",
-                                          c: "plat_enable_misaligned_access",
-                                          lem: "plat_enable_misaligned_access"} : unit -> bool
+function plat_enable_misaligned_access() -> bool = config memory.misaligned.enabled
 
 /* whether mtval stores the bits of a faulting instruction on illegal instruction exceptions */
-val plat_mtval_has_illegal_inst_bits = pure {interpreter: "Platform.mtval_has_illegal_inst_bits",
-                                             c: "plat_mtval_has_illegal_inst_bits",
-                                             lem: "plat_mtval_has_illegal_inst_bits"} : unit -> bool
+function plat_mtval_has_illegal_inst_bits() -> bool = config base.mtval_has_illegal_instruction_bits
 
 /* ROM holding reset vector and device-tree DTB */
-val plat_rom_base   = pure {interpreter: "Platform.rom_base", c: "plat_rom_base", lem: "plat_rom_base"} : unit -> physaddrbits
-val plat_rom_size   = pure {interpreter: "Platform.rom_size", c: "plat_rom_size", lem: "plat_rom_size"} : unit -> physaddrbits
+function plat_rom_base() -> physaddrbits = to_bits(physaddrbits_len, config platform.rom.base : int)
+function plat_rom_size() -> physaddrbits = to_bits(physaddrbits_len, config platform.rom.size : int)
 
 /* Location of clock-interface, which should match with the spec in the DTB */
-val plat_clint_base = pure {interpreter: "Platform.clint_base", c: "plat_clint_base", lem: "plat_clint_base"} : unit -> physaddrbits
-val plat_clint_size = pure {interpreter: "Platform.clint_size", c: "plat_clint_size", lem: "plat_clint_size"} : unit -> physaddrbits
+function plat_clint_base() -> physaddrbits = to_bits(physaddrbits_len, config platform.clint.base : int)
+function plat_clint_size() -> physaddrbits = to_bits(physaddrbits_len, config platform.clint.size : int)
 
 /* Location of HTIF ports */
 val plat_htif_tohost = pure {c: "plat_htif_tohost", lem: "plat_htif_tohost"} : unit -> physaddrbits
@@ -113,7 +107,7 @@ function within_htif_readable forall 'n, 0 < 'n <= max_mem_access . (physaddr(ad
 
 /* CLINT (Core Local Interruptor), based on Spike. */
 
-val plat_insns_per_tick = pure {interpreter: "Platform.insns_per_tick", c: "plat_insns_per_tick", lem: "plat_insns_per_tick"} : unit -> int
+function plat_insns_per_tick() -> int = config platform.instructions_per_tick
 
 // Each hart has a memory-mapped mtimecmp register. Typically these are
 // exposed as an array in CLINT. The CLINT implementation here is currently

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -83,46 +83,53 @@ register misa : Misa =
   ]
 
 /* whether misa is R/W */
-val sys_enable_writable_misa = pure "sys_enable_writable_misa" : unit -> bool
+function sys_enable_writable_misa() -> bool = config base.writable_misa
+
 /* whether misa.c was enabled at boot */
-val sys_enable_rvc = pure "sys_enable_rvc" : unit -> bool
+function sys_enable_rvc() -> bool = config extensions.C.enabled
+
 /* whether misa.{f,d} were enabled at boot */
-val sys_enable_fdext = pure "sys_enable_fdext" : unit -> bool
+function sys_enable_fdext() -> bool = config extensions.FD.enabled
+
 /* whether Svinval was enabled at boot */
-val sys_enable_svinval = pure "sys_enable_svinval" : unit -> bool
+function sys_enable_svinval() -> bool = config extensions.Svinval.enabled
+
 /* whether Zcb was enabled at boot */
-val sys_enable_zcb = pure "sys_enable_zcb" : unit -> bool
+function sys_enable_zcb() -> bool = config extensions.Zcb.enabled
+
 /* whether zfinx was enabled at boot */
-val sys_enable_zfinx = pure "sys_enable_zfinx" : unit -> bool
+function sys_enable_zfinx() -> bool = config extensions.Zfinx.enabled
+
 /* Whether FIOM bit of menvcfg/senvcfg is enabled. It must be enabled if
    supervisor mode is implemented and non-bare addressing modes are supported. */
-val sys_enable_writable_fiom = pure "sys_enable_writable_fiom" : unit -> bool
+function sys_enable_writable_fiom() -> bool = config base.writable_fiom
 
 /* How many PMP entries are implemented. This must be 0, 16 or 64 (this is checked at runtime). */
-val sys_pmp_count = pure "sys_pmp_count" : unit -> range(0, 64)
+function sys_pmp_count() -> {0, 16, 64} = config memory.pmp.count
+
 /* G parameter that specifies the PMP grain size. The grain size is 2^(G+2), e.g.
    G=0 -> 4 bytes, G=10 -> 4096 bytes. */
-val sys_pmp_grain = pure "sys_pmp_grain" : unit -> range(0, 63)
+function sys_pmp_grain() -> range(0, 63) = config memory.pmp.grain
 
 /* Which HPM counters are supported (as a bit mask). Bits [2 .. 0] are ignored. */
-val sys_writable_hpm_counters = pure "sys_writable_hpm_counters" : unit -> bits(32)
+function sys_writable_hpm_counters() -> bits(32) = config base.writable_hpm_counters
 
 /* whether misa.v was enabled at boot */
-val sys_enable_vext = pure "sys_enable_vext" : unit -> bool
+function sys_enable_vext() -> bool = config extensions.V.enabled
 
 /* whether misa.b was enabled at boot */
-val sys_enable_bext = pure "sys_enable_bext" : unit -> bool
+function sys_enable_bext() -> bool = config extensions.B.enabled
 
 // CBO extensions. Zicbop cannot be enabled/disabled because it has no effect
 // at all on this model.
-val sys_enable_zicbom = pure "sys_enable_zicbom" : unit -> bool
-val sys_enable_zicboz = pure "sys_enable_zicboz" : unit -> bool
+function sys_enable_zicbom() -> bool = config extensions.Zicbom.enabled
+function sys_enable_zicboz() -> bool = config extensions.Zicboz.enabled
 
 // Is the Zvkb extension supported.
-val sys_enable_zvkb = pure "sys_enable_zvkb" : unit -> bool
+function sys_enable_zvkb() -> bool = config extensions.Zvkb.enabled
 
 // Is the Sstc stimecmp extension supported.
-val sys_enable_sstc = pure "sys_enable_sstc" : unit -> bool
+function sys_enable_sstc() -> bool = config extensions.Sstc.enabled
 
 // Supervisor timecmp
 function clause extensionEnabled(Ext_Sstc) = sys_enable_sstc()

--- a/model/riscv_vlen.sail
+++ b/model/riscv_vlen.sail
@@ -6,18 +6,14 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-val sys_vector_elen_exp = pure "sys_vector_elen_exp" : unit -> range(3, 16)
-
-function get_elen_pow() -> range(3, 16) = sys_vector_elen_exp()
+function get_elen_pow() -> range(3, 16) = config extensions.V.elen_exp
 
 /* Note: ELEN=32 requires a different encoding of the CSR vtype.
  * The current version of vtype implementation corresponds to the ELEN=64 configuration.
  * TODO: the configurarion of ELEN and its corresponding vtype implementations.
  */
 
-val sys_vector_vlen_exp = pure "sys_vector_vlen_exp" : unit -> range(3, 16)
-
-function get_vlen_pow() -> range(3, 16) = sys_vector_vlen_exp()
+function get_vlen_pow() -> range(3, 16) = config extensions.V.vlen_exp
 
 type vlenmax : Int = 65536
 

--- a/sail_runtime/CMakeLists.txt
+++ b/sail_runtime/CMakeLists.txt
@@ -15,6 +15,10 @@ add_library(sail_runtime
     "${sail_dir}/lib/sail_failure.c"
     "${sail_dir}/lib/sail_failure.h"
     "${sail_dir}/lib/sail_coverage.h"
+    "${sail_dir}/lib/cJSON.c"
+    "${sail_dir}/lib/cJSON.h"
+    "${sail_dir}/lib/sail_config.c"
+    "${sail_dir}/lib/sail_config.h"
 )
 
 target_include_directories(sail_runtime

--- a/test/first_party/CMakeLists.txt
+++ b/test/first_party/CMakeLists.txt
@@ -94,6 +94,7 @@ foreach (xlen IN ITEMS 32 64)
         endif()
 
         set(elf "${arch}_${test_source}.elf")
+        set(config "${arch}_${test_source}.json")
 
         add_custom_command(
             OUTPUT ${elf}
@@ -136,11 +137,31 @@ foreach (xlen IN ITEMS 32 64)
             COMMENT "Compiling ${test_source}"
         )
 
-        add_custom_target(build_${arch}_${test_source} ALL DEPENDS ${elf})
+        if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/${test_source}.filter")
+            add_custom_command(
+                OUTPUT ${config}
+                DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/${test_source}.filter"
+                COMMAND jq
+                    -f "${CMAKE_CURRENT_SOURCE_DIR}/src/${test_source}.filter"
+                    "${CMAKE_SOURCE_DIR}/config/default.json"
+                    > ${config}
+                VERBATIM
+                COMMENT "Creating ${config}"
+            )
+        else()
+            add_custom_command(
+                OUTPUT ${config}
+                COMMAND ${CMAKE_COMMAND} -E copy
+                    "${CMAKE_SOURCE_DIR}/config/default.json"
+                    "${config}"
+            )
+        endif()
+
+        add_custom_target(build_${arch}_${test_source} ALL DEPENDS ${elf} ${config})
 
         add_test(
             NAME "first_party_${arch}_${test_source}"
-            COMMAND $<TARGET_FILE:riscv_sim_${arch}> --pmp-count 16 ${elf}
+            COMMAND $<TARGET_FILE:riscv_sim_${arch}> --config ${config} ${elf}
         )
     endforeach()
 endforeach()

--- a/test/riscv-tests/CMakeLists.txt
+++ b/test/riscv-tests/CMakeLists.txt
@@ -12,7 +12,10 @@ foreach (arch IN ITEMS "rv32d" "rv64d")
 
         add_test(
             NAME "${arch}_${elf_name}"
-            COMMAND $<TARGET_FILE:riscv_sim_${arch}> ${elf}
+            COMMAND
+                $<TARGET_FILE:riscv_sim_${arch}>
+                --config "${CMAKE_SOURCE_DIR}/config/default.json"
+                ${elf}
         )
     endforeach()
 endforeach()


### PR DESCRIPTION
This is the first in a series of PRs (and probably patches to this PR) aiming to replace the ad-hoc C stubs used for configuration with a Sail-native configuration system using a separate configuration file. This is a draft PR as it needs a new release of Sail to work.

This PR is split into two commits:

1. The first simply updates the CMake build system to include the Sail JSON handling code, and adds a simulator option to pass a configuration file but does not change the model code whatsoever. The file config/default.json is added to store all the default configuration options (but is empty in this commit). I took the `-c` short option away from the sail coverage option, as it isn't even built in by default.
2. The second replaces the existing options in the simulator. The only behaviour change is the handling of `rom_base` and `rom_size` is slightly different, in that it'll just print if the configuration values don't match what the C code that creates the reset vector and writes the DTB expect rather than setting the values.

Note that this PR isn't aiming to add all the configuration we want for MC100 or beyond, it's just a direct port of existing functionality.

With this adding a new configurable option to the model is easy, add `config x.y.z : T` anywhere in the model, and then add `x.y.z` into the JSON file, and it'll just work.

TODOs:

1. Update the other Sail targets. This configuration system works across all Sail backends, but the CMake commands for them need to be updated to reflect this
2. Sail can generate a JSON schema that will validate any provided config fits into the model, that hasn't been set up yet. The default config should be JSON schema validated in CI as well.
3. We probably want some more friendly way to write the configuration rather than plain JSON, that could be specific to this repository, or by writing a script that imports values from riscv-config or UDB, or both. I haven't decided the best way to go yet.