### PR TITLE
 Handle address translation for misaligned loads and stores better

### DIFF
--- a/Makefile.old
+++ b/Makefile.old
@@ -92,6 +92,7 @@ SAIL_SYS_SRCS += riscv_zicntr_control.sail
 SAIL_SYS_SRCS += riscv_softfloat_interface.sail riscv_fdext_regs.sail riscv_fdext_control.sail
 SAIL_SYS_SRCS += riscv_sys_control.sail     # general exception handling
 SAIL_SYS_SRCS += riscv_smcntrpmf.sail
+SAIL_SYS_SRCS += riscv_inst_retire.sail
 
 SAIL_VM_SRCS += riscv_vmem_pte.sail
 SAIL_VM_SRCS += riscv_vmem_ptw.sail

--- a/Makefile.old
+++ b/Makefile.old
@@ -69,6 +69,7 @@ SAIL_DEFAULT_INST += riscv_insts_zicbom.sail
 SAIL_DEFAULT_INST += riscv_insts_zicboz.sail
 SAIL_DEFAULT_INST += riscv_insts_zvbb.sail
 SAIL_DEFAULT_INST += riscv_insts_zvbc.sail
+SAIL_DEFAULT_INST += riscv_insts_zvknhab.sail
 SAIL_DEFAULT_INST += riscv_insts_zimop.sail
 SAIL_DEFAULT_INST += riscv_insts_zcmop.sail
 
@@ -96,6 +97,7 @@ SAIL_VM_SRCS += riscv_vmem_pte.sail
 SAIL_VM_SRCS += riscv_vmem_ptw.sail
 SAIL_VM_SRCS += riscv_vmem_tlb.sail
 SAIL_VM_SRCS += riscv_vmem.sail
+SAIL_VM_SRCS += riscv_vmem_utils.sail
 
 # Non-instruction sources
 PRELUDE = prelude.sail riscv_errors.sail $(SAIL_XLEN) $(SAIL_FLEN) $(SAIL_VLEN) prelude_mem_addrtype.sail prelude_mem_metadata.sail prelude_mem.sail arithmetic.sail
@@ -110,10 +112,11 @@ SAIL_ARCH_SRCS = $(PRELUDE)
 SAIL_ARCH_SRCS += riscv_extensions.sail riscv_types_common.sail riscv_types_ext.sail riscv_types.sail
 SAIL_ARCH_SRCS += riscv_vmem_types.sail $(SAIL_REGS_SRCS) $(SAIL_SYS_SRCS) riscv_platform.sail
 SAIL_ARCH_SRCS += riscv_sstc.sail
-SAIL_ARCH_SRCS += riscv_mem.sail $(SAIL_VM_SRCS)
-SAIL_ARCH_RVFI_SRCS = $(PRELUDE) rvfi_dii.sail riscv_extensions.sail riscv_types_common.sail riscv_types_ext.sail riscv_types.sail riscv_vmem_types.sail $(SAIL_REGS_SRCS) $(SAIL_SYS_SRCS) riscv_platform.sail riscv_mem.sail $(SAIL_VM_SRCS) riscv_types_kext.sail riscv_inst_retire.sail
-SAIL_ARCH_SRCS += riscv_types_kext.sail    # Shared/common code for the cryptography extension.
+SAIL_ARCH_SRCS += riscv_mem.sail
 SAIL_ARCH_SRCS += riscv_inst_retire.sail
+SAIL_ARCH_SRCS += $(SAIL_VM_SRCS)
+SAIL_ARCH_RVFI_SRCS = $(PRELUDE) rvfi_dii.sail riscv_extensions.sail riscv_types_common.sail riscv_types_ext.sail riscv_types.sail riscv_vmem_types.sail $(SAIL_REGS_SRCS) $(SAIL_SYS_SRCS) riscv_platform.sail riscv_mem.sail riscv_inst_retire.sail $(SAIL_VM_SRCS) riscv_types_kext.sail
+SAIL_ARCH_SRCS += riscv_types_kext.sail riscv_zvk_utils.sail   # Shared/common code for the cryptography extension.
 
 SAIL_STEP_SRCS = riscv_step_common.sail riscv_step_ext.sail riscv_decode_ext.sail riscv_fetch.sail riscv_step.sail
 RVFI_STEP_SRCS = riscv_step_common.sail riscv_step_rvfi.sail riscv_decode_ext.sail riscv_fetch_rvfi.sail riscv_step.sail
@@ -202,7 +205,7 @@ RISCV_EXTRAS_LEM = $(addprefix handwritten_support/,$(RISCV_EXTRAS_LEM_FILES))
 .PHONY:
 
 all: c_emulator/riscv_sim_$(ARCH)
-.PHONY: all
+.PHONY: all check_properties
 
 # the following ensures empty sail-generated .c files don't hang around and
 # break future builds if sail exits badly

--- a/config/default.json
+++ b/config/default.json
@@ -14,7 +14,10 @@
       "count": 16
     },
     "misaligned": {
-      "supported": true
+      "supported": true,
+      "byte_by_byte": false,
+      "order_decreasing": false,
+      "allowed_within_exp": 0
     },
     "translation": {
       "dirty_update": false

--- a/doc/ReadingGuide.md
+++ b/doc/ReadingGuide.md
@@ -80,9 +80,15 @@ such as the platform memory map.
   appropriate access fault. This file also contains definitions that
   are used in the weak memory concurrency model.
 
-- The `riscv_vmem_*.sail` files describe the S-mode address
-  translation. See the [Virtual Memory Notes](./notes_Virtual_Memory.adoc)
-  for details.
+- The `riscv_vmem_{types,pte,ptw,tlb}.sail` and `riscv_vmem.sail`
+  files describe the S-mode address translation.
+  See the [Virtual Memory Notes](./notes_Virtual_Memory.adoc) for
+  details.
+
+- The `riscv_vmem_utils.sail` file provides a higher level interface
+  to virtual memory for load/store style instructions that handles
+  address translation and accesses to misaligned addresses taking
+  platform configuration options into account.
 
 - The `riscv_addr_checks_common.sail` and `riscv_addr_checks.sail`
   contain extension hooks to support the checking and transformation

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -135,6 +135,7 @@ foreach (xlen IN ITEMS 32 64)
                 "riscv_vmem_ptw.sail"
                 "riscv_vmem_tlb.sail"
                 "riscv_vmem.sail"
+                "riscv_vmem_utils.sail"
             )
 
             set(prelude
@@ -178,10 +179,10 @@ foreach (xlen IN ITEMS 32 64)
                 "riscv_vmem_types.sail"
                 ${sail_regs_srcs}
                 ${sail_sys_srcs}
-                "riscv_inst_retire.sail"
                 "riscv_platform.sail"
                 "riscv_sstc.sail"
                 "riscv_mem.sail"
+                "riscv_inst_retire.sail"
                 ${sail_vm_srcs}
                 # Shared/common code for the cryptography extension.
                 "riscv_types_kext.sail"

--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -107,7 +107,8 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
   /* normal non-rmem case
    * RMEM: SC is allowed to succeed (but might fail later)
    */
-  match vmem_write(rs1, zeros(), width_bytes, rs2, aq & rl, rl, true) {
+  let data = X(rs2)[width_bytes * 8 - 1 .. 0];
+  match vmem_write(rs1, zeros(), width_bytes, data, aq & rl, rl, true) {
     Ok(b) => {
       X(rd) = zero_extend(bool_bits(~(b)));
       cancel_reservation();

--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -70,7 +70,7 @@ function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
   // This is checked during decoding.
   assert(width_bytes <= xlen_bytes);
 
-  match vmem_read(rs1, zeros(), width_bytes, aq, aq & rl, true) {
+  match vmem_read(rs1, zeros(), width_bytes, Read(Data), aq, aq & rl, true) {
     Ok(data) => {
       X(rd) = sign_extend(data);
       RETIRE_SUCCESS
@@ -108,7 +108,7 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
    * RMEM: SC is allowed to succeed (but might fail later)
    */
   let data = X(rs2)[width_bytes * 8 - 1 .. 0];
-  match vmem_write(rs1, zeros(), width_bytes, data, aq & rl, rl, true) {
+  match vmem_write(rs1, zeros(), width_bytes, data, Write(Data), aq & rl, rl, true) {
     Ok(b) => {
       X(rd) = zero_extend(bool_bits(~(b)));
       cancel_reservation();

--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -70,26 +70,12 @@ function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
   // This is checked during decoding.
   assert(width_bytes <= xlen_bytes);
 
-  /* Get the address, X(rs1) (no offset).
-    * Extensions might perform additional checks on address validity.
-    */
-  match ext_data_get_addr(rs1, zeros(), Read(Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => Ext_DataAddr_Check_Failure(e),
-    Ext_DataAddr_OK(vaddr) => {
-      /* "LR faults like a normal load, even though it's in the AMO major opcode space."
-        * - Andrew Waterman, isa-dev, 10 Jul 2018.
-        */
-      if not(is_aligned(bits_of(vaddr), width))
-      then Memory_Exception(vaddr, E_Load_Addr_Align())
-      else match translateAddr(vaddr, Read(Data)) {
-        TR_Failure(e, _)    => Memory_Exception(vaddr, e),
-        TR_Address(addr, _) =>
-          match mem_read(Read(Data), addr, width_bytes, aq, aq & rl, true) {
-            Ok(result) => { load_reservation(bits_of(addr)); X(rd) = sign_extend(result); RETIRE_SUCCESS },
-            Err(e)     => Memory_Exception(vaddr, e),
-          },
-      }
-    }
+  match vmem_read(rs1, zeros(), width_bytes, aq, aq & rl, true) {
+    Ok(data) => {
+      X(rd) = sign_extend(data);
+      RETIRE_SUCCESS
+    },
+    Err(e) => e,
   }
 }
 
@@ -110,50 +96,24 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
   // This is checked during decoding.
   assert(width_bytes <= xlen_bytes);
 
-  if speculate_conditional () == false then {
-    /* should only happen in rmem
-     * rmem: allow SC to fail very early
+  if speculate_conditional() == false then {
+    /* should only happen in RMEM
+     * RMEM: allow SC to fail very early
      */
-    X(rd) = zero_extend(0b1); RETIRE_SUCCESS
-  } else {
-    /* normal non-rmem case
-      * rmem: SC is allowed to succeed (but might fail later)
-      */
-    /* Get the address, X(rs1) (no offset).
-      * Extensions might perform additional checks on address validity.
-      */
-    match ext_data_get_addr(rs1, zeros(), Write(Data), width_bytes) {
-      Ext_DataAddr_Error(e)  => Ext_DataAddr_Check_Failure(e),
-      Ext_DataAddr_OK(vaddr) => {
-        if not(is_aligned(bits_of(vaddr), width))
-        then Memory_Exception(vaddr, E_SAMO_Addr_Align())
-        else {
-          match translateAddr(vaddr, Write(Data)) {  /* Write and ReadWrite are equivalent here:
-                                                      * both result in a SAMO exception */
-            TR_Failure(e, _) => Memory_Exception(vaddr, e),
-            TR_Address(addr, _) => {
-              // Check reservation with physical address.
-              if not(match_reservation(bits_of(addr))) then {
-                /* cannot happen in rmem */
-                X(rd) = zero_extend(0b1); cancel_reservation(); RETIRE_SUCCESS
-              } else {
-                match mem_write_ea(addr, width_bytes, aq & rl, rl, true) {
-                  Err(e) => Memory_Exception(vaddr, e),
-                  Ok(_)  => {
-                    let rs2_val = X(rs2);
-                    match mem_write_value(addr, width_bytes, rs2_val[width_bytes * 8 - 1 .. 0], aq & rl, rl, true) {
-                      Ok(true)  => { X(rd) = zero_extend(0b0); cancel_reservation(); RETIRE_SUCCESS },
-                      Ok(false) => { X(rd) = zero_extend(0b1); cancel_reservation(); RETIRE_SUCCESS },
-                      Err(e)    => Memory_Exception(vaddr, e),
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+    X(rd) = zero_extend(0b1);
+    return RETIRE_SUCCESS
+  };
+
+  /* normal non-rmem case
+   * RMEM: SC is allowed to succeed (but might fail later)
+   */
+  match vmem_write(rs1, zeros(), width_bytes, rs2, aq & rl, rl, true) {
+    Ok(b) => {
+      X(rd) = zero_extend(bool_bits(~(b)));
+      cancel_reservation();
+      RETIRE_SUCCESS
+    },
+    Err(e) => e,
   }
 }
 
@@ -195,7 +155,7 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
   match ext_data_get_addr(rs1, zeros(), ReadWrite(Data, Data), width_bytes) {
     Ext_DataAddr_Error(e)  => Ext_DataAddr_Check_Failure(e),
     Ext_DataAddr_OK(vaddr) => {
-      if not(is_aligned(bits_of(vaddr), width))
+      if not(is_aligned_addr(bits_of(vaddr), width))
       then Memory_Exception(vaddr, E_SAMO_Addr_Align())
       else match translateAddr(vaddr, ReadWrite(Data, Data)) {
         TR_Failure(e, _) => Memory_Exception(vaddr, e),

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -276,24 +276,15 @@ union clause ast = LOAD : (bits(12), regidx, regidx, bool, word_width, bool, boo
 
 /* unsigned loads are only present for widths strictly less than xlen,
    signed loads also present for widths equal to xlen */
-mapping clause encdec = LOAD(imm, rs1, rd, is_unsigned, size, false, false)
-  <-> imm @ encdec_reg(rs1) @ bool_bits(is_unsigned) @ size_enc(size) @ encdec_reg(rd) @ 0b0000011
-  when (size_bytes(size) < xlen_bytes) | (not(is_unsigned) & size_bytes(size) <= xlen_bytes)
+function valid_load_encdec(width : word_width, is_unsigned : bool) -> bool =
+  (size_bytes(width) < xlen_bytes) | (not(is_unsigned) & size_bytes(width) <= xlen_bytes)
 
 val extend_value : forall 'n, 0 < 'n <= xlen. (bool, bits('n)) -> xlenbits
 function extend_value(is_unsigned, value) = if is_unsigned then zero_extend(value) else sign_extend(value)
 
-function is_aligned(vaddr : xlenbits, width : word_width) -> bool =
-  match width {
-    BYTE   => true,
-    HALF   => vaddr[0..0] == zeros(),
-    WORD   => vaddr[1..0] == zeros(),
-    DOUBLE => vaddr[2..0] == zeros(),
-  }
-
-// Return true if the address is misaligned and we don't support misaligned access.
-function check_misaligned(vaddr : virtaddr, width : word_width) -> bool =
-  not(plat_enable_misaligned_access()) & not(is_aligned(bits_of(vaddr), width))
+mapping clause encdec = LOAD(imm, rs1, rd, is_unsigned, width, false, false)
+  <-> imm @ encdec_reg(rs1) @ bool_bits(is_unsigned) @ size_enc(width) @ encdec_reg(rd) @ 0b0000011
+  when valid_load_encdec(width, is_unsigned)
 
 function clause execute (LOAD(imm, rs1, rd, is_unsigned, width, aq, rl)) = {
   let offset : xlenbits = sign_extend(imm);
@@ -302,22 +293,12 @@ function clause execute (LOAD(imm, rs1, rd, is_unsigned, width, aq, rl)) = {
   // This is checked during decoding.
   assert(width_bytes <= xlen_bytes);
 
-  /* Get the address, X(rs1) + offset.
-     Some extensions perform additional checks on address validity. */
-  match ext_data_get_addr(rs1, offset, Read(Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => Ext_DataAddr_Check_Failure(e),
-    Ext_DataAddr_OK(vaddr) => {
-      if   check_misaligned(vaddr, width)
-      then Memory_Exception(vaddr, E_Load_Addr_Align())
-      else match translateAddr(vaddr, Read(Data)) {
-        TR_Failure(e, _) => Memory_Exception(vaddr, e),
-        TR_Address(paddr, _) =>
-          match mem_read(Read(Data), paddr, width_bytes, aq, rl, false) {
-            Ok(result) => { X(rd) = extend_value(is_unsigned, result); RETIRE_SUCCESS },
-            Err(e)     => Memory_Exception(vaddr, e),
-          },
-      }
+  match vmem_read(rs1, offset, width_bytes, aq, rl, false) {
+    Ok(data) => {
+      X(rd) = extend_value(is_unsigned, data);
+      RETIRE_SUCCESS
     },
+    Err(e) => e,
   }
 }
 
@@ -339,18 +320,16 @@ mapping maybe_u = {
   false <-> ""
 }
 
-mapping clause assembly = LOAD(imm, rs1, rd, is_unsigned, size, aq, rl)
-  <-> "l" ^ size_mnemonic(size) ^ maybe_u(is_unsigned) ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_signed_12(imm) ^ "(" ^ reg_name(rs1) ^ ")"
+mapping clause assembly = LOAD(imm, rs1, rd, is_unsigned, width, aq, rl)
+  <-> "l" ^ size_mnemonic(width) ^ maybe_u(is_unsigned) ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_signed_12(imm) ^ "(" ^ reg_name(rs1) ^ ")"
 
 /* ****************************************************************** */
 union clause ast = STORE : (bits(12), regidx, regidx, word_width, bool, bool)
 
-mapping clause encdec = STORE(imm7 @ imm5, rs2, rs1, size, false, false)
-  <-> imm7 : bits(7) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ imm5 : bits(5) @ 0b0100011
-  when size_bytes(size) <= xlen_bytes
+mapping clause encdec = STORE(imm7 @ imm5, rs2, rs1, width, false, false)
+  <-> imm7 : bits(7) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(width) @ imm5 : bits(5) @ 0b0100011
+  when size_bytes(width) <= xlen_bytes
 
-/* NOTE: Currently, we only EA if address translation is successful.
-   This may need revisiting. */
 function clause execute (STORE(imm, rs2, rs1, width, aq, rl)) = {
   let offset : xlenbits = sign_extend(imm);
   let width_bytes = size_bytes(width);
@@ -358,34 +337,14 @@ function clause execute (STORE(imm, rs2, rs1, width, aq, rl)) = {
   // This is checked during decoding.
   assert(width_bytes <= xlen_bytes);
 
-  /* Get the address, X(rs1) + offset.
-     Some extensions perform additional checks on address validity. */
-  match ext_data_get_addr(rs1, offset, Write(Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => Ext_DataAddr_Check_Failure(e),
-    Ext_DataAddr_OK(vaddr) =>
-      if   check_misaligned(vaddr, width)
-      then Memory_Exception(vaddr, E_SAMO_Addr_Align())
-      else match translateAddr(vaddr, Write(Data)) {
-        TR_Failure(e, _)    => Memory_Exception(vaddr, e),
-        TR_Address(paddr, _) => {
-          match mem_write_ea(paddr, width_bytes, aq, rl, false) {
-            Err(e) => Memory_Exception(vaddr, e),
-            Ok(_)  => {
-              let rs2_val = X(rs2);
-              match mem_write_value(paddr, width_bytes, rs2_val[width_bytes * 8 - 1 .. 0], aq, rl, false) {
-                Ok(true)  => RETIRE_SUCCESS,
-                Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                Err(e)    => Memory_Exception(vaddr, e)
-              }
-            }
-          }
-        }
-      }
+  match vmem_write(rs1, offset, width_bytes, rs2, aq, rl, false) {
+    Ok(_) => RETIRE_SUCCESS,
+    Err(e) => e,
   }
 }
 
-mapping clause assembly = STORE(imm, rs2, rs1, size, aq, rl)
-  <-> "s" ^ size_mnemonic(size) ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_signed_12(imm) ^ opt_spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
+mapping clause assembly = STORE(imm, rs2, rs1, width, aq, rl)
+  <-> "s" ^ size_mnemonic(width) ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_signed_12(imm) ^ opt_spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
 
 /* ****************************************************************** */
 union clause ast = ADDIW : (bits(12), regidx, regidx)

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -337,7 +337,8 @@ function clause execute (STORE(imm, rs2, rs1, width, aq, rl)) = {
   // This is checked during decoding.
   assert(width_bytes <= xlen_bytes);
 
-  match vmem_write(rs1, offset, width_bytes, rs2, aq, rl, false) {
+  let data = X(rs2)[width_bytes * 8 - 1 .. 0];
+  match vmem_write(rs1, offset, width_bytes, data, aq, rl, false) {
     Ok(_) => RETIRE_SUCCESS,
     Err(e) => e,
   }

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -293,7 +293,7 @@ function clause execute (LOAD(imm, rs1, rd, is_unsigned, width, aq, rl)) = {
   // This is checked during decoding.
   assert(width_bytes <= xlen_bytes);
 
-  match vmem_read(rs1, offset, width_bytes, aq, rl, false) {
+  match vmem_read(rs1, offset, width_bytes, Read(Data), aq, rl, false) {
     Ok(data) => {
       X(rd) = extend_value(is_unsigned, data);
       RETIRE_SUCCESS
@@ -338,7 +338,7 @@ function clause execute (STORE(imm, rs2, rs1, width, aq, rl)) = {
   assert(width_bytes <= xlen_bytes);
 
   let data = X(rs2)[width_bytes * 8 - 1 .. 0];
-  match vmem_write(rs1, offset, width_bytes, data, aq, rl, false) {
+  match vmem_write(rs1, offset, width_bytes, data, Write(Data), aq, rl, false) {
     Ok(_) => RETIRE_SUCCESS,
     Err(e) => e,
   }

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -295,24 +295,9 @@ function clause execute(LOAD_FP(imm, rs1, rd, width)) = {
   assert(width_bytes <= flen_bytes);
 
   let offset : xlenbits = sign_extend(imm);
-  /* Get the address, X(rs1) + offset.
-     Some extensions perform additional checks on address validity. */
-  match ext_data_get_addr(rs1, offset, Read(Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => Ext_DataAddr_Check_Failure(e),
-    Ext_DataAddr_OK(vaddr) => {
-      if   check_misaligned(vaddr, width)
-      then Memory_Exception(vaddr, E_Load_Addr_Align())
-      else match translateAddr(vaddr, Read(Data)) {
-        TR_Failure(e, _)    => Memory_Exception(vaddr, e),
-        TR_Address(addr, _) => {
-          let (aq, rl, res) = (false, false, false);
-          match mem_read(Read(Data), addr, width_bytes, aq, rl, res) {
-            Ok(result) => { F(rd) = nan_box(result); RETIRE_SUCCESS },
-            Err(e)     => Memory_Exception(vaddr, e),
-          }
-        },
-      }
-    }
+  match vmem_read(rs1, offset, width_bytes, false, false, false) {
+    Ok(result) => { F(rd) = nan_box(result); RETIRE_SUCCESS },
+    Err(e)     => e,
   }
 }
 
@@ -355,31 +340,11 @@ function clause execute (STORE_FP(imm, rs2, rs1, width)) = {
   assert(width_bytes <= flen_bytes);
 
   let offset : xlenbits = sign_extend(imm);
-  let (aq, rl, con) = (false, false, false);
-  /* Get the address, X(rs1) + offset.
-     Some extensions perform additional checks on address validity. */
-  match ext_data_get_addr(rs1, offset, Write(Data), width_bytes) {
-    Ext_DataAddr_Error(e)  => Ext_DataAddr_Check_Failure(e),
-    Ext_DataAddr_OK(vaddr) => {
-      if   check_misaligned(vaddr, width)
-      then Memory_Exception(vaddr, E_SAMO_Addr_Align())
-      else match translateAddr(vaddr, Write(Data)) {
-        TR_Failure(e, _)    => Memory_Exception(vaddr, e),
-        TR_Address(addr, _) => {
-          match mem_write_ea(addr, width_bytes, aq, rl, false) {
-            Err(e) => Memory_Exception(vaddr, e),
-            Ok(_)  => {
-              let rs2_val = F(rs2);
-              match mem_write_value(addr, width_bytes, rs2_val[width_bytes * 8 - 1 .. 0], aq, rl, con) {
-                Ok(true)  => RETIRE_SUCCESS,
-                Ok(false) => { internal_error(__FILE__, __LINE__, "store got false from mem_write_value") },
-                Err(e)    => Memory_Exception(vaddr, e)
-              }
-            },
-          }
-        }
-      }
-    }
+  let data = F(rs2)[width_bytes * 8 - 1 ..  0];
+  match vmem_write(rs1, offset, width_bytes, data, false, false, false) {
+    Ok(true)  => RETIRE_SUCCESS,
+    Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
+    Err(e)    => e,
   }
 }
 

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -295,7 +295,7 @@ function clause execute(LOAD_FP(imm, rs1, rd, width)) = {
   assert(width_bytes <= flen_bytes);
 
   let offset : xlenbits = sign_extend(imm);
-  match vmem_read(rs1, offset, width_bytes, false, false, false) {
+  match vmem_read(rs1, offset, width_bytes, Read(Data), false, false, false) {
     Ok(result) => { F(rd) = nan_box(result); RETIRE_SUCCESS },
     Err(e)     => e,
   }
@@ -341,7 +341,7 @@ function clause execute (STORE_FP(imm, rs2, rs1, width)) = {
 
   let offset : xlenbits = sign_extend(imm);
   let data = F(rs2)[width_bytes * 8 - 1 ..  0];
-  match vmem_write(rs1, offset, width_bytes, data, false, false, false) {
+  match vmem_write(rs1, offset, width_bytes, data, Write(Data), false, false, false) {
     Ok(true)  => RETIRE_SUCCESS,
     Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
     Err(e)    => e,

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -87,7 +87,7 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
       set_vstart(to_bits(16, i));
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = (i * nf + j) * load_width_bytes;
-        match vmem_read(rs1, to_bits(xlen, elem_offset), load_width_bytes, false, false, false) {
+        match vmem_read(rs1, to_bits(xlen, elem_offset), load_width_bytes, Read(Data), false, false, false) {
           Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
           Err(e)   => return e,
         }
@@ -151,7 +151,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
       if mask[i] == bitone then { /* active segments */
         foreach (j from 0 to (nf - 1)) {
           let elem_offset = (i * nf + j) * load_width_bytes;
-          match vmem_read(rs1, to_bits(xlen, elem_offset), load_width_bytes, false, false, false) {
+          match vmem_read(rs1, to_bits(xlen, elem_offset), load_width_bytes, Read(Data), false, false, false) {
             Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
             Err(e)   => if i == 0 then return e
                         else {
@@ -229,7 +229,7 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
         let elem_offset = (i * nf + j) * load_width_bytes;
         let vs = vregidx_offset(vs3, to_bits(5, j * EMUL_reg));
         let data = read_single_element(load_width_bytes * 8, i, vs);
-        match vmem_write(rs1, to_bits(xlen, elem_offset), load_width_bytes, data, false, false, false) {
+        match vmem_write(rs1, to_bits(xlen, elem_offset), load_width_bytes, data, Write(Data), false, false, false) {
           Ok(true)  => (),
           Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
           Err(e)    => return e,
@@ -288,7 +288,7 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
       set_vstart(to_bits(16, i));
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = i * rs2_val + j * load_width_bytes;
-        match vmem_read(rs1, to_bits(xlen, elem_offset), load_width_bytes, false, false, false) {
+        match vmem_read(rs1, to_bits(xlen, elem_offset), load_width_bytes, Read(Data), false, false, false) {
           Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
           Err(e)   => return e,
         }
@@ -352,7 +352,7 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
         let elem_offset = i * rs2_val + j * load_width_bytes;
         let vs = vregidx_offset(vs3, to_bits(5, j * EMUL_reg));
         let data = read_single_element(load_width_bytes * 8, i, vs);
-        match vmem_write(rs1, to_bits(xlen, elem_offset), load_width_bytes, data, false, false, false) {
+        match vmem_write(rs1, to_bits(xlen, elem_offset), load_width_bytes, data, Write(Data), false, false, false) {
           Ok(true)  => (),
           Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
           Err(e)    => return e,
@@ -412,7 +412,7 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
       set_vstart(to_bits(16, i));
       foreach (j from 0 to (nf - 1)) {
         let elem_offset : int = unsigned(vs2_val[i]) + j * EEW_data_bytes;
-        match vmem_read(rs1, to_bits(xlen, elem_offset), EEW_data_bytes, false, false, false) {
+        match vmem_read(rs1, to_bits(xlen, elem_offset), EEW_data_bytes, Read(Data), false, false, false) {
           Ok(elem) => write_single_element(EEW_data_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_data_reg)), elem),
           Err(e)   => return e,
         }
@@ -506,7 +506,7 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
         let elem_offset : int = unsigned(vs2_val[i]) + j * EEW_data_bytes;
         let vs = vregidx_offset(vs3, to_bits(5, j * EMUL_data_reg));
         let data = read_single_element(EEW_data_bytes * 8, i, vs);
-        match vmem_write(rs1, to_bits(xlen, elem_offset), EEW_data_bytes, data, false, false, false) {
+        match vmem_write(rs1, to_bits(xlen, elem_offset), EEW_data_bytes, data, Write(Data), false, false, false) {
           Ok(true)  => (),
           Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
           Err(e)    => return e,
@@ -591,7 +591,7 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
     foreach (i from elem_to_align to (elem_per_reg - 1)) {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
-      match vmem_read(rs1, to_bits(xlen, elem_offset), load_width_bytes, false, false, false) {
+      match vmem_read(rs1, to_bits(xlen, elem_offset), load_width_bytes, Read(Data), false, false, false) {
         Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, cur_field)), elem),
         Err(e)   => return e,
       };
@@ -604,7 +604,7 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
     foreach (i from 0 to (elem_per_reg - 1)) {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
-      match vmem_read(rs1, to_bits(xlen, elem_offset), load_width_bytes, false, false, false) {
+      match vmem_read(rs1, to_bits(xlen, elem_offset), load_width_bytes, Read(Data), false, false, false) {
         Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j)), elem),
         Err(e)   => return e,
       };
@@ -656,7 +656,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
       let elem_offset : int = cur_elem * load_width_bytes;
       let vs = vregidx_offset(vs3, to_bits(5, cur_field));
       let data = read_single_element(load_width_bytes * 8, i, vs);
-      match vmem_write(rs1, to_bits(xlen, elem_offset), load_width_bytes, data, false, false, false) {
+      match vmem_write(rs1, to_bits(xlen, elem_offset), load_width_bytes, data, Write(Data), false, false, false) {
         Ok(true)  => (),
         Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
         Err(e)    => return e,
@@ -671,7 +671,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
     foreach (i from 0 to (elem_per_reg - 1)) {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
-      match vmem_write(rs1, to_bits(xlen, elem_offset), load_width_bytes, vs3_val[i], false, false, false) {
+      match vmem_write(rs1, to_bits(xlen, elem_offset), load_width_bytes, vs3_val[i], Write(Data), false, false, false) {
         Ok(true)  => (),
         Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
         Err(e)    => return e,
@@ -724,12 +724,12 @@ function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
     if i < evl then { /* active elements */
       set_vstart(to_bits(16, i));
       if op == VLM then { /* load */
-        match vmem_read(rs1, to_bits(xlen, i), 1, false, false, false) {
+        match vmem_read(rs1, to_bits(xlen, i), 1, Read(Data), false, false, false) {
           Ok(elem) => write_single_element(8, i, vd_or_vs3, elem),
           Err(e)   => return e,
         }
       } else if op == VSM then { /* store */
-        match vmem_write(rs1, to_bits(xlen, i), 1, vd_or_vs3_val[i], false, false, false) {
+        match vmem_write(rs1, to_bits(xlen, i), 1, vd_or_vs3_val[i], Write(Data), false, false, false) {
           Ok(true)  => (),
           Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
           Err(e)    => return e,

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -87,20 +87,9 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
       set_vstart(to_bits(16, i));
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = (i * nf + j) * load_width_bytes;
-        match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
-          Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
-          Ext_DataAddr_OK(vaddr) =>
-              if check_misaligned(vaddr, width_type)
-              then return Memory_Exception(vaddr, E_Load_Addr_Align())
-              else match translateAddr(vaddr, Read(Data)) {
-                TR_Failure(e, _)     => return Memory_Exception(vaddr, e),
-                TR_Address(paddr, _) => {
-                  match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                    Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
-                    Err(e)   => return Memory_Exception(vaddr, e)
-                  }
-                }
-              }
+        match vmem_read(rs1, to_bits(xlen, elem_offset), load_width_bytes, false, false, false) {
+          Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
+          Err(e)   => return e,
         }
       }
     } else { /* prestart, masked or tail segments */
@@ -162,47 +151,14 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
       if mask[i] == bitone then { /* active segments */
         foreach (j from 0 to (nf - 1)) {
           let elem_offset = (i * nf + j) * load_width_bytes;
-          match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
-            Ext_DataAddr_Error(e)  => {
-              if i == 0 then return Ext_DataAddr_Check_Failure(e)
-              else {
-                vl = to_bits(xlen, i);
-                csr_write_callback("vl", vl);
-                trimmed = true
-              }
-            },
-            Ext_DataAddr_OK(vaddr) => {
-              if check_misaligned(vaddr, width_type) then {
-                if i == 0 then return Memory_Exception(vaddr, E_Load_Addr_Align())
-                else {
-                  vl = to_bits(xlen, i);
-                  csr_write_callback("vl", vl);
-                  trimmed = true
-                }
-              } else match translateAddr(vaddr, Read(Data)) {
-                TR_Failure(e, _)     => {
-                  if i == 0 then return Memory_Exception(vaddr, e)
-                  else {
-                    vl = to_bits(xlen, i);
-                    csr_write_callback("vl", vl);
-                    trimmed = true
-                  }
-                },
-                TR_Address(paddr, _) => {
-                  match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                    Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
-                    Err(e)   => {
-                      if i == 0 then return Memory_Exception(vaddr, e)
-                      else {
-                        vl = to_bits(xlen, i);
-                        csr_write_callback("vl", vl);
-                        trimmed = true
-                      }
-                    }
-                  }
-                }
-              }
-            }
+          match vmem_read(rs1, to_bits(xlen, elem_offset), load_width_bytes, false, false, false) {
+            Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
+            Err(e)   => if i == 0 then return e
+                        else {
+                          vl = to_bits(xlen, i);
+                          csr_write_callback("vl", vl);
+                          trimmed = true
+                        },
           }
         }
       } else { /* prestart, masked or tail segments */
@@ -271,27 +227,12 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
       set_vstart(to_bits(16, i));
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = (i * nf + j) * load_width_bytes;
-        match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), load_width_bytes) {
-          Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
-          Ext_DataAddr_OK(vaddr) =>
-            if check_misaligned(vaddr, width_type)
-            then return Memory_Exception(vaddr, E_SAMO_Addr_Align())
-            else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => return Memory_Exception(vaddr, e),
-              TR_Address(paddr, _) => {
-                match mem_write_ea(paddr, load_width_bytes, false, false, false) {
-                  Err(e) => return Memory_Exception(vaddr, e),
-                  Ok(_)  => {
-                    let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(5, j * EMUL_reg)));
-                    match mem_write_value(paddr, load_width_bytes, elem_val, false, false, false) {
-                      Ok(true)  => (),
-                      Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                      Err(e)    => return Memory_Exception(vaddr, e)
-                    }
-                  }
-                }
-              }
-            }
+        let vs = vregidx_offset(vs3, to_bits(5, j * EMUL_reg));
+        let data = read_single_element(load_width_bytes * 8, i, vs);
+        match vmem_write(rs1, to_bits(xlen, elem_offset), load_width_bytes, data, false, false, false) {
+          Ok(true)  => (),
+          Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
+          Err(e)    => return e,
         }
       }
     }
@@ -347,20 +288,9 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
       set_vstart(to_bits(16, i));
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = i * rs2_val + j * load_width_bytes;
-        match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
-          Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
-          Ext_DataAddr_OK(vaddr) =>
-            if check_misaligned(vaddr, width_type)
-            then return Memory_Exception(vaddr, E_Load_Addr_Align())
-            else match translateAddr(vaddr, Read(Data)) {
-              TR_Failure(e, _)     => return Memory_Exception(vaddr, e),
-              TR_Address(paddr, _) => {
-                match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                  Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
-                  Err(e)   => return Memory_Exception(vaddr, e)
-                }
-              }
-            }
+        match vmem_read(rs1, to_bits(xlen, elem_offset), load_width_bytes, false, false, false) {
+          Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
+          Err(e)   => return e,
         }
       }
     } else { /* prestart, masked or tail segments */
@@ -420,27 +350,12 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
       set_vstart(to_bits(16, i));
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = i * rs2_val + j * load_width_bytes;
-        match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), load_width_bytes) {
-          Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
-          Ext_DataAddr_OK(vaddr) =>
-            if check_misaligned(vaddr, width_type)
-            then return Memory_Exception(vaddr, E_SAMO_Addr_Align())
-            else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => return Memory_Exception(vaddr, e),
-              TR_Address(paddr, _) => {
-                match mem_write_ea(paddr, load_width_bytes, false, false, false) {
-                  Err(e) => return Memory_Exception(vaddr, e),
-                  Ok(_)  => {
-                    let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(5, j * EMUL_reg)));
-                    match mem_write_value(paddr, load_width_bytes, elem_val, false, false, false) {
-                      Ok(true)  => (),
-                      Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                      Err(e)    => return Memory_Exception(vaddr, e)
-                    }
-                  }
-                }
-              }
-            }
+        let vs = vregidx_offset(vs3, to_bits(5, j * EMUL_reg));
+        let data = read_single_element(load_width_bytes * 8, i, vs);
+        match vmem_write(rs1, to_bits(xlen, elem_offset), load_width_bytes, data, false, false, false) {
+          Ok(true)  => (),
+          Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
+          Err(e)    => return e,
         }
       }
     }
@@ -497,20 +412,9 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
       set_vstart(to_bits(16, i));
       foreach (j from 0 to (nf - 1)) {
         let elem_offset : int = unsigned(vs2_val[i]) + j * EEW_data_bytes;
-        match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), EEW_data_bytes) {
-          Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
-          Ext_DataAddr_OK(vaddr) =>
-            if check_misaligned(vaddr, width_type)
-            then return Memory_Exception(vaddr, E_Load_Addr_Align())
-            else match translateAddr(vaddr, Read(Data)) {
-              TR_Failure(e, _)     => return Memory_Exception(vaddr, e),
-              TR_Address(paddr, _) => {
-                match mem_read(Read(Data), paddr, EEW_data_bytes, false, false, false) {
-                  Ok(elem) => write_single_element(EEW_data_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_data_reg)), elem),
-                  Err(e)   => return Memory_Exception(vaddr, e)
-                }
-              }
-            }
+        match vmem_read(rs1, to_bits(xlen, elem_offset), EEW_data_bytes, false, false, false) {
+          Ok(elem) => write_single_element(EEW_data_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_data_reg)), elem),
+          Err(e)   => return e,
         }
       }
     } else { /* prestart, masked or tail segments */
@@ -600,27 +504,12 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
       set_vstart(to_bits(16, i));
       foreach (j from 0 to (nf - 1)) {
         let elem_offset : int = unsigned(vs2_val[i]) + j * EEW_data_bytes;
-        match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), EEW_data_bytes) {
-          Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
-          Ext_DataAddr_OK(vaddr) =>
-            if check_misaligned(vaddr, width_type)
-            then return Memory_Exception(vaddr, E_SAMO_Addr_Align())
-            else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => return Memory_Exception(vaddr, e),
-              TR_Address(paddr, _) => {
-                match mem_write_ea(paddr, EEW_data_bytes, false, false, false) {
-                  Err(e) => return Memory_Exception(vaddr, e),
-                  Ok(_)  => {
-                    let elem_val : bits('db * 8) = read_single_element(EEW_data_bytes * 8, i, vregidx_offset(vs3, to_bits(5, j * EMUL_data_reg)));
-                    match mem_write_value(paddr, EEW_data_bytes, elem_val, false, false, false) {
-                      Ok(true)  => (),
-                      Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                      Err(e)    => return Memory_Exception(vaddr, e)
-                    }
-                  }
-                }
-              }
-            }
+        let vs = vregidx_offset(vs3, to_bits(5, j * EMUL_data_reg));
+        let data = read_single_element(EEW_data_bytes * 8, i, vs);
+        match vmem_write(rs1, to_bits(xlen, elem_offset), EEW_data_bytes, data, false, false, false) {
+          Ok(true)  => (),
+          Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
+          Err(e)    => return e,
         }
       }
     }
@@ -702,20 +591,9 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
     foreach (i from elem_to_align to (elem_per_reg - 1)) {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
-      match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
-        Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
-        Ext_DataAddr_OK(vaddr) =>
-          if check_misaligned(vaddr, width_type)
-          then return Memory_Exception(vaddr, E_Load_Addr_Align())
-          else match translateAddr(vaddr, Read(Data)) {
-            TR_Failure(e, _)     => return Memory_Exception(vaddr, e),
-            TR_Address(paddr, _) => {
-              match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, cur_field)), elem),
-                Err(e)   => return Memory_Exception(vaddr, e)
-              }
-            }
-          }
+      match vmem_read(rs1, to_bits(xlen, elem_offset), load_width_bytes, false, false, false) {
+        Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, cur_field)), elem),
+        Err(e)   => return e,
       };
       cur_elem = cur_elem + 1
     };
@@ -726,20 +604,9 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
     foreach (i from 0 to (elem_per_reg - 1)) {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
-      match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
-        Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
-        Ext_DataAddr_OK(vaddr) =>
-          if check_misaligned(vaddr, width_type)
-          then return Memory_Exception(vaddr, E_Load_Addr_Align())
-          else match translateAddr(vaddr, Read(Data)) {
-            TR_Failure(e, _)     => return Memory_Exception(vaddr, e),
-            TR_Address(paddr, _) => {
-              match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j)), elem),
-                Err(e)   => return Memory_Exception(vaddr, e)
-              }
-            }
-          }
+      match vmem_read(rs1, to_bits(xlen, elem_offset), load_width_bytes, false, false, false) {
+        Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j)), elem),
+        Err(e)   => return e,
       };
       cur_elem = cur_elem + 1
     }
@@ -787,27 +654,12 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
     foreach (i from elem_to_align to (elem_per_reg - 1)) {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset : int = cur_elem * load_width_bytes;
-      match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), load_width_bytes) {
-        Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
-        Ext_DataAddr_OK(vaddr) =>
-          if check_misaligned(vaddr, width_type)
-          then return Memory_Exception(vaddr, E_SAMO_Addr_Align())
-          else match translateAddr(vaddr, Write(Data)) {
-            TR_Failure(e, _)     => return Memory_Exception(vaddr, e),
-            TR_Address(paddr, _) => {
-              match mem_write_ea(paddr, load_width_bytes, false, false, false) {
-                Err(e) => return Memory_Exception(vaddr, e),
-                Ok(_)  => {
-                  let elem : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(5, cur_field)));
-                  match mem_write_value(paddr, load_width_bytes, elem, false, false, false) {
-                    Ok(true)  => (),
-                    Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                    Err(e)    => return Memory_Exception(vaddr, e)
-                  }
-                }
-              }
-            }
-          }
+      let vs = vregidx_offset(vs3, to_bits(5, cur_field));
+      let data = read_single_element(load_width_bytes * 8, i, vs);
+      match vmem_write(rs1, to_bits(xlen, elem_offset), load_width_bytes, data, false, false, false) {
+        Ok(true)  => (),
+        Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
+        Err(e)    => return e,
       };
       cur_elem = cur_elem + 1
     };
@@ -819,26 +671,10 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
     foreach (i from 0 to (elem_per_reg - 1)) {
       set_vstart(to_bits(16, cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
-      match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), load_width_bytes) {
-        Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
-        Ext_DataAddr_OK(vaddr) =>
-          if check_misaligned(vaddr, width_type)
-          then return Memory_Exception(vaddr, E_SAMO_Addr_Align())
-          else match translateAddr(vaddr, Write(Data)) {
-            TR_Failure(e, _)     => return Memory_Exception(vaddr, e),
-            TR_Address(paddr, _) => {
-              match mem_write_ea(paddr, load_width_bytes, false, false, false) {
-                Err(e) => return Memory_Exception(vaddr, e),
-                Ok(_)  => {
-                  match mem_write_value(paddr, load_width_bytes, vs3_val[i], false, false, false) {
-                    Ok(true)  => (),
-                    Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                    Err(e)    => return Memory_Exception(vaddr, e)
-                  }
-                }
-              }
-            }
-          }
+      match vmem_write(rs1, to_bits(xlen, elem_offset), load_width_bytes, vs3_val[i], false, false, false) {
+        Ok(true)  => (),
+        Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
+        Err(e)    => return e,
       };
       cur_elem = cur_elem + 1
     }
@@ -888,42 +724,15 @@ function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
     if i < evl then { /* active elements */
       set_vstart(to_bits(16, i));
       if op == VLM then { /* load */
-        match ext_data_get_addr(rs1, to_bits(xlen, i), Read(Data), 1) {
-          Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
-          Ext_DataAddr_OK(vaddr) =>
-            if check_misaligned(vaddr, width_type)
-            then return Memory_Exception(vaddr, E_Load_Addr_Align())
-            else match translateAddr(vaddr, Read(Data)) {
-              TR_Failure(e, _)     => return Memory_Exception(vaddr, e),
-              TR_Address(paddr, _) => {
-                match mem_read(Read(Data), paddr, 1, false, false, false) {
-                  Ok(elem) => write_single_element(8, i, vd_or_vs3, elem),
-                  Err(e)   => return Memory_Exception(vaddr, e)
-                }
-              }
-            }
+        match vmem_read(rs1, to_bits(xlen, i), 1, false, false, false) {
+          Ok(elem) => write_single_element(8, i, vd_or_vs3, elem),
+          Err(e)   => return e,
         }
       } else if op == VSM then { /* store */
-        match ext_data_get_addr(rs1, to_bits(xlen, i), Write(Data), 1) {
-          Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
-          Ext_DataAddr_OK(vaddr) =>
-            if check_misaligned(vaddr, width_type)
-            then return Memory_Exception(vaddr, E_SAMO_Addr_Align())
-            else match translateAddr(vaddr, Write(Data)) {
-              TR_Failure(e, _)     => return Memory_Exception(vaddr, e),
-              TR_Address(paddr, _) => {
-                match mem_write_ea(paddr, 1, false, false, false) {
-                  Err(e) => return Memory_Exception(vaddr, e),
-                  Ok(_)  => {
-                    match mem_write_value(paddr, 1, vd_or_vs3_val[i], false, false, false) {
-                      Ok(true)  => (),
-                      Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                      Err(e)    => return Memory_Exception(vaddr, e)
-                    }
-                  }
-                }
-              }
-            }
+        match vmem_write(rs1, to_bits(xlen, i), 1, vd_or_vs3_val[i], false, false, false) {
+          Ok(true)  => (),
+          Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
+          Err(e)    => return e,
         }
       }
     } else { /* tail elements for mask load, always with agnostic policy */

--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -33,10 +33,27 @@
  * The internal implementation first performs a PMP check (if PMP is
  * enabled), and then dispatches to MMIO regions or physical memory as
  * per the platform memory map.
+ *
+ * A helper to check address alignment is also provided in the external API.
+ *
+ *   is_aligned_addr - checks for alignment of a physical or virtual address
  */
 
-function is_aligned_addr forall 'n. (Physaddr(addr) : physaddr, width : int('n)) -> bool =
+function is_aligned_paddr forall 'n. (Physaddr(addr) : physaddr, width : int('n)) -> bool =
   unsigned(addr) % width == 0
+
+function is_aligned_vaddr forall 'n. (Virtaddr(addr) : virtaddr, width : int('n)) -> bool =
+  unsigned(addr) % width == 0
+
+function is_aligned_bits(vaddr : xlenbits, width : word_width) -> bool =
+  match width {
+    BYTE   => true,
+    HALF   => vaddr[0..0] == zeros(),
+    WORD   => vaddr[1..0] == zeros(),
+    DOUBLE => vaddr[2..0] == zeros(),
+  }
+
+overload is_aligned_addr = {is_aligned_paddr, is_aligned_vaddr, is_aligned_bits}
 
 function read_kind_of_flags (aq : bool, rl : bool, res : bool) -> option(read_kind) =
   match (aq, rl, res) {

--- a/model/riscv_termination.sail
+++ b/model/riscv_termination.sail
@@ -93,6 +93,9 @@ function hartSupports_measure(ext : extension) -> int =
 
 termination_measure hartSupports(ext) = hartSupports_measure(ext)
 
+termination_measure vmem_write_addr repeat n
+termination_measure vmem_read repeat n
+
 $iftarget coq
 // The top-level loop isn't terminating, but we put a limit so that it can still be included in the Coq output
 termination_measure loop while 100

--- a/model/riscv_vmem_utils.sail
+++ b/model/riscv_vmem_utils.sail
@@ -9,15 +9,22 @@
 /* This file implements utility functions for accessing memory that
  * can be used by instruction definitions.
  *
+ * These memory accessors performs address translation and return a
+ * Retire_Failure on error.  In order to support RVWMO memory model,
+ * address and when possible data arguments are passed as their source
+ * registers.  The `vmem_read` read accessor uses Read(Data) accesses,
+ * while the `vmem_write_*` variants use Write(Data) accesses.
+ *
+ * All addresses are provided in integer source register arguments.
+ * For write accessors, there are functions for each kind of source
+ * data register type (integer, floating point, vector).
+ *
  * The external API of this module is:
  *
  *   check_misaligned - checks for the alignment of a virtual address given platform settings
  *
- *  These memory accessors take arguments specifying the registers containing the data and
- *  address values:
- *
- *   vmem_read -  performs address translation and retrieves data using Read(Data) accesses
- *   vmem_write - performs address translation and writes data using Write(Data) accesses
+ *   vmem_read        - reads data of the specified width
+ *   vmem_write       - writes a specified data payload
  */
 
 /* This is a external option that controls the order in which the model
@@ -105,7 +112,58 @@ function misaligned_order(n) = {
   }
 }
 
-/* External API */
+val vmem_write_addr : forall 'width, 'width in {1, 2, 4, 8} & ('width <= xlen_bytes | 'width <= flen_bytes).
+  (virtaddr, int('width), bits(8 * 'width), bool, bool, bool) -> result(bool, ExecutionResult)
+
+function vmem_write_addr(vaddr, width, data, aq, rl, res) = {
+  /* If the store is misaligned or an allowed misaligned access, split into `n`
+     (single-copy-atomic) memory operations, each of `bytes` width. If the store is
+     aligned, then `n` = 1 and bytes will remain unchanged. */
+  let ('n, 'bytes) = split_misaligned(vaddr, width);
+
+  let (first, last, step) = misaligned_order(n);
+  var i : range(0, 'n - 1) = first;
+  var finished : bool = false;
+
+  var write_success : bool = true;
+  let vaddr = bits_of(vaddr);
+  repeat {
+    let offset = i;
+    let vaddr = vaddr + (offset * bytes);
+    match translateAddr(Virtaddr(vaddr), Write(Data)) {
+      TR_Failure(e, _) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+
+      /* NOTE: Currently, we only announce the effective address if address translation is successful.
+         This may need revisiting, particularly in the misaligned case. */
+      TR_Address(paddr, _) => {
+        /* If res is true, the load should be aligned, and this loop should only execute once */
+        if res & not(match_reservation(bits_of(paddr))) then {
+          write_success = false
+        } else match mem_write_ea(paddr, bytes, aq, rl, res) {
+          Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+
+          Ok(()) => {
+            let write_value = data[(8 * (offset + 1) * bytes) - 1 .. 8 * offset * bytes];
+            match mem_write_value(paddr, bytes, write_value, aq, rl, res) {
+              Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+              Ok(s)  => write_success = write_success & s,
+            }
+          }
+        }
+      }
+    };
+
+    if offset == last then {
+      finished = true
+    } else {
+      i = offset + step
+    }
+  } until finished;
+
+  Ok(write_success)
+}
+
+/****    External API    ****/
 
 function check_misaligned(vaddr : virtaddr, width : word_width) -> bool = {
   if plat_enable_misaligned_access() then {
@@ -115,7 +173,7 @@ function check_misaligned(vaddr : virtaddr, width : word_width) -> bool = {
   }
 }
 
-val vmem_read : forall 'width, 'width in {1, 2, 4, 8} & 'width <= xlen_bytes.
+val vmem_read : forall 'width, 'width in {1, 2, 4, 8} & ('width <= xlen_bytes | 'width <= flen_bytes).
   (regidx, xlenbits, int('width), bool, bool, bool) -> result(bits(8 * 'width), ExecutionResult)
 
 function vmem_read(rs, offset, width, aq, rl, res) = {
@@ -179,71 +237,11 @@ function vmem_read(rs, offset, width, aq, rl, res) = {
   Ok(data)
 }
 
-val vmem_write_addr : forall 'width, 'width in {1, 2, 4, 8} & 'width <= xlen_bytes.
-  (virtaddr, int('width), bits(8 * 'width), bool, bool, bool) -> result(bool, ExecutionResult)
+val vmem_write : forall 'width, 'width in {1, 2, 4, 8} & ('width <= xlen_bytes | 'width <= flen_bytes).
+  (regidx, xlenbits, int('width), bits(8 * 'width), bool, bool, bool) -> result(bool, ExecutionResult)
 
-function vmem_write_addr(vaddr, width, data, aq, rl, res) = {
-  /* If the store is misaligned or an allowed misaligned access, split into `n`
-     (single-copy-atomic) memory operations, each of `bytes` width. If the store is
-     aligned, then `n` = 1 and bytes will remain unchanged. */
-  let ('n, 'bytes) = split_misaligned(vaddr, width);
-
-  let (first, last, step) = misaligned_order(n);
-  var i : range(0, 'n - 1) = first;
-  var finished : bool = false;
-
-  var write_success : bool = true;
-  let vaddr = bits_of(vaddr);
-  repeat {
-    let offset = i;
-    let vaddr = vaddr + (offset * bytes);
-    match translateAddr(Virtaddr(vaddr), Write(Data)) {
-      TR_Failure(e, _) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
-
-      /* NOTE: Currently, we only announce the effective address if address translation is successful.
-         This may need revisiting, particularly in the misaligned case. */
-      TR_Address(paddr, _) => {
-        /* If res is true, the load should be aligned, and this loop should only execute once */
-        if res & not(match_reservation(bits_of(paddr))) then {
-          write_success = false
-        } else match mem_write_ea(paddr, bytes, aq, rl, res) {
-          Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
-
-          Ok(()) => {
-            let write_value = data[(8 * (offset + 1) * bytes) - 1 .. 8 * offset * bytes];
-            match mem_write_value(paddr, bytes, write_value, aq, rl, res) {
-              Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
-              Ok(s)  => write_success = write_success & s,
-            }
-          }
-        }
-      }
-    };
-
-    if offset == last then {
-      finished = true
-    } else {
-      i = offset + step
-    }
-  } until finished;
-
-  Ok(write_success)
-}
-
-/* Currently this function takes the X register index as an argument.
- * It does this so the register access only occurs after the effective
- * address for the access has been announced. This is for the RVWMO
- * operational model.
- */
-// TODO: I think the above comment can be deleted according to
-// https://github.com/riscv/sail-riscv/issues/766#issuecomment-2698992551
-// I'm keeping it here for confirmation during code review.
-
-val vmem_write : forall 'width, 'width in {1, 2, 4, 8} & 'width <= xlen_bytes.
-  (regidx, xlenbits, int('width), regidx, bool, bool, bool) -> result(bool, ExecutionResult)
-
-function vmem_write(rs_addr, offset, width, rs_data, aq, rl, res) = {
-  /* Get the address, X(rs1) (no offset).
+function vmem_write(rs_addr, offset, width, data, aq, rl, res) = {
+  /* Get the address, X(rs_addr) (no offset).
    * Extensions might perform additional checks on address validity.
    */
   let vaddr : virtaddr = match ext_data_get_addr(rs_addr, offset, Write(Data), width) {
@@ -251,15 +249,8 @@ function vmem_write(rs_addr, offset, width, rs_data, aq, rl, res) = {
     Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
   };
 
-  if res then {
-    if not(is_aligned_addr(vaddr, width))
-    then return Err(Memory_Exception(vaddr, E_SAMO_Addr_Align()));
-  } else {
-    if   check_misaligned(vaddr, size_bytes(width))
-    then return Err(Memory_Exception(vaddr, E_SAMO_Addr_Align()));
-  };
-
-  let data = X(rs_data)[width * 8 - 1 .. 0];
+  if   check_misaligned(vaddr, size_bytes(width))
+  then return Err(Memory_Exception(vaddr, E_SAMO_Addr_Align()));
 
   vmem_write_addr(vaddr, width, data, aq, rl, res)
 }

--- a/model/riscv_vmem_utils.sail
+++ b/model/riscv_vmem_utils.sail
@@ -1,0 +1,265 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+/* This file implements utility functions for accessing memory that
+ * can be used by instruction definitions.
+ *
+ * The external API of this module is:
+ *
+ *   check_misaligned - checks for the alignment of a virtual address given platform settings
+ *
+ *  These memory accessors take arguments specifying the registers containing the data and
+ *  address values:
+ *
+ *   vmem_read -  performs address translation and retrieves data using Read(Data) accesses
+ *   vmem_write - performs address translation and writes data using Write(Data) accesses
+ */
+
+/* This is a external option that controls the order in which the model
+ * performs misaligned accesses.
+ */
+function sys_misaligned_order_decreasing() -> bool = config memory.misaligned.order_decreasing
+
+/* This is an external option that, when true, causes all misaligned accesses
+ * to be split into single byte operations.  Otherwise, misaligned accesses
+ * are split into multiple accesses of smaller widths such that each of the latter
+ * accesses is aligned.
+ */
+function sys_misaligned_byte_by_byte() -> bool = config memory.misaligned.byte_by_byte
+
+/* This is an external option that returns an integer N, such that
+ * when N is greater than zero, misaligned accesses to physical memory
+ * (as atomic events) are allowed provided the access occurs within a
+ * naturally aligned 2^N byte region.  This region must be smaller than
+ * the page size (i.e. 2^12 = 4096 bytes).
+ */
+function sys_misaligned_allowed_within_exp() -> range(0, 11) = config memory.misaligned.allowed_within_exp
+
+/* Check if an 'n byte access for an address is within an aligned 2^'r byte region */
+val access_within : forall 'width 'n 'r, 0 <= 'r <= 'width & 1 <= 'n <= 2^'r.
+  (bits('width), int('n), int('r)) -> bool
+function access_within(addr, bytes, region_width_exp) = {
+  let mask : bits('width) = ~(zero_extend(ones(region_width_exp)));
+  (addr & mask) == ((addr + (bytes - 1)) & mask)
+}
+
+/* This property demonstrates that when bytes == 2^region_width_exp, the access_within check above is
+ * equivalent to a regular alignment check (for a constrained set of inputs to help the SMT solver).
+ */
+$[property]
+function prop_access_within_is_aligned(addr : bits(32), region_width_exp : bits(4)) -> bool = {
+  let region_width_exp = unsigned(region_width_exp);
+  let bytes = 2 ^ region_width_exp;
+  access_within(addr, bytes, region_width_exp) == (unsigned(addr) % bytes == 0)
+}
+
+/* A 1-byte access is always within a 2^0 = 1-byte region. */
+$[property]
+function prop_access_within_single(addr : bits(32)) -> bool = {
+  access_within(addr, 1, 0)
+}
+
+val allowed_misaligned : forall 'width, 'width > 0. (xlenbits, int('width)) -> bool
+
+function allowed_misaligned(vaddr, width) = {
+  let region_width_exp = sys_misaligned_allowed_within_exp();
+  let region_width = 2 ^ region_width_exp;
+
+  if width > region_width then return false;
+
+  access_within(vaddr, width, region_width_exp)
+}
+
+val split_misaligned : forall 'width, 'width > 0.
+  (virtaddr, int('width)) -> {'n 'bytes, 'width == 'n * 'bytes & 'bytes > 0. (int('n), int('bytes))}
+
+function split_misaligned(vaddr, width) = {
+  let vaddr_bits = bits_of(vaddr);
+  if is_aligned_addr(vaddr, width) | allowed_misaligned(vaddr_bits, width) then (1, width)
+  else if sys_misaligned_byte_by_byte() then (width, 1)
+  else {
+    let bytes_per_access = 2 ^ count_trailing_zeros(vaddr_bits);
+    let num_accesses = width / bytes_per_access;
+    assert(width == num_accesses * bytes_per_access);
+    (num_accesses, bytes_per_access)
+  }
+}
+
+type valid_misaligned_order('n, 'first, 'last, 'step) -> Bool =
+    ('first == 0 & 'last == 'n - 1 & 'step == 1)
+  | ('first == 'n - 1 & 'last == 0 & 'step == -1)
+
+val misaligned_order : forall 'n.
+  int('n) -> {'first 'last 'step, valid_misaligned_order('n, 'first, 'last, 'step). (int('first), int('last), int('step))}
+
+function misaligned_order(n) = {
+  if sys_misaligned_order_decreasing() then {
+    (n - 1, 0, -1)
+  } else {
+    (0, n - 1, 1)
+  }
+}
+
+/* External API */
+
+function check_misaligned(vaddr : virtaddr, width : word_width) -> bool = {
+  if plat_enable_misaligned_access() then {
+    false
+  } else {
+    not(is_aligned_addr(vaddr, size_bytes(width)))
+  }
+}
+
+val vmem_read : forall 'width, 'width in {1, 2, 4, 8} & 'width <= xlen_bytes.
+  (regidx, xlenbits, int('width), bool, bool, bool) -> result(bits(8 * 'width), ExecutionResult)
+
+function vmem_read(rs, offset, width, aq, rl, res) = {
+  /* Get the address, X(rs1) + offset.
+   * Some extensions perform additional checks on address validity.
+   */
+  let vaddr : virtaddr = match ext_data_get_addr(rs, offset, Read(Data), width) {
+    Ext_DataAddr_OK(vaddr) => vaddr,
+    Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
+  };
+
+  // TODO: Rationalize to use a single alignment definition if possible.
+  if res then {
+    /* "LR faults like a normal load, even though it's in the AMO major opcode space."
+     * - Andrew Waterman, isa-dev, 10 Jul 2018.
+     */
+    if   not(is_aligned_addr(vaddr, width))
+    then return Err(Memory_Exception(vaddr, E_Load_Addr_Align()));
+  } else {
+    if check_misaligned(vaddr, size_bytes(width))
+    then return Err(Memory_Exception(vaddr, E_Load_Addr_Align()));
+  };
+
+  /* If the load is misaligned or an allowed misaligned access, split into `n`
+     (single-copy-atomic) memory operations, each of `bytes` width. If the load is
+     aligned, then `n` = 1 and bytes will remain unchanged. */
+  let ('n, 'bytes) = split_misaligned(vaddr, width);
+  var data = zeros(8 * n * bytes);
+
+  let (first, last, step) = misaligned_order(n);
+  var i : range(0, 'n - 1) = first;
+  var finished : bool = false;
+
+  let vaddr = bits_of(vaddr);
+  repeat {
+    let offset = i;
+    let vaddr = vaddr + (offset * bytes);
+    match translateAddr(Virtaddr(vaddr), Read(Data)) {
+      TR_Failure(e, _) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+
+      TR_Address(paddr, _) => match mem_read(Read(Data), paddr, bytes, aq, rl, res) {
+        Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+
+        Ok(v) => {
+          if res then {
+            load_reservation(bits_of(paddr))
+          };
+
+          data[(8 * (offset + 1) * bytes) - 1 .. 8 * offset * bytes] = v
+        },
+      }
+    };
+
+    if offset == last then {
+      finished = true
+    } else {
+      i = offset + step
+    }
+  } until finished;
+
+  Ok(data)
+}
+
+val vmem_write_addr : forall 'width, 'width in {1, 2, 4, 8} & 'width <= xlen_bytes.
+  (virtaddr, int('width), bits(8 * 'width), bool, bool, bool) -> result(bool, ExecutionResult)
+
+function vmem_write_addr(vaddr, width, data, aq, rl, res) = {
+  /* If the store is misaligned or an allowed misaligned access, split into `n`
+     (single-copy-atomic) memory operations, each of `bytes` width. If the store is
+     aligned, then `n` = 1 and bytes will remain unchanged. */
+  let ('n, 'bytes) = split_misaligned(vaddr, width);
+
+  let (first, last, step) = misaligned_order(n);
+  var i : range(0, 'n - 1) = first;
+  var finished : bool = false;
+
+  var write_success : bool = true;
+  let vaddr = bits_of(vaddr);
+  repeat {
+    let offset = i;
+    let vaddr = vaddr + (offset * bytes);
+    match translateAddr(Virtaddr(vaddr), Write(Data)) {
+      TR_Failure(e, _) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+
+      /* NOTE: Currently, we only announce the effective address if address translation is successful.
+         This may need revisiting, particularly in the misaligned case. */
+      TR_Address(paddr, _) => {
+        /* If res is true, the load should be aligned, and this loop should only execute once */
+        if res & not(match_reservation(bits_of(paddr))) then {
+          write_success = false
+        } else match mem_write_ea(paddr, bytes, aq, rl, res) {
+          Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+
+          Ok(()) => {
+            let write_value = data[(8 * (offset + 1) * bytes) - 1 .. 8 * offset * bytes];
+            match mem_write_value(paddr, bytes, write_value, aq, rl, res) {
+              Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+              Ok(s)  => write_success = write_success & s,
+            }
+          }
+        }
+      }
+    };
+
+    if offset == last then {
+      finished = true
+    } else {
+      i = offset + step
+    }
+  } until finished;
+
+  Ok(write_success)
+}
+
+/* Currently this function takes the X register index as an argument.
+ * It does this so the register access only occurs after the effective
+ * address for the access has been announced. This is for the RVWMO
+ * operational model.
+ */
+// TODO: I think the above comment can be deleted according to
+// https://github.com/riscv/sail-riscv/issues/766#issuecomment-2698992551
+// I'm keeping it here for confirmation during code review.
+
+val vmem_write : forall 'width, 'width in {1, 2, 4, 8} & 'width <= xlen_bytes.
+  (regidx, xlenbits, int('width), regidx, bool, bool, bool) -> result(bool, ExecutionResult)
+
+function vmem_write(rs_addr, offset, width, rs_data, aq, rl, res) = {
+  /* Get the address, X(rs1) (no offset).
+   * Extensions might perform additional checks on address validity.
+   */
+  let vaddr : virtaddr = match ext_data_get_addr(rs_addr, offset, Write(Data), width) {
+    Ext_DataAddr_OK(vaddr) => vaddr,
+    Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
+  };
+
+  if res then {
+    if not(is_aligned_addr(vaddr, width))
+    then return Err(Memory_Exception(vaddr, E_SAMO_Addr_Align()));
+  } else {
+    if   check_misaligned(vaddr, size_bytes(width))
+    then return Err(Memory_Exception(vaddr, E_SAMO_Addr_Align()));
+  };
+
+  let data = X(rs_data)[width * 8 - 1 .. 0];
+
+  vmem_write_addr(vaddr, width, data, aq, rl, res)
+}

--- a/model/riscv_vmem_utils.sail
+++ b/model/riscv_vmem_utils.sail
@@ -12,8 +12,7 @@
  * These memory accessors performs address translation and return a
  * Retire_Failure on error.  In order to support RVWMO memory model,
  * address and when possible data arguments are passed as their source
- * registers.  The `vmem_read` read accessor uses Read(Data) accesses,
- * while the `vmem_write_*` variants use Write(Data) accesses.
+ * registers.
  *
  * All addresses are provided in integer source register arguments.
  * For write accessors, there are functions for each kind of source
@@ -113,9 +112,10 @@ function misaligned_order(n) = {
 }
 
 val vmem_write_addr : forall 'width, 'width in {1, 2, 4, 8} & ('width <= xlen_bytes | 'width <= flen_bytes).
-  (virtaddr, int('width), bits(8 * 'width), bool, bool, bool) -> result(bool, ExecutionResult)
+  (virtaddr, int('width), bits(8 * 'width), AccessType(ext_access_type), bool, bool, bool)
+  -> result(bool, ExecutionResult)
 
-function vmem_write_addr(vaddr, width, data, aq, rl, res) = {
+function vmem_write_addr(vaddr, width, data, acc, aq, rl, res) = {
   /* If the store is misaligned or an allowed misaligned access, split into `n`
      (single-copy-atomic) memory operations, each of `bytes` width. If the store is
      aligned, then `n` = 1 and bytes will remain unchanged. */
@@ -130,7 +130,7 @@ function vmem_write_addr(vaddr, width, data, aq, rl, res) = {
   repeat {
     let offset = i;
     let vaddr = vaddr + (offset * bytes);
-    match translateAddr(Virtaddr(vaddr), Write(Data)) {
+    match translateAddr(Virtaddr(vaddr), acc) {
       TR_Failure(e, _) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
 
       /* NOTE: Currently, we only announce the effective address if address translation is successful.
@@ -174,13 +174,14 @@ function check_misaligned(vaddr : virtaddr, width : word_width) -> bool = {
 }
 
 val vmem_read : forall 'width, 'width in {1, 2, 4, 8} & ('width <= xlen_bytes | 'width <= flen_bytes).
-  (regidx, xlenbits, int('width), bool, bool, bool) -> result(bits(8 * 'width), ExecutionResult)
+  (regidx, xlenbits, int('width), AccessType(ext_access_type), bool, bool, bool)
+  -> result(bits(8 * 'width), ExecutionResult)
 
-function vmem_read(rs, offset, width, aq, rl, res) = {
+function vmem_read(rs, offset, width, acc, aq, rl, res) = {
   /* Get the address, X(rs1) + offset.
    * Some extensions perform additional checks on address validity.
    */
-  let vaddr : virtaddr = match ext_data_get_addr(rs, offset, Read(Data), width) {
+  let vaddr : virtaddr = match ext_data_get_addr(rs, offset, acc, width) {
     Ext_DataAddr_OK(vaddr) => vaddr,
     Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
   };
@@ -211,10 +212,10 @@ function vmem_read(rs, offset, width, aq, rl, res) = {
   repeat {
     let offset = i;
     let vaddr = vaddr + (offset * bytes);
-    match translateAddr(Virtaddr(vaddr), Read(Data)) {
+    match translateAddr(Virtaddr(vaddr), acc) {
       TR_Failure(e, _) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
 
-      TR_Address(paddr, _) => match mem_read(Read(Data), paddr, bytes, aq, rl, res) {
+      TR_Address(paddr, _) => match mem_read(acc, paddr, bytes, aq, rl, res) {
         Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
 
         Ok(v) => {
@@ -238,13 +239,14 @@ function vmem_read(rs, offset, width, aq, rl, res) = {
 }
 
 val vmem_write : forall 'width, 'width in {1, 2, 4, 8} & ('width <= xlen_bytes | 'width <= flen_bytes).
-  (regidx, xlenbits, int('width), bits(8 * 'width), bool, bool, bool) -> result(bool, ExecutionResult)
+  (regidx, xlenbits, int('width), bits(8 * 'width), AccessType(ext_access_type), bool, bool, bool)
+  -> result(bool, ExecutionResult)
 
-function vmem_write(rs_addr, offset, width, data, aq, rl, res) = {
+function vmem_write(rs_addr, offset, width, data, acc, aq, rl, res) = {
   /* Get the address, X(rs_addr) (no offset).
    * Extensions might perform additional checks on address validity.
    */
-  let vaddr : virtaddr = match ext_data_get_addr(rs_addr, offset, Write(Data), width) {
+  let vaddr : virtaddr = match ext_data_get_addr(rs_addr, offset, acc, width) {
     Ext_DataAddr_OK(vaddr) => vaddr,
     Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
   };
@@ -252,5 +254,5 @@ function vmem_write(rs_addr, offset, width, data, aq, rl, res) = {
   if   check_misaligned(vaddr, size_bytes(width))
   then return Err(Memory_Exception(vaddr, E_SAMO_Addr_Align()));
 
-  vmem_write_addr(vaddr, width, data, aq, rl, res)
+  vmem_write_addr(vaddr, width, data, acc, aq, rl, res)
 }


### PR DESCRIPTION
Refactor the LOAD and STORE instruction so they split misaligned
accesses into multiple sub-accesses and perform address translation
separately. This means we should handle the case where a misaligned
access straddles a page boundary in a sensible way, even if we don't
yet cover the full range of possibilities allowed for any RISC-V
implementation.

There are options for the order in which misaligned happen, i.e. from
high-to-low or from low-to-high as well as the granularity of the splitting,
either all the way to bytes or to the largest aligned size. The splitting
can also be disabled if an implementation supports misaligned accesses in hardware.

In addition tidy up the implementation in a few ways:

- Very long lines on the LOAD encdec were fixed by adding a helper

- Add some linebreaks in the code so it reads as less claustrophobic

- Ensure we use the same names for arguments in encdec/execute/assembly.
  Previously we used 'size' and 'width'. I opted for 'width' consistently.

Co-authored-by: Alasdair Armstrong <alasdair.armstrong@cl.cam.ac.uk>