### PR TITLE
Fix macOS compilation and add to CI

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request, workflow_dispatch, merge_group]
 
 jobs:
-  build:
+  build_matrix:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -75,3 +75,13 @@ jobs:
         with:
           name: event.json
           path: ${{ github.event_path }}
+
+  # This is here so that the "Status checks that are required" Github
+  # option doesn't need to list all of the matrix jobs (it doesn't seem
+  # to work if you just specify the job ID of the matrix itself).
+  build:
+    runs-on: ubuntu-latest
+    needs: [build_matrix]
+    steps:
+      - name: Dummy
+        run: echo 'Jobs need at least one step.'

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -4,20 +4,49 @@ on: [push, pull_request, workflow_dispatch, merge_group]
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-latest]
+    env:
+      SAIL_VERSION: "0.19"
+
     steps:
-      - name: Install packages
-        run: sudo apt install -y --no-install-recommends pkg-config libgmp-dev curl ninja-build jq
-
-      - name: Install sail from binary
-        run: |
-          sudo mkdir -p /usr/local
-          curl --location https://github.com/rems-project/sail/releases/download/0.19-linux-binary/sail.tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
-
       - name: Check out repository code
         uses: actions/checkout@v4
 
+      - name: Install packages (Linux)
+        if: startsWith(matrix.os, 'ubuntu-')
+        run: |
+          sudo apt install -y --no-install-recommends pkg-config libgmp-dev curl ninja-build jq
+
+      - name: Install packages (macOS)
+        if: startsWith(matrix.os, 'macos-')
+        run: |
+          brew install opam llvm lld
+          echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+
+      - name: Install Sail (Linux)
+        if: startsWith(matrix.os, 'ubuntu-')
+        run: |
+          sudo mkdir -p /usr/local
+          curl --location https://github.com/rems-project/sail/releases/download/$SAIL_VERSION-linux-binary/sail.tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
+
+      - name: Install Sail (macOS)
+        if: startsWith(matrix.os, 'macos-')
+        run: |
+          opam init --auto-setup --bare
+          opam switch create default 5.3.0
+          eval $(opam env)
+          opam update
+          opam install -y sail.$SAIL_VERSION
+
+      - name: Load OPAM environment (macOS)
+        if: startsWith(matrix.os, 'macos-' )
+        run: echo "$HOME/.opam/default/bin" >> $GITHUB_PATH
+
       - name: Ensure pre-commit checks pass
+        if: startsWith(matrix.os, 'ubuntu-')
         run: python3 -m pip install pre-commit && pre-commit run --all-files --show-diff-on-failure --color=always
 
       - name: Build and test simulators
@@ -33,7 +62,7 @@ jobs:
           ctest --test-dir build --output-junit tests.xml --output-on-failure
 
       - name: Upload test results
-        if: always()
+        if: startsWith(matrix.os, 'ubuntu-')
         uses: actions/upload-artifact@v4
         with:
           name: tests.xml
@@ -41,7 +70,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload event payload
-        if: always()
+        if: startsWith(matrix.os, 'ubuntu-')
         uses: actions/upload-artifact@v4
         with:
           name: event.json

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request, workflow_dispatch, merge_group]
 
 jobs:
-  build_matrix:
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -79,7 +79,7 @@ jobs:
   # This is here so that the "Status checks that are required" Github
   # option doesn't need to list all of the matrix jobs (it doesn't seem
   # to work if you just specify the job ID of the matrix itself).
-  build:
+  ci_pass:
     runs-on: ubuntu-latest
     needs: [build_matrix]
     steps:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -81,7 +81,7 @@ jobs:
   # to work if you just specify the job ID of the matrix itself).
   ci_pass:
     runs-on: ubuntu-latest
-    needs: [build_matrix]
+    needs: [build]
     steps:
       - name: Dummy
         run: echo 'Jobs need at least one step.'

--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -49,7 +49,7 @@ foreach (xlen IN ITEMS 32 64)
             add_dependencies(riscv_sim_${arch} generated_model_${arch})
 
             target_link_libraries(riscv_sim_${arch}
-                PRIVATE softfloat sail_runtime default_config GMP::GMP
+                PRIVATE softfloat sail_runtime default_config
             )
 
             target_include_directories(riscv_sim_${arch}

--- a/sail_runtime/CMakeLists.txt
+++ b/sail_runtime/CMakeLists.txt
@@ -18,6 +18,7 @@ target_include_directories(sail_runtime
     PUBLIC "${sail_dir}/lib"
 )
 target_compile_options(sail_runtime PRIVATE -Wno-extra -Wno-unused)
+target_link_libraries(sail_runtime PUBLIC GMP::GMP)
 
 if (COVERAGE)
     find_package(Threads REQUIRED)


### PR DESCRIPTION
Unfortunately since a Sail compiler binary for Mac is not yet available this uses OPAM. Once one is available we'll switch to that.

This also fixes a dependency ordering error on all platforms - `sail_runtime` depends on GMP but this wasn't declared so it could fail if you didn't have GMP already available (i.e. you were building it from source).