### PR TITLE
Add prettier pre-commit hook

### DIFF
--- a/.github/workflows/compile-lean.yml
+++ b/.github/workflows/compile-lean.yml
@@ -15,55 +15,55 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: System dependencies (ubuntu)
-      if: startsWith(matrix.os, 'ubuntu')
-      run: |
-        sudo apt install build-essential libgmp-dev z3 cvc4 opam
+      - name: System dependencies (ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt install build-essential libgmp-dev z3 cvc4 opam
 
-    - name: Restore cached opam
-      id: cache-opam-restore
-      uses: actions/cache/restore@v4
-      with:
-        path: ~/.opam
-        key: ${{ matrix.os }}-${{ matrix.version }}
+      - name: Restore cached opam
+        id: cache-opam-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.opam
+          key: ${{ matrix.os }}-${{ matrix.version }}
 
-    - name: Setup opam
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-      run: |
-        opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
-        opam install dune
+      - name: Setup opam
+        if: steps.cache-opam-restore.outputs.cache-hit != 'true'
+        run: |
+          opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
+          opam install dune
 
-    - name: Install Sail
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-      run: |
-        git clone https://github.com/rems-project/sail.git
-        eval $(opam env)
-        (cd sail; opam install sail --deps-only --yes)
-        (cd sail; make install)
+      - name: Install Sail
+        if: steps.cache-opam-restore.outputs.cache-hit != 'true'
+        run: |
+          git clone https://github.com/rems-project/sail.git
+          eval $(opam env)
+          (cd sail; opam install sail --deps-only --yes)
+          (cd sail; make install)
 
-    - name: Save cached opam
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-      id: cache-opam-save
-      uses: actions/cache/save@v4
-      with:
-        path: ~/.opam
-        key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}
+      - name: Save cached opam
+        if: steps.cache-opam-restore.outputs.cache-hit != 'true'
+        id: cache-opam-save
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.opam
+          key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}
 
-    - name: Install Lean
-      run: |
-        wget -q https://raw.githubusercontent.com/leanprover-community/mathlib4/master/scripts/install_debian.sh
-        bash install_debian.sh ; rm -f install_debian.sh
+      - name: Install Lean
+        run: |
+          wget -q https://raw.githubusercontent.com/leanprover-community/mathlib4/master/scripts/install_debian.sh
+          bash install_debian.sh ; rm -f install_debian.sh
 
-    - name: Build the Sail RISCV Model for Lean
-      run: |
-        eval $(opam config env)
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
-        cmake --build build/ --target generated_lean_rv64d
+      - name: Build the Sail RISCV Model for Lean
+        run: |
+          eval $(opam config env)
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          cmake --build build/ --target generated_lean_rv64d
 
-    - name: Use Lean to build the model and report errors
-      run: |
-        source ~/.profile
-        cd build/model/Lean_RV64D/
-        lake build
+      - name: Use Lean to build the model and report errors
+        run: |
+          source ~/.profile
+          cd build/model/Lean_RV64D/
+          lake build

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -6,43 +6,43 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-    - name: Install packages
-      run: sudo apt install -y --no-install-recommends pkg-config libgmp-dev curl ninja-build jq
+      - name: Install packages
+        run: sudo apt install -y --no-install-recommends pkg-config libgmp-dev curl ninja-build jq
 
-    - name: Install sail from binary
-      run: |
-        sudo mkdir -p /usr/local
-        curl --location https://github.com/rems-project/sail/releases/download/0.19-linux-binary/sail.tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
+      - name: Install sail from binary
+        run: |
+          sudo mkdir -p /usr/local
+          curl --location https://github.com/rems-project/sail/releases/download/0.19-linux-binary/sail.tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
 
-    - name: Check out repository code
-      uses: actions/checkout@v4
+      - name: Check out repository code
+        uses: actions/checkout@v4
 
-    - name: Ensure pre-commit checks pass
-      run: python3 -m pip install pre-commit && pre-commit run --all-files --show-diff-on-failure --color=always
+      - name: Ensure pre-commit checks pass
+        run: python3 -m pip install pre-commit && pre-commit run --all-files --show-diff-on-failure --color=always
 
-    - name: Build and test simulators
-      run: |
-        # Ninja is used because the CMake Makefile generator doesn't
-        # build top-level targets in parallel unfortunately.
-        cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DFIRST_PARTY_TESTS=TRUE
-        # By default only the rv32d and rv64d emulators are build,
-        # but we want to build more targets here to ensure they
-        # can at least build without errors.
-        ninja -C build all riscv_sim_rv32d_rvfi generated_smt_rv64f generated_docs_rv64d
-        # These targets do not work with Sail 0.18: generated_rmem_rv32d_rmem generated_coq_rv64f_coq
-        ctest --test-dir build --output-junit tests.xml --output-on-failure
+      - name: Build and test simulators
+        run: |
+          # Ninja is used because the CMake Makefile generator doesn't
+          # build top-level targets in parallel unfortunately.
+          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DFIRST_PARTY_TESTS=TRUE
+          # By default only the rv32d and rv64d emulators are build,
+          # but we want to build more targets here to ensure they
+          # can at least build without errors.
+          ninja -C build all riscv_sim_rv32d_rvfi generated_smt_rv64f generated_docs_rv64d
+          # These targets do not work with Sail 0.18: generated_rmem_rv32d_rmem generated_coq_rv64f_coq
+          ctest --test-dir build --output-junit tests.xml --output-on-failure
 
-    - name: Upload test results
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: tests.xml
-        path: build/tests.xml
-        if-no-files-found: error
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tests.xml
+          path: build/tests.xml
+          if-no-files-found: error
 
-    - name: Upload event payload
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: event.json
-        path: ${{ github.event_path }}
+      - name: Upload event payload
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: event.json
+          path: ${{ github.event_path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,17 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release, e.g. 1.0.0'
+        description: "Version to release, e.g. 1.0.0"
         required: true
       notes:
-        description: 'Release notes'
+        description: "Release notes"
         required: false
       prerelease:
-        description: 'Is this a pre-release (beta, RC, etc.)?'
+        description: "Is this a pre-release (beta, RC, etc.)?"
         required: false
         type: boolean
       draft:
-        description: 'Is this a draft release (not public; you can publish it later)?'
+        description: "Is this a draft release (not public; you can publish it later)?"
         required: false
         type: boolean
 
@@ -36,50 +36,50 @@ jobs:
     container: ${{ matrix.container }}
 
     steps:
-    # This must be before checkout otherwise Github will use a zip of the
-    # code instead of git clone.
-    - name: Install dependencies (Linux)
-      if: startsWith(matrix.os, 'ubuntu')
-      run: |
-        dnf update -y --enablerepo=devel
-        dnf install -y --enablerepo=devel \
-            pkg-config \
-            gmp-static \
-            libstdc++-static \
-            curl \
-            git \
-            make \
-            gcc \
-            gcc-c++ \
-            cmake \
-            ninja-build
-        curl --location --output sail.tar.gz https://github.com/rems-project/sail/releases/download/0.19-linux-binary/sail.tar.gz
-        tar --directory=/usr/local --strip-components=1 --extract --file sail.tar.gz
+      # This must be before checkout otherwise Github will use a zip of the
+      # code instead of git clone.
+      - name: Install dependencies (Linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          dnf update -y --enablerepo=devel
+          dnf install -y --enablerepo=devel \
+              pkg-config \
+              gmp-static \
+              libstdc++-static \
+              curl \
+              git \
+              make \
+              gcc \
+              gcc-c++ \
+              cmake \
+              ninja-build
+          curl --location --output sail.tar.gz https://github.com/rems-project/sail/releases/download/0.19-linux-binary/sail.tar.gz
+          tar --directory=/usr/local --strip-components=1 --extract --file sail.tar.gz
 
-    # TODO: Mac
-    # - name: Install dependencies (Mac)
-    #   if: startsWith(matrix.os, 'macos')
-    #   run: |
-    #     brew install --force --overwrite ...
+      # TODO: Mac
+      # - name: Install dependencies (Mac)
+      #   if: startsWith(matrix.os, 'macos')
+      #   run: |
+      #     brew install --force --overwrite ...
 
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Build simulators and JSON
-      run: |
-        cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DSTATIC=TRUE
-        cd build
-        ninja all generated_docs_rv64d
-        ctest
-        cpack
+      - name: Build simulators and JSON
+        run: |
+          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DSTATIC=TRUE
+          cd build
+          ninja all generated_docs_rv64d
+          ctest
+          cpack
 
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: release-${{ matrix.name }}
-        path: |
-          build/sail_riscv-*
-          build/model/riscv_model_rv64d.json
-        if-no-files-found: error
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.name }}
+          path: |
+            build/sail_riscv-*
+            build/model/riscv_model_rv64d.json
+          if-no-files-found: error
 
   release:
     needs: build
@@ -88,16 +88,16 @@ jobs:
       # Required to create a release.
       contents: write
     steps:
-    - name: Download artifacts
-      uses: actions/download-artifact@v4
-    - name: Create release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: |
-          release-linux-amd64/sail_riscv-Linux-x86_64.tar.gz
-          release-linux-amd64/model/riscv_model_rv64d.json
-        fail_on_unmatched_files: true
-        tag_name: ${{ inputs.version }}
-        body: ${{ inputs.notes }}
-        prerelease: ${{ inputs.prerelease }}
-        draft: ${{ inputs.draft }}
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            release-linux-amd64/sail_riscv-Linux-x86_64.tar.gz
+            release-linux-amd64/model/riscv_model_rv64d.json
+          fail_on_unmatched_files: true
+          tag_name: ${{ inputs.version }}
+          body: ${{ inputs.notes }}
+          prerelease: ${{ inputs.prerelease }}
+          draft: ${{ inputs.draft }}

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -4,48 +4,48 @@ on:
   workflow_run:
     workflows: ["CI"]
     types:
-    - completed
+      - completed
 
 jobs:
   publish-test-results:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion != 'skipped'
     steps:
-    - name: Download artifacts
-      uses: actions/github-script@v6
-      with:
-        script: |
-          var fs = require('fs');
-          var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-             owner: context.repo.owner,
-             repo: context.repo.repo,
-             run_id: ${{github.event.workflow_run.id }},
-          });
-          var matchArtifacts = artifacts.data.artifacts.filter((artifact) => {
-            return artifact.name == 'tests.xml' || artifact.name == 'event.json'
-          });
-          var count = matchArtifacts.length;
-          for (var i = 0; i < count; i++) {
-            var matchArtifact = matchArtifacts[i];
-            var download = await github.rest.actions.downloadArtifact({
+      - name: Download artifacts
+        uses: actions/github-script@v6
+        with:
+          script: |
+            var fs = require('fs');
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
+               run_id: ${{github.event.workflow_run.id }},
             });
-            var name = matchArtifact.name;
-            var dest = name + '.zip'
-            fs.writeFileSync('${{github.workspace}}/' + dest, Buffer.from(download.data));
-            console.log("Downloaded", name, "as", dest);
-          }
-    - name: Extract test results
-      run: unzip tests.xml.zip
-    - name: Extract event payload
-      run: unzip event.json.zip
-    - name: Publish test results
-      uses: EnricoMi/publish-unit-test-result-action@v2
-      with:
-        commit: ${{ github.event.workflow_run.head_sha }}
-        event_file: event.json
-        event_name: ${{ github.event.workflow_run.event }}
-        files: tests.xml
+            var matchArtifacts = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == 'tests.xml' || artifact.name == 'event.json'
+            });
+            var count = matchArtifacts.length;
+            for (var i = 0; i < count; i++) {
+              var matchArtifact = matchArtifacts[i];
+              var download = await github.rest.actions.downloadArtifact({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 artifact_id: matchArtifact.id,
+                 archive_format: 'zip',
+              });
+              var name = matchArtifact.name;
+              var dest = name + '.zip'
+              fs.writeFileSync('${{github.workspace}}/' + dest, Buffer.from(download.data));
+              console.log("Downloaded", name, "as", dest);
+            }
+      - name: Extract test results
+        run: unzip tests.xml.zip
+      - name: Extract event payload
+        run: unzip event.json.zip
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: tests.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,30 +1,34 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-exclude: '^(prover_snapshots)|(generated_definitions)|(dependencies/[^/]+/)'
+exclude: "^(prover_snapshots)|(generated_definitions)|(dependencies/[^/]+/)"
 minimum_pre_commit_version: 3.2.0
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
-    -   id: trailing-whitespace
+      - id: trailing-whitespace
         # Do not strip trailing whitespace from patches or SVG images.
         # TODO: the objdump outputs should probably not be part of the repo.
         exclude: '.*\.(diff|dump|patch|svg)'
-    -   id: end-of-file-fixer
+      - id: end-of-file-fixer
         # Do not strip trailing newlines from patches or SVG images.
         # TODO: the objdump outputs should probably not be part of the repo.
         exclude: '.*\.(diff|dump|patch|svg)'
-    -   id: check-yaml
-    -   id: check-added-large-files
-    -   id: check-executables-have-shebangs
-    -   id: check-shebang-scripts-are-executable
--   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: 'v19.1.7'
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: "v19.1.7"
     hooks:
-    -   id: clang-format
-        types_or: [c, c++]  # Don't try running clang-format on .json files
--   repo: https://github.com/Lucas-C/pre-commit-hooks
+      - id: clang-format
+        types_or: [c, c++] # Don't try running clang-format on .json files
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:
-    -   id: forbid-tabs
+      - id: forbid-tabs
         exclude: '.*\.(diff|dump|patch|svg|S|old)|Makefile*'
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.5.3
+    hooks:
+      - id: prettier

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -1,5 +1,4 @@
-Code Style
-==========
+# Code Style
 
 This document is an incomplete description of the predominant style used in the
 RISC-V Sail model.
@@ -10,50 +9,49 @@ For C the formatting rules should be followed where applicable.
 For other languages, follow the standard style for that language if it exists;
 for example, Python should follow the standard PEP-8 style.
 
-Formatting
-----------
+## Formatting
 
-* Block-level indentation uses two spaces
+- Block-level indentation uses two spaces
 
-* Tabs should not be used
+- Tabs should not be used
 
-* There should be no trailing spaces on any lines
+- There should be no trailing spaces on any lines
 
-* All files should end with a newline character
+- All files should end with a newline character
 
-* Unix-style line endings should be used
+- Unix-style line endings should be used
 
-* Files should be free from leading, trailing and double blank lines
+- Files should be free from leading, trailing and double blank lines
 
-* There should be one space either side of operators such as `=` and `+`
+- There should be one space either side of operators such as `=` and `+`
 
-* There should be no spaces before and one space after `,`
+- There should be no spaces before and one space after `,`
 
-* There should be one space after control flow keywords such as `if`, `foreach`
+- There should be one space after control flow keywords such as `if`, `foreach`
   and `match`
 
-* There should be no spaces between a function name and its arguments, for both
+- There should be no spaces between a function name and its arguments, for both
   definitions (valspecs, function definitions and function clauses) and calls,
   nor should there be any spaces immediately within the parentheses
 
-* There should be no spaces between a vector and the opening square bracket for
+- There should be no spaces between a vector and the opening square bracket for
   indexing or slicing, nor should there be any spaces immediately within the
   square brackets
 
-* For large blocks of code with repetitive structure where it improves
+- For large blocks of code with repetitive structure where it improves
   readability, additional whitespace may be inserted to align corresponding
   elements horizontally with each other, within reason
 
-* Avoid unnecessary parentheses and curly braces unless doing so seriously
+- Avoid unnecessary parentheses and curly braces unless doing so seriously
   hurts readability
 
-* When modifying existing code that does not conform to this style, prefer
+- When modifying existing code that does not conform to this style, prefer
   matching the existing style
 
-* Files should have suitable copyright headers.
+- Files should have suitable copyright headers.
 
-* Some mapping clauses, especially for instruction decoding (`encdec`)
-  clauses, can be quite long.  Unless these clauses appear in a group
+- Some mapping clauses, especially for instruction decoding (`encdec`)
+  clauses, can be quite long. Unless these clauses appear in a group
   (see below), conditional mapping clauses should use the `when`
   construct if both sides of the mapping are conditioned on the same
   predicate expression; the two sides of the mapping and the `when`
@@ -65,51 +63,50 @@ mapping clause encdec = LOAD(imm, rs1, rd, is_unsigned, size, false, false)
   when (size_bytes(size) < xlen_bytes) | (not(is_unsigned) & size_bytes(size) <= xlen_bytes)
 ```
 
-  If these mapping clauses appear in a group (e.g., see `SHIFTIOP`),
-  they should preferably be each on a single line, with their
-  corresponding elements vertically aligned.
+If these mapping clauses appear in a group (e.g., see `SHIFTIOP`),
+they should preferably be each on a single line, with their
+corresponding elements vertically aligned.
 
-Implementation
---------------
+## Implementation
 
-* Since this is the official model intended to be included as part of the
+- Since this is the official model intended to be included as part of the
   RISC-V specifications, readability is paramount, including to those not
   already familiar with the details of that field of Computer Science (e.g.
   floating-point or cryptography)
 
-* All instructions should be built as part of both the RV32 and RV64 models so
+- All instructions should be built as part of both the RV32 and RV64 models so
   as to provide a path to supporting mutable MXL/SXL/UXL; if necessary,
   constructs like `assert(xlen == 32)` at the start of the body can be
   used to suppress any type errors that arise as a result
 
-* Avoid the use of hard-coded constants like 32 even if the instruction is
+- Avoid the use of hard-coded constants like 32 even if the instruction is
   RV32-specific, instead favouring `xlen` or a computed constant to
   more clearly express the underlying intent
 
-* Local variables should be made immutable whenever possible, but short
+- Local variables should be made immutable whenever possible, but short
   imperative loops with a small amount of local mutable state are preferred
   over less-readable functional-style recursive equivalents
 
-* Choose carefully between integer and bitvector types, and avoid multiple
+- Choose carefully between integer and bitvector types, and avoid multiple
   round-trips between the two; for example, if counting something, use a `nat`
   and convert it to an appropriately-sized bitvector at the point it is stored
   in a register, but keep register source values as bitvectors until they are
   needed to be interpreted as integers (see the implementation of `MUL` as an
   example)
 
-* Use Sail's `newtype` constructs to differentiate between types with
+- Use Sail's `newtype` constructs to differentiate between types with
   the same underlying representation (e.g. they are bitvectors of the
   same length) for added type safety
 
-* Prefer `bool` over `bits(1)` when a value logically represents true or false
+- Prefer `bool` over `bits(1)` when a value logically represents true or false
   rather than being a single bit with a numeric meaning, and vice-versa
 
-* Do not use strings for anything that is not text
+- Do not use strings for anything that is not text
 
-* No new compile-time warnings from the Sail compiler should be introduced
+- No new compile-time warnings from the Sail compiler should be introduced
   (this does not include C warnings for the code generated by the Sail
   compiler)
 
-* Do not use the `ext*` types and hooks for standard extensions unless
+- Do not use the `ext*` types and hooks for standard extensions unless
   providing a stub implementation; these are reserved for use by out-of-tree
   extensions that provide their own non-stub implementations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,4 @@
-Contributing
-============
+# Contributing
 
 When contributing, please follow the [code style](CODE_STYLE.md) in use.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-RISCV Sail Model
-================
+# RISCV Sail Model
 
 This repository contains a formal specification of the RISC-V architecture, written in
-[Sail](https://github.com/rems-project/sail).   It has been adopted by the RISC-V Foundation.
+[Sail](https://github.com/rems-project/sail). It has been adopted by the RISC-V Foundation.
 
 The model specifies
 assembly language formats of the instructions, the corresponding
@@ -11,28 +10,21 @@ A [reading guide](doc/ReadingGuide.md) to the model is provided in the
 [doc/](doc/) subdirectory, along with a guide on [how to
 extend](doc/ExtendingGuide.md) the model.
 
-
 Latex or AsciiDoc definitions can be generated from the model that are suitable for inclusion in reference documentation.
 There is also the newer [Sail AsciiDoctor documentation support for RISC-V](https://github.com/Alasdair/asciidoctor-sail/blob/master/doc/built/sail_to_asciidoc.pdf).
 
-
-What is Sail?
--------------
+## What is Sail?
 
 [Sail](https://github.com/rems-project/sail) is a language for describing the instruction-set architecture
 (ISA) semantics of processors: the architectural specification of the behaviour of machine instructions. Sail is an
 engineer-friendly language, much like earlier vendor pseudocode, but more precisely defined and with tooling to support a wide range of use-cases.
-<p>
 
-Given a Sail specification, the tool can type-check it, generate documentation snippets (in LaTeX or AsciiDoc), generate executable emulators, show specification coverage, generate versions of the ISA for relaxed memory model tools, support automated instruction-sequence test generation, generate  theorem-prover definitions for
+Given a Sail specification, the tool can type-check it, generate documentation snippets (in LaTeX or AsciiDoc), generate executable emulators, show specification coverage, generate versions of the ISA for relaxed memory model tools, support automated instruction-sequence test generation, generate theorem-prover definitions for
 interactive proof (in Isabelle, Rocq, and Lean), support proof about binary code (in Islaris), and (in progress) generate a reference ISA model in SystemVerilog that can be used for formal hardware verification.
-<p>
 
-  <img width="800" src="https://www.cl.cam.ac.uk/~pes20/sail/overview-sail.png?">
-<p>
+<img width="800" src="https://www.cl.cam.ac.uk/~pes20/sail/overview-sail.png?">
 
-Getting started
----------------
+## Getting started
 
 ### Building the model
 
@@ -67,14 +59,14 @@ $ build/c_emulator/riscv_sim_<arch> <elf-file>
 
 A suite of RV32 and RV64 test programs derived from the
 [`riscv-tests`](https://github.com/riscv/riscv-tests) test-suite is
-included under [test/riscv-tests/](test/riscv-tests/).  The test-suite
+included under [test/riscv-tests/](test/riscv-tests/). The test-suite
 can be run using `make test` or `ctest` in the build directory.
 
 ### Configuring platform options
 
 The model is configured using a JSON file specifying various tunable
-options.  The default configuration used for the model can be examined
-using `build/c_emulator/riscv_sim_<arch> --print-default-config`.  To
+options. The default configuration used for the model can be examined
+using `build/c_emulator/riscv_sim_<arch> --print-default-config`. To
 use a custom configuration, save the default configuration into a
 file, edit it as needed, and pass it to the simulator using the
 `--config` option.
@@ -87,9 +79,9 @@ Information on other options for the simulator is available from
 For booting operating system images, see the information under the
 [os-boot/](os-boot/) subdirectory.
 
-Supported RISC-V ISA features
------------------------------
-#### The Sail specification currently captures the following ISA extensions and features:
+## Supported RISC-V ISA features
+
+### The Sail specification currently captures the following ISA extensions and features:
 
 - RV32I and RV64I base ISAs, v2.1
 - Zifencei extension for instruction-fetch fence, v2.0
@@ -134,13 +126,13 @@ The following unratified extensions are supported and can be enabled using the `
 
 **For a list of unsupported extensions and features, see the [Extension Roadmap](https://github.com/riscv/sail-riscv/wiki/Extension-Roadmap).**
 
-Example RISC-V instruction specifications
-----------------------------------
+## Example RISC-V instruction specifications
 
 These are verbatim excerpts from the model file containing the base instructions, [riscv_insts_base.sail](model/riscv_insts_base.sail), with a few comments added.
 
 ### ITYPE (or ADDI)
-~~~~~
+
+```
 /* the assembly abstract syntax tree (AST) clause for the ITYPE instructions */
 
 union clause ast = ITYPE : (bits(12), regidx, regidx, iop)
@@ -186,11 +178,11 @@ mapping itype_mnemonic : iop <-> string = {
 
 mapping clause assembly = ITYPE(imm, rs1, rd, op)
                       <-> itype_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_signed_12(imm)
-~~~~~~
+```
 
 ### SRET
 
-~~~~~
+```
 union clause ast = SRET : unit
 
 mapping clause encdec = SRET() <-> 0b0001000 @ 0b00010 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
@@ -212,11 +204,9 @@ function clause execute SRET() = {
 }
 
 mapping clause assembly = SRET() <-> "sret"
-~~~~~
+```
 
-
-Sequential execution
-----------
+## Sequential execution
 
 The model builds a C emulator that can execute RISC-V ELF
 files, and both emulators provide platform support sufficient to boot
@@ -233,25 +223,22 @@ The files in the C emulator directory implements ELF loading and the
 platform devices, defines the physical memory map, and usees command-line
 options to select implementation-specific ISA choices.
 
-
 ### Use for specification coverage measurement in testing
 
 The Sail-generated C emulator can measure specification branch
 coverage of any executed tests, displaying the results as per-file
 tables and as html-annotated versions of the model source.
 
-
 ### Use as test oracle in tandem verification
 
 For tandem verification of random instruction streams, the tools support the
 protocols used in [TestRIG](https://github.com/CTSRD-CHERI/TestRIG) to
 directly inject instructions into the C emulator and produce trace
-information in RVFI format.  This has been used for cross testing
+information in RVFI format. This has been used for cross testing
 against spike and the [RVBS](https://github.com/CTSRD-CHERI/RVBS)
 specification written in Bluespec SystemVerilog.
 
-Concurrent execution
---------------------
+## Concurrent execution
 
 The ISA model is integrated with the operational model of the RISC-V
 relaxed memory model, RVWMO (as described in an appendix of the [RISC-V
@@ -259,14 +246,13 @@ user-level specification](https://github.com/riscv/riscv-isa-manual/releases/tag
 in the development of the RISC-V concurrency architecture; this is
 part of the [RMEM](http://www.cl.cam.ac.uk/users/pes20/rmem) tool.
 It is also integrated with the RISC-V axiomatic concurrency model
- as part of the [isla-axiomatic](https://isla-axiomatic.cl.cam.ac.uk/) tool.
+as part of the [isla-axiomatic](https://isla-axiomatic.cl.cam.ac.uk/) tool.
 
 ### Concurrent testing
 
-
 As part of the University of Cambridge/ INRIA concurrency architecture work, those groups produced and
 released a library of approximately 7000 [litmus
-tests](https://github.com/litmus-tests/litmus-tests-riscv).  The
+tests](https://github.com/litmus-tests/litmus-tests-riscv). The
 operational and axiomatic RISC-V concurrency models are in sync for
 these tests, and they moreover agree with the corresponding ARM
 architected behaviour for the tests in common.
@@ -275,8 +261,7 @@ Those tests have also been run on RISC-V hardware, on a SiFive RISC-V
 FU540 multicore proto board (Freedom Unleashed), kindly on loan from
 Imperas. To date, only sequentially consistent behaviour was observed there.
 
-Generating theorem-prover definitions
---------------------------------------
+## Generating theorem-prover definitions
 
 Sail aims to support the generation of idiomatic theorem prover
 definitions across multiple tools. At present it supports Isabelle,
@@ -294,12 +279,10 @@ monad over an effect datatype of memory actions. This monad is also
 used as part of the aforementioned concurrency support via the RMEM
 tool.
 
-
 The files under `handwritten_support` provide library definitions for
 each prover.
 
-Directory Structure
--------------------
+## Directory Structure
 
 ```
 sail-riscv
@@ -316,20 +299,17 @@ sail-riscv
 - os-boot                 // information and sample files for booting OS images
 ```
 
-Licence
--------
+## Licence
 
 The model is made available under the BSD two-clause licence in LICENCE.
 
-Authors
--------
+## Authors
 
 Originally written by Prashanth Mundkur at SRI International, and further developed by others, especially researchers at the University of Cambridge.
 
 See `LICENCE` and Git blame for a complete list of authors.
 
-Funding
--------
+## Funding
 
 This software was developed by the above within the Rigorous
 Engineering of Mainstream Systems (REMS) project, partly funded by

--- a/config/default.json
+++ b/config/default.json
@@ -1,196 +1,196 @@
 {
-    "base" : {
-        "writable_misa" : true,
-        "writable_fiom" : true,
-        "writable_hpm_counters" : {
-            "len" : 32,
-            "value" : "0xFFFF_FFFF"
-        },
-        "mtval_has_illegal_instruction_bits" : false
+  "base": {
+    "writable_misa": true,
+    "writable_fiom": true,
+    "writable_hpm_counters": {
+      "len": 32,
+      "value": "0xFFFF_FFFF"
     },
-    "memory" : {
-        "pmp" : {
-            "grain" : 0,
-            "count" : 16
-        },
-        "misaligned" : {
-            "supported" : true
-        },
-        "translation" : {
-            "dirty_update" : false
-        }
+    "mtval_has_illegal_instruction_bits": false
+  },
+  "memory": {
+    "pmp": {
+      "grain": 0,
+      "count": 16
     },
-    "platform" : {
-        "reset_vector" : 4096,
-        "cache_block_size_exp" : 6,
-        "ram" : {
-            "base" : 2147483648,
-            "size" : 2147483648
-        },
-        "rom" : {
-            "base" : 4096,
-            "size" : 4096
-        },
-        "clint" : {
-            "base" : 33554432,
-            "size" : 786432
-        },
-        "instructions_per_tick" : 100,
-        "wfi_is_nop" : true
+    "misaligned": {
+      "supported": true
     },
-    "extensions" : {
-        "M" : {
-            "supported" : true
-        },
-        "A" : {
-            "supported" : true
-        },
-        "FD" : {
-            "supported" : true
-        },
-        "V" : {
-            "supported" : true,
-            "vlen_exp" : 9,
-            "elen_exp" : 6,
-            "vl_use_ceil" : false
-        },
-        "B" : {
-            "supported" : true
-        },
-        "S" : {
-            "supported" : true
-        },
-        "U" : {
-            "supported" : true
-        },
-        "Zicbom" : {
-            "supported" : true
-        },
-        "Zicboz" : {
-            "supported" : true
-        },
-        "Zicond" : {
-            "supported" : true
-        },
-        "Zicntr" : {
-            "supported" : true
-        },
-        "Zifencei" : {
-            "supported" : true
-        },
-        "Zihpm" : {
-            "supported" : true
-        },
-        "Zimop" : {
-            "supported" : true
-        },
-        "Zmmul" : {
-            "supported" : false
-        },
-        "Zaamo" : {
-            "supported" : false
-        },
-        "Zabha" : {
-            "supported" : true
-        },
-        "Zalrsc" : {
-            "supported" : false
-        },
-        "Zfa" : {
-            "supported" : true
-        },
-        "Zfh" : {
-            "supported" : true
-        },
-        "Zfhmin" : {
-            "supported" : false
-        },
-        "Zfinx" : {
-            "supported" : false
-        },
-        "Zca" : {
-            "supported" : true
-        },
-        "Zcf" : {
-            "supported" : true
-        },
-        "Zcd" : {
-            "supported" : true
-        },
-        "Zcb" : {
-            "supported" : true
-        },
-        "Zcmop" : {
-            "supported" : true
-        },
-        "Zba" : {
-            "supported" : false
-        },
-        "Zbb" : {
-            "supported" : false
-        },
-        "Zbs" : {
-            "supported" : false
-        },
-        "Zbc" : {
-            "supported" : true
-        },
-        "Zbkb" : {
-            "supported" : true
-        },
-        "Zbkc" : {
-            "supported" : true
-        },
-        "Zbkx" : {
-            "supported" : true
-        },
-        "Zknd" : {
-            "supported" : true
-        },
-        "Zkne" : {
-            "supported" : true
-        },
-        "Zknh" : {
-            "supported" : true
-        },
-        "Zkr" : {
-            "supported" : true
-        },
-        "Zksed" : {
-            "supported" : true
-        },
-        "Zksh" : {
-            "supported" : true
-        },
-        "Zhinx" : {
-            "supported" : false
-        },
-        "Zvbb" : {
-            "supported" : true
-        },
-        "Zvkb" : {
-            "supported" : false
-        },
-        "Zvbc" : {
-            "supported" : true
-        },
-        "Zvknha" : {
-            "supported" : true
-        },
-        "Zvknhb" : {
-            "supported" : true
-        },
-        "Sscofpmf" : {
-            "supported" : true
-        },
-        "Smcntrpmf" : {
-            "supported" : true
-        },
-        "Sstc" : {
-            "supported" : true
-        },
-        "Svinval" : {
-            "supported" : true
-        }
+    "translation": {
+      "dirty_update": false
     }
+  },
+  "platform": {
+    "reset_vector": 4096,
+    "cache_block_size_exp": 6,
+    "ram": {
+      "base": 2147483648,
+      "size": 2147483648
+    },
+    "rom": {
+      "base": 4096,
+      "size": 4096
+    },
+    "clint": {
+      "base": 33554432,
+      "size": 786432
+    },
+    "instructions_per_tick": 100,
+    "wfi_is_nop": true
+  },
+  "extensions": {
+    "M": {
+      "supported": true
+    },
+    "A": {
+      "supported": true
+    },
+    "FD": {
+      "supported": true
+    },
+    "V": {
+      "supported": true,
+      "vlen_exp": 9,
+      "elen_exp": 6,
+      "vl_use_ceil": false
+    },
+    "B": {
+      "supported": true
+    },
+    "S": {
+      "supported": true
+    },
+    "U": {
+      "supported": true
+    },
+    "Zicbom": {
+      "supported": true
+    },
+    "Zicboz": {
+      "supported": true
+    },
+    "Zicond": {
+      "supported": true
+    },
+    "Zicntr": {
+      "supported": true
+    },
+    "Zifencei": {
+      "supported": true
+    },
+    "Zihpm": {
+      "supported": true
+    },
+    "Zimop": {
+      "supported": true
+    },
+    "Zmmul": {
+      "supported": false
+    },
+    "Zaamo": {
+      "supported": false
+    },
+    "Zabha": {
+      "supported": true
+    },
+    "Zalrsc": {
+      "supported": false
+    },
+    "Zfa": {
+      "supported": true
+    },
+    "Zfh": {
+      "supported": true
+    },
+    "Zfhmin": {
+      "supported": false
+    },
+    "Zfinx": {
+      "supported": false
+    },
+    "Zca": {
+      "supported": true
+    },
+    "Zcf": {
+      "supported": true
+    },
+    "Zcd": {
+      "supported": true
+    },
+    "Zcb": {
+      "supported": true
+    },
+    "Zcmop": {
+      "supported": true
+    },
+    "Zba": {
+      "supported": false
+    },
+    "Zbb": {
+      "supported": false
+    },
+    "Zbs": {
+      "supported": false
+    },
+    "Zbc": {
+      "supported": true
+    },
+    "Zbkb": {
+      "supported": true
+    },
+    "Zbkc": {
+      "supported": true
+    },
+    "Zbkx": {
+      "supported": true
+    },
+    "Zknd": {
+      "supported": true
+    },
+    "Zkne": {
+      "supported": true
+    },
+    "Zknh": {
+      "supported": true
+    },
+    "Zkr": {
+      "supported": true
+    },
+    "Zksed": {
+      "supported": true
+    },
+    "Zksh": {
+      "supported": true
+    },
+    "Zhinx": {
+      "supported": false
+    },
+    "Zvbb": {
+      "supported": true
+    },
+    "Zvkb": {
+      "supported": false
+    },
+    "Zvbc": {
+      "supported": true
+    },
+    "Zvknha": {
+      "supported": true
+    },
+    "Zvknhb": {
+      "supported": true
+    },
+    "Sscofpmf": {
+      "supported": true
+    },
+    "Smcntrpmf": {
+      "supported": true
+    },
+    "Sstc": {
+      "supported": true
+    },
+    "Svinval": {
+      "supported": true
+    }
+  }
 }

--- a/doc/ExtendingGuide.md
+++ b/doc/ExtendingGuide.md
@@ -1,69 +1,64 @@
-Extending the model
-===================
+# Extending the model
 
 > [!WARNING]
 > This document is undergoing updates and is not fully up to date
 > with the current state of the model. Please refer to the
 > [Sail code](../model/) itself for the most up to date information.
 
-Changing the register representation
-------------------------------------
+## Changing the register representation
 
 One can change the base register representation from an `XLEN`-length
 bitvector by supplying a different definition of the `regtype` type,
 and functions that convert between that type and the default
-`XLEN`-length bitvector.  The interface for this is specified in
-`riscv_reg_type.sail`.  An extension can implement a different
+`XLEN`-length bitvector. The interface for this is specified in
+`riscv_reg_type.sail`. An extension can implement a different
 representation in a file that follows that interface, and use it with
 the rest of the model.
 
-Adding architectural state
---------------------------
+## Adding architectural state
 
 Adding registers (such as for floating-point) would involve naming
 them and defining their read and write accessors, as is done for the
 integer registers in `riscv_types.sail`, `riscv_reg_type.sail` and
-`riscv_regs.sail`.  For modularity, these new definitions should be
-added in separate files.  If any of these registers are
+`riscv_regs.sail`. For modularity, these new definitions should be
+added in separate files. If any of these registers are
 control-and-status registers (CSRs), or depend on
 privilege level (such as hypervisor-mode registers), additional access
 control checks would need to be provided as is done for the standard
-CSRs in `riscv_sys_regs.sail` and `riscv_sys_control.sail`.  Access to
+CSRs in `riscv_sys_regs.sail` and `riscv_sys_control.sail`. Access to
 newly added CSRs can be hooked in `riscv_csr_ext.sail`. In addition,
 the bits `mstatus.XS` and `mstatus.SD` may need to be updated
 or extended to handle any extended register state.
 
 Adding a new privilege level or functionality restricted by privilege
 level will normally be accompanied by defining new exception causes
-and their encodings.  This will require modifying and extending the
+and their encodings. This will require modifying and extending the
 existing definitions for privilege levels and exceptions in
 `riscv_types.sail`, and modifying the exception handling and privilege
 transition functions in `riscv_sys_control.sail`.
 
-Modifying exception handling
-----------------------------
+## Modifying exception handling
 
 An extension that needs to interact closely with exception handling
 may need to capture additional information at the time of an
-exception.  This is supported using the `ext` field in the
+exception. This is supported using the `ext` field in the
 `sync_exception` type in `riscv_sync_exception.sail`, which is where
-the extension can store this information.  The addresses involved in
+the extension can store this information. The addresses involved in
 exception handling can be modified by following the interface provided
-in `riscv_sys_exceptions.sail`.  New exception codes can be introduced
+in `riscv_sys_exceptions.sail`. New exception codes can be introduced
 using the `E_Extension` variant of the `ExceptionType` in
 `riscv_types`.
 
-Adding low-level platform functionality
----------------------------------------
+## Adding low-level platform functionality
 
 Adding support for new devices such as interrupt controllers and
 similar memory-mapped I/O (MMIO) entities strictly falls outside the
 purview of the formal model itself, and typically is not done
-directly in the Sail model.  However, bindings to this external
+directly in the Sail model. However, bindings to this external
 functionality can be provided to Sail definitions using the `extern`
 construct of the Sail language. `riscv_platform.sail` can be examined
 to see how this is done for the SiFive core-local interrupt (CLINT)
-controller, the HTIF timer and terminal devices.  The
+controller, the HTIF timer and terminal devices. The
 implementation of the actual functionality provided by these MMIO
 devices would need to be added to the C emulators.
 
@@ -71,8 +66,7 @@ If this functionality requires the definition of new interrupt
 sources, their encodings would need to be added to `riscv_types.sail`,
 and their delegation and handling added to `riscv_sys_control.sail`.
 
-Modifying physical memory access
---------------------------------
+## Modifying physical memory access
 
 Physical memory addressing and access is defined in `riscv_mem.sail`.
 Any new regions of memory that are accessible via physical addresses
@@ -80,45 +74,43 @@ will require modifying the `mem_read`, `mem_write_value` or their
 supporting functions `checked_mem_read` and `checked_mem_write`.
 
 The model supports storing and retrieving metadata along with memory
-values at each physical memory address.  The default interface for
-this is defined in `prelude_mem_metadata.sail`.  An extension can
+values at each physical memory address. The default interface for
+this is defined in `prelude_mem_metadata.sail`. An extension can
 customize the default implementation there to support its metadata
 type.
 
 The actual content of such memory, and its modification, can be
-defined in separate Sail files.  This functionality will have access
-to any newly defined architectural state.  One can examine how normal
+defined in separate Sail files. This functionality will have access
+to any newly defined architectural state. One can examine how normal
 physical memory access is implemented in `riscv_mem.sail` with helpers
 in `prelude_mem.sail` and `prelude_mem_metadata.sail`.
 
-Extending virtual memory and address translation
-------------------------------------------------
+## Extending virtual memory and address translation
 
 Virtual memory is implemented in `riscv_vmem.sail`, and defining new
 address translation schemes will require modifying the top-level
-`translateAddr` function.  New types of memory access can be defined
-using the definitions in `riscv_vmem_types`.  Any access control
+`translateAddr` function. New types of memory access can be defined
+using the definitions in `riscv_vmem_types`. Any access control
 checks on virtual addresses and the specifics of the new address
-translation can be specified in a separate file.  This functionality
+translation can be specified in a separate file. This functionality
 can access any newly defined architectural state.
 
 The RV64 architecture has reserved bits in the PTE that can be
-utilized for research experimentation.  These bits can be accessed and
+utilized for research experimentation. These bits can be accessed and
 modified using the `ext_pte` argument in functions implementing the
-page-table walk.  The information computed by and used during the
+page-table walk. The information computed by and used during the
 page-table can also be varied using the `ext_ptw` argument, which can
-be defined and used by extensions as needed.  Extensions can override
+be defined and used by extensions as needed. Extensions can override
 the definitions of `checkPTEPermission` and `ext_get_ptw_error` to
 generate and process this custom information, and
 `ext_translate_exception` to convert any custom errors into
 extension-specific exceptions.
 
-Checking and transforming memory addresses
-------------------------------------------
+## Checking and transforming memory addresses
 
 An extension may wish to perform validity checks and transformations
 on addresses generated by an instruction before a memory access is
-performed with the generated address.  This is supported using the
+performed with the generated address. This is supported using the
 types defined in `riscv_addr_checks_common.sail`, with a default
 implementation in `riscv_addr_checks.sail`.
 
@@ -126,11 +118,10 @@ The handling of the memory addresses involved during exception
 handling can be extending using the interface defined in
 `riscv_sys_exceptions.sail`.
 
-Checking and transforming the program counter
----------------------------------------------
+## Checking and transforming the program counter
 
 An extension might want to similarly check and transform accesses to
-the program counter.  This is supported by supplying implementations
+the program counter. This is supported by supplying implementations
 of the functions defined in `riscv_pc_access.sail`.
 
 In addition, dynamically enabling and disabling the RVC extension has
@@ -139,40 +130,36 @@ RVC are ignored if the PC becomes unaligned in the base architecture.
 Extensions can also veto these attempts by appropriately defining
 `ext_veto_disable_C`.
 
-Adding new instructions
------------------------
+## Adding new instructions
 
 This is typically simpler than adding new architectural state or
-memory interposition.  Each new set of instructions can be specified
+memory interposition. Each new set of instructions can be specified
 in a separate self-contained file, with their instruction encodings,
 assembly language specifications and the corresponding encoders and
 decoders, and execution semantics. `riscv.sail` can be examined for
-examples on how this can done.  These instruction definitions can
+examples on how this can done. These instruction definitions can
 access any newly defined architectural state and perform virtual or
 physical memory accesses as is done in `riscv.sail`.
 
-Interposing on instruction decode
----------------------------------
+## Interposing on instruction decode
 
 An extension may wish to check and transform a decoded instruction.
 This is supported via a post-decode extension hook, the default
 implementation of which is provided in `riscv_decode_ext.sail`.
 
-General guidelines
-------------------
+## General guidelines
 
 For any new extension, it is helpful to factor it out into the above
-items.  When specifying and implementing the extension, it is expected
+items. When specifying and implementing the extension, it is expected
 to be easier to implement it in the above listed order.
 
-Example
--------
+## Example
 
 As an example, one can examine the implementation of the 'N' extension
-for user-level interrupt handling.  The architectural state to support
+for user-level interrupt handling. The architectural state to support
 'N' is specified in `riscv_next_regs.sail`, added CSR and control
 functionality is in `riscv_next_control.sail`, and added instructions
-are in `riscv_insts_next.sail`.  Access to the CSRs added by the
+are in `riscv_insts_next.sail`. Access to the CSRs added by the
 extension are hooked in `riscv_csr_ext.sail`.
 
 In addition, privilege transition and interrupt delegation logic in

--- a/doc/ReadingGuide.md
+++ b/doc/ReadingGuide.md
@@ -1,17 +1,16 @@
-A guide to reading the specification
-------------------------------------
+## A guide to reading the specification
 
 > [!WARNING]
 > This document is undergoing updates and is not fully up to date
 > with the current state of the model. Please refer to the
 > [Sail code](../model/) itself for the most up to date information.
 
-The model is written in the Sail language.  Although specifications in
+The model is written in the Sail language. Although specifications in
 Sail are quite readable as pseudocode, it would help to have the [Sail
 manual](https://alasdair.github.io/manual.html) handy.
 
 The Sail modules in the `model` directory have the structure shown
-below.  Arrows indicate a dependency relationship, and _italics_
+below. Arrows indicate a dependency relationship, and _italics_
 indicate fragments that are not strictly part of the specification,
 such as the platform memory map.
 
@@ -19,19 +18,19 @@ such as the platform memory map.
 
 - `riscv_xlen32.sail` and `riscv_xlen64.sail` define xlen dependent
   variables (`log2_xlen_bytes` and `physaddrbits_len`) for RV32 and
-  RV64.  One of them is chosen during the build using the ARCH variable.
+  RV64. One of them is chosen during the build using the ARCH variable.
 
-- `prelude_*.sail` contain useful Sail library functions.  These
-  files should be referred to as needed.  The lowest level memory
+- `prelude_*.sail` contain useful Sail library functions. These
+  files should be referred to as needed. The lowest level memory
   access primitives are defined in `prelude_mem.sail`, and are
   implemented by the various Sail backends. `prelude_mem.sail`
   depends on the value of `xlen`.
 
-- `riscv_types.sail` contains some basic RISC-V definitions.  This
+- `riscv_types.sail` contains some basic RISC-V definitions. This
   file should be read first, since these definitions
   are used throughout the specification, such as privilege levels,
   register indices, interrupt and exception definitions
-  and enumerations, and types used to define memory accesses.  The
+  and enumerations, and types used to define memory accesses. The
   register type is separately defined in `riscv_reg_type.sail` so that
   extensions of the model can redefine it if required.
 
@@ -45,7 +44,7 @@ such as the platform memory map.
 
 - `riscv_sys_regs.sail` describes the privileged architectural state,
   viz. M-mode and S-mode CSRs, and contains helpers to interpret their
-  content, such as WLRL and WARL fields.  `riscv_sys_control.sail`
+  content, such as WLRL and WARL fields. `riscv_sys_control.sail`
   describes interrupt and exception delegation and dispatch, and the
   handling of privilege transitions. `riscv_sys_exceptions.sail`
   defines the handling of the addresses involved in exception
@@ -54,31 +53,31 @@ such as the platform memory map.
 
   Since WLRL and WARL fields are intended to capture platform-specific
   functionality, future versions of the model might separate their
-  handling functions out into a separate platform-defined file.  The
+  handling functions out into a separate platform-defined file. The
   current implementation of these functions usually implement the same
   behavior as the Spike emulator.
 
 - `riscv_pmp_regs.sail` and `riscv_pmp_control.sail` implement support
-  for physical memory protection (PMP).  `riscv_pmp_regs` handle read
+  for physical memory protection (PMP). `riscv_pmp_regs` handle read
   and write access to the PMP registers, while `riscv_pmp_control`
   implements the permission checking and matching priority.
 
 - `riscv_platform.sail` contains platform-specific functionality for
-  the model.  It contains the physical memory map, the local interrupt
+  the model. It contains the physical memory map, the local interrupt
   controller, and the MMIO interfaces to the clock, timer and terminal
-  devices.  Sail `extern` definitions are used to connect externally
+  devices. Sail `extern` definitions are used to connect externally
   provided (i.e. external to the Sail model) platform functionality,
   such as those provided by the platform support in the C
-  emulator.  This file also contains the externally selectable
+  emulator. This file also contains the externally selectable
   options for platform behavior, such as the handling of misaligned
   memory accesses, the handling of PTE dirty-bit updates during
-  address translation, etc.  These platform options can be specified
+  address translation, etc. These platform options can be specified
   via command line switches in the C emulator.
 
 - `riscv_mem.sail` contains the functions that convert accesses to
   physical addresses into accesses to physical memory, or MMIO
   accesses to the devices provided by the platform, or into the
-  appropriate access fault.  This file also contains definitions that
+  appropriate access fault. This file also contains definitions that
   are used in the weak memory concurrency model.
 
 - The `riscv_vmem_*.sail` files describe the S-mode address
@@ -87,16 +86,16 @@ such as the platform memory map.
 
 - The `riscv_addr_checks_common.sail` and `riscv_addr_checks.sail`
   contain extension hooks to support the checking and transformation
-  of memory addresses during the execution of an instruction.  The
+  of memory addresses during the execution of an instruction. The
   transformed addresses are used for any address translation; however,
   any memory access exceptions are reported in terms of the original
   memory address (i.e. the one generated by the instruction, not the
   hook).
 
 - Files matching `riscv_insts_*.sail` capture the instruction
-  definitions and their assembly language formats.  Each file contains
+  definitions and their assembly language formats. Each file contains
   the instructions for an extension, with `riscv_insts_base.sail` containing
-  the base integer instruction set.  Each instruction is represented
+  the base integer instruction set. Each instruction is represented
   as a variant clause of the `ast` type, and its execution semantics
   are represented as a clause of the `execute` function. `mapping`
   clauses specify the encoding and decoding of each instruction to and
@@ -104,7 +103,7 @@ such as the platform memory map.
   Hint instructions that are not implicitly handled elsewhere are
   explicitly handled in `riscv_insts_hints.sail`.
 
-- `riscv_fetch.sail` contains the instruction fetch function.  It
+- `riscv_fetch.sail` contains the instruction fetch function. It
   supports checking and transformation of the fetch address as
   described above.
 
@@ -113,15 +112,14 @@ such as the platform memory map.
   The `step` function performs the instruction fetch, handles any
   fetch errors, decodes the fetched value, dispatches the execution of
   the decoded instruction, and checks for any pending interrupts that may
-  need to be handled.  A `loop` function implements the execute loop,
+  need to be handled. A `loop` function implements the execute loop,
   and uses the same HTIF (host-target interface) mechanism as the
   Spike emulator to detect termination of execution.
 
 Note that the files above are listed in dependency order, i.e. files
 earlier in the order do not depend on later files.
 
-Structure of the C emulator
-----------------------------
+## Structure of the C emulator
 
 The diagram below illustrates how the C emulator is built from the
 Sail model.
@@ -129,7 +127,7 @@ Sail model.
 <img src="figs/riscvcsimdeps.svg">
 
 The nodes that are not colored are the handwritten C files for the C
-emulator.  The black arrows indicate dependency relationships, while
+emulator. The black arrows indicate dependency relationships, while
 the red arrow indicates a file generated by the Sail compiler from
 Sail source files.
 
@@ -142,7 +140,7 @@ map.
 
 The generated C model `riscv_sim_$ARCH` is built from the Sail
 sources by the Sail compiler for the specified architecture $ARCH,
-either RV32 or RV64.  It contains calls to the platform interface
+either RV32 or RV64. It contains calls to the platform interface
 `riscv_platform` for platform-specific information; the latter is
 typically defined as externally specified in the Sail file
 `riscv_platform.sail`.

--- a/os-boot/README.md
+++ b/os-boot/README.md
@@ -1,11 +1,10 @@
-Booting OS images
-=================
+# Booting OS images
 
 The Sail model implements a very simple platform based on the one
-implemented by the Spike reference simulator.  It implements a console
+implemented by the Spike reference simulator. It implements a console
 output port similar to Spike's HTIF (host-target interface) mechanism,
 and an interrupt controller based on Spike's CLINT (core-local
-interrupt controller).  Console input is not currently supported.
+interrupt controller). Console input is not currently supported.
 
 32-bit OS boots require a workaround for the 64-bit HTIF interface,
 which is currently not supported.
@@ -17,38 +16,36 @@ installable on Ubuntu and Debian machines with
 sudo apt install device-tree-compiler
 ```
 
-Booting Linux with the C backend
---------------------------------
+## Booting Linux with the C backend
 
 The C model needs an ELF-version of the BBL (Berkeley-Boot-Loader)
-that contains the Linux kernel as an embedded payload.  It also needs
+that contains the Linux kernel as an embedded payload. It also needs
 a DTB (device-tree blob) file describing the platform (say in the file
-`spike.dtb`).  Once those are available (see below for suggestions),
+`spike.dtb`). Once those are available (see below for suggestions),
 the model should be run as:
 
 ```
 $ ./c_emulator/riscv_sim_<arch> -t console.log -b spike.dtb bbl > execution-trace.log 2>&1 &
 $ tail -f console.log
 ```
+
 The `console.log` file contains the console boot messages. For maximum
 performance and benchmarking a model without any execution tracing is
 available on the optimize branch (`git checkout optimize`) of this
 repository. This currently requires the latest Sail built from source.
 
-Caveats for OS boot
--------------------
+## Caveats for OS boot
 
 - Some OS toolchains generate obsolete LR/SC instructions with now
-  illegal combinations of `.aq` and `.rl` flags.  You can work-around
+  illegal combinations of `.aq` and `.rl` flags. You can work-around
   this by changing `riscv_mem.sail` to accept these flags.
 
 - One needs to manually ensure that the DTB used for the C model
   accurately describes the physical memory map implemented in the C
-  platform.  This will not be needed once the C model can generate its
+  platform. This will not be needed once the C model can generate its
   own DTB.
 
-Sample Linux image
-------------------
+## Sample Linux image
 
 `rv64-linux-4.15.0-gcc-7.2.0-64mb.bbl` contains a sample Linux RV64
 image that can be booted as follows, after first generating the

--- a/test/README.md
+++ b/test/README.md
@@ -1,4 +1,4 @@
 # Tests
 
-* `riscv-tests` - a collection of very old pre-compiled ELFs from [the `riscv-tests` repo](https://github.com/riscv-software-src/riscv-tests). These are bare minimum tests; not very exhaustive at all.
-* `first_party` - tests specifically designed for this Sail model. These tests are not designed to test all the features of RISC-V. Rather they are for testing new code that we add, and bug fixes.
+- `riscv-tests` - a collection of very old pre-compiled ELFs from [the `riscv-tests` repo](https://github.com/riscv-software-src/riscv-tests). These are bare minimum tests; not very exhaustive at all.
+- `first_party` - tests specifically designed for this Sail model. These tests are not designed to test all the features of RISC-V. Rather they are for testing new code that we add, and bug fixes.

--- a/test/riscv-tests/README
+++ b/test/riscv-tests/README
@@ -3,6 +3,7 @@ All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
+
 1. Redistributions of source code must retain the above copyright
    notice, this list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright


### PR DESCRIPTION
Primarily added for formatting json files, but also formats markdown and yaml.

I noticed #866 makes significant formatting changes to the `default.json` config file. It probably makes sense to have an auto formatter that is enforced in CI for JSON files (especially as I expect we will add more preset configs as time goes on) to make changes easier to review going forward, similar to what we already do with `clang-format`. Prettier seems like one of the more popular JSON formatters, so I went with that. By default, it also formats Markdown and YAML files, but if we'd rather, I can disable that and only do the JSON files.