### PR TITLE
Explicitly request C++17 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.20)
 
 project(sail_riscv)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED  ON)
 set(SAIL_REQUIRED_VER 0.19)
 
 # Make users explicitly pick a build type so they don't get

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.20)
 project(sail_riscv)
 
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED  ON)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(SAIL_REQUIRED_VER 0.19)
 
 # Make users explicitly pick a build type so they don't get

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.20)
 project(sail_riscv)
 
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(SAIL_REQUIRED_VER 0.19)
 
 # Make users explicitly pick a build type so they don't get


### PR DESCRIPTION
Not all compilers default to C++17, so we need to tell CMake to request c++17 (for std::optional).

Fixes https://github.com/riscv/sail-riscv/issues/812
Needed since https://github.com/riscv/sail-riscv/pull/784