### PR TITLE
Improvements to prelude

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -136,6 +136,7 @@ foreach (xlen IN ITEMS 32 64)
                 "prelude_mem_addrtype.sail"
                 "prelude_mem_metadata.sail"
                 "prelude_mem.sail"
+                "arithmetic.sail"
             )
 
             if (variant STREQUAL "rvfi")

--- a/model/arithmetic.sail
+++ b/model/arithmetic.sail
@@ -1,0 +1,18 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+/* Carry-less multiply. */
+val carryless_mul : forall 'n, 'n > 0. (bits('n), bits('n)) -> bits(2 * 'n)
+function carryless_mul(a, b) = {
+  var result : bits(2 * 'n) = zeros();
+  foreach (i from 0 to ('n - 1)) {
+    if   a[i] == bitone
+    then result = result ^ (zero_extend(b) << i);
+  };
+  result
+}

--- a/model/prelude.sail
+++ b/model/prelude.sail
@@ -191,14 +191,15 @@ function rotatel (v, n) =
 overload operator >>> = {rotate_bits_right, rotater}
 overload operator <<< = {rotate_bits_left, rotatel}
 
-function reverse_bits_in_byte (xs : bits(8)) -> bits(8) = {
-  var ys : bits(8) = zeros();
-  foreach (i from 0 to 7)
-    ys[i] = xs[7-i];
+val reverse_bits : forall 'n, 'n > 0. bits('n) -> bits('n)
+function reverse_bits (xs)  = {
+  var ys : bits('n) = zeros();
+  foreach (i from 0 to ('n - 1))
+    ys[i] = xs['n - 1 - i];
   ys
 }
 
-overload reverse = {reverse_bits_in_byte}
+overload reverse = {reverse_bits}
 
 overload operator / = {quot_positive_round_zero, quot_round_zero}
 overload operator * = {mult_atom, mult_int}

--- a/model/riscv_insts_zbc.sail
+++ b/model/riscv_insts_zbc.sail
@@ -20,12 +20,8 @@ mapping clause assembly = RISCV_CLMUL(rs2, rs1, rd)
   <-> "clmul" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
 function clause execute (RISCV_CLMUL(rs2, rs1, rd)) = {
-  let rs1_val = X(rs1);
-  let rs2_val = X(rs2);
-  var result : xlenbits = zeros();
-  foreach (i from 0 to (xlen_val - 1))
-    if rs2_val[i] == bitone then result = result ^ (rs1_val << i);
-  X(rd) = result;
+  let prod = carryless_mul(X(rs1), X(rs2));
+  X(rd) = prod[xlen - 1 .. 0];
   RETIRE_SUCCESS
 }
 
@@ -40,12 +36,8 @@ mapping clause assembly = RISCV_CLMULH(rs2, rs1, rd)
   <-> "clmulh" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
 function clause execute (RISCV_CLMULH(rs2, rs1, rd)) = {
-  let rs1_val = X(rs1);
-  let rs2_val = X(rs2);
-  var result : xlenbits = zeros();
-  foreach (i from 0 to (xlen_val - 1))
-    if rs2_val[i] == bitone then result = result ^ (rs1_val >> (xlen_val - i));
-  X(rd) = result;
+  let prod = carryless_mul(X(rs1), X(rs2));
+  X(rd) = prod[2 * xlen - 1 .. xlen];
   RETIRE_SUCCESS
 }
 
@@ -60,11 +52,7 @@ mapping clause assembly = RISCV_CLMULR(rs2, rs1, rd)
   <-> "clmulr" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
 function clause execute (RISCV_CLMULR(rs2, rs1, rd)) = {
-  let rs1_val = X(rs1);
-  let rs2_val = X(rs2);
-  var result : xlenbits = zeros();
-  foreach (i from 0 to (xlen_val - 1))
-    if rs2_val[i] == bitone then result = result ^ (rs1_val >> (xlen_val - i - 1));
-  X(rd) = result;
+  let prod = carryless_mul(reverse(X(rs1)), reverse(X(rs2)));
+  X(rd) = reverse(prod[xlen - 1 .. 0]);
   RETIRE_SUCCESS
 }

--- a/model/riscv_insts_zvbc.sail
+++ b/model/riscv_insts_zvbc.sail
@@ -34,9 +34,9 @@ function clause execute (VCLMUL_VV(vm, vs2, vs1, vd)) = {
 
   foreach (i from 0 to ('n - 1)) {
     if mask[i] == bitone then {
-      foreach (n from 0 to (SEW - 1))
-        if vs2_val[i][n] == bitone then result[i] = result[i] ^ (vs1_val[i] << n);
-    };
+      let prod  = carryless_mul(vs1_val[i], vs2_val[i]);
+      result[i] = prod['m - 1 .. 0];
+    }
   };
   write_vreg('n, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
@@ -70,9 +70,9 @@ function clause execute (VCLMUL_VX(vm, vs2, rs1, vd)) = {
 
   foreach (i from 0 to ('n - 1)) {
     if mask[i] == bitone then {
-      foreach (n from 0 to (SEW - 1))
-        if vs2_val[i][n] == bitone then result[i] = result[i] ^ (rs1_val << n);
-    };
+      let prod  = carryless_mul(rs1_val, vs2_val[i]);
+      result[i] = prod['m - 1 .. 0];
+    }
   };
   write_vreg('n, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
@@ -105,9 +105,9 @@ function clause execute (VCLMULH_VV(vm, vs2, vs1, vd)) = {
 
   foreach (i from 0 to ('n - 1)) {
     if mask[i] == bitone then {
-      foreach (n from 1 to (SEW - 1))
-        if vs2_val[i][n] == bitone then result[i] = result[i] ^ (vs1_val[i] >> (SEW - n));
-    };
+      let prod  = carryless_mul(vs1_val[i], vs2_val[i]);
+      result[i] = prod[2 * SEW - 1 .. SEW];
+    }
   };
   write_vreg('n, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
@@ -141,9 +141,9 @@ function clause execute (VCLMULH_VX(vm, vs2, rs1, vd)) = {
 
   foreach (i from 0 to ('n - 1)) {
     if mask[i] == bitone then {
-      foreach (n from 1 to (SEW - 1))
-        if vs2_val[i][n] == bitone then result[i] = result[i] ^ (rs1_val >> (SEW - n));
-    };
+      let prod  = carryless_mul(rs1_val, vs2_val[i]);
+      result[i] = prod[2 * SEW - 1 .. SEW];
+    }
   };
   write_vreg('n, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());


### PR DESCRIPTION
Make the `reverse` function more generic; add a helper for carryless multiply and use it in the appropriate scalar and vector instructions.

Tested against upstream `riscv-tests` and the vector test suite.
