### PR TITLE
Change default instructions_per_tick to 2

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -35,7 +35,7 @@
       "base": 33554432,
       "size": 786432
     },
-    "instructions_per_tick": 100,
+    "instructions_per_tick": 2,
     "wfi_is_nop": true
   },
   "extensions": {


### PR DESCRIPTION
Fixes #193. This parameter controls how many instructions need to complete for the cycle CSR to increment. While this is implementation defined (and likely not constant even within a given implementation), a default of 2 seems a lot more natural than 100.