### PR TITLE
Refactor `vext_mem` remove redundant type annotations and simplify

### DIFF
--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -142,8 +142,7 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
                 /* cannot happen in rmem */
                 X(rd) = zero_extend(0b1); cancel_reservation(); RETIRE_SUCCESS
               } else {
-                let eares = mem_write_ea(addr, width_bytes, aq & rl, rl, true);
-                match eares {
+                match mem_write_ea(addr, width_bytes, aq & rl, rl, true) {
                   Err(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
                   Ok(_)  => {
                     let rs2_val = X(rs2);
@@ -205,9 +204,8 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
       else match translateAddr(vaddr, ReadWrite(Data, Data)) {
         TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
         TR_Address(addr, _) => {
-          let eares = mem_write_ea(addr, width_bytes, aq & rl, rl, true);
           let rs2_val = X(rs2)[width_bytes * 8 - 1 .. 0];
-          match eares {
+          match mem_write_ea(addr, width_bytes, aq & rl, rl, true) {
             Err(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
             Ok(_) => {
               match mem_read(ReadWrite(Data, Data), addr, width_bytes, aq, aq & rl, true) {

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -369,8 +369,7 @@ function clause execute (STORE(imm, rs2, rs1, width, aq, rl)) = {
       else match translateAddr(vaddr, Write(Data)) {
         TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
         TR_Address(paddr, _) => {
-          let eares = mem_write_ea(paddr, width_bytes, aq, rl, false);
-          match (eares) {
+          match mem_write_ea(paddr, width_bytes, aq, rl, false) {
             Err(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
             Ok(_)  => {
               let rs2_val = X(rs2);

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -263,13 +263,11 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
             else match translateAddr(vaddr, Write(Data)) {
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
               TR_Address(paddr, _) => {
-                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
-                match (eares) {
+                match mem_write_ea(paddr, load_width_bytes, false, false, false) {
                   Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                   Ok(_)  => {
                     let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(5, j * EMUL_reg)));
-                    let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, elem_val, false, false, false);
-                    match (res) {
+                    match mem_write_value(paddr, load_width_bytes, elem_val, false, false, false) {
                       Ok(true)  => (),
                       Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                       Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
@@ -404,13 +402,11 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
             else match translateAddr(vaddr, Write(Data)) {
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
               TR_Address(paddr, _) => {
-                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
-                match (eares) {
+                match mem_write_ea(paddr, load_width_bytes, false, false, false) {
                   Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                   Ok(_)  => {
                     let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(5, j * EMUL_reg)));
-                    let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, elem_val, false, false, false);
-                    match (res) {
+                    match mem_write_value(paddr, load_width_bytes, elem_val, false, false, false) {
                       Ok(true)  => (),
                       Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                       Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
@@ -573,13 +569,11 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
             else match translateAddr(vaddr, Write(Data)) {
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
               TR_Address(paddr, _) => {
-                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, EEW_data_bytes, false, false, false);
-                match (eares) {
+                match mem_write_ea(paddr, EEW_data_bytes, false, false, false) {
                   Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                   Ok(_)  => {
                     let elem_val : bits('db * 8) = read_single_element(EEW_data_bytes * 8, i, vregidx_offset(vs3, to_bits(5, j * EMUL_data_reg)));
-                    let res : MemoryOpResult(bool) = mem_write_value(paddr, EEW_data_bytes, elem_val, false, false, false);
-                    match (res) {
+                    match mem_write_value(paddr, EEW_data_bytes, elem_val, false, false, false) {
                       Ok(true)  => (),
                       Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                       Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
@@ -751,13 +745,11 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
           else match translateAddr(vaddr, Write(Data)) {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
             TR_Address(paddr, _) => {
-              let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
-              match (eares) {
+              match mem_write_ea(paddr, load_width_bytes, false, false, false) {
                 Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                 Ok(_)  => {
                   let elem : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(5, cur_field)));
-                  let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, elem, false, false, false);
-                  match (res) {
+                  match mem_write_value(paddr, load_width_bytes, elem, false, false, false) {
                     Ok(true)  => (),
                     Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                     Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
@@ -785,12 +777,10 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
           else match translateAddr(vaddr, Write(Data)) {
             TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
             TR_Address(paddr, _) => {
-              let eares : MemoryOpResult(unit) = mem_write_ea(paddr, load_width_bytes, false, false, false);
-              match (eares) {
+              match mem_write_ea(paddr, load_width_bytes, false, false, false) {
                 Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                 Ok(_)  => {
-                  let res : MemoryOpResult(bool) = mem_write_value(paddr, load_width_bytes, vs3_val[i], false, false, false);
-                  match (res) {
+                  match mem_write_value(paddr, load_width_bytes, vs3_val[i], false, false, false) {
                     Ok(true)  => (),
                     Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                     Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }
@@ -868,12 +858,10 @@ function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
             else match translateAddr(vaddr, Write(Data)) {
               TR_Failure(e, _)     => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
               TR_Address(paddr, _) => {
-                let eares : MemoryOpResult(unit) = mem_write_ea(paddr, 1, false, false, false);
-                match (eares) {
+                match mem_write_ea(paddr, 1, false, false, false) {
                   Err(e) => { handle_mem_exception(vaddr, e); return RETIRE_FAIL },
                   Ok(_)  => {
-                    let res : MemoryOpResult(bool) = mem_write_value(paddr, 1, vd_or_vs3_val[i], false, false, false);
-                    match (res) {
+                    match mem_write_value(paddr, 1, vd_or_vs3_val[i], false, false, false) {
                       Ok(true)  => (),
                       Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                       Err(e)    => { handle_mem_exception(vaddr, e); return RETIRE_FAIL }


### PR DESCRIPTION
These changes align with the general LOAD and STORE implementation pattern used elsewhere in the codebase.