### PR TITLE
Bump required sail compiler version to 0.19 and remove zlib dependency

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install sail from binary
       run: |
         sudo mkdir -p /usr/local
-        curl --location https://github.com/rems-project/sail/releases/download/0.18-linux-binary/sail.tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
+        curl --location https://github.com/rems-project/sail/releases/download/0.19-linux-binary/sail.tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
 
     - name: Check out repository code
       uses: actions/checkout@v4

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Install packages
-      run: sudo apt install -y --no-install-recommends zlib1g-dev pkg-config libgmp-dev curl ninja-build
+      run: sudo apt install -y --no-install-recommends pkg-config libgmp-dev curl ninja-build
 
     - name: Install sail from binary
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
             gcc-c++ \
             cmake \
             ninja-build
-        curl --location --output sail.tar.gz https://github.com/rems-project/sail/releases/download/0.18-linux-binary/sail.tar.gz
+        curl --location --output sail.tar.gz https://github.com/rems-project/sail/releases/download/0.19-linux-binary/sail.tar.gz
         tar --directory=/usr/local --strip-components=1 --extract --file sail.tar.gz
 
     # TODO: Mac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,6 @@ jobs:
         dnf install -y --enablerepo=devel \
             pkg-config \
             gmp-static \
-            zlib-static \
             curl \
             git \
             make \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,17 +69,6 @@ endif()
 
 # These are the main requirements.
 # Don't use `REQUIRED` so that we can print custom help messages.
-find_package(ZLIB)
-if (NOT ZLIB_FOUND)
-    if (APPLE)
-        message(FATAL_ERROR "Zlib not found. Try 'brew install zlib'.")
-    elseif (UNIX)
-        message(FATAL_ERROR "Zlib not found. Try 'sudo apt install zlib1g-dev' or 'sudo dnf install zlib-devel'.")
-    else()
-        message(FATAL_ERROR "Zlib not found.")
-    endif()
-endif()
-
 option(DOWNLOAD_GMP "Download libgmp and build the library locally instead of using a system installation" OFF)
 if (DOWNLOAD_GMP)
     include(ExternalProject)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.20)
 
 project(sail_riscv)
 
+set(SAIL_REQUIRED_VER 0.19)
+
 # Make users explicitly pick a build type so they don't get
 # surprised when the default gives a very slow emulator.
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -160,7 +162,6 @@ include(CPack)
 add_custom_target(csim DEPENDS riscv_sim_rv32d riscv_sim_rv64d)
 add_custom_target(check DEPENDS generated_model_rv32d generated_model_rv64d)
 
-# TODO: Support static linking.
 # TODO: Add `interpret` target.
 # TODO: Add isabelle target.
 # TODO: Add lem target.

--- a/Makefile.old
+++ b/Makefile.old
@@ -156,12 +156,8 @@ GMP_FLAGS = $(shell pkg-config --cflags gmp)
 # N.B. GMP does not have pkg-config metadata on Ubuntu 18.04 so default to -lgmp
 GMP_LIBS = $(shell pkg-config --libs gmp || echo -lgmp)
 
-# TODO: Remove Zlib when upgrading to Sail 0.19; it is no longer a requirement.
-ZLIB_FLAGS = $(shell pkg-config --cflags zlib)
-ZLIB_LIBS = $(shell pkg-config --libs zlib)
-
-C_FLAGS = -I $(SAIL_LIB_DIR) -I c_emulator $(GMP_FLAGS) $(ZLIB_FLAGS) $(SOFTFLOAT_FLAGS)
-C_LIBS  = $(GMP_LIBS) $(ZLIB_LIBS) $(SOFTFLOAT_LIBS)
+C_FLAGS = -I $(SAIL_LIB_DIR) -I c_emulator $(GMP_FLAGS) $(SOFTFLOAT_FLAGS)
+C_LIBS  = $(GMP_LIBS) $(SOFTFLOAT_LIBS)
 
 # SAIL_FLAGS = -dtc_verbose 4
 

--- a/Makefile.old
+++ b/Makefile.old
@@ -124,7 +124,7 @@ SAIL_RMEM_SRCS = $(addprefix model/,$(SAIL_ARCH_SRCS) $(SAIL_RMEM_INST_SRCS) $(S
 SAIL_RVFI_SRCS = $(addprefix model/,$(SAIL_ARCH_RVFI_SRCS) $(SAIL_SEQ_INST_SRCS) $(RVFI_STEP_SRCS))
 SAIL_COQ_SRCS  = $(addprefix model/,$(SAIL_ARCH_SRCS) $(SAIL_SEQ_INST_SRCS) $(SAIL_OTHER_SRCS) $(SAIL_OTHER_COQ_SRCS))
 
-SAIL_FLAGS += --require-version 0.18
+SAIL_FLAGS += --require-version 0.19
 SAIL_FLAGS += --strict-var
 SAIL_FLAGS += -dno_cast
 SAIL_DOC_FLAGS ?= -doc_embed plain

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ ./build_simulators.sh
 
 will build the simulators in `build/c_emulator/riscv_sim_rv{32,64}d`.
 
-If you get an error message saying `sail: unknown option '--require-version'.` it's because your Sail compiler is too old. You need version 0.18 or later.
+If you get an error message saying `sail: unknown option '--require-version'.` it's because your Sail compiler is too old. You need version 0.19 or later.
 
 By default the RV32D and RV64D emulators are built, without RVFI-DII support.
 You can see a complete list of targets by running `make help` in the

--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -48,7 +48,7 @@ foreach (xlen IN ITEMS 32 64)
             add_dependencies(riscv_sim_${arch} generated_model_${arch})
 
             target_link_libraries(riscv_sim_${arch}
-                PRIVATE softfloat sail_runtime GMP::GMP ZLIB::ZLIB
+                PRIVATE softfloat sail_runtime GMP::GMP
             )
 
             target_include_directories(riscv_sim_${arch}

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -230,7 +230,7 @@ foreach (xlen IN ITEMS 32 64)
                         # deprecated because it is error-prone.
                         --strict-var
                         # Minimum required Sail compiler version.
-                        --require-version 0.18
+                        --require-version ${SAIL_REQUIRED_VER}
                         # Optimisations.
                         -O --Oconstant-fold
                         # Cache Z3 results in z3_problems file to speed up incremental compilation.
@@ -298,6 +298,8 @@ foreach (xlen IN ITEMS 32 64)
                         -o ${CMAKE_CURRENT_BINARY_DIR}
                         # The name of the JSON file.
                         --doc-bundle ${model_doc}
+                        # Minimum required Sail compiler version.
+                        --require-version ${SAIL_REQUIRED_VER}
                         # Input files.
                         ${sail_srcs}
                 )
@@ -321,6 +323,8 @@ foreach (xlen IN ITEMS 32 64)
                         --smt
                         # The prefix of the output files.
                         -o "${CMAKE_CURRENT_BINARY_DIR}/model"
+                        # Minimum required Sail compiler version.
+                        --require-version ${SAIL_REQUIRED_VER}
                         # Input files.
                         ${sail_srcs}
                     COMMAND ${CMAKE_COMMAND} -E touch ${smt_stamp_file}
@@ -353,6 +357,8 @@ foreach (xlen IN ITEMS 32 64)
                         --isa-output-dir ${CMAKE_CURRENT_BINARY_DIR}
                         # The prefix of the output files.
                         -o "lem_${arch}"
+                        # Minimum required Sail compiler version.
+                        --require-version ${SAIL_REQUIRED_VER}
                         # Input files.
                         ${sail_srcs}
                 )
@@ -370,6 +376,8 @@ foreach (xlen IN ITEMS 32 64)
                         --tofrominterp-output-dir ${CMAKE_CURRENT_BINARY_DIR}
                         # The prefix of the output files.
                         -o "rmem_${arch}"
+                        # Minimum required Sail compiler version.
+                        --require-version ${SAIL_REQUIRED_VER}
                         # Input files.
                         ${sail_srcs}
                 )
@@ -384,6 +392,8 @@ foreach (xlen IN ITEMS 32 64)
                         --marshal
                         # The prefix of the output files.
                         -o "rmem_${arch}"
+                        # Minimum required Sail compiler version.
+                        --require-version ${SAIL_REQUIRED_VER}
                         # Input files.
                         ${sail_srcs}
                 )
@@ -412,6 +422,8 @@ foreach (xlen IN ITEMS 32 64)
                         --coq-output-dir ${CMAKE_CURRENT_BINARY_DIR}
                         # The prefix of the output files.
                         -o "coq_${arch}"
+                        # Minimum required Sail compiler version.
+                        --require-version ${SAIL_REQUIRED_VER}
                         # Input files.
                         ${sail_srcs}
                 )
@@ -431,7 +443,7 @@ foreach (xlen IN ITEMS 32 64)
                         ${SAIL_BIN}
                         --lean
                         --memo-z3
-                        --require-version 0.19
+                        --require-version ${SAIL_REQUIRED_VER}
                         --lean-output-dir ${CMAKE_CURRENT_BINARY_DIR}
                         --lean-force-output
                         --lean-noncomputable


### PR DESCRIPTION
There are a whole lot of other small improvements to make once we bump to 0.19 (enabling the theorem provers in CI, when guards for encdec, etc.), but I figured I’d start with the dependency simplification since building the model has been such a big focus lately.