### PR TITLE
Add termination measures to the Lean backend

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -201,7 +201,7 @@ foreach (xlen IN ITEMS 32 64)
                 "riscv_step.sail"
             )
 
-            if (variant STREQUAL "rocq")
+            if (variant STREQUAL "rocq" OR variant STREQUAL "lean")
                 list(APPEND sail_step_srcs
                     "riscv_termination.sail"
                 )


### PR DESCRIPTION
This commit enables the use of termination measures by the Lean backend.
