### PR TITLE
Fix PMP test

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -11,7 +11,7 @@
     "memory" : {
         "pmp" : {
             "grain" : 0,
-            "count" : 0
+            "count" : 16
         },
         "misaligned" : {
             "enabled" : false

--- a/test/first_party/CMakeLists.txt
+++ b/test/first_party/CMakeLists.txt
@@ -141,7 +141,9 @@ foreach (xlen IN ITEMS 32 64)
         if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/${test_source}.filter")
             add_custom_command(
                 OUTPUT ${config}
-                DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/${test_source}.filter"
+                DEPENDS
+                    "${CMAKE_SOURCE_DIR}/config/default.json"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/src/${test_source}.filter"
                 COMMAND jq
                     -f "${CMAKE_CURRENT_SOURCE_DIR}/src/${test_source}.filter"
                     "${CMAKE_SOURCE_DIR}/config/default.json"
@@ -152,9 +154,12 @@ foreach (xlen IN ITEMS 32 64)
         else()
             add_custom_command(
                 OUTPUT ${config}
+                DEPENDS
+                    "${CMAKE_SOURCE_DIR}/config/default.json"
                 COMMAND ${CMAKE_COMMAND} -E copy
                     "${CMAKE_SOURCE_DIR}/config/default.json"
                     "${config}"
+                VERBATIM
             )
         endif()
 


### PR DESCRIPTION
Somehow the config changes got through CI without this breakage being detected. Alasdair added a `jq` based system to allow tests to have modified configs, but it wasn't being used for the PMP test which needs PMPs to be enabled (by default they weren't).

I'm not totally convinced by the `jq` approach and to avoid the immediate need to add `jq` everywhere and learn how its filters work I just change the default config to enable PMPs.

I also fixed a couple of missing `DEPENDS`.