### PR TITLE
Display test output for failing tests in CI

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -30,7 +30,7 @@ jobs:
         # can at least build without errors.
         ninja -C build all riscv_sim_rv32d_rvfi generated_smt_rv64f generated_docs_rv64d
         # These targets do not work with Sail 0.18: generated_rmem_rv32d_rmem generated_coq_rv64f_coq
-        ctest --test-dir build --output-junit tests.xml
+        ctest --test-dir build --output-junit tests.xml --output-on-failure
 
     - name: Upload test results
       if: always()


### PR DESCRIPTION
Display the output of failing tests in CI to make debugging easier.