### PR TITLE
Fix minstreth behaviour

### DIFF
--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -16,12 +16,13 @@ function step(step_no : int) -> bool = {
   /*
    * This records whether or not minstret should be incremented when
    * the instruction is retired. Since retirement occurs before CSR
-   * writes we initialise it based on mcountinhibit here, before it is
-   * potentially changed. This is also set to false if minstret is
-   * written.  See the note near the minstret declaration for more
-   * information.
+   * writes we initialise it based on mcountinhibit here, before
+   * mcountinhibit is potentially changed. We also mark minstret(h) as not
+   * having been explicitly written yet.
    */
   minstret_increment = should_inc_minstret(cur_privilege);
+  minstret_write = None();
+  minstreth_write = None();
 
   let (retired, stepped) : (Retired, bool) =
     match dispatchInterrupt(cur_privilege) {
@@ -79,11 +80,10 @@ function step(step_no : int) -> bool = {
 
   tick_pc();
 
-  /* update minstret */
-  match retired {
-    RETIRE_SUCCESS => retire_instruction(),
-    RETIRE_FAIL    => ()
-  };
+  // Only increment minstret if the instruction retired successfully.
+  if retired != RETIRE_SUCCESS then minstret_increment = false;
+
+  update_minstret();
 
   /* for step extensions */
   ext_post_step_hook();

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -685,7 +685,6 @@ function update_minstret() -> unit = {
   };
 }
 
-
 /* machine information registers */
 register mvendorid : bits(32) = zeros()
 register mimpid : xlenbits = zeros()

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -676,7 +676,7 @@ function update_minstret() -> unit = {
 
   // Then apply explicit writes to minstret (if any).
   match minstret_write {
-    Some(v) => minstret = [minstret with (sizeof(xlen) - 1) .. 0 = v],
+    Some(v) => minstret = [minstret with (xlen - 1) .. 0 = v],
     None() => (),
   };
   match minstreth_write {

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -644,23 +644,47 @@ register mtime : bits(64)
 
 /* minstret
  *
- * minstret is an architectural register, and can be written to.  The
- * spec says that minstret increments on instruction retires need to
+ * This model-internal register is the full 64 bit minstret counter,
+ * regardless of xlen. For xlen=32, this will be split across minstret
+ * and minstreth CSRs.
+ * The spec says that minstret increments on instruction retires need to
  * occur before any explicit writes to instret.  However, in our
  * simulation loop, we need to execute an instruction to find out
  * whether it retired, and hence can only increment instret after
- * execution.  To avoid doing this in the case minstret was explicitly
+ * execution. To avoid doing this in the case minstret was explicitly
  * written to, we track whether it should increment in a separate
- * model-internal register.
+ * model-internal register. We keep track of any explicit CSR writes in
+ * the registers below and apply them after incrementing.
  */
 register minstret : bits(64)
 
 /* Should minstret be incremented when the instruction is retired. */
 register minstret_increment : bool
 
-function retire_instruction() -> unit = {
-  if minstret_increment then minstret = minstret + 1;
+// If there's an explicit write to minstret(h) then it is stored here because
+// it needs to be applied *after* the implicit increment due to instruction
+// retirement.
+register minstret_write : option(bits(xlen))
+register minstreth_write : option(bits(32))
+
+function update_minstret() -> unit = {
+  // First increment minstret due to instruction retirement
+  // if it was not disabled by mcountinhibit.IR.
+  if minstret_increment then {
+    minstret = minstret + 1;
+  };
+
+  // Then apply explicit writes to minstret (if any).
+  match minstret_write {
+    Some(v) => minstret = [minstret with (sizeof(xlen) - 1) .. 0 = v],
+    None() => (),
+  };
+  match minstreth_write {
+    Some(v) => minstret = [minstret with 63 .. 32 = v],
+    None() => (),
+  };
 }
+
 
 /* machine information registers */
 register mvendorid : bits(32) = zeros()

--- a/model/riscv_zicntr_control.sail
+++ b/model/riscv_zicntr_control.sail
@@ -47,6 +47,6 @@ function clause read_CSR(0xB80 if xlen == 32)= mcycle[63 .. 32]
 function clause read_CSR(0xB82 if xlen == 32) = minstret[63 .. 32]
 
 function clause write_CSR(0xB00, value) = { mcycle[(xlen - 1) .. 0] = value; value }
-function clause write_CSR(0xB02, value) = { minstret[(xlen - 1) .. 0] = value; minstret_increment = false; value }
+function clause write_CSR(0xB02, value) = { minstret_write = Some(value); value }
 function clause write_CSR((0xB80, value) if xlen == 32) = { mcycle[63 .. 32] = value; value }
-function clause write_CSR((0xB82, value) if xlen == 32) = { minstret[63 .. 32] = value; minstret_increment = false; value }
+function clause write_CSR((0xB82, value) if xlen == 32) = { minstreth_write = Some(value); value }


### PR DESCRIPTION
The previous code switched between explicit updates to all 64 bits of `minstret` and automatically incrementing it via a `minstret_increment` boolean. Unfortunately that doesn't work for RV32 where you can write to one half of the 64-bits *and* the other half is still automatically incremented.

This change fixes that, so the writes to each half are stored until after the automatic increment, and then applied.

Note the behaviour for this is not well specified in the ISA manual (see https://github.com/riscv/riscv-isa-manual/issues/1255) however this seems like the most plausible interpretation and it is what Spike implements and it makes sense.

Tested via some internal testing and this directed test sequence (which also passes on Spike):

```
    # Zero minstret. This gets us into a known state and also deals with
    # simulators that use X.
    csrw minstreth, zero
    csrw minstret, zero

    # Basic test of explicit write to minstret with the same value it already had.

    nop # Increment instret to 1.
    csrr t0, minstret # Should read 1 and then increment to 2.
    csrr t1, minstret # Should read 2 and then increment to 3.
    csrrwi t2, minstret, 3 # Should read 3 and then write 3, suppressing the increment to 4.
    csrrwi t3, minstret, 10 # Should read 3 and write 10.
    csrr t4, minstret # Should read 10.

    li t5, 1
    bne t0, t5, fail
    li t5, 2
    bne t1, t5, fail
    li t5, 3
    bne t2, t5, fail
    bne t3, t5, fail
    li t5, 10
    bne t4, t5, fail

    # Explicitly write 0x00000000FFFFFFFF
    li t0, 0xFFFFFFFF
    csrw minstreth, zero
    csrw minstret, t0
    # Minstret should be 0x00000000FFFFFFFF now.
    # Write 2 to minstreth. instret should now be 0x0000000200000000
    csrwi minstreth, 2
    csrr t1, minstreth

    li t2, 2
    bne t1, t2, fail

    # Try again but this time we'll write to the bottom half.
    li t0, 0xFFFFFFFF
    csrw minstreth, zero
    csrw minstret, t0
    # Minstret should be 0x00000000FFFFFFFF now.
    # Write 2 to minstret. instret should now be 0x0000000100000002
    csrwi minstret, 2
    csrr t1, minstreth

    li t2, 1
    bne t1, t2, fail

    # Check wrapping around 0xFFFFFFFFFFFFFFFF works.
    li t0, -1
    csrw minstreth, t0
    csrw minstret, t0 # Set instret to 0xFFFFFFFFFFFFFFFF
    csrr t1, minstret # Should read 0xFFFFFFFFFFFFFFFF and increment instret to 0.
    csrr t2, minstret # Should read 0.

    bne t1, t0, fail
    bne t2, zero, fail
```