### PR TITLE
Add cmake_policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
+cmake_policy(VERSION 3.20...3.31)
 
 project(sail_riscv)
 


### PR DESCRIPTION
This tells CMake that we've tested it up to version 3.31 so it can enable newer policies that are available in versions up to that point and not warn us about them.

Fixes #818. Tested with CMake 4 and `./build_simulators.sh`.