### PR TITLE
Add support for Zvknha and Zvknhb extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Supported RISC-V ISA features
 - Zvbb extension for vector basic bit-manipulation, v1.0
 - Zvbc extension for vector carryless multiplication, v1.0
 - Zvkb extension for vector cryptography bit-manipulation, v1.0
+- Zvknha and Zvknhb extensions for vector cryptography NIST Suite: Vector SHA-2 Secure Hash, v1.0
 - Machine, Supervisor, and User modes
 - Smcntrpmf extension for cycle and instret privilege mode filtering, v1.0
 - Sscofpmf extension for Count Overflow and Mode-Based Filtering, v1.0

--- a/config/default.json
+++ b/config/default.json
@@ -173,6 +173,12 @@
         "Zvbc" : {
             "supported" : true
         },
+        "Zvknha" : {
+            "supported" : true
+        },
+        "Zvknhb" : {
+            "supported" : true
+        },
         "Sscofpmf" : {
             "supported" : true
         },

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -88,6 +88,7 @@ foreach (xlen IN ITEMS 32 64)
                 "riscv_insts_zicboz.sail"
                 "riscv_insts_zvbb.sail"
                 "riscv_insts_zvbc.sail"
+                "riscv_insts_zvknhab.sail"
                 # Zimop and Zcmop should be at the end so they can be overridden by earlier extensions
                 "riscv_insts_zimop.sail"
                 "riscv_insts_zcmop.sail"
@@ -180,6 +181,7 @@ foreach (xlen IN ITEMS 32 64)
                 ${sail_vm_srcs}
                 # Shared/common code for the cryptography extension.
                 "riscv_types_kext.sail"
+                "riscv_zvk_utils.sail"
             )
 
             if (variant STREQUAL "rvfi")

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -179,6 +179,12 @@ function clause hartSupports(Ext_Zvkb) = config extensions.Zvkb.supported
 // Vector Carryless Multiplication
 enum clause extension = Ext_Zvbc
 function clause hartSupports(Ext_Zvbc) = config extensions.Zvbc.supported
+// NIST Suite: Vector SHA-2 Secure Hash
+enum clause extension = Ext_Zvknha
+function clause hartSupports(Ext_Zvknha) = config extensions.Zvknha.supported
+
+enum clause extension = Ext_Zvknhb
+function clause hartSupports(Ext_Zvknhb) = config extensions.Zvknhb.supported
 
 // Count Overflow and Mode-Based Filtering
 enum clause extension = Ext_Sscofpmf

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -172,6 +172,17 @@ function get_scalar(rs1, SEW) = {
   }
 }
 
+/* Extracts 4 consecutive vector elements starting from index 4*i */
+val get_velem_quad : forall 'n 'm 'p, 'n > 0 & 'm > 0 & 'p >= 0 & 4 * 'p + 3 < 'n. (vector('n, bits('m)), int('p)) -> bits(4 * 'm)
+function get_velem_quad(v, i) = v[4 * i + 3] @ v[4 * i + 2] @ v[4 * i + 1] @ v[4 * i]
+
+/* Divide the input bitvector into 4 equal slices and store them in vd starting at position 4*i */
+val write_velem_quad : forall 'p 'n 'm, 8 <= 'n <= 64 & 'm > 0 & 'p >= 0. (vregidx, int('n), bits('m), int('p)) -> unit
+function write_velem_quad(vd, SEW, input, i) = {
+  foreach(j from 0 to 3)
+    write_single_element(SEW, 4 * i + j, vd, slice(input, j * SEW, SEW));
+}
+
 /* Get the starting element index from csr vtype */
 val get_start_element : unit -> nat
 function get_start_element() = {

--- a/model/riscv_insts_zvknhab.sail
+++ b/model/riscv_insts_zvknhab.sail
@@ -1,0 +1,153 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+function clause currentlyEnabled(Ext_Zvknha) = hartSupports(Ext_Zvknha) & currentlyEnabled(Ext_V)
+function clause currentlyEnabled(Ext_Zvknhb) = hartSupports(Ext_Zvknhb) & currentlyEnabled(Ext_V)
+
+union clause ast = VSHA2MS_VV : (vregidx, vregidx, vregidx)
+
+mapping clause encdec = VSHA2MS_VV(vs2, vs1, vd)
+  <-> 0b1011011 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  when (currentlyEnabled(Ext_Zvknha) & get_sew() == 32) | (currentlyEnabled(Ext_Zvknhb) & (get_sew() == 32 | get_sew() == 64)) & zvknhab_check_encdec(vs2, vs1, vd)
+
+mapping clause assembly = VSHA2MS_VV(vs2, vs1, vd)
+  <-> "vsha2ms.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ vreg_name(vs1)
+
+function clause execute (VSHA2MS_VV(vs2, vs1, vd)) = {
+  let 'SEW     = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  assert(SEW == 32 | SEW == 64);
+
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  var w : vector(20, bits('SEW)) = vector_init(zeros());
+
+  let eg_len   = (unsigned(vl) / 4);
+  let eg_start = (unsigned(vstart) / 4);
+
+  foreach (i from eg_start to (eg_len - 1)) {
+    assert(i * 4 + 3 < num_elem);
+
+    w = [w with
+      0  = vd_val[i*4],
+      1  = vd_val[i*4+1],
+      2  = vd_val[i*4+2],
+      3  = vd_val[i*4+3],
+
+      4  = vs2_val[i*4],
+      9  = vs2_val[i*4+1],
+      10 = vs2_val[i*4+2],
+      11 = vs2_val[i*4+3],
+
+      12 = vs1_val[i*4],
+      13 = vs1_val[i*4+1],
+      14 = vs1_val[i*4+2],
+      15 = vs1_val[i*4+3]
+    ];
+
+    w[16] = sig1(w[14], SEW) + w[9]  + sig0(w[1], SEW) + w[0];
+    w[17] = sig1(w[15], SEW) + w[10] + sig0(w[2], SEW) + w[1];
+    w[18] = sig1(w[16], SEW) + w[11] + sig0(w[3], SEW) + w[2];
+    w[19] = sig1(w[17], SEW) + w[12] + sig0(w[4], SEW) + w[3];
+
+    write_velem_quad(vd, SEW, w[19] @ w[18] @ w[17] @ w[16], i);
+  };
+
+  set_vstart(zeros());
+  RETIRE_SUCCESS
+}
+
+union clause ast = ZVKSHA2TYPE : (zvkfunct6, vregidx, vregidx, vregidx)
+
+mapping encdec_zvkfunct6 : zvkfunct6 <-> bits(6) = {
+  ZVK_VSHA2CH <-> 0b101110,
+  ZVK_VSHA2CL <-> 0b101111,
+}
+
+mapping clause encdec = ZVKSHA2TYPE(funct6, vs2, vs1, vd)
+  <-> encdec_zvkfunct6(funct6) @ 0b1 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  when (currentlyEnabled(Ext_Zvknha) & get_sew() == 32) | (currentlyEnabled(Ext_Zvknhb) & (get_sew() == 32 | get_sew() == 64)) & zvknhab_check_encdec(vs2, vs1, vd)
+
+mapping vsha2c_mnemonic : zvkfunct6 <-> string = {
+  ZVK_VSHA2CH <-> "vsha2ch.vv",
+  ZVK_VSHA2CL <-> "vsha2cl.vv",
+}
+
+mapping clause assembly = ZVKSHA2TYPE(funct6, vs2, vs1, vd)
+  <-> vsha2c_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ spc() ^ vreg_name(vs2) ^ spc() ^ vreg_name(vs1)
+
+function clause execute (ZVKSHA2TYPE(funct6, vs2, vs1, vd)) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  assert(SEW == 32 | SEW == 64);
+
+  let vs2_val = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vs1_val = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vd_val  = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let eg_len   = (unsigned(vl) / 4);
+  let eg_start = (unsigned(vstart) / 4);
+
+  foreach (i from eg_start to (eg_len - 1)) {
+    assert(i * 4 + 3 < num_elem);
+
+    var f = vs2_val[i*4+0];
+    var e = vs2_val[i*4+1];
+    var b = vs2_val[i*4+2];
+    var a = vs2_val[i*4+3];
+
+    var h = vd_val[i*4+0];
+    var g = vd_val[i*4+1];
+    var d = vd_val[i*4+2];
+    var c = vd_val[i*4+3];
+
+    let MessageSchedPlusC = get_velem_quad(vs1_val, i);
+
+    let w0 = if funct6 == ZVK_VSHA2CL
+             then MessageSchedPlusC[(SEW * 1) - 1 .. 0]
+             else MessageSchedPlusC[(SEW * 3) - 1 .. (SEW * 2)];
+
+    let w1 = if funct6 == ZVK_VSHA2CL
+             then MessageSchedPlusC[(SEW * 2) - 1 .. SEW]
+             else MessageSchedPlusC[(SEW * 4) - 1 .. (SEW * 3)];
+
+    var T1 = h + sum1(e, SEW) + ch(e,f,g) + w0;
+    var T2 = sum0(a, SEW) + maj(a, b, c);
+
+    h  = g;
+    g  = f;
+    f  = e;
+    e  = d + T1;
+    d  = c;
+    c  = b;
+    b  = a;
+    a  = T1 + T2;
+
+    T1 = h + sum1(e, SEW) + ch(e, f, g) + w1;
+    T2 = sum0(a, SEW) + maj(a, b, c);
+    h  = g;
+    g  = f;
+    f  = e;
+    e  = d + T1;
+    d  = c;
+    c  = b;
+    b  = a;
+    a  = T1 + T2;
+
+    write_velem_quad(vd, SEW, a @ b @ e @ f, i);
+  };
+
+  set_vstart(zeros());
+  RETIRE_SUCCESS
+}

--- a/model/riscv_insts_zvknhab.sail
+++ b/model/riscv_insts_zvknhab.sail
@@ -54,10 +54,10 @@ function clause execute (VSHA2MS_VV(vs2, vs1, vd)) = {
       15 = vs1_val[i*4+3]
     ];
 
-    w[16] = sig1(w[14], SEW) + w[9]  + sig0(w[1], SEW) + w[0];
-    w[17] = sig1(w[15], SEW) + w[10] + sig0(w[2], SEW) + w[1];
-    w[18] = sig1(w[16], SEW) + w[11] + sig0(w[3], SEW) + w[2];
-    w[19] = sig1(w[17], SEW) + w[12] + sig0(w[4], SEW) + w[3];
+    w[16] = zvk_sig1(w[14], SEW) + w[9]  + zvk_sig0(w[1], SEW) + w[0];
+    w[17] = zvk_sig1(w[15], SEW) + w[10] + zvk_sig0(w[2], SEW) + w[1];
+    w[18] = zvk_sig1(w[16], SEW) + w[11] + zvk_sig0(w[3], SEW) + w[2];
+    w[19] = zvk_sig1(w[17], SEW) + w[12] + zvk_sig0(w[4], SEW) + w[3];
 
     write_velem_quad(vd, SEW, w[19] @ w[18] @ w[17] @ w[16], i);
   };
@@ -112,18 +112,18 @@ function clause execute (ZVKSHA2TYPE(funct6, vs2, vs1, vd)) = {
     var d = vd_val[i*4+2];
     var c = vd_val[i*4+3];
 
-    let MessageSchedPlusC = get_velem_quad(vs1_val, i);
+    let message_sched_plus_c = get_velem_quad(vs1_val, i);
 
     let w0 = if funct6 == ZVK_VSHA2CL
-             then MessageSchedPlusC[(SEW * 1) - 1 .. 0]
-             else MessageSchedPlusC[(SEW * 3) - 1 .. (SEW * 2)];
+             then message_sched_plus_c[(SEW * 1) - 1 .. 0]
+             else message_sched_plus_c[(SEW * 3) - 1 .. (SEW * 2)];
 
     let w1 = if funct6 == ZVK_VSHA2CL
-             then MessageSchedPlusC[(SEW * 2) - 1 .. SEW]
-             else MessageSchedPlusC[(SEW * 4) - 1 .. (SEW * 3)];
+             then message_sched_plus_c[(SEW * 2) - 1 .. SEW]
+             else message_sched_plus_c[(SEW * 4) - 1 .. (SEW * 3)];
 
-    var T1 = h + sum1(e, SEW) + ch(e,f,g) + w0;
-    var T2 = sum0(a, SEW) + maj(a, b, c);
+    var T1 = h + zvk_sum1(e, SEW) + zvk_ch(e,f,g) + w0;
+    var T2 = zvk_sum0(a, SEW) + zvk_maj(a, b, c);
 
     h  = g;
     g  = f;
@@ -134,8 +134,8 @@ function clause execute (ZVKSHA2TYPE(funct6, vs2, vs1, vd)) = {
     b  = a;
     a  = T1 + T2;
 
-    T1 = h + sum1(e, SEW) + ch(e, f, g) + w1;
-    T2 = sum0(a, SEW) + maj(a, b, c);
+    T1 = h + zvk_sum1(e, SEW) + zvk_ch(e, f, g) + w1;
+    T2 = zvk_sum0(a, SEW) + zvk_maj(a, b, c);
     h  = g;
     g  = f;
     f  = e;

--- a/model/riscv_zvk_utils.sail
+++ b/model/riscv_zvk_utils.sail
@@ -1,0 +1,74 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+val zvk_valid_reg_overlap : (vregidx, vregidx, int) -> bool
+function zvk_valid_reg_overlap(rs, rd, emul_pow) = {
+  let reg_group_size = if emul_pow > 0 then 2 ^ emul_pow else 1;
+  let rs_int = unsigned(vregidx_bits(rs));
+  let rd_int = unsigned(vregidx_bits(rd));
+  (rs_int + reg_group_size <= rd_int) | (rd_int + reg_group_size <= rs_int)
+}
+
+function zvk_check_encdec(EGW: int, EGS: int) -> bool = (unsigned(vl) % EGS == 0) & (unsigned(vstart) % EGS == 0) & (2 ^ get_lmul_pow() * VLEN) >= EGW
+
+/*
+ * Utility functions for Zvknh[ab]
+ * ----------------------------------------------------------------------
+ */
+
+enum zvkfunct6 = {ZVK_VSHA2CH, ZVK_VSHA2CL}
+
+function zvknhab_check_encdec(vs2: vregidx, vs1: vregidx, vd: vregidx) -> bool = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  zvk_check_encdec(SEW, 4) & zvk_valid_reg_overlap(vs1, vd, LMUL_pow) & zvk_valid_reg_overlap(vs2, vd, LMUL_pow);
+}
+
+val ROTR : forall 'n 'm 'p, 'n >= 0. (bits('n), int('m), int('p)) -> bits('n)
+function ROTR (x, n, SEW) = (x >> to_bits('n, n)) | (x << (to_bits('n, SEW) - to_bits('n, n)))
+
+val SHR : forall 'n 'm, 'n >= 0. (bits('n), int('m)) -> bits('n)
+function SHR (x, n) = x >> to_bits('n, n)
+
+val sig0 : forall 'n 'm, 'n >= 0 & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
+function sig0 (x, SEW) = {
+  match SEW {
+    32 => (ROTR(x, 7, SEW) ^ ROTR(x, 18, SEW) ^ SHR(x, 3)),
+    64 => (ROTR(x, 1, SEW) ^ ROTR(x,  8, SEW) ^ SHR(x, 7)),
+  }
+}
+
+val sig1 : forall 'n 'm, 'n >= 0 & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
+function sig1 (x, SEW) = {
+  match SEW {
+    32 => (ROTR(x, 17, SEW) ^ ROTR(x, 19, SEW) ^ SHR(x, 10)),
+    64 => (ROTR(x, 19, SEW) ^ ROTR(x, 61, SEW) ^ SHR(x,  6)),
+  }
+}
+
+val sum0 : forall 'n 'm, 'n >= 0 & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
+function sum0 (x, SEW) = {
+  match SEW {
+    32 => (ROTR(x,  2, SEW) ^ ROTR(x, 13, SEW) ^ ROTR(x, 22, SEW)),
+    64 => (ROTR(x, 28, SEW) ^ ROTR(x, 34, SEW) ^ ROTR(x, 39, SEW)),
+  }
+}
+
+val sum1 : forall 'n 'm, 'n >= 0 & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
+function sum1 (x, SEW) = {
+  match SEW {
+    32 => (ROTR(x,  6, SEW) ^ ROTR(x, 11, SEW) ^ ROTR(x, 25, SEW)),
+    64 => (ROTR(x, 14, SEW) ^ ROTR(x, 18, SEW) ^ ROTR(x, 41, SEW)),
+  }
+}
+
+val ch : forall 'n, 'n >= 0. (bits('n), bits('n), bits('n)) -> bits('n)
+function ch (x, y, z) = (x & y) ^ (~(x) & z)
+
+val maj : forall 'n, 'n >= 0. (bits('n), bits('n), bits('n)) -> bits('n)
+function maj (x, y, z) = (x & y) ^ (x & z) ^ (y & z)

--- a/model/riscv_zvk_utils.sail
+++ b/model/riscv_zvk_utils.sail
@@ -29,46 +29,40 @@ function zvknhab_check_encdec(vs2: vregidx, vs1: vregidx, vd: vregidx) -> bool =
   zvk_check_encdec(SEW, 4) & zvk_valid_reg_overlap(vs1, vd, LMUL_pow) & zvk_valid_reg_overlap(vs2, vd, LMUL_pow);
 }
 
-val ROTR : forall 'n 'm 'p, 'n >= 0. (bits('n), int('m), int('p)) -> bits('n)
-function ROTR (x, n, SEW) = (x >> to_bits('n, n)) | (x << (to_bits('n, SEW) - to_bits('n, n)))
-
-val SHR : forall 'n 'm, 'n >= 0. (bits('n), int('m)) -> bits('n)
-function SHR (x, n) = x >> to_bits('n, n)
-
-val sig0 : forall 'n 'm, 'n >= 0 & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
-function sig0 (x, SEW) = {
+val zvk_sig0 : forall 'n 'm, 'n == 'm & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
+function zvk_sig0(x, SEW) = {
   match SEW {
-    32 => (ROTR(x, 7, SEW) ^ ROTR(x, 18, SEW) ^ SHR(x, 3)),
-    64 => (ROTR(x, 1, SEW) ^ ROTR(x,  8, SEW) ^ SHR(x, 7)),
+    32 => ((x >>> 7) ^ (x >>> 18) ^ (x >> to_bits('n, 3))),
+    64 => ((x >>> 1) ^ (x >>>  8) ^ (x >> to_bits('n, 7))),
   }
 }
 
-val sig1 : forall 'n 'm, 'n >= 0 & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
-function sig1 (x, SEW) = {
+val zvk_sig1 : forall 'n 'm, 'n == 'm & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
+function zvk_sig1(x, SEW) = {
   match SEW {
-    32 => (ROTR(x, 17, SEW) ^ ROTR(x, 19, SEW) ^ SHR(x, 10)),
-    64 => (ROTR(x, 19, SEW) ^ ROTR(x, 61, SEW) ^ SHR(x,  6)),
+    32 => ((x >>> 17) ^ (x >>> 19) ^ (x >> to_bits('n, 10))),
+    64 => ((x >>> 19) ^ (x >>> 61) ^ (x >> to_bits('n,  6))),
   }
 }
 
-val sum0 : forall 'n 'm, 'n >= 0 & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
-function sum0 (x, SEW) = {
+val zvk_sum0 : forall 'n 'm, 'n == 'm & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
+function zvk_sum0(x, SEW) = {
   match SEW {
-    32 => (ROTR(x,  2, SEW) ^ ROTR(x, 13, SEW) ^ ROTR(x, 22, SEW)),
-    64 => (ROTR(x, 28, SEW) ^ ROTR(x, 34, SEW) ^ ROTR(x, 39, SEW)),
+    32 => ((x >>>  2) ^ (x >>> 13) ^ (x >>> 22)),
+    64 => ((x >>> 28) ^ (x >>> 34) ^ (x >>> 39)),
   }
 }
 
-val sum1 : forall 'n 'm, 'n >= 0 & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
-function sum1 (x, SEW) = {
+val zvk_sum1 : forall 'n 'm, 'n == 'm & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
+function zvk_sum1(x, SEW) = {
   match SEW {
-    32 => (ROTR(x,  6, SEW) ^ ROTR(x, 11, SEW) ^ ROTR(x, 25, SEW)),
-    64 => (ROTR(x, 14, SEW) ^ ROTR(x, 18, SEW) ^ ROTR(x, 41, SEW)),
+    32 => ((x >>>  6) ^ (x >>> 11) ^ (x >>> 25)),
+    64 => ((x >>> 14) ^ (x >>> 18) ^ (x >>> 41)),
   }
 }
 
-val ch : forall 'n, 'n >= 0. (bits('n), bits('n), bits('n)) -> bits('n)
-function ch (x, y, z) = (x & y) ^ (~(x) & z)
+val zvk_ch : forall 'n, 'n >= 0. (bits('n), bits('n), bits('n)) -> bits('n)
+function zvk_ch(x, y, z) = (x & y) ^ (~(x) & z)
 
-val maj : forall 'n, 'n >= 0. (bits('n), bits('n), bits('n)) -> bits('n)
-function maj (x, y, z) = (x & y) ^ (x & z) ^ (y & z)
+val zvk_maj : forall 'n, 'n >= 0. (bits('n), bits('n), bits('n)) -> bits('n)
+function zvk_maj(x, y, z) = (x & y) ^ (x & z) ^ (y & z)


### PR DESCRIPTION
Add following instructions:

```
vsha2ms.vv
vsha2ch.vv
vsha2cl.vv
```

Tested with [riscv-vector-tests](https://github.com/chipsalliance/riscv-vector-tests).