### PR TITLE
Add enable-experimental flag for unratified extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Supported RISC-V ISA features
 - Sv32, Sv39, Sv48 and Sv57 page-based virtual-memory systems
 - Physical Memory Protection (PMP)
 
+<!-- Uncomment the following section when unratified extensions are added
+The following unratified extensions are supported and can be enabled using the `--enable-experimental-extensions` flag:
+-  -->
+
 **For a list of unsupported extensions and features, see the [Extension Roadmap](https://github.com/riscv/sail-riscv/wiki/Extension-Roadmap).**
 
 Example RISC-V instruction specifications

--- a/c_emulator/riscv_platform.cpp
+++ b/c_emulator/riscv_platform.cpp
@@ -71,6 +71,11 @@ mach_bits plat_htif_tohost(unit)
   return rv_htif_tohost;
 }
 
+bool sys_enable_experimental_extensions(unit)
+{
+  return rv_enable_experimental_extensions;
+}
+
 unit memea(mach_bits, sail_int)
 {
   return UNIT;

--- a/c_emulator/riscv_platform.h
+++ b/c_emulator/riscv_platform.h
@@ -17,6 +17,8 @@ unit plat_term_write(mach_bits);
 
 mach_bits plat_htif_tohost(unit);
 
+bool sys_enable_experimental_extensions(unit);
+
 unit memea(mach_bits, sail_int);
 
 #ifdef __cplusplus

--- a/c_emulator/riscv_platform_impl.cpp
+++ b/c_emulator/riscv_platform_impl.cpp
@@ -19,6 +19,8 @@ uint64_t rv_16_random_bits(void)
 
 uint64_t rv_htif_tohost = UINT64_C(0x80001000);
 
+bool rv_enable_experimental_extensions = false;
+
 int term_fd = 1; // set during startup
 void plat_term_write_impl(char c)
 {

--- a/c_emulator/riscv_platform_impl.h
+++ b/c_emulator/riscv_platform_impl.h
@@ -9,6 +9,8 @@ extern uint64_t rv_16_random_bits(void);
 
 extern uint64_t rv_htif_tohost;
 
+extern bool rv_enable_experimental_extensions;
+
 extern FILE *trace_log;
 extern int term_fd;
 void plat_term_write_impl(char c);

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -33,6 +33,7 @@ enum {
   OPT_TRACE_OUTPUT = 1000,
   OPT_PRINT_CONFIG,
   OPT_SAILCOV,
+  OPT_ENABLE_EXPERIMENTAL_EXTENSIONS,
 };
 
 static bool do_show_times = false;
@@ -92,26 +93,28 @@ char *sailcov_file = NULL;
 #endif
 
 static struct option options[] = {
-    {"device-tree-blob",      required_argument, 0, 'b'             },
-    {"terminal-log",          required_argument, 0, 't'             },
-    {"show-times",            required_argument, 0, 'p'             },
-    {"report-arch",           no_argument,       0, 'a'             },
-    {"test-signature",        required_argument, 0, 'T'             },
-    {"signature-granularity", required_argument, 0, 'g'             },
+    {"device-tree-blob",               required_argument, 0, 'b'             },
+    {"terminal-log",                   required_argument, 0, 't'             },
+    {"show-times",                     required_argument, 0, 'p'             },
+    {"report-arch",                    no_argument,       0, 'a'             },
+    {"test-signature",                 required_argument, 0, 'T'             },
+    {"signature-granularity",          required_argument, 0, 'g'             },
 #ifdef RVFI_DII
-    {"rvfi-dii",              required_argument, 0, 'r'             },
+    {"rvfi-dii",                       required_argument, 0, 'r'             },
 #endif
-    {"help",                  no_argument,       0, 1               },
-    {"config",                required_argument, 0, 'c'             },
-    {"print-default-config",  no_argument,       0, OPT_PRINT_CONFIG},
-    {"trace",                 optional_argument, 0, 'v'             },
-    {"no-trace",              optional_argument, 0, 'V'             },
-    {"trace-output",          required_argument, 0, OPT_TRACE_OUTPUT},
-    {"inst-limit",            required_argument, 0, 'l'             },
+    {"help",                           no_argument,       0, 1               },
+    {"config",                         required_argument, 0, 'c'             },
+    {"print-default-config",           no_argument,       0, OPT_PRINT_CONFIG},
+    {"trace",                          optional_argument, 0, 'v'             },
+    {"no-trace",                       optional_argument, 0, 'V'             },
+    {"trace-output",                   required_argument, 0, OPT_TRACE_OUTPUT},
+    {"inst-limit",                     required_argument, 0, 'l'             },
+    {"enable-experimental-extensions", no_argument,       0,
+     OPT_ENABLE_EXPERIMENTAL_EXTENSIONS                                      },
 #ifdef SAILCOV
-    {"sailcov-file",          required_argument, 0, OPT_SAILCOV     },
+    {"sailcov-file",                   required_argument, 0, OPT_SAILCOV     },
 #endif
-    {0,                       0,                 0, 0               }
+    {0,                                0,                 0, 0               }
 };
 
 static void print_usage(const char *argv0, int ec)
@@ -269,6 +272,10 @@ static int process_args(int argc, char **argv)
       insn_limit = val;
       break;
     }
+    case OPT_ENABLE_EXPERIMENTAL_EXTENSIONS:
+      fprintf(stderr, "enabling unratified extensions.\n");
+      rv_enable_experimental_extensions = true;
+      break;
 #ifdef SAILCOV
     case OPT_SAILCOV:
       sailcov_file = strdup(optarg);

--- a/model/prelude.sail
+++ b/model/prelude.sail
@@ -238,3 +238,6 @@ type max_mem_access : Int = 4096
 
 // Type used for memory access widths. Zero byte accesses are not allowed.
 type mem_access_width = range(1, max_mem_access)
+
+// Enable unratified extensions
+val sys_enable_experimental_extensions = pure "sys_enable_experimental_extensions" : unit -> bool


### PR DESCRIPTION
Per discussion at today's meeting, this adds a command line switch to enable unratified/experimental extensions. Each unratified extension should also have its own enable switch using the standard config system, so enabling an unratified extension will require both enabling it in the configuration file and passing the `--enable-experimental` flag.