### PR TITLE
Minor cleanups to M extension

### DIFF
--- a/model/prelude.sail
+++ b/model/prelude.sail
@@ -49,12 +49,10 @@ val sub_vec_int = pure {c: "sub_bits_int", lean: "BitVec.subInt", _: "sub_vec_in
 overload operator - = {sub_vec, sub_vec_int}
 
 val quot_positive_round_zero = pure {interpreter: "quot_round_zero", lem: "hardware_quot", lean: "Int.tdiv", c: "tdiv_int", coq: "Z.quot"} : forall 'n 'm, 'n >= 0 & 'm > 0. (int('n), int('m)) -> int(div('n, 'm))
-
 val quot_round_zero = pure {interpreter: "quot_round_zero", lem: "hardware_quot", c: "tdiv_int", coq: "Z.quot", lean: "Int.tdiv"} : (int, int) -> int
-val rem_round_zero = pure {interpreter: "rem_round_zero", lem: "hardware_mod", c: "tmod_int", coq: "Z.rem", lean: "Int.tmod"} : (int, int) -> int
 
-/* The following defines % as euclidean modulus */
-overload operator % = {emod_int}
+val rem_positive_round_zero = pure {interpreter: "rem_round_zero", lem: "hardware_mod", c: "tmod_int", coq: "Z.rem", lean: "Int.tmod"} : forall 'n 'm, 'n >= 0 & 'm > 0. (int('n), int('m)) -> int(mod('n, 'm))
+val rem_round_zero = pure {interpreter: "rem_round_zero", lem: "hardware_mod", c: "tmod_int", coq: "Z.rem", lean: "Int.tmod"} : (int, int) -> int
 
 overload min = {min_int}
 overload max = {max_int}
@@ -102,11 +100,6 @@ mapping bool_bit : bool <-> bit = {
 mapping bool_bits : bool <-> bits(1) = {
   true   <-> 0b1,
   false  <-> 0b0,
-}
-
-mapping bool_not_bits : bool <-> bits(1) = {
-  true   <-> 0b0,
-  false  <-> 0b1,
 }
 
 // These aliases make the conversion direction a bit clearer.
@@ -216,8 +209,9 @@ function reverse_bits (xs)  = {
   ys
 }
 
-overload operator / = {quot_positive_round_zero, quot_round_zero}
 overload operator * = {mult_atom, mult_int}
+overload operator / = {quot_positive_round_zero, quot_round_zero}
+overload operator % = {rem_positive_round_zero, rem_round_zero}
 
 /* helper for vector extension
  * 1. EEW between 8 and 64
@@ -261,5 +255,5 @@ val sys_enable_experimental_extensions = pure "sys_enable_experimental_extension
 // Print a bit vector in hex. If it is not a multiple of 4
 // bits in length zero extend it so it is (bits_str() prints
 // bit vectors that aren't a multiple of 4 bits in binary).
-function hex_bits_str forall 'n . (x : bits('n)) -> string =
+function hex_bits_str forall 'n, 'n >= 0 . (x : bits('n)) -> string =
   bits_str(zero_extend((3 - (('n + 3) % 4)) + 'n, x))

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -304,7 +304,7 @@ function clause execute (LOAD(imm, rs1, rd, is_unsigned, width)) = {
 
 mapping maybe_u : bool <-> string = {
   true  <-> "u",
-  false <-> ""
+  false <-> "",
 }
 
 mapping clause assembly = LOAD(imm, rs1, rd, is_unsigned, width)

--- a/model/riscv_insts_mext.sail
+++ b/model/riscv_insts_mext.sail
@@ -6,10 +6,9 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-/* ****************************************************************** */
-/* This file specifies the instructions in the 'M' extension.         */
-
-/* ****************************************************************** */
+/********************************************************************/
+/* This file specifies the instructions in the 'M' extension.       */
+/********************************************************************/
 
 function clause currentlyEnabled(Ext_M) = hartSupports(Ext_M) & misa[M] == 0b1
 function clause currentlyEnabled(Ext_Zmmul) = hartSupports(Ext_Zmmul) | currentlyEnabled(Ext_M)
@@ -20,7 +19,7 @@ mapping encdec_mul_op : mul_op <-> bits(3) = {
   struct { high = false, signed_rs1 = true,  signed_rs2 = true  } <-> 0b000,
   struct { high = true,  signed_rs1 = true,  signed_rs2 = true  } <-> 0b001,
   struct { high = true,  signed_rs1 = true,  signed_rs2 = false } <-> 0b010,
-  struct { high = true,  signed_rs1 = false, signed_rs2 = false } <-> 0b011
+  struct { high = true,  signed_rs1 = false, signed_rs2 = false } <-> 0b011,
 }
 
 mapping clause encdec = MUL(rs2, rs1, rd, mul_op)
@@ -28,15 +27,15 @@ mapping clause encdec = MUL(rs2, rs1, rd, mul_op)
   when currentlyEnabled(Ext_M) | currentlyEnabled(Ext_Zmmul)
 
 function clause execute (MUL(rs2, rs1, rd, mul_op)) = {
-  let rs1_val = X(rs1);
-  let rs2_val = X(rs2);
-  let rs1_int : int = if mul_op.signed_rs1 then signed(rs1_val) else unsigned(rs1_val);
-  let rs2_int : int = if mul_op.signed_rs2 then signed(rs2_val) else unsigned(rs2_val);
-  let result_wide = to_bits_unsafe(2 * xlen, rs1_int * rs2_int);
-  let result = if   mul_op.high
-               then result_wide[(2 * xlen - 1) .. xlen]
-               else result_wide[(xlen - 1) .. 0];
-  X(rd) = result;
+  let rs1_bits = X(rs1);
+  let rs2_bits = X(rs2);
+  let rs1_int = if mul_op.signed_rs1 then signed(rs1_bits) else unsigned(rs1_bits);
+  let rs2_int = if mul_op.signed_rs2 then signed(rs2_bits) else unsigned(rs2_bits);
+
+  let result_wide = to_bits_truncate(2 * xlen, rs1_int * rs2_int);
+  X(rd) = if   mul_op.high
+          then result_wide[(2 * xlen - 1) .. xlen]
+          else result_wide[(xlen - 1) .. 0];
   RETIRE_SUCCESS
 }
 
@@ -44,7 +43,7 @@ mapping mul_mnemonic : mul_op <-> string = {
   struct { high = false, signed_rs1 = true,  signed_rs2 = true  } <-> "mul",
   struct { high = true,  signed_rs1 = true,  signed_rs2 = true  } <-> "mulh",
   struct { high = true,  signed_rs1 = true,  signed_rs2 = false } <-> "mulhsu",
-  struct { high = true,  signed_rs1 = false, signed_rs2 = false } <-> "mulhu"
+  struct { high = true,  signed_rs1 = false, signed_rs2 = false } <-> "mulhu",
 }
 
 mapping clause assembly = MUL(rs2, rs1, rd, mul_op)
@@ -53,50 +52,47 @@ mapping clause assembly = MUL(rs2, rs1, rd, mul_op)
 /* ****************************************************************** */
 union clause ast = DIV : (regidx, regidx, regidx, bool)
 
-mapping clause encdec = DIV(rs2, rs1, rd, s)
-  <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b10 @ bool_not_bits(s) @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = DIV(rs2, rs1, rd, is_unsigned)
+  <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b10 @ bool_bits(is_unsigned) @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_M)
 
-function clause execute (DIV(rs2, rs1, rd, s)) = {
-  let rs1_val = X(rs1);
-  let rs2_val = X(rs2);
-  let rs1_int : int = if s then signed(rs1_val) else unsigned(rs1_val);
-  let rs2_int : int = if s then signed(rs2_val) else unsigned(rs2_val);
-  let q : int = if rs2_int == 0 then -1 else quot_round_zero(rs1_int, rs2_int);
-  /* check for signed overflow */
-  let q': int = if s & q > xlen_max_signed then xlen_min_signed else q;
-  X(rd) = to_bits_unsafe(xlen, q');
+function clause execute (DIV(rs2, rs1, rd, is_unsigned)) = {
+  let rs1_bits = X(rs1);
+  let rs2_bits = X(rs2);
+  let rs1_int = if is_unsigned then unsigned(rs1_bits) else signed(rs1_bits);
+  let rs2_int = if is_unsigned then unsigned(rs2_bits) else signed(rs2_bits);
+
+  let quotient = if rs2_int == 0 then -1 else (rs1_int / rs2_int);
+  // Check for signed overflow.
+  let quotient = if not(is_unsigned) & quotient >= 2 ^ (xlen - 1) then 0 - 2 ^ (xlen - 1) else quotient;
+  X(rd) = to_bits_truncate(quotient);
   RETIRE_SUCCESS
 }
 
-mapping maybe_not_u : bool <-> string = {
-  false <-> "u",
-  true  <-> ""
-}
-
-mapping clause assembly = DIV(rs2, rs1, rd, s)
-  <-> "div" ^ maybe_not_u(s) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
+mapping clause assembly = DIV(rs2, rs1, rd, is_unsigned)
+  <-> "div" ^ maybe_u(is_unsigned) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
 /* ****************************************************************** */
 union clause ast = REM : (regidx, regidx, regidx, bool)
 
-mapping clause encdec = REM(rs2, rs1, rd, s)
-  <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b11 @ bool_not_bits(s) @ encdec_reg(rd) @ 0b0110011
+mapping clause encdec = REM(rs2, rs1, rd, is_unsigned)
+  <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b11 @ bool_bits(is_unsigned) @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_M)
 
-function clause execute (REM(rs2, rs1, rd, s)) = {
+function clause execute (REM(rs2, rs1, rd, is_unsigned)) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
-  let rs1_int : int = if s then signed(rs1_val) else unsigned(rs1_val);
-  let rs2_int : int = if s then signed(rs2_val) else unsigned(rs2_val);
-  let r : int = if rs2_int == 0 then rs1_int else rem_round_zero(rs1_int, rs2_int);
-  /* signed overflow case returns zero naturally as required due to -1 divisor */
-  X(rd) = to_bits_unsafe(xlen, r);
+  let rs1_int = if is_unsigned then unsigned(rs1_val) else signed(rs1_val);
+  let rs2_int = if is_unsigned then unsigned(rs2_val) else signed(rs2_val);
+
+  let r = if rs2_int == 0 then rs1_int else (rs1_int % rs2_int);
+  // Signed overflow case returns zero naturally as required due to -1 divisor.
+  X(rd) = to_bits_truncate(r);
   RETIRE_SUCCESS
 }
 
-mapping clause assembly = REM(rs2, rs1, rd, s)
-  <-> "rem" ^ maybe_not_u(s) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
+mapping clause assembly = REM(rs2, rs1, rd, is_unsigned)
+  <-> "rem" ^ maybe_u(is_unsigned) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
 /* ****************************************************************** */
 union clause ast = MULW : (regidx, regidx, regidx)
@@ -106,14 +102,13 @@ mapping clause encdec = MULW(rs2, rs1, rd)
   when xlen == 64 & (currentlyEnabled(Ext_M) | currentlyEnabled(Ext_Zmmul))
 
 function clause execute (MULW(rs2, rs1, rd)) = {
-  let rs1_val = X(rs1)[31..0];
-  let rs2_val = X(rs2)[31..0];
-  let rs1_int : int = signed(rs1_val);
-  let rs2_int : int = signed(rs2_val);
-  /* to_bits_unsafe requires expansion to 64 bits followed by truncation */
-  let result32 = to_bits_unsafe(64, rs1_int * rs2_int)[31..0];
-  let result : xlenbits = sign_extend(result32);
-  X(rd) = result;
+  let rs1_bits = X(rs1)[31..0];
+  let rs2_bits = X(rs2)[31..0];
+  let rs1_int = signed(rs1_bits);
+  let rs2_int = signed(rs2_bits);
+
+  let result32 : bits(32) = to_bits_truncate(rs1_int * rs2_int);
+  X(rd) = sign_extend(result32);
   RETIRE_SUCCESS
 }
 
@@ -124,44 +119,46 @@ mapping clause assembly = MULW(rs2, rs1, rd)
 /* ****************************************************************** */
 union clause ast = DIVW : (regidx, regidx, regidx, bool)
 
-mapping clause encdec = DIVW(rs2, rs1, rd, s)
-  <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b10 @ bool_not_bits(s) @ encdec_reg(rd) @ 0b0111011
+mapping clause encdec = DIVW(rs2, rs1, rd, is_unsigned)
+  <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b10 @ bool_bits(is_unsigned) @ encdec_reg(rd) @ 0b0111011
   when xlen == 64 & currentlyEnabled(Ext_M)
 
-function clause execute (DIVW(rs2, rs1, rd, s)) = {
-  let rs1_val = X(rs1)[31..0];
-  let rs2_val = X(rs2)[31..0];
-  let rs1_int : int = if s then signed(rs1_val) else unsigned(rs1_val);
-  let rs2_int : int = if s then signed(rs2_val) else unsigned(rs2_val);
-  let q : int = if rs2_int == 0 then -1 else quot_round_zero(rs1_int, rs2_int);
-  /* check for signed overflow */
-  let q': int = if s & q > (2 ^ 31 - 1) then  (0 - (2 ^ 31)) else q;
-  X(rd) = sign_extend(to_bits_unsafe(32, q'));
+function clause execute (DIVW(rs2, rs1, rd, is_unsigned)) = {
+  let rs1_bits = X(rs1)[31..0];
+  let rs2_bits = X(rs2)[31..0];
+  let rs1_int = if is_unsigned then unsigned(rs1_bits) else signed(rs1_bits);
+  let rs2_int = if is_unsigned then unsigned(rs2_bits) else signed(rs2_bits);
+
+  let quotient = if rs2_int == 0 then -1 else (rs1_int / rs2_int);
+  // Check for signed overflow.
+  let quotient = if not(is_unsigned) & quotient >= 2 ^ 31 then (0 - (2 ^ 31)) else quotient;
+  X(rd) = sign_extend(to_bits_truncate(32, quotient));
   RETIRE_SUCCESS
 }
 
-mapping clause assembly = DIVW(rs2, rs1, rd, s)
-  <-> "div" ^ maybe_not_u(s) ^ "w" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
+mapping clause assembly = DIVW(rs2, rs1, rd, is_unsigned)
+  <-> "div" ^ maybe_u(is_unsigned) ^ "w" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
   when xlen == 64
 
 /* ****************************************************************** */
 union clause ast = REMW : (regidx, regidx, regidx, bool)
 
-mapping clause encdec = REMW(rs2, rs1, rd, s)
-  <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b11 @ bool_not_bits(s) @ encdec_reg(rd) @ 0b0111011
+mapping clause encdec = REMW(rs2, rs1, rd, is_unsigned)
+  <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b11 @ bool_bits(is_unsigned) @ encdec_reg(rd) @ 0b0111011
   when xlen == 64 & currentlyEnabled(Ext_M)
 
-function clause execute (REMW(rs2, rs1, rd, s)) = {
-  let rs1_val = X(rs1)[31..0];
-  let rs2_val = X(rs2)[31..0];
-  let rs1_int : int = if s then signed(rs1_val) else unsigned(rs1_val);
-  let rs2_int : int = if s then signed(rs2_val) else unsigned(rs2_val);
-  let r : int = if rs2_int == 0 then rs1_int else rem_round_zero(rs1_int, rs2_int);
-  /* signed overflow case returns zero naturally as required due to -1 divisor */
-  X(rd) = sign_extend(to_bits_unsafe(32, r));
+function clause execute (REMW(rs2, rs1, rd, is_unsigned)) = {
+  let rs1_bits = X(rs1)[31..0];
+  let rs2_bits = X(rs2)[31..0];
+  let rs1_int = if is_unsigned then unsigned(rs1_bits) else signed(rs1_bits);
+  let rs2_int = if is_unsigned then unsigned(rs2_bits) else signed(rs2_bits);
+
+  let r = if rs2_int == 0 then rs1_int else (rs1_int % rs2_int);
+  // Signed overflow case returns zero naturally as required due to -1 divisor.
+  X(rd) = sign_extend(to_bits_truncate(32, r));
   RETIRE_SUCCESS
 }
 
-mapping clause assembly = REMW(rs2, rs1, rd, s)
-  <-> "rem" ^ maybe_not_u(s) ^ "w" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
+mapping clause assembly = REMW(rs2, rs1, rd, is_unsigned)
+  <-> "rem" ^ maybe_u(is_unsigned) ^ "w" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
   when xlen == 64

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -7,9 +7,6 @@
 /*=======================================================================================*/
 
 /* Basic type and function definitions used pervasively in the model. */
-let xlen_max_unsigned = 2 ^ xlen - 1
-let xlen_max_signed = 2 ^ (xlen - 1) - 1
-let xlen_min_signed = 0 - 2 ^ (xlen - 1)
 
 type half = bits(16)
 type word = bits(32)

--- a/model/riscv_zvk_utils.sail
+++ b/model/riscv_zvk_utils.sail
@@ -87,7 +87,7 @@ function zvk_ff1(X, Y, Z) = X ^ Y ^ Z
 val zvk_ff2 : (bits(32), bits(32), bits(32)) -> bits(32)
 function zvk_ff2(X, Y, Z) = (X & Y) | (X & Z) | (Y & Z)
 
-val zvk_ff_j : (bits(32), bits(32), bits(32), int) -> bits(32)
+val zvk_ff_j : (bits(32), bits(32), bits(32), nat) -> bits(32)
 function zvk_ff_j(X, Y, Z, J) = if J <= 15 then zvk_ff1(X, Y, Z) else zvk_ff2(X, Y, Z)
 
 val zvk_gg1 : (bits(32), bits(32), bits(32)) -> bits(32)
@@ -96,13 +96,13 @@ function zvk_gg1(X, Y, Z) = X ^ Y ^ Z
 val zvk_gg2 : (bits(32), bits(32), bits(32)) -> bits(32)
 function zvk_gg2(X, Y, Z) = (X & Y) | (~(X) & Z)
 
-val zvk_gg_j : (bits(32), bits(32), bits(32), int) -> bits(32)
+val zvk_gg_j : (bits(32), bits(32), bits(32), nat) -> bits(32)
 function zvk_gg_j(X, Y, Z, J) = if J <= 15 then zvk_gg1(X, Y, Z) else zvk_gg2(X, Y, Z)
 
-val zvk_t_j : int -> bits(32)
+val zvk_t_j : nat -> bits(32)
 function zvk_t_j(J) = if J <= 15 then 0x79CC4519 else 0x7A879D8A
 
-function zvk_sm3_round(A_H : vector(8, bits(32)), w : bits(32), x : bits(32), j : int) -> vector(8, bits(32)) = {
+function zvk_sm3_round(A_H : vector(8, bits(32)), w : bits(32), x : bits(32), j : nat) -> vector(8, bits(32)) = {
   let t_j = zvk_t_j(j) <<< (j % 32);
   let ss1 = ((A_H[0] <<< 12) + A_H[4] + t_j) <<< 7;
   let ss2 = ss1 ^ (A_H[0] <<< 12);


### PR DESCRIPTION
Various minor improvement:

1. Instead of an `s` bool to indicate that DIV and REM are *not* the U(nsigned) variants, I inverted it. This removes the need for `bool_not_bits` and `maybe_not_u`. I also used a more descriptive variable name than `s`.

2. Change `operator %` to use truncated division instead of Euclidian division. We already had `/` using Euclidian division so this is more consistent. It also matches what RISC-V uses for `div`/`rem` so we can then use the operators in those functions' `execute` clauses.

3. Inline `xlen_max_unsigned` etc. which are only used once.

4. Rename `rs1_val` to `rs1_bits` which I think is a better name.

5. Removed some unnecessary `int` type annotations (these actually make the code worse since they discard more specific type information).

6. Simplify MULW 32-bit truncation.

7. Explicitly use `to_bits_truncate` which is intentional in this case.

I think we could potentially do the signed overflow detection more like a real chip would do it (just detect the specific values that can cause it rather than using a comparison), but I left it for now.