### PR TITLE
Enable misaligned accesses in default config for riscv-tests

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -14,7 +14,7 @@
             "count" : 16
         },
         "misaligned" : {
-            "supported" : false
+            "supported" : true
         },
         "translation" : {
             "dirty_update" : false


### PR DESCRIPTION
As discussed in the golden model meeting, this should allow the default configuration to pass all of the riscv-tests.

Fixes #841 