### PR TITLE
Fix precommit failure

### DIFF
--- a/.github/workflows/rocq.yml
+++ b/.github/workflows/rocq.yml
@@ -13,27 +13,27 @@ jobs:
       # (e.g. https://github.com/actions/checkout/issues/47)
       options: --user root
     steps:
-    - name: Install packages
-      run: |
-        apt update
-        apt install -y --no-install-recommends cmake
-        eval `opam env --safe`
-        # We're still using Rocq's old name for compatibility with versions < 9
-        opam install -y coq=9.0.0 coq-sail-stdpp=0.19
+      - name: Install packages
+        run: |
+          apt update
+          apt install -y --no-install-recommends cmake
+          eval `opam env --safe`
+          # We're still using Rocq's old name for compatibility with versions < 9
+          opam install -y coq=9.0.0 coq-sail-stdpp=0.19
 
-    - name: Install sail from binary
-      run: |
-        curl --location https://github.com/rems-project/sail/releases/download/0.19-linux-binary/sail.tar.gz | tar xvz --directory=/usr/local --strip-components=1
+      - name: Install sail from binary
+        run: |
+          curl --location https://github.com/rems-project/sail/releases/download/0.19-linux-binary/sail.tar.gz | tar xvz --directory=/usr/local --strip-components=1
 
-    - name: Check out repository code
-      uses: actions/checkout@v4
+      - name: Check out repository code
+        uses: actions/checkout@v4
 
-    - name: Generate Rocq model
-      run: |
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDOWNLOAD_GMP=FALSE
-        cmake --build build --target generated_rocq_rv64d
+      - name: Generate Rocq model
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDOWNLOAD_GMP=FALSE
+          cmake --build build --target generated_rocq_rv64d
 
-    - name: Compile Rocq output
-      run: |
-        eval `opam env --safe`
-        cmake --build build --target build_rocq_rv64d
+      - name: Compile Rocq output
+        run: |
+          eval `opam env --safe`
+          cmake --build build --target build_rocq_rv64d


### PR DESCRIPTION
#864 was merged after #868, but without the changes from #868 merged into it, so it passed the CI from that branch but failed CI once merged into master. This fixes the precommit errors with it.