### PR TITLE
Remove explicit type annotations and redundant type variables in Vector code

### DIFF
--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -46,20 +46,17 @@ mapping clause encdec = VVTYPE(funct6, vm, vs2, vs1, vd)
 
 function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW_pow  = get_sew_pow();
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -72,18 +69,18 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
         VV_VAND          => vs2_val[i] & vs1_val[i],
         VV_VOR           => vs2_val[i] | vs1_val[i],
         VV_VXOR          => vs2_val[i] ^ vs1_val[i],
-        VV_VSADDU        => unsigned_saturation('m, zero_extend('m + 1, vs2_val[i]) + zero_extend('m + 1, vs1_val[i])),
-        VV_VSADD         => signed_saturation('m, sign_extend('m + 1, vs2_val[i]) + sign_extend('m + 1, vs1_val[i])),
+        VV_VSADDU        => unsigned_saturation(SEW, zero_extend(SEW + 1, vs2_val[i]) + zero_extend(SEW + 1, vs1_val[i])),
+        VV_VSADD         => signed_saturation(SEW, sign_extend(SEW + 1, vs2_val[i]) + sign_extend(SEW + 1, vs1_val[i])),
         VV_VSSUBU        => {
                               if unsigned(vs2_val[i]) < unsigned(vs1_val[i]) then zeros()
-                              else unsigned_saturation('m, zero_extend('m + 1, vs2_val[i]) - zero_extend('m + 1, vs1_val[i]))
+                              else unsigned_saturation(SEW, zero_extend(SEW + 1, vs2_val[i]) - zero_extend(SEW + 1, vs1_val[i]))
                             },
-        VV_VSSUB         => signed_saturation('m, sign_extend('m + 1, vs2_val[i]) - sign_extend('m + 1, vs1_val[i])),
+        VV_VSSUB         => signed_saturation(SEW, sign_extend(SEW + 1, vs2_val[i]) - sign_extend(SEW + 1, vs1_val[i])),
         VV_VSMUL         => {
-                              let result_mul = to_bits('m * 2, signed(vs2_val[i]) * signed(vs1_val[i]));
-                              let rounding_incr = get_fixed_rounding_incr(result_mul, 'm - 1);
-                              let result_wide = (result_mul >> ('m - 1)) + zero_extend('m * 2, rounding_incr);
-                              signed_saturation('m, result_wide['m..0])
+                              let result_mul = to_bits(SEW * 2, signed(vs2_val[i]) * signed(vs1_val[i]));
+                              let rounding_incr = get_fixed_rounding_incr(result_mul, SEW - 1);
+                              let result_wide = (result_mul >> (SEW - 1)) + zero_extend(SEW * 2, rounding_incr);
+                              signed_saturation(SEW, result_wide[SEW..0])
                             },
         VV_VSLL          => {
                               let shift_amount = get_shift_amount(vs1_val[i], SEW);
@@ -95,19 +92,19 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
                             },
         VV_VSRA          => {
                               let shift_amount = get_shift_amount(vs1_val[i], SEW);
-                              let v_double : bits('m * 2) = sign_extend(vs2_val[i]);
+                              let v_double : bits('SEW * 2) = sign_extend(vs2_val[i]);
                               slice(v_double >> shift_amount, 0, SEW)
                             },
         VV_VSSRL         => {
                               let shift_amount = get_shift_amount(vs1_val[i], SEW);
                               let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
-                              (vs2_val[i] >> shift_amount) + zero_extend('m, rounding_incr)
+                              (vs2_val[i] >> shift_amount) + zero_extend(SEW, rounding_incr)
                             },
         VV_VSSRA         => {
                               let shift_amount = get_shift_amount(vs1_val[i], SEW);
                               let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
-                              let v_double : bits('m * 2) = sign_extend(vs2_val[i]);
-                              slice(v_double >> shift_amount, 0, SEW) + zero_extend('m, rounding_incr)
+                              let v_double : bits('SEW * 2) = sign_extend(vs2_val[i]);
+                              slice(v_double >> shift_amount, 0, SEW) + zero_extend(SEW, rounding_incr)
                             },
         VV_VMINU         => to_bits(SEW, min(unsigned(vs2_val[i]), unsigned(vs1_val[i]))),
         VV_VMIN          => to_bits(SEW, min(signed(vs2_val[i]), signed(vs1_val[i]))),
@@ -117,16 +114,16 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
                               if (vs1 == vd | vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
                               let idx = unsigned(vs1_val[i]);
                               let VLMAX = 2 ^ (LMUL_pow + VLEN_pow - SEW_pow);
-                              assert(VLMAX <= 'n);
+                              assert(VLMAX <= num_elem);
                               if idx < VLMAX then vs2_val[idx] else zeros()
                             },
         VV_VRGATHEREI16  => {
                               if (vs1 == vd | vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
                               /* vrgatherei16.vv uses SEW/LMUL for the data in vs2 but EEW=16 and EMUL = (16/SEW)*LMUL for the indices in vs1 */
-                              let vs1_new : vector('n, bits(16)) = read_vreg(num_elem, 16, 4 + LMUL_pow - SEW_pow, vs1);
+                              let vs1_new = read_vreg(num_elem, 16, 4 + LMUL_pow - SEW_pow, vs1);
                               let idx = unsigned(vs1_new[i]);
                               let VLMAX = 2 ^ (LMUL_pow + VLEN_pow - SEW_pow);
-                              assert(VLMAX <= 'n);
+                              assert(VLMAX <= num_elem);
                               if idx < VLMAX then vs2_val[idx] else zeros()
                             }
       }
@@ -179,24 +176,20 @@ mapping clause encdec = NVSTYPE(funct6, vm, vs2, vs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -211,8 +204,8 @@ function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
                       },
         NVS_VNSRA  => {
                         let shift_amount = get_shift_amount(vs1_val[i], SEW_widen);
-                        let v_double : bits('o * 2) = sign_extend(vs2_val[i]);
-                        let arith_shifted : bits('o) = slice(v_double >> shift_amount, 0, SEW_widen);
+                        let v_double : bits('SEW_widen * 2) = sign_extend(vs2_val[i]);
+                        let arith_shifted : bits('SEW_widen) = slice(v_double >> shift_amount, 0, SEW_widen);
                         slice(arith_shifted, 0, SEW)
                       }
       }
@@ -246,24 +239,20 @@ mapping clause encdec = NVTYPE(funct6, vm, vs2, vs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -275,13 +264,13 @@ function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
       let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
       result[i] = match funct6 {
         NV_VNCLIPU => {
-                        let result_wide = (vs2_val[i] >> shift_amount) + zero_extend('o, rounding_incr);
-                        unsigned_saturation('m, result_wide);
+                        let result_wide = (vs2_val[i] >> shift_amount) + zero_extend(SEW_widen, rounding_incr);
+                        unsigned_saturation(SEW, result_wide);
                       },
         NV_VNCLIP  => {
-                        let v_double : bits('m * 4) = sign_extend(vs2_val[i]);
-                        let result_wide = slice(v_double >> shift_amount, 0, 'o) + zero_extend('o, rounding_incr);
-                        signed_saturation('m, result_wide);
+                        let v_double : bits('SEW * 4) = sign_extend(vs2_val[i]);
+                        let result_wide = slice(v_double >> shift_amount, 0, SEW_widen) + zero_extend(SEW_widen, rounding_incr);
+                        signed_saturation(SEW, result_wide);
                       }
       }
     }
@@ -310,21 +299,19 @@ mapping clause encdec = MASKTYPEV (vs2, vs1,  vd)
 function clause execute(MASKTYPEV(vs2, vs1, vd)) = {
   let start_element = get_start_element();
   let end_element   = get_end_element();
-  let SEW           = get_sew();
+  let 'SEW          = get_sew();
   let LMUL_pow      = get_lmul_pow();
-  let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
+  let 'num_elem     = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
 
   if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, 0b0, zvreg);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  var result  : vector('n, bits('m)) = vector_init(zeros());
+  let vm_val  = read_vmask(num_elem, 0b0, zvreg);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
 
   let tail_ag : agtype = get_vtype_vta();
   foreach (i from 0 to (num_elem - 1)) {
@@ -357,18 +344,16 @@ mapping clause encdec = MOVETYPEV (vs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(MOVETYPEV(vs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, 0b1, zvreg);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, 0b1, zvreg);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -416,19 +401,17 @@ mapping clause encdec = VXTYPE(funct6, vm, vs2, rs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let rs1_val : bits('m)             = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -442,18 +425,18 @@ function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
         VX_VAND    => vs2_val[i] & rs1_val,
         VX_VOR     => vs2_val[i] | rs1_val,
         VX_VXOR    => vs2_val[i] ^ rs1_val,
-        VX_VSADDU  => unsigned_saturation('m, zero_extend('m + 1, vs2_val[i]) + zero_extend('m + 1, rs1_val) ),
-        VX_VSADD   => signed_saturation('m, sign_extend('m + 1, vs2_val[i]) + sign_extend('m + 1, rs1_val) ),
+        VX_VSADDU  => unsigned_saturation(SEW, zero_extend(SEW + 1, vs2_val[i]) + zero_extend(SEW + 1, rs1_val) ),
+        VX_VSADD   => signed_saturation(SEW, sign_extend(SEW + 1, vs2_val[i]) + sign_extend(SEW + 1, rs1_val) ),
         VX_VSSUBU  => {
                         if unsigned(vs2_val[i]) < unsigned(rs1_val) then zeros()
-                        else unsigned_saturation('m, zero_extend('m + 1, vs2_val[i]) - zero_extend('m + 1, rs1_val) )
+                        else unsigned_saturation(SEW, zero_extend(SEW + 1, vs2_val[i]) - zero_extend(SEW + 1, rs1_val) )
                       },
-        VX_VSSUB   => signed_saturation('m, sign_extend('m + 1, vs2_val[i]) - sign_extend('m + 1, rs1_val) ),
+        VX_VSSUB   => signed_saturation(SEW, sign_extend(SEW + 1, vs2_val[i]) - sign_extend(SEW + 1, rs1_val) ),
         VX_VSMUL   => {
-                        let result_mul = to_bits('m * 2, signed(vs2_val[i]) * signed(rs1_val));
-                        let rounding_incr = get_fixed_rounding_incr(result_mul, 'm - 1);
-                        let result_wide = (result_mul >> ('m - 1)) + zero_extend('m * 2, rounding_incr);
-                        signed_saturation('m, result_wide['m..0])
+                        let result_mul = to_bits(SEW * 2, signed(vs2_val[i]) * signed(rs1_val));
+                        let rounding_incr = get_fixed_rounding_incr(result_mul, SEW - 1);
+                        let result_wide = (result_mul >> (SEW - 1)) + zero_extend(SEW * 2, rounding_incr);
+                        signed_saturation(SEW, result_wide[SEW..0])
                       },
         VX_VSLL    => {
                         let shift_amount = get_shift_amount(rs1_val, SEW);
@@ -465,19 +448,19 @@ function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
                       },
         VX_VSRA    => {
                         let shift_amount = get_shift_amount(rs1_val, SEW);
-                        let v_double : bits('m * 2) = sign_extend(vs2_val[i]);
+                        let v_double : bits('SEW * 2) = sign_extend(vs2_val[i]);
                         slice(v_double >> shift_amount, 0, SEW)
                       },
         VX_VSSRL   => {
                         let shift_amount = get_shift_amount(rs1_val, SEW);
                         let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
-                        (vs2_val[i] >> shift_amount) + zero_extend('m, rounding_incr)
+                        (vs2_val[i] >> shift_amount) + zero_extend(SEW, rounding_incr)
                       },
         VX_VSSRA   => {
                         let shift_amount = get_shift_amount(rs1_val, SEW);
                         let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
-                        let v_double : bits('m * 2) = sign_extend(vs2_val[i]);
-                        slice(v_double >> shift_amount, 0, SEW) + zero_extend('m, rounding_incr)
+                        let v_double : bits('SEW * 2) = sign_extend(vs2_val[i]);
+                        slice(v_double >> shift_amount, 0, SEW) + zero_extend(SEW, rounding_incr)
                       },
         VX_VMINU   => to_bits(SEW, min(unsigned(vs2_val[i]), unsigned(rs1_val))),
         VX_VMIN    => to_bits(SEW, min(signed(vs2_val[i]), signed(rs1_val))),
@@ -532,24 +515,20 @@ mapping clause encdec = NXSTYPE(funct6, vm, vs2, rs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  let rs1_val : bits('m)             = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -564,8 +543,8 @@ function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
                       },
         NXS_VNSRA  => {
                         let shift_amount = get_shift_amount(rs1_val, SEW_widen);
-                        let v_double : bits('o * 2) = sign_extend(vs2_val[i]);
-                        let arith_shifted : bits('o) = slice(v_double >> shift_amount, 0, SEW_widen);
+                        let v_double : bits('SEW_widen * 2) = sign_extend(vs2_val[i]);
+                        let arith_shifted : bits('SEW_widen) = slice(v_double >> shift_amount, 0, SEW_widen);
                         slice(arith_shifted, 0, SEW)
                       }
       }
@@ -599,24 +578,20 @@ mapping clause encdec = NXTYPE(funct6, vm, vs2, rs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  let rs1_val : bits('m)             = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -628,13 +603,13 @@ function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
       let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
       result[i] = match funct6 {
         NX_VNCLIPU => {
-                        let result_wide = (vs2_val[i] >> shift_amount) + zero_extend('o, rounding_incr);
-                        unsigned_saturation('m, result_wide)
+                        let result_wide = (vs2_val[i] >> shift_amount) + zero_extend(SEW_widen, rounding_incr);
+                        unsigned_saturation(SEW, result_wide)
                       },
         NX_VNCLIP  => {
-                        let v_double : bits('m * 4) = sign_extend(vs2_val[i]);
-                        let result_wide = slice(v_double >> shift_amount, 0, 'o) + zero_extend('o, rounding_incr);
-                        signed_saturation('m, result_wide)
+                        let v_double : bits('SEW * 4) = sign_extend(vs2_val[i]);
+                        let result_wide = slice(v_double >> shift_amount, 0, SEW_widen) + zero_extend(SEW_widen, rounding_incr);
+                        signed_saturation(SEW, result_wide)
                       }
       }
     }
@@ -669,20 +644,18 @@ mapping clause encdec = VXSG(funct6, vm, vs2, rs1, vd)
 
 function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let SEW_pow  = get_sew_pow();
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
   let rs1_val : nat                  = unsigned(X(rs1));
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -696,13 +669,13 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
                           },
         VX_VSLIDEDOWN  => {
                             let VLMAX = 2 ^ (LMUL_pow + VLEN_pow - SEW_pow);
-                            assert(VLMAX > 0 & VLMAX <= 'n);
+                            assert(VLMAX > 0 & VLMAX <= num_elem);
                             if i + rs1_val < VLMAX then vs2_val[i + rs1_val] else zeros()
                           },
         VX_VRGATHER    => {
                             if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
                             let VLMAX = 2 ^ (LMUL_pow + VLEN_pow - SEW_pow);
-                            assert(VLMAX > 0 & VLMAX <= 'n);
+                            assert(VLMAX > 0 & VLMAX <= num_elem);
                             if rs1_val < VLMAX then vs2_val[rs1_val] else zeros()
                           }
       }
@@ -733,21 +706,19 @@ mapping clause encdec = MASKTYPEX(vs2, rs1, vd)
 function clause execute(MASKTYPEX(vs2, rs1, vd)) = {
   let start_element = get_start_element();
   let end_element   = get_end_element();
-  let SEW           = get_sew();
+  let 'SEW          = get_sew();
   let LMUL_pow      = get_lmul_pow();
-  let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
+  let 'num_elem     = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
 
   if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b0, zvreg);
-  let rs1_val : bits('m)             = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  var result  : vector('n, bits('m)) = vector_init(zeros());
+  let vm_val  = read_vmask(num_elem, 0b0, zvreg);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
 
   let tail_ag : agtype = get_vtype_vta();
   foreach (i from 0 to (num_elem - 1)) {
@@ -780,18 +751,16 @@ mapping clause encdec = MOVETYPEX (rs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(MOVETYPEX(rs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let rs1_val : bits('m)             = get_scalar(rs1, 'm);
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zvreg);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vm_val  = read_vmask(num_elem, 0b1, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -831,19 +800,17 @@ mapping clause encdec = VITYPE(funct6, vm, vs2, simm, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let imm_val : bits('m)             = sign_extend(simm);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val = read_vmask(num_elem, vm, zvreg);
+  let imm_val : bits('SEW) = sign_extend(simm);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -856,31 +823,31 @@ function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
         VI_VAND    => vs2_val[i] & imm_val,
         VI_VOR     => vs2_val[i] | imm_val,
         VI_VXOR    => vs2_val[i] ^ imm_val,
-        VI_VSADDU  => unsigned_saturation('m, zero_extend('m + 1, vs2_val[i]) + zero_extend('m + 1, imm_val) ),
-        VI_VSADD   => signed_saturation('m, sign_extend('m + 1, vs2_val[i]) + sign_extend('m + 1, imm_val) ),
+        VI_VSADDU  => unsigned_saturation(SEW, zero_extend(SEW + 1, vs2_val[i]) + zero_extend(SEW + 1, imm_val) ),
+        VI_VSADD   => signed_saturation(SEW, sign_extend(SEW + 1, vs2_val[i]) + sign_extend(SEW + 1, imm_val) ),
         VI_VSLL    => {
-                        let shift_amount = get_shift_amount(zero_extend('m, simm), SEW);
+                        let shift_amount = get_shift_amount(zero_extend(SEW, simm), SEW);
                         vs2_val[i] << shift_amount
                       },
         VI_VSRL    => {
-                        let shift_amount = get_shift_amount(zero_extend('m, simm), SEW);
+                        let shift_amount = get_shift_amount(zero_extend(SEW, simm), SEW);
                         vs2_val[i] >> shift_amount
                       },
         VI_VSRA    => {
-                        let shift_amount = get_shift_amount(zero_extend('m, simm), SEW);
-                        let v_double : bits('m * 2) = sign_extend(vs2_val[i]);
+                        let shift_amount = get_shift_amount(zero_extend(SEW, simm), SEW);
+                        let v_double : bits('SEW * 2) = sign_extend(vs2_val[i]);
                         slice(v_double >> shift_amount, 0, SEW)
                       },
         VI_VSSRL   => {
-                        let shift_amount = get_shift_amount(zero_extend('m, simm), SEW);
+                        let shift_amount = get_shift_amount(zero_extend(SEW, simm), SEW);
                         let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
-                        (vs2_val[i] >> shift_amount) + zero_extend('m, rounding_incr)
+                        (vs2_val[i] >> shift_amount) + zero_extend(SEW, rounding_incr)
                       },
         VI_VSSRA   => {
-                        let shift_amount = get_shift_amount(zero_extend('m, simm), SEW);
+                        let shift_amount = get_shift_amount(zero_extend(SEW, simm), SEW);
                         let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
-                        let v_double : bits('m * 2) = sign_extend(vs2_val[i]);
-                        slice(v_double >> shift_amount, 0, SEW) + zero_extend('m, rounding_incr)
+                        let v_double : bits('SEW * 2) = sign_extend(vs2_val[i]);
+                        slice(v_double >> shift_amount, 0, SEW) + zero_extend(SEW, rounding_incr)
                       }
       }
     }
@@ -923,24 +890,20 @@ mapping clause encdec = NISTYPE(funct6, vm, vs2, simm, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(NISTYPE(funct6, vm, vs2, simm, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  let imm_val : bits('m)             = sign_extend(simm);
-  let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let imm_val : bits('SEW) = sign_extend(simm);
+  let vs2_val = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -955,8 +918,8 @@ function clause execute(NISTYPE(funct6, vm, vs2, simm, vd)) = {
                       },
         NIS_VNSRA  => {
                         let shift_amount = get_shift_amount(imm_val, SEW_widen);
-                        let v_double : bits('o * 2) = sign_extend(vs2_val[i]);
-                        let arith_shifted : bits('o) = slice(v_double >> shift_amount, 0, SEW_widen);
+                        let v_double : bits('SEW_widen * 2) = sign_extend(vs2_val[i]);
+                        let arith_shifted : bits('SEW_widen) = slice(v_double >> shift_amount, 0, SEW_widen);
                         slice(arith_shifted, 0, SEW)
                       }
       }
@@ -990,24 +953,20 @@ mapping clause encdec = NITYPE(funct6, vm, vs2, simm, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(NITYPE(funct6, vm, vs2, simm, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  let imm_val : bits('m)             = sign_extend(simm);
-  let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let imm_val : bits('SEW) = sign_extend(simm);
+  let vs2_val = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -1019,13 +978,13 @@ function clause execute(NITYPE(funct6, vm, vs2, simm, vd)) = {
       let rounding_incr = get_fixed_rounding_incr(vs2_val[i], shift_amount);
       result[i] = match funct6 {
         NI_VNCLIPU => {
-                        let result_wide = (vs2_val[i] >> shift_amount) + zero_extend('o, rounding_incr);
-                        unsigned_saturation('m, result_wide)
+                        let result_wide = (vs2_val[i] >> shift_amount) + zero_extend(SEW_widen, rounding_incr);
+                        unsigned_saturation(SEW, result_wide)
                       },
         NI_VNCLIP  => {
-                        let v_double : bits('m * 4) = sign_extend(vs2_val[i]);
-                        let result_wide = slice(v_double >> shift_amount, 0, 'o) + zero_extend('o, rounding_incr);
-                        signed_saturation('m, result_wide)
+                        let v_double : bits('SEW * 4) = sign_extend(vs2_val[i]);
+                        let result_wide = slice(v_double >> shift_amount, 0, SEW_widen) + zero_extend(SEW_widen, rounding_incr);
+                        signed_saturation(SEW, result_wide)
                       }
       }
     }
@@ -1060,20 +1019,18 @@ mapping clause encdec = VISG(funct6, vm, vs2, simm, vd)
 
 function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let SEW_pow  = get_sew_pow();
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let VLEN_pow = get_vlen_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let imm_val : nat                  = unsigned(zero_extend(xlen, simm));
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let imm_val = unsigned(zero_extend(xlen, simm));
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -1087,13 +1044,13 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
                           },
         VI_VSLIDEDOWN  => {
                             let VLMAX = 2 ^ (LMUL_pow + VLEN_pow - SEW_pow);
-                            assert(VLMAX > 0 & VLMAX <= 'n);
+                            assert(VLMAX > 0 & VLMAX <= num_elem);
                             if i + imm_val < VLMAX then vs2_val[i + imm_val] else zeros()
                           },
         VI_VRGATHER    => {
                             if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
                             let VLMAX = 2 ^ (LMUL_pow + VLEN_pow - SEW_pow);
-                            assert(VLMAX > 0 & VLMAX <= 'n);
+                            assert(VLMAX > 0 & VLMAX <= num_elem);
                             if imm_val < VLMAX then vs2_val[imm_val] else zeros()
                           }
       }
@@ -1124,21 +1081,19 @@ mapping clause encdec = MASKTYPEI(vs2, simm, vd)
 function clause execute(MASKTYPEI(vs2, simm, vd)) = {
   let start_element = get_start_element();
   let end_element   = get_end_element();
-  let SEW           = get_sew();
+  let 'SEW          = get_sew();
   let LMUL_pow      = get_lmul_pow();
-  let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
+  let 'num_elem     = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
 
   if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b0, zvreg);
-  let imm_val : bits('m)             = sign_extend(simm);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  var result  : vector('n, bits('m)) = vector_init(zeros());
+  let vm_val = read_vmask(num_elem, 0b0, zvreg);
+  let imm_val : bits('SEW) = sign_extend(simm);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
 
   let tail_ag : agtype = get_vtype_vta();
   foreach (i from 0 to (num_elem - 1)) {
@@ -1171,18 +1126,16 @@ mapping clause encdec = MOVETYPEI (vd, simm)
   when extensionEnabled(Ext_V)
 
 function clause execute(MOVETYPEI(vd, simm)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zvreg);
-  let imm_val : bits('m)             = sign_extend(simm);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val = read_vmask(num_elem, 0b1, zvreg);
+  let imm_val : bits('SEW) = sign_extend(simm);
+  let vd_val = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -1208,21 +1161,19 @@ mapping clause encdec = VMVRTYPE(vs2, simm, vd)
 
 function clause execute(VMVRTYPE(vs2, simm, vd)) = {
   let start_element = get_start_element();
-  let SEW     = get_sew();
+  let 'SEW    = get_sew();
   let imm_val = unsigned(zero_extend(xlen, simm));
   let EMUL    = imm_val + 1;
 
   if not(EMUL == 1 | EMUL == 2 | EMUL == 4 | EMUL == 8) then { handle_illegal(); return RETIRE_FAIL };
 
   let EMUL_pow = log2(EMUL);
-  let num_elem = get_num_elem(EMUL_pow, SEW);
-  let 'n = num_elem;
-  let 'm = SEW;
+  let 'num_elem = get_num_elem(EMUL_pow, SEW);
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zvreg);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, EMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, EMUL_pow, vd);
-  var result  : vector('n, bits('m)) = vector_init(zeros());
+  let vm_val  = read_vmask(num_elem, 0b1, zvreg);
+  let vs2_val = read_vreg(num_elem, SEW, EMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, EMUL_pow, vd);
+  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
 
   foreach (i from 0 to (num_elem - 1)) {
     result[i] = if i < start_element then vd_val[i] else vs2_val[i]
@@ -1266,19 +1217,17 @@ mapping clause encdec = MVVTYPE(funct6, vm, vs2, vs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -1287,24 +1236,24 @@ function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
     if mask[i] == bitone then {
       result[i] = match funct6 {
         MVV_VAADDU   => {
-                          let result_add = zero_extend('m + 1, vs2_val[i]) + zero_extend('m + 1, vs1_val[i]);
+                          let result_add = zero_extend(SEW + 1, vs2_val[i]) + zero_extend(SEW + 1, vs1_val[i]);
                           let rounding_incr = get_fixed_rounding_incr(result_add, 1);
-                          slice(result_add >> 1, 0, 'm) + zero_extend('m, rounding_incr)
+                          slice(result_add >> 1, 0, SEW) + zero_extend(SEW, rounding_incr)
                         },
         MVV_VAADD    => {
-                          let result_add = sign_extend('m + 1, vs2_val[i]) + sign_extend('m + 1, vs1_val[i]);
+                          let result_add = sign_extend(SEW + 1, vs2_val[i]) + sign_extend(SEW + 1, vs1_val[i]);
                           let rounding_incr = get_fixed_rounding_incr(result_add, 1);
-                          slice(result_add >> 1, 0, 'm) + zero_extend('m, rounding_incr)
+                          slice(result_add >> 1, 0, SEW) + zero_extend(SEW, rounding_incr)
                         },
         MVV_VASUBU   => {
-                          let result_sub = zero_extend('m + 1, vs2_val[i]) - zero_extend('m + 1, vs1_val[i]);
+                          let result_sub = zero_extend(SEW + 1, vs2_val[i]) - zero_extend(SEW + 1, vs1_val[i]);
                           let rounding_incr = get_fixed_rounding_incr(result_sub, 1);
-                          slice(result_sub >> 1, 0, 'm) + zero_extend('m, rounding_incr)
+                          slice(result_sub >> 1, 0, SEW) + zero_extend(SEW, rounding_incr)
                         },
         MVV_VASUB    => {
-                          let result_sub = sign_extend('m + 1, vs2_val[i]) - sign_extend('m + 1, vs1_val[i]);
+                          let result_sub = sign_extend(SEW + 1, vs2_val[i]) - sign_extend(SEW + 1, vs1_val[i]);
                           let rounding_incr = get_fixed_rounding_incr(result_sub, 1);
-                          slice(result_sub >> 1, 0, 'm) + zero_extend('m, rounding_incr)
+                          slice(result_sub >> 1, 0, SEW) + zero_extend(SEW, rounding_incr)
                         },
         MVV_VMUL     => get_slice_int(SEW, signed(vs2_val[i]) * signed(vs1_val[i]), 0),
         MVV_VMULH    => get_slice_int(SEW, signed(vs2_val[i]) * signed(vs1_val[i]), SEW),
@@ -1375,19 +1324,17 @@ mapping clause encdec = MVVMATYPE(funct6, vm, vs2, vs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -1435,10 +1382,10 @@ mapping clause encdec = WVVTYPE(funct6, vm, vs2, vs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
@@ -1446,14 +1393,10 @@ function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
@@ -1505,24 +1448,20 @@ mapping clause encdec = WVTYPE(funct6, vm, vs2, vs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(WVTYPE(funct6, vm, vs2, vs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen))
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
@@ -1568,10 +1507,10 @@ mapping clause encdec =  WMVVTYPE(funct6, vm, vs2, vs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
@@ -1579,14 +1518,10 @@ function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
@@ -1639,13 +1574,9 @@ function clause execute(VEXT2TYPE(funct6, vm, vs2, vd)) = {
       not(valid_reg_overlap(vs2, vd, LMUL_pow_half, LMUL_pow))
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_half;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_half, LMUL_pow_half, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vs2_val = read_vreg(num_elem, SEW_half, LMUL_pow_half, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -1696,13 +1627,9 @@ function clause execute(VEXT4TYPE(funct6, vm, vs2, vd)) = {
       not(valid_reg_overlap(vs2, vd, LMUL_pow_quart, LMUL_pow))
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_quart;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_quart, LMUL_pow_quart, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vs2_val = read_vreg(num_elem, SEW_quart, LMUL_pow_quart, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -1753,13 +1680,9 @@ function clause execute(VEXT8TYPE(funct6, vm, vs2, vd)) = {
       not(valid_reg_overlap(vs2, vd, LMUL_pow_eighth, LMUL_pow))
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_eighth;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_eighth, LMUL_pow_eighth, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vs2_val = read_vreg(num_elem, SEW_eighth, LMUL_pow_eighth, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -1795,16 +1718,14 @@ mapping clause encdec = VMVXS(vs2, rd)
   when extensionEnabled(Ext_V)
 
 function clause execute(VMVXS(vs2, rd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
   if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
 
   assert(num_elem > 0);
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, 0, vs2);
+  let vs2_val = read_vreg(num_elem, SEW, 0, vs2);
   X(rd) = if xlen < SEW then slice(vs2_val[0], 0, xlen)
           else if xlen > SEW then sign_extend(vs2_val[0])
           else vs2_val[0];
@@ -1826,21 +1747,19 @@ mapping clause encdec = MVVCOMPRESS(vs2, vs1, vd)
 function clause execute(MVVCOMPRESS(vs2, vs1, vd)) = {
   let start_element = get_start_element();
   let end_element = get_end_element();
-  let SEW = get_sew();
+  let 'SEW = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let 'num_elem = get_num_elem(LMUL_pow, SEW);
 
   /* vcompress should always be executed with a vstart of 0 */
   if start_element != 0 | vs1 == vd | vs2 == vd | illegal_vd_unmasked()
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let vs1_val : bits('n)             = read_vmask(num_elem, 0b0, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  var result  : vector('n, bits('m)) = vector_init(zeros());
+  let vs1_val = read_vmask(num_elem, 0b0, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
 
   /* body elements */
   var vd_idx : nat = 0;
@@ -1848,7 +1767,7 @@ function clause execute(MVVCOMPRESS(vs2, vs1, vd)) = {
     if i <= end_element then {
       if vs1_val[i] == bitone then {
         let 'p = vd_idx;
-        assert('p < 'n);
+        assert('p < num_elem);
         result['p] = vs2_val[i];
         vd_idx = vd_idx + 1;
       }
@@ -1899,19 +1818,17 @@ mapping clause encdec = MVXTYPE(funct6, vm, vs2, rs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let rs1_val : bits('m)             = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -1920,24 +1837,24 @@ function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
     if mask[i] == bitone then {
       result[i] = match funct6 {
         MVX_VAADDU       => {
-                              let result_add = zero_extend('m + 1, vs2_val[i]) + zero_extend('m + 1, rs1_val);
+                              let result_add = zero_extend(SEW + 1, vs2_val[i]) + zero_extend(SEW + 1, rs1_val);
                               let rounding_incr = get_fixed_rounding_incr(result_add, 1);
-                              slice(result_add >> 1, 0, 'm) + zero_extend('m, rounding_incr)
+                              slice(result_add >> 1, 0, SEW) + zero_extend(SEW, rounding_incr)
                             },
         MVX_VAADD        => {
-                              let result_add = sign_extend('m + 1, vs2_val[i]) + sign_extend('m + 1, rs1_val);
+                              let result_add = sign_extend(SEW + 1, vs2_val[i]) + sign_extend(SEW + 1, rs1_val);
                               let rounding_incr = get_fixed_rounding_incr(result_add, 1);
-                              slice(result_add >> 1, 0, 'm) + zero_extend('m, rounding_incr)
+                              slice(result_add >> 1, 0, SEW) + zero_extend(SEW, rounding_incr)
                             },
         MVX_VASUBU       => {
-                              let result_sub = zero_extend('m + 1, vs2_val[i]) - zero_extend('m + 1, rs1_val);
+                              let result_sub = zero_extend(SEW + 1, vs2_val[i]) - zero_extend(SEW + 1, rs1_val);
                               let rounding_incr = get_fixed_rounding_incr(result_sub, 1);
-                              slice(result_sub >> 1, 0, 'm) + zero_extend('m, rounding_incr)
+                              slice(result_sub >> 1, 0, SEW) + zero_extend(SEW, rounding_incr)
                             },
         MVX_VASUB        => {
-                              let result_sub = sign_extend('m + 1, vs2_val[i]) - sign_extend('m + 1, rs1_val);
+                              let result_sub = sign_extend(SEW + 1, vs2_val[i]) - sign_extend(SEW + 1, rs1_val);
                               let rounding_incr = get_fixed_rounding_incr(result_sub, 1);
-                              slice(result_sub >> 1, 0, 'm) + zero_extend('m, rounding_incr)
+                              slice(result_sub >> 1, 0, SEW) + zero_extend(SEW, rounding_incr)
                             },
         MVX_VSLIDE1UP    => {
                               if (vs2 == vd) then { handle_illegal(); return RETIRE_FAIL };
@@ -2019,19 +1936,17 @@ mapping clause encdec = MVXMATYPE(funct6, vm, vs2, rs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let rs1_val : bits('m)             = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -2080,24 +1995,20 @@ mapping clause encdec = WVXTYPE(funct6, vm, vs2, rs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(WVXTYPE(funct6, vm, vs2, rs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
-  let rs1_val : bits('m)             = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
@@ -2149,23 +2060,19 @@ mapping clause encdec = WXTYPE(funct6, vm, vs2, rs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(WXTYPE(funct6, vm, vs2, rs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen)
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
-  let rs1_val : bits('m)             = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
@@ -2212,24 +2119,20 @@ mapping clause encdec = WMVXTYPE(funct6, vm, vs2, rs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(WMVXTYPE(funct6, vm, vs2, rs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
-  let rs1_val : bits('m)             = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
@@ -2268,18 +2171,16 @@ mapping clause encdec = VMVSX(rs1, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(VMVSX(rs1, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
   if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
 
   assert(num_elem > 0);
-  let 'n = num_elem;
-  let 'm = SEW;
 
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zvreg);
-  let rs1_val : bits('m)             = get_scalar(rs1, 'm);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
+  let vm_val  = read_vmask(num_elem, 0b1, zvreg);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vd_val  = read_vreg(num_elem, SEW, 0, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, 0, vd_val, vm_val);
   var result = initial_result;

--- a/model/riscv_insts_vext_fp.sail
+++ b/model/riscv_insts_vext_fp.sail
@@ -33,20 +33,17 @@ mapping clause encdec = FVVTYPE(funct6, vm, vs2, vs1, vd)
 
 function clause execute(FVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let rm_3b    = fcsr[FRM];
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW != 8);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)            = read_vmask(num_elem, vm, zvreg);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -60,9 +57,9 @@ function clause execute(FVVTYPE(funct6, vm, vs2, vs1, vd)) = {
         FVV_VMAX     => fp_max(vs2_val[i], vs1_val[i]),
         FVV_VMUL     => fp_mul(rm_3b, vs2_val[i], vs1_val[i]),
         FVV_VDIV     => fp_div(rm_3b, vs2_val[i], vs1_val[i]),
-        FVV_VSGNJ    => [vs1_val[i]['m - 1]] @ vs2_val[i][('m - 2)..0],
-        FVV_VSGNJN   => (0b1 ^ [vs1_val[i]['m - 1]]) @ vs2_val[i][('m - 2)..0],
-        FVV_VSGNJX   => ([vs2_val[i]['m - 1]] ^ [vs1_val[i]['m - 1]]) @ vs2_val[i][('m - 2)..0]
+        FVV_VSGNJ    => [vs1_val[i]['SEW - 1]] @ vs2_val[i][('SEW - 2)..0],
+        FVV_VSGNJN   => (0b1 ^ [vs1_val[i]['SEW - 1]]) @ vs2_val[i][('SEW - 2)..0],
+        FVV_VSGNJX   => ([vs2_val[i]['SEW - 1]] ^ [vs1_val[i]['SEW - 1]]) @ vs2_val[i][('SEW - 2)..0]
       }
     }
   };
@@ -115,13 +112,10 @@ function clause execute(FVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
   if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW != 8);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -187,14 +181,10 @@ function clause execute(FWVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW >= 16 & SEW_widen <= 64);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
@@ -252,14 +242,10 @@ function clause execute(FWVVMATYPE(funct6, vm, vs1, vs2, vd)) = {
   then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW >= 16 & SEW_widen <= 64);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
@@ -315,14 +301,10 @@ function clause execute(FWVTYPE(funct6, vm, vs2, vs1, vd)) = {
   then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW >= 16 & SEW_widen <= 64);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
@@ -367,19 +349,16 @@ mapping clause encdec = VFUNARY0(vm, vs2, vfunary0, vd)
 
 function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
   let rm_3b    = fcsr[FRM];
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW != 8);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -388,7 +367,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
     if mask[i] == bitone then {
       result[i] = match vfunary0 {
         FV_CVT_XU_F      => {
-                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                                 16 => riscv_f16ToUi16(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToUi32(rm_3b, vs2_val[i]),
                                 64 => riscv_f64ToUi64(rm_3b, vs2_val[i])
@@ -397,7 +376,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
                               elem
                             },
         FV_CVT_X_F       => {
-                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                                 16 => riscv_f16ToI16(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToI32(rm_3b, vs2_val[i]),
                                 64 => riscv_f64ToI64(rm_3b, vs2_val[i])
@@ -406,7 +385,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
                               elem
                             },
         FV_CVT_F_XU      => {
-                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                                 16 => riscv_ui32ToF16(rm_3b, zero_extend(vs2_val[i])),
                                 32 => riscv_ui32ToF32(rm_3b, vs2_val[i]),
                                 64 => riscv_ui64ToF64(rm_3b, vs2_val[i])
@@ -415,7 +394,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
                               elem
                             },
         FV_CVT_F_X       => {
-                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                                 16 => riscv_i32ToF16(rm_3b, sign_extend(vs2_val[i])),
                                 32 => riscv_i32ToF32(rm_3b, vs2_val[i]),
                                 64 => riscv_i64ToF64(rm_3b, vs2_val[i])
@@ -424,7 +403,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
                               elem
                             },
         FV_CVT_RTZ_XU_F  => {
-                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                                 16 => riscv_f16ToUi16(0b001, vs2_val[i]),
                                 32 => riscv_f32ToUi32(0b001, vs2_val[i]),
                                 64 => riscv_f64ToUi64(0b001, vs2_val[i])
@@ -433,7 +412,7 @@ function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
                               elem
                             },
         FV_CVT_RTZ_X_F   => {
-                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                                 16 => riscv_f16ToI16(0b001, vs2_val[i]),
                                 32 => riscv_f32ToI32(0b001, vs2_val[i]),
                                 64 => riscv_f64ToI64(0b001, vs2_val[i])
@@ -484,7 +463,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
@@ -492,13 +471,9 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
   then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW >= 8 & SEW_widen <= 64);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
@@ -507,7 +482,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
     if mask[i] == bitone then {
       result[i] = match vfwunary0 {
         FWV_CVT_XU_F     => {
-                              let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW_widen)) = match SEW {
                                 8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_f16ToUi32(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToUi64(rm_3b, vs2_val[i])
@@ -516,7 +491,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                               elem
                             },
         FWV_CVT_X_F      => {
-                              let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW_widen)) = match SEW {
                                 8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_f16ToI32(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToI64(rm_3b, vs2_val[i])
@@ -525,7 +500,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                               elem
                             },
         FWV_CVT_F_XU     => {
-                              let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW_widen)) = match SEW {
                                 8  => riscv_ui32ToF16(rm_3b, zero_extend(vs2_val[i])),
                                 16 => riscv_ui32ToF32(rm_3b, zero_extend(vs2_val[i])),
                                 32 => riscv_ui32ToF64(rm_3b, vs2_val[i])
@@ -534,7 +509,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                               elem
                             },
         FWV_CVT_F_X      => {
-                              let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW_widen)) = match SEW {
                                 8  => riscv_i32ToF16(rm_3b, sign_extend(vs2_val[i])),
                                 16 => riscv_i32ToF32(rm_3b, sign_extend(vs2_val[i])),
                                 32 => riscv_i32ToF64(rm_3b, vs2_val[i])
@@ -543,7 +518,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                               elem
                             },
         FWV_CVT_F_F      => {
-                              let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW_widen)) = match SEW {
                                 8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_f16ToF32(rm_3b, vs2_val[i]),
                                 32 => riscv_f32ToF64(rm_3b, vs2_val[i])
@@ -552,7 +527,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                               elem
                             },
         FWV_CVT_RTZ_XU_F => {
-                              let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW_widen)) = match SEW {
                                 8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_f16ToUi32(0b001, vs2_val[i]),
                                 32 => riscv_f32ToUi64(0b001, vs2_val[i])
@@ -561,7 +536,7 @@ function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
                               elem
                             },
         FWV_CVT_RTZ_X_F  => {
-                              let (fflags, elem) : (bits_fflags, bits('o)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW_widen)) = match SEW {
                                 8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_f16ToI32(0b001, vs2_val[i]),
                                 32 => riscv_f32ToI64(0b001, vs2_val[i])
@@ -611,10 +586,10 @@ mapping clause encdec = VFNUNARY0(vm, vs2, vfnunary0, vd)
 
 function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
   let rm_3b    = fcsr[FRM];
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
@@ -622,13 +597,9 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
   then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW != 64);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs2_val = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -637,7 +608,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
     if mask[i] == bitone then {
       result[i] = match vfnunary0 {
         FNV_CVT_XU_F     => {
-                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                                 8  => riscv_f16ToUi8(rm_3b, vs2_val[i]),
                                 16 => riscv_f32ToUi16(rm_3b, vs2_val[i]),
                                 32 => riscv_f64ToUi32(rm_3b, vs2_val[i])
@@ -646,7 +617,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                               elem
                             },
         FNV_CVT_X_F      => {
-                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                                 8  => riscv_f16ToI8(rm_3b, vs2_val[i]),
                                 16 => riscv_f32ToI16(rm_3b, vs2_val[i]),
                                 32 => riscv_f64ToI32(rm_3b, vs2_val[i])
@@ -655,7 +626,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                               elem
                             },
         FNV_CVT_F_XU     => {
-                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                                 8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_ui32ToF16(rm_3b, vs2_val[i]),
                                 32 => riscv_ui64ToF32(rm_3b, vs2_val[i])
@@ -664,7 +635,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                               elem
                             },
         FNV_CVT_F_X      => {
-                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                                 8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_i32ToF16(rm_3b, vs2_val[i]),
                                 32 => riscv_i64ToF32(rm_3b, vs2_val[i])
@@ -673,7 +644,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                               elem
                             },
         FNV_CVT_F_F      => {
-                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                                 8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_f32ToF16(rm_3b, vs2_val[i]),
                                 32 => riscv_f64ToF32(rm_3b, vs2_val[i])
@@ -682,7 +653,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                               elem
                             },
         FNV_CVT_ROD_F_F  => {
-                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                                 8  => { handle_illegal(); return RETIRE_FAIL },
                                 16 => riscv_f32ToF16(0b110, vs2_val[i]),
                                 32 => riscv_f64ToF32(0b110, vs2_val[i])
@@ -691,7 +662,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                               elem
                             },
         FNV_CVT_RTZ_XU_F => {
-                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                                 8  => riscv_f16ToUi8(0b001, vs2_val[i]),
                                 16 => riscv_f32ToUi16(0b001, vs2_val[i]),
                                 32 => riscv_f64ToUi32(0b001, vs2_val[i])
@@ -700,7 +671,7 @@ function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
                               elem
                             },
         FNV_CVT_RTZ_X_F  => {
-                              let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                              let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                                 8  => riscv_f16ToI8(0b001, vs2_val[i]),
                                 16 => riscv_f32ToI16(0b001, vs2_val[i]),
                                 32 => riscv_f64ToI32(0b001, vs2_val[i])
@@ -747,19 +718,16 @@ mapping clause encdec = VFUNARY1(vm, vs2, vfunary1, vd)
 
 function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
   let rm_3b    = fcsr[FRM];
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW != 8);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -768,7 +736,7 @@ function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
     if mask[i] == bitone then {
       result[i] = match vfunary1 {
         FVV_VSQRT      => {
-                            let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                            let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                               16  => riscv_f16Sqrt(rm_3b, vs2_val[i]),
                               32  => riscv_f32Sqrt(rm_3b, vs2_val[i]),
                               64  => riscv_f64Sqrt(rm_3b, vs2_val[i])
@@ -777,7 +745,7 @@ function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
                             elem
                           },
         FVV_VRSQRT7    => {
-                            let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                            let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                               16  => riscv_f16Rsqrte7(rm_3b, vs2_val[i]),
                               32  => riscv_f32Rsqrte7(rm_3b, vs2_val[i]),
                               64  => riscv_f64Rsqrte7(rm_3b, vs2_val[i])
@@ -786,7 +754,7 @@ function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
                             elem
                           },
         FVV_VREC7      => {
-                            let (fflags, elem) : (bits_fflags, bits('m)) = match 'm {
+                            let (fflags, elem) : (bits_fflags, bits('SEW)) = match SEW {
                               16  => riscv_f16Recip7(rm_3b, vs2_val[i]),
                               32  => riscv_f32Recip7(rm_3b, vs2_val[i]),
                               64  => riscv_f64Recip7(rm_3b, vs2_val[i])
@@ -830,11 +798,8 @@ function clause execute(VFMVFS(vs2, rd)) = {
   then { handle_illegal(); return RETIRE_FAIL };
   assert(num_elem > 0 & SEW != 8);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, 0, vs2);
-  match 'm {
+  let vs2_val = read_vreg(num_elem, SEW, 0, vs2);
+  match SEW {
     16 => F_H(rd) = vs2_val[0],
     32 => F_S(rd) = vs2_val[0],
     64 => F_D(rd) = vs2_val[0]
@@ -872,20 +837,17 @@ mapping clause encdec = FVFTYPE(funct6, vm, vs2, rs1, vd)
 
 function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   let rm_3b    = fcsr[FRM];
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW != 8);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let rs1_val = get_scalar_fp(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -901,9 +863,9 @@ function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
         VF_VMUL          => fp_mul(rm_3b, vs2_val[i], rs1_val),
         VF_VDIV          => fp_div(rm_3b, vs2_val[i], rs1_val),
         VF_VRDIV         => fp_div(rm_3b, rs1_val, vs2_val[i]),
-        VF_VSGNJ         => [rs1_val['m - 1]] @ vs2_val[i][('m - 2)..0],
-        VF_VSGNJN        => (0b1 ^ [rs1_val['m - 1]]) @ vs2_val[i][('m - 2)..0],
-        VF_VSGNJX        => ([vs2_val[i]['m - 1]] ^ [rs1_val['m - 1]]) @ vs2_val[i][('m - 2)..0],
+        VF_VSGNJ         => [rs1_val['SEW - 1]] @ vs2_val[i][('SEW - 2)..0],
+        VF_VSGNJN        => (0b1 ^ [rs1_val['SEW - 1]]) @ vs2_val[i][('SEW - 2)..0],
+        VF_VSGNJX        => ([vs2_val[i]['SEW - 1]] ^ [rs1_val['SEW - 1]]) @ vs2_val[i][('SEW - 2)..0],
         VF_VSLIDE1UP     => {
                               if vs2 == vd then { handle_illegal(); return RETIRE_FAIL };
                               if i == 0 then rs1_val else vs2_val[i - 1]
@@ -969,13 +931,10 @@ function clause execute(FVFMATYPE(funct6, vm, vs2, rs1, vd)) = {
   if illegal_fp_normal(vd, vm, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW != 8);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let rs1_val = get_scalar_fp(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -1040,14 +999,10 @@ function clause execute(FWVFTYPE(funct6, vm, vs2, rs1, vd)) = {
   then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW >= 16 & SEW_widen <= 64);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
-  let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let rs1_val = get_scalar_fp(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
@@ -1104,14 +1059,10 @@ function clause execute(FWVFMATYPE(funct6, vm, rs1, vs2, vd)) = {
   then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW >= 16 & SEW_widen <= 64);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
-  let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let rs1_val = get_scalar_fp(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
@@ -1166,14 +1117,10 @@ function clause execute(FWFTYPE(funct6, vm, vs2, rs1, vd)) = {
   then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW >= 16 & SEW_widen <= 64);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
-
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
-  let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
-  let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let rs1_val = get_scalar_fp(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
@@ -1212,22 +1159,19 @@ function clause execute(VFMERGE(vs2, rs1, vd)) = {
   let rm_3b         = fcsr[FRM];
   let start_element = get_start_element();
   let end_element   = get_end_element();
-  let SEW           = get_sew();
+  let 'SEW          = get_sew();
   let LMUL_pow      = get_lmul_pow();
-  let num_elem      = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
+  let 'num_elem     = get_num_elem(LMUL_pow, SEW); /* max(VLMAX,VLEN/SEW)) */
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); /* VLMAX */
 
   if illegal_fp_vd_masked(vd, SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW != 8);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b0, zvreg);
-  let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-  var result  : vector('n, bits('m)) = vector_init(zeros());
+  let vm_val  = read_vmask(num_elem, 0b0, zvreg);
+  let rs1_val = get_scalar_fp(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  var result : vector('num_elem, bits('SEW)) = vector_init(zeros());
 
   let tail_ag : agtype = get_vtype_vta();
   foreach (i from 0 to (num_elem - 1)) {
@@ -1269,12 +1213,9 @@ function clause execute(VFMV(rs1, vd)) = {
   if illegal_fp_vd_unmasked(SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW != 8);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zvreg);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let rs1_val = get_scalar_fp(rs1, SEW);
+  let vm_val  = read_vmask(num_elem, 0b1, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -1306,12 +1247,9 @@ function clause execute(VFMVSF(rs1, vd)) = {
   if illegal_fp_vd_unmasked(SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
   assert(num_elem > 0 & SEW != 8);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, 0b1, zvreg);
-  let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
+  let vm_val  = read_vmask(num_elem, 0b1, zvreg);
+  let rs1_val = get_scalar_fp(rs1, SEW);
+  let vd_val  = read_vreg(num_elem, SEW, 0, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, 0, vd_val, vm_val);
   var result = initial_result;

--- a/model/riscv_insts_vext_fp_red.sail
+++ b/model/riscv_insts_vext_fp_red.sail
@@ -37,16 +37,12 @@ function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_po
 
   if unsigned(vl) == 0 then return RETIRE_SUCCESS; /* if vl=0, no operation is performed */
 
-  let 'n = num_elem_vs;
-  let 'd = num_elem_vd;
-  let 'm = SEW;
+  let vm_val  = read_vmask(num_elem_vs, vm, zvreg);
+  let vd_val  = read_vreg(num_elem_vd, SEW, 0, vd);
+  let vs2_val = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
+  let mask    = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
 
-  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zvreg);
-  let vd_val  : vector('d, bits('m)) = read_vreg(num_elem_vd, SEW, 0, vd);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
-  let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
-
-  var sum : bits('m) = read_single_element(SEW, 0, vs1); /* vs1 regardless of LMUL setting */
+  var sum = read_single_element(SEW, 0, vs1); /* vs1 regardless of LMUL setting */
   foreach (i from 0 to (num_elem_vs - 1)) {
     if mask[i] == bitone then {
       sum = match funct6 {
@@ -79,17 +75,12 @@ function process_rfvv_widen(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow
 
   if unsigned(vl) == 0 then return RETIRE_SUCCESS; /* if vl=0, no operation is performed */
 
-  let 'n = num_elem_vs;
-  let 'd = num_elem_vd;
-  let 'm = SEW;
-  let 'o = SEW_widen;
+  let vm_val  = read_vmask(num_elem_vs, vm, zvreg);
+  let vd_val  = read_vreg(num_elem_vd, SEW_widen, 0, vd);
+  let vs2_val = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
+  let mask    = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
 
-  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zvreg);
-  let vd_val  : vector('d, bits('o)) = read_vreg(num_elem_vd, SEW_widen, 0, vd);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
-  let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
-
-  var sum : bits('o) = read_single_element(SEW_widen, 0, vs1); /* vs1 regardless of LMUL setting */
+  var sum = read_single_element(SEW_widen, 0, vs1); /* vs1 regardless of LMUL setting */
   foreach (i from 0 to (num_elem_vs - 1)) {
     if mask[i] == bitone then {
       /* currently ordered/unordered sum reductions do the same operations */

--- a/model/riscv_insts_vext_fp_vm.sail
+++ b/model/riscv_insts_vext_fp_vm.sail
@@ -35,13 +35,10 @@ function clause execute(FVVMTYPE(funct6, vm, vs2, vs1, vd)) = {
   if illegal_fp_vd_unmasked(SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW != 8);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vmask(num_elem, 0b0, vd);
 
   let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -99,13 +96,10 @@ function clause execute(FVFMTYPE(funct6, vm, vs2, rs1, vd)) = {
   if illegal_fp_vd_unmasked(SEW, rm_3b) then { handle_illegal(); return RETIRE_FAIL };
   assert(SEW != 8);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
-  let rs1_val : bits('m)                  = get_scalar_fp(rs1, 'm);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let rs1_val = get_scalar_fp(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vmask(num_elem, 0b0, vd);
 
   let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;

--- a/model/riscv_insts_vext_mask.sail
+++ b/model/riscv_insts_vext_mask.sail
@@ -36,12 +36,9 @@ function clause execute(MMTYPE(funct6, vs2, vs1, vd)) = {
 
   if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vs1_val : bits('n) = read_vmask(num_elem, 0b0, vs1);
-  let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
-  let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
+  let vs1_val = read_vmask(num_elem, 0b0, vs1);
+  let vs2_val = read_vmask(num_elem, 0b0, vs2);
+  let vd_val  = read_vmask(num_elem, 0b0, vd);
 
   let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, 0, vd_val);
   var result = initial_result;
@@ -94,11 +91,8 @@ function clause execute(VCPOP_M(vm, vs2, rd)) = {
 
   if illegal_vd_unmasked() | not(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs2_val = read_vmask(num_elem, 0b0, vs2);
 
   let (_, mask) = init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val);
 
@@ -129,11 +123,8 @@ function clause execute(VFIRST_M(vm, vs2, rd)) = {
 
   if illegal_vd_unmasked() | not(assert_vstart(0)) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs2_val = read_vmask(num_elem, 0b0, vs2);
 
   let (_, mask) = init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val);
 
@@ -167,12 +158,9 @@ function clause execute(VMSBF_M(vm, vs2, vd)) = {
   if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
-  let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs2_val = read_vmask(num_elem, 0b0, vs2);
+  let vd_val  = read_vmask(num_elem, 0b0, vd);
 
   let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val);
   var result = initial_result;
@@ -208,12 +196,9 @@ function clause execute(VMSIF_M(vm, vs2, vd)) = {
   if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
-  let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs2_val = read_vmask(num_elem, 0b0, vs2);
+  let vd_val  = read_vmask(num_elem, 0b0, vd);
 
   let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val);
   var result = initial_result;
@@ -249,12 +234,9 @@ function clause execute(VMSOF_M(vm, vs2, vd)) = {
   if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
-  let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs2_val = read_vmask(num_elem, 0b0, vs2);
+  let vd_val  = read_vmask(num_elem, 0b0, vd);
 
   let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val);
   var result = initial_result;
@@ -294,12 +276,9 @@ function clause execute(VIOTA_M(vm, vs2, vd)) = {
   if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
   then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
-  let vs2_val : bits('n)     = read_vmask(num_elem, 0b0, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs2_val = read_vmask(num_elem, 0b0, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -334,11 +313,8 @@ function clause execute(VID_V(vm, vd)) = {
 
   if illegal_normal(vd, vm) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val = read_vmask(num_elem, vm, zvreg);
+  let vd_val = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;

--- a/model/riscv_insts_vext_red.sail
+++ b/model/riscv_insts_vext_red.sail
@@ -26,7 +26,7 @@ mapping clause encdec = RIVVTYPE(funct6, vm, vs2, vs1, vd)
 function clause execute(RIVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
   let num_elem_vs = get_num_elem(LMUL_pow, SEW);
   let num_elem_vd = get_num_elem(0, SEW_widen); /* vd regardless of LMUL setting */
@@ -35,20 +35,15 @@ function clause execute(RIVVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   if unsigned(vl) == 0 then return RETIRE_SUCCESS; /* if vl=0, no operation is performed */
 
-  let 'n = num_elem_vs;
-  let 'd = num_elem_vd;
-  let 'm = SEW;
-  let 'o = SEW_widen;
+  let vm_val  = read_vmask(num_elem_vs, vm, zvreg);
+  let vd_val  = read_vreg(num_elem_vd, SEW_widen, 0, vd);
+  let vs2_val = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
+  let mask    = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
 
-  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zvreg);
-  let vd_val  : vector('d, bits('o)) = read_vreg(num_elem_vd, SEW_widen, 0, vd);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
-  let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
-
-  var sum : bits('o) = read_single_element(SEW_widen, 0, vs1); /* vs1 regardless of LMUL setting */
+  var sum = read_single_element(SEW_widen, 0, vs1); /* vs1 regardless of LMUL setting */
   foreach (i from 0 to (num_elem_vs - 1)) {
     if mask[i] == bitone then {
-      let elem : bits('o) = match funct6 {
+      let elem : bits('SEW_widen) = match funct6 {
         IVV_VWREDSUMU  => to_bits(SEW_widen, unsigned(vs2_val[i])),
         IVV_VWREDSUM   => to_bits(SEW_widen, signed(vs2_val[i]))
       };
@@ -99,16 +94,12 @@ function clause execute(RMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   if unsigned(vl) == 0 then return RETIRE_SUCCESS; /* if vl=0, no operation is performed */
 
-  let 'n = num_elem_vs;
-  let 'd = num_elem_vd;
-  let 'm = SEW;
+  let vm_val  = read_vmask(num_elem_vs, vm, zvreg);
+  let vd_val  = read_vreg(num_elem_vd, SEW, 0, vd);
+  let vs2_val = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
+  let mask    = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
 
-  let vm_val  : bits('n)     = read_vmask(num_elem_vs, vm, zvreg);
-  let vd_val  : vector('d, bits('m)) = read_vreg(num_elem_vd, SEW, 0, vd);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
-  let mask    : bits('n)     = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
-
-  var sum : bits('m) = read_single_element(SEW, 0, vs1); /* vs1 regardless of LMUL setting */
+  var sum = read_single_element(SEW, 0, vs1); /* vs1 regardless of LMUL setting */
   foreach (i from 0 to (num_elem_vs - 1)) {
     if mask[i] == bitone then {
       sum = match funct6 {

--- a/model/riscv_insts_vext_vm.sail
+++ b/model/riscv_insts_vext_vm.sail
@@ -33,13 +33,10 @@ function clause execute(VVMTYPE(funct6, vs2, vs1, vd)) = {
 
   if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zvreg);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
+  let vm_val  = read_vmask_carry(num_elem, 0b0, zvreg);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vmask(num_elem, 0b0, vd);
 
   let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
   var result = initial_result;
@@ -89,12 +86,9 @@ function clause execute(VVMCTYPE(funct6, vs2, vs1, vd)) = {
 
   if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vmask(num_elem, 0b0, vd);
 
   let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
   var result = initial_result;
@@ -140,20 +134,17 @@ mapping clause encdec = VVMSTYPE(funct6, vs2, vs1, vd)
 function clause execute(VVMSTYPE(funct6, vs2, vs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let 'num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
   /* for bypassing normal masking in init_masked_result */
-  let vec_trues : bits('n) = ones();
+  let vec_trues : bits('num_elem) = ones();
 
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zvreg);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask_carry(num_elem, 0b0, zvreg);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues);
   var result = initial_result;
@@ -204,13 +195,10 @@ function clause execute(VVCMPTYPE(funct6, vm, vs2, vs1, vd)) = {
 
   if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vmask(num_elem, 0b0, vd);
 
   let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -268,13 +256,10 @@ function clause execute(VXMTYPE(funct6, vs2, rs1, vd)) = {
 
   if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zvreg);
-  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
+  let vm_val  = read_vmask_carry(num_elem, 0b0, zvreg);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vmask(num_elem, 0b0, vd);
 
   let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
   var result = initial_result;
@@ -324,12 +309,9 @@ function clause execute(VXMCTYPE(funct6, vs2, rs1, vd)) = {
 
   if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let rs1_val : bits('m)             = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vmask(num_elem, 0b0, vd);
 
   let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
   var result = initial_result;
@@ -375,20 +357,17 @@ mapping clause encdec = VXMSTYPE(funct6, vs2, rs1, vd)
 function clause execute(VXMSTYPE(funct6, vs2, rs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let 'num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
   /* for bypassing normal masking in init_masked_result */
-  let vec_trues : bits('n) = ones();
+  let vec_trues : bits('num_elem) = ones();
 
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zvreg);
-  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask_carry(num_elem, 0b0, zvreg);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues);
   var result = initial_result;
@@ -441,13 +420,10 @@ function clause execute(VXCMPTYPE(funct6, vm, vs2, rs1, vd)) = {
 
   if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
-  let rs1_val : bits('m)                  = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vmask(num_elem, 0b0, vd);
 
   let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -502,19 +478,16 @@ mapping clause encdec = VIMTYPE(funct6, vs2, simm, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(VIMTYPE(funct6, vs2, simm, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zvreg);
-  let imm_val : bits('m)                  = sign_extend(simm);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
+  let vm_val  = read_vmask_carry(num_elem, 0b0, zvreg);
+  let imm_val : bits('SEW) = sign_extend(simm);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vmask(num_elem, 0b0, vd);
 
   let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
   var result = initial_result;
@@ -555,18 +528,15 @@ mapping clause encdec = VIMCTYPE(funct6, vs2, simm, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(VIMCTYPE(funct6, vs2, simm, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let imm_val : bits('m)             = sign_extend(simm);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
+  let imm_val : bits('SEW) = sign_extend(simm);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vmask(num_elem, 0b0, vd);
 
   let (initial_result, mask) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
   var result = initial_result;
@@ -607,22 +577,19 @@ mapping clause encdec = VIMSTYPE(funct6, vs2, simm, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(VIMSTYPE(funct6, vs2, simm, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let 'num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_vd_masked(vd) then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
   /* for bypassing normal masking in init_masked_result */
-  let vec_trues : bits('n) = ones();
+  let vec_trues : bits('num_elem) = ones();
 
-  let vm_val  : bits('n)     = read_vmask_carry(num_elem, 0b0, zvreg);
-  let imm_val : bits('m)                  = sign_extend(simm);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask_carry(num_elem, 0b0, zvreg);
+  let imm_val : bits('SEW) = sign_extend(simm);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues);
   var result = initial_result;
@@ -665,19 +632,16 @@ mapping clause encdec = VICMPTYPE(funct6, vm, vs2, simm, vd)
   when extensionEnabled(Ext_V)
 
 function clause execute(VICMPTYPE(funct6, vm, vs2, simm, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_vd_unmasked() then { handle_illegal(); return RETIRE_FAIL };
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)     = read_vmask(num_elem, vm, zvreg);
-  let imm_val : bits('m)                  = sign_extend(simm);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : bits('n)     = read_vmask(num_elem, 0b0, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let imm_val : bits('SEW) = sign_extend(simm);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vmask(num_elem, 0b0, vd);
 
   let (initial_result, mask) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;

--- a/model/riscv_insts_zvbb.sail
+++ b/model/riscv_insts_zvbb.sail
@@ -24,13 +24,10 @@ function clause execute (VANDN_VV(vm, vs1, vs2, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -58,13 +55,10 @@ function clause execute (VANDN_VX(vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let rs1_val : bits('m) = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -88,23 +82,20 @@ mapping clause assembly = VBREV_V(vm, vs2, vd)
   <-> "vbrev.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 function clause execute (VBREV_V(vm, vs2, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
-      var output : bits('m) = zeros();
+      var output : bits('SEW) = zeros();
       foreach (j from 0 to (SEW - 1))
         output[SEW - 1 - j] = vs2_val[i][j];
       result[i] = output;
@@ -125,23 +116,20 @@ mapping clause assembly = VBREV8_V(vm, vs2, vd)
   <-> "vbrev8.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 function clause execute (VBREV8_V(vm, vs2, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)= read_vmask(num_elem, vm, zvreg);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
-      var output : bits('m) = zeros();
+      var output : bits('SEW) = zeros();
       foreach (j from 0 to (SEW - 8) by 8)
         output[j+7..j] = reverse(vs2_val[i][j+7..j]);
       result[i] = output;
@@ -162,23 +150,20 @@ mapping clause assembly = VREV8_V(vm, vs2, vd)
   <-> "vrev8.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 function clause execute (VREV8_V(vm, vs2, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
-      var output : bits('m) = zeros();
+      var output : bits('SEW) = zeros();
       foreach (j from 0 to (SEW - 8) by 8)
         output[(j + 7)..j] = vs2_val[i][(SEW - j - 1) .. (SEW - j - 8)];
       result[i] = output;
@@ -203,12 +188,9 @@ function clause execute (VCLZ_V(vm, vs2, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -216,7 +198,7 @@ function clause execute (VCLZ_V(vm, vs2, vd)) = {
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
       let clz = count_leading_zeros(vs2_val[i]);
-      result[i] = to_bits('m, clz);
+      result[i] = to_bits(SEW, clz);
     };
   };
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
@@ -238,12 +220,9 @@ function clause execute (VCTZ_V(vm, vs2, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -251,7 +230,7 @@ function clause execute (VCTZ_V(vm, vs2, vd)) = {
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
       let ctz = count_trailing_zeros(vs2_val[i]);
-      result[i] = to_bits('m, ctz);
+      result[i] = to_bits(SEW, ctz);
     };
   };
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
@@ -273,12 +252,9 @@ function clause execute (VCPOP_V(vm, vs2, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
@@ -311,20 +287,17 @@ function clause execute (VROL_VV(vm, vs1, vs2, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then
-      result[i] = vs2_val[i] <<< (vs1_val[i] & to_bits('m, SEW - 1));
+      result[i] = vs2_val[i] <<< (vs1_val[i] & to_bits(SEW, SEW - 1));
   };
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
@@ -345,20 +318,17 @@ function clause execute (VROL_VX(vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let rs1_val : bits('m) = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then
-      result[i] = vs2_val[i] <<< (rs1_val & to_bits('m, SEW - 1));
+      result[i] = vs2_val[i] <<< (rs1_val & to_bits(SEW, SEW - 1));
   };
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
@@ -379,20 +349,17 @@ function clause execute (VROR_VV(vm, vs1, vs2, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then
-      result[i] = vs2_val[i] >>> (vs1_val[i] & to_bits('m, SEW - 1));
+      result[i] = vs2_val[i] >>> (vs1_val[i] & to_bits(SEW, SEW - 1));
   };
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
@@ -413,20 +380,17 @@ function clause execute (VROR_VX(vm, vs2, rs1, vd)) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let rs1_val : bits('m) = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then
-      result[i] = vs2_val[i] >>> (rs1_val & to_bits('m, SEW - 1));
+      result[i] = vs2_val[i] >>> (rs1_val & to_bits(SEW, SEW - 1));
   };
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
@@ -443,24 +407,21 @@ mapping clause assembly = VROR_VI(vm, vs2, uimm, vd)
  <-> "vror.vi" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(uimm) ^ maybe_vmask(vm)
 
 function clause execute (VROR_VI(vm, vs2, uimm, vd)) = {
-  let SEW      = get_sew();
+  let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val   : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let uimm_val : bits('m) = zero_extend(uimm);
-  let vs2_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val   : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vm_val   = read_vmask(num_elem, vm, zvreg);
+  let uimm_val : bits('SEW) = zero_extend(uimm);
+  let vs2_val  = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val   = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
   let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then
-      result[i] = vs2_val[i] >>> (uimm_val & to_bits('m, SEW - 1));
+      result[i] = vs2_val[i] >>> (uimm_val & to_bits(SEW, SEW - 1));
   };
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
@@ -480,26 +441,22 @@ function clause execute (VWSLL_VV(vm, vs2, vs1, vd)) = {
   let SEW            = get_sew();
   let LMUL_pow       = get_lmul_pow();
   let num_elem       = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
+  let vm_val      = read_vmask(num_elem, vm, zvreg);
+  let vs1_val_vec = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val_vec = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val      = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
 
-  let vm_val      : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let vs1_val_vec : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
-  let vs2_val_vec : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val      : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
-
-  let SEW_widen_bits = to_bits(SEW_widen, 'o);
+  let SEW_widen_bits = to_bits(SEW_widen, SEW_widen);
   let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
-      let vs1_val : bits('o) = zero_extend(vs1_val_vec[i]);
-      let vs2_val : bits('o) = zero_extend(vs2_val_vec[i]);
+      let vs1_val : bits('SEW_widen) = zero_extend(vs1_val_vec[i]);
+      let vs2_val : bits('SEW_widen) = zero_extend(vs2_val_vec[i]);
       result[i] = vs2_val << (vs1_val & zero_extend(SEW_widen_bits - 1));
     };
   };
@@ -521,25 +478,21 @@ function clause execute (VWSLL_VX(vm, vs2, rs1, vd)) = {
   let SEW            = get_sew();
   let LMUL_pow       = get_lmul_pow();
   let num_elem       = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
+  let vm_val      = read_vmask(num_elem, vm, zvreg);
+  let rs1_val : bits('SEW_widen) = zero_extend(get_scalar(rs1, SEW));
+  let vs2_val_vec = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val      = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
 
-  let vm_val      : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let rs1_val     : bits('o) = zero_extend(get_scalar(rs1, SEW));
-  let vs2_val_vec : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val      : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
-
-  let SEW_widen_bits = to_bits(SEW_widen, 'o);
+  let SEW_widen_bits = to_bits(SEW_widen, SEW_widen);
   let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
-      let vs2_val : bits('o) = zero_extend(vs2_val_vec[i]);
+      let vs2_val : bits('SEW_widen) = zero_extend(vs2_val_vec[i]);
       result[i] = vs2_val << (rs1_val & zero_extend(SEW_widen_bits - 1));
     };
   };
@@ -561,25 +514,21 @@ function clause execute (VWSLL_VI(vm, vs2, uimm, vd)) = {
   let SEW            = get_sew();
   let LMUL_pow       = get_lmul_pow();
   let num_elem       = get_num_elem(LMUL_pow, SEW);
-  let SEW_widen      = SEW * 2;
+  let 'SEW_widen     = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  let 'n = num_elem;
-  let 'm = SEW;
-  let 'o = SEW_widen;
+  let vm_val      = read_vmask(num_elem, vm, zvreg);
+  let uimm_val : bits('SEW_widen) = zero_extend(uimm);
+  let vs2_val_vec = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val      = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
 
-  let vm_val      : bits('n) = read_vmask(num_elem, vm, zvreg);
-  let uimm_val    : bits('o) = zero_extend(uimm);
-  let vs2_val_vec : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val      : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
-
-  let SEW_widen_bits = to_bits(SEW_widen, 'o);
+  let SEW_widen_bits = to_bits(SEW_widen, SEW_widen);
   let (initial_result, mask) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
-        let vs2_val : bits('o) = zero_extend(vs2_val_vec[i]);
+        let vs2_val : bits('SEW_widen) = zero_extend(vs2_val_vec[i]);
         result[i] = vs2_val << (uimm_val & zero_extend(SEW_widen_bits - 1));
     };
   };

--- a/model/riscv_insts_zvbc.sail
+++ b/model/riscv_insts_zvbc.sail
@@ -21,24 +21,23 @@ function clause execute (VCLMUL_VV(vm, vs2, vs1, vd)) = {
   let SEW       = get_sew();
   let LMUL_pow  = get_lmul_pow();
 
-  let 'n = get_num_elem(LMUL_pow, SEW);
-  let 'm = SEW;
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let vm_val  : bits('n) = read_vmask('n, vm, zvreg);
-  let vd_val  : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vd);
-  let vs1_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
-  foreach (i from 0 to ('n - 1)) {
+  foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
       let prod  = carryless_mul(vs1_val[i], vs2_val[i]);
-      result[i] = prod['m - 1 .. 0];
+      result[i] = prod[SEW - 1 .. 0];
     }
   };
-  write_vreg('n, SEW, LMUL_pow, vd, result);
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }
@@ -56,25 +55,24 @@ function clause execute (VCLMUL_VX(vm, vs2, rs1, vd)) = {
   let SEW       = get_sew();
   let LMUL_pow  = get_lmul_pow();
 
-  let 'n = get_num_elem(LMUL_pow, SEW);
-  let 'm = SEW;
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let vm_val  : bits('n) = read_vmask('n, vm, zvreg);
-  let vd_val  : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let rs1_val : bits('m) = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs2);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
-  foreach (i from 0 to ('n - 1)) {
+  foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
       let prod  = carryless_mul(rs1_val, vs2_val[i]);
-      result[i] = prod['m - 1 .. 0];
+      result[i] = prod[SEW - 1 .. 0];
     }
   };
-  write_vreg('n, SEW, LMUL_pow, vd, result);
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }
@@ -92,24 +90,23 @@ function clause execute (VCLMULH_VV(vm, vs2, vs1, vd)) = {
   let SEW       = get_sew();
   let LMUL_pow  = get_lmul_pow();
 
-  let 'n = get_num_elem(LMUL_pow, SEW);
-  let 'm = SEW;
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let vm_val  : bits('n) = read_vmask('n, vm, zvreg);
-  let vd_val  : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vd);
-  let vs1_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs1);
-  let vs2_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs2);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
-  foreach (i from 0 to ('n - 1)) {
+  foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
       let prod  = carryless_mul(vs1_val[i], vs2_val[i]);
       result[i] = prod[2 * SEW - 1 .. SEW];
     }
   };
-  write_vreg('n, SEW, LMUL_pow, vd, result);
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }
@@ -127,25 +124,24 @@ function clause execute (VCLMULH_VX(vm, vs2, rs1, vd)) = {
   let SEW       = get_sew();
   let LMUL_pow  = get_lmul_pow();
 
-  let 'n = get_num_elem(LMUL_pow, SEW);
-  let 'm = SEW;
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  let vm_val  : bits('n) = read_vmask('n, vm, zvreg);
-  let vd_val  : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vd);
+  let vm_val  = read_vmask(num_elem, vm, zvreg);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let rs1_val : bits('m) = get_scalar(rs1, SEW);
-  let vs2_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs2);
+  let rs1_val = get_scalar(rs1, SEW);
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) = init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val);
+  let (initial_result, mask) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
-  foreach (i from 0 to ('n - 1)) {
+  foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
       let prod  = carryless_mul(rs1_val, vs2_val[i]);
       result[i] = prod[2 * SEW - 1 .. SEW];
     }
   };
-  write_vreg('n, SEW, LMUL_pow, vd, result);
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }


### PR DESCRIPTION
This removes a load of the redundant type variables `let 'n = num_elem` in favour of using `'num_elem` directly (and similarly for `SEW`).

I also removed a load of the explicit type annotations which are not needed.