### PR TITLE
Add Support for Zvbb and Zvkb

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -78,6 +78,7 @@ foreach (xlen IN ITEMS 32 64)
                 ${vext_srcs}
                 "riscv_insts_zicbom.sail"
                 "riscv_insts_zicboz.sail"
+                "riscv_insts_zvbb.sail"
             )
 
             if (variant STREQUAL "rmem")

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -116,3 +116,8 @@ enum clause extension = Ext_Svpbmt
 
 // Cycle and Instret Privilege Mode Filtering
 enum clause extension = Ext_Smcntrpmf
+
+// Vector Basic Bit-manipulation
+enum clause extension = Ext_Zvbb
+// Vector Cryptography Bit-manipulation
+enum clause extension = Ext_Zvkb

--- a/model/riscv_insts_zvbb.sail
+++ b/model/riscv_insts_zvbb.sail
@@ -1,0 +1,598 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+function clause extensionEnabled(Ext_Zvbb) = true
+
+function clause extensionEnabled(Ext_Zvkb) = extensionEnabled(Ext_Zvbb)
+
+union clause ast = VANDN_VV : (bits(1), vregidx, vregidx, vregidx)
+
+mapping clause encdec = VANDN_VV(vm, vs1, vs2, vd)
+  <-> 0b000001 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
+  when extensionEnabled(Ext_Zvbb) | extensionEnabled(Ext_Zvkb)
+
+mapping clause assembly = VANDN_VV(vm, vs1, vs2, vd)
+  <-> "vandn.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+function clause execute (VANDN_VV(vm, vs1, vs2, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
+  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then {
+      let op1   = vs1_val[i];
+      let op2   = vs2_val[i];
+      result[i] = (~(op1) & op2);
+    };
+  };
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = zeros();
+  RETIRE_SUCCESS
+}
+
+union clause ast = VANDN_VX : (bits(1), vregidx, regidx, vregidx)
+
+mapping clause encdec = VANDN_VX(vm, vs2, rs1, vd)
+  <-> 0b000001 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
+  when extensionEnabled(Ext_Zvbb) |  extensionEnabled(Ext_Zvkb)
+
+mapping clause assembly = VANDN_VX(vm, vs2, rs1, vd)
+  <-> "vandn.vx" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+
+function clause execute (VANDN_VX(vm, vs2, rs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
+  let rs1_val : bits('m) = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem- 1)) {
+    if mask[i] == bitone then {
+      let op1   = rs1_val;
+      let op2   = vs2_val[i];
+      result[i] = ~(op1) & op2;
+    };
+  };
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = zeros();
+  RETIRE_SUCCESS
+}
+
+union clause ast = VBREV_V : (bits(1), vregidx, vregidx)
+
+mapping clause encdec = VBREV_V(vm, vs2, vd)
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01010 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
+  when extensionEnabled(Ext_Zvbb)
+
+mapping clause assembly = VBREV_V(vm, vs2, vd)
+  <-> "vbrev.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+function clause execute (VBREV_V(vm, vs2, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then {
+      let input  : bits('m) = vs2_val[i];
+      var output : bits('m) = zeros();
+      foreach (j from 0 to (SEW - 1))
+        output[SEW - 1 - j] = input[j];
+      result[i] = output;
+    };
+  };
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = zeros();
+  RETIRE_SUCCESS
+}
+
+union clause ast = VBREV8_V : (bits(1), vregidx, vregidx)
+
+mapping clause encdec = VBREV8_V(vm, vs2, vd)
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01000 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
+  when extensionEnabled(Ext_Zvbb) |  extensionEnabled(Ext_Zvkb)
+
+mapping clause assembly = VBREV8_V(vm, vs2, vd)
+  <-> "vbrev8.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+function clause execute (VBREV8_V(vm, vs2, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : bits('n)= read_vmask(num_elem, vm, zvreg);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then {
+      let input  : bits('m) = vs2_val[i];
+      var output : bits('m) = zeros();
+      foreach (j from 0 to (SEW - 8) by 8)
+        output[j+7..j] = reverse_bits_in_byte(input[j+7..j]);
+      result[i] = output;
+    };
+  };
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = zeros();
+  RETIRE_SUCCESS
+}
+
+union clause ast = VREV8_V : (bits(1), vregidx, vregidx)
+
+mapping clause encdec = VREV8_V(vm, vs2, vd)
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01001 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
+  when extensionEnabled(Ext_Zvbb) |  extensionEnabled(Ext_Zvkb)
+
+mapping clause assembly = VREV8_V(vm, vs2, vd)
+  <-> "vrev8.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+function clause execute (VREV8_V(vm, vs2, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then {
+      let input  : bits('m) = vs2_val[i];
+      var output : bits('m) = zeros();
+      foreach (j from 0 to (SEW - 8) by 8)
+        output[(j + 7)..j] = input[(SEW - j - 1) .. (SEW - j - 8)];
+      result[i] = output;
+    };
+  };
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = zeros();
+  RETIRE_SUCCESS
+}
+
+union clause ast = VCLZ_V : (bits(1), vregidx, vregidx)
+
+mapping clause encdec = VCLZ_V (vm, vs2, vd)
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01100 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
+  when extensionEnabled(Ext_Zvbb)
+
+mapping clause assembly = VCLZ_V (vm, vs2, vd)
+  <-> "vclz.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+
+function clause execute (VCLZ_V(vm, vs2, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then {
+      let clz = count_leading_zeros(vs2_val[i]);
+      result[i] = to_bits('m, clz);
+    };
+  };
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = zeros();
+  RETIRE_SUCCESS
+}
+
+union clause ast = VCTZ_V : (bits(1), vregidx, vregidx)
+
+mapping clause encdec = VCTZ_V (vm, vs2, vd)
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01101 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
+  when extensionEnabled(Ext_Zvbb)
+
+mapping clause assembly = VCTZ_V (vm, vs2, vd)
+  <-> "vctz.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+
+function clause execute (VCTZ_V(vm, vs2, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then {
+      let ctz = count_trailing_zeros(vs2_val[i]);
+      result[i] = to_bits('m, ctz);
+    };
+  };
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = zeros();
+  RETIRE_SUCCESS
+}
+
+union clause ast = VCPOP_V : (bits(1), vregidx, vregidx)
+
+mapping clause encdec = VCPOP_V (vm, vs2, vd)
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01110 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
+  when extensionEnabled(Ext_Zvbb)
+
+mapping clause assembly = VCPOP_V (vm, vs2, vd)
+  <-> "vcpop.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ maybe_vmask(vm)
+
+function clause execute (VCPOP_V(vm, vs2, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then {
+      foreach (j from 0 to (SEW - 1)) {
+        if vs2_val[i][j] == bitone then {
+          result[i] = result[i] + 1;
+        };
+      }
+    };
+  };
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = zeros();
+  RETIRE_SUCCESS
+}
+
+union clause ast = VROL_VV : (bits(1), vregidx, vregidx, vregidx)
+
+mapping clause encdec = VROL_VV(vm, vs1, vs2, vd)
+  <-> 0b010101 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
+  when extensionEnabled(Ext_Zvbb) |  extensionEnabled(Ext_Zvkb)
+
+mapping clause assembly = VROL_VV(vm, vs1, vs2, vd)
+ <-> "vrol.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+function clause execute (VROL_VV(vm, vs1, vs2, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
+  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then
+      result[i] = rotate_bits_left(vs2_val[i], (vs1_val[i] & (to_bits('m, SEW - 1))));
+  };
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = zeros();
+  RETIRE_SUCCESS
+}
+
+union clause ast = VROL_VX : (bits(1), vregidx, regidx, vregidx)
+
+mapping clause encdec = VROL_VX(vm, vs2, rs1, vd)
+  <-> 0b010101 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
+  when extensionEnabled(Ext_Zvbb) |  extensionEnabled(Ext_Zvkb)
+
+mapping clause assembly = VROL_VX(vm, vs2, rs1, vd)
+ <-> "vrol.vx" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+
+function clause execute (VROL_VX(vm, vs2, rs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
+  let rs1_val : bits('m) = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then
+      result[i] = rotate_bits_left(vs2_val[i], (rs1_val) & to_bits('m, SEW - 1));
+  };
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = zeros();
+  RETIRE_SUCCESS
+}
+
+union clause ast = VROR_VV : (bits(1), vregidx, vregidx, vregidx)
+
+mapping clause encdec = VROR_VV(vm, vs1, vs2, vd)
+  <-> 0b010100 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
+  when extensionEnabled(Ext_Zvbb) |  extensionEnabled(Ext_Zvkb)
+
+mapping clause assembly = VROR_VV(vm, vs1, vs2, vd)
+ <-> "vror.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+function clause execute (VROR_VV(vm, vs1, vs2, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
+  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then
+      result[i] = rotate_bits_right(vs2_val[i], (vs1_val[i] & (to_bits('m, SEW - 1))));
+  };
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = zeros();
+  RETIRE_SUCCESS
+}
+
+union clause ast = VROR_VX : (bits(1), vregidx, regidx, vregidx)
+
+mapping clause encdec = VROR_VX(vm, vs2, rs1, vd)
+  <-> 0b010100 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
+  when extensionEnabled(Ext_Zvbb) |  extensionEnabled(Ext_Zvkb)
+
+mapping clause assembly = VROR_VX(vm, vs2, rs1, vd)
+ <-> "vror.vx" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1)^ maybe_vmask(vm)
+
+function clause execute (VROR_VX(vm, vs2, rs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
+  let rs1_val : bits('m) = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then
+      result[i] = rotate_bits_right(vs2_val[i], (rs1_val & to_bits('m, SEW - 1)));
+  };
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = zeros();
+  RETIRE_SUCCESS
+}
+
+union clause ast = VROR_VI : (bits(1), vregidx, bits(5), vregidx)
+
+mapping clause encdec = VROR_VI(vm, vs2, uimm, vd)
+  <-> 0b010100 @ vm @ encdec_vreg(vs2) @ uimm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
+  when extensionEnabled(Ext_Zvbb) |  extensionEnabled(Ext_Zvkb)
+
+mapping clause assembly = VROR_VI(vm, vs2, uimm, vd)
+ <-> "vror.vi" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(uimm) ^ maybe_vmask(vm)
+
+function clause execute (VROR_VI(vm, vs2, uimm, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val   : bits('n) = read_vmask(num_elem, vm, zvreg);
+  let uimm_val : bits('m) = zero_extend(uimm);
+  let vs2_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val   : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then
+      result[i] = rotate_bits_right(vs2_val[i], (uimm_val & to_bits('m, SEW - 1)));
+  };
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  vstart = zeros();
+  RETIRE_SUCCESS
+}
+
+union clause ast = VWSLL_VV : (bits(1), vregidx, vregidx, vregidx)
+
+mapping clause encdec = VWSLL_VV (vm, vs2, vs1, vd)
+  <-> 0b110101 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
+  when extensionEnabled(Ext_Zvbb)
+
+mapping clause assembly = VWSLL_VV (vm, vs2, vs1, vd)
+  <-> "vwsll.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ sep() ^ maybe_vmask(vm)
+
+function clause execute (VWSLL_VV(vm, vs2, vs1, vd)) = {
+  let SEW            = get_sew();
+  let LMUL_pow       = get_lmul_pow();
+  let num_elem       = get_num_elem(LMUL_pow, SEW);
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val      : bits('n) = read_vmask(num_elem, vm, zvreg);
+  let vs1_val_vec : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val_vec : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val      : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+
+  let (initial_result, mask)  = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then {
+      let SEW_widen_bits = to_bits(SEW_widen, 'o);
+      let vs1_val : bits('o) = zero_extend(vs1_val_vec[i]);
+      let vs2_val : bits('o) = zero_extend(vs2_val_vec[i]);
+      result[i] = vs2_val << (vs1_val & zero_extend(SEW_widen_bits - 1));
+    };
+  };
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  vstart = zeros();
+  RETIRE_SUCCESS
+}
+
+union clause ast = VWSLL_VX : (bits(1), vregidx, regidx, vregidx)
+
+mapping clause encdec = VWSLL_VX (vm, vs2, rs1, vd)
+  <-> 0b110101 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
+  when extensionEnabled(Ext_Zvbb)
+
+mapping clause assembly = VWSLL_VX (vm, vs2, rs1, vd)
+  <-> "vwsll.vx" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
+
+function clause execute (VWSLL_VX(vm, vs2, rs1, vd)) = {
+  let SEW            = get_sew();
+  let LMUL_pow       = get_lmul_pow();
+  let num_elem       = get_num_elem(LMUL_pow, SEW);
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val      : bits('n) = read_vmask(num_elem, vm, zvreg);
+  let rs1_val     : bits('o) = zero_extend(get_scalar(rs1, SEW));
+  let vs2_val_vec : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val      : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+
+  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then {
+      let SEW_widen_bits = to_bits(SEW_widen, 'o);
+      let vs2_val : bits('o) = zero_extend(vs2_val_vec[i]);
+      result[i] = vs2_val << (rs1_val & zero_extend(SEW_widen_bits - 1));
+    };
+  };
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  vstart = zeros();
+  RETIRE_SUCCESS
+}
+
+union clause ast = VWSLL_VI : (bits(1), vregidx, bits(5), vregidx)
+
+mapping clause encdec = VWSLL_VI (vm, vs2, uimm, vd)
+  <-> 0b110101 @ vm @ encdec_vreg(vs2) @ uimm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
+  when extensionEnabled(Ext_Zvbb)
+
+mapping clause assembly = VWSLL_VI (vm, vs2, uimm, vd)
+  <-> "vwsll.vi" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(uimm) ^ sep() ^ maybe_vmask(vm)
+
+function clause execute (VWSLL_VI(vm, vs2, uimm, vd)) = {
+  let SEW            = get_sew();
+  let LMUL_pow       = get_lmul_pow();
+  let num_elem       = get_num_elem(LMUL_pow, SEW);
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val      : bits('n) = read_vmask(num_elem, vm, zvreg);
+  let uimm_val    : bits('o) = zero_extend(uimm);
+  let vs2_val_vec : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val      : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+
+  let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == bitone then {
+        let SEW_widen_bits = to_bits(SEW_widen, 'o);
+        let vs2_val : bits('o) = zero_extend(vs2_val_vec[i]);
+        result[i] = vs2_val << (uimm_val & zero_extend(SEW_widen_bits - 1));
+    };
+  };
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  vstart = zeros();
+  RETIRE_SUCCESS
+}


### PR DESCRIPTION
Add support for Zvbb and Zvkb with following instructions:

```
vandn.[vv,vx]
vbrev.v
vbrev8.v
vrev8.v
vclz.v
vctz.v
vcpop.v
vrol.[vv,vx]
vror.[vv,vx,vi]
vwsll.[vv,vx,vi]
```

CI will fail due to the use of `when`, which is unsupported in Sail versions below 0.19.

Based on #558 and #236

The instruction set for the Zvbb (this extension is a superset of the Zvkb extension) and Zvkb extensions has evolved over time. 
* This PR makes sure that the instructions are assigned to their corresponding extension
* Adds a missing instruction
* Simplifies the code

Code was tested with the risc-v vector test suite with (VLEN=512 and ELEN=64)

Once we can configure Sail, we can add the Zvbb and Zvbk option to enable or disable accordingly.