### PR TITLE
Make Rocq workflow run on request.

### DIFF
--- a/.github/workflows/rocq.yml
+++ b/.github/workflows/rocq.yml
@@ -1,6 +1,6 @@
 name: Rocq
 
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
There are still occasional bugs in the backend that are blocking PRs being merged.

See https://github.com/riscv/sail-riscv/pull/862#issuecomment-2839700728