### PR TITLE
Make Zicsr extension configurable

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -82,6 +82,9 @@
     "Zicntr": {
       "supported": true
     },
+    "Zicsr": {
+      "supported": true
+    },
     "Zifencei": {
       "supported": true
     },

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -64,6 +64,9 @@ function clause hartSupports(Ext_Zicntr) = config extensions.Zicntr.supported
 // Integer Conditional Operations
 enum clause extension = Ext_Zicond
 function clause hartSupports(Ext_Zicond) = config extensions.Zicond.supported
+// Extension for Control and Status Register (CSR) Instructions
+enum clause extension = Ext_Zicsr
+function clause hartSupports(Ext_Zicsr) = config extensions.Zicsr.supported
 // Instruction-Fetch Fence
 enum clause extension = Ext_Zifencei
 function clause hartSupports(Ext_Zifencei) = config extensions.Zifencei.supported

--- a/model/riscv_fdext_control.sail
+++ b/model/riscv_fdext_control.sail
@@ -15,9 +15,9 @@
 
 /* **************************************************************** */
 
-function clause currentlyEnabled(Ext_F) = hartSupports(Ext_F) & (misa[F] == 0b1) & (mstatus[FS] != 0b00)
-function clause currentlyEnabled(Ext_D) = hartSupports(Ext_D) & (misa[D] == 0b1) & (mstatus[FS] != 0b00) & flen >= 64
-function clause currentlyEnabled(Ext_Zfinx) = hartSupports(Ext_Zfinx)
+function clause currentlyEnabled(Ext_F) = hartSupports(Ext_F) & (misa[F] == 0b1) & (mstatus[FS] != 0b00) & currentlyEnabled(Ext_Zicsr)
+function clause currentlyEnabled(Ext_D) = hartSupports(Ext_D) & (misa[D] == 0b1) & (mstatus[FS] != 0b00) & flen >= 64 & currentlyEnabled(Ext_Zicsr)
+function clause currentlyEnabled(Ext_Zfinx) = hartSupports(Ext_Zfinx) & currentlyEnabled(Ext_Zicsr)
 
 /* Floating Point CSRs */
 mapping clause csr_name_map = 0x001  <-> "fflags"

--- a/model/riscv_insts_zicsr.sail
+++ b/model/riscv_insts_zicsr.sail
@@ -9,6 +9,8 @@
 /* ****************************************************************** */
 /* This file specifies the instructions in the 'Zicsr' extension.     */
 /* ****************************************************************** */
+function clause currentlyEnabled(Ext_Zicsr) = hartSupports(Ext_Zicsr)
+
 union clause ast = CSRReg  : (csreg, regidx, regidx, csrop)
 union clause ast = CSRImm  : (csreg, bits(5), regidx, csrop)
 
@@ -20,9 +22,11 @@ mapping encdec_csrop : csrop <-> bits(2) = {
 
 mapping clause encdec = CSRReg(csr, rs1, rd, op)
   <-> csr @ encdec_reg(rs1) @ 0b0 @ encdec_csrop(op) @ encdec_reg(rd) @ 0b1110011
+  when currentlyEnabled(Ext_Zicsr)
 
 mapping clause encdec = CSRImm(csr, imm, rd, op)
   <-> csr @ imm @ 0b1 @ encdec_csrop(op) @ encdec_reg(rd) @ 0b1110011
+  when currentlyEnabled(Ext_Zicsr)
 
 function doCSR(csr : csreg, rs1_val : xlenbits, rd : regidx, op : csrop, is_CSR_Write: bool) -> ExecutionResult = {
   if not(check_CSR(csr, cur_privilege, is_CSR_Write))

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -137,8 +137,8 @@ function clause write_CSR(0x301, value) = { misa = legalize_misa(misa, value); m
 // Are supervisor/user mode currently enabled? Although
 // unlikely and not currently supported by the model,
 // you are technically allowed to have writable misa[U/S].
-function clause currentlyEnabled(Ext_U) = hartSupports(Ext_U) & misa[U] == 0b1
-function clause currentlyEnabled(Ext_S) = hartSupports(Ext_S) & misa[S] == 0b1
+function clause currentlyEnabled(Ext_U) = hartSupports(Ext_U) & misa[U] == 0b1 & currentlyEnabled(Ext_Zicsr)
+function clause currentlyEnabled(Ext_S) = hartSupports(Ext_S) & misa[S] == 0b1 & currentlyEnabled(Ext_Zicsr)
 
 function clause currentlyEnabled(Ext_Svbare) = currentlyEnabled(Ext_S)
 function clause currentlyEnabled(Ext_Sv32) = hartSupports(Ext_Sv32) &  currentlyEnabled(Ext_S)

--- a/model/riscv_vext_control.sail
+++ b/model/riscv_vext_control.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function clause currentlyEnabled(Ext_V) = hartSupports(Ext_V) & (misa[V] == 0b1) & (mstatus[VS] != 0b00)
+function clause currentlyEnabled(Ext_V) = hartSupports(Ext_V) & (misa[V] == 0b1) & (mstatus[VS] != 0b00) & currentlyEnabled(Ext_Zicsr)
 
 // Note: The spec recommends trapping if vstart is out of bounds but the
 // current implementation does not do that because write_CSR() doesn't

--- a/model/riscv_zicntr_control.sail
+++ b/model/riscv_zicntr_control.sail
@@ -5,7 +5,7 @@
 /*                                                                                       */
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
-function clause currentlyEnabled(Ext_Zicntr) = hartSupports(Ext_Zicntr)
+function clause currentlyEnabled(Ext_Zicntr) = hartSupports(Ext_Zicntr) & currentlyEnabled(Ext_Zicsr)
 
 /* unprivileged counters/timers */
 mapping clause csr_name_map = 0xC00  <-> "cycle"

--- a/model/riscv_zihpm.sail
+++ b/model/riscv_zihpm.sail
@@ -7,7 +7,7 @@
 /*=======================================================================================*/
 
 /* Hardware Performance Monitoring counters */
-function clause currentlyEnabled(Ext_Zihpm) = hartSupports(Ext_Zihpm) & currentlyEnabled(Ext_Zicntr)
+function clause currentlyEnabled(Ext_Zihpm) = hartSupports(Ext_Zihpm) & currentlyEnabled(Ext_Zicsr)
 
 /* Hardware performance monitoring counters */
 mapping clause csr_name_map = 0xC03  <-> "hpmcounter3"


### PR DESCRIPTION
As mentioned in #849, the spec states that the Zicsr extension is Extension for Control and Status Register (CSR) Instructions. Therefore, the encdec sections of the AST CSRReg and CSRImm are guard with a `when` condition to achieve this purpose.