### PR TITLE
Rename pte_is_ptr to pte_is_non_leaf for clarity

### DIFF
--- a/model/riscv_vmem.sail
+++ b/model/riscv_vmem.sail
@@ -112,7 +112,7 @@ function pt_walk(
       else {
         let ppn = PPN_of_PTE(pte); // 22 or 44.
         let global = global | (pte_flags[G] == 0b1);
-        if pte_is_ptr(pte_flags) then {
+        if pte_is_non_leaf(pte_flags) then {
           // Non-Leaf PTE
           if level > 0 then
             // follow the pointer to walk next level

--- a/model/riscv_vmem_pte.sail
+++ b/model/riscv_vmem_pte.sail
@@ -64,7 +64,7 @@ bitfield PTE_Flags : pte_flags_bits = {
 }
 
 // PRIVATE: check if a PTE is a pointer to next level (non-leaf)
-function pte_is_ptr(pte_flags : PTE_Flags) -> bool =
+function pte_is_non_leaf(pte_flags : PTE_Flags) -> bool =
     pte_flags[X] == 0b0
   & pte_flags[W] == 0b0
   & pte_flags[R] == 0b0


### PR DESCRIPTION
This has caught us (Codasip) out before. One could make the argument that a leaf PTE is a pointer to a physical address. Renaming it to `pte_is_non_leaf` removes any ambiguity.