### PR TITLE
Remove unused zeros overload

### DIFF
--- a/model/prelude.sail
+++ b/model/prelude.sail
@@ -87,12 +87,11 @@ val zero_extend : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)
 function sign_extend(m, v) = sail_sign_extend(v, m)
 function zero_extend(m, v) = sail_zero_extend(v, m)
 
-val zeros_implicit : forall 'n, 'n >= 0 . implicit('n) -> bits('n)
-function zeros_implicit (n) = sail_zeros(n)
-overload zeros = {zeros_implicit}
+val zeros : forall 'n, 'n >= 0 . implicit('n) -> bits('n)
+function zeros (n) = sail_zeros(n)
 
 val ones : forall 'n, 'n >= 0 . implicit('n) -> bits('n)
-function ones (n) = sail_ones (n)
+function ones (n) = sail_ones(n)
 
 mapping bool_bit : bool <-> bit = {
   true <-> bitone,

--- a/model/riscv_insts_zicsr.sail
+++ b/model/riscv_insts_zicsr.sail
@@ -55,7 +55,7 @@ function clause execute CSRReg(csr, rs1, rd, op) =
   doCSR(csr, X(rs1), rd, op, (op == CSRRW) | (rs1 != zreg))
 
 function clause execute CSRImm(csr, imm, rd, op) =
-  doCSR(csr, zero_extend(imm), rd, op, (op == CSRRW) | (imm != zeros_implicit()))
+  doCSR(csr, zero_extend(imm), rd, op, (op == CSRRW) | (imm != zeros()))
 
 mapping csr_mnemonic : csrop <-> string = {
   CSRRW <-> "csrrw",


### PR DESCRIPTION
For some reason there was a `zeros` overload, but it wasn't used.