### PR TITLE
Add configuration options for (almost) all supported extensions

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -38,7 +38,10 @@
         "instructions_per_tick" : 100
     },
     "extensions" : {
-        "C" : {
+        "M" : {
+            "supported" : true
+        },
+        "A" : {
             "supported" : true
         },
         "FD" : {
@@ -51,22 +54,121 @@
             "vl_use_ceil" : false
         },
         "B" : {
+            "supported" : true
+        },
+        "S" : {
+            "supported" : true
+        },
+        "U" : {
+            "supported" : true
+        },
+        "Zicbom" : {
+            "supported" : true
+        },
+        "Zicboz" : {
+            "supported" : true
+        },
+        "Zicond" : {
+            "supported" : true
+        },
+        "Zicsr" : {
+            "supported" : true
+        },
+        "Zicntr" : {
+            "supported" : true
+        },
+        "Zifencei" : {
+            "supported" : true
+        },
+        "Zihpm" : {
+            "supported" : true
+        },
+        "Zimop" : {
+            "supported" : true
+        },
+        "Zmmul" : {
             "supported" : false
         },
-        "Svinval" : {
+        "Zaamo" : {
             "supported" : false
         },
-        "Zcb" : {
+        "Zabha" : {
+            "supported" : true
+        },
+        "Zalrsc" : {
+            "supported" : false
+        },
+        "Zfa" : {
+            "supported" : true
+        },
+        "Zfh" : {
+            "supported" : true
+        },
+        "Zfhmin" : {
             "supported" : false
         },
         "Zfinx" : {
             "supported" : false
         },
-        "Zicbom" : {
+        "Zca" : {
+            "supported" : true
+        },
+        "Zcf" : {
+            "supported" : true
+        },
+        "Zcd" : {
+            "supported" : true
+        },
+        "Zcb" : {
+            "supported" : true
+        },
+        "Zcmop" : {
+            "supported" : true
+        },
+        "Zba" : {
             "supported" : false
         },
-        "Zicboz" : {
+        "Zbb" : {
             "supported" : false
+        },
+        "Zbs" : {
+            "supported" : false
+        },
+        "Zbc" : {
+            "supported" : true
+        },
+        "Zbkb" : {
+            "supported" : true
+        },
+        "Zbkc" : {
+            "supported" : true
+        },
+        "Zbkx" : {
+            "supported" : true
+        },
+        "Zknd" : {
+            "supported" : true
+        },
+        "Zkne" : {
+            "supported" : true
+        },
+        "Zknh" : {
+            "supported" : true
+        },
+        "Zkr" : {
+            "supported" : true
+        },
+        "Zksed" : {
+            "supported" : true
+        },
+        "Zksh" : {
+            "supported" : true
+        },
+        "Zhinx" : {
+            "supported" : false
+        },
+        "Zvbb" : {
+            "supported" : true
         },
         "Zvkb" : {
             "supported" : false
@@ -74,8 +176,17 @@
         "Zvbc" : {
             "supported" : true
         },
+        "Sscofpmf" : {
+            "supported" : true
+        },
+        "Smcntrpmf" : {
+            "supported" : true
+        },
         "Sstc" : {
-            "supported" : false
+            "supported" : true
+        },
+        "Svinval" : {
+            "supported" : true
         }
     }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -71,9 +71,6 @@
         "Zicond" : {
             "supported" : true
         },
-        "Zicsr" : {
-            "supported" : true
-        },
         "Zicntr" : {
             "supported" : true
         },

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -113,7 +113,7 @@ enum clause extension = Ext_Zcd
 function clause hartSupports(Ext_Zcd) = config extensions.Zcd.supported
 // Code Size Reduction: compressed single precision floating point loads and stores
 enum clause extension = Ext_Zcf
-function clause hartSupports(Ext_Zcf) = config extensions.Zcf.supported
+function clause hartSupports(Ext_Zcf) = config extensions.Zcf.supported : bool & (xlen == 32)
 // Compressed May-Be-Operations
 enum clause extension = Ext_Zcmop
 function clause hartSupports(Ext_Zcmop) = config extensions.Zcmop.supported
@@ -123,7 +123,7 @@ function clause hartSupports(Ext_Zcmop) = config extensions.Zcmop.supported
 //   - Zcf is supported if F is supported (on rv32)
 //   - Zcd is supported if D is supported
 enum clause extension = Ext_C
-function clause hartSupports(Ext_C) = hartSupports(Ext_Zca) & (hartSupports(Ext_Zcf) | ~(hartSupports(Ext_F)) | xlen != 32) & (hartSupports(Ext_Zcd) | ~(hartSupports(Ext_D)))
+function clause hartSupports(Ext_C) = hartSupports(Ext_Zca) & (hartSupports(Ext_Zcf) | not(hartSupports(Ext_F)) | xlen != 32) & (hartSupports(Ext_Zcd) | not(hartSupports(Ext_D)))
 
 // Bit Manipulation: Address generation
 enum clause extension = Ext_Zba

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -26,15 +26,16 @@ scattered function currentlyEnabled
 
 // Integer Multiplication and Division; not Machine!
 enum clause extension = Ext_M
+function clause hartSupports(Ext_M) = config extensions.M.supported
+// Atomic Instructions
+enum clause extension = Ext_A
+function clause hartSupports(Ext_A) = config extensions.A.supported
 // Single-Precision Floating-Point
 enum clause extension = Ext_F
 function clause hartSupports(Ext_F) = config extensions.FD.supported
 // Double-Precision Floating-Point
 enum clause extension = Ext_D
 function clause hartSupports(Ext_D) = config extensions.FD.supported // TODO: Separate F and D supported flags
-// Compressed Instructions
-enum clause extension = Ext_C
-function clause hartSupports(Ext_C) = config extensions.C.supported
 // Bit Manipulation
 enum clause extension = Ext_B
 function clause hartSupports(Ext_B) = config extensions.B.supported
@@ -43,8 +44,10 @@ enum clause extension = Ext_V
 function clause hartSupports(Ext_V) = config extensions.V.supported
 // Supervisor
 enum clause extension = Ext_S
+function clause hartSupports(Ext_S) = config extensions.S.supported
 // User
 enum clause extension = Ext_U
+function clause hartSupports(Ext_U) = config extensions.U.supported
 
 // Cache-Block Management Instructions
 enum clause extension = Ext_Zicbom
@@ -54,83 +57,122 @@ enum clause extension = Ext_Zicboz
 function clause hartSupports(Ext_Zicboz) = config extensions.Zicboz.supported
 // Base Counters and Timers
 enum clause extension = Ext_Zicntr
+function clause hartSupports(Ext_Zicntr) = config extensions.Zicntr.supported
 // Integer Conditional Operations
 enum clause extension = Ext_Zicond
+function clause hartSupports(Ext_Zicond) = config extensions.Zicond.supported
 // Instruction-Fetch Fence
 enum clause extension = Ext_Zifencei
+function clause hartSupports(Ext_Zifencei) = config extensions.Zifencei.supported
 // Hardware Performance Counters
 enum clause extension = Ext_Zihpm
+function clause hartSupports(Ext_Zihpm) = config extensions.Zihpm.supported
 // May-Be-Operations
 enum clause extension = Ext_Zimop
+function clause hartSupports(Ext_Zimop) = config extensions.Zimop.supported
 
 // Multiplication and Division: Multiplication only
 enum clause extension = Ext_Zmmul
+function clause hartSupports(Ext_Zmmul) = config extensions.Zmmul.supported
 
 // Atomic Memory Operations
 enum clause extension = Ext_Zaamo
+function clause hartSupports(Ext_Zaamo) = config extensions.Zaamo.supported
 // Byte and Halfword Atomic Memory Operations
 enum clause extension = Ext_Zabha
+function clause hartSupports(Ext_Zabha) = config extensions.Zabha.supported
 // Load-Reserved/Store-Conditional Instructions
 enum clause extension = Ext_Zalrsc
+function clause hartSupports(Ext_Zalrsc) = config extensions.Zalrsc.supported
 
 // Additional Floating-Point Instructions
 enum clause extension = Ext_Zfa
+function clause hartSupports(Ext_Zfa) = config extensions.Zfa.supported
 // Half-Precision Floating-Point
 enum clause extension = Ext_Zfh
+function clause hartSupports(Ext_Zfh) = config extensions.Zfh.supported
 // Minimal Half-Precision Floating-Point
 enum clause extension = Ext_Zfhmin
+function clause hartSupports(Ext_Zfhmin) = config extensions.Zfhmin.supported
 // Floating-Point in Integer Registers (single precision)
 enum clause extension = Ext_Zfinx
 function clause hartSupports(Ext_Zfinx) = config extensions.Zfinx.supported
 
 // Floating-Point in Integer Registers (double precision)
 enum clause extension = Ext_Zdinx
+function clause hartSupports(Ext_Zdinx) = config extensions.Zfinx.supported // TODO: Separate Zfinx and Zdinx supported flags
 
 // Code Size Reduction: compressed instructions excluding floating point loads and stores
 enum clause extension = Ext_Zca
+function clause hartSupports(Ext_Zca) = config extensions.Zca.supported
 // Code Size Reduction: additional 16-bit aliases
 enum clause extension = Ext_Zcb
 function clause hartSupports(Ext_Zcb) = config extensions.Zcb.supported
 // Code Size Reduction: compressed double precision floating point loads and stores
 enum clause extension = Ext_Zcd
+function clause hartSupports(Ext_Zcd) = config extensions.Zcd.supported
 // Code Size Reduction: compressed single precision floating point loads and stores
 enum clause extension = Ext_Zcf
+function clause hartSupports(Ext_Zcf) = config extensions.Zcf.supported
 // Compressed May-Be-Operations
 enum clause extension = Ext_Zcmop
+function clause hartSupports(Ext_Zcmop) = config extensions.Zcmop.supported
+// Compressed Instructions
+// C is supported if all of the following are true:
+//   - Zca is supported
+//   - Zcf is supported if F is supported (on rv32)
+//   - Zcd is supported if D is supported
+enum clause extension = Ext_C
+function clause hartSupports(Ext_C) = hartSupports(Ext_Zca) & (hartSupports(Ext_Zcf) | ~(hartSupports(Ext_F)) | xlen != 32) & (hartSupports(Ext_Zcd) | ~(hartSupports(Ext_D)))
 
 // Bit Manipulation: Address generation
 enum clause extension = Ext_Zba
+function clause hartSupports(Ext_Zba) = config extensions.Zba.supported
 // Bit Manipulation: Basic bit-manipulation
 enum clause extension = Ext_Zbb
+function clause hartSupports(Ext_Zbb) = config extensions.Zbb.supported
 // Bit Manipulation: Carry-less multiplication
 enum clause extension = Ext_Zbc
+function clause hartSupports(Ext_Zbc) = config extensions.Zbc.supported
 // Bit Manipulation: Bit-manipulation for Cryptography
 enum clause extension = Ext_Zbkb
+function clause hartSupports(Ext_Zbkb) = config extensions.Zbkb.supported
 // Bit Manipulation: Carry-less multiplication for Cryptography
 enum clause extension = Ext_Zbkc
+function clause hartSupports(Ext_Zbkc) = config extensions.Zbkc.supported
 // Bit Manipulation: Crossbar permutations
 enum clause extension = Ext_Zbkx
+function clause hartSupports(Ext_Zbkx) = config extensions.Zbkx.supported
 // Bit Manipulation: Single-bit instructions
 enum clause extension = Ext_Zbs
+function clause hartSupports(Ext_Zbs) = config extensions.Zbs.supported
 
 // Scalar & Entropy Source Instructions: NIST Suite: AES Decryption
 enum clause extension = Ext_Zknd
+function clause hartSupports(Ext_Zknd) = config extensions.Zknd.supported
 // Scalar & Entropy Source Instructions: NIST Suite: AES Encryption
 enum clause extension = Ext_Zkne
+function clause hartSupports(Ext_Zkne) = config extensions.Zkne.supported
 // Scalar & Entropy Source Instructions: NIST Suite: Hash Function Instructions
 enum clause extension = Ext_Zknh
+function clause hartSupports(Ext_Zknh) = config extensions.Zknh.supported
 // Scalar & Entropy Source Instructions: Entropy Source Extension
 enum clause extension = Ext_Zkr
+function clause hartSupports(Ext_Zkr) = config extensions.Zkr.supported
 // Scalar & Entropy Source Instructions: ShangMi Suite: SM4 Block Cipher Instructions
 enum clause extension = Ext_Zksed
+function clause hartSupports(Ext_Zksed) = config extensions.Zksed.supported
 // Scalar & Entropy Source Instructions: ShangMi Suite: SM3 Hash Cipher Instructions
 enum clause extension = Ext_Zksh
+function clause hartSupports(Ext_Zksh) = config extensions.Zksh.supported
 
 // Floating-Point in Integer Registers (half precision)
 enum clause extension = Ext_Zhinx
+function clause hartSupports(Ext_Zhinx) = config extensions.Zhinx.supported
 
 // Vector Basic Bit-manipulation
 enum clause extension = Ext_Zvbb
+function clause hartSupports(Ext_Zvbb) = config extensions.Zvbb.supported
 // Vector Cryptography Bit-manipulation
 enum clause extension = Ext_Zvkb
 function clause hartSupports(Ext_Zvkb) = config extensions.Zvkb.supported
@@ -140,6 +182,7 @@ function clause hartSupports(Ext_Zvbc) = config extensions.Zvbc.supported
 
 // Count Overflow and Mode-Based Filtering
 enum clause extension = Ext_Sscofpmf
+function clause hartSupports(Ext_Sscofpmf) = config extensions.Sscofpmf.supported
 // Supervisor-mode Timer Interrupts
 enum clause extension = Ext_Sstc
 function clause hartSupports(Ext_Sstc) = config extensions.Sstc.supported
@@ -148,8 +191,11 @@ enum clause extension = Ext_Svinval
 function clause hartSupports(Ext_Svinval) = config extensions.Svinval.supported
 // NAPOT Translation Contiguity
 enum clause extension = Ext_Svnapot
+function clause hartSupports(Ext_Svnapot) = false // Not supported yet
 // Page-Based Memory Types
 enum clause extension = Ext_Svpbmt
+function clause hartSupports(Ext_Svpbmt) = false // Not supported yet
 
 // Cycle and Instret Privilege Mode Filtering
 enum clause extension = Ext_Smcntrpmf
+function clause hartSupports(Ext_Smcntrpmf) = config extensions.Smcntrpmf.supported

--- a/model/riscv_fdext_control.sail
+++ b/model/riscv_fdext_control.sail
@@ -15,8 +15,8 @@
 
 /* **************************************************************** */
 
-function clause currentlyEnabled(Ext_F) = (misa[F] == 0b1) & (mstatus[FS] != 0b00) & hartSupports(Ext_F)
-function clause currentlyEnabled(Ext_D) = (misa[D] == 0b1) & (mstatus[FS] != 0b00) & hartSupports(Ext_D) & flen >= 64
+function clause currentlyEnabled(Ext_F) = hartSupports(Ext_F) & (misa[F] == 0b1) & (mstatus[FS] != 0b00)
+function clause currentlyEnabled(Ext_D) = hartSupports(Ext_D) & (misa[D] == 0b1) & (mstatus[FS] != 0b00) & flen >= 64
 function clause currentlyEnabled(Ext_Zfinx) = hartSupports(Ext_Zfinx)
 
 /* Floating Point CSRs */

--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -11,7 +11,8 @@
 
 /* ****************************************************************** */
 
-function clause currentlyEnabled(Ext_Zabha) = true
+function clause currentlyEnabled(Ext_A) = hartSupports(Ext_A) & misa[A] == 0b1
+function clause currentlyEnabled(Ext_Zabha) = hartSupports(Ext_Zabha) & currentlyEnabled(Ext_Zaamo)
 
 // Some print utils for lr/sc.
 
@@ -53,7 +54,7 @@ function amo_width_valid(size : word_width) -> bool = {
 }
 
 /* ****************************************************************** */
-function clause currentlyEnabled(Ext_Zalrsc) = misa[A] == 0b1
+function clause currentlyEnabled(Ext_Zalrsc) = hartSupports(Ext_Zalrsc) | currentlyEnabled(Ext_A)
 
 union clause ast = LOADRES : (bool, bool, regidx, word_width, regidx)
 
@@ -168,7 +169,7 @@ mapping clause assembly = STORECON(aq, rl, rs2, rs1, size, rd)
   <-> "sc." ^ size_mnemonic(size) ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs2) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
 
 /* ****************************************************************** */
-function clause currentlyEnabled(Ext_Zaamo) = misa[A] == 0b1
+function clause currentlyEnabled(Ext_Zaamo) = hartSupports(Ext_Zaamo) | currentlyEnabled(Ext_A)
 
 union clause ast = AMO : (amoop, bool, bool, regidx, regidx, word_width, regidx)
 

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -9,8 +9,8 @@
 /* ****************************************************************** */
 /* This file specifies the instructions in the base integer set.      */
 
-function clause currentlyEnabled(Ext_C) = misa[C] == 0b1 & hartSupports(Ext_C)
-function clause currentlyEnabled(Ext_Zca) = currentlyEnabled(Ext_C)
+function clause currentlyEnabled(Ext_C) = hartSupports(Ext_C) & misa[C] == 0b1
+function clause currentlyEnabled(Ext_Zca) = hartSupports(Ext_Zca) & (currentlyEnabled(Ext_C) | not(hartSupports(Ext_C)))
 
 /* ****************************************************************** */
 union clause ast = UTYPE : (bits(20), regidx, uop)

--- a/model/riscv_insts_dext.sail
+++ b/model/riscv_insts_dext.sail
@@ -224,7 +224,7 @@ function fle_D   (v1,       v2,        is_quiet) = {
 /* **************************************************************** */
 /* Helper functions for 'encdec()'                                  */
 
-function clause currentlyEnabled(Ext_Zdinx) = hartSupports(Ext_Zfinx) & flen >= 64
+function clause currentlyEnabled(Ext_Zdinx) = hartSupports(Ext_Zdinx) & flen >= 64 // TODO: Separate Zfinx and Zdinx
 
 function haveDoubleFPU() -> bool = currentlyEnabled(Ext_D) | currentlyEnabled(Ext_Zdinx)
 

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -25,11 +25,8 @@
 
 /* **************************************************************** */
 
-// TODO: Add config flags to control Zfh and Zfhmin
-function clause currentlyEnabled(Ext_Zfh) = (misa[F] == 0b1) & (mstatus[FS] != 0b00)
-
-// Zfhmin is a subset of Zfh. This can be changed to currentlyEnabled(Ext_Zfh) | sys_enable_zfhmin() when more configuration is implemented.
-function clause currentlyEnabled(Ext_Zfhmin) = currentlyEnabled(Ext_Zfh)
+function clause currentlyEnabled(Ext_Zfh) =  hartSupports(Ext_Zfh) & currentlyEnabled(Ext_F)
+function clause currentlyEnabled(Ext_Zfhmin) =  (hartSupports(Ext_Zfhmin) & currentlyEnabled(Ext_F)) | currentlyEnabled(Ext_Zfh)
 
 mapping encdec_rounding_mode : rounding_mode <-> bits(3) = {
   RM_RNE <-> 0b000,

--- a/model/riscv_insts_mext.sail
+++ b/model/riscv_insts_mext.sail
@@ -11,8 +11,8 @@
 
 /* ****************************************************************** */
 
-function clause currentlyEnabled(Ext_M) = misa[M] == 0b1
-function clause currentlyEnabled(Ext_Zmmul) = true
+function clause currentlyEnabled(Ext_M) = hartSupports(Ext_M) & misa[M] == 0b1
+function clause currentlyEnabled(Ext_Zmmul) = hartSupports(Ext_Zmmul) | currentlyEnabled(Ext_M)
 
 
 union clause ast = MUL : (regidx, regidx, regidx, mul_op)

--- a/model/riscv_insts_zba.sail
+++ b/model/riscv_insts_zba.sail
@@ -6,8 +6,8 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_B) = misa[B] == 0b1 & hartSupports(Ext_B)
-function clause currentlyEnabled(Ext_Zba) = true | currentlyEnabled(Ext_B)
+function clause currentlyEnabled(Ext_B) = hartSupports(Ext_B) & misa[B] == 0b1
+function clause currentlyEnabled(Ext_Zba) = hartSupports(Ext_Zba) | currentlyEnabled(Ext_B)
 
 /* ****************************************************************** */
 union clause ast = RISCV_SLLIUW : (bits(6), regidx, regidx)

--- a/model/riscv_insts_zbb.sail
+++ b/model/riscv_insts_zbb.sail
@@ -6,8 +6,8 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_Zbb) = true | currentlyEnabled(Ext_B)
-function clause currentlyEnabled(Ext_Zbkb) = true
+function clause currentlyEnabled(Ext_Zbb) = hartSupports(Ext_Zbb) | currentlyEnabled(Ext_B)
+function clause currentlyEnabled(Ext_Zbkb) = hartSupports(Ext_Zbkb)
 
 /* ****************************************************************** */
 union clause ast = RISCV_RORIW : (bits(5), regidx, regidx)

--- a/model/riscv_insts_zbc.sail
+++ b/model/riscv_insts_zbc.sail
@@ -6,8 +6,8 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_Zbc) = true
-function clause currentlyEnabled(Ext_Zbkc) = true
+function clause currentlyEnabled(Ext_Zbc) = hartSupports(Ext_Zbc)
+function clause currentlyEnabled(Ext_Zbkc) = hartSupports(Ext_Zbkc)
 
 /* ****************************************************************** */
 union clause ast = RISCV_CLMUL : (regidx, regidx, regidx)

--- a/model/riscv_insts_zbkx.sail
+++ b/model/riscv_insts_zbkx.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_Zbkx) = true
+function clause currentlyEnabled(Ext_Zbkx) = hartSupports(Ext_Zbkx)
 
 /* ****************************************************************** */
 union clause ast = RISCV_XPERM8 : (regidx, regidx, regidx)

--- a/model/riscv_insts_zbs.sail
+++ b/model/riscv_insts_zbs.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_Zbs) = true | currentlyEnabled(Ext_B)
+function clause currentlyEnabled(Ext_Zbs) = hartSupports(Ext_Zbs) | currentlyEnabled(Ext_B)
 
 /* ****************************************************************** */
 union clause ast = ZBS_IOP : (bits(6), regidx, regidx, biop_zbs)

--- a/model/riscv_insts_zcd.sail
+++ b/model/riscv_insts_zcd.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_Zcd) = currentlyEnabled(Ext_Zca) & currentlyEnabled(Ext_D) & (xlen == 32 | xlen == 64)
+function clause currentlyEnabled(Ext_Zcd) = hartSupports(Ext_Zcd) & currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zca) & (currentlyEnabled(Ext_C) | not(hartSupports(Ext_C)))
 
 union clause ast = C_FLDSP : (bits(6), fregidx)
 

--- a/model/riscv_insts_zcf.sail
+++ b/model/riscv_insts_zcf.sail
@@ -15,7 +15,7 @@
 
 /* ****************************************************************** */
 
-function clause currentlyEnabled(Ext_Zcf) = currentlyEnabled(Ext_Zca) & currentlyEnabled(Ext_F) & xlen == 32
+function clause currentlyEnabled(Ext_Zcf) = hartSupports(Ext_Zcf) & currentlyEnabled(Ext_F) & currentlyEnabled(Ext_Zca) & (currentlyEnabled(Ext_C) | not(hartSupports(Ext_C)))
 
 union clause ast = C_FLWSP : (bits(6), fregidx)
 

--- a/model/riscv_insts_zcmop.sail
+++ b/model/riscv_insts_zcmop.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_Zcmop) = true & currentlyEnabled(Ext_Zca) // TODO: add configuration
+function clause currentlyEnabled(Ext_Zcmop) = hartSupports(Ext_Zcmop) & currentlyEnabled(Ext_Zca)
 
 union clause ast = ZCMOP : (bits(3))
 

--- a/model/riscv_insts_zfa.sail
+++ b/model/riscv_insts_zfa.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_Zfa) = true
+function clause currentlyEnabled(Ext_Zfa) = hartSupports(Ext_Zfa) & currentlyEnabled(Ext_F)
 
 /* FLI.H */
 

--- a/model/riscv_insts_zfh.sail
+++ b/model/riscv_insts_zfh.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_Zhinx) = hartSupports(Ext_Zfinx)
+function clause currentlyEnabled(Ext_Zhinx) = hartSupports(Ext_Zhinx) & currentlyEnabled(Ext_Zfinx)
 
 /* **************************************************************** */
 /* This file specifies the instructions in the Zfh extension        */

--- a/model/riscv_insts_zicond.sail
+++ b/model/riscv_insts_zicond.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_Zicond) = true
+function clause currentlyEnabled(Ext_Zicond) = hartSupports(Ext_Zicond)
 
 union clause ast = ZICOND_RTYPE : (regidx, regidx, regidx, zicondop)
 

--- a/model/riscv_insts_zifencei.sail
+++ b/model/riscv_insts_zifencei.sail
@@ -11,7 +11,7 @@
 
 /* ****************************************************************** */
 
-function clause currentlyEnabled(Ext_Zifencei) = true
+function clause currentlyEnabled(Ext_Zifencei) = hartSupports(Ext_Zifencei)
 
 union clause ast = FENCEI : unit
 

--- a/model/riscv_insts_zimop.sail
+++ b/model/riscv_insts_zimop.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_Zimop) = true // TODO: add configuration
+function clause currentlyEnabled(Ext_Zimop) = hartSupports(Ext_Zimop)
 
 union clause ast = ZIMOP_MOP_R : (bits(5), regidx, regidx)
 union clause ast = ZIMOP_MOP_RR : (bits(3), regidx, regidx, regidx)

--- a/model/riscv_insts_zkn.sail
+++ b/model/riscv_insts_zkn.sail
@@ -11,7 +11,7 @@
  * ----------------------------------------------------------------------
  */
 
-function clause currentlyEnabled(Ext_Zknh) = true
+function clause currentlyEnabled(Ext_Zknh) = hartSupports(Ext_Zknh)
 
 union clause ast = SHA256SIG0 : (regidx, regidx)
 union clause ast = SHA256SIG1 : (regidx, regidx)
@@ -79,7 +79,7 @@ function clause execute (SHA256SUM1(rs1, rd)) = {
  * ----------------------------------------------------------------------
  */
 
-function clause currentlyEnabled(Ext_Zkne) = true
+function clause currentlyEnabled(Ext_Zkne) = hartSupports(Ext_Zkne)
 
 union clause ast = AES32ESMI : (bits(2), regidx, regidx, regidx)
 
@@ -123,7 +123,7 @@ function clause execute (AES32ESI (bs, rs2, rs1, rd)) = {
  * ----------------------------------------------------------------------
  */
 
-function clause currentlyEnabled(Ext_Zknd) = true
+function clause currentlyEnabled(Ext_Zknd) = hartSupports(Ext_Zknd)
 
 union clause ast = AES32DSMI : (bits(2), regidx, regidx, regidx)
 

--- a/model/riscv_insts_zks.sail
+++ b/model/riscv_insts_zks.sail
@@ -11,7 +11,7 @@
  * ----------------------------------------------------------------------
  */
 
-function clause currentlyEnabled(Ext_Zksh) = true
+function clause currentlyEnabled(Ext_Zksh) = hartSupports(Ext_Zksh)
 
 union clause ast = SM3P0 : (regidx, regidx)
 union clause ast = SM3P1 : (regidx, regidx)
@@ -49,7 +49,7 @@ function clause execute (SM3P1(rs1, rd)) = {
  * ----------------------------------------------------------------------
  */
 
-function clause currentlyEnabled(Ext_Zksed) = true
+function clause currentlyEnabled(Ext_Zksed) = hartSupports(Ext_Zksed)
 
 union clause ast = SM4ED : (bits(2), regidx, regidx, regidx)
 union clause ast = SM4KS : (bits(2), regidx, regidx, regidx)

--- a/model/riscv_insts_zvbb.sail
+++ b/model/riscv_insts_zvbb.sail
@@ -6,9 +6,8 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_Zvbb) = true
-
-function clause currentlyEnabled(Ext_Zvkb) = hartSupports(Ext_Zvkb) | currentlyEnabled(Ext_Zvbb)
+function clause currentlyEnabled(Ext_Zvbb) = hartSupports(Ext_Zvbb) & currentlyEnabled(Ext_V)
+function clause currentlyEnabled(Ext_Zvkb) = (hartSupports(Ext_Zvkb) | currentlyEnabled(Ext_Zvbb)) & currentlyEnabled(Ext_V)
 
 union clause ast = VANDN_VV : (bits(1), vregidx, vregidx, vregidx)
 

--- a/model/riscv_smcntrpmf.sail
+++ b/model/riscv_smcntrpmf.sail
@@ -1,4 +1,4 @@
-function clause currentlyEnabled(Ext_Smcntrpmf) = true
+function clause currentlyEnabled(Ext_Smcntrpmf) = hartSupports(Ext_Smcntrpmf) & currentlyEnabled(Ext_Zicntr)
 
 bitfield CountSmcntrpmf : bits(64) = {
   MINH  : 62,

--- a/model/riscv_sscofpmf.sail
+++ b/model/riscv_sscofpmf.sail
@@ -6,11 +6,8 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-// TODO: Make configurable.
-function sys_enable_sscofpmf() -> bool = true
-
 /* Counter OverFlow and Privilege Mode Filtering */
-function clause currentlyEnabled(Ext_Sscofpmf) = sys_enable_sscofpmf() & currentlyEnabled(Ext_Zihpm)
+function clause currentlyEnabled(Ext_Sscofpmf) = hartSupports(Ext_Sscofpmf) & currentlyEnabled(Ext_Zihpm)
 
 mapping clause csr_name_map = 0xB83  <-> "mhpmcounter3h"
 mapping clause csr_name_map = 0xB84  <-> "mhpmcounter4h"

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -309,14 +309,14 @@ function handle_interrupt(i : InterruptType, del_priv : Privilege) -> unit =
 
 // Reset misa to enable the maximal set of supported extensions.
 function reset_misa() -> unit = {
-  misa[A]   = 0b1;                                     /* atomics */
-  misa[C]   = bool_to_bits(hartSupports(Ext_C));       /* RVC */
-  misa[B]   = bool_to_bits(hartSupports(Ext_B));       /* Bit-manipulation */
-  misa[I]   = 0b1;                                     /* base integer ISA */
-  misa[M]   = 0b1;                                     /* integer multiply/divide */
-  misa[U]   = bool_to_bits(sys_enable_user());         /* user-mode */
-  misa[S]   = bool_to_bits(sys_enable_supervisor());   /* supervisor-mode */
-  misa[V]   = bool_to_bits(hartSupports(Ext_V));       /* vector extension */
+  misa[A]   = bool_to_bits(hartSupports(Ext_A));   /* atomics */
+  misa[C]   = bool_to_bits(hartSupports(Ext_C));   /* RVC */
+  misa[B]   = bool_to_bits(hartSupports(Ext_B));   /* Bit-manipulation */
+  misa[I]   = 0b1;                                 /* base integer ISA */
+  misa[M]   = bool_to_bits(hartSupports(Ext_M));   /* integer multiply/divide */
+  misa[U]   = bool_to_bits(hartSupports(Ext_U));   /* user-mode */
+  misa[S]   = bool_to_bits(hartSupports(Ext_S));   /* supervisor-mode */
+  misa[V]   = bool_to_bits(hartSupports(Ext_V));   /* vector extension */
 
   if   hartSupports(Ext_F) & hartSupports(Ext_Zfinx)
   then internal_error(__FILE__, __LINE__, "F and Zfinx cannot both be enabled!");

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -127,16 +127,11 @@ function clause is_CSR_defined(0x301) = true // misa
 function clause read_CSR(0x301) = misa.bits
 function clause write_CSR(0x301, value) = { misa = legalize_misa(misa, value); misa.bits }
 
-// Are user and supervisor mode supported by the hardware?
-// TODO: Don't hard-code these.
-function sys_enable_user() -> bool = true
-function sys_enable_supervisor() -> bool = true
-
 // Are supervisor/user mode currently enabled? Although
 // unlikely and not currently supported by the model,
 // you are technically allowed to have writable misa[U/S].
-function clause currentlyEnabled(Ext_U) = misa[U] == 0b1
-function clause currentlyEnabled(Ext_S) = misa[S] == 0b1
+function clause currentlyEnabled(Ext_U) = hartSupports(Ext_U) & misa[U] == 0b1
+function clause currentlyEnabled(Ext_S) = hartSupports(Ext_S) & misa[S] == 0b1
 
 /*
  * Illegal values legalized to least privileged mode supported.
@@ -266,8 +261,8 @@ register mstatus : Mstatus = {
   [ Mk_Mstatus(zeros()) with
     // These fields do not exist on RV32 and are read-only zero
     // if the corresponding mode is not supported.
-    SXL = if xlen != 32 & sys_enable_supervisor() then mxl else zeros(),
-    UXL = if xlen != 32 & sys_enable_user() then mxl else zeros(),
+    SXL = if xlen != 32 & hartSupports(Ext_S) then mxl else zeros(),
+    UXL = if xlen != 32 & hartSupports(Ext_U) then mxl else zeros(),
   ]
 }
 

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -108,18 +108,25 @@ function clause currentlyEnabled(Ext_Sstc) = hartSupports(Ext_Sstc)
 val ext_veto_disable_C : unit -> bool
 
 function legalize_misa(m : Misa, v : xlenbits) -> Misa = {
-  let  v = Mk_Misa(v);
+  let v = Mk_Misa(v);
   /* Suppress updates to MISA if MISA is not writable or if by disabling C next PC would become misaligned or an extension vetoes */
   if   not(sys_enable_writable_misa()) | (v[C] == 0b0 & (nextPC[1] == bitone | ext_veto_disable_C()))
   then m
-  else {
-    /* Suppress enabling C if C was disabled at boot (i.e. not supported) */
-    let m = if not(hartSupports(Ext_C)) then m else [m with C = v[C]];
-    /* Suppress updates to misa.{f,d} if disabled at boot */
-    if   not(hartSupports(Ext_F))
-    then m
-    else [m with F = v[F], D = v[D] & v[F]]
-  }
+  else [m with
+    A = if hartSupports(Ext_A) then v[A] else 0b0,
+    B = if hartSupports(Ext_B) then v[B] else 0b0,
+    C = if hartSupports(Ext_C) then v[C] else 0b0,
+    D = if hartSupports(Ext_D) & v[F] == 0b1 then v[D] else 0b0,
+    F = if hartSupports(Ext_F) then v[F] else 0b0,
+    // H = if hartSupports(Ext_H) then v[H] else 0b0, TODO: Not supported yet
+    I = 0b1, // I is currently always supported
+    M = if hartSupports(Ext_M) then v[M] else 0b0,
+    // Q = if hartSupports(Ext_Q) then v[Q] else 0b0, TODO: Not supported yet
+    S = if hartSupports(Ext_S) & v[U] == 0b1 then v[S] else 0b0,
+    U = if hartSupports(Ext_U) then v[U] else 0b0,
+    V = if hartSupports(Ext_V) & v[F] == 0b1 & v[D] == 0b1 then v[V] else 0b0,
+    // X = ... TODO: If custom extensions are present this should be 1
+  ]
 }
 
 mapping clause csr_name_map = 0x301  <-> "misa"

--- a/model/riscv_vext_control.sail
+++ b/model/riscv_vext_control.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_V) = (misa[V] == 0b1) & (mstatus[VS] != 0b00) & hartSupports(Ext_V)
+function clause currentlyEnabled(Ext_V) = hartSupports(Ext_V) & (misa[V] == 0b1) & (mstatus[VS] != 0b00)
 
 // Note: The spec recommends trapping if vstart is out of bounds but the
 // current implementation does not do that because write_CSR() doesn't

--- a/model/riscv_zicntr_control.sail
+++ b/model/riscv_zicntr_control.sail
@@ -5,7 +5,7 @@
 /*                                                                                       */
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
-function clause currentlyEnabled(Ext_Zicntr) = true
+function clause currentlyEnabled(Ext_Zicntr) = hartSupports(Ext_Zicntr)
 
 /* unprivileged counters/timers */
 mapping clause csr_name_map = 0xC00  <-> "cycle"

--- a/model/riscv_zihpm.sail
+++ b/model/riscv_zihpm.sail
@@ -7,7 +7,7 @@
 /*=======================================================================================*/
 
 /* Hardware Performance Monitoring counters */
-function clause currentlyEnabled(Ext_Zihpm) = true
+function clause currentlyEnabled(Ext_Zihpm) = hartSupports(Ext_Zihpm) & currentlyEnabled(Ext_Zicntr)
 
 /* Hardware performance monitoring counters */
 mapping clause csr_name_map = 0xC03  <-> "hpmcounter3"

--- a/model/riscv_zkr_control.sail
+++ b/model/riscv_zkr_control.sail
@@ -7,7 +7,7 @@
 /*=======================================================================================*/
 
 /* Zkr entropy seed source */
-function clause currentlyEnabled(Ext_Zkr) = true
+function clause currentlyEnabled(Ext_Zkr) = hartSupports(Ext_Zkr)
 
 /* Valid return states for reading the seed CSR. */
 enum seed_opst = {


### PR DESCRIPTION
This adds `hartSupports` clauses for all of the remaining extensions and connects them to corresponding `supported` keys in the configuration json. All extensions that were hardcoded to true have been updated to use the new configuration system. 

This also enables all of the (non-conflicting) extensions that were previously disabled (as discussed in #841).

There are a handful of strange cases that will require some discussion and might need to be cleaned up in a future PR:
- The interaction between F/D (and Zfinx/Zdinx) and `FLEN`. This probably can't be properly sorted out until `FLEN` becomes an abstract type that can be set at runtime.
- C/Zca/Zcf/Zcd, A/Zaamo/Zalrsc, and B/Zba/Zbb/Zbs: these all have interesting dependencies between the single letter extension and the smaller sub-extensions.
  - C is the most well defined and there is a clear mapping between it and the sub-extensions. We just need to decide if we want to have configuration keys for just C, just the sub-extensions, or both (which would just result in a bunch of ors).
  - The B `misa` bit means that Zba, Zbb, and Zbs are supported, but the lack of it doesn't mean anything since it was defined after the sub-extensions. My vote for this one would be to have a options for each of the sub-extensions and an additional configuration key for the `misa.B` bit itself.
  - Atomics seem to be the least documented case. I couldn't find anything about the relationship between the `misa.A` bit and the Zaamo/Zalrsc extensions. The A extension is made up of those two sub-extensions, but does that mean turning off the A bit should disable them? How does that work if you only implement one of the two (in which case the A bit cannot be set)? We made need to open an issue against the manual to clarify this one.