### PR TITLE
Add overload bits_of for virtaddr_bits and physaddr_bits

### DIFF
--- a/model/prelude_mem_addrtype.sail
+++ b/model/prelude_mem_addrtype.sail
@@ -16,10 +16,12 @@ let physaddrbits_len = sizeof(physaddrbits_len)
 newtype physaddr = Physaddr : physaddrbits
 newtype virtaddr = Virtaddr : xlenbits
 
-function physaddr_bits(Physaddr(paddr) : physaddr) -> physaddrbits = paddr
+function bits_of_physaddr(Physaddr(paddr) : physaddr) -> physaddrbits = paddr
 
-function virtaddr_bits(Virtaddr(vaddr) : virtaddr) -> xlenbits = vaddr
+function bits_of_virtaddr(Virtaddr(vaddr) : virtaddr) -> xlenbits = vaddr
 
 function sub_virtaddr_xlenbits(Virtaddr(addr) : virtaddr, offset : xlenbits) -> virtaddr = Virtaddr(addr - offset)
 
 overload operator - = { sub_virtaddr_xlenbits }
+
+overload bits_of = { bits_of_physaddr, bits_of_virtaddr }

--- a/model/riscv_fetch.sail
+++ b/model/riscv_fetch.sail
@@ -19,7 +19,7 @@ function fetch() -> FetchResult =
   match ext_fetch_check_pc(PC, PC) {
     Ext_FetchAddr_Error(e)   => F_Ext_Error(e),
     Ext_FetchAddr_OK(use_pc) => {
-      let use_pc_bits = virtaddr_bits(use_pc);
+      let use_pc_bits = bits_of(use_pc);
       if   (use_pc_bits[0] != bitzero | (use_pc_bits[1] != bitzero & not(currentlyEnabled(Ext_Zca))))
       then F_Error(E_Fetch_Addr_Align(), PC)
       else match translateAddr(use_pc, Execute()) {

--- a/model/riscv_fetch_rvfi.sail
+++ b/model/riscv_fetch_rvfi.sail
@@ -17,7 +17,7 @@ function fetch() -> FetchResult = {
     Ext_FetchAddr_Error(e)   => F_Ext_Error(e),
     Ext_FetchAddr_OK(use_pc) => {
       /* then check PC alignment */
-      let use_pc_bits = virtaddr_bits(use_pc);
+      let use_pc_bits = bits_of(use_pc);
       if   (use_pc_bits[0] != bitzero | (use_pc_bits[1] != bitzero & not(currentlyEnabled(Ext_Zca))))
       then F_Error(E_Fetch_Addr_Align(), PC)
       else match translateAddr(use_pc, Execute()) {

--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -87,13 +87,13 @@ function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
       /* "LR faults like a normal load, even though it's in the AMO major opcode space."
         * - Andrew Waterman, isa-dev, 10 Jul 2018.
         */
-      if not(is_aligned(virtaddr_bits(vaddr), width))
+      if not(is_aligned(bits_of(vaddr), width))
       then RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
       else match translateAddr(vaddr, Read(Data)) {
         TR_Failure(e, _)    => RETIRE_FAIL(Memory_Exception(vaddr, e)),
         TR_Address(addr, _) =>
           match mem_read(Read(Data), addr, width_bytes, aq, aq & rl, true) {
-            Ok(result) => { load_reservation(physaddr_bits(addr)); X(rd) = sign_extend(result); RETIRE_SUCCESS },
+            Ok(result) => { load_reservation(bits_of(addr)); X(rd) = sign_extend(result); RETIRE_SUCCESS },
             Err(e)     => RETIRE_FAIL(Memory_Exception(vaddr, e)),
           },
       }
@@ -133,7 +133,7 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
     match ext_data_get_addr(rs1, zeros(), Write(Data), width_bytes) {
       Ext_DataAddr_Error(e)  => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
       Ext_DataAddr_OK(vaddr) => {
-        if not(is_aligned(virtaddr_bits(vaddr), width))
+        if not(is_aligned(bits_of(vaddr), width))
         then RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
         else {
           match translateAddr(vaddr, Write(Data)) {  /* Write and ReadWrite are equivalent here:
@@ -141,7 +141,7 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
             TR_Failure(e, _) => RETIRE_FAIL(Memory_Exception(vaddr, e)),
             TR_Address(addr, _) => {
               // Check reservation with physical address.
-              if not(match_reservation(physaddr_bits(addr))) then {
+              if not(match_reservation(bits_of(addr))) then {
                 /* cannot happen in rmem */
                 X(rd) = zero_extend(0b1); cancel_reservation(); RETIRE_SUCCESS
               } else {
@@ -203,7 +203,7 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
   match ext_data_get_addr(rs1, zeros(), ReadWrite(Data, Data), width_bytes) {
     Ext_DataAddr_Error(e)  => RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
     Ext_DataAddr_OK(vaddr) => {
-      if not(is_aligned(virtaddr_bits(vaddr), width))
+      if not(is_aligned(bits_of(vaddr), width))
       then RETIRE_FAIL(Memory_Exception(vaddr, E_SAMO_Addr_Align()))
       else match translateAddr(vaddr, ReadWrite(Data, Data)) {
         TR_Failure(e, _) => RETIRE_FAIL(Memory_Exception(vaddr, e)),

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -65,7 +65,7 @@ function clause execute (RISCV_JAL(imm, rd)) = {
     Ext_ControlAddr_Error(e) => RETIRE_FAIL(Ext_ControlAddr_Check_Failure(e)),
     Ext_ControlAddr_OK(target) => {
       /* Perform standard alignment check */
-      let target_bits = virtaddr_bits(target);
+      let target_bits = bits_of(target);
       if bit_to_bool(target_bits[1]) & not(currentlyEnabled(Ext_Zca)) then {
         RETIRE_FAIL(Memory_Exception(target, E_Fetch_Addr_Align()))
       } else {
@@ -123,7 +123,7 @@ function clause execute (BTYPE(imm, rs2, rs1, op)) = {
     match ext_control_check_pc(target) {
       Ext_ControlAddr_Error(e) => RETIRE_FAIL(Ext_ControlAddr_Check_Failure(e)),
       Ext_ControlAddr_OK(target) => {
-        let target_bits = virtaddr_bits(target);
+        let target_bits = bits_of(target);
         if bit_to_bool(target_bits[1]) & not(currentlyEnabled(Ext_Zca)) then {
           RETIRE_FAIL(Memory_Exception(target, E_Fetch_Addr_Align()))
         } else {
@@ -293,7 +293,7 @@ function is_aligned(vaddr : xlenbits, width : word_width) -> bool =
 
 // Return true if the address is misaligned and we don't support misaligned access.
 function check_misaligned(vaddr : virtaddr, width : word_width) -> bool =
-  not(plat_enable_misaligned_access()) & not(is_aligned(virtaddr_bits(vaddr), width))
+  not(plat_enable_misaligned_access()) & not(is_aligned(bits_of(vaddr), width))
 
 function clause execute (LOAD(imm, rs1, rd, is_unsigned, width, aq, rl)) = {
   let offset : xlenbits = sign_extend(imm);

--- a/model/riscv_jalr_seq.sail
+++ b/model/riscv_jalr_seq.sail
@@ -21,7 +21,7 @@ function clause execute (RISCV_JALR(imm, rs1, rd)) = {
     Ext_ControlAddr_Error(e) =>
       RETIRE_FAIL(Ext_ControlAddr_Check_Failure(e)),
     Ext_ControlAddr_OK(addr) => {
-      let target = [virtaddr_bits(addr) with 0 = bitzero];  /* clear addr[0] */
+      let target = [bits_of(addr) with 0 = bitzero];  /* clear addr[0] */
       if bit_to_bool(target[1]) & not(currentlyEnabled(Ext_Zca)) then {
         RETIRE_FAIL(Memory_Exception(addr, E_Fetch_Addr_Align()))
       } else {

--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -74,7 +74,7 @@ function phys_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext
     (Read(Data), None()) => Err(E_Load_Access_Fault()),
     (_,          None()) => Err(E_SAMO_Access_Fault()),
     (_,      Some(v, m)) => { if   get_config_print_mem()
-                              then print_mem("mem[" ^ to_str(t) ^ "," ^ BitStr(physaddr_bits(paddr)) ^ "] -> " ^ BitStr(v));
+                              then print_mem("mem[" ^ to_str(t) ^ "," ^ BitStr(bits_of(paddr)) ^ "] -> " ^ BitStr(v));
                               Ok(v, m) }
   }
 }
@@ -198,7 +198,7 @@ $endif
 function phys_mem_write forall 'n, 0 < 'n <= max_mem_access . (wk : write_kind, paddr : physaddr, width : int('n), data : bits(8 * 'n), meta : mem_meta) -> MemoryOpResult(bool) = {
   let result = write_ram(wk, paddr, width, data, meta);
   if   get_config_print_mem()
-  then print_mem("mem[" ^ BitStr(physaddr_bits(paddr)) ^ "] <- " ^ BitStr(data));
+  then print_mem("mem[" ^ BitStr(bits_of(paddr)) ^ "] <- " ^ BitStr(data));
   Ok(result)
 }
 

--- a/model/riscv_vmem.sail
+++ b/model/riscv_vmem.sail
@@ -370,7 +370,7 @@ function translateAddr(
 
   let mode = translationMode(effPriv);
 
-  if mode == Bare then return TR_Address(Physaddr(zero_extend(virtaddr_bits(vAddr))), init_ext_ptw);
+  if mode == Bare then return TR_Address(Physaddr(zero_extend(bits_of(vAddr))), init_ext_ptw);
 
   // Sv39 -> 39, etc.
   let sv_width = satp_mode_width(mode);
@@ -381,8 +381,8 @@ function translateAddr(
   // Cannot use Sv39+ on RV32.
   assert(sv_width == 32 | xlen == 64);
 
-  let svAddr = virtaddr_bits(vAddr)[sv_width - 1 .. 0];
-  if virtaddr_bits(vAddr) != sign_extend(svAddr) then {
+  let svAddr = bits_of(vAddr)[sv_width - 1 .. 0];
+  if bits_of(vAddr) != sign_extend(svAddr) then {
     TR_Failure(translationException(ac, PTW_Invalid_Addr()), init_ext_ptw)
   } else {
     let mxr    = mstatus[MXR] == 0b1;
@@ -403,7 +403,7 @@ function translateAddr(
       TR_Address(ppn, ext_ptw) => {
         // Step 10 of VATP.
         // Append the page offset. This is now a 34 or 56 bit address.
-        let paddr = ppn @ virtaddr_bits(vAddr)[pagesize_bits - 1 .. 0];
+        let paddr = ppn @ bits_of(vAddr)[pagesize_bits - 1 .. 0];
 
         // On RV64 paddr can be 34 or 56 bits, so we zero extend to 64.
         // On RV32 paddr can only be 34 bits. Sail knows this due to


### PR DESCRIPTION
part of #779

Currently I retained other similar functions (`bool_to_bits`, (int) `to_bits`, `exceptionType_to_bits` ...). They seems good for the readability, and also make it easier to goto definitions.
