### PR TITLE
make 34 bit physaddr log readable

### DIFF
--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -74,7 +74,7 @@ function phys_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext
     (Read(Data), None()) => Err(E_Load_Access_Fault()),
     (_,          None()) => Err(E_SAMO_Access_Fault()),
     (_,      Some(v, m)) => { if   get_config_print_mem()
-                              then print_mem("mem[" ^ to_str(t) ^ "," ^ BitStr(physaddr_bits(paddr)) ^ "] -> " ^ BitStr(v));
+                              then print_mem("mem[" ^ to_str(t) ^ "," ^ readable_addr_bits(physaddr_bits(paddr)) ^ "] -> " ^ BitStr(v));
                               Ok(v, m) }
   }
 }

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -24,6 +24,12 @@ val elf_entry = pure {
   c: "elf_entry"
 } : unit -> int
 
+function readable_addr_bits (addr : physaddrbits) -> string = {
+  if physaddrbits_len == 34
+  then BitStr(0b00 @ addr)
+  else BitStr(addr)
+}
+
 // Cache block size is 2^cache_block_size_exp. Max is `max_mem_access` (4096)
 // because this model performs `cbo.zero` with a single write, and the behaviour
 // with cache blocks larger than a page is not clearly defined.
@@ -311,7 +317,7 @@ function reset_htif () -> unit = {
 val htif_load : forall 'n, 'n > 0. (AccessType(ext_access_type), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
 function htif_load(t, Physaddr(paddr), width) = {
   if   get_config_print_platform()
-  then print_platform("htif[" ^ BitStr(paddr) ^ "] -> " ^ BitStr(htif_tohost));
+  then print_platform("htif[" ^ readable_addr_bits(paddr) ^ "] -> " ^ BitStr(htif_tohost));
   /* FIXME: For now, only allow the expected access widths. */
   if      width == 8 & (paddr == plat_htif_tohost())
   then    Ok(zero_extend(64, htif_tohost))         /* FIXME: Redundant zero_extend currently required by Lem backend */
@@ -329,7 +335,7 @@ function htif_load(t, Physaddr(paddr), width) = {
 val htif_store: forall 'n, 0 < 'n <= 8. (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
 function htif_store(Physaddr(paddr), width, data) = {
   if   get_config_print_platform()
-  then print_platform("htif[" ^ BitStr(paddr) ^ "] <- " ^ BitStr(data));
+  then print_platform("htif[" ^ readable_addr_bits(paddr) ^ "] <- " ^ BitStr(data));
   /* Store the written value so that we can ack it later. */
   if      width == 8
   then    { htif_cmd_write = bitone;


### PR DESCRIPTION
As noted in #851, this PR adds a helper function to improve string readability. To address the loss of length information, I propose adding a comment or updating the documentation. If this approach is approved, I can include it in this PR.