### PR TITLE
Only run Lean CI manually

### DIFF
--- a/.github/workflows/compile-lean.yml
+++ b/.github/workflows/compile-lean.yml
@@ -1,6 +1,6 @@
 name: Build and test Lean backend
 
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_dispatch]
 
 env:
   OPAMVERBOSE: 1


### PR DESCRIPTION
The Lean backend is still relatively unstable and it's hard to fix errors for people that aren't familiar with it. This changes it to only be run manually so it doesn't block other changes.

When it's more stable we can re-enable it.