### PR TITLE
Inline machine info register initialization

### DIFF
--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -428,11 +428,6 @@ function mmio_write forall 'n, 0 <'n <= max_mem_access . (paddr : physaddr, widt
 /* Platform initialization and ticking. */
 
 function init_platform() -> unit = {
-  mvendorid = to_bits(32,   (config platform.vendorid : int));
-  marchid   = to_bits(xlen, (config platform.archid : int));
-  mimpid    = to_bits(xlen, (config platform.impid : int));
-  mhartid   = to_bits(xlen, (config platform.hartid : int));
-
   htif_tohost = zeros();
   htif_done   = false;
   htif_exit_code = zeros();

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -639,11 +639,11 @@ register minstret : bits(64)
 register minstret_increment : bool
 
 /* machine information registers */
-register mvendorid : bits(32) = zeros()
-register mimpid : xlenbits = zeros()
-register marchid : xlenbits = zeros()
-/* TODO: this should be readonly, and always 0 for now */
-register mhartid : xlenbits = zeros()
+register mvendorid : bits(32) = to_bits(32,   (config platform.vendorid : int))
+register mimpid    : xlenbits = to_bits(xlen, (config platform.impid : int))
+register marchid   : xlenbits = to_bits(xlen, (config platform.archid : int))
+register mhartid   : xlenbits = to_bits(xlen, (config platform.hartid : int))
+
 register mconfigptr : xlenbits = zeros()
 
 mapping clause csr_name_map = 0xF11  <-> "mvendorid"


### PR DESCRIPTION
Not sure why I didn't think of this when reviewing #880. This inlines the initialization of the machine info registers, similar to what we do for several other registers throughout the model. These values are set at model initialization time.