### PR TITLE
Disable htif when tohost symbol not found

### DIFF
--- a/c_emulator/riscv_platform.cpp
+++ b/c_emulator/riscv_platform.cpp
@@ -66,6 +66,11 @@ unit plat_term_write(mach_bits s)
   return UNIT;
 }
 
+bool plat_enable_htif()
+{
+  return rv_enable_htif;
+}
+
 mach_bits plat_htif_tohost(unit)
 {
   return rv_htif_tohost;

--- a/c_emulator/riscv_platform.h
+++ b/c_emulator/riscv_platform.h
@@ -16,6 +16,7 @@ unit cancel_reservation(unit);
 unit plat_term_write(mach_bits);
 
 mach_bits plat_htif_tohost(unit);
+bool plat_enable_htif();
 
 bool sys_enable_experimental_extensions(unit);
 

--- a/c_emulator/riscv_platform_impl.cpp
+++ b/c_emulator/riscv_platform_impl.cpp
@@ -18,6 +18,7 @@ uint64_t rv_16_random_bits(void)
 }
 
 uint64_t rv_htif_tohost = UINT64_C(0x80001000);
+bool rv_enable_htif = true;
 
 bool rv_enable_experimental_extensions = false;
 

--- a/c_emulator/riscv_platform_impl.h
+++ b/c_emulator/riscv_platform_impl.h
@@ -8,6 +8,7 @@
 extern uint64_t rv_16_random_bits(void);
 
 extern uint64_t rv_htif_tohost;
+extern bool rv_enable_htif;
 
 extern bool rv_enable_experimental_extensions;
 

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -352,10 +352,11 @@ uint64_t load_sail(char *f, bool main_file)
   fprintf(stdout, "ELF Entry @ 0x%" PRIx64 "\n", entry);
   /* locate htif ports */
   if (lookup_sym(f, "tohost", &rv_htif_tohost) < 0) {
-    fprintf(stderr, "Unable to locate htif tohost port.\n");
-    exit(1);
+    fprintf(stderr, "Unable to locate tohost symbol; disabling HTIF.\n");
+    rv_enable_htif = false;
+  } else {
+    fprintf(stdout, "HTIF located at 0x%0" PRIx64 "\n", rv_htif_tohost);
   }
-  fprintf(stderr, "tohost located at 0x%0" PRIx64 "\n", rv_htif_tohost);
   /* locate test-signature locations if any */
   if (!lookup_sym(f, "begin_signature", &begin_sig)) {
     fprintf(stdout, "begin_signature: 0x%0" PRIx64 "\n", begin_sig);

--- a/handwritten_support/RiscvExtras.lean
+++ b/handwritten_support/RiscvExtras.lean
@@ -48,6 +48,7 @@ axiom plat_enable_misaligned_access : Unit → Bool
 axiom plat_mtval_has_illegal_inst_bits  : Unit → Bool
 axiom plat_rom_base : Unit → Arch.pa
 axiom plat_rom_size : Unit → Arch.pa
+axiom plat_enable_htif : Unit → Bool
 axiom plat_htif_tohost : Unit → Arch.pa
 axiom plat_clint_base : Unit → Arch.pa
 axiom plat_clint_size : Unit → Arch.pa

--- a/handwritten_support/riscv_extras.lem
+++ b/handwritten_support/riscv_extras.lem
@@ -87,6 +87,9 @@ let speculate_conditional_success () = return true
 let match_reservation _ = true
 let cancel_reservation () = return ()
 
+val plat_enable_htif : unit -> bool
+let plat_enable_htif () = false
+
 val plat_htif_tohost : unit -> bitvector
 let plat_htif_tohost () = []
 declare ocaml target_rep function plat_htif_tohost = `Platform.htif_tohost`

--- a/handwritten_support/riscv_extras.v
+++ b/handwritten_support/riscv_extras.v
@@ -103,3 +103,4 @@ Definition get_time_ns (_:unit) : Z := 0.
 Definition mults_vec {n} (l : mword n) (r : mword n) : mword (2 * n) := mults_vec l r.
 Definition mult_vec {n} (l : mword n) (r : mword n) : mword (2 * n) := mult_vec l r.
 Definition print_string (_ _:string) : unit := tt.
+Definition plat_enable_htif (_:unit) : bool := false.

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -53,6 +53,10 @@ function plat_rom_size() -> physaddrbits = to_bits(physaddrbits_len, config plat
 function plat_clint_base() -> physaddrbits = to_bits(physaddrbits_len, config platform.clint.base : int)
 function plat_clint_size() -> physaddrbits = to_bits(physaddrbits_len, config platform.clint.size : int)
 
+// Whether HTIF (Host Target InterFace) is enabled. This is used for
+// console output and signalling the end of tests.
+val plat_enable_htif = pure "plat_enable_htif" : unit -> bool
+
 /* Location of HTIF ports */
 val plat_htif_tohost = pure {c: "plat_htif_tohost", lem: "plat_htif_tohost"} : unit -> physaddrbits
 function plat_htif_tohost () = to_bits(physaddrbits_len, elf_tohost ())
@@ -101,10 +105,10 @@ function within_clint forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : ph
 }
 
 function within_htif_writable forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : physaddr, width : int('n)) -> bool =
-    plat_htif_tohost() == addr | (plat_htif_tohost() + 4 == addr & width == 4)
+    plat_enable_htif() & (plat_htif_tohost() == addr | (plat_htif_tohost() + 4 == addr & width == 4))
 
 function within_htif_readable forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : physaddr, width : int('n)) -> bool =
-    plat_htif_tohost() == addr | (plat_htif_tohost() + 4 == addr & width == 4)
+    plat_enable_htif() & (plat_htif_tohost() == addr | (plat_htif_tohost() + 4 == addr & width == 4))
 
 /* CLINT (Core Local Interruptor), based on Spike. */
 


### PR DESCRIPTION
If htif is disabled

- cpp doesn't enforce check on the elf `tohost` symbol
- sail disallow reading and writing to tohost

If the elf does not meet the requirements, sail can at least try to run it instead of exit directly