### PR TITLE
add enable-gates for Zvfh/Zvfhmin extensions.

### DIFF
--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -116,3 +116,8 @@ enum clause extension = Ext_Svpbmt
 
 // Cycle and Instret Privilege Mode Filtering
 enum clause extension = Ext_Smcntrpmf
+
+//  Vector Extension for Half-Precision Floating-Point
+enum clause extension = Ext_Zvfh
+// Vector Extension for Minimal Half-Precision Floating-Point
+enum clause extension = Ext_Zvfhmin

--- a/model/riscv_insts_vext_fp.sail
+++ b/model/riscv_insts_vext_fp.sail
@@ -27,8 +27,8 @@ mapping encdec_fvvfunct6 : fvvfunct6 <-> bits(6) = {
   FVV_VMUL       <-> 0b100100
 }
 
-mapping clause encdec = FVVTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
-  <-> encdec_fvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVVTYPE(funct6, vm, vs2, vs1, vd)                                                       if have_vext_fp()
+  <-> encdec_fvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(FVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -101,8 +101,8 @@ mapping encdec_fvvmafunct6 : fvvmafunct6 <-> bits(6) = {
   FVV_VNMSAC     <-> 0b101111
 }
 
-mapping clause encdec = FVVMATYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
-  <-> encdec_fvvmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVVMATYPE(funct6, vm, vs2, vs1, vd)                                                       if have_vext_fp()
+  <-> encdec_fvvmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(FVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -167,8 +167,8 @@ mapping encdec_fwvvfunct6 : fwvvfunct6 <-> bits(6) = {
   FWVV_VMUL       <-> 0b111000
 }
 
-mapping clause encdec = FWVVTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
-  <-> encdec_fwvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVVTYPE(funct6, vm, vs2, vs1, vd)                                                       if have_vext_fp()
+  <-> encdec_fwvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(FWVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -231,8 +231,8 @@ mapping encdec_fwvvmafunct6 : fwvvmafunct6 <-> bits(6) = {
   FWVV_VNMSAC     <-> 0b111111
 }
 
-mapping clause encdec = FWVVMATYPE(funct6, vm, vs1, vs2, vd)                                                       if extensionEnabled(Ext_V)
-  <-> encdec_fwvvmafunct6(funct6) @ vm @ encdec_vreg(vs1) @ encdec_vreg(vs2) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVVMATYPE(funct6, vm, vs1, vs2, vd)                                                       if have_vext_fp()
+  <-> encdec_fwvvmafunct6(funct6) @ vm @ encdec_vreg(vs1) @ encdec_vreg(vs2) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(FWVVMATYPE(funct6, vm, vs1, vs2, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -294,8 +294,8 @@ mapping encdec_fwvfunct6 : fwvfunct6 <-> bits(6) = {
   FWV_VSUB       <-> 0b110110
 }
 
-mapping clause encdec = FWVTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
-  <-> encdec_fwvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVTYPE(funct6, vm, vs2, vs1, vd)                                                       if have_vext_fp()
+  <-> encdec_fwvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(FWVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -356,8 +356,8 @@ mapping encdec_vfunary0_vs1 : vfunary0 <-> bits(5) = {
   FV_CVT_RTZ_X_F    <-> 0b00111
 }
 
-mapping clause encdec = VFUNARY0(vm, vs2, vfunary0, vd)                                                      if extensionEnabled(Ext_V)
-  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ encdec_vfunary0_vs1(vfunary0) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFUNARY0(vm, vs2, vfunary0, vd)                                                      if have_vext_fp()
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ encdec_vfunary0_vs1(vfunary0) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -464,13 +464,16 @@ mapping encdec_vfwunary0_vs1 : vfwunary0 <-> bits(5) = {
   FWV_CVT_X_F       <-> 0b01001,
   FWV_CVT_F_XU      <-> 0b01010,
   FWV_CVT_F_X       <-> 0b01011,
-  FWV_CVT_F_F       <-> 0b01100,
   FWV_CVT_RTZ_XU_F  <-> 0b01110,
   FWV_CVT_RTZ_X_F   <-> 0b01111
 }
 
-mapping clause encdec = VFWUNARY0(vm, vs2, vfwunary0, vd)                                                      if extensionEnabled(Ext_V)
-  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ encdec_vfwunary0_vs1(vfwunary0) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFWUNARY0(vm, vs2, vfwunary0, vd)                                                      if have_vext_fp()
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ encdec_vfwunary0_vs1(vfwunary0) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
+
+/* Zvfhmin supports vfwcvt.f.f.v and vfncvt.f.f.w only. */
+mapping clause encdec = VFWUNARY0(vm, vs2, FWV_CVT_F_F, vd)                            if have_vext_fp() | extensionEnabled(Ext_Zvfhmin)
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01100 @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp() | extensionEnabled(Ext_Zvfhmin)
 
 function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -592,14 +595,17 @@ mapping encdec_vfnunary0_vs1 : vfnunary0 <-> bits(5) = {
   FNV_CVT_X_F       <-> 0b10001,
   FNV_CVT_F_XU      <-> 0b10010,
   FNV_CVT_F_X       <-> 0b10011,
-  FNV_CVT_F_F       <-> 0b10100,
   FNV_CVT_ROD_F_F   <-> 0b10101,
   FNV_CVT_RTZ_XU_F  <-> 0b10110,
   FNV_CVT_RTZ_X_F   <-> 0b10111
 }
 
-mapping clause encdec = VFNUNARY0(vm, vs2, vfnunary0, vd)                                                      if extensionEnabled(Ext_V)
-  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ encdec_vfnunary0_vs1(vfnunary0) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFNUNARY0(vm, vs2, vfnunary0, vd)                                                      if have_vext_fp()
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ encdec_vfnunary0_vs1(vfnunary0) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
+
+/* Zvfhmin supports vfwcvt.f.f.v and vfncvt.f.f.w only. */
+mapping clause encdec = VFNUNARY0(vm, vs2, FNV_CVT_F_F, vd)                            if have_vext_fp() | extensionEnabled(Ext_Zvfhmin)
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b10100 @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp() | extensionEnabled(Ext_Zvfhmin)
 
 function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -733,8 +739,8 @@ mapping encdec_vfunary1_vs1 : vfunary1 <-> bits(5) = {
   FVV_VCLASS      <-> 0b10000
 }
 
-mapping clause encdec = VFUNARY1(vm, vs2, vfunary1, vd)                                                      if extensionEnabled(Ext_V)
-  <-> 0b010011 @ vm @ encdec_vreg(vs2) @ encdec_vfunary1_vs1(vfunary1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFUNARY1(vm, vs2, vfunary1, vd)                                                      if have_vext_fp()
+  <-> 0b010011 @ vm @ encdec_vreg(vs2) @ encdec_vfunary1_vs1(vfunary1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -808,8 +814,8 @@ mapping clause assembly = VFUNARY1(vm, vs2, vfunary1, vd)
 /* ****************************** OPFVV (VWFUNARY0) ****************************** */
 union clause ast = VFMVFS : (vregidx, fregidx)
 
-mapping clause encdec = VFMVFS(vs2, rd)                                                 if extensionEnabled(Ext_V)
-  <-> 0b010000 @ 0b1 @ encdec_vreg(vs2) @ 0b00000 @ 0b001 @ encdec_freg(rd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFMVFS(vs2, rd)                                                 if have_vext_fp()
+  <-> 0b010000 @ 0b1 @ encdec_vreg(vs2) @ 0b00000 @ 0b001 @ encdec_freg(rd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(VFMVFS(vs2, rd)) = {
   let rm_3b    = fcsr[FRM];
@@ -856,8 +862,8 @@ mapping encdec_fvffunct6 : fvffunct6 <-> bits(6) = {
   VF_VRSUB         <-> 0b100111
 }
 
-mapping clause encdec = FVFTYPE(funct6, vm, vs2, rs1, vd)                                                       if extensionEnabled(Ext_V)
-  <-> encdec_fvffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVFTYPE(funct6, vm, vs2, rs1, vd)                                                       if have_vext_fp()
+  <-> encdec_fvffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -945,8 +951,8 @@ mapping encdec_fvfmafunct6 : fvfmafunct6 <-> bits(6) = {
   VF_VNMSAC     <-> 0b101111
 }
 
-mapping clause encdec = FVFMATYPE(funct6, vm, vs2, rs1, vd)                                                       if extensionEnabled(Ext_V)
-  <-> encdec_fvfmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVFMATYPE(funct6, vm, vs2, rs1, vd)                                                       if have_vext_fp()
+  <-> encdec_fvfmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(FVFMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1011,8 +1017,8 @@ mapping encdec_fwvffunct6 : fwvffunct6 <-> bits(6) = {
   FWVF_VMUL       <-> 0b111000
 }
 
-mapping clause encdec = FWVFTYPE(funct6, vm, vs2, rs1, vd)                                                       if extensionEnabled(Ext_V)
-  <-> encdec_fwvffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVFTYPE(funct6, vm, vs2, rs1, vd)                                                       if have_vext_fp()
+  <-> encdec_fwvffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(FWVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1074,8 +1080,8 @@ mapping encdec_fwvfmafunct6 : fwvfmafunct6 <-> bits(6) = {
   FWVF_VNMSAC     <-> 0b111111
 }
 
-mapping clause encdec = FWVFMATYPE(funct6, vm, rs1, vs2, vd)                                                       if extensionEnabled(Ext_V)
-  <-> encdec_fwvfmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWVFMATYPE(funct6, vm, rs1, vs2, vd)                                                       if have_vext_fp()
+  <-> encdec_fwvfmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(FWVFMATYPE(funct6, vm, rs1, vs2, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1136,8 +1142,8 @@ mapping encdec_fwffunct6 : fwffunct6 <-> bits(6) = {
   FWF_VSUB       <-> 0b110110
 }
 
-mapping clause encdec = FWFTYPE(funct6, vm, vs2, rs1, vd)                                                       if extensionEnabled(Ext_V)
-  <-> encdec_fwffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FWFTYPE(funct6, vm, vs2, rs1, vd)                                                       if have_vext_fp()
+  <-> encdec_fwffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(FWFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1189,8 +1195,8 @@ mapping clause assembly = FWFTYPE(funct6, vm, vs2, rs1, vd)
 /* This instruction operates on all body elements regardless of mask value */
 union clause ast = VFMERGE : (vregidx, fregidx, vregidx)
 
-mapping clause encdec = VFMERGE(vs2, rs1, vd)                                                    if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFMERGE(vs2, rs1, vd)                                                    if have_vext_fp()
+  <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(VFMERGE(vs2, rs1, vd)) = {
   let rm_3b         = fcsr[FRM];
@@ -1240,8 +1246,8 @@ mapping clause assembly = VFMERGE(vs2, rs1, vd)
 /* This instruction shares the encoding with vfmerge.vfm, but with vm=1 and vs2=v0 */
 union clause ast = VFMV : (fregidx, vregidx)
 
-mapping clause encdec = VFMV(rs1, vd)                                                   if extensionEnabled(Ext_V)
-  <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFMV(rs1, vd)                                                   if have_vext_fp()
+  <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(VFMV(rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1277,8 +1283,8 @@ mapping clause assembly = VFMV(rs1, vd)
 /* ****************************** OPFVF (VRFUNARY0) ****************************** */
 union clause ast = VFMVSF : (fregidx, vregidx)
 
-mapping clause encdec = VFMVSF(rs1, vd)                                                 if extensionEnabled(Ext_V)
-  <-> 0b010000 @ 0b1 @ 0b00000 @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = VFMVSF(rs1, vd)                                                 if have_vext_fp()
+  <-> 0b010000 @ 0b1 @ 0b00000 @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(VFMVSF(rs1, vd)) = {
   let rm_3b    = fcsr[FRM];

--- a/model/riscv_insts_vext_fp_red.sail
+++ b/model/riscv_insts_vext_fp_red.sail
@@ -23,8 +23,8 @@ mapping encdec_rfvvfunct6 : rfvvfunct6 <-> bits(6) = {
   FVV_VFWREDUSUM  <-> 0b110001
 }
 
-mapping clause encdec = RFVVTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
-  <-> encdec_rfvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = RFVVTYPE(funct6, vm, vs2, vs1, vd)                                                       if have_vext_fp()
+  <-> encdec_rfvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 val process_rfvv_single: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, int('n), int('m), int('p)) -> Retired
 function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {

--- a/model/riscv_insts_vext_fp_utils.sail
+++ b/model/riscv_insts_vext_fp_utils.sail
@@ -10,14 +10,45 @@
 /* This file implements functions used by vector instructions.                     */
 /* ******************************************************************************* */
 
-/* Check for valid floating-point operation types
+/* TODO: need config flags to control zvfh/zvfhmin */
+function clause extensionEnabled(Ext_Zvfh) = (misa[V] == 0b1) & (mstatus[VS] != 0b00)
+function clause extensionEnabled(Ext_Zvfhmin) = extensionEnabled(Ext_Zvfh) | extensionEnabled(Ext_V)
+
+/* Helper functions for 'encdec()' */
+function have_vext_fp() -> bool = extensionEnabled(Ext_V) | extensionEnabled(Ext_Zvfh)
+
+/* Check for valid floating-point operation types for standard floating-point instructions.
  *  1. Valid element width of floating-point numbers
  *  2. Valid floating-point rounding mode
  */
 val valid_fp_op : ({8, 16, 32, 64}, bits(3)) -> bool
 function valid_fp_op(SEW, rm_3b) = {
-  /* 128-bit floating-point values will be supported in future extensions */
-  let valid_sew = (SEW >= 16 & SEW <= 128);
+  /* SEW=16 is supported by Zvfh, SEW=32/64 is supported by V extension. */
+  let valid_sew : bool = match SEW {
+    8 => false,
+    16 => extensionEnabled(Ext_Zvfh),
+    32 => extensionEnabled(Ext_V),
+    64 => extensionEnabled(Ext_V)
+  };
+  let valid_rm = not(rm_3b == 0b101 | rm_3b == 0b110 | rm_3b == 0b111);
+  valid_sew & valid_rm
+}
+
+/* Check for valid floating-point operation types for floating-point widening/narrowing instructions.
+ *  1. Valid element width of floating-point numbers
+ *  2. Valid floating-point rounding mode
+ */
+val valid_fp_op_variable_width : ({8, 16, 32, 64}, bits(3)) -> bool
+function valid_fp_op_variable_width(SEW, rm_3b) = {
+  /* 1. SEW=8 is allowed in conversions between 8-bit integers and binary16 values supported by Zvfh. 
+     2. SEW=64 is not supported yet, since it causes EEW=128.
+  */
+  let valid_sew : bool = match SEW {
+    8 => extensionEnabled(Ext_Zvfh),
+    16 => extensionEnabled(Ext_V) | extensionEnabled(Ext_Zvfh) | extensionEnabled(Ext_Zvfhmin),
+    32 => extensionEnabled(Ext_V),
+    64 => false
+  };
   let valid_rm = not(rm_3b == 0b101 | rm_3b == 0b110 | rm_3b == 0b111);
   valid_sew & valid_rm
 }
@@ -43,7 +74,7 @@ function illegal_fp_vd_unmasked(SEW, rm_3b) = {
 /* d. Variable width check for floating-point widening/narrowing instructions */
 val illegal_fp_variable_width : (vregidx, bits(1), {8, 16, 32, 64}, bits(3), int, int) -> bool
 function illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_new, LMUL_pow_new) = {
-  not(valid_vtype()) | not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) |
+  not(valid_vtype()) | not(valid_rd_mask(vd, vm)) | not(valid_fp_op_variable_width(SEW, rm_3b)) |
   not(valid_eew_emul(SEW_new, LMUL_pow_new))
 }
 
@@ -56,7 +87,7 @@ function illegal_fp_reduction(SEW, rm_3b) = {
 /* f. Variable width check for floating-point widening reduction instructions */
 val illegal_fp_reduction_widen : ({8, 16, 32, 64}, bits(3), int, int) -> bool
 function illegal_fp_reduction_widen(SEW, rm_3b, SEW_widen, LMUL_pow_widen) = {
-  not(valid_vtype()) | not(assert_vstart(0)) | not(valid_fp_op(SEW, rm_3b)) |
+  not(valid_vtype()) | not(assert_vstart(0)) | not(valid_fp_op_variable_width(SEW, rm_3b)) |
   not(valid_eew_emul(SEW_widen, LMUL_pow_widen))
 }
 

--- a/model/riscv_insts_vext_fp_vm.sail
+++ b/model/riscv_insts_vext_fp_vm.sail
@@ -22,8 +22,8 @@ mapping encdec_fvvmfunct6 : fvvmfunct6 <-> bits(6) = {
   FVVM_VMFNE      <-> 0b011100
 }
 
-mapping clause encdec = FVVMTYPE(funct6, vm, vs2, vs1, vd)                                                       if extensionEnabled(Ext_V)
-  <-> encdec_fvvmfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVVMTYPE(funct6, vm, vs2, vs1, vd)                                                       if have_vext_fp()
+  <-> encdec_fvvmfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(FVVMTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -85,8 +85,8 @@ mapping encdec_fvfmfunct6 : fvfmfunct6 <-> bits(6) = {
   VFM_VMFGE      <-> 0b011111
 }
 
-mapping clause encdec = FVFMTYPE(funct6, vm, vs2, rs1, vd)                                                       if extensionEnabled(Ext_V)
-  <-> encdec_fvfmfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if extensionEnabled(Ext_V)
+mapping clause encdec = FVFMTYPE(funct6, vm, vs2, rs1, vd)                                                       if have_vext_fp()
+  <-> encdec_fvfmfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111 if have_vext_fp()
 
 function clause execute(FVFMTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];


### PR DESCRIPTION
Zvfh/Zvfhmin and the V extension implement the same set of instructions, with the primary differences being in the handling of SEW.
This update addresses SEW handling as follows:
1. For basic instructions, Zvfh only supports SEW = 16, while the V extension supports SEW = 32/64. (`valid_fp_op` in `model/riscv_insts_vext_fp_utils.sail`)
2. For narrowing/widening instructions(`valid_fp_op_variable_width` in `model/riscv_insts_vext_fp_utils.sail`):
   - Both Zvfh/Zvfhmin and the V extension support SEW = 16.
   - SEW = 32 is only supported by the V extension.
   - Notably, Zvfh allows SEW = 8 for 8-bit integers conversion instructions.
3. Zvfhmin only supports `vfwcvt.f.f.v` and `vfncvt.f.f.w`. Therefore, the definition of these instructions has been separated from the other `cvt` instructions.