### PR TITLE
Make to_bits infer its length

### DIFF
--- a/model/main.sail
+++ b/model/main.sail
@@ -15,7 +15,7 @@ $ifdef SYMBOLIC
 
 $include <elf.sail>
 
-function get_entry_point() = to_bits(xlen, elf_entry())
+function get_entry_point() = to_bits(elf_entry())
 
 $else
 

--- a/model/prelude.sail
+++ b/model/prelude.sail
@@ -115,8 +115,8 @@ function bool_to_bits(x : bool) -> bits(1) = bool_bits(x)
 function bits_to_bool(x : bits(1)) -> bool = bool_bits(x)
 
 
-val to_bits : forall 'l, 'l >= 0.(int('l), int) -> bits('l)
-function to_bits (l, n) = get_slice_int(l, n, 0)
+val to_bits : forall 'l, 'l >= 0 . (implicit('l), int) -> bits('l)
+function to_bits(l, n) = get_slice_int(l, n, 0)
 
 infix 4 <_s
 infix 4 >_s
@@ -173,11 +173,11 @@ infix 7 <<<
 
 val rotate_bits_right : forall 'n 'm, 'm >= 0. (bits('n), bits('m)) -> bits('n)
 function rotate_bits_right (v, n) =
-    (v >> n) | (v << (to_bits(length(n), length(v)) - n))
+    (v >> n) | (v << (to_bits(length(v)) - n))
 
 val rotate_bits_left : forall 'n 'm, 'm >= 0. (bits('n), bits('m)) -> bits('n)
 function rotate_bits_left (v, n) =
-    (v << n) | (v >> (to_bits(length(n), length(v)) - n))
+    (v << n) | (v >> (to_bits(length(v)) - n))
 
 val rotater : forall 'm 'n, 'm >= 'n >= 0. (bits('m), int('n)) -> bits('m)
 function rotater (v, n) =

--- a/model/riscv_insts_mext.sail
+++ b/model/riscv_insts_mext.sail
@@ -32,7 +32,7 @@ function clause execute (MUL(rs2, rs1, rd, mul_op)) = {
   let rs2_val = X(rs2);
   let rs1_int : int = if mul_op.signed_rs1 then signed(rs1_val) else unsigned(rs1_val);
   let rs2_int : int = if mul_op.signed_rs2 then signed(rs2_val) else unsigned(rs2_val);
-  let result_wide = to_bits(2 * xlen, rs1_int * rs2_int);
+  let result_wide : bits(2 * xlen) = to_bits(rs1_int * rs2_int);
   let result = if   mul_op.high
                then result_wide[(2 * xlen - 1) .. xlen]
                else result_wide[(xlen - 1) .. 0];
@@ -65,7 +65,7 @@ function clause execute (DIV(rs2, rs1, rd, s)) = {
   let q : int = if rs2_int == 0 then -1 else quot_round_zero(rs1_int, rs2_int);
   /* check for signed overflow */
   let q': int = if s & q > xlen_max_signed then xlen_min_signed else q;
-  X(rd) = to_bits(xlen, q');
+  X(rd) = to_bits(q');
   RETIRE_SUCCESS
 }
 
@@ -91,7 +91,7 @@ function clause execute (REM(rs2, rs1, rd, s)) = {
   let rs2_int : int = if s then signed(rs2_val) else unsigned(rs2_val);
   let r : int = if rs2_int == 0 then rs1_int else rem_round_zero(rs1_int, rs2_int);
   /* signed overflow case returns zero naturally as required due to -1 divisor */
-  X(rd) = to_bits(xlen, r);
+  X(rd) = to_bits(r);
   RETIRE_SUCCESS
 }
 
@@ -108,12 +108,7 @@ mapping clause encdec = MULW(rs2, rs1, rd)
 function clause execute (MULW(rs2, rs1, rd)) = {
   let rs1_val = X(rs1)[31..0];
   let rs2_val = X(rs2)[31..0];
-  let rs1_int : int = signed(rs1_val);
-  let rs2_int : int = signed(rs2_val);
-  /* to_bits requires expansion to 64 bits followed by truncation */
-  let result32 = to_bits(64, rs1_int * rs2_int)[31..0];
-  let result : xlenbits = sign_extend(result32);
-  X(rd) = result;
+  X(rd) = sign_extend(to_bits(32, signed(rs1_val) * signed(rs2_val)));
   RETIRE_SUCCESS
 }
 

--- a/model/riscv_insts_vext_mask.sail
+++ b/model/riscv_insts_vext_mask.sail
@@ -113,7 +113,7 @@ function clause execute(VCPOP_M(vm, vs2, rd)) = {
     if (mask & vs2_val)[i] == bitone then count = count + 1;
   };
 
-  X(rd) = to_bits(xlen, count);
+  X(rd) = to_bits(count);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }
@@ -153,7 +153,7 @@ function clause execute(VFIRST_M(vm, vs2, rd)) = {
     };
   };
 
-  X(rd) = to_bits(xlen, index);
+  X(rd) = to_bits(index);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }
@@ -328,7 +328,7 @@ function clause execute(VIOTA_M(vm, vs2, vd)) = {
   var sum : int = 0;
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
-      result[i] = to_bits(SEW, sum);
+      result[i] = to_bits(sum);
       if vs2_val[i] == bitone then sum = sum + 1
     }
   };
@@ -368,7 +368,7 @@ function clause execute(VID_V(vm, vd)) = {
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] == bitone then result[i] = to_bits(SEW, i)
+    if mask[i] == bitone then result[i] = to_bits(i)
   };
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -84,10 +84,10 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then { /* active segments */
-      set_vstart(to_bits(16, i));
+      set_vstart(to_bits(i));
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = (i * nf + j) * load_width_bytes;
-        match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
+        match ext_data_get_addr(rs1, to_bits(elem_offset), Read(Data), load_width_bytes) {
           Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
               if check_misaligned(vaddr, width_type)
@@ -96,7 +96,7 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
                 TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                 TR_Address(paddr, _) => {
                   match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                    Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
+                    Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(j * EMUL_reg)), elem),
                     Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                   }
                 }
@@ -106,7 +106,7 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
     } else { /* prestart, masked or tail segments */
       foreach (j from 0 to (nf - 1)) {
         let skipped_elem = (result[i] >> (j * load_width_bytes * 8))[(load_width_bytes * 8 - 1) .. 0];
-        write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), skipped_elem)
+        write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(j * EMUL_reg)), skipped_elem)
       }
     }
   };
@@ -162,11 +162,11 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
       if mask[i] == bitone then { /* active segments */
         foreach (j from 0 to (nf - 1)) {
           let elem_offset = (i * nf + j) * load_width_bytes;
-          match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
+          match ext_data_get_addr(rs1, to_bits(elem_offset), Read(Data), load_width_bytes) {
             Ext_DataAddr_Error(e)  => {
               if i == 0 then return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e))
               else {
-                vl = to_bits(xlen, i);
+                vl = to_bits(i);
                 print_reg("CSR vl <- " ^ BitStr(vl));
                 trimmed = true
               }
@@ -175,7 +175,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
               if check_misaligned(vaddr, width_type) then {
                 if i == 0 then return RETIRE_FAIL(Memory_Exception(vaddr, E_Load_Addr_Align()))
                 else {
-                  vl = to_bits(xlen, i);
+                  vl = to_bits(i);
                   print_reg("CSR vl <- " ^ BitStr(vl));
                   trimmed = true
                 }
@@ -183,18 +183,18 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
                 TR_Failure(e, _)     => {
                   if i == 0 then return RETIRE_FAIL(Memory_Exception(vaddr, e))
                   else {
-                    vl = to_bits(xlen, i);
+                    vl = to_bits(i);
                     print_reg("CSR vl <- " ^ BitStr(vl));
                     trimmed = true
                   }
                 },
                 TR_Address(paddr, _) => {
                   match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                    Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
+                    Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(j * EMUL_reg)), elem),
                     Err(e)   => {
                       if i == 0 then return RETIRE_FAIL(Memory_Exception(vaddr, e))
                       else {
-                        vl = to_bits(xlen, i);
+                        vl = to_bits(i);
                         print_reg("CSR vl <- " ^ BitStr(vl));
                         trimmed = true
                       }
@@ -208,7 +208,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
       } else { /* prestart, masked or tail segments */
         foreach (j from 0 to (nf - 1)) {
           let skipped_elem = (result[i] >> (j * load_width_bytes * 8))[(load_width_bytes * 8 - 1) .. 0];
-          write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), skipped_elem)
+          write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(j * EMUL_reg)), skipped_elem)
         }
       }
     } else {
@@ -216,7 +216,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
       if tail_ag == AGNOSTIC then {
         foreach (j from 0 to (nf - 1)) {
           let skipped_elem = (vd_seg[i] >> (j * load_width_bytes * 8))[(load_width_bytes * 8 - 1) .. 0];
-          write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), skipped_elem)
+          write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(j * EMUL_reg)), skipped_elem)
         }
         /* TODO: configuration support for agnostic behavior */
       }
@@ -268,10 +268,10 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then { /* active segments */
-      set_vstart(to_bits(16, i));
+      set_vstart(to_bits(i));
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = (i * nf + j) * load_width_bytes;
-        match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), load_width_bytes) {
+        match ext_data_get_addr(rs1, to_bits(elem_offset), Write(Data), load_width_bytes) {
           Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
@@ -282,7 +282,7 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
                 match mem_write_ea(paddr, load_width_bytes, false, false, false) {
                   Err(e) => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                   Ok(_)  => {
-                    let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(5, j * EMUL_reg)));
+                    let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(j * EMUL_reg)));
                     match mem_write_value(paddr, load_width_bytes, elem_val, false, false, false) {
                       Ok(true)  => (),
                       Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
@@ -344,10 +344,10 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then { /* active segments */
-      set_vstart(to_bits(16, i));
+      set_vstart(to_bits(i));
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = i * rs2_val + j * load_width_bytes;
-        match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
+        match ext_data_get_addr(rs1, to_bits(elem_offset), Read(Data), load_width_bytes) {
           Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
@@ -356,7 +356,7 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
               TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                  Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), elem),
+                  Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(j * EMUL_reg)), elem),
                   Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                 }
               }
@@ -366,7 +366,7 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
     } else { /* prestart, masked or tail segments */
       foreach (j from 0 to (nf - 1)) {
         let skipped_elem = (result[i] >> (j * load_width_bytes * 8))[(load_width_bytes * 8 - 1) .. 0];
-        write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_reg)), skipped_elem)
+        write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(j * EMUL_reg)), skipped_elem)
       }
     }
   };
@@ -417,10 +417,10 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then { /* active segments */
-      set_vstart(to_bits(16, i));
+      set_vstart(to_bits(i));
       foreach (j from 0 to (nf - 1)) {
         let elem_offset = i * rs2_val + j * load_width_bytes;
-        match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), load_width_bytes) {
+        match ext_data_get_addr(rs1, to_bits(elem_offset), Write(Data), load_width_bytes) {
           Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
@@ -431,7 +431,7 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
                 match mem_write_ea(paddr, load_width_bytes, false, false, false) {
                   Err(e) => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                   Ok(_)  => {
-                    let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(5, j * EMUL_reg)));
+                    let elem_val : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(j * EMUL_reg)));
                     match mem_write_value(paddr, load_width_bytes, elem_val, false, false, false) {
                       Ok(true)  => (),
                       Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
@@ -494,10 +494,10 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
   /* currently mop = 1 (unordered) or 3 (ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then { /* active segments */
-      set_vstart(to_bits(16, i));
+      set_vstart(to_bits(i));
       foreach (j from 0 to (nf - 1)) {
         let elem_offset : int = unsigned(vs2_val[i]) + j * EEW_data_bytes;
-        match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), EEW_data_bytes) {
+        match ext_data_get_addr(rs1, to_bits(elem_offset), Read(Data), EEW_data_bytes) {
           Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
@@ -506,7 +506,7 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
               TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
               TR_Address(paddr, _) => {
                 match mem_read(Read(Data), paddr, EEW_data_bytes, false, false, false) {
-                  Ok(elem) => write_single_element(EEW_data_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_data_reg)), elem),
+                  Ok(elem) => write_single_element(EEW_data_bytes * 8, i, vregidx_offset(vd, to_bits(j * EMUL_data_reg)), elem),
                   Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
                 }
               }
@@ -516,7 +516,7 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
     } else { /* prestart, masked or tail segments */
       foreach (j from 0 to (nf - 1)) {
         let skipped_elem = (result[i] >> (j * EEW_data_bytes * 8))[(EEW_data_bytes * 8 - 1) .. 0];
-        write_single_element(EEW_data_bytes * 8, i, vregidx_offset(vd, to_bits(5, j * EMUL_data_reg)), skipped_elem)
+        write_single_element(EEW_data_bytes * 8, i, vregidx_offset(vd, to_bits(j * EMUL_data_reg)), skipped_elem)
       }
     }
   };
@@ -597,10 +597,10 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
   /* currently mop = 1 (unordered) or 3 (ordered) do the same operations */
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then { /* active segments */
-      set_vstart(to_bits(16, i));
+      set_vstart(to_bits(i));
       foreach (j from 0 to (nf - 1)) {
         let elem_offset : int = unsigned(vs2_val[i]) + j * EEW_data_bytes;
-        match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), EEW_data_bytes) {
+        match ext_data_get_addr(rs1, to_bits(elem_offset), Write(Data), EEW_data_bytes) {
           Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
@@ -611,7 +611,7 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
                 match mem_write_ea(paddr, EEW_data_bytes, false, false, false) {
                   Err(e) => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                   Ok(_)  => {
-                    let elem_val : bits('db * 8) = read_single_element(EEW_data_bytes * 8, i, vregidx_offset(vs3, to_bits(5, j * EMUL_data_reg)));
+                    let elem_val : bits('db * 8) = read_single_element(EEW_data_bytes * 8, i, vregidx_offset(vs3, to_bits(j * EMUL_data_reg)));
                     match mem_write_value(paddr, EEW_data_bytes, elem_val, false, false, false) {
                       Ok(true)  => (),
                       Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
@@ -700,9 +700,9 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
 
   if elem_to_align > 0 then {
     foreach (i from elem_to_align to (elem_per_reg - 1)) {
-      set_vstart(to_bits(16, cur_elem));
+      set_vstart(to_bits(cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
-      match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
+      match ext_data_get_addr(rs1, to_bits(elem_offset), Read(Data), load_width_bytes) {
         Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
         Ext_DataAddr_OK(vaddr) =>
           if check_misaligned(vaddr, width_type)
@@ -711,7 +711,7 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
             TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
             TR_Address(paddr, _) => {
               match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, cur_field)), elem),
+                Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(cur_field)), elem),
                 Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
               }
             }
@@ -724,9 +724,9 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
 
   foreach (j from cur_field to (nf - 1)) {
     foreach (i from 0 to (elem_per_reg - 1)) {
-      set_vstart(to_bits(16, cur_elem));
+      set_vstart(to_bits(cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
-      match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Read(Data), load_width_bytes) {
+      match ext_data_get_addr(rs1, to_bits(elem_offset), Read(Data), load_width_bytes) {
         Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
         Ext_DataAddr_OK(vaddr) =>
           if check_misaligned(vaddr, width_type)
@@ -735,7 +735,7 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
             TR_Failure(e, _)     => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
             TR_Address(paddr, _) => {
               match mem_read(Read(Data), paddr, load_width_bytes, false, false, false) {
-                Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(5, j)), elem),
+                Ok(elem) => write_single_element(load_width_bytes * 8, i, vregidx_offset(vd, to_bits(j)), elem),
                 Err(e)   => return RETIRE_FAIL(Memory_Exception(vaddr, e))
               }
             }
@@ -785,9 +785,9 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
 
   if elem_to_align > 0 then {
     foreach (i from elem_to_align to (elem_per_reg - 1)) {
-      set_vstart(to_bits(16, cur_elem));
+      set_vstart(to_bits(cur_elem));
       let elem_offset : int = cur_elem * load_width_bytes;
-      match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), load_width_bytes) {
+      match ext_data_get_addr(rs1, to_bits(elem_offset), Write(Data), load_width_bytes) {
         Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
         Ext_DataAddr_OK(vaddr) =>
           if check_misaligned(vaddr, width_type)
@@ -798,7 +798,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
               match mem_write_ea(paddr, load_width_bytes, false, false, false) {
                 Err(e) => return RETIRE_FAIL(Memory_Exception(vaddr, e)),
                 Ok(_)  => {
-                  let elem : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(5, cur_field)));
+                  let elem : bits('b * 8) = read_single_element(load_width_bytes * 8, i, vregidx_offset(vs3, to_bits(cur_field)));
                   match mem_write_value(paddr, load_width_bytes, elem, false, false, false) {
                     Ok(true)  => (),
                     Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
@@ -815,11 +815,11 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
   };
 
   foreach (j from cur_field to (nf - 1)) {
-    let vs3_val : vector('n, bits('b * 8)) = read_vreg(elem_per_reg, load_width_bytes * 8, 0, vregidx_offset(vs3, to_bits(5, j)));
+    let vs3_val : vector('n, bits('b * 8)) = read_vreg(elem_per_reg, load_width_bytes * 8, 0, vregidx_offset(vs3, to_bits(j)));
     foreach (i from 0 to (elem_per_reg - 1)) {
-      set_vstart(to_bits(16, cur_elem));
+      set_vstart(to_bits(cur_elem));
       let elem_offset = cur_elem * load_width_bytes;
-      match ext_data_get_addr(rs1, to_bits(xlen, elem_offset), Write(Data), load_width_bytes) {
+      match ext_data_get_addr(rs1, to_bits(elem_offset), Write(Data), load_width_bytes) {
         Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
         Ext_DataAddr_OK(vaddr) =>
           if check_misaligned(vaddr, width_type)
@@ -886,9 +886,9 @@ function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
 
   foreach (i from start_element to (num_elem - 1)) {
     if i < evl then { /* active elements */
-      set_vstart(to_bits(16, i));
+      set_vstart(to_bits(i));
       if op == VLM then { /* load */
-        match ext_data_get_addr(rs1, to_bits(xlen, i), Read(Data), 1) {
+        match ext_data_get_addr(rs1, to_bits(i), Read(Data), 1) {
           Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)
@@ -904,7 +904,7 @@ function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
             }
         }
       } else if op == VSM then { /* store */
-        match ext_data_get_addr(rs1, to_bits(xlen, i), Write(Data), 1) {
+        match ext_data_get_addr(rs1, to_bits(i), Write(Data), 1) {
           Ext_DataAddr_Error(e)  => return RETIRE_FAIL(Ext_DataAddr_Check_Failure(e)),
           Ext_DataAddr_OK(vaddr) =>
             if check_misaligned(vaddr, width_type)

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -408,7 +408,7 @@ function read_vreg_seg(num_elem, SEW, LMUL_pow, nf, vrid) = {
   var vreg_list : vector('q, vector('n, bits('m))) = vector_init(vector_init(zeros()));
   var result : vector('n, bits('q * 'm)) = vector_init(zeros());
   foreach (j from 0 to (nf - 1)) {
-    vreg_list[j] = read_vreg(num_elem, SEW, LMUL_pow, vregidx_offset(vrid, to_bits(5, j * LMUL_reg)));
+    vreg_list[j] = read_vreg(num_elem, SEW, LMUL_pow, vregidx_offset(vrid, to_bits(j * LMUL_reg)));
   };
   foreach (i from 0 to (num_elem - 1)) {
     result[i] = zeros('q * 'm);

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -66,7 +66,7 @@ function calculate_new_vl(AVL : int, VLMAX : int) -> xlenbits = {
     }
     else VLMAX;
 
-  to_bits(xlen, new_vl)
+  to_bits(new_vl)
 }
 
 /* *********************************** vsetvli *********************************** */
@@ -100,7 +100,7 @@ function clause execute VSETVLI(ma, ta, sew, lmul, rs1, rd) = {
     X(rd) = vl;
   } else if (rd != zreg) then { /* set vl to VLMAX */
     let AVL = unsigned(ones(xlen));
-    vl = to_bits(xlen, VLMAX);
+    vl = to_bits(VLMAX);
     X(rd) = vl;
   } else { /* keep existing vl */
     let AVL = unsigned(vl);
@@ -152,7 +152,7 @@ function clause execute VSETVL(rs2, rs1, rd) = {
     X(rd) = vl;
   } else if (rd != zreg) then { /* set vl to VLMAX */
     let AVL = unsigned(ones(xlen));
-    vl = to_bits(xlen, VLMAX);
+    vl = to_bits(VLMAX);
     X(rd) = vl;
   } else { /* keep existing vl */
     let AVL = unsigned(vl);

--- a/model/riscv_insts_zvbb.sail
+++ b/model/riscv_insts_zvbb.sail
@@ -233,7 +233,7 @@ function clause execute (VCLZ_V(vm, vs2, vd)) = {
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
       let clz = count_leading_zeros(vs2_val[i]);
-      result[i] = to_bits('m, clz);
+      result[i] = to_bits(clz);
     };
   };
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
@@ -271,7 +271,7 @@ function clause execute (VCTZ_V(vm, vs2, vd)) = {
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == bitone then {
       let ctz = count_trailing_zeros(vs2_val[i]);
-      result[i] = to_bits('m, ctz);
+      result[i] = to_bits(ctz);
     };
   };
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -31,8 +31,8 @@ val elf_entry = pure {
 function plat_cache_block_size_exp() -> range(0, 12) = config platform.cache_block_size_exp
 
 /* Main memory */
-function plat_ram_base() -> physaddrbits = to_bits(physaddrbits_len, config platform.ram.base : int)
-function plat_ram_size() -> physaddrbits = to_bits(physaddrbits_len, config platform.ram.size : int)
+function plat_ram_base() -> physaddrbits = to_bits(config platform.ram.base : int)
+function plat_ram_size() -> physaddrbits = to_bits(config platform.ram.size : int)
 
 /* whether the MMU should update dirty bits in PTEs */
 function plat_enable_dirty_update() -> bool = config memory.translation.dirty_update
@@ -46,16 +46,16 @@ function plat_enable_misaligned_access() -> bool = config memory.misaligned.supp
 function plat_mtval_has_illegal_inst_bits() -> bool = config base.mtval_has_illegal_instruction_bits
 
 /* ROM holding reset vector and device-tree DTB */
-function plat_rom_base() -> physaddrbits = to_bits(physaddrbits_len, config platform.rom.base : int)
-function plat_rom_size() -> physaddrbits = to_bits(physaddrbits_len, config platform.rom.size : int)
+function plat_rom_base() -> physaddrbits = to_bits(config platform.rom.base : int)
+function plat_rom_size() -> physaddrbits = to_bits(config platform.rom.size : int)
 
 /* Location of clock-interface, which should match with the spec in the DTB */
-function plat_clint_base() -> physaddrbits = to_bits(physaddrbits_len, config platform.clint.base : int)
-function plat_clint_size() -> physaddrbits = to_bits(physaddrbits_len, config platform.clint.size : int)
+function plat_clint_base() -> physaddrbits = to_bits(config platform.clint.base : int)
+function plat_clint_size() -> physaddrbits = to_bits(config platform.clint.size : int)
 
 /* Location of HTIF ports */
 val plat_htif_tohost = pure {c: "plat_htif_tohost", lem: "plat_htif_tohost"} : unit -> physaddrbits
-function plat_htif_tohost () = to_bits(physaddrbits_len, elf_tohost ())
+function plat_htif_tohost () = to_bits(elf_tohost())
 // todo: fromhost
 
 /* Physical memory map predicates */

--- a/model/riscv_pmp_control.sail
+++ b/model/riscv_pmp_control.sail
@@ -104,7 +104,7 @@ function accessToFault(acc : AccessType(ext_access_type)) -> ExceptionType =
 
 function pmpCheck forall 'n, 'n > 0. (addr: physaddr, width: int('n), acc: AccessType(ext_access_type), priv: Privilege)
                   -> option(ExceptionType) = {
-  let width : xlenbits = to_bits(xlen, width);
+  let width : xlenbits = to_bits(width);
 
   foreach (i from 0 to 63) {
     let prev_pmpaddr = (if i > 0 then pmpReadAddrReg(i - 1) else zeros());

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -88,7 +88,7 @@ function rX (Regno(r) : regno) -> xlenbits = {
 $ifdef RVFI_DII
 function rvfi_wX (Regno(r) : regno, v : xlenbits) -> unit = {
   rvfi_int_data[rvfi_rd_wdata] = zero_extend(v);
-  rvfi_int_data[rvfi_rd_addr] = to_bits(8,r);
+  rvfi_int_data[rvfi_rd_addr] = to_bits(r);
   rvfi_int_data_present = true;
 }
 $else

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -893,9 +893,8 @@ val get_16_random_bits = impure {
 register vstart : bits(16) /* use the largest possible length of vstart */
 register vl     : xlenbits
 
-function get_vlenb() -> xlenbits = {
-  to_bits(xlen, (2 ^ (get_vlen_pow()) / 8))
-}
+function get_vlenb() -> xlenbits =
+  to_bits(2 ^ get_vlen_pow() / 8)
 
 bitfield Vtype  : xlenbits = {
   vill      : xlen - 1,

--- a/model/riscv_vext_regs.sail
+++ b/model/riscv_vext_regs.sail
@@ -295,7 +295,7 @@ function read_vreg(num_elem, SEW, LMUL_pow, vrid) = {
       foreach (i_lmul from 0 to (2 ^ LMUL_pow_reg - 1)) {
         let r_start_i : int = i_lmul * 'num_elem_single;
         let r_end_i   : int = r_start_i + 'num_elem_single - 1;
-        let vrid_lmul     : vregidx = vregidx_offset(vrid, to_bits(5, i_lmul));
+        let vrid_lmul     : vregidx = vregidx_offset(vrid, to_bits(i_lmul));
         let single_result : vector('num_elem_single, bits('m)) = read_single_vreg('num_elem_single, SEW, vrid_lmul);
         foreach (r_i from r_start_i to r_end_i) {
           let s_i : int = r_i - r_start_i;
@@ -316,7 +316,7 @@ function read_single_element(EEW, index, vrid) = {
   assert(VLEN >= EEW);
   let 'elem_per_reg : int = VLEN / EEW;
   assert('elem_per_reg >= 0);
-  let real_vrid  : vregidx = vregidx_offset(vrid, to_bits(5, index / 'elem_per_reg));
+  let real_vrid  : vregidx = vregidx_offset(vrid, to_bits(index / 'elem_per_reg));
   let real_index : int    = index % 'elem_per_reg;
   let vrid_val : vector('elem_per_reg, bits('m)) = read_single_vreg('elem_per_reg, EEW, real_vrid);
   assert(0 <= real_index & real_index < 'elem_per_reg);
@@ -332,7 +332,7 @@ function write_vreg(num_elem, SEW, LMUL_pow, vrid, vec) = {
   assert('num_elem_single >= 0);
   foreach (i_lmul from 0 to (2 ^ LMUL_pow_reg - 1)) {
     var single_vec : vector('num_elem_single, bits('m)) = vector_init(zeros());
-    let vrid_lmul  : vregidx = vregidx_offset(vrid, to_bits(5, i_lmul));
+    let vrid_lmul  : vregidx = vregidx_offset(vrid, to_bits(i_lmul));
     let r_start_i  : int = i_lmul * 'num_elem_single;
     let r_end_i    : int = r_start_i + 'num_elem_single - 1;
     foreach (r_i from r_start_i to r_end_i) {
@@ -350,7 +350,7 @@ val write_single_element : forall 'm 'x, 8 <= 'm <= 128. (int('m), int('x), vreg
 function write_single_element(EEW, index, vrid, value) = {
   let 'elem_per_reg : int = VLEN / EEW;
   assert('elem_per_reg >= 0);
-  let real_vrid  : vregidx = vregidx_offset(vrid, to_bits(5, index / 'elem_per_reg));
+  let real_vrid  : vregidx = vregidx_offset(vrid, to_bits(index / 'elem_per_reg));
   let real_index : int    = index % 'elem_per_reg;
 
   let vrid_val : vector('elem_per_reg, bits('m)) = read_single_vreg('elem_per_reg, EEW, real_vrid);

--- a/model/riscv_zvk_utils.sail
+++ b/model/riscv_zvk_utils.sail
@@ -32,16 +32,16 @@ function zvknhab_check_encdec(vs2: vregidx, vs1: vregidx, vd: vregidx) -> bool =
 val zvk_sig0 : forall 'n 'm, 'n == 'm & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
 function zvk_sig0(x, SEW) = {
   match SEW {
-    32 => ((x >>> 7) ^ (x >>> 18) ^ (x >> to_bits('n, 3))),
-    64 => ((x >>> 1) ^ (x >>>  8) ^ (x >> to_bits('n, 7))),
+    32 => ((x >>> 7) ^ (x >>> 18) ^ (x >> 3)),
+    64 => ((x >>> 1) ^ (x >>>  8) ^ (x >> 7)),
   }
 }
 
 val zvk_sig1 : forall 'n 'm, 'n == 'm & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
 function zvk_sig1(x, SEW) = {
   match SEW {
-    32 => ((x >>> 17) ^ (x >>> 19) ^ (x >> to_bits('n, 10))),
-    64 => ((x >>> 19) ^ (x >>> 61) ^ (x >> to_bits('n,  6))),
+    32 => ((x >>> 17) ^ (x >>> 19) ^ (x >> 10)),
+    64 => ((x >>> 19) ^ (x >>> 61) ^ (x >>  6)),
   }
 }
 

--- a/model/rvfi_dii.sail
+++ b/model/rvfi_dii.sail
@@ -263,7 +263,7 @@ function rvfi_get_exec_packet_v1 () = {
 
 val rvfi_get_v2_trace_size : unit -> bits(64)
 function rvfi_get_v2_trace_size () = {
-  let trace_size : bits(64) = to_bits(64, 512);
+  let trace_size : bits(64) = to_bits(512);
   let trace_size = if (rvfi_int_data_present) then trace_size + 320 else trace_size;
   let trace_size = if (rvfi_mem_data_present) then trace_size + 704 else trace_size;
   return trace_size >> 3; // we have to return bytes not bits


### PR DESCRIPTION
Make to_bits infer the length of its return value, and remove many of the values that can now be inferred.

I also simplified MULW a bit - since `to_bits()` truncates there's no need for a separate truncation step.

Partially fixes #898.

On reflection we should to #614 before merging this since this kind of loses some information (e.g. the `MULW` `to_bits()`) deliberately truncates, whereas some of the others don't.