### PR TITLE
Revert "Fix minstreth behaviour"

### DIFF
--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -16,13 +16,12 @@ function step(step_no : int) -> bool = {
   /*
    * This records whether or not minstret should be incremented when
    * the instruction is retired. Since retirement occurs before CSR
-   * writes we initialise it based on mcountinhibit here, before
-   * mcountinhibit is potentially changed. We also mark minstret(h) as not
-   * having been explicitly written yet.
+   * writes we initialise it based on mcountinhibit here, before it is
+   * potentially changed. This is also set to false if minstret is
+   * written.  See the note near the minstret declaration for more
+   * information.
    */
   minstret_increment = should_inc_minstret(cur_privilege);
-  minstret_write = None();
-  minstreth_write = None();
 
   let (retired, stepped) : (Retired, bool) =
     match dispatchInterrupt(cur_privilege) {

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -622,45 +622,22 @@ register mtime : bits(64)
 
 /* minstret
  *
- * This model-internal register is the full 64 bit minstret counter,
- * regardless of xlen. For xlen=32, this will be split across minstret
- * and minstreth CSRs.
- * The spec says that minstret increments on instruction retires need to
+ * minstret is an architectural register, and can be written to.  The
+ * spec says that minstret increments on instruction retires need to
  * occur before any explicit writes to instret.  However, in our
  * simulation loop, we need to execute an instruction to find out
  * whether it retired, and hence can only increment instret after
- * execution. To avoid doing this in the case minstret was explicitly
+ * execution.  To avoid doing this in the case minstret was explicitly
  * written to, we track whether it should increment in a separate
- * model-internal register. We keep track of any explicit CSR writes in
- * the registers below and apply them after incrementing.
+ * model-internal register.
  */
 register minstret : bits(64)
 
 /* Should minstret be incremented when the instruction is retired. */
 register minstret_increment : bool
 
-// If there's an explicit write to minstret(h) then it is stored here because
-// it needs to be applied *after* the implicit increment due to instruction
-// retirement.
-register minstret_write : option(bits(xlen)) = None()
-register minstreth_write : option(bits(32)) = None()
-
 function update_minstret() -> unit = {
-  // First increment minstret due to instruction retirement
-  // if it was not disabled by mcountinhibit.IR.
-  if minstret_increment then {
-    minstret = minstret + 1;
-  };
-
-  // Then apply explicit writes to minstret (if any).
-  match minstret_write {
-    Some(v) => minstret = [minstret with (xlen - 1) .. 0 = v],
-    None() => (),
-  };
-  match minstreth_write {
-    Some(v) => minstret = [minstret with 63 .. 32 = v],
-    None() => (),
-  };
+  if minstret_increment then minstret = minstret + 1;
 }
 
 /* machine information registers */

--- a/model/riscv_zicntr_control.sail
+++ b/model/riscv_zicntr_control.sail
@@ -47,6 +47,6 @@ function clause read_CSR(0xB80 if xlen == 32)= mcycle[63 .. 32]
 function clause read_CSR(0xB82 if xlen == 32) = minstret[63 .. 32]
 
 function clause write_CSR(0xB00, value) = { mcycle[(xlen - 1) .. 0] = value; value }
-function clause write_CSR(0xB02, value) = { minstret_write = Some(value); value }
+function clause write_CSR(0xB02, value) = { minstret[(xlen - 1) .. 0] = value; minstret_increment = false; value }
 function clause write_CSR((0xB80, value) if xlen == 32) = { mcycle[63 .. 32] = value; value }
-function clause write_CSR((0xB82, value) if xlen == 32) = { minstreth_write = Some(value); value }
+function clause write_CSR((0xB82, value) if xlen == 32) = { minstret[63 .. 32] = value; minstret_increment = false; value }

--- a/test/first_party/src/test_minstret.S
+++ b/test/first_party/src/test_minstret.S
@@ -38,7 +38,7 @@ main:
     csrw minstreth, zero
     csrw minstret, t0
     # Minstret should be 0x00000000FFFFFFFF now.
-    # Write 2 to minstreth. instret should now be 0x0000000200000000
+    # Write 2 to minstreth. instret should now be 0x00000002FFFFFFFF
     csrwi minstreth, 2
     csrr t1, minstreth
 
@@ -50,12 +50,11 @@ main:
     csrw minstreth, zero
     csrw minstret, t0
     # Minstret should be 0x00000000FFFFFFFF now.
-    # Write 2 to minstret. instret should now be 0x0000000100000002
+    # Write 2 to minstret. instret should now be 0x0000000000000002
     csrwi minstret, 2
     csrr t1, minstreth
 
-    li t2, 1
-    bne t1, t2, fail
+    bnez t1, fail
 
 #endif
 


### PR DESCRIPTION
This reverts commit cd54a3780178d8cf3ca0fa29009fa7f14059e014.

It hasn't been clarified in the ISA manual, but it has been clarified in [this Github issue](1) and in a new test in `riscv-tests` that the original behaviour was expected.

Essentially there are two different concepts: architectural CSRs (the instruction counter) and CSR addresses `minstret`, `minstreth`. The ISA manual conflates these concepts. When it says

> an explicit CSR write suppresses and overrides any implicit writes or modifications to the same CSR by the same instruction.

When it says CSR here it means the architectural CSR, not the CSR address.

I tested this against the new `instret_overflow` test in `riscv-tests`.

[1]: https://github.com/riscv/riscv-isa-manual/issues/1255

Fixes #832 