### PR TITLE
Refactor extension support logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ mapping clause encdec = SRET() <-> 0b0001000 @ 0b00010 @ 0b00000 @ 0b000 @ 0b000
 function clause execute SRET() = {
   let sret_illegal : bool = match cur_privilege {
     User       => true,
-    Supervisor => not(extensionEnabled(Ext_S)) | mstatus[TSR] == 0b1,
-    Machine    => not(extensionEnabled(Ext_S))
+    Supervisor => not(currentlyEnabled(Ext_S)) | mstatus[TSR] == 0b1,
+    Machine    => not(currentlyEnabled(Ext_S))
   };
   if   sret_illegal
   then { handle_illegal(); RETIRE_FAIL }

--- a/config/default.json
+++ b/config/default.json
@@ -14,7 +14,7 @@
             "count" : 16
         },
         "misaligned" : {
-            "enabled" : false
+            "supported" : false
         },
         "translation" : {
             "dirty_update" : false
@@ -39,40 +39,40 @@
     },
     "extensions" : {
         "C" : {
-            "enabled" : true
+            "supported" : true
         },
         "FD" : {
-            "enabled" : true
+            "supported" : true
         },
         "V" : {
-            "enabled" : true,
+            "supported" : true,
             "vlen_exp" : 9,
             "elen_exp" : 6,
             "vl_use_ceil" : false
         },
         "B" : {
-            "enabled" : false
+            "supported" : false
         },
         "Svinval" : {
-            "enabled" : false
+            "supported" : false
         },
         "Zcb" : {
-            "enabled" : false
+            "supported" : false
         },
         "Zfinx" : {
-            "enabled" : false
+            "supported" : false
         },
         "Zicbom" : {
-            "enabled" : false
+            "supported" : false
         },
         "Zicboz" : {
-            "enabled" : false
+            "supported" : false
         },
         "Zvkb" : {
-            "enabled" : false
+            "supported" : false
         },
         "Sstc" : {
-            "enabled" : false
+            "supported" : false
         }
     }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -71,6 +71,9 @@
         "Zvkb" : {
             "supported" : false
         },
+        "Zvbc" : {
+            "supported" : true
+        },
         "Sstc" : {
             "supported" : false
         }

--- a/handwritten_support/RiscvExtras.lean
+++ b/handwritten_support/RiscvExtras.lean
@@ -140,7 +140,7 @@ axiom extern_f16roundToInt : BitVec 3 → BitVec 16 → Bool → Unit
 axiom extern_f32roundToInt : BitVec 3 → BitVec 32 → Bool → Unit
 axiom extern_f64roundToInt : BitVec 3 → BitVec 64 → Bool → Unit
 
--- Termination of extensionEnabled
+-- Termination of currentlyEnabled
 instance : SizeOf extension where
   sizeOf := extension.toCtorIdx
 

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -6,7 +6,20 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
+// Enum with all extensions possibly supported by the model.
 scattered enum extension
+
+// Function used to determine if an extension is supported in the current configuration.
+val hartSupports : extension -> bool
+scattered function hartSupports
+
+// Function used to determine if an extension is currently enabled in the model.
+// This means an extension is supported, *and* any necessary bits are set in the
+// relevant CSRs (misa, mstatus, etc.) to enable its use. It is possible for some
+// extensions to be supported in hardware, but temporarily disabled via a CSR, in
+// which case this function should return false.
+val currentlyEnabled : extension -> bool
+scattered function currentlyEnabled
 
 // Note, these are sorted according to the canonical ordering vaguely described
 // in the `Subset Naming Convention` section of the unprivileged spec.
@@ -15,14 +28,19 @@ scattered enum extension
 enum clause extension = Ext_M
 // Single-Precision Floating-Point
 enum clause extension = Ext_F
+function clause hartSupports(Ext_F) = config extensions.FD.supported
 // Double-Precision Floating-Point
 enum clause extension = Ext_D
+function clause hartSupports(Ext_D) = config extensions.FD.supported // TODO: Separate F and D supported flags
 // Compressed Instructions
 enum clause extension = Ext_C
+function clause hartSupports(Ext_C) = config extensions.C.supported
 // Bit Manipulation
 enum clause extension = Ext_B
+function clause hartSupports(Ext_B) = config extensions.B.supported
 // Vector Operations
 enum clause extension = Ext_V
+function clause hartSupports(Ext_V) = config extensions.V.supported
 // Supervisor
 enum clause extension = Ext_S
 // User
@@ -30,8 +48,10 @@ enum clause extension = Ext_U
 
 // Cache-Block Management Instructions
 enum clause extension = Ext_Zicbom
+function clause hartSupports(Ext_Zicbom) = config extensions.Zicbom.supported
 // Cache-Block Zero Instructions
 enum clause extension = Ext_Zicboz
+function clause hartSupports(Ext_Zicboz) = config extensions.Zicboz.supported
 // Base Counters and Timers
 enum clause extension = Ext_Zicntr
 // Integer Conditional Operations
@@ -61,6 +81,7 @@ enum clause extension = Ext_Zfh
 enum clause extension = Ext_Zfhmin
 // Floating-Point in Integer Registers (single precision)
 enum clause extension = Ext_Zfinx
+function clause hartSupports(Ext_Zfinx) = config extensions.Zfinx.supported
 
 // Floating-Point in Integer Registers (double precision)
 enum clause extension = Ext_Zdinx
@@ -69,6 +90,7 @@ enum clause extension = Ext_Zdinx
 enum clause extension = Ext_Zca
 // Code Size Reduction: additional 16-bit aliases
 enum clause extension = Ext_Zcb
+function clause hartSupports(Ext_Zcb) = config extensions.Zcb.supported
 // Code Size Reduction: compressed double precision floating point loads and stores
 enum clause extension = Ext_Zcd
 // Code Size Reduction: compressed single precision floating point loads and stores
@@ -111,15 +133,19 @@ enum clause extension = Ext_Zhinx
 enum clause extension = Ext_Zvbb
 // Vector Cryptography Bit-manipulation
 enum clause extension = Ext_Zvkb
+function clause hartSupports(Ext_Zvkb) = config extensions.Zvkb.supported
 // Vector Carryless Multiplication
 enum clause extension = Ext_Zvbc
+function clause hartSupports(Ext_Zvbc) = config extensions.Zvbc.supported
 
 // Count Overflow and Mode-Based Filtering
 enum clause extension = Ext_Sscofpmf
 // Supervisor-mode Timer Interrupts
 enum clause extension = Ext_Sstc
+function clause hartSupports(Ext_Sstc) = config extensions.Sstc.supported
 // Fine-Grained Address-Translation Cache Invalidation
 enum clause extension = Ext_Svinval
+function clause hartSupports(Ext_Svinval) = config extensions.Svinval.supported
 // NAPOT Translation Contiguity
 enum clause extension = Ext_Svnapot
 // Page-Based Memory Types

--- a/model/riscv_fdext_control.sail
+++ b/model/riscv_fdext_control.sail
@@ -15,18 +15,18 @@
 
 /* **************************************************************** */
 
-function clause extensionEnabled(Ext_F) = (misa[F] == 0b1) & (mstatus[FS] != 0b00)
-function clause extensionEnabled(Ext_D) = (misa[D] == 0b1) & (mstatus[FS] != 0b00) & flen >= 64
-function clause extensionEnabled(Ext_Zfinx) = sys_enable_zfinx()
+function clause currentlyEnabled(Ext_F) = (misa[F] == 0b1) & (mstatus[FS] != 0b00)
+function clause currentlyEnabled(Ext_D) = (misa[D] == 0b1) & (mstatus[FS] != 0b00) & flen >= 64
+function clause currentlyEnabled(Ext_Zfinx) = sys_enable_zfinx()
 
 /* Floating Point CSRs */
 mapping clause csr_name_map = 0x001  <-> "fflags"
 mapping clause csr_name_map = 0x002  <-> "frm"
 mapping clause csr_name_map = 0x003  <-> "fcsr"
 
-function clause is_CSR_defined (0x001) = extensionEnabled(Ext_F) | extensionEnabled(Ext_Zfinx)
-function clause is_CSR_defined (0x002) = extensionEnabled(Ext_F) | extensionEnabled(Ext_Zfinx)
-function clause is_CSR_defined (0x003) = extensionEnabled(Ext_F) | extensionEnabled(Ext_Zfinx)
+function clause is_CSR_defined (0x001) = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
+function clause is_CSR_defined (0x002) = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
+function clause is_CSR_defined (0x003) = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
 
 function clause read_CSR (0x001) = zero_extend(fcsr[FFLAGS])
 function clause read_CSR (0x002) = zero_extend(fcsr[FRM])

--- a/model/riscv_fdext_control.sail
+++ b/model/riscv_fdext_control.sail
@@ -15,9 +15,9 @@
 
 /* **************************************************************** */
 
-function clause currentlyEnabled(Ext_F) = (misa[F] == 0b1) & (mstatus[FS] != 0b00)
-function clause currentlyEnabled(Ext_D) = (misa[D] == 0b1) & (mstatus[FS] != 0b00) & flen >= 64
-function clause currentlyEnabled(Ext_Zfinx) = sys_enable_zfinx()
+function clause currentlyEnabled(Ext_F) = (misa[F] == 0b1) & (mstatus[FS] != 0b00) & hartSupports(Ext_F)
+function clause currentlyEnabled(Ext_D) = (misa[D] == 0b1) & (mstatus[FS] != 0b00) & hartSupports(Ext_D) & flen >= 64
+function clause currentlyEnabled(Ext_Zfinx) = hartSupports(Ext_Zfinx)
 
 /* Floating Point CSRs */
 mapping clause csr_name_map = 0x001  <-> "fflags"

--- a/model/riscv_fdext_regs.sail
+++ b/model/riscv_fdext_regs.sail
@@ -103,18 +103,18 @@ register f30 : fregtype
 register f31 : fregtype
 
 function dirty_fd_context() -> unit = {
-  assert(sys_enable_fdext());
+  assert(hartSupports(Ext_F));
   mstatus[FS] = extStatus_to_bits(Dirty);
   mstatus[SD] = 0b1;
 }
 
 function dirty_fd_context_if_present() -> unit = {
-  assert(sys_enable_fdext() != sys_enable_zfinx());
-  if sys_enable_fdext() then dirty_fd_context()
+  assert(hartSupports(Ext_F) != hartSupports(Ext_Zfinx));
+  if hartSupports(Ext_F) then dirty_fd_context()
 }
 
 function rF (Fregno(r) : fregno) -> flenbits = {
-  assert(sys_enable_fdext());
+  assert(hartSupports(Ext_F));
   let v : fregtype =
     match r {
       0 => f0,
@@ -155,7 +155,7 @@ function rF (Fregno(r) : fregno) -> flenbits = {
 }
 
 function wF (Fregno(r) : fregno, in_v : flenbits) -> unit = {
-  assert(sys_enable_fdext());
+  assert(hartSupports(Ext_F));
   let v = fregval_into_freg(in_v);
   match r {
     0  => f0 = v,
@@ -212,42 +212,42 @@ overload F = {rF_bits, wF_bits, rF, wF}
 val rF_H : fregidx -> bits(16)
 function rF_H(i) = {
   assert(flen >= 16);
-  assert(sys_enable_fdext() & not(sys_enable_zfinx()));
+  assert(hartSupports(Ext_F) & not(hartSupports(Ext_Zfinx)));
   nan_unbox(F(i))
 }
 
 val wF_H : (fregidx, bits(16)) -> unit
 function wF_H(i, data) = {
   assert(flen >= 16);
-  assert(sys_enable_fdext() & not(sys_enable_zfinx()));
+  assert(hartSupports(Ext_F) & not(hartSupports(Ext_Zfinx)));
   F(i) = nan_box(data)
 }
 
 val rF_S : fregidx -> bits(32)
 function rF_S(i) = {
   assert(flen >= 32);
-  assert(sys_enable_fdext() & not(sys_enable_zfinx()));
+  assert(hartSupports(Ext_F) & not(hartSupports(Ext_Zfinx)));
   nan_unbox(F(i))
 }
 
 val wF_S : (fregidx, bits(32)) -> unit
 function wF_S(i, data) = {
   assert(flen >= 32);
-  assert(sys_enable_fdext() & not(sys_enable_zfinx()));
+  assert(hartSupports(Ext_F) & not(hartSupports(Ext_Zfinx)));
   F(i) = nan_box(data)
 }
 
 val rF_D : fregidx -> bits(64)
 function rF_D(i) = {
   assert(flen >= 64);
-  assert(sys_enable_fdext() & not(sys_enable_zfinx()));
+  assert(hartSupports(Ext_F) & not(hartSupports(Ext_Zfinx)));
   F(i)
 }
 
 val wF_D : (fregidx, bits(64)) -> unit
 function wF_D(i, data) = {
   assert(flen >= 64);
-  assert(sys_enable_fdext() & not(sys_enable_zfinx()));
+  assert(hartSupports(Ext_F) & not(hartSupports(Ext_Zfinx)));
   F(i) = data
 }
 
@@ -258,8 +258,8 @@ overload F_D = { rF_D, wF_D }
 val rF_or_X_H : fregidx -> bits(16)
 function rF_or_X_H(i) = {
   assert(flen >= 16);
-  assert(sys_enable_fdext() != sys_enable_zfinx());
-  if   sys_enable_fdext()
+  assert(hartSupports(Ext_F) != hartSupports(Ext_Zfinx));
+  if   hartSupports(Ext_F)
   then F_H(i)
   else X(fregidx_to_regidx(i))[15..0]
 }
@@ -267,8 +267,8 @@ function rF_or_X_H(i) = {
 val rF_or_X_S : fregidx -> bits(32)
 function rF_or_X_S(i) = {
   assert(flen >= 32);
-  assert(sys_enable_fdext() != sys_enable_zfinx());
-  if   sys_enable_fdext()
+  assert(hartSupports(Ext_F) != hartSupports(Ext_Zfinx));
+  if   hartSupports(Ext_F)
   then F_S(i)
   else X(fregidx_to_regidx(i))[31..0]
 }
@@ -276,8 +276,8 @@ function rF_or_X_S(i) = {
 val rF_or_X_D : fregidx -> bits(64)
 function rF_or_X_D(i) = {
   assert(flen >= 64);
-  assert(sys_enable_fdext() != sys_enable_zfinx());
-  if   sys_enable_fdext()
+  assert(hartSupports(Ext_F) != hartSupports(Ext_Zfinx));
+  if   hartSupports(Ext_F)
   then F_D(i)
   else if xlen >= 64
   then X(fregidx_to_regidx(i))[63..0]
@@ -291,8 +291,8 @@ function rF_or_X_D(i) = {
 val wF_or_X_H : (fregidx, bits(16)) -> unit
 function wF_or_X_H(i, data) = {
   assert(flen >= 16);
-  assert(sys_enable_fdext() != sys_enable_zfinx());
-  if   sys_enable_fdext()
+  assert(hartSupports(Ext_F) != hartSupports(Ext_Zfinx));
+  if   hartSupports(Ext_F)
   then F_H(i) = data
   else X(fregidx_to_regidx(i)) = sign_extend(data)
 }
@@ -300,8 +300,8 @@ function wF_or_X_H(i, data) = {
 val wF_or_X_S : (fregidx, bits(32)) -> unit
 function wF_or_X_S(i, data) = {
   assert(flen >= 32);
-  assert(sys_enable_fdext() != sys_enable_zfinx());
-  if   sys_enable_fdext()
+  assert(hartSupports(Ext_F) != hartSupports(Ext_Zfinx));
+  if   hartSupports(Ext_F)
   then F_S(i) = data
   else X(fregidx_to_regidx(i)) = sign_extend(data)
 }
@@ -309,8 +309,8 @@ function wF_or_X_S(i, data) = {
 val wF_or_X_D : (fregidx, bits(64)) -> unit
 function wF_or_X_D(i, data) = {
   assert (flen >= 64);
-  assert(sys_enable_fdext() != sys_enable_zfinx());
-  if   sys_enable_fdext()
+  assert(hartSupports(Ext_F) != hartSupports(Ext_Zfinx));
+  if   hartSupports(Ext_F)
   then F_D(i) = data
   else if xlen >= 64
   then X(fregidx_to_regidx(i)) = sign_extend(data)
@@ -368,8 +368,8 @@ mapping freg_name_raw : bits(5) <-> string = {
 mapping freg_name : fregidx <-> string = { Fregidx(i) <-> freg_name_raw(i) }
 
 mapping freg_or_reg_name : fregidx <-> string = {
-  forwards f if sys_enable_zfinx() => reg_name(fregidx_to_regidx(f)),
-  backwards reg_name(Regidx(i)) if sys_enable_zfinx() => Fregidx(zero_extend(i)),
+  forwards f if hartSupports(Ext_Zfinx) => reg_name(fregidx_to_regidx(f)),
+  backwards reg_name(Regidx(i)) if hartSupports(Ext_Zfinx) => Fregidx(zero_extend(i)),
   f <-> freg_name(f)
 }
 

--- a/model/riscv_fetch.sail
+++ b/model/riscv_fetch.sail
@@ -20,7 +20,7 @@ function fetch() -> FetchResult =
     Ext_FetchAddr_Error(e)   => F_Ext_Error(e),
     Ext_FetchAddr_OK(use_pc) => {
       let use_pc_bits = virtaddr_bits(use_pc);
-      if   (use_pc_bits[0] != bitzero | (use_pc_bits[1] != bitzero & not(extensionEnabled(Ext_Zca))))
+      if   (use_pc_bits[0] != bitzero | (use_pc_bits[1] != bitzero & not(currentlyEnabled(Ext_Zca))))
       then F_Error(E_Fetch_Addr_Align(), PC)
       else match translateAddr(use_pc, Execute()) {
         TR_Failure(e, _)     => F_Error(e, PC),

--- a/model/riscv_fetch_rvfi.sail
+++ b/model/riscv_fetch_rvfi.sail
@@ -18,7 +18,7 @@ function fetch() -> FetchResult = {
     Ext_FetchAddr_OK(use_pc) => {
       /* then check PC alignment */
       let use_pc_bits = virtaddr_bits(use_pc);
-      if   (use_pc_bits[0] != bitzero | (use_pc_bits[1] != bitzero & not(extensionEnabled(Ext_Zca))))
+      if   (use_pc_bits[0] != bitzero | (use_pc_bits[1] != bitzero & not(currentlyEnabled(Ext_Zca))))
       then F_Error(E_Fetch_Addr_Align(), PC)
       else match translateAddr(use_pc, Execute()) {
         TR_Failure(e, _) => F_Error(e, PC),

--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -11,7 +11,7 @@
 
 /* ****************************************************************** */
 
-function clause extensionEnabled(Ext_Zabha) = true
+function clause currentlyEnabled(Ext_Zabha) = true
 
 // Some print utils for lr/sc.
 
@@ -45,21 +45,21 @@ function lrsc_width_valid(size : word_width) -> bool = {
 
 function amo_width_valid(size : word_width) -> bool = {
   match size {
-    BYTE   => extensionEnabled(Ext_Zabha),
-    HALF   => extensionEnabled(Ext_Zabha),
+    BYTE   => currentlyEnabled(Ext_Zabha),
+    HALF   => currentlyEnabled(Ext_Zabha),
     WORD   => true,
     DOUBLE => xlen >= 64,
   }
 }
 
 /* ****************************************************************** */
-function clause extensionEnabled(Ext_Zalrsc) = misa[A] == 0b1
+function clause currentlyEnabled(Ext_Zalrsc) = misa[A] == 0b1
 
 union clause ast = LOADRES : (bool, bool, regidx, word_width, regidx)
 
 mapping clause encdec = LOADRES(aq, rl, rs1, size, rd)
   <-> 0b00010 @ bool_bits(aq) @ bool_bits(rl) @ 0b00000 @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ encdec_reg(rd) @ 0b0101111
-  when extensionEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
+  when currentlyEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
 
 /* We could set load-reservations on physical or virtual addresses.
  * However most chips (especially multi-core) will use physical addresses.
@@ -108,7 +108,7 @@ union clause ast = STORECON : (bool, bool, regidx, regidx, word_width, regidx)
 
 mapping clause encdec = STORECON(aq, rl, rs2, rs1, size, rd)
   <-> 0b00011 @ bool_bits(aq) @ bool_bits(rl) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ encdec_reg(rd) @ 0b0101111
-  when extensionEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
+  when currentlyEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
 
 /* NOTE: Currently, we only EA if address translation is successful. This may need revisiting. */
 function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
@@ -168,7 +168,7 @@ mapping clause assembly = STORECON(aq, rl, rs2, rs1, size, rd)
   <-> "sc." ^ size_mnemonic(size) ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs2) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
 
 /* ****************************************************************** */
-function clause extensionEnabled(Ext_Zaamo) = misa[A] == 0b1
+function clause currentlyEnabled(Ext_Zaamo) = misa[A] == 0b1
 
 union clause ast = AMO : (amoop, bool, bool, regidx, regidx, word_width, regidx)
 
@@ -186,7 +186,7 @@ mapping encdec_amoop : amoop <-> bits(5) = {
 
 mapping clause encdec = AMO(op, aq, rl, rs2, rs1, size, rd)
   <-> encdec_amoop(op) @ bool_bits(aq) @ bool_bits(rl) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ encdec_reg(rd) @ 0b0101111
-  when extensionEnabled(Ext_Zaamo) & amo_width_valid(size)
+  when currentlyEnabled(Ext_Zaamo) & amo_width_valid(size)
 
 /* NOTE: Currently, we only EA if address translation is successful.
    This may need revisiting. */

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -9,7 +9,7 @@
 /* ****************************************************************** */
 /* This file specifies the instructions in the base integer set.      */
 
-function clause currentlyEnabled(Ext_C) = misa[C] == 0b1
+function clause currentlyEnabled(Ext_C) = misa[C] == 0b1 & hartSupports(Ext_C)
 function clause currentlyEnabled(Ext_Zca) = currentlyEnabled(Ext_C)
 
 /* ****************************************************************** */

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -9,8 +9,8 @@
 /* ****************************************************************** */
 /* This file specifies the instructions in the base integer set.      */
 
-function clause extensionEnabled(Ext_C) = misa[C] == 0b1
-function clause extensionEnabled(Ext_Zca) = extensionEnabled(Ext_C)
+function clause currentlyEnabled(Ext_C) = misa[C] == 0b1
+function clause currentlyEnabled(Ext_Zca) = currentlyEnabled(Ext_C)
 
 /* ****************************************************************** */
 union clause ast = UTYPE : (bits(20), regidx, uop)
@@ -69,7 +69,7 @@ function clause execute (RISCV_JAL(imm, rd)) = {
     Ext_ControlAddr_OK(target) => {
       /* Perform standard alignment check */
       let target_bits = virtaddr_bits(target);
-      if bit_to_bool(target_bits[1]) & not(extensionEnabled(Ext_Zca)) then {
+      if bit_to_bool(target_bits[1]) & not(currentlyEnabled(Ext_Zca)) then {
         handle_mem_exception(target, E_Fetch_Addr_Align());
         RETIRE_FAIL
       } else {
@@ -131,7 +131,7 @@ function clause execute (BTYPE(imm, rs2, rs1, op)) = {
       },
       Ext_ControlAddr_OK(target) => {
         let target_bits = virtaddr_bits(target);
-        if bit_to_bool(target_bits[1]) & not(extensionEnabled(Ext_Zca)) then {
+        if bit_to_bool(target_bits[1]) & not(currentlyEnabled(Ext_Zca)) then {
           handle_mem_exception(target, E_Fetch_Addr_Align());
           RETIRE_FAIL
         } else {
@@ -627,8 +627,8 @@ mapping clause encdec = SRET()
 function clause execute SRET() = {
   let sret_illegal : bool = match cur_privilege {
     User       => true,
-    Supervisor => not(extensionEnabled(Ext_S)) | mstatus[TSR] == 0b1,
-    Machine    => not(extensionEnabled(Ext_S))
+    Supervisor => not(currentlyEnabled(Ext_S)) | mstatus[TSR] == 0b1,
+    Machine    => not(currentlyEnabled(Ext_S))
   };
   if   sret_illegal
   then { handle_illegal(); RETIRE_FAIL }

--- a/model/riscv_insts_dext.sail
+++ b/model/riscv_insts_dext.sail
@@ -224,7 +224,7 @@ function fle_D   (v1,       v2,        is_quiet) = {
 /* **************************************************************** */
 /* Helper functions for 'encdec()'                                  */
 
-function clause currentlyEnabled(Ext_Zdinx) = sys_enable_zfinx() & flen >= 64
+function clause currentlyEnabled(Ext_Zdinx) = hartSupports(Ext_Zfinx) & flen >= 64
 
 function haveDoubleFPU() -> bool = currentlyEnabled(Ext_D) | currentlyEnabled(Ext_Zdinx)
 

--- a/model/riscv_insts_dext.sail
+++ b/model/riscv_insts_dext.sail
@@ -224,15 +224,15 @@ function fle_D   (v1,       v2,        is_quiet) = {
 /* **************************************************************** */
 /* Helper functions for 'encdec()'                                  */
 
-function clause extensionEnabled(Ext_Zdinx) = sys_enable_zfinx() & flen >= 64
+function clause currentlyEnabled(Ext_Zdinx) = sys_enable_zfinx() & flen >= 64
 
-function haveDoubleFPU() -> bool = extensionEnabled(Ext_D) | extensionEnabled(Ext_Zdinx)
+function haveDoubleFPU() -> bool = currentlyEnabled(Ext_D) | currentlyEnabled(Ext_Zdinx)
 
 /* RV32Zdinx requires even register pairs; can be omitted for code  */
 /* not used for RV32Zdinx (i.e. RV64-only or D-only).               */
 val validDoubleRegs : forall 'n, 'n > 0. (implicit('n), vector('n, fregidx)) -> bool
 function validDoubleRegs(n, regs) = {
-  if extensionEnabled(Ext_Zdinx) & xlen == 32 then {
+  if currentlyEnabled(Ext_Zdinx) & xlen == 32 then {
     foreach (i from 0 to (n - 1)) {
       if (fregidx_bits(regs[i])[0] == bitone) then return false;
     }
@@ -844,11 +844,11 @@ mapping clause encdec = F_UN_X_TYPE_D(rs1, rd, FCLASS_D)
 
 mapping clause encdec = F_UN_X_TYPE_D(rs1, rd, FMV_X_D)
                     <-> 0b111_0001 @ 0b00000 @ encdec_freg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011
-                    when extensionEnabled(Ext_D) & xlen >= 64
+                    when currentlyEnabled(Ext_D) & xlen >= 64
 
 mapping clause encdec = F_UN_F_TYPE_D(rs1, rd, FMV_D_X)
                     <-> 0b111_1001 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011
-                    when extensionEnabled(Ext_D) & xlen >= 64
+                    when currentlyEnabled(Ext_D) & xlen >= 64
 
 /* Execution semantics ================================ */
 

--- a/model/riscv_insts_end.sail
+++ b/model/riscv_insts_end.sail
@@ -28,6 +28,7 @@ mapping clause assembly = C_ILLEGAL(s) <-> "c.illegal" ^ spc() ^ hex_bits_16(s)
 
 /* End definitions */
 end extension
+end hartSupports
 end currentlyEnabled
 end ast
 end execute

--- a/model/riscv_insts_end.sail
+++ b/model/riscv_insts_end.sail
@@ -28,7 +28,7 @@ mapping clause assembly = C_ILLEGAL(s) <-> "c.illegal" ^ spc() ^ hex_bits_16(s)
 
 /* End definitions */
 end extension
-end extensionEnabled
+end currentlyEnabled
 end ast
 end execute
 end assembly

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -26,10 +26,10 @@
 /* **************************************************************** */
 
 // TODO: Add config flags to control Zfh and Zfhmin
-function clause extensionEnabled(Ext_Zfh) = (misa[F] == 0b1) & (mstatus[FS] != 0b00)
+function clause currentlyEnabled(Ext_Zfh) = (misa[F] == 0b1) & (mstatus[FS] != 0b00)
 
-// Zfhmin is a subset of Zfh. This can be changed to extensionEnabled(Ext_Zfh) | sys_enable_zfhmin() when more configuration is implemented.
-function clause extensionEnabled(Ext_Zfhmin) = extensionEnabled(Ext_Zfh)
+// Zfhmin is a subset of Zfh. This can be changed to currentlyEnabled(Ext_Zfh) | sys_enable_zfhmin() when more configuration is implemented.
+function clause currentlyEnabled(Ext_Zfhmin) = currentlyEnabled(Ext_Zfh)
 
 mapping encdec_rounding_mode : rounding_mode <-> bits(3) = {
   RM_RNE <-> 0b000,
@@ -265,7 +265,7 @@ function fle_S   (v1,       v2,        is_quiet) = {
 /* **************************************************************** */
 /* Helper functions for 'encdec()'                                  */
 
-function haveSingleFPU() -> bool = extensionEnabled(Ext_F) | extensionEnabled(Ext_Zfinx)
+function haveSingleFPU() -> bool = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
 
 /* ****************************************************************** */
 /* Floating-point loads                                               */
@@ -279,15 +279,15 @@ union clause ast = LOAD_FP : (bits(12), regidx, fregidx, word_width)
 
 mapping clause encdec = LOAD_FP(imm, rs1, rd, HALF)
   <-> imm @ encdec_reg(rs1) @ 0b001 @ encdec_freg(rd) @ 0b000_0111
-  when extensionEnabled(Ext_Zfhmin)
+  when currentlyEnabled(Ext_Zfhmin)
 
 mapping clause encdec = LOAD_FP(imm, rs1, rd, WORD)
   <-> imm @ encdec_reg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b000_0111
-  when extensionEnabled(Ext_F)
+  when currentlyEnabled(Ext_F)
 
 mapping clause encdec = LOAD_FP(imm, rs1, rd, DOUBLE)
   <-> imm @ encdec_reg(rs1) @ 0b011 @ encdec_freg(rd) @ 0b000_0111
-  when extensionEnabled(Ext_D)
+  when currentlyEnabled(Ext_D)
 
 /* Execution semantics ================================ */
 
@@ -339,15 +339,15 @@ union clause ast = STORE_FP : (bits(12), fregidx, regidx, word_width)
 
 mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, HALF)
   <-> imm7 : bits(7) @ encdec_freg(rs2) @ encdec_reg(rs1) @ 0b001 @ imm5 : bits(5) @ 0b010_0111
-  when extensionEnabled(Ext_Zfhmin)
+  when currentlyEnabled(Ext_Zfhmin)
 
 mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, WORD)
   <-> imm7 : bits(7) @ encdec_freg(rs2) @ encdec_reg(rs1) @ 0b010 @ imm5 : bits(5) @ 0b010_0111
-  when extensionEnabled(Ext_F)
+  when currentlyEnabled(Ext_F)
 
 mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, DOUBLE)
   <-> imm7 : bits(7) @ encdec_freg(rs2) @ encdec_reg(rs1) @ 0b011 @ imm5 : bits(5) @ 0b010_0111
-  when extensionEnabled(Ext_D)
+  when currentlyEnabled(Ext_D)
 
 /* Execution semantics ================================ */
 
@@ -943,11 +943,11 @@ mapping clause encdec = F_UN_TYPE_X_S(rs1, rd, FCLASS_S)
 
 mapping clause encdec = F_UN_TYPE_X_S(rs1, rd, FMV_X_W)
                     <-> 0b111_0000 @ 0b00000 @ encdec_freg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011
-                    when extensionEnabled(Ext_F)
+                    when currentlyEnabled(Ext_F)
 
 mapping clause encdec = F_UN_TYPE_F_S(rs1, rd, FMV_W_X)
                     <-> 0b111_1000 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011
-                    when extensionEnabled(Ext_F)
+                    when currentlyEnabled(Ext_F)
 
 /* Execution semantics ================================ */
 

--- a/model/riscv_insts_mext.sail
+++ b/model/riscv_insts_mext.sail
@@ -11,8 +11,8 @@
 
 /* ****************************************************************** */
 
-function clause extensionEnabled(Ext_M) = misa[M] == 0b1
-function clause extensionEnabled(Ext_Zmmul) = true
+function clause currentlyEnabled(Ext_M) = misa[M] == 0b1
+function clause currentlyEnabled(Ext_Zmmul) = true
 
 
 union clause ast = MUL : (regidx, regidx, regidx, mul_op)
@@ -26,7 +26,7 @@ mapping encdec_mul_op : mul_op <-> bits(3) = {
 
 mapping clause encdec = MUL(rs2, rs1, rd, mul_op)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_mul_op(mul_op) @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_M) | extensionEnabled(Ext_Zmmul)
+  when currentlyEnabled(Ext_M) | currentlyEnabled(Ext_Zmmul)
 
 function clause execute (MUL(rs2, rs1, rd, mul_op)) = {
   let rs1_val = X(rs1);
@@ -56,7 +56,7 @@ union clause ast = DIV : (regidx, regidx, regidx, bool)
 
 mapping clause encdec = DIV(rs2, rs1, rd, s)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b10 @ bool_not_bits(s) @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_M)
+  when currentlyEnabled(Ext_M)
 
 function clause execute (DIV(rs2, rs1, rd, s)) = {
   let rs1_val = X(rs1);
@@ -83,7 +83,7 @@ union clause ast = REM : (regidx, regidx, regidx, bool)
 
 mapping clause encdec = REM(rs2, rs1, rd, s)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b11 @ bool_not_bits(s) @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_M)
+  when currentlyEnabled(Ext_M)
 
 function clause execute (REM(rs2, rs1, rd, s)) = {
   let rs1_val = X(rs1);
@@ -104,7 +104,7 @@ union clause ast = MULW : (regidx, regidx, regidx)
 
 mapping clause encdec = MULW(rs2, rs1, rd)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0111011
-  when xlen == 64 & (extensionEnabled(Ext_M) | extensionEnabled(Ext_Zmmul))
+  when xlen == 64 & (currentlyEnabled(Ext_M) | currentlyEnabled(Ext_Zmmul))
 
 function clause execute (MULW(rs2, rs1, rd)) = {
   let rs1_val = X(rs1)[31..0];
@@ -127,7 +127,7 @@ union clause ast = DIVW : (regidx, regidx, regidx, bool)
 
 mapping clause encdec = DIVW(rs2, rs1, rd, s)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b10 @ bool_not_bits(s) @ encdec_reg(rd) @ 0b0111011
-  when xlen == 64 & extensionEnabled(Ext_M)
+  when xlen == 64 & currentlyEnabled(Ext_M)
 
 function clause execute (DIVW(rs2, rs1, rd, s)) = {
   let rs1_val = X(rs1)[31..0];
@@ -150,7 +150,7 @@ union clause ast = REMW : (regidx, regidx, regidx, bool)
 
 mapping clause encdec = REMW(rs2, rs1, rd, s)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b11 @ bool_not_bits(s) @ encdec_reg(rd) @ 0b0111011
-  when xlen == 64 & extensionEnabled(Ext_M)
+  when xlen == 64 & currentlyEnabled(Ext_M)
 
 function clause execute (REMW(rs2, rs1, rd, s)) = {
   let rs1_val = X(rs1)[31..0];

--- a/model/riscv_insts_svinval.sail
+++ b/model/riscv_insts_svinval.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_Svinval) = sys_enable_svinval()
+function clause currentlyEnabled(Ext_Svinval) = hartSupports(Ext_Svinval)
 
 union clause ast = SINVAL_VMA : (regidx, regidx)
 

--- a/model/riscv_insts_svinval.sail
+++ b/model/riscv_insts_svinval.sail
@@ -6,13 +6,13 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause extensionEnabled(Ext_Svinval) = sys_enable_svinval()
+function clause currentlyEnabled(Ext_Svinval) = sys_enable_svinval()
 
 union clause ast = SINVAL_VMA : (regidx, regidx)
 
 mapping clause encdec = SINVAL_VMA(rs1, rs2)
   <-> 0b0001011 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ 0b00000 @ 0b1110011
-  when extensionEnabled(Ext_Svinval)
+  when currentlyEnabled(Ext_Svinval)
 
 function clause execute SINVAL_VMA(rs1, rs2) = {
   execute(SFENCE_VMA(rs1, rs2))
@@ -27,7 +27,7 @@ union clause ast = SFENCE_W_INVAL : unit
 
 mapping clause encdec = SFENCE_W_INVAL()
   <-> 0b0001100 @ 0b00000 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
-  when extensionEnabled(Ext_Svinval)
+  when currentlyEnabled(Ext_Svinval)
 
 function clause execute SFENCE_W_INVAL() = {
   if cur_privilege == User
@@ -43,7 +43,7 @@ union clause ast = SFENCE_INVAL_IR : unit
 
 mapping clause encdec = SFENCE_INVAL_IR()
   <-> 0b0001100 @ 0b00001 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
-  when extensionEnabled(Ext_Svinval)
+  when currentlyEnabled(Ext_Svinval)
 
 function clause execute SFENCE_INVAL_IR() = {
   if cur_privilege == User

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -42,7 +42,7 @@ mapping encdec_vvfunct6 : vvfunct6 <-> bits(6) = {
 
 mapping clause encdec = VVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_vvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW_pow  = get_sew_pow();
@@ -176,7 +176,7 @@ mapping encdec_nvsfunct6 : nvsfunct6 <-> bits(6) = {
 
 mapping clause encdec = NVSTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_nvsfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -243,7 +243,7 @@ mapping encdec_nvfunct6 : nvfunct6 <-> bits(6) = {
 
 mapping clause encdec = NVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_nvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -305,7 +305,7 @@ union clause ast = MASKTYPEV : (vregidx, vregidx, vregidx)
 
 mapping clause encdec = MASKTYPEV (vs2, vs1,  vd)
   <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(MASKTYPEV(vs2, vs1, vd)) = {
   let start_element = get_start_element();
@@ -354,7 +354,7 @@ union clause ast = MOVETYPEV : (vregidx, vregidx)
 
 mapping clause encdec = MOVETYPEV (vs1, vd)
   <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(MOVETYPEV(vs1, vd)) = {
   let SEW      = get_sew();
@@ -413,7 +413,7 @@ mapping encdec_vxfunct6 : vxfunct6 <-> bits(6) = {
 
 mapping clause encdec = VXTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_vxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -529,7 +529,7 @@ mapping encdec_nxsfunct6 : nxsfunct6 <-> bits(6) = {
 
 mapping clause encdec = NXSTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_nxsfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -596,7 +596,7 @@ mapping encdec_nxfunct6 : nxfunct6 <-> bits(6) = {
 
 mapping clause encdec = NXTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_nxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -665,7 +665,7 @@ mapping encdec_vxsgfunct6 : vxsgfunct6 <-> bits(6) = {
 
 mapping clause encdec = VXSG(funct6, vm, vs2, rs1, vd)
   <-> encdec_vxsgfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let SEW_pow  = get_sew_pow();
@@ -728,7 +728,7 @@ union clause ast = MASKTYPEX : (vregidx, regidx, vregidx)
 
 mapping clause encdec = MASKTYPEX(vs2, rs1, vd)
   <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(MASKTYPEX(vs2, rs1, vd)) = {
   let start_element = get_start_element();
@@ -777,7 +777,7 @@ union clause ast = MOVETYPEX : (regidx, vregidx)
 
 mapping clause encdec = MOVETYPEX (rs1, vd)
   <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(MOVETYPEX(rs1, vd)) = {
   let SEW      = get_sew();
@@ -828,7 +828,7 @@ mapping encdec_vifunct6 : vifunct6 <-> bits(6) = {
 
 mapping clause encdec = VITYPE(funct6, vm, vs2, simm, vd)
   <-> encdec_vifunct6(funct6) @ vm @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -920,7 +920,7 @@ mapping encdec_nisfunct6 : nisfunct6 <-> bits(6) = {
 
 mapping clause encdec = NISTYPE(funct6, vm, vs2, simm, vd)
   <-> encdec_nisfunct6(funct6) @ vm @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(NISTYPE(funct6, vm, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -987,7 +987,7 @@ mapping encdec_nifunct6 : nifunct6 <-> bits(6) = {
 
 mapping clause encdec = NITYPE(funct6, vm, vs2, simm, vd)
   <-> encdec_nifunct6(funct6) @ vm @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(NITYPE(funct6, vm, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -1056,7 +1056,7 @@ mapping encdec_visgfunct6 : visgfunct6 <-> bits(6) = {
 
 mapping clause encdec = VISG(funct6, vm, vs2, simm, vd)
   <-> encdec_visgfunct6(funct6) @ vm @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let SEW_pow  = get_sew_pow();
@@ -1119,7 +1119,7 @@ union clause ast = MASKTYPEI : (vregidx, bits(5), vregidx)
 
 mapping clause encdec = MASKTYPEI(vs2, simm, vd)
   <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(MASKTYPEI(vs2, simm, vd)) = {
   let start_element = get_start_element();
@@ -1168,7 +1168,7 @@ union clause ast = MOVETYPEI : (vregidx, bits(5))
 
 mapping clause encdec = MOVETYPEI (vd, simm)
   <-> 0b010111 @ 0b1 @ 0b00000 @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(MOVETYPEI(vd, simm)) = {
   let SEW      = get_sew();
@@ -1204,7 +1204,7 @@ union clause ast = VMVRTYPE : (vregidx, bits(5), vregidx)
 
 mapping clause encdec = VMVRTYPE(vs2, simm, vd)
   <-> 0b100111 @ 0b1 @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VMVRTYPE(vs2, simm, vd)) = {
   let start_element = get_start_element();
@@ -1263,7 +1263,7 @@ mapping encdec_mvvfunct6 : mvvfunct6 <-> bits(6) = {
 
 mapping clause encdec = MVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_mvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -1372,7 +1372,7 @@ mapping encdec_mvvmafunct6 : mvvmafunct6 <-> bits(6) = {
 
 mapping clause encdec = MVVMATYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_mvvmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -1432,7 +1432,7 @@ mapping encdec_wvvfunct6 : wvvfunct6 <-> bits(6) = {
 
 mapping clause encdec = WVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_wvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -1502,7 +1502,7 @@ mapping encdec_wvfunct6 : wvfunct6 <-> bits(6) = {
 
 mapping clause encdec = WVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_wvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(WVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -1565,7 +1565,7 @@ mapping encdec_wmvvfunct6 : wmvvfunct6 <-> bits(6) = {
 
 mapping clause encdec =  WMVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_wmvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -1626,7 +1626,7 @@ mapping vext2_vs1 : vext2funct6 <-> bits(5) = {
 
 mapping clause encdec = VEXT2TYPE(funct6, vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ vext2_vs1(funct6) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VEXT2TYPE(funct6, vm, vs2, vd)) = {
   let SEW = get_sew();
@@ -1683,7 +1683,7 @@ mapping vext4_vs1 : vext4funct6 <-> bits(5) = {
 
 mapping clause encdec = VEXT4TYPE(funct6, vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ vext4_vs1(funct6) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VEXT4TYPE(funct6, vm, vs2, vd)) = {
   let SEW = get_sew();
@@ -1740,7 +1740,7 @@ mapping vext8_vs1 : vext8funct6 <-> bits(5) = {
 
 mapping clause encdec = VEXT8TYPE(funct6, vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ vext8_vs1(funct6) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VEXT8TYPE(funct6, vm, vs2, vd)) = {
   let SEW = get_sew();
@@ -1792,7 +1792,7 @@ union clause ast = VMVXS : (vregidx, regidx)
 
 mapping clause encdec = VMVXS(vs2, rd)
   <-> 0b010000 @ 0b1 @ encdec_vreg(vs2) @ 0b00000 @ 0b010 @ encdec_reg(rd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VMVXS(vs2, rd)) = {
   let SEW      = get_sew();
@@ -1821,7 +1821,7 @@ union clause ast = MVVCOMPRESS : (vregidx, vregidx, vregidx)
 
 mapping clause encdec = MVVCOMPRESS(vs2, vs1, vd)
   <-> 0b010111 @ 0b1 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(MVVCOMPRESS(vs2, vs1, vd)) = {
   let start_element = get_start_element();
@@ -1896,7 +1896,7 @@ mapping encdec_mvxfunct6 : mvxfunct6 <-> bits(6) = {
 
 mapping clause encdec = MVXTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_mvxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -2016,7 +2016,7 @@ mapping encdec_mvxmafunct6 : mvxmafunct6 <-> bits(6) = {
 
 mapping clause encdec = MVXMATYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_mvxmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -2077,7 +2077,7 @@ mapping encdec_wvxfunct6 : wvxfunct6 <-> bits(6) = {
 
 mapping clause encdec = WVXTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_wvxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(WVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -2146,7 +2146,7 @@ mapping encdec_wxfunct6 : wxfunct6 <-> bits(6) = {
 
 mapping clause encdec = WXTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_wxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(WXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -2209,7 +2209,7 @@ mapping encdec_wmvxfunct6 : wmvxfunct6 <-> bits(6) = {
 
 mapping clause encdec = WMVXTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_wmvxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(WMVXTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -2265,7 +2265,7 @@ union clause ast = VMVSX : (regidx, vregidx)
 
 mapping clause encdec = VMVSX(rs1, vd)
   <-> 0b010000 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VMVSX(rs1, vd)) = {
   let SEW      = get_sew();

--- a/model/riscv_insts_vext_fp.sail
+++ b/model/riscv_insts_vext_fp.sail
@@ -29,7 +29,7 @@ mapping encdec_fvvfunct6 : fvvfunct6 <-> bits(6) = {
 
 mapping clause encdec = FVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_fvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(FVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -104,7 +104,7 @@ mapping encdec_fvvmafunct6 : fvvmafunct6 <-> bits(6) = {
 
 mapping clause encdec = FVVMATYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_fvvmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(FVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -171,7 +171,7 @@ mapping encdec_fwvvfunct6 : fwvvfunct6 <-> bits(6) = {
 
 mapping clause encdec = FWVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_fwvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(FWVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -236,7 +236,7 @@ mapping encdec_fwvvmafunct6 : fwvvmafunct6 <-> bits(6) = {
 
 mapping clause encdec = FWVVMATYPE(funct6, vm, vs1, vs2, vd)
   <-> encdec_fwvvmafunct6(funct6) @ vm @ encdec_vreg(vs1) @ encdec_vreg(vs2) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(FWVVMATYPE(funct6, vm, vs1, vs2, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -300,7 +300,7 @@ mapping encdec_fwvfunct6 : fwvfunct6 <-> bits(6) = {
 
 mapping clause encdec = FWVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_fwvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(FWVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -363,7 +363,7 @@ mapping encdec_vfunary0_vs1 : vfunary0 <-> bits(5) = {
 
 mapping clause encdec = VFUNARY0(vm, vs2, vfunary0, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ encdec_vfunary0_vs1(vfunary0) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -477,7 +477,7 @@ mapping encdec_vfwunary0_vs1 : vfwunary0 <-> bits(5) = {
 
 mapping clause encdec = VFWUNARY0(vm, vs2, vfwunary0, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ encdec_vfwunary0_vs1(vfwunary0) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -607,7 +607,7 @@ mapping encdec_vfnunary0_vs1 : vfnunary0 <-> bits(5) = {
 
 mapping clause encdec = VFNUNARY0(vm, vs2, vfnunary0, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ encdec_vfnunary0_vs1(vfnunary0) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -743,7 +743,7 @@ mapping encdec_vfunary1_vs1 : vfunary1 <-> bits(5) = {
 
 mapping clause encdec = VFUNARY1(vm, vs2, vfunary1, vd)
   <-> 0b010011 @ vm @ encdec_vreg(vs2) @ encdec_vfunary1_vs1(vfunary1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -819,7 +819,7 @@ union clause ast = VFMVFS : (vregidx, fregidx)
 
 mapping clause encdec = VFMVFS(vs2, rd)
   <-> 0b010000 @ 0b1 @ encdec_vreg(vs2) @ 0b00000 @ 0b001 @ encdec_freg(rd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VFMVFS(vs2, rd)) = {
   let rm_3b    = fcsr[FRM];
@@ -868,7 +868,7 @@ mapping encdec_fvffunct6 : fvffunct6 <-> bits(6) = {
 
 mapping clause encdec = FVFTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_fvffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -958,7 +958,7 @@ mapping encdec_fvfmafunct6 : fvfmafunct6 <-> bits(6) = {
 
 mapping clause encdec = FVFMATYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_fvfmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(FVFMATYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1025,7 +1025,7 @@ mapping encdec_fwvffunct6 : fwvffunct6 <-> bits(6) = {
 
 mapping clause encdec = FWVFTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_fwvffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(FWVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1089,7 +1089,7 @@ mapping encdec_fwvfmafunct6 : fwvfmafunct6 <-> bits(6) = {
 
 mapping clause encdec = FWVFMATYPE(funct6, vm, rs1, vs2, vd)
   <-> encdec_fwvfmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(FWVFMATYPE(funct6, vm, rs1, vs2, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1152,7 +1152,7 @@ mapping encdec_fwffunct6 : fwffunct6 <-> bits(6) = {
 
 mapping clause encdec = FWFTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_fwffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(FWFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1206,7 +1206,7 @@ union clause ast = VFMERGE : (vregidx, fregidx, vregidx)
 
 mapping clause encdec = VFMERGE(vs2, rs1, vd)
   <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VFMERGE(vs2, rs1, vd)) = {
   let rm_3b         = fcsr[FRM];
@@ -1258,7 +1258,7 @@ union clause ast = VFMV : (fregidx, vregidx)
 
 mapping clause encdec = VFMV(rs1, vd)
   <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VFMV(rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -1296,7 +1296,7 @@ union clause ast = VFMVSF : (fregidx, vregidx)
 
 mapping clause encdec = VFMVSF(rs1, vd)
   <-> 0b010000 @ 0b1 @ 0b00000 @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VFMVSF(rs1, vd)) = {
   let rm_3b    = fcsr[FRM];

--- a/model/riscv_insts_vext_fp_red.sail
+++ b/model/riscv_insts_vext_fp_red.sail
@@ -25,7 +25,7 @@ mapping encdec_rfvvfunct6 : rfvvfunct6 <-> bits(6) = {
 
 mapping clause encdec = RFVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_rfvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 val process_rfvv_single: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, int('n), int('m), int('p)) -> Retired
 function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {

--- a/model/riscv_insts_vext_fp_vm.sail
+++ b/model/riscv_insts_vext_fp_vm.sail
@@ -24,7 +24,7 @@ mapping encdec_fvvmfunct6 : fvvmfunct6 <-> bits(6) = {
 
 mapping clause encdec = FVVMTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_fvvmfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(FVVMTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
@@ -88,7 +88,7 @@ mapping encdec_fvfmfunct6 : fvfmfunct6 <-> bits(6) = {
 
 mapping clause encdec = FVFMTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_fvfmfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(FVFMTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];

--- a/model/riscv_insts_vext_mask.sail
+++ b/model/riscv_insts_vext_mask.sail
@@ -27,7 +27,7 @@ mapping encdec_mmfunct6 : mmfunct6 <-> bits(6) = {
 
 mapping clause encdec = MMTYPE(funct6, vs2, vs1, vd)
   <-> encdec_mmfunct6(funct6) @ 0b1 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(MMTYPE(funct6, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -85,7 +85,7 @@ union clause ast = VCPOP_M : (bits(1), vregidx, regidx)
 
 mapping clause encdec = VCPOP_M(vm, vs2, rd)
   <-> 0b010000 @ vm @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_reg(rd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VCPOP_M(vm, vs2, rd)) = {
   let SEW      = get_sew();
@@ -120,7 +120,7 @@ union clause ast = VFIRST_M : (bits(1), vregidx, regidx)
 
 mapping clause encdec = VFIRST_M(vm, vs2, rd)
   <-> 0b010000 @ vm @ encdec_vreg(vs2) @ 0b10001 @ 0b010 @ encdec_reg(rd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VFIRST_M(vm, vs2, rd)) = {
   let SEW      = get_sew();
@@ -157,7 +157,7 @@ union clause ast = VMSBF_M : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VMSBF_M(vm, vs2, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ 0b00001 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VMSBF_M(vm, vs2, vd)) = {
   let SEW      = get_sew();
@@ -198,7 +198,7 @@ union clause ast = VMSIF_M : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VMSIF_M(vm, vs2, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ 0b00011 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VMSIF_M(vm, vs2, vd)) = {
   let SEW      = get_sew();
@@ -239,7 +239,7 @@ union clause ast = VMSOF_M : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VMSOF_M(vm, vs2, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ 0b00010 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VMSOF_M(vm, vs2, vd)) = {
   let SEW      = get_sew();
@@ -284,7 +284,7 @@ union clause ast = VIOTA_M : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VIOTA_M(vm, vs2, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VIOTA_M(vm, vs2, vd)) = {
   let SEW      = get_sew();
@@ -325,7 +325,7 @@ union clause ast = VID_V : (bits(1), vregidx)
 
 mapping clause encdec = VID_V(vm, vd)
   <-> 0b010100 @ vm @ 0b00000 @ 0b10001 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VID_V(vm, vd)) = {
   let SEW      = get_sew();

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -66,7 +66,7 @@ union clause ast = VLSEGTYPE : (bits(3), bits(1), regidx, vlewidth, vregidx)
 
 mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 val process_vlseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> Retired
 function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
@@ -135,7 +135,7 @@ union clause ast = VLSEGFFTYPE : (bits(3), bits(1), regidx, vlewidth, vregidx)
 
 mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b10000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 val process_vlsegff : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> Retired
 function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
@@ -243,7 +243,7 @@ union clause ast = VSSEGTYPE : (bits(3), bits(1), regidx, vlewidth, vregidx)
 
 mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 val process_vsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> Retired
 function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
@@ -313,7 +313,7 @@ union clause ast = VLSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, vre
 
 mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
   <-> nf @ 0b0 @ 0b10 @ vm @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 val process_vlsseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, regidx, int('p), int('n)) -> Retired
 function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
@@ -383,7 +383,7 @@ union clause ast = VSSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, vre
 
 mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b10 @ vm @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 val process_vssseg : forall 'f 'b 'n 'p, (0 < 'f & 'f <= 8) & ('b in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, regidx, int('p), int('n)) -> Retired
 function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
@@ -454,7 +454,7 @@ union clause ast = VLUXSEGTYPE : (bits(3), bits(1), vregidx, regidx, vlewidth, v
 
 mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   <-> nf @ 0b0 @ 0b01 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 val process_vlxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('ib), int('db), int('ip), int('dp), regidx, vregidx, int('n), int) -> Retired
 function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
@@ -525,7 +525,7 @@ union clause ast = VLOXSEGTYPE : (bits(3), bits(1), vregidx, regidx, vlewidth, v
 
 mapping clause encdec = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   <-> nf @ 0b0 @ 0b11 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
   let EEW_index_pow = vlewidth_pow(width);
@@ -552,7 +552,7 @@ union clause ast = VSUXSEGTYPE : (bits(3), bits(1), vregidx, regidx, vlewidth, v
 
 mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b01 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 val process_vsxseg : forall 'f 'ib 'db 'ip 'dp 'n, (0 < 'f & 'f <= 8) & ('ib in {1, 2, 4, 8}) & ('db in {1, 2, 4, 8}) & ('n > 0). (int('f), bits(1), vregidx, int('ib), int('db), int('ip), int('dp), regidx, vregidx, int('n), int) -> Retired
 function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
@@ -624,7 +624,7 @@ union clause ast = VSOXSEGTYPE : (bits(3), bits(1), vregidx, regidx, vlewidth, v
 
 mapping clause encdec = VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b11 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
   let EEW_index_pow = vlewidth_pow(width);
@@ -651,7 +651,7 @@ union clause ast = VLRETYPE : (bits(3), regidx, vlewidth, vregidx)
 
 mapping clause encdec = VLRETYPE(nf, rs1, width, vd)
   <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 val process_vlre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), vregidx, int('b), regidx, int('n)) -> Retired
 function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
@@ -733,7 +733,7 @@ union clause ast = VSRETYPE : (bits(3), regidx, vregidx)
 
 mapping clause encdec = VSRETYPE(nf, rs1, vs3)
   <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ encdec_reg(rs1) @ 0b000 @ encdec_vreg(vs3) @ 0b0100111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 val process_vsre : forall 'f 'b 'n, ('f in {1, 2, 4, 8}) & ('b in {1, 2, 4, 8}) & ('n >= 0). (int('f), int('b), regidx, vregidx, int('n)) -> Retired
 function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
@@ -834,7 +834,7 @@ mapping encdec_lsop : vmlsop <-> bits(7) = {
 
 mapping clause encdec = VMTYPE(rs1, vd_or_vs3, op)
   <-> 0b000 @ 0b0 @ 0b00 @ 0b1 @ 0b01011 @ encdec_reg(rs1) @ 0b000 @ encdec_vreg(vd_or_vs3) @ encdec_lsop(op)
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 val process_vm : forall 'n 'l, ('n >= 0 & 'l >= 0). (vregidx, regidx, int('n), int('l), vmlsop) -> Retired
 function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {

--- a/model/riscv_insts_vext_red.sail
+++ b/model/riscv_insts_vext_red.sail
@@ -21,7 +21,7 @@ mapping encdec_rivvfunct6 : rivvfunct6 <-> bits(6) = {
 
 mapping clause encdec = RIVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_rivvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(RIVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -87,7 +87,7 @@ mapping encdec_rmvvfunct6 : rmvvfunct6 <-> bits(6) = {
 
 mapping clause encdec = RMVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_rmvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(RMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();

--- a/model/riscv_insts_vext_vm.sail
+++ b/model/riscv_insts_vext_vm.sail
@@ -24,7 +24,7 @@ mapping encdec_vvmfunct6 : vvmfunct6 <-> bits(6) = {
 
 mapping clause encdec = VVMTYPE(funct6, vs2, vs1, vd)
   <-> encdec_vvmfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VVMTYPE(funct6, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -80,7 +80,7 @@ mapping encdec_vvmcfunct6 : vvmcfunct6 <-> bits(6) = {
 
 mapping clause encdec = VVMCTYPE(funct6, vs2, vs1, vd)
   <-> encdec_vvmcfunct6(funct6) @ 0b1 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VVMCTYPE(funct6, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -135,7 +135,7 @@ mapping encdec_vvmsfunct6 : vvmsfunct6 <-> bits(6) = {
 
 mapping clause encdec = VVMSTYPE(funct6, vs2, vs1, vd)
   <-> encdec_vvmsfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VVMSTYPE(funct6, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -195,7 +195,7 @@ mapping encdec_vvcmpfunct6 : vvcmpfunct6 <-> bits(6) = {
 
 mapping clause encdec = VVCMPTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_vvcmpfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VVCMPTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
@@ -259,7 +259,7 @@ mapping encdec_vxmfunct6 : vxmfunct6 <-> bits(6) = {
 
 mapping clause encdec = VXMTYPE(funct6, vs2, rs1, vd)
   <-> encdec_vxmfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VXMTYPE(funct6, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -315,7 +315,7 @@ mapping encdec_vxmcfunct6 : vxmcfunct6 <-> bits(6) = {
 
 mapping clause encdec = VXMCTYPE(funct6, vs2, rs1, vd)
   <-> encdec_vxmcfunct6(funct6) @ 0b1 @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VXMCTYPE(funct6, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -370,7 +370,7 @@ mapping encdec_vxmsfunct6 : vxmsfunct6 <-> bits(6) = {
 
 mapping clause encdec = VXMSTYPE(funct6, vs2, rs1, vd)
   <-> encdec_vxmsfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VXMSTYPE(funct6, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -432,7 +432,7 @@ mapping encdec_vxcmpfunct6 : vxcmpfunct6 <-> bits(6) = {
 
 mapping clause encdec = VXCMPTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_vxcmpfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VXCMPTYPE(funct6, vm, vs2, rs1, vd)) = {
   let SEW      = get_sew();
@@ -499,7 +499,7 @@ mapping encdec_vimfunct6 : vimfunct6 <-> bits(6) = {
 
 mapping clause encdec = VIMTYPE(funct6, vs2, simm, vd)
   <-> encdec_vimfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VIMTYPE(funct6, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -552,7 +552,7 @@ mapping encdec_vimcfunct6 : vimcfunct6 <-> bits(6) = {
 
 mapping clause encdec = VIMCTYPE(funct6, vs2, simm, vd)
   <-> encdec_vimcfunct6(funct6) @ 0b1 @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VIMCTYPE(funct6, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -604,7 +604,7 @@ mapping encdec_vimsfunct6 : vimsfunct6 <-> bits(6) = {
 
 mapping clause encdec = VIMSTYPE(funct6, vs2, simm, vd)
   <-> encdec_vimsfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VIMSTYPE(funct6, vs2, simm, vd)) = {
   let SEW      = get_sew();
@@ -662,7 +662,7 @@ mapping encdec_vicmpfunct6 : vicmpfunct6 <-> bits(6) = {
 
 mapping clause encdec = VICMPTYPE(funct6, vm, vs2, simm, vd)
   <-> encdec_vicmpfunct6(funct6) @ vm @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute(VICMPTYPE(funct6, vm, vs2, simm, vd)) = {
   let SEW      = get_sew();

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -74,7 +74,7 @@ union clause ast = VSETVLI : (bits(1), bits(1), bits(3), bits(3), regidx, regidx
 
 mapping clause encdec = VSETVLI(ma, ta, sew, lmul, rs1, rd)
   <-> 0b0000 @ ma @ ta @ sew @ lmul @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute VSETVLI(ma, ta, sew, lmul, rs1, rd) = {
   let LMUL_pow_ori  = get_lmul_pow();
@@ -126,7 +126,7 @@ union clause ast = VSETVL : (regidx, regidx, regidx)
 
 mapping clause encdec = VSETVL(rs2, rs1, rd)
   <-> 0b1000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute VSETVL(rs2, rs1, rd) = {
   let LMUL_pow_ori  = get_lmul_pow();
@@ -178,7 +178,7 @@ union clause ast = VSETIVLI : ( bits(1), bits(1), bits(3), bits(3), bits(5), reg
 
 mapping clause encdec = VSETIVLI(ma, ta, sew, lmul, uimm, rd)
   <-> 0b1100 @ ma @ ta @ sew @ lmul @ uimm @ 0b111 @ encdec_reg(rd) @ 0b1010111
-  when extensionEnabled(Ext_V)
+  when currentlyEnabled(Ext_V)
 
 function clause execute VSETIVLI(ma, ta, sew, lmul, uimm, rd) = {
   /* set vtype */

--- a/model/riscv_insts_zba.sail
+++ b/model/riscv_insts_zba.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_B) = misa[B] == 0b1
+function clause currentlyEnabled(Ext_B) = misa[B] == 0b1 & hartSupports(Ext_B)
 function clause currentlyEnabled(Ext_Zba) = true | currentlyEnabled(Ext_B)
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zba.sail
+++ b/model/riscv_insts_zba.sail
@@ -6,15 +6,15 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause extensionEnabled(Ext_B) = misa[B] == 0b1
-function clause extensionEnabled(Ext_Zba) = true | extensionEnabled(Ext_B)
+function clause currentlyEnabled(Ext_B) = misa[B] == 0b1
+function clause currentlyEnabled(Ext_Zba) = true | currentlyEnabled(Ext_B)
 
 /* ****************************************************************** */
 union clause ast = RISCV_SLLIUW : (bits(6), regidx, regidx)
 
 mapping clause encdec = RISCV_SLLIUW(shamt, rs1, rd)
   <-> 0b000010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
-  when extensionEnabled(Ext_Zba) & xlen == 64
+  when currentlyEnabled(Ext_Zba) & xlen == 64
 
 mapping clause assembly = RISCV_SLLIUW(shamt, rs1, rd)
   <-> "slli.uw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_6(shamt)
@@ -31,19 +31,19 @@ union clause ast = ZBA_RTYPEUW : (regidx, regidx, regidx, bropw_zba)
 
 mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, RISCV_ADDUW)
   <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0111011
-  when extensionEnabled(Ext_Zba) & xlen == 64
+  when currentlyEnabled(Ext_Zba) & xlen == 64
 
 mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, RISCV_SH1ADDUW)
   <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0111011
-  when extensionEnabled(Ext_Zba) & xlen == 64
+  when currentlyEnabled(Ext_Zba) & xlen == 64
 
 mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, RISCV_SH2ADDUW)
   <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0111011
-  when extensionEnabled(Ext_Zba) & xlen == 64
+  when currentlyEnabled(Ext_Zba) & xlen == 64
 
 mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, RISCV_SH3ADDUW)
   <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0111011
-  when extensionEnabled(Ext_Zba) & xlen == 64
+  when currentlyEnabled(Ext_Zba) & xlen == 64
 
 mapping zba_rtypeuw_mnemonic : bropw_zba <-> string = {
   RISCV_ADDUW    <-> "add.uw",
@@ -74,13 +74,13 @@ union clause ast = ZBA_RTYPE : (regidx, regidx, regidx, brop_zba)
 
 mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, RISCV_SH1ADD)
   <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zba)
+  when currentlyEnabled(Ext_Zba)
 mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, RISCV_SH2ADD)
   <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zba)
+  when currentlyEnabled(Ext_Zba)
 mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, RISCV_SH3ADD)
   <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zba)
+  when currentlyEnabled(Ext_Zba)
 
 mapping zba_rtype_mnemonic : brop_zba <-> string = {
   RISCV_SH1ADD <-> "sh1add",

--- a/model/riscv_insts_zbb.sail
+++ b/model/riscv_insts_zbb.sail
@@ -6,15 +6,15 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause extensionEnabled(Ext_Zbb) = true | extensionEnabled(Ext_B)
-function clause extensionEnabled(Ext_Zbkb) = true
+function clause currentlyEnabled(Ext_Zbb) = true | currentlyEnabled(Ext_B)
+function clause currentlyEnabled(Ext_Zbkb) = true
 
 /* ****************************************************************** */
 union clause ast = RISCV_RORIW : (bits(5), regidx, regidx)
 
 mapping clause encdec = RISCV_RORIW(shamt, rs1, rd)
   <-> 0b0110000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0011011
-  when (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
+  when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 64
 
 mapping clause assembly = RISCV_RORIW(shamt, rs1, rd)
   <-> "roriw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_5(shamt)
@@ -31,7 +31,7 @@ union clause ast = RISCV_RORI : (bits(6), regidx, regidx)
 
 mapping clause encdec = RISCV_RORI(shamt, rs1, rd)
   <-> 0b011000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
-  when (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & (xlen == 64 | shamt[5] == bitzero)
+  when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & (xlen == 64 | shamt[5] == bitzero)
 
 mapping clause assembly = RISCV_RORI(shamt, rs1, rd)
   <-> "rori" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_6(shamt)
@@ -50,11 +50,11 @@ union clause ast = ZBB_RTYPEW : (regidx, regidx, regidx, bropw_zbb)
 
 mapping clause encdec = ZBB_RTYPEW(rs2, rs1, rd, RISCV_ROLW)
   <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0111011
-  when (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
+  when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 64
 
 mapping clause encdec = ZBB_RTYPEW(rs2, rs1, rd, RISCV_RORW)
   <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0111011
-  when (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
+  when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 64
 
 mapping zbb_rtypew_mnemonic : bropw_zbb <-> string = {
   RISCV_ROLW <-> "rolw",
@@ -80,39 +80,39 @@ union clause ast = ZBB_RTYPE : (regidx, regidx, regidx, brop_zbb)
 
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ANDN)
   <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
+  when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
 
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ORN)
   <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
+  when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
 
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_XNOR)
   <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
+  when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
 
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MAX)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbb)
+  when currentlyEnabled(Ext_Zbb)
 
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MAXU)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbb)
+  when currentlyEnabled(Ext_Zbb)
 
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MIN)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbb)
+  when currentlyEnabled(Ext_Zbb)
 
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MINU)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbb)
+  when currentlyEnabled(Ext_Zbb)
 
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ROL)
   <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
+  when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
 
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ROR)
   <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)
+  when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
 
 mapping zbb_rtype_mnemonic : brop_zbb <-> string = {
   RISCV_ANDN <-> "andn",
@@ -156,19 +156,19 @@ union clause ast = ZBB_EXTOP : (regidx, regidx, extop_zbb)
 
 mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_SEXTB)
   <-> 0b0110000 @ 0b00100 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zbb)
+  when currentlyEnabled(Ext_Zbb)
 
 mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_SEXTH)
   <-> 0b0110000 @ 0b00101 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zbb)
+  when currentlyEnabled(Ext_Zbb)
 
 mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_ZEXTH)
   <-> 0b0000100 @ 0b00000 @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbb) & xlen == 32
+  when currentlyEnabled(Ext_Zbb) & xlen == 32
 
 mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_ZEXTH)
   <-> 0b0000100 @ 0b00000 @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0111011
-  when extensionEnabled(Ext_Zbb) & xlen == 64
+  when currentlyEnabled(Ext_Zbb) & xlen == 64
 
 mapping zbb_extop_mnemonic : extop_zbb <-> string = {
   RISCV_SEXTB <-> "sext.b",
@@ -195,11 +195,11 @@ union clause ast = RISCV_REV8 : (regidx, regidx)
 
 mapping clause encdec = RISCV_REV8(rs1, rd)
   <-> 0b011010011000 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
-  when (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 32
+  when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 32
 
 mapping clause encdec = RISCV_REV8(rs1, rd)
   <-> 0b011010111000 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
-  when (extensionEnabled(Ext_Zbb) | extensionEnabled(Ext_Zbkb)) & xlen == 64
+  when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 64
 
 mapping clause assembly = RISCV_REV8(rs1, rd)
   <-> "rev8" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -218,7 +218,7 @@ union clause ast = RISCV_ORCB : (regidx, regidx)
 
 mapping clause encdec = RISCV_ORCB(rs1, rd)
   <-> 0b001010000111 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zbb)
+  when currentlyEnabled(Ext_Zbb)
 
 mapping clause assembly = RISCV_ORCB(rs1, rd)
   <-> "orc.b" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -239,7 +239,7 @@ union clause ast = RISCV_CPOP : (regidx, regidx)
 
 mapping clause encdec = RISCV_CPOP(rs1, rd)
   <-> 0b011000000010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zbb)
+  when currentlyEnabled(Ext_Zbb)
 
 mapping clause assembly = RISCV_CPOP(rs1, rd)
   <-> "cpop" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -258,7 +258,7 @@ union clause ast = RISCV_CPOPW : (regidx, regidx)
 
 mapping clause encdec = RISCV_CPOPW(rs1, rd)
   <-> 0b011000000010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
-  when extensionEnabled(Ext_Zbb) & xlen == 64
+  when currentlyEnabled(Ext_Zbb) & xlen == 64
 
 mapping clause assembly = RISCV_CPOPW(rs1, rd)
   <-> "cpopw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -277,7 +277,7 @@ union clause ast = RISCV_CLZ : (regidx, regidx)
 
 mapping clause encdec = RISCV_CLZ(rs1, rd)
   <-> 0b011000000000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zbb)
+  when currentlyEnabled(Ext_Zbb)
 
 mapping clause assembly = RISCV_CLZ(rs1, rd)
   <-> "clz" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -299,7 +299,7 @@ union clause ast = RISCV_CLZW : (regidx, regidx)
 
 mapping clause encdec = RISCV_CLZW(rs1, rd)
   <-> 0b011000000000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
-  when extensionEnabled(Ext_Zbb) & xlen == 64
+  when currentlyEnabled(Ext_Zbb) & xlen == 64
 
 mapping clause assembly = RISCV_CLZW(rs1, rd)
   <-> "clzw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -321,7 +321,7 @@ union clause ast = RISCV_CTZ : (regidx, regidx)
 
 mapping clause encdec = RISCV_CTZ(rs1, rd)
   <-> 0b011000000001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zbb)
+  when currentlyEnabled(Ext_Zbb)
 
 mapping clause assembly = RISCV_CTZ(rs1, rd)
   <-> "ctz" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -343,7 +343,7 @@ union clause ast = RISCV_CTZW : (regidx, regidx)
 
 mapping clause encdec = RISCV_CTZW(rs1, rd)
   <-> 0b011000000001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
-  when extensionEnabled(Ext_Zbb) & xlen == 64
+  when currentlyEnabled(Ext_Zbb) & xlen == 64
 
 mapping clause assembly = RISCV_CTZW(rs1, rd)
   <-> "ctzw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)

--- a/model/riscv_insts_zbc.sail
+++ b/model/riscv_insts_zbc.sail
@@ -6,15 +6,15 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause extensionEnabled(Ext_Zbc) = true
-function clause extensionEnabled(Ext_Zbkc) = true
+function clause currentlyEnabled(Ext_Zbc) = true
+function clause currentlyEnabled(Ext_Zbkc) = true
 
 /* ****************************************************************** */
 union clause ast = RISCV_CLMUL : (regidx, regidx, regidx)
 
 mapping clause encdec = RISCV_CLMUL(rs2, rs1, rd)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbc) | extensionEnabled(Ext_Zbkc)
+  when currentlyEnabled(Ext_Zbc) | currentlyEnabled(Ext_Zbkc)
 
 mapping clause assembly = RISCV_CLMUL(rs2, rs1, rd)
   <-> "clmul" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
@@ -30,7 +30,7 @@ union clause ast = RISCV_CLMULH : (regidx, regidx, regidx)
 
 mapping clause encdec = RISCV_CLMULH(rs2, rs1, rd)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b011 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbc) | extensionEnabled(Ext_Zbkc)
+  when currentlyEnabled(Ext_Zbc) | currentlyEnabled(Ext_Zbkc)
 
 mapping clause assembly = RISCV_CLMULH(rs2, rs1, rd)
   <-> "clmulh" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
@@ -46,7 +46,7 @@ union clause ast = RISCV_CLMULR : (regidx, regidx, regidx)
 
 mapping clause encdec = RISCV_CLMULR(rs2, rs1, rd)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbc)
+  when currentlyEnabled(Ext_Zbc)
 
 mapping clause assembly = RISCV_CLMULR(rs2, rs1, rd)
   <-> "clmulr" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)

--- a/model/riscv_insts_zbkb.sail
+++ b/model/riscv_insts_zbkb.sail
@@ -11,11 +11,11 @@ union clause ast = ZBKB_RTYPE : (regidx, regidx, regidx, brop_zbkb)
 
 mapping clause encdec = ZBKB_RTYPE(rs2, rs1, rd, RISCV_PACK)
   <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbkb)
+  when currentlyEnabled(Ext_Zbkb)
 
 mapping clause encdec = ZBKB_RTYPE(rs2, rs1, rd, RISCV_PACKH)
   <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbkb)
+  when currentlyEnabled(Ext_Zbkb)
 
 mapping zbkb_rtype_mnemonic : brop_zbkb <-> string = {
   RISCV_PACK  <-> "pack",
@@ -41,7 +41,7 @@ union clause ast = ZBKB_PACKW : (regidx, regidx, regidx)
 
 mapping clause encdec = ZBKB_PACKW(rs2, rs1, rd)
   <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0111011
-  when extensionEnabled(Ext_Zbkb) & xlen == 64
+  when currentlyEnabled(Ext_Zbkb) & xlen == 64
 
 mapping clause assembly = ZBKB_PACKW(rs2, rs1, rd)
   <-> "packw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
@@ -60,7 +60,7 @@ union clause ast = RISCV_ZIP : (regidx, regidx)
 
 mapping clause encdec = RISCV_ZIP(rs1, rd)
   <-> 0b000010001111 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zbkb) & xlen == 32
+  when currentlyEnabled(Ext_Zbkb) & xlen == 32
 
 mapping clause assembly = RISCV_ZIP(rs1, rd)
   <-> "zip" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -82,7 +82,7 @@ union clause ast = RISCV_UNZIP : (regidx, regidx)
 
 mapping clause encdec = RISCV_UNZIP(rs1, rd)
   <-> 0b000010001111 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zbkb) & xlen == 32
+  when currentlyEnabled(Ext_Zbkb) & xlen == 32
 
 mapping clause assembly = RISCV_UNZIP(rs1, rd)
   <-> "unzip" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -104,7 +104,7 @@ union clause ast = RISCV_BREV8 : (regidx, regidx)
 
 mapping clause encdec = RISCV_BREV8(rs1, rd)
   <-> 0b011010000111 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zbkb)
+  when currentlyEnabled(Ext_Zbkb)
 
 mapping clause assembly = RISCV_BREV8(rs1, rd)
   <-> "brev8" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)

--- a/model/riscv_insts_zbkx.sail
+++ b/model/riscv_insts_zbkx.sail
@@ -6,14 +6,14 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause extensionEnabled(Ext_Zbkx) = true
+function clause currentlyEnabled(Ext_Zbkx) = true
 
 /* ****************************************************************** */
 union clause ast = RISCV_XPERM8 : (regidx, regidx, regidx)
 
 mapping clause encdec = RISCV_XPERM8(rs2, rs1, rd)
   <-> 0b0010100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbkx)
+  when currentlyEnabled(Ext_Zbkx)
 
 mapping clause assembly = RISCV_XPERM8(rs2, rs1, rd)
   <-> "xperm8" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
@@ -37,7 +37,7 @@ union clause ast = RISCV_XPERM4 : (regidx, regidx, regidx)
 
 mapping clause encdec = RISCV_XPERM4(rs2, rs1, rd)
   <-> 0b0010100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbkx)
+  when currentlyEnabled(Ext_Zbkx)
 
 mapping clause assembly = RISCV_XPERM4(rs2, rs1, rd)
   <-> "xperm4" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)

--- a/model/riscv_insts_zbs.sail
+++ b/model/riscv_insts_zbs.sail
@@ -6,26 +6,26 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause extensionEnabled(Ext_Zbs) = true | extensionEnabled(Ext_B)
+function clause currentlyEnabled(Ext_Zbs) = true | currentlyEnabled(Ext_B)
 
 /* ****************************************************************** */
 union clause ast = ZBS_IOP : (bits(6), regidx, regidx, biop_zbs)
 
 mapping clause encdec = ZBS_IOP(shamt, rs1, rd, RISCV_BCLRI)
   <-> 0b010010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
+  when currentlyEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
 
 mapping clause encdec = ZBS_IOP(shamt, rs1, rd, RISCV_BEXTI)
   <-> 0b010010 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
+  when currentlyEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
 
 mapping clause encdec = ZBS_IOP(shamt, rs1, rd, RISCV_BINVI)
   <-> 0b011010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
+  when currentlyEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
 
 mapping clause encdec = ZBS_IOP(shamt, rs1, rd, RISCV_BSETI)
   <-> 0b001010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
+  when currentlyEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
 
 mapping zbs_iop_mnemonic : biop_zbs <-> string = {
   RISCV_BCLRI <-> "bclri",
@@ -57,19 +57,19 @@ union clause ast = ZBS_RTYPE : (regidx, regidx, regidx, brop_zbs)
 
 mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, RISCV_BCLR)
   <-> 0b0100100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbs)
+  when currentlyEnabled(Ext_Zbs)
 
 mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, RISCV_BEXT)
   <-> 0b0100100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbs)
+  when currentlyEnabled(Ext_Zbs)
 
 mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, RISCV_BINV)
   <-> 0b0110100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbs)
+  when currentlyEnabled(Ext_Zbs)
 
 mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, RISCV_BSET)
   <-> 0b0010100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zbs)
+  when currentlyEnabled(Ext_Zbs)
 
 mapping zbs_rtype_mnemonic : brop_zbs <-> string = {
   RISCV_BCLR    <-> "bclr",

--- a/model/riscv_insts_zca.sail
+++ b/model/riscv_insts_zca.sail
@@ -18,7 +18,7 @@ union clause ast = C_NOP : unit
 
 mapping clause encdec_compressed = C_NOP()
   <-> 0b000 @ 0b0 @ 0b00000 @ 0b00000 @ 0b01
-  when extensionEnabled(Ext_Zca)
+  when currentlyEnabled(Ext_Zca)
 
 function clause execute C_NOP() = RETIRE_SUCCESS
 
@@ -30,7 +30,7 @@ union clause ast = C_ADDI4SPN : (cregidx, bits(8))
 
 mapping clause encdec_compressed = C_ADDI4SPN(rd, nz96 @ nz54 @ nz3 @ nz2)
   <-> 0b000 @ nz54 : bits(2) @ nz96 : bits(4) @ nz2 : bits(1) @ nz3 : bits(1) @ encdec_creg(rd) @ 0b00
-  when nz96 @ nz54 @ nz3 @ nz2 != 0b00000000 & extensionEnabled(Ext_Zca)
+  when nz96 @ nz54 @ nz3 @ nz2 != 0b00000000 & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_ADDI4SPN(rdc, nzimm)) = {
   let imm : bits(12) = (0b00 @ nzimm @ 0b00);
@@ -48,7 +48,7 @@ union clause ast = C_LW : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_LW(ui6 @ ui53 @ ui2, rs1, rd)
   <-> 0b010 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_creg(rd) @ 0b00
-  when extensionEnabled(Ext_Zca)
+  when currentlyEnabled(Ext_Zca)
 
 function clause execute (C_LW(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
@@ -65,7 +65,7 @@ union clause ast = C_LD : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_LD(ui76 @ ui53, rs1, rd)
   <-> 0b011 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_creg(rd) @ 0b00
-  when xlen == 64 & extensionEnabled(Ext_Zca)
+  when xlen == 64 & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_LD(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
@@ -83,7 +83,7 @@ union clause ast = C_SW : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SW(ui6 @ ui53 @ ui2, rs1, rs2)
   <-> 0b110 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_creg(rs2) @ 0b00
-  when extensionEnabled(Ext_Zca)
+  when currentlyEnabled(Ext_Zca)
 
 function clause execute (C_SW(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
@@ -99,9 +99,9 @@ mapping clause assembly = C_SW(uimm, rsc1, rsc2)
 union clause ast = C_SD : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SD(ui76 @ ui53, rs1, rs2)
-      if xlen == 64 & extensionEnabled(Ext_Zca)
+      if xlen == 64 & currentlyEnabled(Ext_Zca)
   <-> 0b111 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_creg(rs2) @ 0b00
-      if xlen == 64 & extensionEnabled(Ext_Zca)
+      if xlen == 64 & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_SD(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
@@ -120,7 +120,7 @@ union clause ast = C_ADDI : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_ADDI(nzi5 @ nzi40, rsd)
   <-> 0b000 @ nzi5 : bits(1) @ encdec_reg(rsd) @ nzi40 : bits(5) @ 0b01
-  when nzi5 @ nzi40 != 0b000000 & rsd != zreg & extensionEnabled(Ext_Zca)
+  when nzi5 @ nzi40 != 0b000000 & rsd != zreg & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_ADDI(nzi, rsd)) = {
   let imm : bits(12) = sign_extend(nzi);
@@ -136,7 +136,7 @@ union clause ast = C_JAL : (bits(11))
 
 mapping clause encdec_compressed = C_JAL(i11 @ i10 @ i98 @ i7 @ i6 @ i5 @ i4 @ i31)
   <-> 0b001 @ i11 : bits(1) @ i4 : bits(1) @ i98 : bits(2) @ i10 : bits(1) @ i6 : bits(1) @ i7 : bits(1) @ i31 : bits(3) @ i5 : bits(1) @ 0b01
-  when xlen == 32 & extensionEnabled(Ext_Zca)
+  when xlen == 32 & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_JAL(imm)) =
   execute(RISCV_JAL(sign_extend(imm @ 0b0), ra))
@@ -150,7 +150,7 @@ union clause ast = C_ADDIW : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_ADDIW(imm5 @ imm40, rsd)
   <-> 0b001 @ imm5 : bits(1) @ encdec_reg(rsd) @ imm40 : bits(5) @ 0b01
-  when rsd != zreg & xlen == 64 & extensionEnabled(Ext_Zca)
+  when rsd != zreg & xlen == 64 & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_ADDIW(imm, rsd)) =
   execute(ADDIW(sign_extend(imm), rsd, rsd))
@@ -164,7 +164,7 @@ union clause ast = C_LI : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_LI(imm5 @ imm40, rd)
   <-> 0b010 @ imm5 : bits(1) @ encdec_reg(rd) @ imm40 : bits(5) @ 0b01
-  when rd != zreg & extensionEnabled(Ext_Zca)
+  when rd != zreg & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_LI(imm, rd)) = {
   let imm : bits(12) = sign_extend(imm);
@@ -180,7 +180,7 @@ union clause ast = C_ADDI16SP : (bits(6))
 
 mapping clause encdec_compressed = C_ADDI16SP(nzi9 @ nzi87 @ nzi6 @ nzi5 @ nzi4)
   <-> 0b011 @ nzi9 : bits(1) @ /* x2 */ 0b00010 @ nzi4 : bits(1) @ nzi6 : bits(1) @ nzi87 : bits(2) @ nzi5 : bits(1) @ 0b01
-  when nzi9 @ nzi87 @ nzi6 @ nzi5 @ nzi4 != 0b000000 & extensionEnabled(Ext_Zca)
+  when nzi9 @ nzi87 @ nzi6 @ nzi5 @ nzi4 != 0b000000 & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_ADDI16SP(imm)) = {
   let imm : bits(12) = sign_extend(imm @ 0x0);
@@ -196,7 +196,7 @@ union clause ast = C_LUI : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_LUI(imm17 @ imm1612, rd)
   <-> 0b011 @ imm17 : bits(1) @ encdec_reg(rd) @ imm1612 : bits(5) @ 0b01
-  when rd != zreg & rd != sp & imm17 @ imm1612 != 0b000000 & extensionEnabled(Ext_Zca)
+  when rd != zreg & rd != sp & imm17 @ imm1612 != 0b000000 & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_LUI(imm, rd)) = {
   let res : bits(20) = sign_extend(imm);
@@ -212,7 +212,7 @@ union clause ast = C_SRLI : (bits(6), cregidx)
 
 mapping clause encdec_compressed = C_SRLI(nzui5 @ nzui40, rsd)
   <-> 0b100 @ nzui5 : bits(1) @ 0b00 @ encdec_creg(rsd) @ nzui40 : bits(5) @ 0b01
-  when nzui5 @ nzui40 != 0b000000 & (xlen == 64 | nzui5 == 0b0) & extensionEnabled(Ext_Zca)
+  when nzui5 @ nzui40 != 0b000000 & (xlen == 64 | nzui5 == 0b0) & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_SRLI(shamt, rsd)) = {
   let rsd = creg2reg_idx(rsd);
@@ -228,7 +228,7 @@ union clause ast = C_SRAI : (bits(6), cregidx)
 
 mapping clause encdec_compressed = C_SRAI(nzui5 @ nzui40, rsd)
   <-> 0b100 @ nzui5 : bits(1) @ 0b01 @ encdec_creg(rsd) @ nzui40 : bits(5) @ 0b01
-  when nzui5 @ nzui40 != 0b000000 & (xlen == 64 | nzui5 == 0b0) & extensionEnabled(Ext_Zca)
+  when nzui5 @ nzui40 != 0b000000 & (xlen == 64 | nzui5 == 0b0) & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_SRAI(shamt, rsd)) = {
   let rsd = creg2reg_idx(rsd);
@@ -244,7 +244,7 @@ union clause ast = C_ANDI : (bits(6), cregidx)
 
 mapping clause encdec_compressed = C_ANDI(i5 @ i40, rsd)
   <-> 0b100 @ i5 : bits(1) @ 0b10 @ encdec_creg(rsd) @ i40 : bits(5) @ 0b01
-  when extensionEnabled(Ext_Zca)
+  when currentlyEnabled(Ext_Zca)
 
 function clause execute (C_ANDI(imm, rsd)) = {
   let rsd = creg2reg_idx(rsd);
@@ -259,7 +259,7 @@ union clause ast = C_SUB : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SUB(rsd, rs2)
   <-> 0b100 @ 0b0 @ 0b11 @ encdec_creg(rsd) @ 0b00 @ encdec_creg(rs2) @ 0b01
-  when extensionEnabled(Ext_Zca)
+  when currentlyEnabled(Ext_Zca)
 
 function clause execute (C_SUB(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
@@ -275,7 +275,7 @@ union clause ast = C_XOR : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_XOR(rsd, rs2)
   <-> 0b100 @ 0b0 @ 0b11 @ encdec_creg(rsd) @ 0b01 @ encdec_creg(rs2) @ 0b01
-  when extensionEnabled(Ext_Zca)
+  when currentlyEnabled(Ext_Zca)
 
 function clause execute (C_XOR(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
@@ -291,7 +291,7 @@ union clause ast = C_OR : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_OR(rsd, rs2)
   <-> 0b100 @ 0b0 @ 0b11 @ encdec_creg(rsd) @ 0b10 @ encdec_creg(rs2) @ 0b01
-  when extensionEnabled(Ext_Zca)
+  when currentlyEnabled(Ext_Zca)
 
 function clause execute (C_OR(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
@@ -307,7 +307,7 @@ union clause ast = C_AND : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_AND(rsd, rs2)
   <-> 0b100 @ 0b0 @ 0b11 @ encdec_creg(rsd) @ 0b11 @ encdec_creg(rs2) @ 0b01
-  when extensionEnabled(Ext_Zca)
+  when currentlyEnabled(Ext_Zca)
 
 function clause execute (C_AND(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
@@ -323,7 +323,7 @@ union clause ast = C_SUBW : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SUBW(rsd, rs2)
   <-> 0b100 @ 0b1 @ 0b11 @ encdec_creg(rsd) @ 0b00 @ encdec_creg(rs2) @ 0b01
-  when xlen == 64 & extensionEnabled(Ext_Zca)
+  when xlen == 64 & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_SUBW(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
@@ -340,7 +340,7 @@ union clause ast = C_ADDW : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_ADDW(rsd, rs2)
   <-> 0b100 @ 0b1 @ 0b11 @ encdec_creg(rsd) @ 0b01 @ encdec_creg(rs2) @ 0b01
-  when xlen == 64 & extensionEnabled(Ext_Zca)
+  when xlen == 64 & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_ADDW(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
@@ -357,7 +357,7 @@ union clause ast = C_J : (bits(11))
 
 mapping clause encdec_compressed = C_J(i11 @ i10 @ i98 @ i7 @ i6 @ i5 @ i4 @ i31)
   <-> 0b101 @ i11 : bits(1) @ i4 : bits(1) @ i98 : bits(2) @ i10 : bits(1) @ i6 : bits(1) @ i7 : bits(1) @ i31 : bits(3) @ i5 : bits(1) @ 0b01
-  when extensionEnabled(Ext_Zca)
+  when currentlyEnabled(Ext_Zca)
 
 function clause execute (C_J(imm)) =
   execute(RISCV_JAL(sign_extend(imm @ 0b0), zreg))
@@ -370,7 +370,7 @@ union clause ast = C_BEQZ : (bits(8), cregidx)
 
 mapping clause encdec_compressed = C_BEQZ(i8 @ i76 @ i5 @ i43 @ i21, rs)
   <-> 0b110 @ i8 : bits(1) @ i43 : bits(2) @ encdec_creg(rs) @ i76 : bits(2) @ i21 : bits(2) @ i5 : bits(1) @ 0b01
-  when extensionEnabled(Ext_Zca)
+  when currentlyEnabled(Ext_Zca)
 
 function clause execute (C_BEQZ(imm, rs)) =
   execute(BTYPE(sign_extend(imm @ 0b0), zreg, creg2reg_idx(rs), RISCV_BEQ))
@@ -383,7 +383,7 @@ union clause ast = C_BNEZ : (bits(8), cregidx)
 
 mapping clause encdec_compressed = C_BNEZ(i8 @ i76 @ i5 @ i43 @ i21, rs)
   <-> 0b111 @ i8 : bits(1) @ i43 : bits(2) @ encdec_creg(rs) @ i76 : bits(2) @ i21 : bits(2) @ i5 : bits(1) @ 0b01
-  when extensionEnabled(Ext_Zca)
+  when currentlyEnabled(Ext_Zca)
 
 function clause execute (C_BNEZ(imm, rs)) =
   execute(BTYPE(sign_extend(imm @ 0b0), zreg, creg2reg_idx(rs), RISCV_BNE))
@@ -396,7 +396,7 @@ union clause ast = C_SLLI : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_SLLI(nzui5 @ nzui40, rsd)
   <-> 0b000 @ nzui5 : bits(1) @ encdec_reg(rsd) @ nzui40 : bits(5) @ 0b10
-  when nzui5 @ nzui40 != 0b000000 & rsd != zreg & (xlen == 64 | nzui5 == 0b0) & extensionEnabled(Ext_Zca)
+  when nzui5 @ nzui40 != 0b000000 & rsd != zreg & (xlen == 64 | nzui5 == 0b0) & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_SLLI(shamt, rsd)) =
   execute(SHIFTIOP(shamt, rsd, rsd, RISCV_SLLI))
@@ -410,7 +410,7 @@ union clause ast = C_LWSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_LWSP(ui76 @ ui5 @ ui42, rd)
   <-> 0b010 @ ui5 : bits(1) @ encdec_reg(rd) @ ui42 : bits(3) @ ui76 : bits(2) @ 0b10
-  when rd != zreg & extensionEnabled(Ext_Zca)
+  when rd != zreg & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_LWSP(uimm, rd)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
@@ -426,7 +426,7 @@ union clause ast = C_LDSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_LDSP(ui86 @ ui5 @ ui43, rd)
   <-> 0b011 @ ui5 : bits(1) @ encdec_reg(rd) @ ui43 : bits(2) @ ui86 : bits(3) @ 0b10
-  when rd != zreg & xlen == 64 & extensionEnabled(Ext_Zca)
+  when rd != zreg & xlen == 64 & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_LDSP(uimm, rd)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
@@ -442,7 +442,7 @@ union clause ast = C_SWSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_SWSP(ui76 @ ui52, rs2)
   <-> 0b110 @ ui52 : bits(4) @ ui76 : bits(2) @ encdec_reg(rs2) @ 0b10
-  when extensionEnabled(Ext_Zca)
+  when currentlyEnabled(Ext_Zca)
 
 function clause execute (C_SWSP(uimm, rs2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
@@ -457,7 +457,7 @@ union clause ast = C_SDSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_SDSP(ui86 @ ui53, rs2)
   <-> 0b111 @ ui53 : bits(3) @ ui86 : bits(3) @ encdec_reg(rs2) @ 0b10
-  when xlen == 64 & extensionEnabled(Ext_Zca)
+  when xlen == 64 & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_SDSP(uimm, rs2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
@@ -473,7 +473,7 @@ union clause ast = C_JR : (regidx)
 
 mapping clause encdec_compressed = C_JR(rs1)
   <-> 0b100 @ 0b0 @ encdec_reg(rs1) @ 0b00000 @ 0b10
-  when rs1 != zreg & extensionEnabled(Ext_Zca)
+  when rs1 != zreg & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_JR(rs1)) =
   execute(RISCV_JALR(zeros(), rs1, zreg))
@@ -487,7 +487,7 @@ union clause ast = C_JALR : (regidx)
 
 mapping clause encdec_compressed = C_JALR(rs1)
   <-> 0b100 @ 0b1 @ encdec_reg(rs1) @ 0b00000 @ 0b10
-  when rs1 != zreg & extensionEnabled(Ext_Zca)
+  when rs1 != zreg & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_JALR(rs1)) =
   execute(RISCV_JALR(zeros(), rs1, ra))
@@ -501,7 +501,7 @@ union clause ast = C_MV : (regidx, regidx)
 
 mapping clause encdec_compressed = C_MV(rd, rs2)
   <-> 0b100 @ 0b0 @ encdec_reg(rd) @ encdec_reg(rs2) @ 0b10
-  when rd != zreg & rs2 != zreg & extensionEnabled(Ext_Zca)
+  when rd != zreg & rs2 != zreg & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_MV(rd, rs2)) =
   execute(RTYPE(rs2, zreg, rd, RISCV_ADD))
@@ -515,7 +515,7 @@ union clause ast = C_EBREAK : unit
 
 mapping clause encdec_compressed = C_EBREAK()
   <-> 0b100 @ 0b1 @ 0b00000 @ 0b00000 @ 0b10
-  when extensionEnabled(Ext_Zca)
+  when currentlyEnabled(Ext_Zca)
 
 function clause execute C_EBREAK() =
   execute(EBREAK())
@@ -527,7 +527,7 @@ union clause ast = C_ADD : (regidx, regidx)
 
 mapping clause encdec_compressed = C_ADD(rsd, rs2)
   <-> 0b100 @ 0b1 @ encdec_reg(rsd) @ encdec_reg(rs2) @ 0b10
-  when rsd != zreg & rs2 != zreg & extensionEnabled(Ext_Zca)
+  when rsd != zreg & rs2 != zreg & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_ADD(rsd, rs2)) =
   execute(RTYPE(rs2, rsd, rsd, RISCV_ADD))

--- a/model/riscv_insts_zcb.sail
+++ b/model/riscv_insts_zcb.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_Zcb) = sys_enable_zcb() & currentlyEnabled(Ext_Zca)
+function clause currentlyEnabled(Ext_Zcb) = hartSupports(Ext_Zcb) & currentlyEnabled(Ext_Zca)
 
 union clause ast = C_LBU : (bits(2), cregidx, cregidx)
 

--- a/model/riscv_insts_zcb.sail
+++ b/model/riscv_insts_zcb.sail
@@ -6,13 +6,13 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause extensionEnabled(Ext_Zcb) = sys_enable_zcb() & extensionEnabled(Ext_Zca)
+function clause currentlyEnabled(Ext_Zcb) = sys_enable_zcb() & currentlyEnabled(Ext_Zca)
 
 union clause ast = C_LBU : (bits(2), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_LBU(uimm1 @ uimm0, rdc, rs1c)
   <-> 0b100 @ 0b000 @ encdec_creg(rs1c) @ uimm0 : bits(1) @ uimm1 : bits(1) @ encdec_creg(rdc) @ 0b00
-  when extensionEnabled(Ext_Zcb)
+  when currentlyEnabled(Ext_Zcb)
 
 mapping clause assembly = C_LBU(uimm, rdc, rs1c) <->
   "c.lbu" ^ spc() ^ creg_name(rdc) ^ sep() ^ hex_bits_2(uimm) ^ opt_spc() ^ "(" ^ opt_spc() ^ creg_name(rs1c) ^ opt_spc() ^ ")"
@@ -30,7 +30,7 @@ union clause ast = C_LHU : (bits(2), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_LHU(uimm1 @ 0b0, rdc, rs1c)
   <-> 0b100 @ 0b001 @ encdec_creg(rs1c) @ 0b0 @ uimm1 : bits(1) @ encdec_creg(rdc) @ 0b00
-  when extensionEnabled(Ext_Zcb)
+  when currentlyEnabled(Ext_Zcb)
 
 mapping clause assembly = C_LHU(uimm, rdc, rs1c) <->
   "c.lhu" ^ spc() ^ creg_name(rdc) ^ sep() ^ hex_bits_2(uimm) ^ opt_spc() ^ "(" ^ opt_spc() ^ creg_name(rs1c) ^ opt_spc() ^ ")"
@@ -48,7 +48,7 @@ union clause ast = C_LH : (bits(2), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_LH(uimm1 @ 0b0, rdc, rs1c)
   <-> 0b100 @ 0b001 @ encdec_creg(rs1c) @ 0b1 @ uimm1 : bits(1) @ encdec_creg(rdc) @ 0b00
-  when extensionEnabled(Ext_Zcb)
+  when currentlyEnabled(Ext_Zcb)
 
 mapping clause assembly = C_LH(uimm, rdc, rs1c) <->
   "c.lh" ^ spc() ^ creg_name(rdc) ^ sep() ^ hex_bits_2(uimm) ^ opt_spc() ^ "(" ^ opt_spc() ^ creg_name(rs1c) ^ opt_spc() ^ ")"
@@ -66,7 +66,7 @@ union clause ast = C_SB : (bits(2), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SB(uimm1 @ uimm0, rs1c, rs2c)
   <-> 0b100 @ 0b010 @ encdec_creg(rs1c) @ uimm0 : bits(1) @ uimm1 : bits(1) @ encdec_creg(rs2c) @ 0b00
-  when extensionEnabled(Ext_Zcb)
+  when currentlyEnabled(Ext_Zcb)
 
 mapping clause assembly = C_SB(uimm, rs1c, rs2c) <->
   "c.sb" ^ spc() ^ creg_name(rs2c) ^ sep() ^ hex_bits_2(uimm) ^ opt_spc() ^ "(" ^ opt_spc() ^ creg_name(rs1c) ^ opt_spc() ^ ")"
@@ -84,7 +84,7 @@ union clause ast = C_SH : (bits(2), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SH(uimm1 @ 0b0, rs1c, rs2c)
   <-> 0b100 @ 0b011 @ encdec_creg(rs1c) @ 0b0 @ uimm1 : bits(1) @ encdec_creg(rs2c) @ 0b00
-  when extensionEnabled(Ext_Zcb)
+  when currentlyEnabled(Ext_Zcb)
 
 mapping clause assembly = C_SH(uimm, rs1c, rs2c) <->
   "c.sh" ^ spc() ^ creg_name(rs1c) ^ sep() ^ hex_bits_2(uimm) ^ opt_spc() ^ "(" ^ opt_spc() ^ creg_name(rs2c) ^ opt_spc() ^ ")"
@@ -102,7 +102,7 @@ union clause ast = C_ZEXT_B : (cregidx)
 
 mapping clause encdec_compressed = C_ZEXT_B(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b000 @ 0b01
-  when extensionEnabled(Ext_Zcb)
+  when currentlyEnabled(Ext_Zcb)
 
 mapping clause assembly = C_ZEXT_B(rsdc) <->
   "c.zext.b" ^ spc() ^ creg_name(rsdc)
@@ -119,7 +119,7 @@ union clause ast = C_SEXT_B : (cregidx)
 
 mapping clause encdec_compressed = C_SEXT_B(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b001 @ 0b01
-  when extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zbb)
+  when currentlyEnabled(Ext_Zcb) & currentlyEnabled(Ext_Zbb)
 
 mapping clause assembly = C_SEXT_B(rsdc) <->
   "c.sext.b" ^ spc() ^ creg_name(rsdc)
@@ -135,7 +135,7 @@ union clause ast = C_ZEXT_H : (cregidx)
 
 mapping clause encdec_compressed = C_ZEXT_H(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b010 @ 0b01
-  when extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zbb)
+  when currentlyEnabled(Ext_Zcb) & currentlyEnabled(Ext_Zbb)
 
 mapping clause assembly = C_ZEXT_H(rsdc) <->
   "c.zext.h" ^ spc() ^ creg_name(rsdc)
@@ -151,7 +151,7 @@ union clause ast = C_SEXT_H : (cregidx)
 
 mapping clause encdec_compressed = C_SEXT_H(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b011 @ 0b01
-  when extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zbb)
+  when currentlyEnabled(Ext_Zcb) & currentlyEnabled(Ext_Zbb)
 
 mapping clause assembly = C_SEXT_H(rsdc) <->
   "c.sext.h" ^ spc() ^ creg_name(rsdc)
@@ -167,7 +167,7 @@ union clause ast = C_ZEXT_W : (cregidx)
 
 mapping clause encdec_compressed = C_ZEXT_W(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b100 @ 0b01
-  when extensionEnabled(Ext_Zcb) & extensionEnabled(Ext_Zba) & xlen == 64
+  when currentlyEnabled(Ext_Zcb) & currentlyEnabled(Ext_Zba) & xlen == 64
 
 mapping clause assembly = C_ZEXT_W(rsdc) <->
   "c.zext.w" ^ spc() ^ creg_name(rsdc)
@@ -183,7 +183,7 @@ union clause ast = C_NOT : (cregidx)
 
 mapping clause encdec_compressed = C_NOT(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b101 @ 0b01
-  when extensionEnabled(Ext_Zcb)
+  when currentlyEnabled(Ext_Zcb)
 
 mapping clause assembly = C_NOT(rsdc) <->
   "c.not" ^ spc() ^ creg_name(rsdc)
@@ -200,7 +200,7 @@ union clause ast = C_MUL : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_MUL(rsdc, rs2c)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b10 @ encdec_creg(rs2c) @ 0b01
-  when extensionEnabled(Ext_Zcb) & (extensionEnabled(Ext_M) | extensionEnabled(Ext_Zmmul))
+  when currentlyEnabled(Ext_Zcb) & (currentlyEnabled(Ext_M) | currentlyEnabled(Ext_Zmmul))
 
 mapping clause assembly = C_MUL(rsdc, rs2c) <->
   "c.mul" ^ spc() ^ creg_name(rsdc) ^ sep() ^ creg_name(rs2c)

--- a/model/riscv_insts_zcd.sail
+++ b/model/riscv_insts_zcd.sail
@@ -6,13 +6,13 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause extensionEnabled(Ext_Zcd) = extensionEnabled(Ext_Zca) & extensionEnabled(Ext_D) & (xlen == 32 | xlen == 64)
+function clause currentlyEnabled(Ext_Zcd) = currentlyEnabled(Ext_Zca) & currentlyEnabled(Ext_D) & (xlen == 32 | xlen == 64)
 
 union clause ast = C_FLDSP : (bits(6), fregidx)
 
 mapping clause encdec_compressed = C_FLDSP(ui86 @ ui5 @ ui43, rd)
   <-> 0b001 @ ui5 : bits(1) @ encdec_freg(rd) @ ui43 : bits(2) @ ui86 : bits(3) @ 0b10
-  when extensionEnabled(Ext_Zcd)
+  when currentlyEnabled(Ext_Zcd)
 
 function clause execute (C_FLDSP(uimm, rd)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
@@ -29,7 +29,7 @@ union clause ast = C_FSDSP : (bits(6), fregidx)
 
 mapping clause encdec_compressed = C_FSDSP(ui86 @ ui53, rs2)
   <-> 0b101 @ ui53 : bits(3) @ ui86 : bits(3) @ encdec_freg(rs2) @ 0b10
-  when extensionEnabled(Ext_Zcd)
+  when currentlyEnabled(Ext_Zcd)
 
 function clause execute (C_FSDSP(uimm, rs2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
@@ -46,7 +46,7 @@ union clause ast = C_FLD : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_FLD(ui76 @ ui53, rs1, rd)
   <-> 0b001 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_creg(rd) @ 0b00
-  when extensionEnabled(Ext_Zcd)
+  when currentlyEnabled(Ext_Zcd)
 
 function clause execute (C_FLD(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
@@ -65,7 +65,7 @@ union clause ast = C_FSD : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_FSD(ui76 @ ui53, rs1, rs2)
   <-> 0b101 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_creg(rs2) @ 0b00
-  when extensionEnabled(Ext_Zcd)
+  when currentlyEnabled(Ext_Zcd)
 
 function clause execute (C_FSD(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);

--- a/model/riscv_insts_zcf.sail
+++ b/model/riscv_insts_zcf.sail
@@ -15,13 +15,13 @@
 
 /* ****************************************************************** */
 
-function clause extensionEnabled(Ext_Zcf) = extensionEnabled(Ext_Zca) & extensionEnabled(Ext_F) & xlen == 32
+function clause currentlyEnabled(Ext_Zcf) = currentlyEnabled(Ext_Zca) & currentlyEnabled(Ext_F) & xlen == 32
 
 union clause ast = C_FLWSP : (bits(6), fregidx)
 
 mapping clause encdec_compressed = C_FLWSP(ui76 @ ui5 @ ui42, rd)
   <-> 0b011 @ ui5 : bits(1) @ encdec_freg(rd) @ ui42 : bits(3) @ ui76 : bits(2) @ 0b10
-  when extensionEnabled(Ext_Zcf)
+  when currentlyEnabled(Ext_Zcf)
 
 function clause execute (C_FLWSP(imm, rd)) = {
   let imm : bits(12) = zero_extend(imm @ 0b00);
@@ -37,7 +37,7 @@ union clause ast = C_FSWSP : (bits(6), fregidx)
 
 mapping clause encdec_compressed = C_FSWSP(ui76 @ ui52, rs2)
   <-> 0b111 @ ui52 : bits(4) @ ui76 : bits(2) @ encdec_freg(rs2) @ 0b10
-  when extensionEnabled(Ext_Zcf)
+  when currentlyEnabled(Ext_Zcf)
 
 function clause execute (C_FSWSP(uimm, rs2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
@@ -53,7 +53,7 @@ union clause ast = C_FLW : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_FLW(ui6 @ ui53 @ ui2, rs1, rd)
   <-> 0b011 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_creg(rd) @ 0b00
-  when extensionEnabled(Ext_Zcf)
+  when currentlyEnabled(Ext_Zcf)
 
 function clause execute (C_FLW(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
@@ -71,7 +71,7 @@ union clause ast = C_FSW : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_FSW(ui6 @ ui53 @ ui2, rs1, rs2)
   <-> 0b111 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_creg(rs2) @ 0b00
-  when extensionEnabled(Ext_Zcf)
+  when currentlyEnabled(Ext_Zcf)
 
 function clause execute (C_FSW(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);

--- a/model/riscv_insts_zcmop.sail
+++ b/model/riscv_insts_zcmop.sail
@@ -6,13 +6,13 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause extensionEnabled(Ext_Zcmop) = true & extensionEnabled(Ext_Zca) // TODO: add configuration
+function clause currentlyEnabled(Ext_Zcmop) = true & currentlyEnabled(Ext_Zca) // TODO: add configuration
 
 union clause ast = ZCMOP : (bits(3))
 
 mapping clause encdec_compressed = ZCMOP(mop)
   <-> 0b01100 @ mop : bits(3) @ 0b100000 @ 0b01
-  when extensionEnabled(Ext_Zcmop)
+  when currentlyEnabled(Ext_Zcmop)
 
 mapping clause assembly = ZCMOP(mop)
   <-> "c.mop." ^ dec_bits_4(mop @ 0b1)

--- a/model/riscv_insts_zfa.sail
+++ b/model/riscv_insts_zfa.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause extensionEnabled(Ext_Zfa) = true
+function clause currentlyEnabled(Ext_Zfa) = true
 
 /* FLI.H */
 
@@ -14,7 +14,7 @@ union clause ast = RISCV_FLI_H : (bits(5), fregidx)
 
 mapping clause encdec = RISCV_FLI_H(rs1, rd)
   <-> 0b111_1010 @ 0b00001 @ rs1 @ 0b000 @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_Zfh) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLI_H(constantidx, rd)
   <-> "fli.h" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_5(constantidx)
@@ -64,7 +64,7 @@ union clause ast = RISCV_FLI_S : (bits(5), fregidx)
 
 mapping clause encdec = RISCV_FLI_S(rs1, rd)
   <-> 0b111_1000 @ 0b00001 @ rs1 @ 0b000 @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLI_S(constantidx, rd)
   <-> "fli.s" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_5(constantidx)
@@ -114,7 +114,7 @@ union clause ast = RISCV_FLI_D : (bits(5), fregidx)
 
 mapping clause encdec = RISCV_FLI_D(rs1, rd)
   <-> 0b111_1001 @ 0b00001 @ rs1 @ 0b000 @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLI_D(constantidx, rd)
   <-> "fli.d" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_5(constantidx)
@@ -164,7 +164,7 @@ union clause ast = RISCV_FMINM_H : (fregidx, fregidx, fregidx)
 
 mapping clause encdec = RISCV_FMINM_H(rs2, rs1, rd)
   <-> 0b001_0110 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_Zfh) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMINM_H(rs2, rs1, rd)
   <-> "fminm.h" ^ spc() ^ freg_name(rd)
@@ -195,7 +195,7 @@ union clause ast = RISCV_FMAXM_H : (fregidx, fregidx, fregidx)
 
 mapping clause encdec = RISCV_FMAXM_H(rs2, rs1, rd)
   <-> 0b001_0110 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b011 @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_Zfh) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMAXM_H(rs2, rs1, rd)
   <-> "fmaxm.h" ^ spc() ^ freg_name(rd)
@@ -226,7 +226,7 @@ union clause ast = RISCV_FMINM_S : (fregidx, fregidx, fregidx)
 
 mapping clause encdec = RISCV_FMINM_S(rs2, rs1, rd)
   <-> 0b001_0100 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMINM_S(rs2, rs1, rd)
   <-> "fminm.s" ^ spc() ^ freg_name(rd)
@@ -257,7 +257,7 @@ union clause ast = RISCV_FMAXM_S : (fregidx, fregidx, fregidx)
 
 mapping clause encdec = RISCV_FMAXM_S(rs2, rs1, rd)
   <-> 0b001_0100 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b011 @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMAXM_S(rs2, rs1, rd)
   <-> "fmaxm.s" ^ spc() ^ freg_name(rd)
@@ -288,7 +288,7 @@ union clause ast = RISCV_FMINM_D : (fregidx, fregidx, fregidx)
 
 mapping clause encdec = RISCV_FMINM_D(rs2, rs1, rd)
   <-> 0b001_0101 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMINM_D(rs2, rs1, rd)
   <-> "fminm.d" ^ spc() ^ freg_name(rd)
@@ -319,7 +319,7 @@ union clause ast = RISCV_FMAXM_D : (fregidx, fregidx, fregidx)
 
 mapping clause encdec = RISCV_FMAXM_D(rs2, rs1, rd)
   <-> 0b001_0101 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b011 @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FMAXM_D(rs2, rs1, rd)
   <-> "fmaxm.d" ^ spc() ^ freg_name(rd)
@@ -350,7 +350,7 @@ union clause ast = RISCV_FROUND_H : (fregidx, rounding_mode, fregidx)
 
 mapping clause encdec = RISCV_FROUND_H(rs1, rm, rd)
   <-> 0b010_0010 @ 0b00100 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_Zfh) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUND_H(rs1, rm, rd)
   <-> "fround.h" ^ spc() ^ freg_name(rd)
@@ -379,7 +379,7 @@ union clause ast = RISCV_FROUNDNX_H : (fregidx, rounding_mode, fregidx)
 
 mapping clause encdec = RISCV_FROUNDNX_H(rs1, rm, rd)
   <-> 0b010_0010 @ 0b00101 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_Zfh) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUNDNX_H(rs1, rm, rd)
   <-> "froundnx.h" ^ spc() ^ freg_name(rd)
@@ -408,7 +408,7 @@ union clause ast = RISCV_FROUND_S : (fregidx, rounding_mode, fregidx)
 
 mapping clause encdec = RISCV_FROUND_S(rs1, rm, rd)
   <-> 0b010_0000 @ 0b00100 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUND_S(rs1, rm, rd)
   <-> "fround.s" ^ spc() ^ freg_name(rd)
@@ -437,7 +437,7 @@ union clause ast = RISCV_FROUNDNX_S : (fregidx, rounding_mode, fregidx)
 
 mapping clause encdec = RISCV_FROUNDNX_S(rs1, rm, rd)
   <-> 0b010_0000 @ 0b00101 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUNDNX_S(rs1, rm, rd)
   <-> "froundnx.s" ^ spc() ^ freg_name(rd)
@@ -466,7 +466,7 @@ union clause ast = RISCV_FROUND_D : (fregidx, rounding_mode, fregidx)
 
 mapping clause encdec = RISCV_FROUND_D(rs1, rm, rd)
   <-> 0b010_0001 @ 0b00100 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUND_D(rs1, rm, rd)
   <-> "fround.d" ^ spc() ^ freg_name(rd)
@@ -495,7 +495,7 @@ union clause ast = RISCV_FROUNDNX_D : (fregidx, rounding_mode, fregidx)
 
 mapping clause encdec = RISCV_FROUNDNX_D(rs1, rm, rd)
   <-> 0b010_0001 @ 0b00101 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FROUNDNX_D(rs1, rm, rd)
   <-> "froundnx.d" ^ spc() ^ freg_name(rd)
@@ -524,7 +524,7 @@ union clause ast = RISCV_FMVH_X_D : (fregidx, regidx)
 
 mapping clause encdec   = RISCV_FMVH_X_D(rs1, rd)
   <-> 0b111_0001 @ 0b00001 @ encdec_freg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
+  when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa) & in32BitMode()
 
 mapping clause assembly = RISCV_FMVH_X_D(rs1, rd)
   <-> "fmvh.x.d" ^ spc() ^ reg_name(rd)
@@ -543,7 +543,7 @@ union clause ast = RISCV_FMVP_D_X : (regidx, regidx, fregidx)
 
 mapping clause encdec = RISCV_FMVP_D_X(rs2, rs1, rd)
   <-> 0b101_1001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa) & in32BitMode()
+  when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa) & in32BitMode()
 
 mapping clause assembly = RISCV_FMVP_D_X(rs2, rs1, rd)
   <-> "fmvp.d.x" ^ spc() ^ freg_name(rd)
@@ -571,7 +571,7 @@ union clause ast = RISCV_FLEQ_H : (fregidx, fregidx, regidx)
 
 mapping clause encdec = RISCV_FLEQ_H(rs2, rs1, rd)
   <-> 0b101_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_Zfh) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLEQ_H(rs2, rs1, rd)
   <-> "fleq.h" ^ spc() ^ reg_name(rd)
@@ -596,7 +596,7 @@ union clause ast = RISCV_FLTQ_H : (fregidx, fregidx, regidx)
 
 mapping clause encdec = RISCV_FLTQ_H(rs2, rs1, rd)
   <-> 0b101_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_Zfh) & extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_Zfh) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLTQ_H(rs2, rs1, rd)
   <-> "fltq.h" ^ spc() ^ reg_name(rd)
@@ -621,7 +621,7 @@ union clause ast = RISCV_FLEQ_S : (fregidx, fregidx, regidx)
 
 mapping clause encdec = RISCV_FLEQ_S(rs2, rs1, rd)
   <-> 0b101_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLEQ_S(rs2, rs1, rd)
   <-> "fleq.s" ^ spc() ^ reg_name(rd)
@@ -646,7 +646,7 @@ union clause ast = RISCV_FLTQ_S : (fregidx, fregidx, regidx)
 
 mapping clause encdec = RISCV_FLTQ_S(rs2, rs1, rd)
   <-> 0b101_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLTQ_S(rs2, rs1, rd)
   <-> "fltq.s" ^ spc() ^ reg_name(rd)
@@ -672,7 +672,7 @@ union clause ast = RISCV_FLEQ_D : (fregidx, fregidx, regidx)
 
 mapping clause encdec = RISCV_FLEQ_D(rs2, rs1, rd)
   <-> 0b101_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLEQ_D(rs2, rs1, rd)
   <-> "fleq.d" ^ spc() ^ reg_name(rd)
@@ -697,7 +697,7 @@ union clause ast = RISCV_FLTQ_D : (fregidx, fregidx, regidx)
 
 mapping clause encdec = RISCV_FLTQ_D(rs2, rs1, rd)
   <-> 0b101_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FLTQ_D(rs2, rs1, rd)
   <-> "fltq.d" ^ spc() ^ reg_name(rd)
@@ -786,7 +786,7 @@ union clause ast = RISCV_FCVTMOD_W_D : (fregidx, regidx)
 /* We need rounding mode to be explicitly specified to RTZ(0b001) */
 mapping clause encdec = RISCV_FCVTMOD_W_D(rs1, rd)
   <-> 0b110_0001 @ 0b01000 @ encdec_freg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_D) & extensionEnabled(Ext_Zfa)
+  when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = RISCV_FCVTMOD_W_D(rs1, rd)
   <-> "fcvtmod.w.d" ^ spc() ^ reg_name(rd) ^ sep() ^ freg_name(rs1)

--- a/model/riscv_insts_zfh.sail
+++ b/model/riscv_insts_zfh.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_Zhinx) = sys_enable_zfinx()
+function clause currentlyEnabled(Ext_Zhinx) = hartSupports(Ext_Zfinx)
 
 /* **************************************************************** */
 /* This file specifies the instructions in the Zfh extension        */

--- a/model/riscv_insts_zfh.sail
+++ b/model/riscv_insts_zfh.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause extensionEnabled(Ext_Zhinx) = sys_enable_zfinx()
+function clause currentlyEnabled(Ext_Zhinx) = sys_enable_zfinx()
 
 /* **************************************************************** */
 /* This file specifies the instructions in the Zfh extension        */
@@ -164,10 +164,10 @@ function fle_H   (v1,       v2,        is_quiet) = {
 /* **************************************************************** */
 /* Helper functions for 'encdec()'                                  */
 // Full half support.
-function haveHalfFPU() -> bool = extensionEnabled(Ext_Zfh) | extensionEnabled(Ext_Zhinx)
+function haveHalfFPU() -> bool = currentlyEnabled(Ext_Zfh) | currentlyEnabled(Ext_Zhinx)
 // Support for conversion of halves to/from single & double, but no actual
 // calculations with halves.
-function haveHalfMin() -> bool = haveHalfFPU() | extensionEnabled(Ext_Zfhmin)
+function haveHalfMin() -> bool = haveHalfFPU() | currentlyEnabled(Ext_Zfhmin)
 
 /* ****************************************************************** */
 /* Floating-point loads                                               */
@@ -811,11 +811,11 @@ mapping clause encdec = F_UN_X_TYPE_H(rs1, rd, FCLASS_H)
 
 mapping clause encdec = F_UN_X_TYPE_H(rs1, rd, FMV_X_H)
   <-> 0b111_0010 @ 0b00000 @ encdec_freg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_Zfhmin)
+  when currentlyEnabled(Ext_Zfhmin)
 
 mapping clause encdec = F_UN_F_TYPE_H(rs1, rd, FMV_H_X)
   <-> 0b111_1010 @ 0b00000 @ encdec_reg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011
-  when extensionEnabled(Ext_Zfhmin)
+  when currentlyEnabled(Ext_Zfhmin)
 
 /* Execution semantics ================================ */
 

--- a/model/riscv_insts_zicbom.sail
+++ b/model/riscv_insts_zicbom.sail
@@ -8,7 +8,7 @@
 
 // Cache Block Operations - Management
 
-function clause extensionEnabled(Ext_Zicbom) = sys_enable_zicbom()
+function clause currentlyEnabled(Ext_Zicbom) = sys_enable_zicbom()
 
 function cbo_clean_flush_enabled(p : Privilege) -> bool = feature_enabled_for_priv(p, menvcfg[CBCFE][0], senvcfg[CBCFE][0])
 
@@ -23,7 +23,7 @@ mapping encdec_cbop : cbop_zicbom <-> bits(12) = {
 
 mapping clause encdec = RISCV_ZICBOM(cbop, rs1)
   <-> encdec_cbop(cbop) @ encdec_reg(rs1) @ 0b010 @ 0b00000 @ 0b0001111
-  when extensionEnabled(Ext_Zicbom)
+  when currentlyEnabled(Ext_Zicbom)
 
 mapping cbop_mnemonic : cbop_zicbom <-> string = {
   CBO_CLEAN <-> "cbo.clean",
@@ -50,7 +50,7 @@ enum checked_cbop = {CBOP_ILLEGAL, CBOP_ILLEGAL_VIRTUAL, CBOP_INVAL_FLUSH, CBOP_
 // Select the cbop to perform based on the privilege.
 function cbop_priv_check(p: Privilege) -> checked_cbop = {
   let mCBIE : cbie = encdec_cbie(menvcfg[CBIE]);
-  let sCBIE : cbie = if   extensionEnabled(Ext_S)
+  let sCBIE : cbie = if   currentlyEnabled(Ext_S)
                      then encdec_cbie(senvcfg[CBIE])
                      else encdec_cbie(menvcfg[CBIE]);
   match (p, mCBIE, sCBIE) {

--- a/model/riscv_insts_zicbom.sail
+++ b/model/riscv_insts_zicbom.sail
@@ -8,7 +8,7 @@
 
 // Cache Block Operations - Management
 
-function clause currentlyEnabled(Ext_Zicbom) = sys_enable_zicbom()
+function clause currentlyEnabled(Ext_Zicbom) = hartSupports(Ext_Zicbom)
 
 function cbo_clean_flush_enabled(p : Privilege) -> bool = feature_enabled_for_priv(p, menvcfg[CBCFE][0], senvcfg[CBCFE][0])
 

--- a/model/riscv_insts_zicboz.sail
+++ b/model/riscv_insts_zicboz.sail
@@ -8,7 +8,7 @@
 
 // Cache Block Operations - Zero
 
-function clause extensionEnabled(Ext_Zicboz) = sys_enable_zicboz()
+function clause currentlyEnabled(Ext_Zicboz) = sys_enable_zicboz()
 
 function cbo_zero_enabled(p : Privilege) -> bool = feature_enabled_for_priv(p, menvcfg[CBZE][0], senvcfg[CBZE][0])
 
@@ -17,7 +17,7 @@ union clause ast = RISCV_ZICBOZ : (regidx)
 
 mapping clause encdec = RISCV_ZICBOZ(rs1)
   <-> 0b000000000100 @ encdec_reg(rs1) @ 0b010 @ 0b00000 @ 0b0001111
-  when extensionEnabled(Ext_Zicboz)
+  when currentlyEnabled(Ext_Zicboz)
 
 mapping clause assembly = RISCV_ZICBOZ(rs1)
   <-> "cbo.zero" ^ spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"

--- a/model/riscv_insts_zicboz.sail
+++ b/model/riscv_insts_zicboz.sail
@@ -8,7 +8,7 @@
 
 // Cache Block Operations - Zero
 
-function clause currentlyEnabled(Ext_Zicboz) = sys_enable_zicboz()
+function clause currentlyEnabled(Ext_Zicboz) = hartSupports(Ext_Zicboz)
 
 function cbo_zero_enabled(p : Privilege) -> bool = feature_enabled_for_priv(p, menvcfg[CBZE][0], senvcfg[CBZE][0])
 

--- a/model/riscv_insts_zicond.sail
+++ b/model/riscv_insts_zicond.sail
@@ -6,16 +6,16 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause extensionEnabled(Ext_Zicond) = true
+function clause currentlyEnabled(Ext_Zicond) = true
 
 union clause ast = ZICOND_RTYPE : (regidx, regidx, regidx, zicondop)
 
 mapping clause encdec = ZICOND_RTYPE(rs2, rs1, rd, RISCV_CZERO_EQZ)
   <-> 0b0000111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zicond)
+  when currentlyEnabled(Ext_Zicond)
 mapping clause encdec = ZICOND_RTYPE(rs2, rs1, rd, RISCV_CZERO_NEZ)
   <-> 0b0000111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zicond)
+  when currentlyEnabled(Ext_Zicond)
 
 mapping zicond_mnemonic : zicondop <-> string = {
   RISCV_CZERO_EQZ <-> "czero.eqz",

--- a/model/riscv_insts_zifencei.sail
+++ b/model/riscv_insts_zifencei.sail
@@ -11,13 +11,13 @@
 
 /* ****************************************************************** */
 
-function clause extensionEnabled(Ext_Zifencei) = true
+function clause currentlyEnabled(Ext_Zifencei) = true
 
 union clause ast = FENCEI : unit
 
 mapping clause encdec = FENCEI()
   <-> 0b000000000000 @ 0b00000 @ 0b001 @ 0b00000 @ 0b0001111
-  when extensionEnabled(Ext_Zifencei)
+  when currentlyEnabled(Ext_Zifencei)
 
 /* fence.i is a nop for the memory model */
 function clause execute FENCEI() = { /* __barrier(Barrier_RISCV_i); */ RETIRE_SUCCESS }

--- a/model/riscv_insts_zimop.sail
+++ b/model/riscv_insts_zimop.sail
@@ -6,18 +6,18 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause extensionEnabled(Ext_Zimop) = true // TODO: add configuration
+function clause currentlyEnabled(Ext_Zimop) = true // TODO: add configuration
 
 union clause ast = ZIMOP_MOP_R : (bits(5), regidx, regidx)
 union clause ast = ZIMOP_MOP_RR : (bits(3), regidx, regidx, regidx)
 
 mapping clause encdec = ZIMOP_MOP_R(mop_30 @ mop_27_26 @ mop_21_20, rs1, rd)
   <-> 0b1 @ mop_30 : bits(1) @ 0b00 @ mop_27_26 : bits(2) @ 0b0111 @ mop_21_20 : bits(2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b1110011
-  when extensionEnabled(Ext_Zimop)
+  when currentlyEnabled(Ext_Zimop)
 
 mapping clause encdec = ZIMOP_MOP_RR(mop_30 @ mop_27_26, rs2, rs1, rd)
   <-> 0b1 @ mop_30 : bits(1) @ 0b00 @ mop_27_26 : bits(2) @ 0b1 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b1110011
-  when extensionEnabled(Ext_Zimop)
+  when currentlyEnabled(Ext_Zimop)
 
 mapping clause assembly = ZIMOP_MOP_R(mop, rs1, rd)
   <->  "mop.r." ^ dec_bits_5(mop) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)

--- a/model/riscv_insts_zkn.sail
+++ b/model/riscv_insts_zkn.sail
@@ -11,7 +11,7 @@
  * ----------------------------------------------------------------------
  */
 
-function clause extensionEnabled(Ext_Zknh) = true
+function clause currentlyEnabled(Ext_Zknh) = true
 
 union clause ast = SHA256SIG0 : (regidx, regidx)
 union clause ast = SHA256SIG1 : (regidx, regidx)
@@ -20,19 +20,19 @@ union clause ast = SHA256SUM1 : (regidx, regidx)
 
 mapping clause encdec = SHA256SUM0 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zknh)
+  when currentlyEnabled(Ext_Zknh)
 
 mapping clause encdec = SHA256SUM1 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zknh)
+  when currentlyEnabled(Ext_Zknh)
 
 mapping clause encdec = SHA256SIG0 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zknh)
+  when currentlyEnabled(Ext_Zknh)
 
 mapping clause encdec = SHA256SIG1 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00011 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zknh)
+  when currentlyEnabled(Ext_Zknh)
 
 mapping clause assembly = SHA256SIG0 (rs1, rd)
   <-> "sha256sig0" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -79,13 +79,13 @@ function clause execute (SHA256SUM1(rs1, rd)) = {
  * ----------------------------------------------------------------------
  */
 
-function clause extensionEnabled(Ext_Zkne) = true
+function clause currentlyEnabled(Ext_Zkne) = true
 
 union clause ast = AES32ESMI : (bits(2), regidx, regidx, regidx)
 
 mapping clause encdec = AES32ESMI (bs, rs2, rs1, rd)
   <-> bs @ 0b10011 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zkne) & xlen == 32
+  when currentlyEnabled(Ext_Zkne) & xlen == 32
 
 mapping clause assembly = AES32ESMI (bs, rs2, rs1, rd) <->
     "aes32esmi" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_2(bs)
@@ -104,7 +104,7 @@ union clause ast = AES32ESI : (bits(2), regidx, regidx, regidx)
 
 mapping clause encdec = AES32ESI (bs, rs2, rs1, rd)
   <-> bs @ 0b10001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zkne) & xlen == 32
+  when currentlyEnabled(Ext_Zkne) & xlen == 32
 
 mapping clause assembly = AES32ESI (bs, rs2, rs1, rd) <->
     "aes32esi" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_2(bs)
@@ -123,13 +123,13 @@ function clause execute (AES32ESI (bs, rs2, rs1, rd)) = {
  * ----------------------------------------------------------------------
  */
 
-function clause extensionEnabled(Ext_Zknd) = true
+function clause currentlyEnabled(Ext_Zknd) = true
 
 union clause ast = AES32DSMI : (bits(2), regidx, regidx, regidx)
 
 mapping clause encdec = AES32DSMI (bs, rs2, rs1, rd)
   <-> bs @ 0b10111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zknd) & xlen == 32
+  when currentlyEnabled(Ext_Zknd) & xlen == 32
 
 mapping clause assembly = AES32DSMI (bs, rs2, rs1, rd) <->
     "aes32dsmi" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_2(bs)
@@ -148,7 +148,7 @@ union clause ast = AES32DSI  : (bits(2), regidx, regidx, regidx)
 
 mapping clause encdec = AES32DSI (bs, rs2, rs1, rd)
   <-> bs @ 0b10101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zknd) & xlen == 32
+  when currentlyEnabled(Ext_Zknd) & xlen == 32
 
 mapping clause assembly = AES32DSI (bs, rs2, rs1, rd) <->
     "aes32dsi" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_2(bs)
@@ -176,27 +176,27 @@ union clause ast = SHA512SUM1R : (regidx, regidx, regidx)
 
 mapping clause encdec = SHA512SUM0R (rs2, rs1, rd)
   <-> 0b01 @ 0b01000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zknh) & xlen == 32
+  when currentlyEnabled(Ext_Zknh) & xlen == 32
 
 mapping clause encdec = SHA512SUM1R (rs2, rs1, rd)
   <-> 0b01 @ 0b01001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zknh) & xlen == 32
+  when currentlyEnabled(Ext_Zknh) & xlen == 32
 
 mapping clause encdec = SHA512SIG0L (rs2, rs1, rd)
   <-> 0b01 @ 0b01010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zknh) & xlen == 32
+  when currentlyEnabled(Ext_Zknh) & xlen == 32
 
 mapping clause encdec = SHA512SIG0H (rs2, rs1, rd)
   <-> 0b01 @ 0b01110 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zknh) & xlen == 32
+  when currentlyEnabled(Ext_Zknh) & xlen == 32
 
 mapping clause encdec = SHA512SIG1L (rs2, rs1, rd)
   <-> 0b01 @ 0b01011 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zknh) & xlen == 32
+  when currentlyEnabled(Ext_Zknh) & xlen == 32
 
 mapping clause encdec = SHA512SIG1H (rs2, rs1, rd)
   <-> 0b01 @ 0b01111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zknh) & xlen == 32
+  when currentlyEnabled(Ext_Zknh) & xlen == 32
 
 mapping clause assembly = SHA512SIG0L (rs2, rs1, rd)
   <-> "sha512sig0l" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
@@ -267,31 +267,31 @@ union clause ast = AES64DS   : (regidx, regidx, regidx)
 
 mapping clause encdec = AES64KS1I (rnum, rs1, rd)
   <-> 0b00 @ 0b11000 @ 0b1 @ rnum @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when (extensionEnabled(Ext_Zkne) | extensionEnabled(Ext_Zknd)) & (xlen == 64) & (rnum <_u 0xB)
+  when (currentlyEnabled(Ext_Zkne) | currentlyEnabled(Ext_Zknd)) & (xlen == 64) & (rnum <_u 0xB)
 
 mapping clause encdec = AES64IM (rs1, rd)
   <-> 0b00 @ 0b11000 @ 0b00000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zknd) & xlen == 64
+  when currentlyEnabled(Ext_Zknd) & xlen == 64
 
 mapping clause encdec = AES64KS2 (rs2, rs1, rd)
   <-> 0b01 @ 0b11111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when (extensionEnabled(Ext_Zkne) | extensionEnabled(Ext_Zknd)) & xlen == 64
+  when (currentlyEnabled(Ext_Zkne) | currentlyEnabled(Ext_Zknd)) & xlen == 64
 
 mapping clause encdec = AES64ESM (rs2, rs1, rd)
   <-> 0b00 @ 0b11011 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zkne) & xlen == 64
+  when currentlyEnabled(Ext_Zkne) & xlen == 64
 
 mapping clause encdec = AES64ES (rs2, rs1, rd)
   <-> 0b00 @ 0b11001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zkne) & xlen == 64
+  when currentlyEnabled(Ext_Zkne) & xlen == 64
 
 mapping clause encdec = AES64DSM (rs2, rs1, rd)
   <-> 0b00 @ 0b11111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zknd) & xlen == 64
+  when currentlyEnabled(Ext_Zknd) & xlen == 64
 
 mapping clause encdec = AES64DS (rs2, rs1, rd)
   <-> 0b00 @ 0b11101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zknd) & xlen == 64
+  when currentlyEnabled(Ext_Zknd) & xlen == 64
 
 mapping clause assembly = AES64KS1I (rnum, rs1, rd)
   <-> "aes64ks1i" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_4(rnum)
@@ -389,19 +389,19 @@ union clause ast = SHA512SUM1 : (regidx, regidx)
 
 mapping clause encdec = SHA512SUM0 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00100 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zknh) & xlen == 64
+  when currentlyEnabled(Ext_Zknh) & xlen == 64
 
 mapping clause encdec = SHA512SUM1 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00101 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zknh) & xlen == 64
+  when currentlyEnabled(Ext_Zknh) & xlen == 64
 
 mapping clause encdec = SHA512SIG0 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00110 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zknh) & xlen == 64
+  when currentlyEnabled(Ext_Zknh) & xlen == 64
 
 mapping clause encdec = SHA512SIG1 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00111 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zknh) & xlen == 64
+  when currentlyEnabled(Ext_Zknh) & xlen == 64
 
 mapping clause assembly = SHA512SIG0 (rs1, rd)
   <-> "sha512sig0" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)

--- a/model/riscv_insts_zks.sail
+++ b/model/riscv_insts_zks.sail
@@ -11,18 +11,18 @@
  * ----------------------------------------------------------------------
  */
 
-function clause extensionEnabled(Ext_Zksh) = true
+function clause currentlyEnabled(Ext_Zksh) = true
 
 union clause ast = SM3P0 : (regidx, regidx)
 union clause ast = SM3P1 : (regidx, regidx)
 
 mapping clause encdec = SM3P0 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b01000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zksh)
+  when currentlyEnabled(Ext_Zksh)
 
 mapping clause encdec = SM3P1 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b01001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
-  when extensionEnabled(Ext_Zksh)
+  when currentlyEnabled(Ext_Zksh)
 
 mapping clause assembly = SM3P0 (rs1, rd) <->
   "sm3p0" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
@@ -49,18 +49,18 @@ function clause execute (SM3P1(rs1, rd)) = {
  * ----------------------------------------------------------------------
  */
 
-function clause extensionEnabled(Ext_Zksed) = true
+function clause currentlyEnabled(Ext_Zksed) = true
 
 union clause ast = SM4ED : (bits(2), regidx, regidx, regidx)
 union clause ast = SM4KS : (bits(2), regidx, regidx, regidx)
 
 mapping clause encdec = SM4ED (bs, rs2, rs1, rd)
   <-> bs @ 0b11000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zksed)
+  when currentlyEnabled(Ext_Zksed)
 
 mapping clause encdec = SM4KS (bs, rs2, rs1, rd)
   <-> bs @ 0b11010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-  when extensionEnabled(Ext_Zksed)
+  when currentlyEnabled(Ext_Zksed)
 
 mapping clause assembly = SM4ED (bs, rs2, rs1, rd) <->
     "sm4ed" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_2(bs)

--- a/model/riscv_insts_zvbb.sail
+++ b/model/riscv_insts_zvbb.sail
@@ -8,7 +8,7 @@
 
 function clause currentlyEnabled(Ext_Zvbb) = true
 
-function clause currentlyEnabled(Ext_Zvkb) = sys_enable_zvkb() | currentlyEnabled(Ext_Zvbb)
+function clause currentlyEnabled(Ext_Zvkb) = hartSupports(Ext_Zvkb) | currentlyEnabled(Ext_Zvbb)
 
 union clause ast = VANDN_VV : (bits(1), vregidx, vregidx, vregidx)
 

--- a/model/riscv_insts_zvbb.sail
+++ b/model/riscv_insts_zvbb.sail
@@ -6,15 +6,15 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause extensionEnabled(Ext_Zvbb) = true
+function clause currentlyEnabled(Ext_Zvbb) = true
 
-function clause extensionEnabled(Ext_Zvkb) = sys_enable_zvkb() | extensionEnabled(Ext_Zvbb)
+function clause currentlyEnabled(Ext_Zvkb) = sys_enable_zvkb() | currentlyEnabled(Ext_Zvbb)
 
 union clause ast = VANDN_VV : (bits(1), vregidx, vregidx, vregidx)
 
 mapping clause encdec = VANDN_VV(vm, vs1, vs2, vd)
   <-> 0b000001 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvkb)
+  when currentlyEnabled(Ext_Zvkb)
 
 mapping clause assembly = VANDN_VV(vm, vs1, vs2, vd)
   <-> "vandn.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
@@ -48,7 +48,7 @@ union clause ast = VANDN_VX : (bits(1), vregidx, regidx, vregidx)
 
 mapping clause encdec = VANDN_VX(vm, vs2, rs1, vd)
   <-> 0b000001 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvkb)
+  when currentlyEnabled(Ext_Zvkb)
 
 mapping clause assembly = VANDN_VX(vm, vs2, rs1, vd)
   <-> "vandn.vx" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
@@ -82,7 +82,7 @@ union clause ast = VBREV_V : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VBREV_V(vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01010 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvbb)
+  when currentlyEnabled(Ext_Zvbb)
 
 mapping clause assembly = VBREV_V(vm, vs2, vd)
   <-> "vbrev.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
@@ -119,7 +119,7 @@ union clause ast = VBREV8_V : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VBREV8_V(vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01000 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvkb)
+  when currentlyEnabled(Ext_Zvkb)
 
 mapping clause assembly = VBREV8_V(vm, vs2, vd)
   <-> "vbrev8.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
@@ -156,7 +156,7 @@ union clause ast = VREV8_V : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VREV8_V(vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01001 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvkb)
+  when currentlyEnabled(Ext_Zvkb)
 
 mapping clause assembly = VREV8_V(vm, vs2, vd)
   <-> "vrev8.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
@@ -193,7 +193,7 @@ union clause ast = VCLZ_V : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VCLZ_V (vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01100 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvbb)
+  when currentlyEnabled(Ext_Zvbb)
 
 mapping clause assembly = VCLZ_V (vm, vs2, vd)
   <-> "vclz.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ maybe_vmask(vm)
@@ -228,7 +228,7 @@ union clause ast = VCTZ_V : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VCTZ_V (vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01101 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvbb)
+  when currentlyEnabled(Ext_Zvbb)
 
 mapping clause assembly = VCTZ_V (vm, vs2, vd)
   <-> "vctz.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ maybe_vmask(vm)
@@ -263,7 +263,7 @@ union clause ast = VCPOP_V : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VCPOP_V (vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01110 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvbb)
+  when currentlyEnabled(Ext_Zvbb)
 
 mapping clause assembly = VCPOP_V (vm, vs2, vd)
   <-> "vcpop.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ maybe_vmask(vm)
@@ -301,7 +301,7 @@ union clause ast = VROL_VV : (bits(1), vregidx, vregidx, vregidx)
 
 mapping clause encdec = VROL_VV(vm, vs1, vs2, vd)
   <-> 0b010101 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvkb)
+  when currentlyEnabled(Ext_Zvkb)
 
 mapping clause assembly = VROL_VV(vm, vs1, vs2, vd)
  <-> "vrol.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
@@ -335,7 +335,7 @@ union clause ast = VROL_VX : (bits(1), vregidx, regidx, vregidx)
 
 mapping clause encdec = VROL_VX(vm, vs2, rs1, vd)
   <-> 0b010101 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvkb)
+  when currentlyEnabled(Ext_Zvkb)
 
 mapping clause assembly = VROL_VX(vm, vs2, rs1, vd)
  <-> "vrol.vx" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
@@ -369,7 +369,7 @@ union clause ast = VROR_VV : (bits(1), vregidx, vregidx, vregidx)
 
 mapping clause encdec = VROR_VV(vm, vs1, vs2, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvkb)
+  when currentlyEnabled(Ext_Zvkb)
 
 mapping clause assembly = VROR_VV(vm, vs1, vs2, vd)
  <-> "vror.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
@@ -403,7 +403,7 @@ union clause ast = VROR_VX : (bits(1), vregidx, regidx, vregidx)
 
 mapping clause encdec = VROR_VX(vm, vs2, rs1, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvkb)
+  when currentlyEnabled(Ext_Zvkb)
 
 mapping clause assembly = VROR_VX(vm, vs2, rs1, vd)
  <-> "vror.vx" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1)^ maybe_vmask(vm)
@@ -437,7 +437,7 @@ union clause ast = VROR_VI : (bits(1), vregidx, bits(5), vregidx)
 
 mapping clause encdec = VROR_VI(vm, vs2, uimm, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ uimm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvkb)
+  when currentlyEnabled(Ext_Zvkb)
 
 mapping clause assembly = VROR_VI(vm, vs2, uimm, vd)
  <-> "vror.vi" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(uimm) ^ maybe_vmask(vm)
@@ -471,7 +471,7 @@ union clause ast = VWSLL_VV : (bits(1), vregidx, vregidx, vregidx)
 
 mapping clause encdec = VWSLL_VV (vm, vs2, vs1, vd)
   <-> 0b110101 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvbb)
+  when currentlyEnabled(Ext_Zvbb)
 
 mapping clause assembly = VWSLL_VV (vm, vs2, vs1, vd)
   <-> "vwsll.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ sep() ^ maybe_vmask(vm)
@@ -512,7 +512,7 @@ union clause ast = VWSLL_VX : (bits(1), vregidx, regidx, vregidx)
 
 mapping clause encdec = VWSLL_VX (vm, vs2, rs1, vd)
   <-> 0b110101 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvbb)
+  when currentlyEnabled(Ext_Zvbb)
 
 mapping clause assembly = VWSLL_VX (vm, vs2, rs1, vd)
   <-> "vwsll.vx" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ sep() ^ maybe_vmask(vm)
@@ -552,7 +552,7 @@ union clause ast = VWSLL_VI : (bits(1), vregidx, bits(5), vregidx)
 
 mapping clause encdec = VWSLL_VI (vm, vs2, uimm, vd)
   <-> 0b110101 @ vm @ encdec_vreg(vs2) @ uimm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvbb)
+  when currentlyEnabled(Ext_Zvbb)
 
 mapping clause assembly = VWSLL_VI (vm, vs2, uimm, vd)
   <-> "vwsll.vi" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(uimm) ^ sep() ^ maybe_vmask(vm)

--- a/model/riscv_insts_zvbc.sail
+++ b/model/riscv_insts_zvbc.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_Zvbc) = sys_enable_zvbc() & currentlyEnabled(Ext_V)
+function clause currentlyEnabled(Ext_Zvbc) = hartSupports(Ext_Zvbc) & currentlyEnabled(Ext_V)
 
 union clause ast = VCLMUL_VV : (bits(1), vregidx, vregidx, vregidx)
 

--- a/model/riscv_insts_zvbc.sail
+++ b/model/riscv_insts_zvbc.sail
@@ -6,13 +6,13 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause extensionEnabled(Ext_Zvbc) = sys_enable_zvbc() & extensionEnabled(Ext_V)
+function clause currentlyEnabled(Ext_Zvbc) = sys_enable_zvbc() & currentlyEnabled(Ext_V)
 
 union clause ast = VCLMUL_VV : (bits(1), vregidx, vregidx, vregidx)
 
 mapping clause encdec = VCLMUL_VV (vm, vs2, vs1, vd)
   <-> 0b001100 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvbc) & get_sew() == 64
+  when currentlyEnabled(Ext_Zvbc) & get_sew() == 64
 
 mapping clause assembly = VCLMUL_VV (vm, vs2, vs1, vd)
   <-> "vclmul.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
@@ -47,7 +47,7 @@ union clause ast = VCLMUL_VX : (bits(1), vregidx, regidx, vregidx)
 
 mapping clause encdec = VCLMUL_VX (vm, vs2, rs1, vd)
   <-> 0b001100 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvbc) & get_sew() == 64
+  when currentlyEnabled(Ext_Zvbc) & get_sew() == 64
 
 mapping clause assembly = VCLMUL_VX (vm, vs2, rs1, vd)
   <-> "vclmul.vx" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
@@ -83,7 +83,7 @@ union clause ast = VCLMULH_VV : (bits(1), vregidx, vregidx, vregidx)
 
 mapping clause encdec = VCLMULH_VV (vm, vs2, vs1, vd)
   <-> 0b001101 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvbc) & get_sew() == 64
+  when currentlyEnabled(Ext_Zvbc) & get_sew() == 64
 
 mapping clause assembly = VCLMULH_VV (vm, vs2, vs1, vd)
   <-> "vclmulh.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
@@ -118,7 +118,7 @@ union clause ast = VCLMULH_VX : (bits(1), vregidx, regidx, vregidx)
 
 mapping clause encdec = VCLMULH_VX (vm, vs2, rs1, vd)
   <-> 0b001101 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
-  when extensionEnabled(Ext_Zvbc) & get_sew() == 64
+  when currentlyEnabled(Ext_Zvbc) & get_sew() == 64
 
 mapping clause assembly = VCLMULH_VX (vm, vs2, rs1, vd)
   <-> "vclmulh.vx" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)

--- a/model/riscv_jalr_seq.sail
+++ b/model/riscv_jalr_seq.sail
@@ -24,7 +24,7 @@ function clause execute (RISCV_JALR(imm, rs1, rd)) = {
     },
     Ext_ControlAddr_OK(addr) => {
       let target = [virtaddr_bits(addr) with 0 = bitzero];  /* clear addr[0] */
-      if bit_to_bool(target[1]) & not(extensionEnabled(Ext_Zca)) then {
+      if bit_to_bool(target[1]) & not(currentlyEnabled(Ext_Zca)) then {
         handle_mem_exception(addr, E_Fetch_Addr_Align());
         RETIRE_FAIL
       } else {

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -39,7 +39,7 @@ function plat_enable_dirty_update() -> bool = config memory.translation.dirty_up
 /* whether the platform supports misaligned accesses without trapping to M-mode. if false,
  * misaligned loads/stores are trapped to Machine mode.
  */
-function plat_enable_misaligned_access() -> bool = config memory.misaligned.enabled
+function plat_enable_misaligned_access() -> bool = config memory.misaligned.supported
 
 /* whether mtval stores the bits of a faulting instruction on illegal instruction exceptions */
 function plat_mtval_has_illegal_inst_bits() -> bool = config base.mtval_has_illegal_instruction_bits

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -199,12 +199,12 @@ function clint_load(t, Physaddr(addr), width) = {
 
 function clint_dispatch() -> unit = {
   mip[MTI] = bool_to_bits(mtimecmp <=_u mtime);
-  if extensionEnabled(Ext_Sstc) then {
+  if currentlyEnabled(Ext_Sstc) then {
     mip[STI] = bool_to_bits(stimecmp <=_u mtime);
   };
   if get_config_print_platform()
   then print_platform("clint mtime " ^ BitStr(mtime) ^ " (mip.MTI <- " ^ BitStr(mip[MTI]) ^
-    (if extensionEnabled(Ext_Sstc) then ", mip.STI <- " ^ BitStr(mip[STI]) else "") ^ ")");
+    (if currentlyEnabled(Ext_Sstc) then ", mip.STI <- " ^ BitStr(mip[STI]) else "") ^ ")");
 }
 
 val clint_store: forall 'n, 'n > 0. (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)

--- a/model/riscv_smcntrpmf.sail
+++ b/model/riscv_smcntrpmf.sail
@@ -1,4 +1,4 @@
-function clause extensionEnabled(Ext_Smcntrpmf) = true
+function clause currentlyEnabled(Ext_Smcntrpmf) = true
 
 bitfield CountSmcntrpmf : bits(64) = {
   MINH  : 62,
@@ -13,8 +13,8 @@ function legalize_smcntrpmf(c : CountSmcntrpmf, value : bits(64)) -> CountSmcntr
   // For each bit in 61:58, if the associated privilege mode is not implemented, the bit is read-only zero.
   [ c with
     MINH  = v[MINH],
-    SINH  = if extensionEnabled(Ext_S) then v[SINH] else 0b0,
-    UINH  = if extensionEnabled(Ext_U) then v[UINH] else 0b0,
+    SINH  = if currentlyEnabled(Ext_S) then v[SINH] else 0b0,
+    UINH  = if currentlyEnabled(Ext_U) then v[UINH] else 0b0,
     // VSINH = v[VSINH],
     // VUINH = v[VUINH],
   ]
@@ -28,10 +28,10 @@ mapping clause csr_name_map = 0x721  <-> "mcyclecfgh"
 mapping clause csr_name_map = 0x322  <-> "minstretcfg"
 mapping clause csr_name_map = 0x722  <-> "minstretcfgh"
 
-function clause is_CSR_defined(0x321) = extensionEnabled(Ext_Smcntrpmf) // mcyclecfg
-function clause is_CSR_defined(0x721) = extensionEnabled(Ext_Smcntrpmf) & xlen == 32 // mcyclecfgh
-function clause is_CSR_defined(0x322) = extensionEnabled(Ext_Smcntrpmf) // minstretcfg
-function clause is_CSR_defined(0x722) = extensionEnabled(Ext_Smcntrpmf) & xlen == 32 // minstretcfgh
+function clause is_CSR_defined(0x321) = currentlyEnabled(Ext_Smcntrpmf) // mcyclecfg
+function clause is_CSR_defined(0x721) = currentlyEnabled(Ext_Smcntrpmf) & xlen == 32 // mcyclecfgh
+function clause is_CSR_defined(0x322) = currentlyEnabled(Ext_Smcntrpmf) // minstretcfg
+function clause is_CSR_defined(0x722) = currentlyEnabled(Ext_Smcntrpmf) & xlen == 32 // minstretcfgh
 
 function clause read_CSR(0x321) = mcyclecfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x721 if xlen == 32) = mcyclecfg.bits[63 .. 32]

--- a/model/riscv_sscofpmf.sail
+++ b/model/riscv_sscofpmf.sail
@@ -10,7 +10,7 @@
 function sys_enable_sscofpmf() -> bool = true
 
 /* Counter OverFlow and Privilege Mode Filtering */
-function clause extensionEnabled(Ext_Sscofpmf) = sys_enable_sscofpmf() & extensionEnabled(Ext_Zihpm)
+function clause currentlyEnabled(Ext_Sscofpmf) = sys_enable_sscofpmf() & currentlyEnabled(Ext_Zihpm)
 
 mapping clause csr_name_map = 0xB83  <-> "mhpmcounter3h"
 mapping clause csr_name_map = 0xB84  <-> "mhpmcounter4h"
@@ -51,7 +51,7 @@ function write_mhpmeventh(index : hpmidx, value : bits(32)) -> unit =
   mhpmevent[index] = legalize_hpmevent(Mk_HpmEvent(value @ mhpmevent[index].bits[31 .. 0]))
 
 // mhpmevent3..31h
-function clause is_CSR_defined(0b0111001 /* 0x720 */ @ index : bits(5) if unsigned(index) >= 3) = extensionEnabled(Ext_Sscofpmf) & (xlen == 32)
+function clause is_CSR_defined(0b0111001 /* 0x720 */ @ index : bits(5) if unsigned(index) >= 3) = currentlyEnabled(Ext_Sscofpmf) & (xlen == 32)
 function clause read_CSR(0b0111001 /* 0x720 */ @ index : bits(5) if xlen == 32 & unsigned(index) >= 3) = read_mhpmeventh(hpmidx_from_bits(index))
 function clause write_CSR((0b0111001 /* 0x720 */ @ index : bits(5), value) if xlen == 32 & unsigned(index) >= 3) = {
   let index = hpmidx_from_bits(index);
@@ -79,6 +79,6 @@ function get_scountovf(priv : Privilege) -> bits(32) = {
 }
 
 // scountovf
-function clause is_CSR_defined(0xDA0) = extensionEnabled(Ext_Sscofpmf) & extensionEnabled(Ext_S)
+function clause is_CSR_defined(0xDA0) = currentlyEnabled(Ext_Sscofpmf) & currentlyEnabled(Ext_S)
 function clause read_CSR(0xDA0) = zero_extend(get_scountovf(cur_privilege))
 // scountovf is read-only.

--- a/model/riscv_sstc.sail
+++ b/model/riscv_sstc.sail
@@ -10,8 +10,8 @@
 mapping clause csr_name_map = 0x14D  <-> "stimecmp"
 mapping clause csr_name_map = 0x15D  <-> "stimecmph"
 
-function clause is_CSR_defined(0x14D) = extensionEnabled(Ext_S) & extensionEnabled(Ext_Sstc)
-function clause is_CSR_defined(0x15D) = extensionEnabled(Ext_S) & extensionEnabled(Ext_Sstc) & xlen == 32
+function clause is_CSR_defined(0x14D) = currentlyEnabled(Ext_S) & currentlyEnabled(Ext_Sstc)
+function clause is_CSR_defined(0x15D) = currentlyEnabled(Ext_S) & currentlyEnabled(Ext_Sstc) & xlen == 32
 
 function clause read_CSR(0x14D) = stimecmp[xlen - 1 .. 0]
 function clause read_CSR(0x15D if xlen == 32) = stimecmp[63 .. 32]

--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -55,7 +55,7 @@ function step(step_no : int) -> bool = {
               print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ BitStr(PC) ^ " (" ^ BitStr(h) ^ ") " ^ to_str(ast));
             };
             /* check for RVC once here instead of every RVC execute clause. */
-            if extensionEnabled(Ext_Zca) then {
+            if currentlyEnabled(Ext_Zca) then {
               nextPC = PC + 2;
               (execute(ast), true)
             } else {

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -29,7 +29,7 @@ function check_TVM_SATP(csr : csreg, p : Privilege) -> bool =
 function feature_enabled_for_priv(p : Privilege, machine_enable_bit : bit, supervisor_enable_bit : bit) -> bool = match p {
   Machine => true,
   Supervisor => machine_enable_bit == bitone,
-  User => machine_enable_bit == bitone & (not(extensionEnabled(Ext_S)) | supervisor_enable_bit == bitone),
+  User => machine_enable_bit == bitone & (not(currentlyEnabled(Ext_S)) | supervisor_enable_bit == bitone),
 }
 
 // Return true if the counter is enabled OR the CSR is not a counter.
@@ -104,7 +104,7 @@ val cancel_reservation = impure {interpreter: "Platform.cancel_reservation", c: 
 function exception_delegatee(e : ExceptionType, p : Privilege) -> Privilege = {
   let idx   = num_of_ExceptionType(e);
   let super = bit_to_bool(medeleg.bits[idx]);
-  let deleg = if extensionEnabled(Ext_S) & super then Supervisor else Machine;
+  let deleg = if currentlyEnabled(Ext_S) & super then Supervisor else Machine;
   /* We cannot transition to a less-privileged mode. */
   if   privLevel_to_bits(deleg) <_u privLevel_to_bits(p)
   then p else deleg
@@ -132,7 +132,7 @@ function findPendingInterrupt(ip : xlenbits) -> option(InterruptType) = {
  */
 function getPendingSet(priv : Privilege) -> option((xlenbits, Privilege)) = {
   // mideleg can only be non-zero if we support Supervisor mode.
-  assert(extensionEnabled(Ext_S) | mideleg.bits == zeros());
+  assert(currentlyEnabled(Ext_S) | mideleg.bits == zeros());
 
   let pending_m = mip.bits & mie.bits & ~(mideleg.bits);
   let pending_s = mip.bits & mie.bits & mideleg.bits;
@@ -216,7 +216,7 @@ function trap_handler(del_priv : Privilege, intr : bool, c : exc_code, pc : xlen
        prepare_trap_vector(del_priv, mcause)
     },
     Supervisor => {
-       assert (extensionEnabled(Ext_S), "no supervisor mode present for delegation");
+       assert (currentlyEnabled(Ext_S), "no supervisor mode present for delegation");
 
        scause[IsInterrupt] = bool_to_bits(intr);
        scause[Cause]       = zero_extend(c);
@@ -259,7 +259,7 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
       mstatus[MIE]  = mstatus[MPIE];
       mstatus[MPIE] = 0b1;
       cur_privilege   = privLevel_of_bits(mstatus[MPP]);
-      mstatus[MPP]  = privLevel_to_bits(if extensionEnabled(Ext_U) then User else Machine);
+      mstatus[MPP]  = privLevel_to_bits(if currentlyEnabled(Ext_U) then User else Machine);
       if   cur_privilege != Machine
       then mstatus[MPRV] = 0b0;
 

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -309,22 +309,22 @@ function handle_interrupt(i : InterruptType, del_priv : Privilege) -> unit =
 
 // Reset misa to enable the maximal set of supported extensions.
 function reset_misa() -> unit = {
-  misa[A]   = 0b1;                             /* atomics */
-  misa[C]   = bool_to_bits(sys_enable_rvc());  /* RVC */
-  misa[B]   = bool_to_bits(sys_enable_bext()); /* Bit-manipulation */
-  misa[I]   = 0b1;                             /* base integer ISA */
-  misa[M]   = 0b1;                             /* integer multiply/divide */
-  misa[U]   = bool_to_bits(sys_enable_user()); /* user-mode */
-  misa[S]   = bool_to_bits(sys_enable_supervisor()); /* supervisor-mode */
-  misa[V]   = bool_to_bits(sys_enable_vext()); /* vector extension */
+  misa[A]   = 0b1;                                     /* atomics */
+  misa[C]   = bool_to_bits(hartSupports(Ext_C));       /* RVC */
+  misa[B]   = bool_to_bits(hartSupports(Ext_B));       /* Bit-manipulation */
+  misa[I]   = 0b1;                                     /* base integer ISA */
+  misa[M]   = 0b1;                                     /* integer multiply/divide */
+  misa[U]   = bool_to_bits(sys_enable_user());         /* user-mode */
+  misa[S]   = bool_to_bits(sys_enable_supervisor());   /* supervisor-mode */
+  misa[V]   = bool_to_bits(hartSupports(Ext_V));       /* vector extension */
 
-  if   sys_enable_fdext() & sys_enable_zfinx()
+  if   hartSupports(Ext_F) & hartSupports(Ext_Zfinx)
   then internal_error(__FILE__, __LINE__, "F and Zfinx cannot both be enabled!");
 
   /* We currently support both F and D */
-  misa[F]   = bool_to_bits(sys_enable_fdext());      /* single-precision */
+  misa[F]   = bool_to_bits(hartSupports(Ext_F));      /* single-precision */
   misa[D]   = if   flen >= 64
-              then bool_to_bits(sys_enable_fdext())  /* double-precision */
+              then bool_to_bits(hartSupports(Ext_D))  /* double-precision */
               else 0b0;
 }
 

--- a/model/riscv_sys_exceptions.sail
+++ b/model/riscv_sys_exceptions.sail
@@ -83,8 +83,8 @@ mapping clause csr_name_map = 0x141  <-> "sepc"
 mapping clause csr_name_map = 0x305  <-> "mtvec"
 mapping clause csr_name_map = 0x341  <-> "mepc"
 
-function clause is_CSR_defined(0x105) = extensionEnabled(Ext_S) // stvec
-function clause is_CSR_defined(0x141) = extensionEnabled(Ext_S) // sepc
+function clause is_CSR_defined(0x105) = currentlyEnabled(Ext_S) // stvec
+function clause is_CSR_defined(0x141) = currentlyEnabled(Ext_S) // sepc
 function clause is_CSR_defined(0x305) = true // mtvec
 function clause is_CSR_defined(0x341) = true // mepc
 

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -86,19 +86,19 @@ register misa : Misa =
 function sys_enable_writable_misa() -> bool = config base.writable_misa
 
 /* whether misa.c was enabled at boot */
-function sys_enable_rvc() -> bool = config extensions.C.enabled
+function sys_enable_rvc() -> bool = config extensions.C.supported
 
 /* whether misa.{f,d} were enabled at boot */
-function sys_enable_fdext() -> bool = config extensions.FD.enabled
+function sys_enable_fdext() -> bool = config extensions.FD.supported
 
 /* whether Svinval was enabled at boot */
-function sys_enable_svinval() -> bool = config extensions.Svinval.enabled
+function sys_enable_svinval() -> bool = config extensions.Svinval.supported
 
 /* whether Zcb was enabled at boot */
-function sys_enable_zcb() -> bool = config extensions.Zcb.enabled
+function sys_enable_zcb() -> bool = config extensions.Zcb.supported
 
 /* whether zfinx was enabled at boot */
-function sys_enable_zfinx() -> bool = config extensions.Zfinx.enabled
+function sys_enable_zfinx() -> bool = config extensions.Zfinx.supported
 
 /* Whether FIOM bit of menvcfg/senvcfg is enabled. It must be enabled if
    supervisor mode is implemented and non-bare addressing modes are supported. */
@@ -115,23 +115,23 @@ function sys_pmp_grain() -> range(0, 63) = config memory.pmp.grain
 function sys_writable_hpm_counters() -> bits(32) = config base.writable_hpm_counters
 
 /* whether misa.v was enabled at boot */
-function sys_enable_vext() -> bool = config extensions.V.enabled
+function sys_enable_vext() -> bool = config extensions.V.supported
 
 /* whether misa.b was enabled at boot */
-function sys_enable_bext() -> bool = config extensions.B.enabled
+function sys_enable_bext() -> bool = config extensions.B.supported
 
 // CBO extensions. Zicbop cannot be enabled/disabled because it has no effect
 // at all on this model.
-function sys_enable_zicbom() -> bool = config extensions.Zicbom.enabled
-function sys_enable_zicboz() -> bool = config extensions.Zicboz.enabled
+function sys_enable_zicbom() -> bool = config extensions.Zicbom.supported
+function sys_enable_zicboz() -> bool = config extensions.Zicboz.supported
 
 // Is the Zvkb extension supported.
-function sys_enable_zvkb() -> bool = config extensions.Zvkb.enabled
+function sys_enable_zvkb() -> bool = config extensions.Zvkb.supported
 
 // Is the Zvbc extension supported.
 function sys_enable_zvbc() -> bool = true
 // Is the Sstc stimecmp extension supported.
-function sys_enable_sstc() -> bool = config extensions.Sstc.enabled
+function sys_enable_sstc() -> bool = config extensions.Sstc.supported
 
 // Supervisor timecmp
 function clause extensionEnabled(Ext_Sstc) = sys_enable_sstc()

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -85,21 +85,6 @@ register misa : Misa =
 /* whether misa is R/W */
 function sys_enable_writable_misa() -> bool = config base.writable_misa
 
-/* whether misa.c was enabled at boot */
-function sys_enable_rvc() -> bool = config extensions.C.supported
-
-/* whether misa.{f,d} were enabled at boot */
-function sys_enable_fdext() -> bool = config extensions.FD.supported
-
-/* whether Svinval was enabled at boot */
-function sys_enable_svinval() -> bool = config extensions.Svinval.supported
-
-/* whether Zcb was enabled at boot */
-function sys_enable_zcb() -> bool = config extensions.Zcb.supported
-
-/* whether zfinx was enabled at boot */
-function sys_enable_zfinx() -> bool = config extensions.Zfinx.supported
-
 /* Whether FIOM bit of menvcfg/senvcfg is enabled. It must be enabled if
    supervisor mode is implemented and non-bare addressing modes are supported. */
 function sys_enable_writable_fiom() -> bool = config base.writable_fiom
@@ -114,27 +99,8 @@ function sys_pmp_grain() -> range(0, 63) = config memory.pmp.grain
 /* Which HPM counters are supported (as a bit mask). Bits [2 .. 0] are ignored. */
 function sys_writable_hpm_counters() -> bits(32) = config base.writable_hpm_counters
 
-/* whether misa.v was enabled at boot */
-function sys_enable_vext() -> bool = config extensions.V.supported
-
-/* whether misa.b was enabled at boot */
-function sys_enable_bext() -> bool = config extensions.B.supported
-
-// CBO extensions. Zicbop cannot be enabled/disabled because it has no effect
-// at all on this model.
-function sys_enable_zicbom() -> bool = config extensions.Zicbom.supported
-function sys_enable_zicboz() -> bool = config extensions.Zicboz.supported
-
-// Is the Zvkb extension supported.
-function sys_enable_zvkb() -> bool = config extensions.Zvkb.supported
-
-// Is the Zvbc extension supported.
-function sys_enable_zvbc() -> bool = true
-// Is the Sstc stimecmp extension supported.
-function sys_enable_sstc() -> bool = config extensions.Sstc.supported
-
 // Supervisor timecmp
-function clause currentlyEnabled(Ext_Sstc) = sys_enable_sstc()
+function clause currentlyEnabled(Ext_Sstc) = hartSupports(Ext_Sstc)
 
 /* This function allows an extension to veto a write to Misa
    if it would violate an alignment restriction on
@@ -148,9 +114,9 @@ function legalize_misa(m : Misa, v : xlenbits) -> Misa = {
   then m
   else {
     /* Suppress enabling C if C was disabled at boot (i.e. not supported) */
-    let m = if not(sys_enable_rvc()) then m else [m with C = v[C]];
+    let m = if not(hartSupports(Ext_C)) then m else [m with C = v[C]];
     /* Suppress updates to misa.{f,d} if disabled at boot */
-    if   not(sys_enable_fdext())
+    if   not(hartSupports(Ext_F))
     then m
     else [m with F = v[F], D = v[D] & v[F]]
   }
@@ -276,7 +242,7 @@ function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
    * but only if Zfinx isn't enabled.
    * FIXME: This should be made a platform parameter.
    */
-    FS = if sys_enable_zfinx() then extStatus_to_bits(Off) else v[FS],
+    FS = if hartSupports(Ext_Zfinx) then extStatus_to_bits(Off) else v[FS],
     MPP = if have_privLevel(v[MPP]) then v[MPP] else privLevel_to_bits(lowest_supported_privLevel()),
     SPP = if currentlyEnabled(Ext_S) then v[SPP] else 0b0,
     VS = v[VS],
@@ -568,7 +534,7 @@ register mepc : xlenbits
  */
 function legalize_xepc(v : xlenbits) -> xlenbits = {
   // allow writing xepc[1] only if misa.C is enabled or could be enabled.
-  if   sys_enable_rvc()
+  if   hartSupports(Ext_C)
   then [v with 0 = bitzero]
   else [v with 1..0 = zeros()]
 }

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -134,7 +134,7 @@ function sys_enable_zvbc() -> bool = true
 function sys_enable_sstc() -> bool = config extensions.Sstc.supported
 
 // Supervisor timecmp
-function clause extensionEnabled(Ext_Sstc) = sys_enable_sstc()
+function clause currentlyEnabled(Ext_Sstc) = sys_enable_sstc()
 
 /* This function allows an extension to veto a write to Misa
    if it would violate an alignment restriction on
@@ -169,20 +169,20 @@ function sys_enable_supervisor() -> bool = true
 // Are supervisor/user mode currently enabled? Although
 // unlikely and not currently supported by the model,
 // you are technically allowed to have writable misa[U/S].
-function clause extensionEnabled(Ext_U) = misa[U] == 0b1
-function clause extensionEnabled(Ext_S) = misa[S] == 0b1
+function clause currentlyEnabled(Ext_U) = misa[U] == 0b1
+function clause currentlyEnabled(Ext_S) = misa[S] == 0b1
 
 /*
  * Illegal values legalized to least privileged mode supported.
  * Note: the only valid combinations of supported modes are M, M+U, M+S+U.
  */
 function lowest_supported_privLevel() -> Privilege =
-  if extensionEnabled(Ext_U) then User else Machine
+  if currentlyEnabled(Ext_U) then User else Machine
 
 function have_privLevel(priv : priv_level) -> bool =
   match priv {
-    0b00 => extensionEnabled(Ext_U),
-    0b01 => extensionEnabled(Ext_S),
+    0b00 => currentlyEnabled(Ext_U),
+    0b01 => currentlyEnabled(Ext_S),
     0b10 => false,
     0b11 => true,
   }
@@ -263,12 +263,12 @@ function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
     // UXL = if xlen == 64 then v[UXL] else o[UXL],
     // SDT = v[SDT],
     // SPELP = v[SPELP],
-    TSR = if extensionEnabled(Ext_S) then v[TSR] else 0b0,
-    TW = if extensionEnabled(Ext_U) then v[TW] else 0b0,
-    TVM = if extensionEnabled(Ext_S) then v[TVM] else 0b0,
-    MXR = if extensionEnabled(Ext_S) then v[MXR] else 0b0,
-    SUM = if extensionEnabled(Ext_S) then v[SUM] else 0b0, // TODO: Should also be disabled if satp.MODE is read-only 0
-    MPRV = if extensionEnabled(Ext_U) then v[MPRV] else 0b0,
+    TSR = if currentlyEnabled(Ext_S) then v[TSR] else 0b0,
+    TW = if currentlyEnabled(Ext_U) then v[TW] else 0b0,
+    TVM = if currentlyEnabled(Ext_S) then v[TVM] else 0b0,
+    MXR = if currentlyEnabled(Ext_S) then v[MXR] else 0b0,
+    SUM = if currentlyEnabled(Ext_S) then v[SUM] else 0b0, // TODO: Should also be disabled if satp.MODE is read-only 0
+    MPRV = if currentlyEnabled(Ext_U) then v[MPRV] else 0b0,
     /* We don't have any extension context yet. */
     XS = extStatus_to_bits(Off),
   /* FS is WARL, and making FS writable can support the M-mode emulation of an FPU
@@ -278,12 +278,12 @@ function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
    */
     FS = if sys_enable_zfinx() then extStatus_to_bits(Off) else v[FS],
     MPP = if have_privLevel(v[MPP]) then v[MPP] else privLevel_to_bits(lowest_supported_privLevel()),
-    SPP = if extensionEnabled(Ext_S) then v[SPP] else 0b0,
+    SPP = if currentlyEnabled(Ext_S) then v[SPP] else 0b0,
     VS = v[VS],
     MPIE = v[MPIE],
-    SPIE = if extensionEnabled(Ext_S) then v[SPIE] else 0b0,
+    SPIE = if currentlyEnabled(Ext_S) then v[SPIE] else 0b0,
     MIE = v[MIE],
-    SIE = if extensionEnabled(Ext_S) then v[SIE] else 0b0,
+    SIE = if currentlyEnabled(Ext_S) then v[SIE] else 0b0,
   ];
 
   // Set dirty bit to OR of other status bits.
@@ -370,10 +370,10 @@ function legalize_menvcfg(o : MEnvcfg, v : bits(64)) -> MEnvcfg = {
   let v = Mk_MEnvcfg(v);
   [o with
     FIOM = if sys_enable_writable_fiom() then v[FIOM] else 0b0,
-    CBZE = if extensionEnabled(Ext_Zicboz) then v[CBZE] else 0b0,
-    CBCFE = if extensionEnabled(Ext_Zicbom) then v[CBCFE] else 0b0,
-    CBIE = if extensionEnabled(Ext_Zicbom) then (if v[CBIE] != 0b10 then v[CBIE] else 0b00) else 0b00,
-    STCE = if extensionEnabled(Ext_Sstc) then v[STCE] else 0b0,
+    CBZE = if currentlyEnabled(Ext_Zicboz) then v[CBZE] else 0b0,
+    CBCFE = if currentlyEnabled(Ext_Zicbom) then v[CBCFE] else 0b0,
+    CBIE = if currentlyEnabled(Ext_Zicbom) then (if v[CBIE] != 0b10 then v[CBIE] else 0b00) else 0b00,
+    STCE = if currentlyEnabled(Ext_Sstc) then v[STCE] else 0b0,
     // Other extensions are not implemented yet so all other fields are read only zero.
   ]
 }
@@ -382,9 +382,9 @@ function legalize_senvcfg(o : SEnvcfg, v : xlenbits) -> SEnvcfg = {
   let v = Mk_SEnvcfg(v);
   [o with
     FIOM = if sys_enable_writable_fiom() then v[FIOM] else 0b0,
-    CBZE = if extensionEnabled(Ext_Zicboz) then v[CBZE] else 0b0,
-    CBCFE = if extensionEnabled(Ext_Zicbom) then v[CBCFE] else 0b0,
-    CBIE = if extensionEnabled(Ext_Zicbom) then (if v[CBIE] != 0b10 then v[CBIE] else 0b00) else 0b00,
+    CBZE = if currentlyEnabled(Ext_Zicboz) then v[CBZE] else 0b0,
+    CBCFE = if currentlyEnabled(Ext_Zicbom) then v[CBCFE] else 0b0,
+    CBIE = if currentlyEnabled(Ext_Zicbom) then (if v[CBIE] != 0b10 then v[CBIE] else 0b00) else 0b00,
     // Other extensions are not implemented yet so all other fields are read only zero.
   ]
 }
@@ -397,9 +397,9 @@ mapping clause csr_name_map = 0x30A  <-> "menvcfg"
 mapping clause csr_name_map = 0x31A  <-> "menvcfgh"
 mapping clause csr_name_map = 0x10A  <-> "senvcfg"
 
-function clause is_CSR_defined(0x30A) = extensionEnabled(Ext_U) // menvcfg
-function clause is_CSR_defined(0x31A) = extensionEnabled(Ext_U) & (xlen == 32) // menvcfgh
-function clause is_CSR_defined(0x10A) = extensionEnabled(Ext_S) // senvcfg
+function clause is_CSR_defined(0x30A) = currentlyEnabled(Ext_U) // menvcfg
+function clause is_CSR_defined(0x31A) = currentlyEnabled(Ext_U) & (xlen == 32) // menvcfgh
+function clause is_CSR_defined(0x10A) = currentlyEnabled(Ext_S) // senvcfg
 
 function clause read_CSR(0x30A) = menvcfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x31A if xlen == 32) = menvcfg.bits[63 .. 32]
@@ -439,11 +439,11 @@ function legalize_mip(o : Minterrupts, v : xlenbits) -> Minterrupts = {
    * extension, the U-mode bits. */
   let v = Mk_Minterrupts(v);
   [o with
-    SEI = if extensionEnabled(Ext_S) then v[SEI] else 0b0,
-    SSI = if extensionEnabled(Ext_S) then v[SSI] else 0b0,
-    STI = if extensionEnabled(Ext_S) then (
+    SEI = if currentlyEnabled(Ext_S) then v[SEI] else 0b0,
+    SSI = if currentlyEnabled(Ext_S) then v[SSI] else 0b0,
+    STI = if currentlyEnabled(Ext_S) then (
       // STI is read only if Sstc is enabled and STCE is set (it is equal to stimecmp <= mtime).
-      if extensionEnabled(Ext_Sstc) & menvcfg[STCE] == 0b1 then o[STI] else v[STI]
+      if currentlyEnabled(Ext_Sstc) & menvcfg[STCE] == 0b1 then o[STI] else v[STI]
     ) else 0b0,
   ]
 }
@@ -454,9 +454,9 @@ function legalize_mie(o : Minterrupts, v : xlenbits) -> Minterrupts = {
     MEI = v[MEI],
     MTI = v[MTI],
     MSI = v[MSI],
-    SEI = if extensionEnabled(Ext_S) then v[SEI] else 0b0,
-    STI = if extensionEnabled(Ext_S) then v[STI] else 0b0,
-    SSI = if extensionEnabled(Ext_S) then v[SSI] else 0b0,
+    SEI = if currentlyEnabled(Ext_S) then v[SEI] else 0b0,
+    STI = if currentlyEnabled(Ext_S) then v[STI] else 0b0,
+    SSI = if currentlyEnabled(Ext_S) then v[SSI] else 0b0,
   ]
 }
 
@@ -503,9 +503,9 @@ mapping clause csr_name_map = 0x303  <-> "mideleg"
 
 function clause is_CSR_defined(0x304) = true // mie
 function clause is_CSR_defined(0x344) = true // mip
-function clause is_CSR_defined(0x302) = extensionEnabled(Ext_S) // medeleg
-function clause is_CSR_defined(0x312) = extensionEnabled(Ext_S) & xlen == 32 // medelegh
-function clause is_CSR_defined(0x303) = extensionEnabled(Ext_S) // mideleg
+function clause is_CSR_defined(0x302) = currentlyEnabled(Ext_S) // medeleg
+function clause is_CSR_defined(0x312) = currentlyEnabled(Ext_S) & xlen == 32 // medelegh
+function clause is_CSR_defined(0x303) = currentlyEnabled(Ext_S) // mideleg
 
 function clause read_CSR(0x304) = mie.bits
 function clause read_CSR(0x344) = mip.bits
@@ -615,7 +615,7 @@ function legalize_scounteren(c : Counteren, v : xlenbits) -> Counteren = {
 
 register scounteren : Counteren
 mapping clause csr_name_map = 0x106  <-> "scounteren"
-function clause is_CSR_defined(0x106) = extensionEnabled(Ext_S) // scounteren
+function clause is_CSR_defined(0x106) = currentlyEnabled(Ext_S) // scounteren
 function clause read_CSR(0x106) = zero_extend(scounteren.bits)
 function clause write_CSR(0x106, value) = { scounteren = legalize_scounteren(scounteren, value); zero_extend(scounteren.bits) }
 
@@ -627,7 +627,7 @@ function legalize_mcounteren(c : Counteren, v : xlenbits) -> Counteren = {
 
 register mcounteren : Counteren
 mapping clause csr_name_map = 0x306  <-> "mcounteren"
-function clause is_CSR_defined(0x306) = extensionEnabled(Ext_U) // mcounteren
+function clause is_CSR_defined(0x306) = currentlyEnabled(Ext_U) // mcounteren
 function clause read_CSR(0x306) = zero_extend(mcounteren.bits)
 function clause write_CSR(0x306, value) = { mcounteren = legalize_mcounteren(mcounteren, value); zero_extend(mcounteren.bits) }
 
@@ -787,7 +787,7 @@ function legalize_sstatus(m : Mstatus, v : xlenbits) -> Mstatus = {
 }
 
 mapping clause csr_name_map = 0x100  <-> "sstatus"
-function clause is_CSR_defined(0x100) = extensionEnabled(Ext_S) // sstatus
+function clause is_CSR_defined(0x100) = currentlyEnabled(Ext_S) // sstatus
 function clause read_CSR(0x100) = lower_mstatus(mstatus).bits[xlen - 1 .. 0]
 function clause write_CSR(0x100, value) = { mstatus = legalize_sstatus(mstatus, value); mstatus.bits[xlen - 1 .. 0] }
 
@@ -835,7 +835,7 @@ function legalize_sip(m : Minterrupts, d : Minterrupts, v : xlenbits) -> Minterr
 }
 
 mapping clause csr_name_map = 0x144  <-> "sip"
-function clause is_CSR_defined(0x144) = extensionEnabled(Ext_S) // sip
+function clause is_CSR_defined(0x144) = currentlyEnabled(Ext_S) // sip
 function clause read_CSR(0x144) = lower_mip(mip, mideleg).bits
 function clause write_CSR(0x144, value) = { mip = legalize_sip(mip, mideleg, value); mip.bits }
 
@@ -857,7 +857,7 @@ function legalize_sie(m : Minterrupts, d : Minterrupts, v : xlenbits) -> Minterr
 
 
 mapping clause csr_name_map = 0x104  <-> "sie"
-function clause is_CSR_defined(0x104) = extensionEnabled(Ext_S) // sie
+function clause is_CSR_defined(0x104) = currentlyEnabled(Ext_S) // sie
 function clause read_CSR(0x104) = lower_mie(mie, mideleg).bits
 function clause write_CSR(0x104, value) = { mie = legalize_sie(mie, mideleg, value); mie.bits }
 
@@ -873,9 +873,9 @@ mapping clause csr_name_map = 0x140  <-> "sscratch"
 mapping clause csr_name_map = 0x142  <-> "scause"
 mapping clause csr_name_map = 0x143  <-> "stval"
 
-function clause is_CSR_defined(0x140) = extensionEnabled(Ext_S) // sscratch
-function clause is_CSR_defined(0x142) = extensionEnabled(Ext_S) // scause
-function clause is_CSR_defined(0x143) = extensionEnabled(Ext_S) // stval
+function clause is_CSR_defined(0x140) = currentlyEnabled(Ext_S) // sscratch
+function clause is_CSR_defined(0x142) = currentlyEnabled(Ext_S) // scause
+function clause is_CSR_defined(0x143) = currentlyEnabled(Ext_S) // stval
 
 function clause read_CSR(0x140) = sscratch
 function clause read_CSR(0x142) = scause.bits

--- a/model/riscv_termination.sail
+++ b/model/riscv_termination.sail
@@ -46,7 +46,7 @@ function compressed_measure(instr) =
 termination_measure execute(i) = compressed_measure(i)
 termination_measure pt_walk(_,_,_,_,_,_,_,level,_, _) = level
 
-function extensionEnabled_measure(ext : extension) -> int =
+function currentlyEnabled_measure(ext : extension) -> int =
   match ext {
     Ext_Zca => 1, // Ext_C
     Ext_Zfhmin => 1, // Ext_Zfh
@@ -58,7 +58,7 @@ function extensionEnabled_measure(ext : extension) -> int =
     Ext_Zcf => 2, // Ext_Zca, (Ext_F)
     _ => 0
   }
-termination_measure extensionEnabled(ext) = extensionEnabled_measure(ext)
+termination_measure currentlyEnabled(ext) = currentlyEnabled_measure(ext)
 
 // The top-level loop isn't terminating, but we put a limit so that it can still be included in the Coq output
 termination_measure loop while 100

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -13,8 +13,8 @@
 // are set in the relevant CSRs (misa, mstatus, etc.) to enable its use. It is possible
 // for some extensions to be supported in hardware, but temporarily disabled via a CSR,
 // in which case this function should return false.
-val extensionEnabled : extension -> bool
-scattered function extensionEnabled
+val currentlyEnabled : extension -> bool
+scattered function currentlyEnabled
 
 /* this value is only defined for the runtime platform for ELF loading
  * checks, and not used in the model.

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -8,14 +8,6 @@
 
 /* Basic type and function definitions used pervasively in the model. */
 
-// Function used to determine if an extension is enabled in the current configuration.
-// This means an extension is implemented & supported, *and* any necessary bits
-// are set in the relevant CSRs (misa, mstatus, etc.) to enable its use. It is possible
-// for some extensions to be supported in hardware, but temporarily disabled via a CSR,
-// in which case this function should return false.
-val currentlyEnabled : extension -> bool
-scattered function currentlyEnabled
-
 /* this value is only defined for the runtime platform for ELF loading
  * checks, and not used in the model.
  */

--- a/model/riscv_vext_control.sail
+++ b/model/riscv_vext_control.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause extensionEnabled(Ext_V) = (misa[V] == 0b1) & (mstatus[VS] != 0b00)
+function clause currentlyEnabled(Ext_V) = (misa[V] == 0b1) & (mstatus[VS] != 0b00)
 
 // Note: The spec recommends trapping if vstart is out of bounds but the
 // current implementation does not do that because write_CSR() doesn't
@@ -26,13 +26,13 @@ mapping clause csr_name_map = 0xC20  <-> "vl"
 mapping clause csr_name_map = 0xC21  <-> "vtype"
 mapping clause csr_name_map = 0xC22  <-> "vlenb"
 
-function clause is_CSR_defined (0x008) = extensionEnabled(Ext_V) // vstart
-function clause is_CSR_defined (0x009) = extensionEnabled(Ext_V) // vxsat
-function clause is_CSR_defined (0x00A) = extensionEnabled(Ext_V) // vxrm
-function clause is_CSR_defined (0x00F) = extensionEnabled(Ext_V) // vcsr
-function clause is_CSR_defined (0xC20) = extensionEnabled(Ext_V) // vl
-function clause is_CSR_defined (0xC21) = extensionEnabled(Ext_V) // vtype
-function clause is_CSR_defined (0xC22) = extensionEnabled(Ext_V) // vlenb
+function clause is_CSR_defined (0x008) = currentlyEnabled(Ext_V) // vstart
+function clause is_CSR_defined (0x009) = currentlyEnabled(Ext_V) // vxsat
+function clause is_CSR_defined (0x00A) = currentlyEnabled(Ext_V) // vxrm
+function clause is_CSR_defined (0x00F) = currentlyEnabled(Ext_V) // vcsr
+function clause is_CSR_defined (0xC20) = currentlyEnabled(Ext_V) // vl
+function clause is_CSR_defined (0xC21) = currentlyEnabled(Ext_V) // vtype
+function clause is_CSR_defined (0xC22) = currentlyEnabled(Ext_V) // vlenb
 
 function clause read_CSR(0x008) = zero_extend(vstart)
 function clause read_CSR(0x009) = zero_extend(vcsr[vxsat])

--- a/model/riscv_vext_control.sail
+++ b/model/riscv_vext_control.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_V) = (misa[V] == 0b1) & (mstatus[VS] != 0b00)
+function clause currentlyEnabled(Ext_V) = (misa[V] == 0b1) & (mstatus[VS] != 0b00) & hartSupports(Ext_V)
 
 // Note: The spec recommends trapping if vstart is out of bounds but the
 // current implementation does not do that because write_CSR() doesn't

--- a/model/riscv_vext_regs.sail
+++ b/model/riscv_vext_regs.sail
@@ -88,7 +88,7 @@ mapping vreg_name_raw : bits(5) <-> string = {
 mapping vreg_name : vregidx <-> string = { Vregidx(i) <-> vreg_name_raw(i) }
 
 function dirty_v_context() -> unit = {
-  assert(sys_enable_vext());
+  assert(hartSupports(Ext_V));
   mstatus[VS] = extStatus_to_bits(Dirty);
   mstatus[SD] = 0b1;
 }

--- a/model/riscv_vmem.sail
+++ b/model/riscv_vmem.sail
@@ -156,7 +156,7 @@ function pt_walk(
 // PUBLIC: see also riscv_insts_zicsr.sail and other CSR-related files
 register satp : xlenbits
 mapping clause csr_name_map = 0x180  <-> "satp"
-function clause is_CSR_defined(0x180) = extensionEnabled(Ext_S)
+function clause is_CSR_defined(0x180) = currentlyEnabled(Ext_S)
 function clause read_CSR(0x180) = satp
 function clause write_CSR(0x180, value) = { satp = legalize_satp(cur_architecture(), satp, value); satp }
 

--- a/model/riscv_vmem_pte.sail
+++ b/model/riscv_vmem_pte.sail
@@ -70,8 +70,8 @@ function pte_is_non_leaf(pte_flags : PTE_Flags) -> bool =
   & pte_flags[R] == 0b0
 
 // Not supported in the model yet.
-function clause extensionEnabled(Ext_Svnapot) = false
-function clause extensionEnabled(Ext_Svpbmt) = false
+function clause currentlyEnabled(Ext_Svnapot) = false
+function clause currentlyEnabled(Ext_Svpbmt) = false
 
 // PRIVATE: check if a PTE is valid
 function pte_is_invalid(pte_flags : PTE_Flags, pte_ext : PTE_Ext) -> bool =
@@ -80,8 +80,8 @@ function pte_is_invalid(pte_flags : PTE_Flags, pte_ext : PTE_Ext) -> bool =
   // Note, the following requirements depend on the privileged spec version.
   // Early versions do not require this check. This will need to be behind
   // a flag when the Sail model allows specifying the spec version.
-  | (pte_ext[N] != 0b0 & not(extensionEnabled(Ext_Svnapot)))
-  | (pte_ext[PBMT] != zeros() & not(extensionEnabled(Ext_Svpbmt)))
+  | (pte_ext[N] != 0b0 & not(currentlyEnabled(Ext_Svnapot)))
+  | (pte_ext[PBMT] != zeros() & not(currentlyEnabled(Ext_Svpbmt)))
   | pte_ext[reserved] != zeros()
 
 // ----------------

--- a/model/riscv_zicntr_control.sail
+++ b/model/riscv_zicntr_control.sail
@@ -5,7 +5,7 @@
 /*                                                                                       */
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
-function clause extensionEnabled(Ext_Zicntr) = true
+function clause currentlyEnabled(Ext_Zicntr) = true
 
 /* unprivileged counters/timers */
 mapping clause csr_name_map = 0xC00  <-> "cycle"
@@ -15,12 +15,12 @@ mapping clause csr_name_map = 0xC80  <-> "cycleh"
 mapping clause csr_name_map = 0xC81  <-> "timeh"
 mapping clause csr_name_map = 0xC82  <-> "instreth"
 
-function clause is_CSR_defined(0xC00) = extensionEnabled(Ext_Zicntr) // cycle
-function clause is_CSR_defined(0xC01) = extensionEnabled(Ext_Zicntr) // time
-function clause is_CSR_defined(0xC02) = extensionEnabled(Ext_Zicntr) // instret
-function clause is_CSR_defined(0xC80) = extensionEnabled(Ext_Zicntr) & (xlen == 32) // cycleh
-function clause is_CSR_defined(0xC81) = extensionEnabled(Ext_Zicntr) & (xlen == 32) // timeh
-function clause is_CSR_defined(0xC82) = extensionEnabled(Ext_Zicntr) & (xlen == 32) // instreth
+function clause is_CSR_defined(0xC00) = currentlyEnabled(Ext_Zicntr) // cycle
+function clause is_CSR_defined(0xC01) = currentlyEnabled(Ext_Zicntr) // time
+function clause is_CSR_defined(0xC02) = currentlyEnabled(Ext_Zicntr) // instret
+function clause is_CSR_defined(0xC80) = currentlyEnabled(Ext_Zicntr) & (xlen == 32) // cycleh
+function clause is_CSR_defined(0xC81) = currentlyEnabled(Ext_Zicntr) & (xlen == 32) // timeh
+function clause is_CSR_defined(0xC82) = currentlyEnabled(Ext_Zicntr) & (xlen == 32) // instreth
 
 function clause read_CSR(0xC00) = mcycle[(xlen - 1) .. 0]
 function clause read_CSR(0xC01) = mtime[(xlen - 1) .. 0]
@@ -36,10 +36,10 @@ mapping clause csr_name_map = 0xB02  <-> "minstret"
 mapping clause csr_name_map = 0xB80  <-> "mcycleh"
 mapping clause csr_name_map = 0xB82  <-> "minstreth"
 
-function clause is_CSR_defined(0xB00) = extensionEnabled(Ext_Zicntr) // mcycle
-function clause is_CSR_defined(0xB02) = extensionEnabled(Ext_Zicntr) // minstret
-function clause is_CSR_defined(0xB80) = extensionEnabled(Ext_Zicntr) & xlen == 32 // mcycleh
-function clause is_CSR_defined(0xB82) = extensionEnabled(Ext_Zicntr) & xlen == 32 // minstreth
+function clause is_CSR_defined(0xB00) = currentlyEnabled(Ext_Zicntr) // mcycle
+function clause is_CSR_defined(0xB02) = currentlyEnabled(Ext_Zicntr) // minstret
+function clause is_CSR_defined(0xB80) = currentlyEnabled(Ext_Zicntr) & xlen == 32 // mcycleh
+function clause is_CSR_defined(0xB82) = currentlyEnabled(Ext_Zicntr) & xlen == 32 // minstreth
 
 function clause read_CSR(0xB00) = mcycle[(xlen - 1) .. 0]
 function clause read_CSR(0xB02) = minstret[(xlen - 1) .. 0]

--- a/model/riscv_zihpm.sail
+++ b/model/riscv_zihpm.sail
@@ -7,7 +7,7 @@
 /*=======================================================================================*/
 
 /* Hardware Performance Monitoring counters */
-function clause extensionEnabled(Ext_Zihpm) = true
+function clause currentlyEnabled(Ext_Zihpm) = true
 
 /* Hardware performance monitoring counters */
 mapping clause csr_name_map = 0xC03  <-> "hpmcounter3"
@@ -194,10 +194,10 @@ function hpmidx_from_bits(b : bits(5)) -> hpmidx = {
 
 function legalize_hpmevent(v : HpmEvent) -> HpmEvent = {
   [ Mk_HpmEvent(zeros()) with
-    OF = if extensionEnabled(Ext_Sscofpmf) then v[OF] else 0b0,
-    MINH  = if extensionEnabled(Ext_Sscofpmf) then v[MINH] else 0b0,
-    SINH  = if extensionEnabled(Ext_Sscofpmf) & extensionEnabled(Ext_S) then v[SINH] else 0b0,
-    UINH  = if extensionEnabled(Ext_Sscofpmf) & extensionEnabled(Ext_U) then v[UINH] else 0b0,
+    OF = if currentlyEnabled(Ext_Sscofpmf) then v[OF] else 0b0,
+    MINH  = if currentlyEnabled(Ext_Sscofpmf) then v[MINH] else 0b0,
+    SINH  = if currentlyEnabled(Ext_Sscofpmf) & currentlyEnabled(Ext_S) then v[SINH] else 0b0,
+    UINH  = if currentlyEnabled(Ext_Sscofpmf) & currentlyEnabled(Ext_U) then v[UINH] else 0b0,
     VSINH = 0b0, // Hypervisor not supported
     VUINH = 0b0, // Hypervisor not supported
     event = v[event],
@@ -224,7 +224,7 @@ function write_mhpmevent(index : hpmidx, value : xlenbits) -> unit =
   }))
 
 /* Hardware Performance Monitoring event selection */
-function clause is_CSR_defined(0b0011001 /* 0x320 */ @ index : bits(5) if unsigned(index) >= 3) = extensionEnabled(Ext_Zihpm) // mhpmevent3..31
+function clause is_CSR_defined(0b0011001 /* 0x320 */ @ index : bits(5) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) // mhpmevent3..31
 function clause read_CSR(0b0011001 /* 0x320 */ @ index : bits(5) if unsigned(index) >= 3) = read_mhpmevent(hpmidx_from_bits(index))
 function clause write_CSR((0b0011001 /* 0x320 */ @ index : bits(5), value) if unsigned(index) >= 3) = {
   let index = hpmidx_from_bits(index);
@@ -233,8 +233,8 @@ function clause write_CSR((0b0011001 /* 0x320 */ @ index : bits(5), value) if un
 }
 
 /* Hardware Performance Monitoring machine mode counters */
-function clause is_CSR_defined(0b1011000 /* 0xB00 */ @ index : bits(5) if unsigned(index) >= 3) = extensionEnabled(Ext_Zihpm) // mhpmcounter3..31
-function clause is_CSR_defined(0b1011100 /* 0xB80 */ @ index : bits(5) if unsigned(index) >= 3) = extensionEnabled(Ext_Zihpm) & (xlen == 32) // mhpmcounterh3..31
+function clause is_CSR_defined(0b1011000 /* 0xB00 */ @ index : bits(5) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) // mhpmcounter3..31
+function clause is_CSR_defined(0b1011100 /* 0xB80 */ @ index : bits(5) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & (xlen == 32) // mhpmcounterh3..31
 
 function clause read_CSR(0b1011000 /* 0xB00 */ @ index : bits(5) if unsigned(index) >= 3) = read_mhpmcounter(hpmidx_from_bits(index))
 function clause read_CSR(0b1011100 /* 0xB80 */ @ index : bits(5) if xlen == 32 & unsigned(index) >= 3) = read_mhpmcounterh(hpmidx_from_bits(index))
@@ -251,8 +251,8 @@ function clause write_CSR((0b1011100 /* 0xB80 */ @ index : bits(5), value) if xl
 }
 
 /* Hardware Performance Monitoring user mode counters */
-function clause is_CSR_defined(0b1100000 /* 0xC00 */ @ index : bits(5) if unsigned(index) >= 3) = extensionEnabled(Ext_Zihpm) & extensionEnabled(Ext_U) // hpmcounter3..31
-function clause is_CSR_defined(0b1100100 /* 0xC80 */ @ index : bits(5) if unsigned(index) >= 3) = extensionEnabled(Ext_Zihpm) & extensionEnabled(Ext_U) & (xlen == 32) // hpmcounterh3..31
+function clause is_CSR_defined(0b1100000 /* 0xC00 */ @ index : bits(5) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & currentlyEnabled(Ext_U) // hpmcounter3..31
+function clause is_CSR_defined(0b1100100 /* 0xC80 */ @ index : bits(5) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & currentlyEnabled(Ext_U) & (xlen == 32) // hpmcounterh3..31
 
 function clause read_CSR(0b1100000 /* 0xC00 */ @ index : bits(5) if unsigned(index) >= 3) = read_mhpmcounter(hpmidx_from_bits(index))
 function clause read_CSR(0b1100100 /* 0xC80 */ @ index : bits(5) if xlen == 32 & unsigned(index) >= 3) = read_mhpmcounterh(hpmidx_from_bits(index))

--- a/model/riscv_zkr_control.sail
+++ b/model/riscv_zkr_control.sail
@@ -7,7 +7,7 @@
 /*=======================================================================================*/
 
 /* Zkr entropy seed source */
-function clause extensionEnabled(Ext_Zkr) = true
+function clause currentlyEnabled(Ext_Zkr) = true
 
 /* Valid return states for reading the seed CSR. */
 enum seed_opst = {
@@ -42,6 +42,6 @@ function write_seed_csr () -> xlenbits = zeros()
 
 /* CSR mapping */
 mapping clause csr_name_map = 0x015  <-> "seed"
-function clause is_CSR_defined(0x015) = extensionEnabled(Ext_Zkr)
+function clause is_CSR_defined(0x015) = currentlyEnabled(Ext_Zkr)
 function clause read_CSR(0x015) = read_seed_csr()
 function clause write_CSR(0x015, value) = write_seed_csr()


### PR DESCRIPTION
- Update config file to use `supported` instead of `enabled`
- Change `extensionEnabled(...)` scattered function to `currentlySupported(...)` see #495 
- Create `hartSupports(...)` scattered function and replace many of the existing `sys_enable_...()` functions with it. So far this was only done for the simple extensions that already had an entry in the config file. Once we agree upon the approach I can update this PR or open a follow up PR to change the rest of the extensions. This also skips F/D for now because of complications with FLEN.

I recommend reviewing each of the commits separately and keeping the history when we merge this. I can break it out into separate PRs, but it all seemed related enough that I thought it would probably be fine as one PR.