### PR TITLE
Add basic static PMA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ For booting operating system images, see the information under the
 - Svinval extension for fine-grained address-translation cache invalidation, v1.0
 - Svrsw60t59b extension for PTE reserved-for-software bits 60-59, v1.0
 - Physical Memory Protection (PMP)
+- Static memory regions with some static PMAs (Physical Memory Attributes)
 
 <!-- Uncomment the following section when unratified extensions are added
 The following unratified extensions are supported and can be enabled using the `--enable-experimental-extensions` flag:

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -280,16 +280,7 @@ uint64_t load_sail(const std::string &filename, bool main_file)
 
 void write_dtb_to_rom(const std::vector<uint8_t> &dtb)
 {
-  uint64_t rom_base = get_config_uint64({"platform", "rom", "base"});
-  uint64_t rom_size = get_config_uint64({"platform", "rom", "size"});
-
-  uint64_t addr = rom_base;
-
-  if (dtb.size() > rom_size) {
-    throw std::runtime_error("DTB (" + std::to_string(dtb.size())
-                             + " bytes) does not fit in platform.rom.size ("
-                             + std::to_string(rom_size) + " bytes).");
-  }
+  uint64_t addr = get_config_uint64({"memory", "dtb_address"});
 
   for (uint8_t d : dtb) {
     write_mem(addr++, d);

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -27,6 +27,9 @@
       "na4_supported": true,
       "napot_supported": true
     },
+    // This controls global support for misaligned access so it is
+    // checked before address translation. "misaligned_fault" in
+    // "regions" is checked after address translation.
     "misaligned": {
       "supported": true,
       "byte_by_byte": false,
@@ -35,7 +38,86 @@
     },
     "translation": {
       "dirty_update": false
-    }
+    },
+    // Address to write DTB to (if provided).
+    "dtb_address": {
+      "len": 64,
+      "value": "0x1000"
+    },
+    "regions": [
+      // ROM
+      {
+        "base": {
+          "len": 64,
+          "value": "0x1000"
+        },
+        "size": {
+          "len": 64,
+          "value": "0x1000"
+        },
+        "attributes": {
+          "cacheable": true,
+          "coherent": true,
+          "executable": false,
+          "readable": true,
+          "writable": false,
+          "read_idempotent": true,
+          "write_idempotent": true,
+          "misaligned_fault": "NoFault",
+          "reservability": "RsrvNone",
+          "supports_cbo_zero": false
+        },
+        "include_in_device_tree": false
+      },
+      // MMIO
+      {
+        "base": {
+          "len": 64,
+          "value": "0x2000000"
+        },
+        "size": {
+          "len": 64,
+          "value": "0x2000000"
+        },
+        "attributes": {
+          "cacheable": false,
+          "coherent": true,
+          "executable": false,
+          "readable": true,
+          "writable": true,
+          "read_idempotent": false,
+          "write_idempotent": false,
+          "misaligned_fault": "AlignmentFault",
+          "reservability": "RsrvNone",
+          "supports_cbo_zero": false
+        },
+        "include_in_device_tree": false
+      },
+      // RAM
+      {
+        "base": {
+          "len": 64,
+          "value": "0x80000000"
+        },
+        "size": {
+          "len": 64,
+          "value": "0x80000000"
+        },
+        "attributes": {
+          "cacheable": true,
+          "coherent": true,
+          "executable": true,
+          "readable": true,
+          "writable": true,
+          "read_idempotent": true,
+          "write_idempotent": true,
+          "misaligned_fault": "NoFault",
+          "reservability": "RsrvEventual",
+          "supports_cbo_zero": true
+        },
+        "include_in_device_tree": true
+      }
+    ]
   },
   "platform": {
     "vendorid": 0,
@@ -43,15 +125,8 @@
     "impid": 0,
     "hartid": 0,
     "cache_block_size_exp": 6,
-    "ram": {
-      "base": 2147483648,
-      "size": 2147483648
-    },
-    "rom": {
-      "base": 4096,
-      "size": 4096
-    },
     "clint": {
+      // This must be in a suitable memory region (see memory.regions).
       "base": 33554432,
       "size": 786432
     },

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -36,6 +36,9 @@
 
 - Linux boot is now tested in CI.
 
+- Support for specifying arbitrary memory regions and some basic
+  static PMAs (Physical Memory Attributes) has been added.
+
 # Release notes for the 0.8 release
 
 This is a major release with some backwards-incompatible changes.

--- a/model/core/prelude.sail
+++ b/model/core/prelude.sail
@@ -160,6 +160,10 @@ function operator >_u  (x, y) = unsigned(x) > unsigned(y)
 function operator <=_u (x, y) = unsigned(x) <= unsigned(y)
 function operator >=_u (x, y) = unsigned(x) >= unsigned(y)
 
+// Implication. This has the lowest precedence.
+infix 1 ==>
+function operator ==> (x : bool, y : bool) -> bool = not(x) | y
+
 infix 7 >>
 infix 7 <<
 

--- a/model/core/range_util.sail
+++ b/model/core/range_util.sail
@@ -1,0 +1,53 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// Return true if the right-open range `a` is a subset of `b` (or equal to it).
+// Ranges wrap around the end. The 64 bit limit is just so Sail generates more
+// efficient C code.
+function range_subset forall 'n, 0 <= 'n <= 64 . (
+  a_begin : bits('n),
+  a_size  : bits('n),
+  b_begin : bits('n),
+  b_size  : bits('n),
+) -> bool = {
+  // Rotate so that be starts at 0.
+  let a_end = (a_begin + a_size) - b_begin;
+  let b_end = (b_begin + b_size) - b_begin;
+  let a_begin = a_begin - b_begin;
+  a_begin <=_u b_end & a_end <=_u b_end & a_begin <=_u a_end
+}
+
+$[test]
+function test_range_subset() -> unit = {
+  assert(range_subset(0x0, 0x0, 0x0, 0x0));
+  assert(range_subset(0x1, 0x0, 0x1, 0x0));
+  assert(range_subset(0x0, 0x0, 0x0, 0x1));
+  assert(range_subset(0x1, 0x0, 0x0, 0x1));
+  assert(range_subset(0x8, 0xc, 0x8, 0xc));
+  assert(not(range_subset(0x8, 0xc, 0x9, 0xc)));
+  assert(not(range_subset(0x8, 0xc, 0x8, 0xb)));
+  assert(not(range_subset(0x3e, 0xe0, 0xc1, 0x9f)));
+  assert(not(range_subset(0xc1, 0x9f, 0x3e, 0xe0)));
+}
+
+// Check if two ranges are subsets of each other they must be equal.
+$[property]
+function range_subset_equals(a_begin : bits(8), a_size : bits(8), b_begin : bits(8), b_size : bits(8)) -> bool =
+  range_subset(a_begin, a_size, b_begin, b_size) & range_subset(b_begin, b_size, a_begin, a_size)
+    ==> (a_begin == b_begin & a_size == b_size)
+
+// Check that if A is a subset of B, then all indices in A must be in B.
+// Also check that an index exists that is in A but not B then A cannot be a subset of B.
+$[property]
+function range_subset_precise(a_begin : bits(8), a_size : bits(8), b_begin : bits(8), b_size : bits(8), index : bits(8)) -> bool = {
+  let index_in_a = (index - a_begin) <_u a_size;
+  let index_in_b = (index - b_begin) <_u b_size;
+  let is_subset = range_subset(a_begin, a_size, b_begin, b_size);
+
+  (is_subset & index_in_a ==> index_in_b) & ((index_in_a & not(index_in_b)) ==> not(is_subset))
+}

--- a/model/extensions/Zicbom/zicbom_insts.sail
+++ b/model/extensions/Zicbom/zicbom_insts.sail
@@ -98,8 +98,8 @@ function process_clean_inval(rs1, cbop) = {
           // the proper Cache access type when it is available. See
           // https://github.com/riscv/sail-riscv/pull/792
           let ep = effectivePrivilege(Read(Data), mstatus, cur_privilege);
-          let exc_read = phys_access_check(Read(Data), ep, paddr, cache_block_size);
-          let exc_write = phys_access_check(Write(Data), ep, paddr, cache_block_size);
+          let exc_read = phys_access_check(Read(Data), ep, paddr, cache_block_size, false);
+          let exc_write = phys_access_check(Write(Data), ep, paddr, cache_block_size, false);
           match (exc_read, exc_write) {
             // Access is permitted if read OR write are allowed. If neither
             // are allowed then we always report a store exception.

--- a/model/postlude/device_tree.sail
+++ b/model/postlude/device_tree.sail
@@ -99,12 +99,29 @@ function generate_isa_string(fmt : ISA_Format) -> string = {
 
 // Generates the full Device-Tree configuration for the model.
 
+function generate_dts_memories(pmas : list(PMA_Region)) -> string =
+  match pmas {
+    [||] => "",
+    pma :: rest => {
+      if pma.include_in_device_tree then {
+        let base_hi = unsigned(pma.base >> 32);
+        let base_lo = unsigned(pma.base[31 .. 0]);
+        let size_hi = unsigned(pma.size >> 32);
+        let size_lo = unsigned(pma.size[31 .. 0]);
+
+          "  memory@" ^ string_drop(hex_str(unsigned(pma.base)), 2) ^ " {\n"
+        ^ "    device_type = \"memory\";\n"
+        ^ "    reg = <" ^ hex_str(base_hi) ^ " " ^ hex_str(base_lo)
+        ^ " " ^ hex_str(size_hi) ^ " " ^ hex_str(size_lo) ^ ">;\n"
+        ^ "  };\n"
+        ^ generate_dts_memories(rest)
+      } else generate_dts_memories(rest)
+    }
+  }
+
 function generate_dts() -> string = {
   let clock_freq : nat = config platform.clock_frequency;
-  let ram_base_hi = unsigned(plat_ram_base >> 32);
-  let ram_base_lo = unsigned(plat_ram_base[31 .. 0]);
-  let ram_size_hi = unsigned(plat_ram_size >> 32);
-  let ram_size_lo = unsigned(plat_ram_size[31 .. 0]);
+
   let clint_base_hi = unsigned(plat_clint_base >> 32);
   let clint_base_lo = unsigned(plat_clint_base[31 .. 0]);
   let clint_size_hi = unsigned(plat_clint_size >> 32);
@@ -148,11 +165,8 @@ function generate_dts() -> string = {
 ^ "      };\n"
 ^ "    };\n"
 ^ "  };\n"
-^ "  memory@" ^ string_drop(hex_str(unsigned(plat_ram_base)), 2) ^ " {\n"
-^ "    device_type = \"memory\";\n"
-^ "    reg = <" ^ hex_str(ram_base_hi) ^ " " ^ hex_str(ram_base_lo)
-^ " " ^ hex_str(ram_size_hi) ^ " " ^ hex_str(ram_size_lo) ^ ">;\n"
-^ "  };\n"
+^ generate_dts_memories(pma_regions)
+
 ^ "  soc {\n"
 ^ "    #address-cells = <2>;\n"
 ^ "    #size-cells = <2>;\n"

--- a/model/postlude/model.sail
+++ b/model/postlude/model.sail
@@ -36,5 +36,5 @@ function init_model(config_filename : string) -> unit = {
 // See https://github.com/torvalds/linux/blob/master/Documentation/arch/riscv/boot.rst
 function init_boot_requirements() -> unit = {
   X(Regno(10)) = mhartid;
-  X(Regno(11)) = to_bits_checked(config platform.rom.base : int);
+  X(Regno(11)) = trunc(config memory.dtb_address : bits(64));
 }

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -177,39 +177,27 @@ function check_vext_config() -> bool = {
   valid;
 }
 
-function has_overlap(a_lo : nat, a_hi : nat, b_lo : nat, b_hi : nat) -> bool = {
-  not((a_lo < b_lo & a_hi < b_lo) | (b_lo < a_lo & b_hi < a_lo))
-}
+// Return true if a list of PMA regions are sorted and don't overlap.
+function check_pma_regions(pmas : list(PMA_Region), prev_base : bits(64), prev_size : bits(64)) -> bool =
+  match pmas {
+    [||] => true,
+    pma :: rest => {
+      if pma.base <_u prev_base + prev_size then {
+        print_endline("Memory region starting at " ^ bits_str(pma.base) ^
+                      " is not above the end of the previous region starting at " ^
+                      bits_str(prev_base) ^ " and ending at " ^ bits_str(prev_base + prev_size) ^ ".");
+        return false;
+      };
+      check_pma_regions(rest, pma.base, pma.size)
+    },
+  }
 
-// This will change when we have a more general memory layout.
-function check_mem_layout() -> bool = {
-  var valid : bool = true;
-  // Memory regions should not overlap. There are currently only three: ram, rom and clint.
-  let ram_lo = unsigned(plat_ram_base);
-  let ram_hi = unsigned(plat_ram_base) + unsigned(plat_ram_size);
-  let rom_lo = unsigned(plat_rom_base);
-  let rom_hi = unsigned(plat_rom_base) + unsigned(plat_rom_size);
-  let clint_lo = unsigned(plat_clint_base);
-  let clint_hi = unsigned(plat_clint_base) + unsigned(plat_clint_size);
-  if has_overlap(rom_lo, rom_hi, ram_lo, ram_hi)
-  then {
-    valid = false;
-    print_endline("The RAM and ROM regions overlap.");
-  };
-  if has_overlap(clint_lo, clint_hi, rom_lo, rom_hi)
-  then {
-    valid = false;
-    print_endline("The Clint and ROM regions overlap.");
-  };
-  if has_overlap(clint_lo, clint_hi, ram_lo, ram_hi)
-  then {
-    valid = false;
-    print_endline("The Clint and RAM regions overlap.");
-  };
-
-  // Should memory regions also be 4K aligned?
-  valid
-}
+// Check that all memory regions are sorted and don't overlap.
+function check_mem_layout() -> bool =
+  if pma_regions == [||] then {
+    print_endline("No memory regions specified.");
+    false
+  } else check_pma_regions(pma_regions, zeros(), zeros())
 
 function check_pmp() -> bool = {
   var valid : bool = true;

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -12,6 +12,7 @@ core {
     core/prelude_mem_metadata.sail,
     core/prelude_mem.sail,
     core/arithmetic.sail,
+    core/range_util.sail,
     core/rvfi_dii.sail,
     core/rvfi_dii_v1.sail,
     core/rvfi_dii_v2.sail,
@@ -51,12 +52,13 @@ pmp {
 }
 
 sys {
-  requires core, exceptions, pmp, V_core, Smcntrpmf, Zicfilp_regs
+  requires core, exceptions, pmp, V_core, Smcntrpmf, Zicfilp_regs, A_types
 
   files
     sys/sys_reservation.sail,
     sys/sys_control.sail,
     sys/platform.sail,
+    sys/pma.sail,
     sys/mem.sail,
     sys/inst_retire.sail,
     sys/vmem_pte.sail,

--- a/model/sys/mem.sail
+++ b/model/sys/mem.sail
@@ -85,12 +85,93 @@ function phys_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext
   }
 }
 
+function accessFaultFromAccessType(accTy : AccessType(ext_access_type)) -> ExceptionType =
+  match accTy {
+    InstructionFetch() => E_Fetch_Access_Fault(),
+    Read(Data)         => E_Load_Access_Fault(),
+    _                  => E_SAMO_Access_Fault(),
+  }
+
+function alignmentFaultFromAccessType(accTy : AccessType(ext_access_type)) -> ExceptionType =
+  match accTy {
+    InstructionFetch() => E_Fetch_Addr_Align(),
+    Read(Data)         => E_Load_Addr_Align(),
+    _                  => E_SAMO_Addr_Align(),
+  }
+
+function pmaCheck forall 'n, 0 < 'n <= max_mem_access .
+(
+  paddr      : physaddr,
+  width      : int('n),
+  accTy      : AccessType(ext_access_type),
+  res_or_con : bool,
+)  -> option(ExceptionType) = {
+  match matching_pma(pma_regions, paddr, width) {
+    None() => {
+      Some(accessFaultFromAccessType(accTy))
+    },
+    Some(struct { attributes, _ }) => {
+      let misaligned = not(is_aligned_addr(paddr, width));
+      // Check if we need to raise an exception for misalignment.
+      match attributes.misaligned_fault {
+        AccessFault if misaligned => return Some(accessFaultFromAccessType(accTy)),
+        misaligned_fault if misaligned => return Some(alignmentFaultFromAccessType(accTy)),
+        _ => {
+          // Check read/write/execute permissions and PMAs.
+          let canAccess : bool = match accTy {
+            InstructionFetch() => attributes.executable,
+            Read(_)            => attributes.readable & not(res_or_con & attributes.reservability == RsrvNone),
+            Write(_)           => attributes.writable & not(res_or_con & attributes.reservability == RsrvNone),
+            // TODO: Extend AccessType with the specific type of AMO operation. For now we assume all memory
+            // supports all AMO operations.
+            ReadWrite(_, _)    => attributes.readable & attributes.writable,
+            // TODO: Extend AccessType with a Cache() option. See https://github.com/riscv/sail-riscv/pull/792
+            // Cache(Zero)     => attributes.writable & attributes.supports_cbo_zero,
+            // Cache(_)        => internal_error(__FILE__, __LINE__,
+            //                                   "Invalid CacheAccessType; Inval, Clean and Flush check Read/Write permissions."),
+          };
+
+          if get_config_print_platform() & not(canAccess)
+          then print_endline("PMA check failed for " ^ hex_bits_str(bits_of(paddr)) ^ " PMA " ^ to_str(attributes));
+
+          if canAccess then None() else Some(accessFaultFromAccessType(accTy))
+        },
+      }
+    }
+  }
+}
+
+function alignmentOrAccessFaultPriority(exc : ExceptionType) -> range(0, 1) = {
+  match exc {
+    E_Fetch_Access_Fault() => 1,
+    E_Load_Access_Fault()  => 1,
+    E_SAMO_Access_Fault()  => 1,
+    E_Fetch_Addr_Align()   => 0,
+    E_Load_Addr_Align()    => 0,
+    E_SAMO_Addr_Align()    => 0,
+    _ => internal_error(__FILE__, __LINE__, "Invalid exception: " ^ to_str(exc))
+  }
+}
+
+function highestPriorityAlignmentOrAccessFault  (l : ExceptionType, r : ExceptionType) -> ExceptionType =
+  if alignmentOrAccessFaultPriority(l) > alignmentOrAccessFaultPriority(r) then l else r
+
 // Check if access is permitted according to PMPs and PMAs.
-val phys_access_check : forall 'n, 0 < 'n <= max_mem_access . (AccessType(ext_access_type), Privilege, physaddr, int('n)) -> option(ExceptionType)
-function phys_access_check (t, p, paddr, width) = {
-  let pmpError : option(ExceptionType) = if sys_pmp_count == 0 then None() else pmpCheck(paddr, width, t, p);
-  // TODO: Also check PMAs and select the highest priority fault.
-  pmpError
+function phys_access_check forall 'n, 0 < 'n <= max_mem_access . (
+  typ : AccessType(ext_access_type),
+  priv : Privilege,
+  paddr : physaddr,
+  width : int('n),
+  res_or_con : bool,
+) -> option(ExceptionType) = {
+  let pmpError : option(ExceptionType) = if sys_pmp_count == 0 then None() else pmpCheck(paddr, width, typ, priv);
+  let pmaError : option(ExceptionType) = pmaCheck(paddr, width, typ, res_or_con);
+  match (pmpError, pmaError) {
+    (None(), None())     => None(),
+    (Some(e), None())    => Some(e),
+    (None(), Some(e))    => Some(e),
+    (Some(e0), Some(e1)) => Some(highestPriorityAlignmentOrAccessFault(e0, e1)),
+  }
 }
 
 // dispatches to MMIO regions or physical memory regions depending on physical memory map
@@ -104,18 +185,12 @@ function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (
   res: bool,
   meta : bool,
 ) -> MemoryOpResult((bits(8 * 'n), mem_meta)) =
-  match phys_access_check(t, priv, paddr, width) {
+  match phys_access_check(t, priv, paddr, width, res) {
     Some(e) => Err(e),
     None() => {
       if   within_mmio_readable(paddr, width)
       then MemoryOpResult_add_meta(mmio_read(t, paddr, width), default_meta)
-      else if within_phys_mem(paddr, width)
-      then phys_mem_read(t, paddr, width, aq, rl, res, meta)
-      else match t {
-        InstructionFetch() => Err(E_Fetch_Access_Fault()),
-        Read(Data) => Err(E_Load_Access_Fault()),
-        _          => Err(E_SAMO_Access_Fault())
-      }
+      else phys_mem_read(t, paddr, width, aq, rl, res, meta)
     }
   }
 
@@ -176,16 +251,15 @@ function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
   rl : bool,
   con : bool,
 ) -> MemoryOpResult(bool) =
-  match phys_access_check(typ, priv, paddr, width) {
+  match phys_access_check(typ, priv, paddr, width, con) {
     Some(e) => Err(e),
     None() => {
       if   within_mmio_writable(paddr, width)
       then mmio_write(paddr, width, data)
-      else if within_phys_mem(paddr, width)
-      then {
+      else {
         let wk = write_kind_of_flags(aq, rl, con);
         phys_mem_write(wk, paddr, width, data, meta)
-      } else Err(E_SAMO_Access_Fault())
+      }
     }
   }
 

--- a/model/sys/platform.sail
+++ b/model/sys/platform.sail
@@ -18,24 +18,12 @@
 // with cache blocks larger than a page is not clearly defined.
 let plat_cache_block_size_exp : range(0, 12) = config platform.cache_block_size_exp
 
-// Main memory
-// Use `register` instead of `let` since `to_bits_checked` is not a pure initializer
-// due to its use of `assert`.
-register plat_ram_base : physaddrbits = to_bits_checked(config platform.ram.base : int)
-register plat_ram_size : physaddrbits = to_bits_checked(config platform.ram.size : int)
-
 // whether the MMU should update dirty bits in PTEs
 let plat_enable_dirty_update : bool = config memory.translation.dirty_update
 
 // whether the platform supports misaligned accesses without trapping to M-mode. if false,
 // misaligned loads/stores are trapped to Machine mode.
 let plat_enable_misaligned_access : bool = config memory.misaligned.supported
-
-// ROM holding reset vector and device-tree DTB
-// Use `register` instead of `let` since `to_bits_checked` is not a pure initializer
-// due to its use of `assert`.
-register plat_rom_base : physaddrbits = to_bits_checked(config platform.rom.base : int)
-register plat_rom_size : physaddrbits = to_bits_checked(config platform.rom.size : int)
 
 // Location of clock-interface, which should match with the spec in the DTB
 // Use `register` instead of `let` since `to_bits_checked` is not a pure initializer
@@ -49,37 +37,6 @@ register htif_tohost_base : option(physaddrbits) = None()
 let htif_tohost_size = 8
 // This is called externally. bits(64) is used because it's easier to deal with from C.
 function enable_htif(tohost_addr : bits(64)) -> unit = htif_tohost_base = Some(trunc(tohost_addr))
-
-// Physical memory map predicates
-
-function within_phys_mem forall 'n, 'n <= max_mem_access. (Physaddr(addr) : physaddr, width : int('n)) -> bool = {
-  // To avoid overflow issues when physical memory extends to the end
-  // of the addressable range, we need to perform address bound checks
-  // on unsigned unbounded integers.
-  let addr_int     = unsigned(addr);
-  let ram_base_int = unsigned(plat_ram_base);
-  let rom_base_int = unsigned(plat_rom_base);
-  let ram_size_int = unsigned(plat_ram_size);
-  let rom_size_int = unsigned(plat_rom_size);
-
-  // todo: iterate over segment list
-  if      (  ram_base_int <= addr_int
-           & (addr_int + sizeof('n)) <= (ram_base_int + ram_size_int))
-  then    true
-  else if (  rom_base_int <= addr_int
-           & (addr_int + sizeof('n)) <= (rom_base_int + rom_size_int))
-  then    true
-  else {
-    if get_config_print_platform() then {
-      print_log("within_phys_mem: " ^ bits_str(addr) ^ " not within phys-mem:");
-      print_log("  plat_rom_base: " ^ bits_str(plat_rom_base));
-      print_log("  plat_rom_size: " ^ bits_str(plat_rom_size));
-      print_log("  plat_ram_base: " ^ bits_str(plat_ram_base));
-      print_log("  plat_ram_size: " ^ bits_str(plat_ram_size));
-    };
-    false
-  }
-}
 
 function within_clint forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : physaddr, width : int('n)) -> bool = {
   // To avoid overflow issues when physical memory extends to the end

--- a/model/sys/pma.sail
+++ b/model/sys/pma.sail
@@ -1,0 +1,140 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// Implementation of Physical Memory Attributes. These describe
+// how memory accesses to different regions of memory behave.
+// Very little is specified about PMAs, and there is no standard
+// interface to query or control them. This implementation only
+// provides static PMAs (dynamic PMAs are possible) and there
+// is no way to query them (this information would normally be
+// available in Device Tree, ACPI, or just "known").
+//
+// Since they are mostly implementation-defined, we try to
+// provide a range of useful options that are likely to cover
+// most implementations.
+
+// Set of atomic instructions supported by memory.
+// Each value is a superset of the previous ones.
+enum AtomicSupport = {
+  AMONone,
+  AMOSwap,
+  AMOLogical,
+  AMOArithmetic,
+  // These require Zacas.
+  AMOCASW,
+  AMOCASD,
+  AMOCASQ,
+}
+
+mapping atomic_support_str : AtomicSupport <-> string = {
+  AMONone       <-> "AMONone",
+  AMOSwap       <-> "AMOSwap",
+  AMOLogical    <-> "AMOLogical",
+  AMOArithmetic <-> "AMOArithmetic",
+  AMOCASW       <-> "AMOCASW",
+  AMOCASD       <-> "AMOCASD",
+  AMOCASQ       <-> "AMOCASQ",
+}
+overload to_str = {atomic_support_str}
+
+enum Reservability = { RsrvNone, RsrvNonEventual, RsrvEventual }
+
+mapping reservability_str : Reservability <-> string = {
+  RsrvNone        <-> "RsrvNone",
+  RsrvNonEventual <-> "RsrvNonEventual",
+  RsrvEventual    <-> "RsrvEventual",
+}
+overload to_str = {reservability_str}
+
+// Do misaligned accesses (of any kind) to this region cause
+// a fault, and if so which kind. This is for regions that
+// only support aligned accesses.
+enum misaligned_fault = { NoFault, AccessFault, AlignmentFault }
+
+mapping misaligned_fault_str : misaligned_fault <-> string = {
+  NoFault        <-> "NoFault",
+  AccessFault    <-> "AccessFault",
+  AlignmentFault <-> "AlignmentFault",
+}
+overload to_str = {misaligned_fault_str}
+
+// Physical Memory Attributes for a region.
+struct PMA = {
+  // These have no effect on the model currently but they are affected
+  // by PBMT so they need to be here if the resulting PMA is verified.
+  cacheable        : bool,
+  coherent         : bool,
+  // If false then attempting to access this PMA during instruction fetch
+  // will cause a fetch access fault.
+  executable       : bool,
+  // If false when reading/writing for data access then this will cause
+  // an access fault.
+  readable         : bool,
+  writable         : bool,
+  read_idempotent  : bool,
+  write_idempotent : bool,
+  // Optionally cause an access/alignment fault on misaligned access.
+  misaligned_fault : misaligned_fault,
+  // TODO: Atomicity PMA. This is not supported yet because
+  // the AccessType needs to be extended to indicate the AMO type.
+  // atomic_support   : AtomicSupport,
+  reservability    : Reservability,
+  // Flags whether this memory supports CBO.zero. Note that main memory regions must
+  // have this set.
+  supports_cbo_zero : bool,
+  // TODO: Misaligned Atomicity Granule PMA
+  // TODO: Memory Ordering PMA
+}
+
+// A region of memory and its Physical Memory Attributes.
+struct PMA_Region = {
+  // TODO: These should be physaddrbits, but currently that doesn't work due to a compiler bug:
+  // https://github.com/rems-project/sail/issues/1392
+  base       : bits(64),
+  size       : bits(64),
+  attributes : PMA,
+  // If set to `false` this will be excluded from the generated device tree.
+  // This doesn't affect Sail's execution at all; it's just a convenience
+  // for generating a device tree that matches the PMAs.
+  include_in_device_tree : bool,
+}
+
+// Get the first PMA that matches a given address range.
+function matching_pma(pmas : list(PMA_Region), addr : physaddr, width : mem_access_width) -> option(PMA_Region) = {
+  match pmas {
+    [||] => None(),
+    pma :: rest => {
+      if range_subset(zero_extend(bits_of(addr)), to_bits(width), pma.base, pma.size)
+      then Some(pma)
+      else matching_pma(rest, addr, width)
+    },
+  }
+}
+
+function pma_attributes_to_str(attr : PMA) -> string =
+  (if attr.cacheable then " cacheable" else "") ^
+  (if attr.coherent then " coherent" else "") ^
+  (if attr.executable then " executable" else "") ^
+  (if attr.readable then " readable" else "") ^
+  (if attr.writable then " writable" else "") ^
+  (if attr.read_idempotent then " read-idempotent" else "") ^
+  (if attr.write_idempotent then " write-idempotent" else "") ^
+  " misaligned_fault:" ^ to_str(attr.misaligned_fault) ^
+  // TODO: Atomicity PMA.
+  // " " ^ to_str(attr.atomic_support) ^
+  " " ^ to_str(attr.reservability) ^
+  (if attr.supports_cbo_zero then " supports_cbo_zero" else "")
+
+function pma_region_to_str(region : PMA_Region) -> string =
+  "base: " ^ bits_str(region.base) ^ " size: " ^ bits_str(region.size)
+    ^ pma_attributes_to_str(region.attributes)
+
+overload to_str = {pma_attributes_to_str, pma_region_to_str}
+
+// The list of PMAs. These must be sorted and cannot overlap.
+register pma_regions : list(PMA_Region) = config memory.regions


### PR DESCRIPTION
Add basic support for static PMAs specified in the config file. Support for the AMO level is not fully added yet because it needs to be added to `AccessType`.

This also adds an implication operator `==>` which is useful for writing SMT properties.