### PR TITLE
Update Rocq termination information and add CI

### DIFF
--- a/.github/workflows/rocq.yml
+++ b/.github/workflows/rocq.yml
@@ -8,7 +8,7 @@ jobs:
     env:
       OPAMROOT: /home/rocq/.opam
     container:
-      image: rocq/rocq-prover:9.0
+      image: rocq/rocq-prover:9.0.0
       # github requires root to access some resources from outside the container
       # (e.g. https://github.com/actions/checkout/issues/47)
       options: --user root
@@ -19,7 +19,7 @@ jobs:
         apt install -y --no-install-recommends cmake
         eval `opam env --safe`
         # We're still using Rocq's old name for compatibility with versions < 9
-        opam install -y coq coq-sail-stdpp
+        opam install -y coq=9.0.0 coq-sail-stdpp=0.19
 
     - name: Install sail from binary
       run: |

--- a/.github/workflows/rocq.yml
+++ b/.github/workflows/rocq.yml
@@ -1,0 +1,39 @@
+name: Rocq
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      OPAMROOT: /home/rocq/.opam
+    container:
+      image: rocq/rocq-prover:9.0
+      # github requires root to access some resources from outside the container
+      # (e.g. https://github.com/actions/checkout/issues/47)
+      options: --user root
+    steps:
+    - name: Install packages
+      run: |
+        apt update
+        apt install -y --no-install-recommends cmake
+        eval `opam env --safe`
+        # We're still using Rocq's old name for compatibility with versions < 9
+        opam install -y coq coq-sail-stdpp
+
+    - name: Install sail from binary
+      run: |
+        curl --location https://github.com/rems-project/sail/releases/download/0.19-linux-binary/sail.tar.gz | tar xvz --directory=/usr/local --strip-components=1
+
+    - name: Check out repository code
+      uses: actions/checkout@v4
+
+    - name: Generate Rocq model
+      run: |
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDOWNLOAD_GMP=FALSE
+        cmake --build build --target generated_rocq_rv64d
+
+    - name: Compile Rocq output
+      run: |
+        eval `opam env --safe`
+        cmake --build build --target build_rocq_rv64d

--- a/model/riscv_termination.sail
+++ b/model/riscv_termination.sail
@@ -91,5 +91,7 @@ function hartSupports_measure(ext : extension) -> int =
 
 termination_measure hartSupports(ext) = hartSupports_measure(ext)
 
+$iftarget coq
 // The top-level loop isn't terminating, but we put a limit so that it can still be included in the Coq output
 termination_measure loop while 100
+$endif

--- a/model/riscv_termination.sail
+++ b/model/riscv_termination.sail
@@ -16,6 +16,7 @@ function compressed_measure(instr) =
     C_SD (uimm,rsc1,rsc2) => 1,
     C_ADDI (nzi,rsd) => 1,
     C_JAL (imm) => 1,
+    C_ADDIW (imm,rsd) => 1,
     C_LI (imm,rd) => 1,
     C_ADDI16SP (imm) => 1,
     C_LUI (imm,rd) => 1,
@@ -41,6 +42,14 @@ function compressed_measure(instr) =
     C_MV (rd,rs2) => 1,
     C_EBREAK (tt) => 1,
     C_ADD (rsd,rs2) => 1,
+    C_FLDSP(uimm, rd) => 1,
+    C_FSDSP(uimm, rs2) => 1,
+    C_FLD(uimm, rsc, rdc) => 1,
+    C_FSD(uimm, rsc1, rsc2) => 1,
+    C_FLWSP(imm, rd) => 1,
+    C_FSWSP(uimm, rs2) => 1,
+    C_FLW(uimm, rsc, rdc) => 1,
+    C_FSW(uimm, rsc1, rsc2) => 1,
     _ => 0
   }
 termination_measure execute(i) = compressed_measure(i)
@@ -49,16 +58,38 @@ termination_measure pt_walk(_,_,_,_,_,_,_,level,_, _) = level
 function currentlyEnabled_measure(ext : extension) -> int =
   match ext {
     Ext_Zca => 1, // Ext_C
-    Ext_Zfhmin => 1, // Ext_Zfh
     Ext_Zba => 1, // Ext_B
     Ext_Zbb => 1, // Ext_B
     Ext_Zbs => 1, // Ext_B
     Ext_Zcb => 2, // Ext_Zca
     Ext_Zcd => 2, // Ext_Zca, (Ext_D)
     Ext_Zcf => 2, // Ext_Zca, (Ext_F)
+    Ext_Zabha => 2, // Ext_Zaamo
+    Ext_Zalrsc => 1, // Ext_A
+    Ext_Zaamo => 1, // Ext_A
+    Ext_Zfh => 1, // Ext_F
+    Ext_Zfhmin => 2, // Ext_F, Ext_Zfh
+    Ext_Zmmul => 1, // Ext_M
+    Ext_Zcmop => 2, // Ext_Zca
+    Ext_Zfa => 1, // Ext_F
+    Ext_Zhinx => 1, // Ext_Zfinx
+    Ext_Zvbb => 1, // Ext_V
+    Ext_Zvkb => 2, // Ext_Zvbb, Ext_V
+    Ext_Zvbc => 1, // Ext_V
+    Ext_Smcntrpmf => 1, // Ext_Zicntr
+    Ext_Sscofpmf => 2, // Ext_Zihpm
+    Ext_Zihpm => 1, // Ext_Zicntr
     _ => 0
   }
 termination_measure currentlyEnabled(ext) = currentlyEnabled_measure(ext)
+
+function hartSupports_measure(ext : extension) -> int =
+  match ext {
+    Ext_C => 1,
+    _ => 0,
+  }
+
+termination_measure hartSupports(ext) = hartSupports_measure(ext)
 
 // The top-level loop isn't terminating, but we put a limit so that it can still be included in the Coq output
 termination_measure loop while 100


### PR DESCRIPTION
The termination measures should be fine (although I wish I had a nice way to generate most of these...)

The CI is based on a standard Rocq Docker image and uses the Sail release binary like the main CI job.  I suppose it could be made a job within the main workflow, but I think a separate workflow is better because it can be easily disabled if it causes trouble.