### PR TITLE
Add cmake support for Rocq

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,9 @@ add_subdirectory("c_emulator")
 # Old pre-compiled riscv-tests & first-party tests.
 add_subdirectory("test")
 
+# Handwritten support files for provers
+add_subdirectory("handwritten_support")
+
 # Release packaging.
 if (NOT CPACK_GENERATOR)
     if (WINDOWS)

--- a/coq-sail-riscv.opam
+++ b/coq-sail-riscv.opam
@@ -2,34 +2,23 @@ opam-version: "2.0"
 name: "coq-sail-riscv"
 version: "0.5"
 maintainer: "Sail Devs <cl-sail-dev@lists.cam.ac.uk>"
-authors: [
-  "Alasdair Armstrong"
-  "Thomas Bauereiss"
-  "Brian Campbell"
-  "Shaked Flur"
-  "Jonathan French"
-  "Prashanth Mundkur"
-  "Robert Norton"
-  "Christopher Pulte"
-  "Peter Sewell"
-]
-homepage: "https://github.com/rems-project/sail-riscv/"
-bug-reports: "https://github.com/rems-project/sail-riscv/issues"
-license: "BSD3"
-dev-repo: "git+https://github.com/rems-project/sail-riscv.git"
+authors: "Sail RISC-V contributors"
+homepage: "https://github.com/riscv/sail-riscv/"
+bug-reports: "https://github.com/riscv/sail-riscv/issues"
+license: "BSD-2-Clause"
+dev-repo: "git+https://github.com/riscv/sail-riscv.git"
 build: [
-  [make "ARCH=RV64" "riscv_coq_build"]
-  [make "ARCH=RV32" "riscv_coq_build"]
+  ["cmake" "-S" "." "-B" "build" "-DCMAKE_BUILD_TYPE=RelWithDebInfo" "-DDOWNLOAD_GMP=FALSE"]
+  ["cmake" "--build" "build" "--target" "build_rocq_rv64d" "build_rocq_rv32d"]
 ]
-install: [make "riscv_coq_install"]
+install: [
+  ["sh" "-c" "install -d `coqc -where`/user-contrib/Riscv"]
+  ["sh" "-c" "install build/rocq/* `coqc -where`/user-contrib/Riscv"]
+]
 depends: [
-  "ocaml" {>= "4.06.1"}
-  "ocamlfind"
-  "ocamlbuild"
-  "sail"
-  "coq-sail-stdpp"
-  "conf-gmp"
-  "conf-zlib"
+  "sail" {>= "0.19"}
+  "coq-sail-stdpp" {>= "0.19"}
+  "conf-cmake"
 ]
 synopsis:
-  "A model of the RISC-V instruction set architecture in Coq, generated from Sail"
+  "A model of the RISC-V instruction set architecture in Rocq, generated from Sail"

--- a/handwritten_support/CMakeLists.txt
+++ b/handwritten_support/CMakeLists.txt
@@ -1,0 +1,16 @@
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/rocq")
+foreach(basename IN ITEMS "riscv_extras" "mem_metadata")
+    add_custom_command(
+        DEPENDS "${basename}.v"
+        VERBATIM
+        OUTPUT "${CMAKE_BINARY_DIR}/rocq/${basename}.vo"
+        COMMENT "Building Rocq ${basename} file"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND
+            coqc
+            -R "${CMAKE_BINARY_DIR}/rocq" Riscv
+            -o "${CMAKE_BINARY_DIR}/rocq/${basename}.vo"
+            "${basename}.v"
+    )
+endforeach()
+add_custom_target(build_rocq_common DEPENDS "${CMAKE_BINARY_DIR}/rocq/riscv_extras.vo" "${CMAKE_BINARY_DIR}/rocq/mem_metadata.vo")

--- a/handwritten_support/riscv_extras.v
+++ b/handwritten_support/riscv_extras.v
@@ -178,6 +178,7 @@ Definition mult_vec {n} (l : mword n) (r : mword n) : mword (2 * n) := mult_vec 
 
 Definition print_endline (_:string) : unit := tt.
 Definition prerr_endline (_:string) : unit := tt.
+Definition print_string (_ _:string) : unit := tt.
 Definition prerr_string (_:string) : unit := tt.
 Definition putchar {T} (_:T) : unit := tt.
 Require DecimalString.
@@ -195,6 +196,7 @@ Axiom sys_enable_bext : unit -> bool.
 Axiom sys_enable_zicbom : unit -> bool.
 Axiom sys_enable_zicboz : unit -> bool.
 Axiom sys_enable_sstc : unit -> bool.
+Axiom sys_enable_zvkb : unit -> bool.
 Axiom sys_writable_hpm_counters : unit -> mword 32.
 
 Axiom sys_vext_vl_use_ceil : unit -> bool.

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -1,13 +1,13 @@
 foreach (xlen IN ITEMS 32 64)
     foreach (flen IN ITEMS 32 64)
-        foreach (variant IN ITEMS "" "rvfi" "coq" "rmem" "lean")
+        foreach (variant IN ITEMS "" "rvfi" "rocq" "rmem" "lean")
             set(arch "rv${xlen}")
             if (flen EQUAL 32)
                 string(APPEND arch "f")
             else()
                 string(APPEND arch "d")
             endif()
-            if (variant)
+            if (variant STREQUAL "rvfi")
                 string(APPEND arch "_${variant}")
             endif()
 
@@ -185,7 +185,7 @@ foreach (xlen IN ITEMS 32 64)
                 "riscv_step.sail"
             )
 
-            if (variant STREQUAL "coq")
+            if (variant STREQUAL "rocq")
                 list(APPEND sail_step_srcs
                     "riscv_termination.sail"
                 )
@@ -408,29 +408,45 @@ foreach (xlen IN ITEMS 32 64)
                 )
             endif()
 
-            # Build Coq definitions.
-            if (variant STREQUAL "coq")
+            # Build Rocq (formerly Coq) definitions.
+            if (variant STREQUAL "rocq")
                 add_custom_command(
                     DEPENDS ${sail_srcs}
                     VERBATIM
-                    OUTPUT "coq_${arch}.?"
-                    COMMENT "Building Coq definitions from Sail model (${arch})"
+                    OUTPUT "${CMAKE_BINARY_DIR}/rocq/${arch}.v" "${CMAKE_BINARY_DIR}/rocq/${arch}_types.v"
+                    COMMENT "Building Rocq definitions from Sail model (${arch})"
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     COMMAND
                         ${SAIL_BIN}
-                        -dcoq_undef_axioms
+                        --dcoq-undef-axioms
                         --coq
                         --coq-lib riscv_extras
                         --coq-lib mem_metadata
-                        --coq-output-dir ${CMAKE_CURRENT_BINARY_DIR}
+                        --coq-output-dir "${CMAKE_BINARY_DIR}/rocq"
                         # The prefix of the output files.
-                        -o "coq_${arch}"
+                        -o "${arch}"
                         # Minimum required Sail compiler version.
                         --require-version ${SAIL_REQUIRED_VER}
                         # Input files.
                         ${sail_srcs}
                 )
-                add_custom_target(generated_coq_${arch} DEPENDS "coq_${arch}.?")
+                add_custom_command(
+                    DEPENDS build_rocq_common "${CMAKE_BINARY_DIR}/rocq/${arch}.v" "${CMAKE_BINARY_DIR}/rocq/${arch}_types.v"
+                    VERBATIM
+                    OUTPUT "${CMAKE_BINARY_DIR}/rocq/${arch}.vo" "${CMAKE_BINARY_DIR}/rocq/${arch}_types.vo"
+                    COMMENT "Building Rocq definitions from Sail model (${arch})"
+                    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/rocq"
+                    COMMAND
+                        coqc
+                        -R . Riscv
+                        "${arch}_types.v"
+                    COMMAND
+                        coqc
+                        -R . Riscv
+                        "${arch}.v"
+                )
+                add_custom_target(generated_rocq_${arch} DEPENDS "${CMAKE_BINARY_DIR}/rocq/${arch}.v")
+                add_custom_target(build_rocq_${arch} DEPENDS "${CMAKE_BINARY_DIR}/rocq/${arch}.vo")
             endif()
 
             # Build Lean definitions


### PR DESCRIPTION
This includes changing the prover name from Coq to its new name Rocq, updating the opam package file, adding a couple of built-in functions to the handwritten portion, and building the resulting Rocq code.  The output is all gathered in one rocq build directory to keep the namespace manageable and convenient.

It also drops the extra `_variant` from the name of lem/rmem/rocq output, which is rather redundant.

This pull request doesn't include CI.  That will come later once I've sorted out some reasonable caching to avoid rebuilding Rocq too often (or avoid it entirely).