### PR TITLE
Fix linker script for GNU ld

### DIFF
--- a/test/first_party/src/common/link.ld
+++ b/test/first_party/src/common/link.ld
@@ -13,9 +13,9 @@ MEMORY
 
 SECTIONS
 {
-  /* MMIO devices. PMA must make this uncacheable (doesn't
-     matter in Sail because there are no caches). */
-  .bss.mmio : { *(.bss.mmio) } >if_mmio
+  /* Go to the start of memory, otherwise GNU ld (but not lld) will
+  try to start allocating at 0. */
+  . = ORIGIN(if_ram);
 
   /* Stack first so in theory we get stack overlow detection. */
   .stack ALIGN(16) (NOLOAD) : {
@@ -47,4 +47,8 @@ SECTIONS
   /* Thread-local data */
   .tdata : { *(.tdata) } >if_ram
   .tbss : { *(.tbss) } >if_ram
+
+  /* MMIO devices. PMA must make this uncacheable (doesn't
+     matter in Sail because there are no caches). */
+  .bss.mmio : { *(.bss.mmio) } >if_mmio
 }


### PR DESCRIPTION
It seems like lld and ld interpret linker scripts slightly differently. `lld` would put `.bss.mmio` in `if_mmio`, and then when you put `.stack` in `if_ram` it would sensibly reset put it at the start of `if_ram`. However `ld` is a bit dumber and just continues in `if_mmio` leading to overflow.

`ld` also requires manually skipping to the start of `if_ram`, otherwise it tries to allocate starting at 0.

Fixes #799