### PR TITLE
Remove redundant RISCV_ prefixes on internal ast nodes and enums.

### DIFF
--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -16,8 +16,8 @@ function clause currentlyEnabled(Ext_Zca) = hartSupports(Ext_Zca) & (currentlyEn
 union clause ast = UTYPE : (bits(20), regidx, uop)
 
 mapping encdec_uop : uop <-> bits(7) = {
-  RISCV_LUI   <-> 0b0110111,
-  RISCV_AUIPC <-> 0b0010111
+  LUI   <-> 0b0110111,
+  AUIPC <-> 0b0010111
 }
 
 mapping clause encdec = UTYPE(imm, rd, op)
@@ -26,30 +26,30 @@ mapping clause encdec = UTYPE(imm, rd, op)
 function clause execute (UTYPE(imm, rd, op)) = {
   let off : xlenbits = sign_extend(imm @ 0x000);
   X(rd) = match op {
-    RISCV_LUI   => off,
-    RISCV_AUIPC => get_arch_pc() + off
+    LUI   => off,
+    AUIPC => get_arch_pc() + off
   };
   RETIRE_SUCCESS
 }
 
 mapping utype_mnemonic : uop <-> string = {
-  RISCV_LUI   <-> "lui",
-  RISCV_AUIPC <-> "auipc"
+  LUI   <-> "lui",
+  AUIPC <-> "auipc"
 }
 
 mapping clause assembly = UTYPE(imm, rd, op)
   <-> utype_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_signed_20(imm)
 
 /* ****************************************************************** */
-union clause ast = RISCV_JAL : (bits(21), regidx)
+union clause ast = JAL : (bits(21), regidx)
 
-mapping clause encdec = RISCV_JAL(imm_19 @ imm_7_0 @ imm_8 @ imm_18_13 @ imm_12_9 @ 0b0, rd)
+mapping clause encdec = JAL(imm_19 @ imm_7_0 @ imm_8 @ imm_18_13 @ imm_12_9 @ 0b0, rd)
   <-> imm_19 : bits(1) @ imm_18_13 : bits(6) @ imm_12_9 : bits(4) @ imm_8 : bits(1) @ imm_7_0 : bits(8) @ encdec_reg(rd) @ 0b1101111
 
 /*
 ideally we want some syntax like
 
-mapping clause encdec = RISCV_JAL(imm @ 0b0, rd) <-> imm[19] @ imm[9..0] @ imm[10] @ imm[18..11] @ encdec_reg(rd) @ 0b1101111
+mapping clause encdec = JAL(imm @ 0b0, rd) <-> imm[19] @ imm[9..0] @ imm[10] @ imm[18..11] @ encdec_reg(rd) @ 0b1101111
 
 match bv {
   imm[19] @ imm[9..0] @ imm[10] @ imm[18..11] -> imm @ 0b0
@@ -58,7 +58,7 @@ match bv {
 but this is difficult
 */
 
-function clause execute (RISCV_JAL(imm, rd)) = {
+function clause execute (JAL(imm, rd)) = {
   let target = PC + sign_extend(imm);
   /* Extensions get the first checks on the prospective target address. */
   match ext_control_check_pc(target) {
@@ -79,16 +79,16 @@ function clause execute (RISCV_JAL(imm, rd)) = {
 
 /* TODO: handle 2-byte-alignment in mappings */
 
-mapping clause assembly = RISCV_JAL(imm, rd)
+mapping clause assembly = JAL(imm, rd)
   <-> "jal" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_signed_21(imm)
 
 /* ****************************************************************** */
-union clause ast = RISCV_JALR : (bits(12), regidx, regidx)
+union clause ast = JALR : (bits(12), regidx, regidx)
 
-mapping clause encdec = RISCV_JALR(imm, rs1, rd)
+mapping clause encdec = JALR(imm, rs1, rd)
   <-> imm @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b1100111
 
-mapping clause assembly = RISCV_JALR(imm, rs1, rd)
+mapping clause assembly = JALR(imm, rs1, rd)
   <-> "jalr" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_signed_12(imm) ^ "(" ^ reg_name(rs1) ^ ")"
 
 /* see riscv_jalr_seq.sail or riscv_jalr_rmem.sail for the execute clause. */
@@ -97,12 +97,12 @@ mapping clause assembly = RISCV_JALR(imm, rs1, rd)
 union clause ast = BTYPE : (bits(13), regidx, regidx, bop)
 
 mapping encdec_bop : bop <-> bits(3) = {
-  RISCV_BEQ  <-> 0b000,
-  RISCV_BNE  <-> 0b001,
-  RISCV_BLT  <-> 0b100,
-  RISCV_BGE  <-> 0b101,
-  RISCV_BLTU <-> 0b110,
-  RISCV_BGEU <-> 0b111
+  BEQ  <-> 0b000,
+  BNE  <-> 0b001,
+  BLT  <-> 0b100,
+  BGE  <-> 0b101,
+  BLTU <-> 0b110,
+  BGEU <-> 0b111
 }
 
 mapping clause encdec = BTYPE(imm7_6 @ imm5_0 @ imm7_5_0 @ imm5_4_1 @ 0b0, rs2, rs1, op)
@@ -110,12 +110,12 @@ mapping clause encdec = BTYPE(imm7_6 @ imm5_0 @ imm7_5_0 @ imm5_4_1 @ 0b0, rs2, 
 
 function clause execute (BTYPE(imm, rs2, rs1, op)) = {
   let taken : bool = match op {
-    RISCV_BEQ  => X(rs1) == X(rs2),
-    RISCV_BNE  => X(rs1) != X(rs2),
-    RISCV_BLT  => X(rs1) <_s X(rs2),
-    RISCV_BGE  => X(rs1) >=_s X(rs2),
-    RISCV_BLTU => X(rs1) <_u X(rs2),
-    RISCV_BGEU => X(rs1) >=_u X(rs2)
+    BEQ  => X(rs1) == X(rs2),
+    BNE  => X(rs1) != X(rs2),
+    BLT  => X(rs1) <_s X(rs2),
+    BGE  => X(rs1) >=_s X(rs2),
+    BLTU => X(rs1) <_u X(rs2),
+    BGEU => X(rs1) >=_u X(rs2)
   };
   if taken then {
     let target = PC + sign_extend(imm);
@@ -136,12 +136,12 @@ function clause execute (BTYPE(imm, rs2, rs1, op)) = {
 }
 
 mapping btype_mnemonic : bop <-> string = {
-  RISCV_BEQ  <-> "beq",
-  RISCV_BNE  <-> "bne",
-  RISCV_BLT  <-> "blt",
-  RISCV_BGE  <-> "bge",
-  RISCV_BLTU <-> "bltu",
-  RISCV_BGEU <-> "bgeu"
+  BEQ  <-> "beq",
+  BNE  <-> "bne",
+  BLT  <-> "blt",
+  BGE  <-> "bge",
+  BLTU <-> "bltu",
+  BGEU <-> "bgeu"
 }
 
 mapping clause assembly = BTYPE(imm, rs2, rs1, op)
@@ -151,12 +151,12 @@ mapping clause assembly = BTYPE(imm, rs2, rs1, op)
 union clause ast = ITYPE : (bits(12), regidx, regidx, iop)
 
 mapping encdec_iop : iop <-> bits(3) = {
-  RISCV_ADDI  <-> 0b000,
-  RISCV_SLTI  <-> 0b010,
-  RISCV_SLTIU <-> 0b011,
-  RISCV_ANDI  <-> 0b111,
-  RISCV_ORI   <-> 0b110,
-  RISCV_XORI  <-> 0b100
+  ADDI  <-> 0b000,
+  SLTI  <-> 0b010,
+  SLTIU <-> 0b011,
+  ANDI  <-> 0b111,
+  ORI   <-> 0b110,
+  XORI  <-> 0b100
 }
 
 mapping clause encdec = ITYPE(imm, rs1, rd, op)
@@ -165,23 +165,23 @@ mapping clause encdec = ITYPE(imm, rs1, rd, op)
 function clause execute (ITYPE (imm, rs1, rd, op)) = {
   let immext : xlenbits = sign_extend(imm);
   X(rd) = match op {
-    RISCV_ADDI  => X(rs1) + immext,
-    RISCV_SLTI  => zero_extend(bool_to_bits(X(rs1) <_s immext)),
-    RISCV_SLTIU => zero_extend(bool_to_bits(X(rs1) <_u immext)),
-    RISCV_ANDI  => X(rs1) & immext,
-    RISCV_ORI   => X(rs1) | immext,
-    RISCV_XORI  => X(rs1) ^ immext
+    ADDI  => X(rs1) + immext,
+    SLTI  => zero_extend(bool_to_bits(X(rs1) <_s immext)),
+    SLTIU => zero_extend(bool_to_bits(X(rs1) <_u immext)),
+    ANDI  => X(rs1) & immext,
+    ORI   => X(rs1) | immext,
+    XORI  => X(rs1) ^ immext
   };
   RETIRE_SUCCESS
 }
 
 mapping itype_mnemonic : iop <-> string = {
-  RISCV_ADDI  <-> "addi",
-  RISCV_SLTI  <-> "slti",
-  RISCV_SLTIU <-> "sltiu",
-  RISCV_XORI  <-> "xori",
-  RISCV_ORI   <-> "ori",
-  RISCV_ANDI  <-> "andi"
+  ADDI  <-> "addi",
+  SLTI  <-> "slti",
+  SLTIU <-> "sltiu",
+  XORI  <-> "xori",
+  ORI   <-> "ori",
+  ANDI  <-> "andi"
 }
 
 mapping clause assembly = ITYPE(imm, rs1, rd, op)
@@ -191,35 +191,35 @@ mapping clause assembly = ITYPE(imm, rs1, rd, op)
 union clause ast = SHIFTIOP : (bits(6), regidx, regidx, sop)
 
 mapping encdec_sop : sop <-> bits(3) = {
-  RISCV_SLLI <-> 0b001,
-  RISCV_SRLI <-> 0b101,
-  RISCV_SRAI <-> 0b101
+  SLLI <-> 0b001,
+  SRLI <-> 0b101,
+  SRAI <-> 0b101
 }
 
-mapping clause encdec = SHIFTIOP(shamt, rs1, rd, RISCV_SLLI)
+mapping clause encdec = SHIFTIOP(shamt, rs1, rd, SLLI)
   <-> 0b000000 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when xlen == 64 | shamt[5] == bitzero
-mapping clause encdec = SHIFTIOP(shamt, rs1, rd, RISCV_SRLI)
+mapping clause encdec = SHIFTIOP(shamt, rs1, rd, SRLI)
   <-> 0b000000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
   when xlen == 64 | shamt[5] == bitzero
-mapping clause encdec = SHIFTIOP(shamt, rs1, rd, RISCV_SRAI)
+mapping clause encdec = SHIFTIOP(shamt, rs1, rd, SRAI)
   <-> 0b010000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
   when xlen == 64 | shamt[5] == bitzero
 
 function clause execute (SHIFTIOP(shamt, rs1, rd, op)) = {
   // The decoder guard ensures that shamt[5] = 0 for RV32.
   X(rd) = match op {
-    RISCV_SLLI => X(rs1) << shamt,
-    RISCV_SRLI => X(rs1) >> shamt,
-    RISCV_SRAI => shift_bits_right_arith(X(rs1), shamt),
+    SLLI => X(rs1) << shamt,
+    SRLI => X(rs1) >> shamt,
+    SRAI => shift_bits_right_arith(X(rs1), shamt),
   };
   RETIRE_SUCCESS
 }
 
 mapping shiftiop_mnemonic : sop <-> string = {
-  RISCV_SLLI <-> "slli",
-  RISCV_SRLI <-> "srli",
-  RISCV_SRAI <-> "srai"
+  SLLI <-> "slli",
+  SRLI <-> "srli",
+  SRAI <-> "srai"
 }
 
 mapping clause assembly = SHIFTIOP(shamt, rs1, rd, op)
@@ -228,44 +228,44 @@ mapping clause assembly = SHIFTIOP(shamt, rs1, rd, op)
 /* ****************************************************************** */
 union clause ast = RTYPE : (regidx, regidx, regidx, rop)
 
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_ADD)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SLT)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SLTU) <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b011 @ encdec_reg(rd) @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_AND)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_OR)   <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_XOR)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SLL)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SRL)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SUB)  <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
-mapping clause encdec = RTYPE(rs2, rs1, rd, RISCV_SRA)  <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, ADD)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, SLT)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, SLTU) <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b011 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, AND)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, OR)   <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, XOR)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, SLL)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, SRL)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, SUB)  <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = RTYPE(rs2, rs1, rd, SRA)  <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
 
 function clause execute (RTYPE(rs2, rs1, rd, op)) = {
   X(rd) = match op {
-    RISCV_ADD  => X(rs1) + X(rs2),
-    RISCV_SLT  => zero_extend(bool_to_bits(X(rs1) <_s X(rs2))),
-    RISCV_SLTU => zero_extend(bool_to_bits(X(rs1) <_u X(rs2))),
-    RISCV_AND  => X(rs1) & X(rs2),
-    RISCV_OR   => X(rs1) | X(rs2),
-    RISCV_XOR  => X(rs1) ^ X(rs2),
-    RISCV_SLL  => X(rs1) << X(rs2)[log2_xlen - 1 .. 0],
-    RISCV_SRL  => X(rs1) >> X(rs2)[log2_xlen - 1 .. 0],
-    RISCV_SUB  => X(rs1) - X(rs2),
-    RISCV_SRA  => shift_bits_right_arith(X(rs1), X(rs2)[log2_xlen - 1 .. 0]),
+    ADD  => X(rs1) + X(rs2),
+    SLT  => zero_extend(bool_to_bits(X(rs1) <_s X(rs2))),
+    SLTU => zero_extend(bool_to_bits(X(rs1) <_u X(rs2))),
+    AND  => X(rs1) & X(rs2),
+    OR   => X(rs1) | X(rs2),
+    XOR  => X(rs1) ^ X(rs2),
+    SLL  => X(rs1) << X(rs2)[log2_xlen - 1 .. 0],
+    SRL  => X(rs1) >> X(rs2)[log2_xlen - 1 .. 0],
+    SUB  => X(rs1) - X(rs2),
+    SRA  => shift_bits_right_arith(X(rs1), X(rs2)[log2_xlen - 1 .. 0]),
   };
   RETIRE_SUCCESS
 }
 
 mapping rtype_mnemonic : rop <-> string = {
-  RISCV_ADD  <-> "add",
-  RISCV_SLT  <-> "slt",
-  RISCV_SLTU <-> "sltu",
-  RISCV_AND  <-> "and",
-  RISCV_OR   <-> "or",
-  RISCV_XOR  <-> "xor",
-  RISCV_SLL  <-> "sll",
-  RISCV_SRL  <-> "srl",
-  RISCV_SUB  <-> "sub",
-  RISCV_SRA  <-> "sra"
+  ADD  <-> "add",
+  SLT  <-> "slt",
+  SLTU <-> "sltu",
+  AND  <-> "and",
+  OR   <-> "or",
+  XOR  <-> "xor",
+  SLL  <-> "sll",
+  SRL  <-> "srl",
+  SUB  <-> "sub",
+  SRA  <-> "sra"
 }
 
 mapping clause assembly = RTYPE(rs2, rs1, rd, op)
@@ -407,19 +407,19 @@ mapping clause assembly = ADDIW(imm, rs1, rd)
 /* ****************************************************************** */
 union clause ast = RTYPEW : (regidx, regidx, regidx, ropw)
 
-mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_ADDW)
+mapping clause encdec = RTYPEW(rs2, rs1, rd, ADDW)
   <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0111011
   when xlen == 64
-mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_SUBW)
+mapping clause encdec = RTYPEW(rs2, rs1, rd, SUBW)
   <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0111011
   when xlen == 64
-mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_SLLW)
+mapping clause encdec = RTYPEW(rs2, rs1, rd, SLLW)
   <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0111011
   when xlen == 64
-mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_SRLW)
+mapping clause encdec = RTYPEW(rs2, rs1, rd, SRLW)
   <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0111011
   when xlen == 64
-mapping clause encdec = RTYPEW(rs2, rs1, rd, RISCV_SRAW)
+mapping clause encdec = RTYPEW(rs2, rs1, rd, SRAW)
   <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0111011
   when xlen == 64
 
@@ -427,22 +427,22 @@ function clause execute (RTYPEW(rs2, rs1, rd, op)) = {
   let rs1_val = X(rs1)[31..0];
   let rs2_val = X(rs2)[31..0];
   let result : bits(32) = match op {
-    RISCV_ADDW => rs1_val + rs2_val,
-    RISCV_SUBW => rs1_val - rs2_val,
-    RISCV_SLLW => rs1_val << rs2_val[4..0],
-    RISCV_SRLW => rs1_val >> rs2_val[4..0],
-    RISCV_SRAW => shift_bits_right_arith(rs1_val, rs2_val[4..0]),
+    ADDW => rs1_val + rs2_val,
+    SUBW => rs1_val - rs2_val,
+    SLLW => rs1_val << rs2_val[4..0],
+    SRLW => rs1_val >> rs2_val[4..0],
+    SRAW => shift_bits_right_arith(rs1_val, rs2_val[4..0]),
   };
   X(rd) = sign_extend(result);
   RETIRE_SUCCESS
 }
 
 mapping rtypew_mnemonic : ropw <-> string = {
-  RISCV_ADDW <-> "addw",
-  RISCV_SUBW <-> "subw",
-  RISCV_SLLW <-> "sllw",
-  RISCV_SRLW <-> "srlw",
-  RISCV_SRAW <-> "sraw"
+  ADDW <-> "addw",
+  SUBW <-> "subw",
+  SLLW <-> "sllw",
+  SRLW <-> "srlw",
+  SRAW <-> "sraw"
 }
 
 mapping clause assembly = RTYPEW(rs2, rs1, rd, op)
@@ -452,31 +452,31 @@ mapping clause assembly = RTYPEW(rs2, rs1, rd, op)
 /* ****************************************************************** */
 union clause ast = SHIFTIWOP : (bits(5), regidx, regidx, sopw)
 
-mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SLLIW)
+mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, SLLIW)
   <-> 0b0000000 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
   when xlen == 64
-mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SRLIW)
+mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, SRLIW)
   <-> 0b0000000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0011011
   when xlen == 64
-mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, RISCV_SRAIW)
+mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, SRAIW)
   <-> 0b0100000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0011011
   when xlen == 64
 
 function clause execute (SHIFTIWOP(shamt, rs1, rd, op)) = {
   let rs1_val = X(rs1)[31..0];
   let result : bits(32) = match op {
-    RISCV_SLLIW => rs1_val << shamt,
-    RISCV_SRLIW => rs1_val >> shamt,
-    RISCV_SRAIW => shift_bits_right_arith(rs1_val, shamt),
+    SLLIW => rs1_val << shamt,
+    SRLIW => rs1_val >> shamt,
+    SRAIW => shift_bits_right_arith(rs1_val, shamt),
   };
   X(rd) = sign_extend(result);
   RETIRE_SUCCESS
 }
 
 mapping shiftiwop_mnemonic : sopw <-> string = {
-  RISCV_SLLIW <-> "slliw",
-  RISCV_SRLIW <-> "srliw",
-  RISCV_SRAIW <-> "sraiw"
+  SLLIW <-> "slliw",
+  SRLIW <-> "srliw",
+  SRAIW <-> "sraiw"
 }
 
 mapping clause assembly = SHIFTIWOP(shamt, rs1, rd, op)

--- a/model/riscv_insts_zba.sail
+++ b/model/riscv_insts_zba.sail
@@ -10,16 +10,16 @@ function clause currentlyEnabled(Ext_B) = hartSupports(Ext_B) & misa[B] == 0b1
 function clause currentlyEnabled(Ext_Zba) = hartSupports(Ext_Zba) | currentlyEnabled(Ext_B)
 
 /* ****************************************************************** */
-union clause ast = RISCV_SLLIUW : (bits(6), regidx, regidx)
+union clause ast = SLLIUW : (bits(6), regidx, regidx)
 
-mapping clause encdec = RISCV_SLLIUW(shamt, rs1, rd)
+mapping clause encdec = SLLIUW(shamt, rs1, rd)
   <-> 0b000010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
   when currentlyEnabled(Ext_Zba) & xlen == 64
 
-mapping clause assembly = RISCV_SLLIUW(shamt, rs1, rd)
+mapping clause assembly = SLLIUW(shamt, rs1, rd)
   <-> "slli.uw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_6(shamt)
 
-function clause execute (RISCV_SLLIUW(shamt, rs1, rd)) = {
+function clause execute (SLLIUW(shamt, rs1, rd)) = {
   let rs1_val = X(rs1);
   let result : xlenbits = zero_extend(rs1_val[31..0]) << shamt;
   X(rd) = result;
@@ -29,27 +29,27 @@ function clause execute (RISCV_SLLIUW(shamt, rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = ZBA_RTYPEUW : (regidx, regidx, regidx, bropw_zba)
 
-mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, RISCV_ADDUW)
+mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, ADDUW)
   <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0111011
   when currentlyEnabled(Ext_Zba) & xlen == 64
 
-mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, RISCV_SH1ADDUW)
+mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, SH1ADDUW)
   <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0111011
   when currentlyEnabled(Ext_Zba) & xlen == 64
 
-mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, RISCV_SH2ADDUW)
+mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, SH2ADDUW)
   <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0111011
   when currentlyEnabled(Ext_Zba) & xlen == 64
 
-mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, RISCV_SH3ADDUW)
+mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, SH3ADDUW)
   <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0111011
   when currentlyEnabled(Ext_Zba) & xlen == 64
 
 mapping zba_rtypeuw_mnemonic : bropw_zba <-> string = {
-  RISCV_ADDUW    <-> "add.uw",
-  RISCV_SH1ADDUW <-> "sh1add.uw",
-  RISCV_SH2ADDUW <-> "sh2add.uw",
-  RISCV_SH3ADDUW <-> "sh3add.uw"
+  ADDUW    <-> "add.uw",
+  SH1ADDUW <-> "sh1add.uw",
+  SH2ADDUW <-> "sh2add.uw",
+  SH3ADDUW <-> "sh3add.uw"
 }
 
 mapping clause assembly = ZBA_RTYPEUW(rs2, rs1, rd, op)
@@ -59,10 +59,10 @@ function clause execute (ZBA_RTYPEUW(rs2, rs1, rd, op)) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
   let shamt : bits(2) = match op {
-    RISCV_ADDUW    => 0b00,
-    RISCV_SH1ADDUW => 0b01,
-    RISCV_SH2ADDUW => 0b10,
-    RISCV_SH3ADDUW => 0b11
+    ADDUW    => 0b00,
+    SH1ADDUW => 0b01,
+    SH2ADDUW => 0b10,
+    SH3ADDUW => 0b11
   };
   let result : xlenbits = (zero_extend(rs1_val[31..0]) << shamt) + rs2_val;
   X(rd) = result;
@@ -72,20 +72,20 @@ function clause execute (ZBA_RTYPEUW(rs2, rs1, rd, op)) = {
 /* ****************************************************************** */
 union clause ast = ZBA_RTYPE : (regidx, regidx, regidx, brop_zba)
 
-mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, RISCV_SH1ADD)
+mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, SH1ADD)
   <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zba)
-mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, RISCV_SH2ADD)
+mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, SH2ADD)
   <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zba)
-mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, RISCV_SH3ADD)
+mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, SH3ADD)
   <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zba)
 
 mapping zba_rtype_mnemonic : brop_zba <-> string = {
-  RISCV_SH1ADD <-> "sh1add",
-  RISCV_SH2ADD <-> "sh2add",
-  RISCV_SH3ADD <-> "sh3add"
+  SH1ADD <-> "sh1add",
+  SH2ADD <-> "sh2add",
+  SH3ADD <-> "sh3add"
 }
 
 mapping clause assembly = ZBA_RTYPE(rs2, rs1, rd, op)
@@ -95,9 +95,9 @@ function clause execute (ZBA_RTYPE(rs2, rs1, rd, op)) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
   let shamt : bits(2) = match op {
-    RISCV_SH1ADD => 0b01,
-    RISCV_SH2ADD => 0b10,
-    RISCV_SH3ADD => 0b11
+    SH1ADD => 0b01,
+    SH2ADD => 0b10,
+    SH3ADD => 0b11
   };
   let result : xlenbits = (rs1_val << shamt) + rs2_val;
   X(rd) = result;

--- a/model/riscv_insts_zbb.sail
+++ b/model/riscv_insts_zbb.sail
@@ -10,16 +10,16 @@ function clause currentlyEnabled(Ext_Zbb) = hartSupports(Ext_Zbb) | currentlyEna
 function clause currentlyEnabled(Ext_Zbkb) = hartSupports(Ext_Zbkb)
 
 /* ****************************************************************** */
-union clause ast = RISCV_RORIW : (bits(5), regidx, regidx)
+union clause ast = RORIW : (bits(5), regidx, regidx)
 
-mapping clause encdec = RISCV_RORIW(shamt, rs1, rd)
+mapping clause encdec = RORIW(shamt, rs1, rd)
   <-> 0b0110000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0011011
   when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 64
 
-mapping clause assembly = RISCV_RORIW(shamt, rs1, rd)
+mapping clause assembly = RORIW(shamt, rs1, rd)
   <-> "roriw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_5(shamt)
 
-function clause execute (RISCV_RORIW(shamt, rs1, rd)) = {
+function clause execute (RORIW(shamt, rs1, rd)) = {
   let rs1_val = (X(rs1))[31..0];
   let result : xlenbits = sign_extend(rs1_val >>> shamt);
   X(rd) = result;
@@ -27,16 +27,16 @@ function clause execute (RISCV_RORIW(shamt, rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = RISCV_RORI : (bits(6), regidx, regidx)
+union clause ast = RORI : (bits(6), regidx, regidx)
 
-mapping clause encdec = RISCV_RORI(shamt, rs1, rd)
+mapping clause encdec = RORI(shamt, rs1, rd)
   <-> 0b011000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
   when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & (xlen == 64 | shamt[5] == bitzero)
 
-mapping clause assembly = RISCV_RORI(shamt, rs1, rd)
+mapping clause assembly = RORI(shamt, rs1, rd)
   <-> "rori" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_6(shamt)
 
-function clause execute (RISCV_RORI(shamt, rs1, rd)) = {
+function clause execute (RORI(shamt, rs1, rd)) = {
   let rs1_val = X(rs1);
   let result : xlenbits = if xlen == 32
                           then rs1_val >>> shamt[4..0]
@@ -48,17 +48,17 @@ function clause execute (RISCV_RORI(shamt, rs1, rd)) = {
 /* ****************************************************************** */
 union clause ast = ZBB_RTYPEW : (regidx, regidx, regidx, bropw_zbb)
 
-mapping clause encdec = ZBB_RTYPEW(rs2, rs1, rd, RISCV_ROLW)
+mapping clause encdec = ZBB_RTYPEW(rs2, rs1, rd, ROLW)
   <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0111011
   when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 64
 
-mapping clause encdec = ZBB_RTYPEW(rs2, rs1, rd, RISCV_RORW)
+mapping clause encdec = ZBB_RTYPEW(rs2, rs1, rd, RORW)
   <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0111011
   when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 64
 
 mapping zbb_rtypew_mnemonic : bropw_zbb <-> string = {
-  RISCV_ROLW <-> "rolw",
-  RISCV_RORW <-> "rorw"
+  ROLW <-> "rolw",
+  RORW <-> "rorw"
 }
 
 mapping clause assembly = ZBB_RTYPEW(rs2, rs1, rd, op)
@@ -68,8 +68,8 @@ function clause execute (ZBB_RTYPEW(rs2, rs1, rd, op)) = {
   let rs1_val = (X(rs1))[31..0];
   let shamt = (X(rs2))[4..0];
   let result : bits(32) = match op {
-    RISCV_ROLW => rs1_val <<< shamt,
-    RISCV_RORW => rs1_val >>> shamt
+    ROLW => rs1_val <<< shamt,
+    RORW => rs1_val >>> shamt
   };
   X(rd) = sign_extend(result);
   RETIRE_SUCCESS
@@ -78,52 +78,52 @@ function clause execute (ZBB_RTYPEW(rs2, rs1, rd, op)) = {
 /* ****************************************************************** */
 union clause ast = ZBB_RTYPE : (regidx, regidx, regidx, brop_zbb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ANDN)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, ANDN)
   <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ORN)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, ORN)
   <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_XNOR)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, XNOR)
   <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MAX)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, MAX)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MAXU)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, MAXU)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MIN)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, MIN)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_MINU)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, MINU)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ROL)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, ROL)
   <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
 
-mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, RISCV_ROR)
+mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, ROR)
   <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
 
 mapping zbb_rtype_mnemonic : brop_zbb <-> string = {
-  RISCV_ANDN <-> "andn",
-  RISCV_ORN  <-> "orn",
-  RISCV_XNOR <-> "xnor",
-  RISCV_MAX  <-> "max",
-  RISCV_MAXU <-> "maxu",
-  RISCV_MIN  <-> "min",
-  RISCV_MINU <-> "minu",
-  RISCV_ROL  <-> "rol",
-  RISCV_ROR  <-> "ror"
+  ANDN <-> "andn",
+  ORN  <-> "orn",
+  XNOR <-> "xnor",
+  MAX  <-> "max",
+  MAXU <-> "maxu",
+  MIN  <-> "min",
+  MINU <-> "minu",
+  ROL  <-> "rol",
+  ROR  <-> "ror"
 }
 
 mapping clause assembly = ZBB_RTYPE(rs2, rs1, rd, op)
@@ -133,17 +133,17 @@ function clause execute (ZBB_RTYPE(rs2, rs1, rd, op)) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
   let result : xlenbits = match op {
-    RISCV_ANDN => rs1_val & ~(rs2_val),
-    RISCV_ORN  => rs1_val | ~(rs2_val),
-    RISCV_XNOR => ~(rs1_val ^ rs2_val),
-    RISCV_MAX  => to_bits(xlen, max(signed(rs1_val),   signed(rs2_val))),
-    RISCV_MAXU => to_bits(xlen, max(unsigned(rs1_val), unsigned(rs2_val))),
-    RISCV_MIN  => to_bits(xlen, min(signed(rs1_val),   signed(rs2_val))),
-    RISCV_MINU => to_bits(xlen, min(unsigned(rs1_val), unsigned(rs2_val))),
-    RISCV_ROL  => if xlen == 32
+    ANDN => rs1_val & ~(rs2_val),
+    ORN  => rs1_val | ~(rs2_val),
+    XNOR => ~(rs1_val ^ rs2_val),
+    MAX  => to_bits(xlen, max(signed(rs1_val),   signed(rs2_val))),
+    MAXU => to_bits(xlen, max(unsigned(rs1_val), unsigned(rs2_val))),
+    MIN  => to_bits(xlen, min(signed(rs1_val),   signed(rs2_val))),
+    MINU => to_bits(xlen, min(unsigned(rs1_val), unsigned(rs2_val))),
+    ROL  => if xlen == 32
                   then rs1_val <<< rs2_val[4..0]
                   else rs1_val <<< rs2_val[5..0],
-    RISCV_ROR  => if xlen == 32
+    ROR  => if xlen == 32
                   then rs1_val >>> rs2_val[4..0]
                   else rs1_val >>> rs2_val[5..0]
   };
@@ -154,26 +154,26 @@ function clause execute (ZBB_RTYPE(rs2, rs1, rd, op)) = {
 /* ****************************************************************** */
 union clause ast = ZBB_EXTOP : (regidx, regidx, extop_zbb)
 
-mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_SEXTB)
+mapping clause encdec = ZBB_EXTOP(rs1, rd, SEXTB)
   <-> 0b0110000 @ 0b00100 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbb)
 
-mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_SEXTH)
+mapping clause encdec = ZBB_EXTOP(rs1, rd, SEXTH)
   <-> 0b0110000 @ 0b00101 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbb)
 
-mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_ZEXTH)
+mapping clause encdec = ZBB_EXTOP(rs1, rd, ZEXTH)
   <-> 0b0000100 @ 0b00000 @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb) & xlen == 32
 
-mapping clause encdec = ZBB_EXTOP(rs1, rd, RISCV_ZEXTH)
+mapping clause encdec = ZBB_EXTOP(rs1, rd, ZEXTH)
   <-> 0b0000100 @ 0b00000 @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0111011
   when currentlyEnabled(Ext_Zbb) & xlen == 64
 
 mapping zbb_extop_mnemonic : extop_zbb <-> string = {
-  RISCV_SEXTB <-> "sext.b",
-  RISCV_SEXTH <-> "sext.h",
-  RISCV_ZEXTH <-> "zext.h"
+  SEXTB <-> "sext.b",
+  SEXTH <-> "sext.h",
+  ZEXTH <-> "zext.h"
 }
 
 mapping clause assembly = ZBB_EXTOP(rs1, rd, op)
@@ -182,29 +182,29 @@ mapping clause assembly = ZBB_EXTOP(rs1, rd, op)
 function clause execute (ZBB_EXTOP(rs1, rd, op)) = {
   let rs1_val = X(rs1);
   let result : xlenbits = match op {
-    RISCV_SEXTB => sign_extend(rs1_val[7..0]),
-    RISCV_SEXTH => sign_extend(rs1_val[15..0]),
-    RISCV_ZEXTH => zero_extend(rs1_val[15..0])
+    SEXTB => sign_extend(rs1_val[7..0]),
+    SEXTH => sign_extend(rs1_val[15..0]),
+    ZEXTH => zero_extend(rs1_val[15..0])
   };
   X(rd) = result;
   RETIRE_SUCCESS
 }
 
 /* ****************************************************************** */
-union clause ast = RISCV_REV8 : (regidx, regidx)
+union clause ast = REV8 : (regidx, regidx)
 
-mapping clause encdec = RISCV_REV8(rs1, rd)
+mapping clause encdec = REV8(rs1, rd)
   <-> 0b011010011000 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
   when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 32
 
-mapping clause encdec = RISCV_REV8(rs1, rd)
+mapping clause encdec = REV8(rs1, rd)
   <-> 0b011010111000 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
   when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 64
 
-mapping clause assembly = RISCV_REV8(rs1, rd)
+mapping clause assembly = REV8(rs1, rd)
   <-> "rev8" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (RISCV_REV8(rs1, rd)) = {
+function clause execute (REV8(rs1, rd)) = {
   let rs1_val = X(rs1);
   var result : xlenbits = zeros();
   foreach (i from 0 to (xlen - 8) by 8)
@@ -214,16 +214,16 @@ function clause execute (RISCV_REV8(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = RISCV_ORCB : (regidx, regidx)
+union clause ast = ORCB : (regidx, regidx)
 
-mapping clause encdec = RISCV_ORCB(rs1, rd)
+mapping clause encdec = ORCB(rs1, rd)
   <-> 0b001010000111 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbb)
 
-mapping clause assembly = RISCV_ORCB(rs1, rd)
+mapping clause assembly = ORCB(rs1, rd)
   <-> "orc.b" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (RISCV_ORCB(rs1, rd)) = {
+function clause execute (ORCB(rs1, rd)) = {
   let rs1_val = X(rs1);
   var result : xlenbits = zeros();
   foreach (i from 0 to (xlen - 8) by 8)
@@ -235,16 +235,16 @@ function clause execute (RISCV_ORCB(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = RISCV_CPOP : (regidx, regidx)
+union clause ast = CPOP : (regidx, regidx)
 
-mapping clause encdec = RISCV_CPOP(rs1, rd)
+mapping clause encdec = CPOP(rs1, rd)
   <-> 0b011000000010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbb)
 
-mapping clause assembly = RISCV_CPOP(rs1, rd)
+mapping clause assembly = CPOP(rs1, rd)
   <-> "cpop" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (RISCV_CPOP(rs1, rd)) = {
+function clause execute (CPOP(rs1, rd)) = {
   let rs1_val = X(rs1);
   var result : nat = 0;
   foreach (i from 0 to (xlen_val - 1))
@@ -254,16 +254,16 @@ function clause execute (RISCV_CPOP(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = RISCV_CPOPW : (regidx, regidx)
+union clause ast = CPOPW : (regidx, regidx)
 
-mapping clause encdec = RISCV_CPOPW(rs1, rd)
+mapping clause encdec = CPOPW(rs1, rd)
   <-> 0b011000000010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
   when currentlyEnabled(Ext_Zbb) & xlen == 64
 
-mapping clause assembly = RISCV_CPOPW(rs1, rd)
+mapping clause assembly = CPOPW(rs1, rd)
   <-> "cpopw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (RISCV_CPOPW(rs1, rd)) = {
+function clause execute (CPOPW(rs1, rd)) = {
   let rs1_val = X(rs1);
   var result : nat = 0;
   foreach (i from 0 to 31)
@@ -273,16 +273,16 @@ function clause execute (RISCV_CPOPW(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = RISCV_CLZ : (regidx, regidx)
+union clause ast = CLZ : (regidx, regidx)
 
-mapping clause encdec = RISCV_CLZ(rs1, rd)
+mapping clause encdec = CLZ(rs1, rd)
   <-> 0b011000000000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbb)
 
-mapping clause assembly = RISCV_CLZ(rs1, rd)
+mapping clause assembly = CLZ(rs1, rd)
   <-> "clz" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (RISCV_CLZ(rs1, rd)) = {
+function clause execute (CLZ(rs1, rd)) = {
   let rs1_val = X(rs1);
   var result : nat = 0;
   var done : bool = false;
@@ -295,16 +295,16 @@ function clause execute (RISCV_CLZ(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = RISCV_CLZW : (regidx, regidx)
+union clause ast = CLZW : (regidx, regidx)
 
-mapping clause encdec = RISCV_CLZW(rs1, rd)
+mapping clause encdec = CLZW(rs1, rd)
   <-> 0b011000000000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
   when currentlyEnabled(Ext_Zbb) & xlen == 64
 
-mapping clause assembly = RISCV_CLZW(rs1, rd)
+mapping clause assembly = CLZW(rs1, rd)
   <-> "clzw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (RISCV_CLZW(rs1, rd)) = {
+function clause execute (CLZW(rs1, rd)) = {
   let rs1_val = X(rs1);
   var result : nat = 0;
   var done : bool = false;
@@ -317,16 +317,16 @@ function clause execute (RISCV_CLZW(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = RISCV_CTZ : (regidx, regidx)
+union clause ast = CTZ : (regidx, regidx)
 
-mapping clause encdec = RISCV_CTZ(rs1, rd)
+mapping clause encdec = CTZ(rs1, rd)
   <-> 0b011000000001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbb)
 
-mapping clause assembly = RISCV_CTZ(rs1, rd)
+mapping clause assembly = CTZ(rs1, rd)
   <-> "ctz" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (RISCV_CTZ(rs1, rd)) = {
+function clause execute (CTZ(rs1, rd)) = {
   let rs1_val = X(rs1);
   var result : nat = 0;
   var done : bool = false;
@@ -339,16 +339,16 @@ function clause execute (RISCV_CTZ(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = RISCV_CTZW : (regidx, regidx)
+union clause ast = CTZW : (regidx, regidx)
 
-mapping clause encdec = RISCV_CTZW(rs1, rd)
+mapping clause encdec = CTZW(rs1, rd)
   <-> 0b011000000001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
   when currentlyEnabled(Ext_Zbb) & xlen == 64
 
-mapping clause assembly = RISCV_CTZW(rs1, rd)
+mapping clause assembly = CTZW(rs1, rd)
   <-> "ctzw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (RISCV_CTZW(rs1, rd)) = {
+function clause execute (CTZW(rs1, rd)) = {
   let rs1_val = X(rs1);
   var result : nat = 0;
   var done : bool = false;

--- a/model/riscv_insts_zbc.sail
+++ b/model/riscv_insts_zbc.sail
@@ -10,48 +10,48 @@ function clause currentlyEnabled(Ext_Zbc) = hartSupports(Ext_Zbc)
 function clause currentlyEnabled(Ext_Zbkc) = hartSupports(Ext_Zbkc)
 
 /* ****************************************************************** */
-union clause ast = RISCV_CLMUL : (regidx, regidx, regidx)
+union clause ast = CLMUL : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_CLMUL(rs2, rs1, rd)
+mapping clause encdec = CLMUL(rs2, rs1, rd)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbc) | currentlyEnabled(Ext_Zbkc)
 
-mapping clause assembly = RISCV_CLMUL(rs2, rs1, rd)
+mapping clause assembly = CLMUL(rs2, rs1, rd)
   <-> "clmul" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (RISCV_CLMUL(rs2, rs1, rd)) = {
+function clause execute (CLMUL(rs2, rs1, rd)) = {
   let prod = carryless_mul(X(rs1), X(rs2));
   X(rd) = prod[xlen - 1 .. 0];
   RETIRE_SUCCESS
 }
 
 /* ****************************************************************** */
-union clause ast = RISCV_CLMULH : (regidx, regidx, regidx)
+union clause ast = CLMULH : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_CLMULH(rs2, rs1, rd)
+mapping clause encdec = CLMULH(rs2, rs1, rd)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b011 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbc) | currentlyEnabled(Ext_Zbkc)
 
-mapping clause assembly = RISCV_CLMULH(rs2, rs1, rd)
+mapping clause assembly = CLMULH(rs2, rs1, rd)
   <-> "clmulh" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (RISCV_CLMULH(rs2, rs1, rd)) = {
+function clause execute (CLMULH(rs2, rs1, rd)) = {
   let prod = carryless_mul(X(rs1), X(rs2));
   X(rd) = prod[2 * xlen - 1 .. xlen];
   RETIRE_SUCCESS
 }
 
 /* ****************************************************************** */
-union clause ast = RISCV_CLMULR : (regidx, regidx, regidx)
+union clause ast = CLMULR : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_CLMULR(rs2, rs1, rd)
+mapping clause encdec = CLMULR(rs2, rs1, rd)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbc)
 
-mapping clause assembly = RISCV_CLMULR(rs2, rs1, rd)
+mapping clause assembly = CLMULR(rs2, rs1, rd)
   <-> "clmulr" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (RISCV_CLMULR(rs2, rs1, rd)) = {
+function clause execute (CLMULR(rs2, rs1, rd)) = {
   X(rd) = carryless_mulr(X(rs1), X(rs2));
   RETIRE_SUCCESS
 }

--- a/model/riscv_insts_zbkb.sail
+++ b/model/riscv_insts_zbkb.sail
@@ -9,17 +9,17 @@
 /* ****************************************************************** */
 union clause ast = ZBKB_RTYPE : (regidx, regidx, regidx, brop_zbkb)
 
-mapping clause encdec = ZBKB_RTYPE(rs2, rs1, rd, RISCV_PACK)
+mapping clause encdec = ZBKB_RTYPE(rs2, rs1, rd, PACK)
   <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbkb)
 
-mapping clause encdec = ZBKB_RTYPE(rs2, rs1, rd, RISCV_PACKH)
+mapping clause encdec = ZBKB_RTYPE(rs2, rs1, rd, PACKH)
   <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbkb)
 
 mapping zbkb_rtype_mnemonic : brop_zbkb <-> string = {
-  RISCV_PACK  <-> "pack",
-  RISCV_PACKH <-> "packh"
+  PACK  <-> "pack",
+  PACKH <-> "packh"
 }
 
 mapping clause assembly = ZBKB_RTYPE(rs2, rs1, rd, op)
@@ -29,8 +29,8 @@ function clause execute (ZBKB_RTYPE(rs2, rs1, rd, op)) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
   let result : xlenbits = match op {
-    RISCV_PACK  => rs2_val[(xlen_bytes*4 - 1)..0] @ rs1_val[(xlen_bytes*4 - 1)..0],
-    RISCV_PACKH => zero_extend(rs2_val[7..0] @ rs1_val[7..0])
+    PACK  => rs2_val[(xlen_bytes*4 - 1)..0] @ rs1_val[(xlen_bytes*4 - 1)..0],
+    PACKH => zero_extend(rs2_val[7..0] @ rs1_val[7..0])
   };
   X(rd) = result;
   RETIRE_SUCCESS
@@ -56,16 +56,16 @@ function clause execute (ZBKB_PACKW(rs2, rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = RISCV_ZIP : (regidx, regidx)
+union clause ast = ZIP : (regidx, regidx)
 
-mapping clause encdec = RISCV_ZIP(rs1, rd)
+mapping clause encdec = ZIP(rs1, rd)
   <-> 0b000010001111 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbkb) & xlen == 32
 
-mapping clause assembly = RISCV_ZIP(rs1, rd)
+mapping clause assembly = ZIP(rs1, rd)
   <-> "zip" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (RISCV_ZIP(rs1, rd)) = {
+function clause execute (ZIP(rs1, rd)) = {
   assert(xlen == 32);
   let rs1_val = X(rs1);
   var result : xlenbits = zeros();
@@ -78,16 +78,16 @@ function clause execute (RISCV_ZIP(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = RISCV_UNZIP : (regidx, regidx)
+union clause ast = UNZIP : (regidx, regidx)
 
-mapping clause encdec = RISCV_UNZIP(rs1, rd)
+mapping clause encdec = UNZIP(rs1, rd)
   <-> 0b000010001111 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbkb) & xlen == 32
 
-mapping clause assembly = RISCV_UNZIP(rs1, rd)
+mapping clause assembly = UNZIP(rs1, rd)
   <-> "unzip" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (RISCV_UNZIP(rs1, rd)) = {
+function clause execute (UNZIP(rs1, rd)) = {
   assert(xlen == 32);
   let rs1_val = X(rs1);
   var result : xlenbits = zeros();
@@ -100,16 +100,16 @@ function clause execute (RISCV_UNZIP(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = RISCV_BREV8 : (regidx, regidx)
+union clause ast = BREV8 : (regidx, regidx)
 
-mapping clause encdec = RISCV_BREV8(rs1, rd)
+mapping clause encdec = BREV8(rs1, rd)
   <-> 0b011010000111 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbkb)
 
-mapping clause assembly = RISCV_BREV8(rs1, rd)
+mapping clause assembly = BREV8(rs1, rd)
   <-> "brev8" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (RISCV_BREV8(rs1, rd)) = {
+function clause execute (BREV8(rs1, rd)) = {
   let rs1_val = X(rs1);
   var result : xlenbits = zeros();
   foreach (i from 0 to (xlen - 8) by 8)

--- a/model/riscv_insts_zbkx.sail
+++ b/model/riscv_insts_zbkx.sail
@@ -9,16 +9,16 @@
 function clause currentlyEnabled(Ext_Zbkx) = hartSupports(Ext_Zbkx)
 
 /* ****************************************************************** */
-union clause ast = RISCV_XPERM8 : (regidx, regidx, regidx)
+union clause ast = XPERM8 : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_XPERM8(rs2, rs1, rd)
+mapping clause encdec = XPERM8(rs2, rs1, rd)
   <-> 0b0010100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbkx)
 
-mapping clause assembly = RISCV_XPERM8(rs2, rs1, rd)
+mapping clause assembly = XPERM8(rs2, rs1, rd)
   <-> "xperm8" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (RISCV_XPERM8(rs2, rs1, rd)) = {
+function clause execute (XPERM8(rs2, rs1, rd)) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
   var result : xlenbits = zeros();
@@ -33,16 +33,16 @@ function clause execute (RISCV_XPERM8(rs2, rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = RISCV_XPERM4 : (regidx, regidx, regidx)
+union clause ast = XPERM4 : (regidx, regidx, regidx)
 
-mapping clause encdec = RISCV_XPERM4(rs2, rs1, rd)
+mapping clause encdec = XPERM4(rs2, rs1, rd)
   <-> 0b0010100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbkx)
 
-mapping clause assembly = RISCV_XPERM4(rs2, rs1, rd)
+mapping clause assembly = XPERM4(rs2, rs1, rd)
   <-> "xperm4" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (RISCV_XPERM4(rs2, rs1, rd)) = {
+function clause execute (XPERM4(rs2, rs1, rd)) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
   var result : xlenbits = zeros();

--- a/model/riscv_insts_zbs.sail
+++ b/model/riscv_insts_zbs.sail
@@ -11,27 +11,27 @@ function clause currentlyEnabled(Ext_Zbs) = hartSupports(Ext_Zbs) | currentlyEna
 /* ****************************************************************** */
 union clause ast = ZBS_IOP : (bits(6), regidx, regidx, biop_zbs)
 
-mapping clause encdec = ZBS_IOP(shamt, rs1, rd, RISCV_BCLRI)
+mapping clause encdec = ZBS_IOP(shamt, rs1, rd, BCLRI)
   <-> 0b010010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
 
-mapping clause encdec = ZBS_IOP(shamt, rs1, rd, RISCV_BEXTI)
+mapping clause encdec = ZBS_IOP(shamt, rs1, rd, BEXTI)
   <-> 0b010010 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
 
-mapping clause encdec = ZBS_IOP(shamt, rs1, rd, RISCV_BINVI)
+mapping clause encdec = ZBS_IOP(shamt, rs1, rd, BINVI)
   <-> 0b011010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
 
-mapping clause encdec = ZBS_IOP(shamt, rs1, rd, RISCV_BSETI)
+mapping clause encdec = ZBS_IOP(shamt, rs1, rd, BSETI)
   <-> 0b001010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
 
 mapping zbs_iop_mnemonic : biop_zbs <-> string = {
-  RISCV_BCLRI <-> "bclri",
-  RISCV_BEXTI <-> "bexti",
-  RISCV_BINVI <-> "binvi",
-  RISCV_BSETI <-> "bseti"
+  BCLRI <-> "bclri",
+  BEXTI <-> "bexti",
+  BINVI <-> "binvi",
+  BSETI <-> "bseti"
 }
 
 mapping clause assembly = ZBS_IOP(shamt, rs1, rd, op)
@@ -43,10 +43,10 @@ function clause execute (ZBS_IOP(shamt, rs1, rd, op)) = {
                         then zero_extend(0b1) << shamt[4..0]
                         else zero_extend(0b1) << shamt;
   let result : xlenbits = match op {
-    RISCV_BCLRI => rs1_val & ~(mask),
-    RISCV_BEXTI => zero_extend(bool_to_bits((rs1_val & mask) != zeros())),
-    RISCV_BINVI => rs1_val ^ mask,
-    RISCV_BSETI => rs1_val | mask
+    BCLRI => rs1_val & ~(mask),
+    BEXTI => zero_extend(bool_to_bits((rs1_val & mask) != zeros())),
+    BINVI => rs1_val ^ mask,
+    BSETI => rs1_val | mask
   };
   X(rd) = result;
   RETIRE_SUCCESS
@@ -55,27 +55,27 @@ function clause execute (ZBS_IOP(shamt, rs1, rd, op)) = {
 /* ****************************************************************** */
 union clause ast = ZBS_RTYPE : (regidx, regidx, regidx, brop_zbs)
 
-mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, RISCV_BCLR)
+mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, BCLR)
   <-> 0b0100100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbs)
 
-mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, RISCV_BEXT)
+mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, BEXT)
   <-> 0b0100100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbs)
 
-mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, RISCV_BINV)
+mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, BINV)
   <-> 0b0110100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbs)
 
-mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, RISCV_BSET)
+mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, BSET)
   <-> 0b0010100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbs)
 
 mapping zbs_rtype_mnemonic : brop_zbs <-> string = {
-  RISCV_BCLR    <-> "bclr",
-  RISCV_BEXT    <-> "bext",
-  RISCV_BINV    <-> "binv",
-  RISCV_BSET    <-> "bset"
+  BCLR    <-> "bclr",
+  BEXT    <-> "bext",
+  BINV    <-> "binv",
+  BSET    <-> "bset"
 }
 
 mapping clause assembly = ZBS_RTYPE(rs2, rs1, rd, op)
@@ -88,10 +88,10 @@ function clause execute (ZBS_RTYPE(rs2, rs1, rd, op)) = {
                         then zero_extend(0b1) << rs2_val[4..0]
                         else zero_extend(0b1) << rs2_val[5..0];
   let result : xlenbits = match op {
-    RISCV_BCLR => rs1_val & ~(mask),
-    RISCV_BEXT => zero_extend(bool_to_bits((rs1_val & mask) != zeros())),
-    RISCV_BINV => rs1_val ^ mask,
-    RISCV_BSET => rs1_val | mask
+    BCLR => rs1_val & ~(mask),
+    BEXT => zero_extend(bool_to_bits((rs1_val & mask) != zeros())),
+    BINV => rs1_val ^ mask,
+    BSET => rs1_val | mask
   };
   X(rd) = result;
   RETIRE_SUCCESS

--- a/model/riscv_insts_zca.sail
+++ b/model/riscv_insts_zca.sail
@@ -35,7 +35,7 @@ mapping clause encdec_compressed = C_ADDI4SPN(rd, nz96 @ nz54 @ nz3 @ nz2)
 function clause execute (C_ADDI4SPN(rdc, nzimm)) = {
   let imm : bits(12) = (0b00 @ nzimm @ 0b00);
   let rd = creg2reg_idx(rdc);
-  execute(ITYPE(imm, sp, rd, RISCV_ADDI))
+  execute(ITYPE(imm, sp, rd, ADDI))
 }
 
 mapping clause assembly = C_ADDI4SPN(rdc, nzimm)
@@ -124,7 +124,7 @@ mapping clause encdec_compressed = C_ADDI(nzi5 @ nzi40, rsd)
 
 function clause execute (C_ADDI(nzi, rsd)) = {
   let imm : bits(12) = sign_extend(nzi);
-  execute(ITYPE(imm, rsd, rsd, RISCV_ADDI))
+  execute(ITYPE(imm, rsd, rsd, ADDI))
 }
 
 mapping clause assembly = C_ADDI(nzi, rsd)
@@ -139,7 +139,7 @@ mapping clause encdec_compressed = C_JAL(i11 @ i10 @ i98 @ i7 @ i6 @ i5 @ i4 @ i
   when xlen == 32 & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_JAL(imm)) =
-  execute(RISCV_JAL(sign_extend(imm @ 0b0), ra))
+  execute(JAL(sign_extend(imm @ 0b0), ra))
 
 mapping clause assembly = C_JAL(imm)
   <-> "c.jal" ^ spc() ^ hex_bits_signed_12(imm @ 0b0)
@@ -168,7 +168,7 @@ mapping clause encdec_compressed = C_LI(imm5 @ imm40, rd)
 
 function clause execute (C_LI(imm, rd)) = {
   let imm : bits(12) = sign_extend(imm);
-  execute(ITYPE(imm, zreg, rd, RISCV_ADDI))
+  execute(ITYPE(imm, zreg, rd, ADDI))
 }
 
 mapping clause assembly = C_LI(imm, rd)
@@ -184,7 +184,7 @@ mapping clause encdec_compressed = C_ADDI16SP(nzi9 @ nzi87 @ nzi6 @ nzi5 @ nzi4)
 
 function clause execute (C_ADDI16SP(imm)) = {
   let imm : bits(12) = sign_extend(imm @ 0x0);
-  execute(ITYPE(imm, sp, sp, RISCV_ADDI))
+  execute(ITYPE(imm, sp, sp, ADDI))
 }
 
 mapping clause assembly = C_ADDI16SP(imm)
@@ -200,7 +200,7 @@ mapping clause encdec_compressed = C_LUI(imm17 @ imm1612, rd)
 
 function clause execute (C_LUI(imm, rd)) = {
   let res : bits(20) = sign_extend(imm);
-  execute(UTYPE(res, rd, RISCV_LUI))
+  execute(UTYPE(res, rd, LUI))
 }
 
 mapping clause assembly = C_LUI(imm, rd)
@@ -216,7 +216,7 @@ mapping clause encdec_compressed = C_SRLI(nzui5 @ nzui40, rsd)
 
 function clause execute (C_SRLI(shamt, rsd)) = {
   let rsd = creg2reg_idx(rsd);
-  execute(SHIFTIOP(shamt, rsd, rsd, RISCV_SRLI))
+  execute(SHIFTIOP(shamt, rsd, rsd, SRLI))
 }
 
 mapping clause assembly = C_SRLI(shamt, rsd)
@@ -232,7 +232,7 @@ mapping clause encdec_compressed = C_SRAI(nzui5 @ nzui40, rsd)
 
 function clause execute (C_SRAI(shamt, rsd)) = {
   let rsd = creg2reg_idx(rsd);
-  execute(SHIFTIOP(shamt, rsd, rsd, RISCV_SRAI))
+  execute(SHIFTIOP(shamt, rsd, rsd, SRAI))
 }
 
 mapping clause assembly = C_SRAI(shamt, rsd)
@@ -248,7 +248,7 @@ mapping clause encdec_compressed = C_ANDI(i5 @ i40, rsd)
 
 function clause execute (C_ANDI(imm, rsd)) = {
   let rsd = creg2reg_idx(rsd);
-  execute(ITYPE(sign_extend(imm), rsd, rsd, RISCV_ANDI))
+  execute(ITYPE(sign_extend(imm), rsd, rsd, ANDI))
 }
 
 mapping clause assembly = C_ANDI(imm, rsd)
@@ -264,7 +264,7 @@ mapping clause encdec_compressed = C_SUB(rsd, rs2)
 function clause execute (C_SUB(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
   let rs2 = creg2reg_idx(rs2);
-  execute(RTYPE(rs2, rsd, rsd, RISCV_SUB))
+  execute(RTYPE(rs2, rsd, rsd, SUB))
 }
 
 mapping clause assembly = C_SUB(rsd, rs2)
@@ -280,7 +280,7 @@ mapping clause encdec_compressed = C_XOR(rsd, rs2)
 function clause execute (C_XOR(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
   let rs2 = creg2reg_idx(rs2);
-  execute(RTYPE(rs2, rsd, rsd, RISCV_XOR))
+  execute(RTYPE(rs2, rsd, rsd, XOR))
 }
 
 mapping clause assembly = C_XOR(rsd, rs2)
@@ -296,7 +296,7 @@ mapping clause encdec_compressed = C_OR(rsd, rs2)
 function clause execute (C_OR(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
   let rs2 = creg2reg_idx(rs2);
-  execute(RTYPE(rs2, rsd, rsd, RISCV_OR))
+  execute(RTYPE(rs2, rsd, rsd, OR))
 }
 
 mapping clause assembly = C_OR(rsd, rs2)
@@ -312,7 +312,7 @@ mapping clause encdec_compressed = C_AND(rsd, rs2)
 function clause execute (C_AND(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
   let rs2 = creg2reg_idx(rs2);
-  execute(RTYPE(rs2, rsd, rsd, RISCV_AND))
+  execute(RTYPE(rs2, rsd, rsd, AND))
 }
 
 mapping clause assembly = C_AND(rsd, rs2)
@@ -328,7 +328,7 @@ mapping clause encdec_compressed = C_SUBW(rsd, rs2)
 function clause execute (C_SUBW(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
   let rs2 = creg2reg_idx(rs2);
-  execute(RTYPEW(rs2, rsd, rsd, RISCV_SUBW))
+  execute(RTYPEW(rs2, rsd, rsd, SUBW))
 }
 
 mapping clause assembly = C_SUBW(rsd, rs2)
@@ -345,7 +345,7 @@ mapping clause encdec_compressed = C_ADDW(rsd, rs2)
 function clause execute (C_ADDW(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
   let rs2 = creg2reg_idx(rs2);
-  execute(RTYPEW(rs2, rsd, rsd, RISCV_ADDW))
+  execute(RTYPEW(rs2, rsd, rsd, ADDW))
 }
 
 mapping clause assembly = C_ADDW(rsd, rs2)
@@ -360,7 +360,7 @@ mapping clause encdec_compressed = C_J(i11 @ i10 @ i98 @ i7 @ i6 @ i5 @ i4 @ i31
   when currentlyEnabled(Ext_Zca)
 
 function clause execute (C_J(imm)) =
-  execute(RISCV_JAL(sign_extend(imm @ 0b0), zreg))
+  execute(JAL(sign_extend(imm @ 0b0), zreg))
 
 mapping clause assembly = C_J(imm)
   <-> "c.j" ^ spc() ^ hex_bits_signed_12(imm @ 0b0)
@@ -373,7 +373,7 @@ mapping clause encdec_compressed = C_BEQZ(i8 @ i76 @ i5 @ i43 @ i21, rs)
   when currentlyEnabled(Ext_Zca)
 
 function clause execute (C_BEQZ(imm, rs)) =
-  execute(BTYPE(sign_extend(imm @ 0b0), zreg, creg2reg_idx(rs), RISCV_BEQ))
+  execute(BTYPE(sign_extend(imm @ 0b0), zreg, creg2reg_idx(rs), BEQ))
 
 mapping clause assembly = C_BEQZ(imm, rs)
   <-> "c.beqz" ^ spc() ^ creg_name(rs) ^ sep() ^ hex_bits_signed_8(imm)
@@ -386,7 +386,7 @@ mapping clause encdec_compressed = C_BNEZ(i8 @ i76 @ i5 @ i43 @ i21, rs)
   when currentlyEnabled(Ext_Zca)
 
 function clause execute (C_BNEZ(imm, rs)) =
-  execute(BTYPE(sign_extend(imm @ 0b0), zreg, creg2reg_idx(rs), RISCV_BNE))
+  execute(BTYPE(sign_extend(imm @ 0b0), zreg, creg2reg_idx(rs), BNE))
 
 mapping clause assembly = C_BNEZ(imm, rs)
   <-> "c.bnez" ^ spc() ^ creg_name(rs) ^ sep() ^ hex_bits_signed_8(imm)
@@ -399,7 +399,7 @@ mapping clause encdec_compressed = C_SLLI(nzui5 @ nzui40, rsd)
   when nzui5 @ nzui40 != 0b000000 & rsd != zreg & (xlen == 64 | nzui5 == 0b0) & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_SLLI(shamt, rsd)) =
-  execute(SHIFTIOP(shamt, rsd, rsd, RISCV_SLLI))
+  execute(SHIFTIOP(shamt, rsd, rsd, SLLI))
 
 mapping clause assembly = C_SLLI(shamt, rsd)
   <-> "c.slli" ^ spc() ^ reg_name(rsd) ^ sep() ^ hex_bits_6(shamt)
@@ -476,7 +476,7 @@ mapping clause encdec_compressed = C_JR(rs1)
   when rs1 != zreg & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_JR(rs1)) =
-  execute(RISCV_JALR(zeros(), rs1, zreg))
+  execute(JALR(zeros(), rs1, zreg))
 
 mapping clause assembly = C_JR(rs1)
   <-> "c.jr" ^ spc() ^ reg_name(rs1)
@@ -490,7 +490,7 @@ mapping clause encdec_compressed = C_JALR(rs1)
   when rs1 != zreg & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_JALR(rs1)) =
-  execute(RISCV_JALR(zeros(), rs1, ra))
+  execute(JALR(zeros(), rs1, ra))
 
 mapping clause assembly = C_JALR(rs1)
   <-> "c.jalr" ^ spc() ^ reg_name(rs1)
@@ -504,7 +504,7 @@ mapping clause encdec_compressed = C_MV(rd, rs2)
   when rd != zreg & rs2 != zreg & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_MV(rd, rs2)) =
-  execute(RTYPE(rs2, zreg, rd, RISCV_ADD))
+  execute(RTYPE(rs2, zreg, rd, ADD))
 
 mapping clause assembly = C_MV(rd, rs2)
   <-> "c.mv" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs2)
@@ -530,7 +530,7 @@ mapping clause encdec_compressed = C_ADD(rsd, rs2)
   when rsd != zreg & rs2 != zreg & currentlyEnabled(Ext_Zca)
 
 function clause execute (C_ADD(rsd, rs2)) =
-  execute(RTYPE(rs2, rsd, rsd, RISCV_ADD))
+  execute(RTYPE(rs2, rsd, rsd, ADD))
 
 mapping clause assembly = C_ADD(rsd, rs2)
   <-> "c.add" ^ spc() ^ reg_name(rsd) ^ sep() ^ reg_name(rs2)

--- a/model/riscv_insts_zcb.sail
+++ b/model/riscv_insts_zcb.sail
@@ -126,7 +126,7 @@ mapping clause assembly = C_SEXT_B(rsdc) <->
 
 function clause execute C_SEXT_B(rsdc) = {
   let rsd = creg2reg_idx(rsdc);
-  execute(ZBB_EXTOP(rsd, rsd, RISCV_SEXTB))
+  execute(ZBB_EXTOP(rsd, rsd, SEXTB))
 }
 
 /* ****************************************************************** */
@@ -142,7 +142,7 @@ mapping clause assembly = C_ZEXT_H(rsdc) <->
 
 function clause execute C_ZEXT_H(rsdc) = {
   let rsd = creg2reg_idx(rsdc);
-  execute(ZBB_EXTOP(rsd, rsd, RISCV_ZEXTH))
+  execute(ZBB_EXTOP(rsd, rsd, ZEXTH))
 }
 
 /* ****************************************************************** */
@@ -158,7 +158,7 @@ mapping clause assembly = C_SEXT_H(rsdc) <->
 
 function clause execute C_SEXT_H(rsdc) = {
   let rsd = creg2reg_idx(rsdc);
-  execute(ZBB_EXTOP(rsd, rsd,  RISCV_SEXTH))
+  execute(ZBB_EXTOP(rsd, rsd,  SEXTH))
 }
 
 /* ****************************************************************** */
@@ -174,7 +174,7 @@ mapping clause assembly = C_ZEXT_W(rsdc) <->
 
 function clause execute C_ZEXT_W(rsdc) = {
   let rsd = creg2reg_idx(rsdc);
-  execute (ZBA_RTYPEUW(zreg, rsd, rsd, RISCV_ADDUW))
+  execute (ZBA_RTYPEUW(zreg, rsd, rsd, ADDUW))
 }
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zfa.sail
+++ b/model/riscv_insts_zfa.sail
@@ -10,16 +10,16 @@ function clause currentlyEnabled(Ext_Zfa) = hartSupports(Ext_Zfa) & currentlyEna
 
 /* FLI.H */
 
-union clause ast = RISCV_FLI_H : (bits(5), fregidx)
+union clause ast = FLI_H : (bits(5), fregidx)
 
-mapping clause encdec = RISCV_FLI_H(constantidx, rd)
+mapping clause encdec = FLI_H(constantidx, rd)
   <-> 0b111_1010 @ 0b00001 @ constantidx @ 0b000 @ encdec_freg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_Zfh) & currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FLI_H(constantidx, rd)
+mapping clause assembly = FLI_H(constantidx, rd)
   <-> "fli.h" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_5(constantidx)
 
-function clause execute (RISCV_FLI_H(constantidx, rd)) = {
+function clause execute (FLI_H(constantidx, rd)) = {
   let bits : bits(16) = match constantidx {
     0b00000 => { 0xbc00 },  /* -1.0 */
     0b00001 => { 0x0400 },  /* minimum positive normal */
@@ -60,16 +60,16 @@ function clause execute (RISCV_FLI_H(constantidx, rd)) = {
 
 /* FLI.S */
 
-union clause ast = RISCV_FLI_S : (bits(5), fregidx)
+union clause ast = FLI_S : (bits(5), fregidx)
 
-mapping clause encdec = RISCV_FLI_S(constantidx, rd)
+mapping clause encdec = FLI_S(constantidx, rd)
   <-> 0b111_1000 @ 0b00001 @ constantidx @ 0b000 @ encdec_freg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FLI_S(constantidx, rd)
+mapping clause assembly = FLI_S(constantidx, rd)
   <-> "fli.s" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_5(constantidx)
 
-function clause execute (RISCV_FLI_S(constantidx, rd)) = {
+function clause execute (FLI_S(constantidx, rd)) = {
   let bits : bits(32) = match constantidx {
     0b00000 => { 0xbf800000 },  /* -1.0 */
     0b00001 => { 0x00800000 },  /* minimum positive normal */
@@ -110,16 +110,16 @@ function clause execute (RISCV_FLI_S(constantidx, rd)) = {
 
 /* FLI.D */
 
-union clause ast = RISCV_FLI_D : (bits(5), fregidx)
+union clause ast = FLI_D : (bits(5), fregidx)
 
-mapping clause encdec = RISCV_FLI_D(constantidx, rd)
+mapping clause encdec = FLI_D(constantidx, rd)
   <-> 0b111_1001 @ 0b00001 @ constantidx @ 0b000 @ encdec_freg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FLI_D(constantidx, rd)
+mapping clause assembly = FLI_D(constantidx, rd)
   <-> "fli.d" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_5(constantidx)
 
-function clause execute (RISCV_FLI_D(constantidx, rd)) = {
+function clause execute (FLI_D(constantidx, rd)) = {
   let bits : bits(64) = match constantidx {
     0b00000 => { 0xbff0000000000000 },  /* -1.0 */
     0b00001 => { 0x0010000000000000 },  /* minimum positive normal */
@@ -160,18 +160,18 @@ function clause execute (RISCV_FLI_D(constantidx, rd)) = {
 
 /* FMINM.H */
 
-union clause ast = RISCV_FMINM_H : (fregidx, fregidx, fregidx)
+union clause ast = FMINM_H : (fregidx, fregidx, fregidx)
 
-mapping clause encdec = RISCV_FMINM_H(rs2, rs1, rd)
+mapping clause encdec = FMINM_H(rs2, rs1, rd)
   <-> 0b001_0110 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_Zfh) & currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FMINM_H(rs2, rs1, rd)
+mapping clause assembly = FMINM_H(rs2, rs1, rd)
   <-> "fminm.h" ^ spc() ^ freg_name(rd)
                 ^ sep() ^ freg_name(rs1)
                 ^ sep() ^ freg_name(rs2)
 
-function clause execute (RISCV_FMINM_H(rs2, rs1, rd)) = {
+function clause execute (FMINM_H(rs2, rs1, rd)) = {
   let rs1_val_H = F_H(rs1);
   let rs2_val_H = F_H(rs2);
 
@@ -191,18 +191,18 @@ function clause execute (RISCV_FMINM_H(rs2, rs1, rd)) = {
 
 /* FMAXM.H */
 
-union clause ast = RISCV_FMAXM_H : (fregidx, fregidx, fregidx)
+union clause ast = FMAXM_H : (fregidx, fregidx, fregidx)
 
-mapping clause encdec = RISCV_FMAXM_H(rs2, rs1, rd)
+mapping clause encdec = FMAXM_H(rs2, rs1, rd)
   <-> 0b001_0110 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b011 @ encdec_freg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_Zfh) & currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FMAXM_H(rs2, rs1, rd)
+mapping clause assembly = FMAXM_H(rs2, rs1, rd)
   <-> "fmaxm.h" ^ spc() ^ freg_name(rd)
                 ^ sep() ^ freg_name(rs1)
                 ^ sep() ^ freg_name(rs2)
 
-function clause execute (RISCV_FMAXM_H(rs2, rs1, rd)) = {
+function clause execute (FMAXM_H(rs2, rs1, rd)) = {
   let rs1_val_H = F_H(rs1);
   let rs2_val_H = F_H(rs2);
 
@@ -222,18 +222,18 @@ function clause execute (RISCV_FMAXM_H(rs2, rs1, rd)) = {
 
 /* FMINM.S */
 
-union clause ast = RISCV_FMINM_S : (fregidx, fregidx, fregidx)
+union clause ast = FMINM_S : (fregidx, fregidx, fregidx)
 
-mapping clause encdec = RISCV_FMINM_S(rs2, rs1, rd)
+mapping clause encdec = FMINM_S(rs2, rs1, rd)
   <-> 0b001_0100 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FMINM_S(rs2, rs1, rd)
+mapping clause assembly = FMINM_S(rs2, rs1, rd)
   <-> "fminm.s" ^ spc() ^ freg_name(rd)
                 ^ sep() ^ freg_name(rs1)
                 ^ sep() ^ freg_name(rs2)
 
-function clause execute (RISCV_FMINM_S(rs2, rs1, rd)) = {
+function clause execute (FMINM_S(rs2, rs1, rd)) = {
   let rs1_val_S = F_S(rs1);
   let rs2_val_S = F_S(rs2);
 
@@ -253,18 +253,18 @@ function clause execute (RISCV_FMINM_S(rs2, rs1, rd)) = {
 
 /* FMAXM.S */
 
-union clause ast = RISCV_FMAXM_S : (fregidx, fregidx, fregidx)
+union clause ast = FMAXM_S : (fregidx, fregidx, fregidx)
 
-mapping clause encdec = RISCV_FMAXM_S(rs2, rs1, rd)
+mapping clause encdec = FMAXM_S(rs2, rs1, rd)
   <-> 0b001_0100 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b011 @ encdec_freg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FMAXM_S(rs2, rs1, rd)
+mapping clause assembly = FMAXM_S(rs2, rs1, rd)
   <-> "fmaxm.s" ^ spc() ^ freg_name(rd)
                 ^ sep() ^ freg_name(rs1)
                 ^ sep() ^ freg_name(rs2)
 
-function clause execute (RISCV_FMAXM_S(rs2, rs1, rd)) = {
+function clause execute (FMAXM_S(rs2, rs1, rd)) = {
   let rs1_val_S = F_S(rs1);
   let rs2_val_S = F_S(rs2);
 
@@ -284,18 +284,18 @@ function clause execute (RISCV_FMAXM_S(rs2, rs1, rd)) = {
 
 /* FMINM.D */
 
-union clause ast = RISCV_FMINM_D : (fregidx, fregidx, fregidx)
+union clause ast = FMINM_D : (fregidx, fregidx, fregidx)
 
-mapping clause encdec = RISCV_FMINM_D(rs2, rs1, rd)
+mapping clause encdec = FMINM_D(rs2, rs1, rd)
   <-> 0b001_0101 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FMINM_D(rs2, rs1, rd)
+mapping clause assembly = FMINM_D(rs2, rs1, rd)
   <-> "fminm.d" ^ spc() ^ freg_name(rd)
                 ^ sep() ^ freg_name(rs1)
                 ^ sep() ^ freg_name(rs2)
 
-function clause execute (RISCV_FMINM_D(rs2, rs1, rd)) = {
+function clause execute (FMINM_D(rs2, rs1, rd)) = {
   let rs1_val_D = F_D(rs1);
   let rs2_val_D = F_D(rs2);
 
@@ -315,18 +315,18 @@ function clause execute (RISCV_FMINM_D(rs2, rs1, rd)) = {
 
 /* FMAXM.D */
 
-union clause ast = RISCV_FMAXM_D : (fregidx, fregidx, fregidx)
+union clause ast = FMAXM_D : (fregidx, fregidx, fregidx)
 
-mapping clause encdec = RISCV_FMAXM_D(rs2, rs1, rd)
+mapping clause encdec = FMAXM_D(rs2, rs1, rd)
   <-> 0b001_0101 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b011 @ encdec_freg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FMAXM_D(rs2, rs1, rd)
+mapping clause assembly = FMAXM_D(rs2, rs1, rd)
   <-> "fmaxm.d" ^ spc() ^ freg_name(rd)
                 ^ sep() ^ freg_name(rs1)
                 ^ sep() ^ freg_name(rs2)
 
-function clause execute (RISCV_FMAXM_D(rs2, rs1, rd)) = {
+function clause execute (FMAXM_D(rs2, rs1, rd)) = {
   let rs1_val_D = F_D(rs1);
   let rs2_val_D = F_D(rs2);
 
@@ -346,18 +346,18 @@ function clause execute (RISCV_FMAXM_D(rs2, rs1, rd)) = {
 
 /* FROUND.H */
 
-union clause ast = RISCV_FROUND_H : (fregidx, rounding_mode, fregidx)
+union clause ast = FROUND_H : (fregidx, rounding_mode, fregidx)
 
-mapping clause encdec = RISCV_FROUND_H(rs1, rm, rd)
+mapping clause encdec = FROUND_H(rs1, rm, rd)
   <-> 0b010_0010 @ 0b00100 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_Zfh) & currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FROUND_H(rs1, rm, rd)
+mapping clause assembly = FROUND_H(rs1, rm, rd)
   <-> "fround.h" ^ spc() ^ freg_name(rd)
                  ^ sep() ^ freg_name(rs1)
                  ^ sep() ^ frm_mnemonic(rm)
 
-function clause execute (RISCV_FROUND_H(rs1, rm, rd)) = {
+function clause execute (FROUND_H(rs1, rm, rd)) = {
   let rs1_val_H = F_H(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
@@ -375,18 +375,18 @@ function clause execute (RISCV_FROUND_H(rs1, rm, rd)) = {
 
 /* FROUNDNX.H */
 
-union clause ast = RISCV_FROUNDNX_H : (fregidx, rounding_mode, fregidx)
+union clause ast = FROUNDNX_H : (fregidx, rounding_mode, fregidx)
 
-mapping clause encdec = RISCV_FROUNDNX_H(rs1, rm, rd)
+mapping clause encdec = FROUNDNX_H(rs1, rm, rd)
   <-> 0b010_0010 @ 0b00101 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_Zfh) & currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FROUNDNX_H(rs1, rm, rd)
+mapping clause assembly = FROUNDNX_H(rs1, rm, rd)
   <-> "froundnx.h" ^ spc() ^ freg_name(rd)
                    ^ sep() ^ freg_name(rs1)
                    ^ sep() ^ frm_mnemonic(rm)
 
-function clause execute (RISCV_FROUNDNX_H(rs1, rm, rd)) = {
+function clause execute (FROUNDNX_H(rs1, rm, rd)) = {
   let rs1_val_H = F_H(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
@@ -404,18 +404,18 @@ function clause execute (RISCV_FROUNDNX_H(rs1, rm, rd)) = {
 
 /* FROUND.S */
 
-union clause ast = RISCV_FROUND_S : (fregidx, rounding_mode, fregidx)
+union clause ast = FROUND_S : (fregidx, rounding_mode, fregidx)
 
-mapping clause encdec = RISCV_FROUND_S(rs1, rm, rd)
+mapping clause encdec = FROUND_S(rs1, rm, rd)
   <-> 0b010_0000 @ 0b00100 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FROUND_S(rs1, rm, rd)
+mapping clause assembly = FROUND_S(rs1, rm, rd)
   <-> "fround.s" ^ spc() ^ freg_name(rd)
                  ^ sep() ^ freg_name(rs1)
                  ^ sep() ^ frm_mnemonic(rm)
 
-function clause execute (RISCV_FROUND_S(rs1, rm, rd)) = {
+function clause execute (FROUND_S(rs1, rm, rd)) = {
   let rs1_val_S = F_S(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
@@ -433,18 +433,18 @@ function clause execute (RISCV_FROUND_S(rs1, rm, rd)) = {
 
 /* FROUNDNX.S */
 
-union clause ast = RISCV_FROUNDNX_S : (fregidx, rounding_mode, fregidx)
+union clause ast = FROUNDNX_S : (fregidx, rounding_mode, fregidx)
 
-mapping clause encdec = RISCV_FROUNDNX_S(rs1, rm, rd)
+mapping clause encdec = FROUNDNX_S(rs1, rm, rd)
   <-> 0b010_0000 @ 0b00101 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FROUNDNX_S(rs1, rm, rd)
+mapping clause assembly = FROUNDNX_S(rs1, rm, rd)
   <-> "froundnx.s" ^ spc() ^ freg_name(rd)
                    ^ sep() ^ freg_name(rs1)
                    ^ sep() ^ frm_mnemonic(rm)
 
-function clause execute (RISCV_FROUNDNX_S(rs1, rm, rd)) = {
+function clause execute (FROUNDNX_S(rs1, rm, rd)) = {
   let rs1_val_S = F_S(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
@@ -462,18 +462,18 @@ function clause execute (RISCV_FROUNDNX_S(rs1, rm, rd)) = {
 
 /* FROUND.D */
 
-union clause ast = RISCV_FROUND_D : (fregidx, rounding_mode, fregidx)
+union clause ast = FROUND_D : (fregidx, rounding_mode, fregidx)
 
-mapping clause encdec = RISCV_FROUND_D(rs1, rm, rd)
+mapping clause encdec = FROUND_D(rs1, rm, rd)
   <-> 0b010_0001 @ 0b00100 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FROUND_D(rs1, rm, rd)
+mapping clause assembly = FROUND_D(rs1, rm, rd)
   <-> "fround.d" ^ spc() ^ freg_name(rd)
                  ^ sep() ^ freg_name(rs1)
                  ^ sep() ^ frm_mnemonic(rm)
 
-function clause execute (RISCV_FROUND_D(rs1, rm, rd)) = {
+function clause execute (FROUND_D(rs1, rm, rd)) = {
   let rs1_val_D = F_D(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
@@ -491,18 +491,18 @@ function clause execute (RISCV_FROUND_D(rs1, rm, rd)) = {
 
 /* FROUNDNX.D */
 
-union clause ast = RISCV_FROUNDNX_D : (fregidx, rounding_mode, fregidx)
+union clause ast = FROUNDNX_D : (fregidx, rounding_mode, fregidx)
 
-mapping clause encdec = RISCV_FROUNDNX_D(rs1, rm, rd)
+mapping clause encdec = FROUNDNX_D(rs1, rm, rd)
   <-> 0b010_0001 @ 0b00101 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FROUNDNX_D(rs1, rm, rd)
+mapping clause assembly = FROUNDNX_D(rs1, rm, rd)
   <-> "froundnx.d" ^ spc() ^ freg_name(rd)
                    ^ sep() ^ freg_name(rs1)
                    ^ sep() ^ frm_mnemonic(rm)
 
-function clause execute (RISCV_FROUNDNX_D(rs1, rm, rd)) = {
+function clause execute (FROUNDNX_D(rs1, rm, rd)) = {
   let rs1_val_D = F_D(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
@@ -520,17 +520,17 @@ function clause execute (RISCV_FROUNDNX_D(rs1, rm, rd)) = {
 
 /* FMVH.X.D */
 
-union clause ast = RISCV_FMVH_X_D : (fregidx, regidx)
+union clause ast = FMVH_X_D : (fregidx, regidx)
 
-mapping clause encdec   = RISCV_FMVH_X_D(rs1, rd)
+mapping clause encdec   = FMVH_X_D(rs1, rd)
   <-> 0b111_0001 @ 0b00001 @ encdec_freg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa) & in32BitMode()
 
-mapping clause assembly = RISCV_FMVH_X_D(rs1, rd)
+mapping clause assembly = FMVH_X_D(rs1, rd)
   <-> "fmvh.x.d" ^ spc() ^ reg_name(rd)
                  ^ sep() ^ freg_name(rs1)
 
-function clause execute (RISCV_FMVH_X_D(rs1, rd)) = {
+function clause execute (FMVH_X_D(rs1, rd)) = {
   let rs1_val_D           = F_D(rs1)[63..32];
   let rd_val_X : xlenbits = sign_extend(rs1_val_D);
   X(rd)                   = rd_val_X;
@@ -539,18 +539,18 @@ function clause execute (RISCV_FMVH_X_D(rs1, rd)) = {
 
 /* FMVP.X.D */
 
-union clause ast = RISCV_FMVP_D_X : (regidx, regidx, fregidx)
+union clause ast = FMVP_D_X : (regidx, regidx, fregidx)
 
-mapping clause encdec = RISCV_FMVP_D_X(rs2, rs1, rd)
+mapping clause encdec = FMVP_D_X(rs2, rs1, rd)
   <-> 0b101_1001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa) & in32BitMode()
 
-mapping clause assembly = RISCV_FMVP_D_X(rs2, rs1, rd)
+mapping clause assembly = FMVP_D_X(rs2, rs1, rd)
   <-> "fmvp.d.x" ^ spc() ^ freg_name(rd)
                  ^ sep() ^ reg_name(rs1)
                  ^ sep() ^ reg_name(rs2)
 
-function clause execute (RISCV_FMVP_D_X(rs2, rs1, rd)) = {
+function clause execute (FMVP_D_X(rs2, rs1, rd)) = {
   let rs1_val_X     = X(rs1)[31..0];
   let rs2_val_X     = X(rs2)[31..0];
 
@@ -567,18 +567,18 @@ function clause execute (RISCV_FMVP_D_X(rs2, rs1, rd)) = {
 
 /* FLEQ.H */
 
-union clause ast = RISCV_FLEQ_H : (fregidx, fregidx, regidx)
+union clause ast = FLEQ_H : (fregidx, fregidx, regidx)
 
-mapping clause encdec = RISCV_FLEQ_H(rs2, rs1, rd)
+mapping clause encdec = FLEQ_H(rs2, rs1, rd)
   <-> 0b101_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_Zfh) & currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FLEQ_H(rs2, rs1, rd)
+mapping clause assembly = FLEQ_H(rs2, rs1, rd)
   <-> "fleq.h" ^ spc() ^ reg_name(rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
-function clause execute(RISCV_FLEQ_H(rs2, rs1, rd)) = {
+function clause execute(FLEQ_H(rs2, rs1, rd)) = {
   let rs1_val_H = F_H(rs1);
   let rs2_val_H = F_H(rs2);
 
@@ -592,18 +592,18 @@ function clause execute(RISCV_FLEQ_H(rs2, rs1, rd)) = {
 
 /* FLTQ.H */
 
-union clause ast = RISCV_FLTQ_H : (fregidx, fregidx, regidx)
+union clause ast = FLTQ_H : (fregidx, fregidx, regidx)
 
-mapping clause encdec = RISCV_FLTQ_H(rs2, rs1, rd)
+mapping clause encdec = FLTQ_H(rs2, rs1, rd)
   <-> 0b101_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_Zfh) & currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FLTQ_H(rs2, rs1, rd)
+mapping clause assembly = FLTQ_H(rs2, rs1, rd)
   <-> "fltq.h" ^ spc() ^ reg_name(rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
-function clause execute(RISCV_FLTQ_H(rs2, rs1, rd)) = {
+function clause execute(FLTQ_H(rs2, rs1, rd)) = {
   let rs1_val_H = F_H(rs1);
   let rs2_val_H = F_H(rs2);
 
@@ -617,18 +617,18 @@ function clause execute(RISCV_FLTQ_H(rs2, rs1, rd)) = {
 
 /* FLEQ.S */
 
-union clause ast = RISCV_FLEQ_S : (fregidx, fregidx, regidx)
+union clause ast = FLEQ_S : (fregidx, fregidx, regidx)
 
-mapping clause encdec = RISCV_FLEQ_S(rs2, rs1, rd)
+mapping clause encdec = FLEQ_S(rs2, rs1, rd)
   <-> 0b101_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FLEQ_S(rs2, rs1, rd)
+mapping clause assembly = FLEQ_S(rs2, rs1, rd)
   <-> "fleq.s" ^ spc() ^ reg_name(rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
-function clause execute(RISCV_FLEQ_S(rs2, rs1, rd)) = {
+function clause execute(FLEQ_S(rs2, rs1, rd)) = {
   let rs1_val_S = F_S(rs1);
   let rs2_val_S = F_S(rs2);
 
@@ -642,18 +642,18 @@ function clause execute(RISCV_FLEQ_S(rs2, rs1, rd)) = {
 
 /* FLTQ.S */
 
-union clause ast = RISCV_FLTQ_S : (fregidx, fregidx, regidx)
+union clause ast = FLTQ_S : (fregidx, fregidx, regidx)
 
-mapping clause encdec = RISCV_FLTQ_S(rs2, rs1, rd)
+mapping clause encdec = FLTQ_S(rs2, rs1, rd)
   <-> 0b101_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FLTQ_S(rs2, rs1, rd)
+mapping clause assembly = FLTQ_S(rs2, rs1, rd)
   <-> "fltq.s" ^ spc() ^ reg_name(rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
-function clause execute(RISCV_FLTQ_S(rs2, rs1, rd)) = {
+function clause execute(FLTQ_S(rs2, rs1, rd)) = {
   let rs1_val_S = F_S(rs1);
   let rs2_val_S = F_S(rs2);
 
@@ -668,18 +668,18 @@ function clause execute(RISCV_FLTQ_S(rs2, rs1, rd)) = {
 
 /* FLEQ.D */
 
-union clause ast = RISCV_FLEQ_D : (fregidx, fregidx, regidx)
+union clause ast = FLEQ_D : (fregidx, fregidx, regidx)
 
-mapping clause encdec = RISCV_FLEQ_D(rs2, rs1, rd)
+mapping clause encdec = FLEQ_D(rs2, rs1, rd)
   <-> 0b101_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FLEQ_D(rs2, rs1, rd)
+mapping clause assembly = FLEQ_D(rs2, rs1, rd)
   <-> "fleq.d" ^ spc() ^ reg_name(rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
-function clause execute(RISCV_FLEQ_D(rs2, rs1, rd)) = {
+function clause execute(FLEQ_D(rs2, rs1, rd)) = {
   let rs1_val_D = F_D(rs1);
   let rs2_val_D = F_D(rs2);
 
@@ -693,18 +693,18 @@ function clause execute(RISCV_FLEQ_D(rs2, rs1, rd)) = {
 
 /* FLTQ.D */
 
-union clause ast = RISCV_FLTQ_D : (fregidx, fregidx, regidx)
+union clause ast = FLTQ_D : (fregidx, fregidx, regidx)
 
-mapping clause encdec = RISCV_FLTQ_D(rs2, rs1, rd)
+mapping clause encdec = FLTQ_D(rs2, rs1, rd)
   <-> 0b101_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FLTQ_D(rs2, rs1, rd)
+mapping clause assembly = FLTQ_D(rs2, rs1, rd)
   <-> "fltq.d" ^ spc() ^ reg_name(rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
-function clause execute(RISCV_FLTQ_D(rs2, rs1, rd)) = {
+function clause execute(FLTQ_D(rs2, rs1, rd)) = {
   let rs1_val_D = F_D(rs1);
   let rs2_val_D = F_D(rs2);
 
@@ -781,17 +781,17 @@ function fcvtmod_helper(x64) = {
   }
 }
 
-union clause ast = RISCV_FCVTMOD_W_D : (fregidx, regidx)
+union clause ast = FCVTMOD_W_D : (fregidx, regidx)
 
 /* We need rounding mode to be explicitly specified to RTZ(0b001) */
-mapping clause encdec = RISCV_FCVTMOD_W_D(rs1, rd)
+mapping clause encdec = FCVTMOD_W_D(rs1, rd)
   <-> 0b110_0001 @ 0b01000 @ encdec_freg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011
   when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
-mapping clause assembly = RISCV_FCVTMOD_W_D(rs1, rd)
+mapping clause assembly = FCVTMOD_W_D(rs1, rd)
   <-> "fcvtmod.w.d" ^ spc() ^ reg_name(rd) ^ sep() ^ freg_name(rs1)
 
-function clause execute(RISCV_FCVTMOD_W_D(rs1, rd)) = {
+function clause execute(FCVTMOD_W_D(rs1, rd)) = {
   let rs1_val_D = F_D(rs1);
   let (fflags, rd_val) = fcvtmod_helper(rs1_val_D);
   accrue_fflags(fflags);

--- a/model/riscv_insts_zicbom.sail
+++ b/model/riscv_insts_zicbom.sail
@@ -13,7 +13,7 @@ function clause currentlyEnabled(Ext_Zicbom) = hartSupports(Ext_Zicbom)
 function cbo_clean_flush_enabled(p : Privilege) -> bool = feature_enabled_for_priv(p, menvcfg[CBCFE][0], senvcfg[CBCFE][0])
 
 /* ****************************************************************** */
-union clause ast = RISCV_ZICBOM : (cbop_zicbom, regidx)
+union clause ast = ZICBOM : (cbop_zicbom, regidx)
 
 mapping encdec_cbop : cbop_zicbom <-> bits(12) = {
   CBO_CLEAN <-> 0b000000000001,
@@ -21,7 +21,7 @@ mapping encdec_cbop : cbop_zicbom <-> bits(12) = {
   CBO_INVAL <-> 0b000000000000,
 }
 
-mapping clause encdec = RISCV_ZICBOM(cbop, rs1)
+mapping clause encdec = ZICBOM(cbop, rs1)
   <-> encdec_cbop(cbop) @ encdec_reg(rs1) @ 0b010 @ 0b00000 @ 0b0001111
   when currentlyEnabled(Ext_Zicbom)
 
@@ -31,7 +31,7 @@ mapping cbop_mnemonic : cbop_zicbom <-> string = {
   CBO_INVAL <-> "cbo.inval"
 }
 
-mapping clause assembly = RISCV_ZICBOM(cbop, rs1)
+mapping clause assembly = ZICBOM(cbop, rs1)
   <-> cbop_mnemonic(cbop) ^ spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
 
 /* CBIE from xenvcfg */
@@ -135,17 +135,17 @@ function process_clean_inval(rs1, cbop) = {
   }
 }
 
-function clause execute(RISCV_ZICBOM(CBO_CLEAN, rs1)) =
+function clause execute(ZICBOM(CBO_CLEAN, rs1)) =
   if   cbo_clean_flush_enabled(cur_privilege)
   then process_clean_inval(rs1, CBO_CLEAN)
   else RETIRE_FAIL(Illegal_Instruction())
 
-function clause execute(RISCV_ZICBOM(CBO_FLUSH, rs1)) =
+function clause execute(ZICBOM(CBO_FLUSH, rs1)) =
   if   cbo_clean_flush_enabled(cur_privilege)
   then process_clean_inval(rs1, CBO_FLUSH)
   else RETIRE_FAIL(Illegal_Instruction())
 
-function clause execute(RISCV_ZICBOM(CBO_INVAL, rs1)) =
+function clause execute(ZICBOM(CBO_INVAL, rs1)) =
   match cbop_priv_check(cur_privilege) {
     CBOP_ILLEGAL         => RETIRE_FAIL(Illegal_Instruction()),
     CBOP_ILLEGAL_VIRTUAL => internal_error(__FILE__, __LINE__, "unimplemented"),

--- a/model/riscv_insts_zicboz.sail
+++ b/model/riscv_insts_zicboz.sail
@@ -13,16 +13,16 @@ function clause currentlyEnabled(Ext_Zicboz) = hartSupports(Ext_Zicboz)
 function cbo_zero_enabled(p : Privilege) -> bool = feature_enabled_for_priv(p, menvcfg[CBZE][0], senvcfg[CBZE][0])
 
 /* ****************************************************************** */
-union clause ast = RISCV_ZICBOZ : (regidx)
+union clause ast = ZICBOZ : (regidx)
 
-mapping clause encdec = RISCV_ZICBOZ(rs1)
+mapping clause encdec = ZICBOZ(rs1)
   <-> 0b000000000100 @ encdec_reg(rs1) @ 0b010 @ 0b00000 @ 0b0001111
   when currentlyEnabled(Ext_Zicboz)
 
-mapping clause assembly = RISCV_ZICBOZ(rs1)
+mapping clause assembly = ZICBOZ(rs1)
   <-> "cbo.zero" ^ spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
 
-function clause execute(RISCV_ZICBOZ(rs1)) = {
+function clause execute(ZICBOZ(rs1)) = {
   if cbo_zero_enabled(cur_privilege) then {
     let rs1_val = X(rs1);
     let cache_block_size_exp = plat_cache_block_size_exp();

--- a/model/riscv_insts_zicond.sail
+++ b/model/riscv_insts_zicond.sail
@@ -10,22 +10,22 @@ function clause currentlyEnabled(Ext_Zicond) = hartSupports(Ext_Zicond)
 
 union clause ast = ZICOND_RTYPE : (regidx, regidx, regidx, zicondop)
 
-mapping clause encdec = ZICOND_RTYPE(rs2, rs1, rd, RISCV_CZERO_EQZ)
+mapping clause encdec = ZICOND_RTYPE(rs2, rs1, rd, CZERO_EQZ)
   <-> 0b0000111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zicond)
-mapping clause encdec = ZICOND_RTYPE(rs2, rs1, rd, RISCV_CZERO_NEZ)
+mapping clause encdec = ZICOND_RTYPE(rs2, rs1, rd, CZERO_NEZ)
   <-> 0b0000111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zicond)
 
 mapping zicond_mnemonic : zicondop <-> string = {
-  RISCV_CZERO_EQZ <-> "czero.eqz",
-  RISCV_CZERO_NEZ <-> "czero.nez"
+  CZERO_EQZ <-> "czero.eqz",
+  CZERO_NEZ <-> "czero.nez"
 }
 
 mapping clause assembly = ZICOND_RTYPE(rs2, rs1, rd, op)
   <-> zicond_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (ZICOND_RTYPE(rs2, rs1, rd, RISCV_CZERO_EQZ)) = {
+function clause execute (ZICOND_RTYPE(rs2, rs1, rd, CZERO_EQZ)) = {
   let value = X(rs1);
   let condition = X(rs2);
   let result : xlenbits = if condition == zeros() then zeros() else value;
@@ -33,7 +33,7 @@ function clause execute (ZICOND_RTYPE(rs2, rs1, rd, RISCV_CZERO_EQZ)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (ZICOND_RTYPE(rs2, rs1, rd, RISCV_CZERO_NEZ)) = {
+function clause execute (ZICOND_RTYPE(rs2, rs1, rd, CZERO_NEZ)) = {
   let value = X(rs1);
   let condition = X(rs2);
   let result : xlenbits = if condition != zeros() then zeros() else value;

--- a/model/riscv_jalr_rmem.sail
+++ b/model/riscv_jalr_rmem.sail
@@ -8,7 +8,7 @@
 
 /* The definition for the memory model. */
 
-function clause execute (RISCV_JALR(imm, rs1, rd)) = {
+function clause execute (JALR(imm, rs1, rd)) = {
   /* FIXME: this does not check for a misaligned target address. See riscv_jalr_seq.sail. */
   /* write rd before anything else to prevent unintended strength */
   X(rd) = nextPC; /* compatible with JALR, C.JR and C.JALR */

--- a/model/riscv_jalr_seq.sail
+++ b/model/riscv_jalr_seq.sail
@@ -8,7 +8,7 @@
 
 /* The definition for the sequential model. */
 
-function clause execute (RISCV_JALR(imm, rs1, rd)) = {
+function clause execute (JALR(imm, rs1, rd)) = {
 /* For the sequential model, the memory-model definition doesn't work directly
  * if rs1 = rd.  We would effectively have to keep a regfile for reads and another for
  * writes, and swap on instruction completion.  This could perhaps be optimized in

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -305,46 +305,38 @@ function satpMode_of_bits(a : Architecture, m : satp_mode) -> option(SATPMode) =
 type csrRW = bits(2)  /* read/write */
 
 /* instruction opcode grouping */
-enum uop = {RISCV_LUI, RISCV_AUIPC}               /* upper immediate ops */
-enum bop = {RISCV_BEQ, RISCV_BNE, RISCV_BLT,
-            RISCV_BGE, RISCV_BLTU, RISCV_BGEU}    /* branch ops */
-enum iop = {RISCV_ADDI, RISCV_SLTI, RISCV_SLTIU,
-            RISCV_XORI, RISCV_ORI, RISCV_ANDI}    /* immediate ops */
-enum sop = {RISCV_SLLI, RISCV_SRLI, RISCV_SRAI}   /* shift ops */
-enum rop = {RISCV_ADD, RISCV_SUB, RISCV_SLL, RISCV_SLT,
-            RISCV_SLTU, RISCV_XOR, RISCV_SRL, RISCV_SRA,
-            RISCV_OR, RISCV_AND}                  /* reg-reg ops */
+enum uop = {LUI, AUIPC}                          /* upper immediate ops */
+enum bop = {BEQ, BNE, BLT, BGE, BLTU, BGEU}      /* branch ops */
+enum iop = {ADDI, SLTI, SLTIU, XORI, ORI, ANDI}  /* immediate ops */
+enum sop = {SLLI, SRLI, SRAI}                    /* shift ops */
+enum rop = {ADD, SUB, SLL, SLT, SLTU, XOR,
+            SRL, SRA, OR, AND}                   /* reg-reg ops */
 
-enum ropw  = {RISCV_ADDW, RISCV_SUBW, RISCV_SLLW,
-              RISCV_SRLW, RISCV_SRAW}             /* reg-reg 32-bit ops */
-enum sopw = {RISCV_SLLIW, RISCV_SRLIW,
-             RISCV_SRAIW}                         /* RV64-only shift ops */
+enum ropw  = {ADDW, SUBW, SLLW, SRLW, SRAW}           /* reg-reg 32-bit ops */
+enum sopw  = {SLLIW, SRLIW, SRAIW}                    /* RV64-only shift ops */
 enum amoop = {AMOSWAP, AMOADD, AMOXOR, AMOAND, AMOOR,
-              AMOMIN, AMOMAX, AMOMINU, AMOMAXU}   /* AMO ops */
-enum csrop = {CSRRW, CSRRS, CSRRC}                /* CSR ops */
+              AMOMIN, AMOMAX, AMOMINU, AMOMAXU}       /* AMO ops */
+enum csrop = {CSRRW, CSRRS, CSRRC}                    /* CSR ops */
 
 enum cbop_zicbom = {CBO_CLEAN, CBO_FLUSH, CBO_INVAL}  /* Zicbom ops */
 
-enum brop_zba = {RISCV_SH1ADD, RISCV_SH2ADD, RISCV_SH3ADD}
+enum brop_zba = {SH1ADD, SH2ADD, SH3ADD}
 
-enum brop_zbb = {RISCV_ANDN, RISCV_ORN, RISCV_XNOR, RISCV_MAX,
-                 RISCV_MAXU, RISCV_MIN, RISCV_MINU, RISCV_ROL,
-                 RISCV_ROR}
+enum brop_zbb = {ANDN, ORN, XNOR, MAX, MAXU, MIN, MINU, ROL, ROR}
 
-enum brop_zbkb = {RISCV_PACK, RISCV_PACKH}
+enum brop_zbkb = {PACK, PACKH}
 
-enum brop_zbs = {RISCV_BCLR, RISCV_BEXT, RISCV_BINV, RISCV_BSET}
+enum brop_zbs = {BCLR, BEXT, BINV, BSET}
 
-enum bropw_zba = {RISCV_ADDUW, RISCV_SH1ADDUW, RISCV_SH2ADDUW,
-                  RISCV_SH3ADDUW}
+enum bropw_zba = {ADDUW, SH1ADDUW, SH2ADDUW, SH3ADDUW}
 
-enum bropw_zbb = {RISCV_ROLW, RISCV_RORW}
+enum bropw_zbb = {ROLW, RORW}
 
-enum biop_zbs = {RISCV_BCLRI, RISCV_BEXTI, RISCV_BINVI, RISCV_BSETI}
+enum biop_zbs = {BCLRI, BEXTI, BINVI, BSETI}
 
-enum extop_zbb = {RISCV_SEXTB, RISCV_SEXTH, RISCV_ZEXTH}
+enum extop_zbb = {SEXTB, SEXTH, ZEXTH}
 
-enum zicondop = {RISCV_CZERO_EQZ, RISCV_CZERO_NEZ}
+enum zicondop = {CZERO_EQZ, CZERO_NEZ}
 
 // Get the bit encoding of word_width.
 mapping size_enc : word_width <-> bits(2) = {


### PR DESCRIPTION
Pretty straightforward cleanup.