### PR TITLE
Make truncate infer its length

### DIFF
--- a/model/prelude.sail
+++ b/model/prelude.sail
@@ -93,6 +93,11 @@ function zeros (n) = sail_zeros(n)
 val ones : forall 'n, 'n >= 0 . implicit('n) -> bits('n)
 function ones (n) = sail_ones(n)
 
+// Implicit version of truncate. Unfortunately the non-implicit version
+// isn't called `sail_truncate()` by Sail so we can't name this `truncate()`.
+val trunc : forall 'm 'n, 'm >= 0 & 'm <= 'n. (implicit('m), bits('n)) -> bits('m)
+function trunc(m, v) = truncate(v, m)
+
 mapping bool_bit : bool <-> bit = {
   true <-> bitone,
   false <-> bitzero,

--- a/model/riscv_fdext_regs.sail
+++ b/model/riscv_fdext_regs.sail
@@ -65,7 +65,7 @@ function cregidx_to_fregidx (Cregidx(b) : cregidx) -> fregidx = Fregidx(0b01 @ b
  * marks the places we need to consider it
  */
 function fregidx_to_regidx (Fregidx(b) : fregidx) -> regidx =
-  Regidx(truncate(b, let Regidx(zreg_bits) = zreg in length(zreg_bits)))
+  Regidx(trunc(b))
 
 mapping encdec_freg : fregidx <-> bits(5) = { Fregidx(r) <-> r }
 

--- a/model/riscv_vmem_tlb.sail
+++ b/model/riscv_vmem_tlb.sail
@@ -61,7 +61,7 @@ function tlb_get_ppn forall 'v, is_sv_mode('v) . (
   // be zero_extend(ones(9 or 10)). The lowest 9 or 10 bits will
   // be taken from the translated vpn. The bits above that from the
   // cached ppn.
-  truncate(ppn | (vpn & levelMask), if 'v == 32 then 22 else 44)
+  trunc(ppn | (vpn & levelMask))
 }
 
 // 64 entries is based on benchmarks of Linux boots and is where you stop


### PR DESCRIPTION
Unfortunately I had to rename it to trunc, but I think this is still better.

Partially fixes #898 

Better name suggestions welcome! @Alasdair FYI; I don't know if you have a plan for breaking changes to the standard library at some point but maybe add this to the list!