### PR TITLE
Add a project version and build information to the simulator.

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+        with:
+          # Git history is needed for `git describe` in the build to work.
+          fetch-depth: 0
 
       - name: Install packages (Linux)
         if: startsWith(matrix.os, 'ubuntu-')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,8 @@ if(POLICY CMP0135)
     cmake_policy(SET CMP0135 OLD)
 endif()
 
-project(sail_riscv)
+include(cmake/project_version.cmake)
+project(sail_riscv VERSION ${sail_riscv_release_version})
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)

--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -7,15 +7,14 @@ execute_process(
 )
 message(STATUS "Sail version: ${sail_version}")
 
+# The --version is is usually a multiline output; the first line is the most useful.
 execute_process(
     COMMAND ${CMAKE_CXX_COMPILER} --version
-    OUTPUT_VARIABLE compiler_version_blob
+    COMMAND head -n 1
+    OUTPUT_VARIABLE cxx_compiler_version
     OUTPUT_STRIP_TRAILING_WHITESPACE
     COMMAND_ERROR_IS_FATAL ANY
 )
-# This is usually a multiline output; the first line is the most useful.
-string(REGEX MATCHALL "[^\n\r]+" compiler_version_strings ${compiler_version_blob})
-list(GET compiler_version_strings 0 cxx_compiler_version)
 message(STATUS "CXX compiler version: ${cxx_compiler_version}")
 
 # make version available to emulator

--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -14,8 +14,7 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
     COMMAND_ERROR_IS_FATAL ANY
 )
-string(REGEX MATCHALL "[^\n\r]+" compiler_version_strings ${compiler_version_blob})
-list(GET compiler_version_strings 0 cxx_compiler_version)
+string(REGEX MATCH "[^\n\r]*" cxx_compiler_version ${compiler_version_blob})
 message(STATUS "CXX compiler version: ${cxx_compiler_version}")
 
 # make version available to emulator

--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -10,11 +10,12 @@ message(STATUS "Sail version: ${sail_version}")
 # The --version is is usually a multiline output; the first line is the most useful.
 execute_process(
     COMMAND ${CMAKE_CXX_COMPILER} --version
-    COMMAND head -n 1
-    OUTPUT_VARIABLE cxx_compiler_version
+    OUTPUT_VARIABLE compiler_version_blob
     OUTPUT_STRIP_TRAILING_WHITESPACE
     COMMAND_ERROR_IS_FATAL ANY
 )
+string(REGEX MATCHALL "[^\n\r]+" compiler_version_strings ${compiler_version_blob})
+list(GET compiler_version_strings 0 cxx_compiler_version)
 message(STATUS "CXX compiler version: ${cxx_compiler_version}")
 
 # make version available to emulator

--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -1,3 +1,26 @@
+# Extract version and build info.
+execute_process(
+    COMMAND ${SAIL_BIN} --version
+    OUTPUT_VARIABLE sail_version
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+)
+message(STATUS "Sail version: ${sail_version}")
+
+execute_process(
+    COMMAND ${CMAKE_CXX_COMPILER} --version
+    OUTPUT_VARIABLE compiler_version_blob
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+)
+# This is usually a multiline output; the first line is the most useful.
+string(REGEX MATCHALL "[^\n\r]+" compiler_version_strings ${compiler_version_blob})
+list(GET compiler_version_strings 0 cxx_compiler_version)
+message(STATUS "CXX compiler version: ${cxx_compiler_version}")
+
+# make version available to emulator
+configure_file(sail_riscv_version.cpp.in sail_riscv_version.cpp @ONLY)
+
 ## A library that contains the C model and support code.
 
 add_library(riscv_model
@@ -15,6 +38,8 @@ add_library(riscv_model
     riscv_softfloat.h
     config_utils.h
     config_utils.cpp
+    sail_riscv_version.h
+    "${CMAKE_CURRENT_BINARY_DIR}/sail_riscv_version.cpp"
     "${CMAKE_BINARY_DIR}/sail_riscv_model.c"
     "${CMAKE_BINARY_DIR}/sail_riscv_model.h"
 )

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -177,10 +177,17 @@ static void print_isa(void)
 
 static void print_build_info(void)
 {
-  printf("Sail RISC-V release: %s\n", version_info::release_version.c_str());
-  printf("Sail RISC-V git: %s\n", version_info::git_version.c_str());
-  printf("Sail: %s\n", version_info::sail_version.c_str());
-  printf("C++ compiler: %s\n", version_info::cxx_compiler_version.c_str());
+  printf("Sail RISC-V release: %.*s\n",
+         static_cast<int>(version_info::release_version.length()),
+         version_info::release_version.data());
+  printf("Sail RISC-V git: %.*s\n",
+         static_cast<int>(version_info::git_version.length()),
+         version_info::git_version.data());
+  printf("Sail: %.*s\n", static_cast<int>(version_info::sail_version.length()),
+         version_info::sail_version.data());
+  printf("C++ compiler: %.*s\n",
+         static_cast<int>(version_info::cxx_compiler_version.length()),
+         version_info::cxx_compiler_version.data());
 }
 
 static bool is_32bit_model(void)
@@ -283,7 +290,8 @@ static int process_args(int argc, char **argv)
       break;
     }
     case OPT_PRINT_VERSION:
-      printf("%s\n", version_info::release_version.c_str());
+      printf("%.*s\n", static_cast<int>(version_info::release_version.length()),
+             version_info::release_version.data());
       exit(EXIT_SUCCESS);
     case OPT_BUILD_INFO:
       print_build_info();

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -177,17 +177,12 @@ static void print_isa(void)
 
 static void print_build_info(void)
 {
-  printf("Sail RISC-V release: %.*s\n",
-         static_cast<int>(version_info::release_version.length()),
-         version_info::release_version.data());
-  printf("Sail RISC-V git: %.*s\n",
-         static_cast<int>(version_info::git_version.length()),
-         version_info::git_version.data());
-  printf("Sail: %.*s\n", static_cast<int>(version_info::sail_version.length()),
-         version_info::sail_version.data());
-  printf("C++ compiler: %.*s\n",
-         static_cast<int>(version_info::cxx_compiler_version.length()),
-         version_info::cxx_compiler_version.data());
+  std::cout << "Sail RISC-V release: " << version_info::release_version
+            << std::endl;
+  std::cout << "Sail RISC-V git: " << version_info::git_version << std::endl;
+  std::cout << "Sail: " << version_info::sail_version << std::endl;
+  std::cout << "C++ compiler: " << version_info::cxx_compiler_version
+            << std::endl;
 }
 
 static bool is_32bit_model(void)
@@ -290,8 +285,7 @@ static int process_args(int argc, char **argv)
       break;
     }
     case OPT_PRINT_VERSION:
-      printf("%.*s\n", static_cast<int>(version_info::release_version.length()),
-             version_info::release_version.data());
+      std::cout << version_info::release_version << std::endl;
       exit(EXIT_SUCCESS);
     case OPT_BUILD_INFO:
       print_build_info();

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -26,6 +26,7 @@
 #include "rvfi_dii.h"
 #include "default_config.h"
 #include "config_utils.h"
+#include "sail_riscv_version.h"
 
 enum {
   OPT_TRACE_OUTPUT = 1000,
@@ -33,6 +34,8 @@ enum {
   OPT_VALIDATE_CONFIG,
   OPT_SAILCOV,
   OPT_ENABLE_EXPERIMENTAL_EXTENSIONS,
+  OPT_PRINT_VERSION,
+  OPT_BUILD_INFO,
   OPT_PRINT_DTS,
   OPT_PRINT_ISA,
 };
@@ -110,6 +113,8 @@ static struct option options[] = {
     {"rvfi-dii",                       required_argument, 0, 'r'                },
     {"help",                           no_argument,       0, 'h'                },
     {"config",                         required_argument, 0, 'c'                },
+    {"version",                        no_argument,       0, OPT_PRINT_VERSION  },
+    {"build-info",                     no_argument,       0, OPT_BUILD_INFO     },
     {"print-default-config",           no_argument,       0, OPT_PRINT_CONFIG   },
     {"validate-config",                no_argument,       0, OPT_VALIDATE_CONFIG},
     {"trace",                          optional_argument, 0, 'v'                },
@@ -168,6 +173,14 @@ static void print_isa(void)
   fprintf(stdout, "%s\n", isa);
   KILL(sail_string)(&isa);
   exit(EXIT_SUCCESS);
+}
+
+static void print_build_info(void)
+{
+  printf("Sail RISC-V release: %s\n", version_info::release_version.c_str());
+  printf("Sail RISC-V git: %s\n", version_info::git_version.c_str());
+  printf("Sail: %s\n", version_info::sail_version.c_str());
+  printf("C++ compiler: %s\n", version_info::cxx_compiler_version.c_str());
 }
 
 static bool is_32bit_model(void)
@@ -269,6 +282,12 @@ static int process_args(int argc, char **argv)
       }
       break;
     }
+    case OPT_PRINT_VERSION:
+      printf("%s\n", version_info::release_version.c_str());
+      exit(EXIT_SUCCESS);
+    case OPT_BUILD_INFO:
+      print_build_info();
+      exit(EXIT_SUCCESS);
     case OPT_PRINT_CONFIG:
       printf("%s", DEFAULT_JSON);
       exit(EXIT_SUCCESS);

--- a/c_emulator/sail_riscv_version.cpp.in
+++ b/c_emulator/sail_riscv_version.cpp.in
@@ -1,0 +1,6 @@
+#include "sail_riscv_version.h"
+
+const std::string version_info::release_version = "@sail_riscv_release_version@";
+const std::string version_info::git_version = "@sail_riscv_git_version@";
+const std::string version_info::sail_version = "@sail_version@";
+const std::string version_info::cxx_compiler_version = "@cxx_compiler_version@";

--- a/c_emulator/sail_riscv_version.cpp.in
+++ b/c_emulator/sail_riscv_version.cpp.in
@@ -1,8 +1,10 @@
 #include "sail_riscv_version.h"
 
-using namespace version_info;
+namespace version_info {
 
-const std::string release_version = "@sail_riscv_release_version@";
-const std::string git_version = "@sail_riscv_git_version@";
-const std::string sail_version = "@sail_version@";
-const std::string cxx_compiler_version = "@cxx_compiler_version@";
+const std::string_view release_version = "@sail_riscv_release_version@";
+const std::string_view git_version = "@sail_riscv_git_version@";
+const std::string_view sail_version = "@sail_version@";
+const std::string_view cxx_compiler_version = "@cxx_compiler_version@";
+
+}

--- a/c_emulator/sail_riscv_version.cpp.in
+++ b/c_emulator/sail_riscv_version.cpp.in
@@ -1,6 +1,8 @@
 #include "sail_riscv_version.h"
 
-const std::string version_info::release_version = "@sail_riscv_release_version@";
-const std::string version_info::git_version = "@sail_riscv_git_version@";
-const std::string version_info::sail_version = "@sail_version@";
-const std::string version_info::cxx_compiler_version = "@cxx_compiler_version@";
+using namespace version_info;
+
+const std::string release_version = "@sail_riscv_release_version@";
+const std::string git_version = "@sail_riscv_git_version@";
+const std::string sail_version = "@sail_version@";
+const std::string cxx_compiler_version = "@cxx_compiler_version@";

--- a/c_emulator/sail_riscv_version.h
+++ b/c_emulator/sail_riscv_version.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <string>
+#include <string_view>
 
 namespace version_info {
 
-static const std::string release_version;
-static const std::string git_version;
-static const std::string sail_version;
-static const std::string cxx_compiler_version;
+extern const std::string_view release_version;
+extern const std::string_view git_version;
+extern const std::string_view sail_version;
+extern const std::string_view cxx_compiler_version;
 
 };

--- a/c_emulator/sail_riscv_version.h
+++ b/c_emulator/sail_riscv_version.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+struct version_info {
+  static const std::string release_version;
+  static const std::string git_version;
+  static const std::string sail_version;
+  static const std::string cxx_compiler_version;
+};

--- a/c_emulator/sail_riscv_version.h
+++ b/c_emulator/sail_riscv_version.h
@@ -2,9 +2,11 @@
 
 #include <string>
 
-struct version_info {
-  static const std::string release_version;
-  static const std::string git_version;
-  static const std::string sail_version;
-  static const std::string cxx_compiler_version;
+namespace version_info {
+
+static const std::string release_version;
+static const std::string git_version;
+static const std::string sail_version;
+static const std::string cxx_compiler_version;
+
 };

--- a/cmake/project_version.cmake
+++ b/cmake/project_version.cmake
@@ -1,0 +1,28 @@
+# Increment this appropriately at tag-and-release time.
+set(sail_riscv_release_version "0.7")
+
+# Sets GIT_EXECUTABLE
+find_package(Git)
+
+if (Git_FOUND)
+  # We could remove --tags if we started annotating the release tags.
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --tags HEAD
+    RESULT_VARIABLE git_error
+    OUTPUT_VARIABLE git_describe
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+else()
+  set(git_error TRUE)
+endif()
+
+if (git_error)
+  message(STATUS "Failed to run git describe: ${git_error}")
+
+  set(sail_riscv_git_version   "unknown commit")
+else()
+  set(sail_riscv_git_version   ${git_describe})
+endif()
+
+# Log versions in the build log.
+message(STATUS "Building versions: ${sail_riscv_git_version} (git), ${sail_riscv_release_version} (cmake).")

--- a/cmake/project_version.cmake
+++ b/cmake/project_version.cmake
@@ -6,8 +6,9 @@ find_package(Git)
 
 if (Git_FOUND)
   # We could remove --tags if we started annotating the release tags.
+  # --broken allows building in a corrupt git repo.
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --tags HEAD
+    COMMAND ${GIT_EXECUTABLE} describe --tags --dirty --broken
     RESULT_VARIABLE git_error
     OUTPUT_VARIABLE git_describe
     OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -18,7 +19,6 @@ endif()
 
 if (git_error)
   message(STATUS "Failed to run git describe: ${git_error}")
-
   set(sail_riscv_git_version   "unknown commit")
 else()
   set(sail_riscv_git_version   ${git_describe})


### PR DESCRIPTION
The project version is retrieved using a `--version` option.

The build info is retrieved using `--build-info`. This currently shows the Sail and C++ compiler versions, and the git info for sail-riscv if available.

