### PR TITLE
Capitalize Physaddr and Virtaddr constructors

### DIFF
--- a/model/prelude_mem.sail
+++ b/model/prelude_mem.sail
@@ -80,7 +80,7 @@ instantiation sail_mem_write with
 
 val write_ram : forall 'n, 0 < 'n <= max_mem_access. (write_kind, physaddr, int('n), bits(8 * 'n), mem_meta) -> bool
 
-function write_ram(wk, physaddr(addr), width, data, meta) = {
+function write_ram(wk, Physaddr(addr), width, data, meta) = {
   let request : Mem_write_request('n, 64, physaddrbits, unit, RISCV_strong_access) = struct {
     access_kind = match wk {
       Write_plain => AK_explicit(struct { variety = AV_plain, strength = AS_normal }),
@@ -114,13 +114,13 @@ function write_ram(wk, physaddr(addr), width, data, meta) = {
 }
 
 val write_ram_ea : forall 'n, 0 < 'n <= max_mem_access. (write_kind, physaddr, int('n)) -> unit
-function write_ram_ea(wk, physaddr(addr), width) = ()
+function write_ram_ea(wk, Physaddr(addr), width) = ()
 
 instantiation sail_mem_read with
   pa_bits = physaddrbits_zero_extend
 
 val read_ram : forall 'n, 0 < 'n <= max_mem_access.  (read_kind, physaddr, int('n), bool) -> (bits(8 * 'n), mem_meta)
-function read_ram(rk, physaddr(addr), width, read_meta) = {
+function read_ram(rk, Physaddr(addr), width, read_meta) = {
   let meta = if read_meta then __ReadRAM_Meta(addr, width) else default_meta;
   let request : Mem_read_request('n, 64, physaddrbits, unit, RISCV_strong_access) = struct {
     access_kind = match rk {

--- a/model/prelude_mem_addrtype.sail
+++ b/model/prelude_mem_addrtype.sail
@@ -13,13 +13,13 @@ type physaddrbits = bits(physaddrbits_len)
 
 let physaddrbits_len = sizeof(physaddrbits_len)
 
-newtype physaddr = physaddr : physaddrbits
-newtype virtaddr = virtaddr : xlenbits
+newtype physaddr = Physaddr : physaddrbits
+newtype virtaddr = Virtaddr : xlenbits
 
-function physaddr_bits(physaddr(paddr) : physaddr) -> physaddrbits = paddr
+function physaddr_bits(Physaddr(paddr) : physaddr) -> physaddrbits = paddr
 
-function virtaddr_bits(virtaddr(vaddr) : virtaddr) -> xlenbits = vaddr
+function virtaddr_bits(Virtaddr(vaddr) : virtaddr) -> xlenbits = vaddr
 
-function sub_virtaddr_xlenbits(virtaddr(addr) : virtaddr, offset : xlenbits) -> virtaddr = virtaddr(addr - offset)
+function sub_virtaddr_xlenbits(Virtaddr(addr) : virtaddr, offset : xlenbits) -> virtaddr = Virtaddr(addr - offset)
 
 overload operator - = { sub_virtaddr_xlenbits }

--- a/model/riscv_addr_checks.sail
+++ b/model/riscv_addr_checks.sail
@@ -18,7 +18,7 @@ type ext_fetch_addr_error = unit
  *           any address translation errors are reported for pc, not the returned value.
  */
 function ext_fetch_check_pc(start_pc : xlenbits, pc : xlenbits) -> Ext_FetchAddr_Check(ext_fetch_addr_error) =
-  Ext_FetchAddr_OK(virtaddr(pc))
+  Ext_FetchAddr_OK(Virtaddr(pc))
 
 function ext_handle_fetch_check_error(err : ext_fetch_addr_error) -> unit =
   ()
@@ -38,11 +38,11 @@ type ext_control_addr_error = unit
 
 /* the control address is derived from a non-PC register, e.g. in JALR */
 function ext_control_check_addr(pc : xlenbits) -> Ext_ControlAddr_Check(ext_control_addr_error) =
-  Ext_ControlAddr_OK(virtaddr(pc))
+  Ext_ControlAddr_OK(Virtaddr(pc))
 
 /* the control address is derived from the PC register, e.g. in JAL */
 function ext_control_check_pc(pc : xlenbits) -> Ext_ControlAddr_Check(ext_control_addr_error) =
-  Ext_ControlAddr_OK(virtaddr(pc))
+  Ext_ControlAddr_OK(Virtaddr(pc))
 
 function ext_handle_control_check_error(err : ext_control_addr_error) -> unit =
   ()
@@ -56,7 +56,7 @@ type ext_data_addr_error = unit
    Extensions might override and add additional checks. */
 function ext_data_get_addr(base : regidx, offset : xlenbits, acc : AccessType(ext_access_type), width : mem_access_width)
          -> Ext_DataAddr_Check(ext_data_addr_error) =
-  let addr = virtaddr(X(base) + offset) in
+  let addr = Virtaddr(X(base) + offset) in
   Ext_DataAddr_OK(addr)
 
 function ext_handle_data_check_error(err : ext_data_addr_error) -> unit =

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -649,7 +649,7 @@ mapping clause encdec = EBREAK()
   <-> 0b000000000001 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
 
 function clause execute EBREAK() = {
-  handle_mem_exception(virtaddr(PC), E_Breakpoint());
+  handle_mem_exception(Virtaddr(PC), E_Breakpoint());
   RETIRE_FAIL
 }
 

--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -35,7 +35,7 @@
  * per the platform memory map.
  */
 
-function is_aligned_addr forall 'n. (physaddr(addr) : physaddr, width : int('n)) -> bool =
+function is_aligned_addr forall 'n. (Physaddr(addr) : physaddr, width : int('n)) -> bool =
   unsigned(addr) % width == 0
 
 function read_kind_of_flags (aq : bool, rl : bool, res : bool) -> option(read_kind) =
@@ -119,7 +119,7 @@ function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (
 
 $ifdef RVFI_DII
 val rvfi_read : forall 'n, 'n > 0. (physaddr, int('n), MemoryOpResult((bits(8 * 'n), mem_meta))) -> unit
-function rvfi_read (physaddr(addr), width, result) = {
+function rvfi_read (Physaddr(addr), width, result) = {
   rvfi_mem_data[rvfi_mem_addr] = zero_extend(addr);
   rvfi_mem_data_present = true;
   match result {
@@ -133,7 +133,7 @@ function rvfi_read (physaddr(addr), width, result) = {
 }
 $else
 val rvfi_read : forall 'n, 'n > 0. (physaddr, int('n), MemoryOpResult((bits(8 * 'n), mem_meta))) -> unit
-function rvfi_read (physaddr(addr), width, result) = ()
+function rvfi_read (Physaddr(addr), width, result) = ()
 $endif
 
 val mem_read      : forall 'n, 0 < 'n <= max_mem_access . (AccessType(ext_access_type), physaddr, int('n), bool, bool, bool)       -> MemoryOpResult(bits(8 * 'n))
@@ -174,7 +174,7 @@ function mem_write_ea (addr, width, aq, rl, con) =
 
 $ifdef RVFI_DII
 val rvfi_write : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), mem_meta, MemoryOpResult(bool)) -> unit
-function rvfi_write (physaddr(addr), width, value, meta, result) = {
+function rvfi_write (Physaddr(addr), width, value, meta, result) = {
   rvfi_mem_data[rvfi_mem_addr] = zero_extend(addr);
   rvfi_mem_data_present = true;
   match result {
@@ -191,7 +191,7 @@ function rvfi_write (physaddr(addr), width, value, meta, result) = {
 }
 $else
 val rvfi_write : forall 'n, 'n > 0. (physaddr, int('n), bits(8 * 'n), mem_meta, MemoryOpResult(bool)) -> unit
-function rvfi_write (physaddr(addr), width, value, meta, result) = ()
+function rvfi_write (Physaddr(addr), width, value, meta, result) = ()
 $endif
 
 // only used for actual memory regions, to avoid MMIO effects

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -65,7 +65,7 @@ function plat_htif_tohost () = to_bits(physaddrbits_len, elf_tohost ())
 
 /* Physical memory map predicates */
 
-function within_phys_mem forall 'n, 'n <= max_mem_access. (physaddr(addr) : physaddr, width : int('n)) -> bool = {
+function within_phys_mem forall 'n, 'n <= max_mem_access. (Physaddr(addr) : physaddr, width : int('n)) -> bool = {
   /* To avoid overflow issues when physical memory extends to the end
    * of the addressable range, we need to perform address bound checks
    * on unsigned unbounded integers.
@@ -93,7 +93,7 @@ function within_phys_mem forall 'n, 'n <= max_mem_access. (physaddr(addr) : phys
   }
 }
 
-function within_clint forall 'n, 0 < 'n <= max_mem_access . (physaddr(addr) : physaddr, width : int('n)) -> bool = {
+function within_clint forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : physaddr, width : int('n)) -> bool = {
   /* To avoid overflow issues when physical memory extends to the end
    * of the addressable range, we need to perform address bound checks
    * on unsigned unbounded integers.
@@ -105,10 +105,10 @@ function within_clint forall 'n, 0 < 'n <= max_mem_access . (physaddr(addr) : ph
   & (addr_int + sizeof('n)) <= (clint_base_int + clint_size_int)
 }
 
-function within_htif_writable forall 'n, 0 < 'n <= max_mem_access . (physaddr(addr) : physaddr, width : int('n)) -> bool =
+function within_htif_writable forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : physaddr, width : int('n)) -> bool =
     plat_htif_tohost() == addr | (plat_htif_tohost() + 4 == addr & width == 4)
 
-function within_htif_readable forall 'n, 0 < 'n <= max_mem_access . (physaddr(addr) : physaddr, width : int('n)) -> bool =
+function within_htif_readable forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : physaddr, width : int('n)) -> bool =
     plat_htif_tohost() == addr | (plat_htif_tohost() + 4 == addr & width == 4)
 
 /* CLINT (Core Local Interruptor), based on Spike. */
@@ -144,7 +144,7 @@ let MTIME_BASE       : physaddrbits = zero_extend(0x0bff8)
 let MTIME_BASE_HI    : physaddrbits = zero_extend(0x0bffc)
 
 val clint_load : forall 'n, 'n > 0. (AccessType(ext_access_type), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
-function clint_load(t, physaddr(addr), width) = {
+function clint_load(t, Physaddr(addr), width) = {
   let addr = addr - plat_clint_base ();
   /* FIXME: For now, only allow exact aligned access. */
   if addr == MSIP_BASE & ('n == 8 | 'n == 4)
@@ -214,7 +214,7 @@ function clint_dispatch() -> unit = {
 }
 
 val clint_store: forall 'n, 'n > 0. (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
-function clint_store(physaddr(addr), width, data) = {
+function clint_store(Physaddr(addr), width, data) = {
   let addr = addr - plat_clint_base ();
   if addr == MSIP_BASE & ('n == 8 | 'n == 4) then {
     if   get_config_print_platform()
@@ -315,7 +315,7 @@ function reset_htif () -> unit = {
  */
 
 val htif_load : forall 'n, 'n > 0. (AccessType(ext_access_type), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
-function htif_load(t, physaddr(paddr), width) = {
+function htif_load(t, Physaddr(paddr), width) = {
   if   get_config_print_platform()
   then print_platform("htif[" ^ BitStr(paddr) ^ "] -> " ^ BitStr(htif_tohost));
   /* FIXME: For now, only allow the expected access widths. */
@@ -333,7 +333,7 @@ function htif_load(t, physaddr(paddr), width) = {
 }
 
 val htif_store: forall 'n, 0 < 'n <= 8. (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
-function htif_store(physaddr(paddr), width, data) = {
+function htif_store(Physaddr(paddr), width, data) = {
   if   get_config_print_platform()
   then print_platform("htif[" ^ BitStr(paddr) ^ "] <- " ^ BitStr(data));
   /* Store the written value so that we can ack it later. */

--- a/model/riscv_pmp_control.sail
+++ b/model/riscv_pmp_control.sail
@@ -39,7 +39,7 @@ function pmpRangeMatch(
   else    PMP_PartialMatch
 
 function pmpMatchAddr(
-  physaddr(addr) : physaddr,
+  Physaddr(addr) : physaddr,
   width : xlenbits,
   ent : Pmpcfg_ent,
   pmpaddr : xlenbits,

--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -42,7 +42,7 @@ function step(step_no : int) -> bool = {
           },
           /* standard error */
           F_Error(e, addr) => {
-            handle_mem_exception(virtaddr(addr), e);
+            handle_mem_exception(Virtaddr(addr), e);
             (RETIRE_FAIL, false)
           },
           /* non-error cases: */

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -290,7 +290,7 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
   }
 }
 
-function handle_mem_exception(virtaddr(addr) : virtaddr, e : ExceptionType) -> unit = {
+function handle_mem_exception(Virtaddr(addr) : virtaddr, e : ExceptionType) -> unit = {
   let t : sync_exception = struct { trap    = e,
                                     excinfo = Some(addr),
                                     ext     = None() } in

--- a/model/riscv_vmem.sail
+++ b/model/riscv_vmem.sail
@@ -98,7 +98,7 @@ function pt_walk(
   // pte_addr of 56 bits and physaddr of 34 bits (because you can't
   // use Sv39+ on RV32).
   assert(sv_width == 32 | xlen == 64);
-  let pte_addr = physaddr(zero_extend(pte_addr));
+  let pte_addr = Physaddr(zero_extend(pte_addr));
 
   // Read this-level PTE from mem
   match read_pte(pte_addr, 2 ^ log_pte_size_bytes) {
@@ -360,7 +360,7 @@ function translateAddr(
 
   let mode = translationMode(effPriv);
 
-  if mode == Bare then return TR_Address(physaddr(zero_extend(virtaddr_bits(vAddr))), init_ext_ptw);
+  if mode == Bare then return TR_Address(Physaddr(zero_extend(virtaddr_bits(vAddr))), init_ext_ptw);
 
   // Sv39 -> 39, etc.
   let sv_width = satp_mode_width(mode);
@@ -394,7 +394,7 @@ function translateAddr(
         // On RV64 paddr can be 34 or 56 bits, so we zero extend to 64.
         // On RV32 paddr can only be 34 bits. Sail knows this due to
         // the assertion above.
-        TR_Address(physaddr(zero_extend(paddr)), ext_ptw)
+        TR_Address(Physaddr(zero_extend(paddr)), ext_ptw)
       },
       TR_Failure(f, ext_ptw)  => TR_Failure(translationException(ac, f), ext_ptw)
     }


### PR DESCRIPTION
As discussed in #779, this makes `Physaddr` and `Virtaddr` consistent with `Regidx`. The type is lowercase and the constructor is capitalized.