### PR TITLE
Add support for Smstateen and Ssstateen extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ For booting operating system images, see the information under the
 - Sscofpmf extension for Count Overflow and Mode-Based Filtering, v1.0
 - Sstc extension for Supervisor-mode Timer Interrupts, v1.0
 - Svinval extension for fine-grained address-translation cache invalidation, v1.0
+- Smstateen/Ssstateen extensions for fine-grained privileged state access control, v1.0
 - Sv32, Sv39, Sv48 and Sv57 page-based virtual-memory systems
 - Svbare extension for Bare mode virtual-memory translation
 - Physical Memory Protection (PMP)

--- a/config/default.json
+++ b/config/default.json
@@ -199,6 +199,12 @@
     "Svinval": {
       "supported": true
     },
+    "Smstateen": {
+      "supported": false
+    },
+    "Ssstateen": {
+      "supported": false
+    },
     "Svbare": {
       "supported": true
     },

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -166,6 +166,7 @@ foreach (xlen IN ITEMS 32 64)
                 ${sail_check_srcs}
                 "riscv_vreg_type.sail"
                 "riscv_vext_regs.sail"
+                "riscv_stateen_regs.sail"
             )
 
             set(sail_arch_srcs

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -193,6 +193,9 @@ function clause hartSupports(Ext_Zvksh) = config extensions.Zvksh.supported
 // Count Overflow and Mode-Based Filtering
 enum clause extension = Ext_Sscofpmf
 function clause hartSupports(Ext_Sscofpmf) = config extensions.Sscofpmf.supported
+// Supervisor-mode view of the state-enable extension
+enum clause extension = Ext_Ssstateen
+function clause hartSupports(Ext_Ssstateen) = config extensions.Ssstateen.supported
 // Supervisor-mode Timer Interrupts
 enum clause extension = Ext_Sstc
 function clause hartSupports(Ext_Sstc) = config extensions.Sstc.supported
@@ -220,3 +223,6 @@ function clause hartSupports(Ext_Sv57) = config extensions.Sv57.supported : bool
 // Cycle and Instret Privilege Mode Filtering
 enum clause extension = Ext_Smcntrpmf
 function clause hartSupports(Ext_Smcntrpmf) = config extensions.Smcntrpmf.supported
+// Machine-mode view of the state-enable extension
+enum clause extension = Ext_Smstateen
+function clause hartSupports(Ext_Smstateen) = config extensions.Smstateen.supported

--- a/model/riscv_insts_dext.sail
+++ b/model/riscv_insts_dext.sail
@@ -226,7 +226,7 @@ function fle_D   (v1,       v2,        is_quiet) = {
 
 function clause currentlyEnabled(Ext_Zdinx) = hartSupports(Ext_Zdinx) & flen >= 64 // TODO: Separate Zfinx and Zdinx
 
-function haveDoubleFPU() -> bool = currentlyEnabled(Ext_D) | currentlyEnabled(Ext_Zdinx)
+function haveDoubleFPU() -> bool = currentlyEnabled(Ext_D) | (currentlyEnabled(Ext_Zdinx) & not(stateen_fp_trap_illegal()))
 
 /* RV32Zdinx requires even register pairs; can be omitted for code  */
 /* not used for RV32Zdinx (i.e. RV64-only or D-only).               */

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -262,7 +262,7 @@ function fle_S   (v1,       v2,        is_quiet) = {
 /* **************************************************************** */
 /* Helper functions for 'encdec()'                                  */
 
-function haveSingleFPU() -> bool = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
+function haveSingleFPU() -> bool = currentlyEnabled(Ext_F) | (currentlyEnabled(Ext_Zfinx) & not(stateen_fp_trap_illegal()))
 
 /* ****************************************************************** */
 /* Floating-point loads                                               */

--- a/model/riscv_insts_zfh.sail
+++ b/model/riscv_insts_zfh.sail
@@ -164,7 +164,7 @@ function fle_H   (v1,       v2,        is_quiet) = {
 /* **************************************************************** */
 /* Helper functions for 'encdec()'                                  */
 // Full half support.
-function haveHalfFPU() -> bool = currentlyEnabled(Ext_Zfh) | currentlyEnabled(Ext_Zhinx)
+function haveHalfFPU() -> bool = currentlyEnabled(Ext_Zfh) | (currentlyEnabled(Ext_Zhinx) & not(stateen_fp_trap_illegal()))
 // Support for conversion of halves to/from single & double, but no actual
 // calculations with halves.
 function haveHalfMin() -> bool = haveHalfFPU() | currentlyEnabled(Ext_Zfhmin)

--- a/model/riscv_stateen_regs.sail
+++ b/model/riscv_stateen_regs.sail
@@ -1,0 +1,487 @@
+ /*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+function clause currentlyEnabled(Ext_Smstateen) = hartSupports(Ext_Smstateen)
+function clause currentlyEnabled(Ext_Ssstateen) = hartSupports(Ext_Ssstateen)
+
+function enable_mstateen() -> bool = hartSupports(Ext_Smstateen)
+function enable_sstateen() -> bool = currentlyEnabled(Ext_S) & (currentlyEnabled(Ext_Smstateen) | currentlyEnabled(Ext_Ssstateen))
+function enable_hstateen() -> bool = false /* TODO currentlyEnabled(Ext_H) */ & (currentlyEnabled(Ext_Smstateen) | currentlyEnabled(Ext_Ssstateen))
+
+bitfield Mstateen0 : bits(64) = {
+  SE0     : 63,
+  ENVCFG  : 62,
+
+  CSRIND  : 60,
+  AIA     : 59,
+  IMSIC   : 58,
+  CONTEXT : 57,
+  P1P13   : 56,
+  P1P14   : 55,
+  CTR     : 54,
+
+  JVT     : 2,
+  FCSR    : 1,
+  C       : 0,
+}
+
+function legalize_mstateen0(m : Mstateen0, v : bits(64)) -> Mstateen0 = {
+  let v = Mk_Mstateen0(v);
+
+  [m with
+    SE0     = v[SE0],
+    ENVCFG  = if currentlyEnabled(Ext_S) /* TODO | currentlyEnabled(Ext_H) */ then v[ENVCFG] else 0b0,
+
+    CSRIND  = 0b0, // Not implemented yet
+    AIA     = 0b0, // Not implemented yet
+    IMSIC   = 0b0, // Not implemented yet
+    CONTEXT = 0b0, // Not implemented yet
+    P1P13   = 0b0, // Not implemented yet
+    P1P14   = 0b0, // Not implemented yet
+    CTR     = 0b0, // Not implemented yet
+
+    JVT     = 0b0, // Not implemented yet
+    FCSR    = if misa[F] == 0b1 then 0b0 else v[FCSR],
+    C       = 0b0,
+  ];
+}
+
+register mstateen0 : Mstateen0 = legalize_mstateen0(Mk_Mstateen0(zeros()), zeros())
+
+mapping clause csr_name_map = 0x30C  <-> "mstateen0"
+mapping clause csr_name_map = 0x31C  <-> "mstateen0h"
+
+function clause is_CSR_defined(0x30C) = enable_mstateen()
+function clause is_CSR_defined(0x31C) = enable_mstateen() & (xlen == 32)
+
+function clause read_CSR(0x30C) = mstateen0.bits[xlen - 1 .. 0]
+function clause read_CSR(0x31C if xlen == 32) = mstateen0.bits[63 .. 32]
+
+function clause write_CSR((0x30C, value) if xlen == 32) = { mstateen0 = legalize_mstateen0(mstateen0, mstateen0.bits[63 .. 32] @ value); mstateen0.bits[31 .. 0] }
+function clause write_CSR((0x30C, value) if xlen == 64) = { mstateen0 = legalize_mstateen0(mstateen0, value); mstateen0.bits }
+function clause write_CSR((0x31C, value) if xlen == 32) = { mstateen0 = legalize_mstateen0(mstateen0, value @ mstateen0.bits[31 .. 0]); mstateen0.bits[63 .. 32] }
+
+bitfield Mstateen1 : bits(64) = {
+  SE1 : 63, // There is no official name for bit 63 yet
+}
+
+function legalize_mstateen1(m : Mstateen1, v : bits(64)) -> Mstateen1 = {
+  let v = Mk_Mstateen1(v);
+
+  [m with
+    SE1 = v[SE1]
+  ];
+}
+
+register mstateen1 : Mstateen1 = legalize_mstateen1(Mk_Mstateen1(zeros()), zeros())
+
+mapping clause csr_name_map = 0x30D  <-> "mstateen1"
+mapping clause csr_name_map = 0x31D  <-> "mstateen1h"
+
+function clause is_CSR_defined(0x30D) = enable_mstateen()
+function clause is_CSR_defined(0x31D) = enable_mstateen() & (xlen == 32)
+
+function clause read_CSR(0x30D) = mstateen1.bits[xlen - 1 .. 0]
+function clause read_CSR(0x31D if xlen == 32) = mstateen1.bits[63 .. 32]
+
+function clause write_CSR((0x30D, value) if xlen == 32) = { mstateen1 = legalize_mstateen1(mstateen1, mstateen1.bits[63 .. 32] @ value); mstateen1.bits[31 .. 0] }
+function clause write_CSR((0x30D, value) if xlen == 64) = { mstateen1 = legalize_mstateen1(mstateen1, value); mstateen1.bits }
+function clause write_CSR((0x31D, value) if xlen == 32) = { mstateen1 = legalize_mstateen1(mstateen1, value @ mstateen1.bits[31 .. 0]); mstateen1.bits[63 .. 32] }
+
+bitfield Mstateen2 : bits(64) = {
+  SE2 : 63, // There is no official name for bit 63 yet
+}
+
+function legalize_mstateen2(m : Mstateen2, v : bits(64)) -> Mstateen2 = {
+  let v = Mk_Mstateen2(v);
+
+  [m with
+    SE2 = v[SE2]
+  ];
+}
+
+register mstateen2 : Mstateen2 = legalize_mstateen2(Mk_Mstateen2(zeros()), zeros())
+
+mapping clause csr_name_map = 0x30E  <-> "mstateen2"
+mapping clause csr_name_map = 0x31E  <-> "mstateen2h"
+
+function clause is_CSR_defined(0x30E) = enable_mstateen()
+function clause is_CSR_defined(0x31E) = enable_mstateen() & (xlen == 32)
+
+function clause read_CSR(0x30E) = mstateen2.bits[xlen - 1 .. 0]
+function clause read_CSR(0x31E if xlen == 32) = mstateen2.bits[63 .. 32]
+
+function clause write_CSR((0x30E, value) if xlen == 32) = { mstateen2 = legalize_mstateen2(mstateen2, mstateen2.bits[63 .. 32] @ value); mstateen2.bits[31 .. 0] }
+function clause write_CSR((0x30E, value) if xlen == 64) = { mstateen2 = legalize_mstateen2(mstateen2, value); mstateen2.bits }
+function clause write_CSR((0x31E, value) if xlen == 32) = { mstateen2 = legalize_mstateen2(mstateen2, value @ mstateen2.bits[31 .. 0]); mstateen2.bits[63 .. 32] }
+
+bitfield Mstateen3 : bits(64) = {
+  SE3 : 63, // There is no official name for bit 63 yet
+}
+
+function legalize_mstateen3(m : Mstateen3, v : bits(64)) -> Mstateen3 = {
+  let v = Mk_Mstateen3(v);
+
+  [m with
+    SE3 = v[SE3]
+  ];
+}
+
+register mstateen3 : Mstateen3 = legalize_mstateen3(Mk_Mstateen3(zeros()), zeros())
+
+mapping clause csr_name_map = 0x30F  <-> "mstateen3"
+mapping clause csr_name_map = 0x31F  <-> "mstateen3h"
+
+function clause is_CSR_defined(0x30F) = enable_mstateen()
+function clause is_CSR_defined(0x31F) = enable_mstateen() & (xlen == 32)
+
+function clause read_CSR(0x30F) = mstateen3.bits[xlen - 1 .. 0]
+function clause read_CSR(0x31F if xlen == 32) = mstateen3.bits[63 .. 32]
+
+function clause write_CSR((0x30F, value) if xlen == 32) = { mstateen3 = legalize_mstateen3(mstateen3, mstateen3.bits[63 .. 32] @ value); mstateen3.bits[31 .. 0] }
+function clause write_CSR((0x30F, value) if xlen == 64) = { mstateen3 = legalize_mstateen3(mstateen3, value); mstateen3.bits }
+function clause write_CSR((0x31F, value) if xlen == 32) = { mstateen3 = legalize_mstateen3(mstateen3, value @ mstateen3.bits[31 .. 0]); mstateen3.bits[63 .. 32] }
+
+function get_mstateen(idx : {0, 1, 2, 3}) -> (bits(64)) = {
+  if not(enable_mstateen()) then 0xFFFFFFFFFFFFFFFF
+  else match idx {
+    0 => mstateen0.bits,
+    1 => mstateen1.bits,
+    2 => mstateen2.bits,
+    3 => mstateen3.bits,
+  }
+}
+
+bitfield Hstateen0 : bits(64) = {
+  SE0     : 63,
+  ENVCFG  : 62,
+
+  CSRIND  : 60,
+  AIA     : 59,
+  IMSIC   : 58,
+  CONTEXT : 57,
+
+  CTR     : 54,
+
+  JVT     : 2,
+  FCSR    : 1,
+  C       : 0,
+}
+
+function legalize_hstateen0(h : Hstateen0, v : bits(64)) -> Hstateen0 = {
+  let v = Mk_Hstateen0(v);
+
+  let permission_mask : bits(64) = get_mstateen(0);
+
+  [h with
+    SE0     = if permission_mask[63] == bitone then v[SE0] else h[SE0],
+    ENVCFG  = if currentlyEnabled(Ext_S) /* currentlyEnabled(Ext_H) */ then (if permission_mask[62] == bitone then v[ENVCFG] else h[ENVCFG]) else 0b0,
+
+    CSRIND  = 0b0, // Not implemented yet
+    AIA     = 0b0, // Not implemented yet
+    IMSIC   = 0b0, // Not implemented yet
+    CONTEXT = 0b0, // Not implemented yet
+
+    CTR     = 0b0, // Not implemented yet
+
+    JVT     = 0b0, // Not implemented yet
+    FCSR    = if misa[F] == 0b1 then 0b0 else (if permission_mask[1] == bitone then v[FCSR] else h[FCSR]),
+    C       = 0b0,
+  ];
+}
+
+register hstateen0 : Hstateen0 = legalize_hstateen0(Mk_Hstateen0(zeros()), zeros())
+
+mapping clause csr_name_map = 0x60C  <-> "hstateen0"
+mapping clause csr_name_map = 0x61C  <-> "hstateen0h"
+
+function clause is_CSR_defined(0x60C) = enable_hstateen()
+function clause is_CSR_defined(0x61C) = enable_hstateen() & (xlen == 32)
+
+function clause read_CSR(0x60C) = hstateen0.bits[xlen - 1 .. 0]
+function clause read_CSR(0x61C if xlen == 32) = hstateen0.bits[63 .. 32]
+
+function clause write_CSR((0x60C, value) if xlen == 32) = { hstateen0 = legalize_hstateen0(hstateen0, hstateen0.bits[63 .. 32] @ value); hstateen0.bits[31 .. 0] }
+function clause write_CSR((0x60C, value) if xlen == 64) = { hstateen0 = legalize_hstateen0(hstateen0, value); hstateen0.bits }
+function clause write_CSR((0x61C, value) if xlen == 32) = { hstateen0 = legalize_hstateen0(hstateen0, value @ hstateen0.bits[31 .. 0]); hstateen0.bits[63 .. 32] }
+
+bitfield Hstateen1 : bits(64) = {
+  SE1 : 63, // There is no official name for bit 63 yet
+}
+
+function legalize_hstateen1(h : Hstateen1, v : bits(64)) -> Hstateen1 = {
+  let v = Mk_Hstateen1(v);
+
+  let permission_mask : bits(64) = get_mstateen(1);
+
+  [h with
+    SE1 = if permission_mask[63] == bitone then v[SE1] else h[SE1],
+  ];
+}
+
+register hstateen1 : Hstateen1 = legalize_hstateen1(Mk_Hstateen1(zeros()), zeros())
+
+mapping clause csr_name_map = 0x60D  <-> "hstateen1"
+mapping clause csr_name_map = 0x61D  <-> "hstateen1h"
+
+function clause is_CSR_defined(0x60D) = enable_hstateen()
+function clause is_CSR_defined(0x61D) = enable_hstateen() & (xlen == 32)
+
+function clause read_CSR(0x60D) = hstateen1.bits[xlen - 1 .. 0]
+function clause read_CSR(0x61D if xlen == 32) = hstateen1.bits[63 .. 32]
+
+function clause write_CSR((0x60D, value) if xlen == 32) = { hstateen1 = legalize_hstateen1(hstateen1, hstateen1.bits[63 .. 32] @ value); hstateen1.bits[31 .. 0] }
+function clause write_CSR((0x60D, value) if xlen == 64) = { hstateen1 = legalize_hstateen1(hstateen1, value); hstateen1.bits }
+function clause write_CSR((0x61D, value) if xlen == 32) = { hstateen1 = legalize_hstateen1(hstateen1, value @ hstateen1.bits[31 .. 0]); hstateen1.bits[63 .. 32] }
+
+bitfield Hstateen2 : bits(64) = {
+  SE2 : 63, // There is no official name for bit 63 yet
+}
+
+function legalize_hstateen2(h : Hstateen2, v : bits(64)) -> Hstateen2 = {
+  let v = Mk_Hstateen2(v);
+
+  let permission_mask : bits(64) = get_mstateen(2);
+
+  [h with
+    SE2 = if permission_mask[63] == bitone then v[SE2] else h[SE2],
+  ];
+}
+
+register hstateen2 : Hstateen2 = legalize_hstateen2(Mk_Hstateen2(zeros()), zeros())
+
+mapping clause csr_name_map = 0x60E  <-> "hstateen2"
+mapping clause csr_name_map = 0x61E  <-> "hstateen2h"
+
+function clause is_CSR_defined(0x60E) = enable_hstateen()
+function clause is_CSR_defined(0x61E) = enable_hstateen() & (xlen == 32)
+
+function clause read_CSR(0x60E) = hstateen2.bits[xlen - 1 .. 0]
+function clause read_CSR(0x61E if xlen == 32) = hstateen2.bits[63 .. 32]
+
+function clause write_CSR((0x60E, value) if xlen == 32) = { hstateen2 = legalize_hstateen2(hstateen2, hstateen2.bits[63 .. 32] @ value); hstateen2.bits[31 .. 0] }
+function clause write_CSR((0x60E, value) if xlen == 64) = { hstateen2 = legalize_hstateen2(hstateen2, value); hstateen2.bits }
+function clause write_CSR((0x61E, value) if xlen == 32) = { hstateen2 = legalize_hstateen2(hstateen2, value @ hstateen2.bits[31 .. 0]); hstateen2.bits[63 .. 32] }
+
+bitfield Hstateen3 : bits(64) = {
+  SE3 : 63, // There is no official name for bit 63 yet
+}
+
+function legalize_hstateen3(h : Hstateen3, v : bits(64)) -> Hstateen3 = {
+  let v = Mk_Hstateen3(v);
+
+  let permission_mask : bits(64) = get_mstateen(3);
+
+  [h with
+    SE3 = if permission_mask[63] == bitone then v[SE3] else h[SE3],
+  ];
+}
+
+register hstateen3 : Hstateen3 = legalize_hstateen3(Mk_Hstateen3(zeros()), zeros())
+
+mapping clause csr_name_map = 0x60F  <-> "hstateen3"
+mapping clause csr_name_map = 0x61F  <-> "hstateen3h"
+
+function clause is_CSR_defined(0x60F) = enable_hstateen()
+function clause is_CSR_defined(0x61F) = enable_hstateen() & (xlen == 32)
+
+function clause read_CSR(0x60F) = hstateen3.bits[xlen - 1 .. 0]
+function clause read_CSR(0x61F if xlen == 32) = hstateen3.bits[63 .. 32]
+
+function clause write_CSR((0x60F, value) if xlen == 32) = { hstateen3 = legalize_hstateen3(hstateen3, hstateen3.bits[63 .. 32] @ value); hstateen3.bits[31 .. 0] }
+function clause write_CSR((0x60F, value) if xlen == 64) = { hstateen3 = legalize_hstateen3(hstateen3, value); hstateen3.bits }
+function clause write_CSR((0x61F, value) if xlen == 32) = { hstateen3 = legalize_hstateen3(hstateen3, value @ hstateen3.bits[31 .. 0]); hstateen3.bits[63 .. 32] }
+
+function get_hstateen(idx : {0, 1, 2, 3}) -> (bits(64)) = {
+  if not(enable_hstateen()) then 0xFFFFFFFFFFFFFFFF
+  else match idx {
+    0 => hstateen0.bits,
+    1 => hstateen1.bits,
+    2 => hstateen2.bits,
+    3 => hstateen3.bits,
+  }
+}
+
+bitfield Sstateen0 : bits(32) = {
+  JVT  : 2,
+  FCSR : 1,
+  C    : 0,
+}
+
+function legalize_sstateen0(s : Sstateen0, v : bits(32)) -> Sstateen0 = {
+  let v = Mk_Sstateen0(v);
+
+  let permission_mask : bits(64) = get_mstateen(0) & get_hstateen(0);
+
+  [s with
+    JVT  = 0b0, // Not implemented yet
+    FCSR = if misa[F] == 0b1 then 0b0 else (if permission_mask[1] == bitone then v[FCSR] else s[FCSR]),
+    C    = 0b0,
+  ];
+}
+
+register sstateen0 : Sstateen0 = legalize_sstateen0(Mk_Sstateen0(zeros()), zeros())
+mapping clause csr_name_map = 0x10C  <-> "sstateen0"
+function clause is_CSR_defined(0x10C) = enable_sstateen()
+function clause read_CSR(0x10C) = zero_extend(sstateen0.bits)
+function clause write_CSR(0x10C, value) = { sstateen0 = legalize_sstateen0(sstateen0, value[31 .. 0]); zero_extend(sstateen0.bits) }
+
+type Sstateen1 = bits(32)
+
+function legalize_sstateen1(s : Sstateen1, v : bits(32)) -> Sstateen1 = {
+  s
+}
+
+register sstateen1 : Sstateen1 = legalize_sstateen1(zeros(), zeros())
+mapping clause csr_name_map = 0x10D  <-> "sstateen1"
+function clause is_CSR_defined(0x10D) = enable_sstateen()
+function clause read_CSR(0x10D) = zero_extend(sstateen1)
+function clause write_CSR(0x10D, value) = { sstateen1 = legalize_sstateen1(sstateen1, value[31 .. 0]); zero_extend(sstateen1) }
+
+type Sstateen2 = bits(32)
+
+function legalize_sstateen2(s : Sstateen2, v : bits(32)) -> Sstateen2 = {
+  s
+}
+
+register sstateen2 : Sstateen2 = legalize_sstateen2(zeros(), zeros())
+mapping clause csr_name_map = 0x10E  <-> "sstateen2"
+function clause is_CSR_defined(0x10E) = enable_sstateen()
+function clause read_CSR(0x10E) = zero_extend(sstateen2)
+function clause write_CSR(0x10E, value) = { sstateen2 = legalize_sstateen2(sstateen2, value[31 .. 0]); zero_extend(sstateen2) }
+
+type Sstateen3 = bits(32)
+
+function legalize_sstateen3(s : Sstateen3, v : bits(32)) -> Sstateen3 = {
+  s
+}
+
+register sstateen3 : Sstateen3 = legalize_sstateen3(zeros(), zeros())
+mapping clause csr_name_map = 0x10F  <-> "sstateen3"
+function clause is_CSR_defined(0x10F) = enable_sstateen()
+function clause read_CSR(0x10F) = zero_extend(sstateen3)
+function clause write_CSR(0x10F, value) = { sstateen3 = legalize_sstateen3(sstateen3, value[31 .. 0]); zero_extend(sstateen3) }
+
+function get_sstateen(idx : {0, 1, 2, 3}) -> bits(64) = {
+  if not(enable_sstateen()) then 0xFFFFFFFFFFFFFFFF
+  else match idx {
+    // Expanding sstateen from 32 to 64 bits simplifies permission mask handling.
+    // Since some supervisor CSRs are managed in higher privilege modes, we set the prefix to 1's
+    // to prevent these permission bits from being modified during the bitwise AND.
+    0 => 0xFFFFFFFF @ sstateen0.bits,
+    // sstateen1, stateen2 and sstateen3 are read-only zero for now
+    1 => zeros(),
+    2 => zeros(),
+    3 => zeros(),
+  }
+}
+
+mapping stateen_idx : {0, 1, 2, 3} <-> bits(4) = {
+  0 <-> 0b1100, // 0xC
+  1 <-> 0b1101, // 0xD
+  2 <-> 0b1110, // 0xE
+  3 <-> 0b1111, // 0xF
+}
+
+enum stateen_control_bits = {STATEEN_FCSR, STATEEN_ENVCFG, STATEEN_SE}
+
+mapping csr_permission_idx : stateen_control_bits <-> {1, 62, 63} = {
+  STATEEN_SE     <-> 63,
+  //stateen0
+  STATEEN_ENVCFG <-> 62,
+  STATEEN_FCSR   <-> 1,
+}
+
+/* Computes a bit-level permission mask by performing a bitwise AND across the
+ * stateen bits from all higher privilege modes. Access to a corresponding bitfield
+ * is granted only if each bit is set to 1 in the same bitfield of the stateen
+ * registers at all higher privilege modes.
+ */
+function get_stateen_permission_mask (idx : {0, 1, 2, 3}) -> bits(64) = {
+  let mstateen = get_mstateen(idx);
+  let hstateen = get_hstateen(idx);
+  let sstateen = get_sstateen(idx);
+  match cur_privilege {
+    Machine    => 0xFFFFFFFFFFFFFFFF,
+    Supervisor => mstateen & hstateen,
+    User       => mstateen & hstateen & sstateen,
+  }
+}
+
+/*
+ * Allows access to the corresponding *stateen register at the current privilege level,
+ * provided that *stateen[SE] is set to 1 in all higher privilege levels.
+*/
+function check_stateen_access_permission(csr : csreg) -> bool = {
+  let idx  = stateen_idx(csr[3..0]);
+  let mask = get_stateen_permission_mask(idx);
+  match cur_privilege {
+    Machine    => true,
+    Supervisor => mask[csr_permission_idx(STATEEN_SE)] == bitone,
+    User       => false,
+  }
+}
+
+/*
+ * Checks whether floating-point instructions use X (integer) registers.
+ * TODO: Add currentlyEnabled(Ext_Zhinxmin)
+ */
+function fp_in_x_registers_active() -> bool =
+  misa[F] == 0b0 & (currentlyEnabled(Ext_Zfinx) | currentlyEnabled(Ext_Zdinx) | currentlyEnabled(Ext_Zhinx))
+
+/*
+ * Maps a CSR address to the corresponding stateen permission bit and stateen id
+ *
+ * Returns an optional tuple:
+ *   (stateen bitfield, stateen id)
+ *
+ * Add more mappings as needed
+ */
+function csr_to_stateen_bit(csr : csreg) -> option((stateen_control_bits, {0, 1, 2, 3})) = {
+  match csr {
+    0x10A /* senvcfg */ => Some((STATEEN_ENVCFG, 0)),
+    0x001 /* fflags  */ => if fp_in_x_registers_active() then Some((STATEEN_FCSR, 0)) else None(),
+    0x002 /* frm     */ => if fp_in_x_registers_active() then Some((STATEEN_FCSR, 0)) else None(),
+    0x003 /* fcsr    */ => if fp_in_x_registers_active() then Some((STATEEN_FCSR, 0)) else None(),
+    _     => None(),
+  }
+}
+
+/*
+ * Verifies whether access to CSRs protected by the Smstateen or Ssstateen
+ * extensions is allowed at the current privilege level.
+ */
+function check_CSR_access_permission(csr : csreg) -> bool = {
+  match csr_to_stateen_bit(csr) {
+    Some((bit_idx, stateen_register_index)) => {
+      let mask = get_stateen_permission_mask(stateen_register_index);
+      mask[csr_permission_idx(bit_idx)] == bitone
+    },
+    None() => true
+  }
+}
+
+/*
+ * Triggers an illegal instruction exception if a floating-point instruction
+ * using X registers is executed without the required stateen0 CSR permission.
+ *
+ * Note: Machine mode can always perform floating-point instructions
+ */
+function stateen_fp_trap_illegal() -> bool = {
+  let mask = get_stateen_permission_mask(0);
+  fp_in_x_registers_active() & mask[csr_permission_idx(STATEEN_FCSR)] == bitzero
+}
+
+function reset_stateen() -> unit = {
+  if enable_mstateen() then {
+    mstateen0.bits = zeros();
+    mstateen1.bits = zeros();
+    mstateen2.bits = zeros();
+    mstateen3.bits = zeros();
+  }
+}

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -68,6 +68,31 @@ function check_seed_CSR (csr : csreg, p : Privilege, isWrite : bool) -> bool = {
   }
 }
 
+/*
+ * This function checks whether the current privilege mode is either:
+ * (1) accessing its corresponding stateen register with the appropriate access rights, or
+ * (2) accessing an extension-related CSR for which it has permission.
+ */
+function check_Stateen(csr : csreg, p : Privilege) -> bool = {
+  // mstateen* CSRs are implicitly handled and are always accessible in machine mode.
+  // TODO: Add (hstateen0, hstateen1, etc.) once Hypervisor is implemented
+  if ( csr == 0x10C /* stateen0 */ | csr == 0x10D /* stateen1 */ | csr == 0x10E /* stateen2 */ | csr == 0x10F /* stateen3 */ ) then {
+    match (p) {
+        Machine    => true,
+        Supervisor => check_stateen_access_permission(csr),
+        User       => false,
+      };
+  }
+  // Check if a CSR access is granted
+  else {
+    match (p) {
+      Machine    => true,
+      Supervisor => check_CSR_access_permission(csr),
+      User       => check_CSR_access_permission(csr),
+    };
+  }
+}
+
 function check_CSR(csr : csreg, p : Privilege, isWrite : bool) -> bool =
     is_CSR_defined(csr)
   & check_CSR_priv(csr, p)
@@ -79,6 +104,7 @@ function check_CSR(csr : csreg, p : Privilege, isWrite : bool) -> bool =
   & check_Counteren(csr, p)
   & check_Stimecmp(csr, p)
   & check_seed_CSR(csr, p, isWrite)
+  & check_Stateen(csr, p)
 
 /* Reservation handling for LR/SC.
  *
@@ -390,6 +416,9 @@ function reset_sys() -> unit = {
   // "Writable PMP registers’ A and L fields are set to 0, unless the platform
   // mandates a different reset value for some PMP registers’ A and L fields."
   reset_pmp();
+
+  // "On reset, all writable mstateen bits are initialized by the hardware to zeros."
+  reset_stateen();
 
   // TODO: Probably need to remove these vector resets too but it needs
   // refactoring anyway. See https://github.com/riscv/sail-riscv/issues/566 etc.


### PR DESCRIPTION
The actual tests can be found in https://github.com/nadime15/riscv-tests/tree/test_stateen and in https://github.com/nadime15/riscv-test-env/tree/env_stateen

The tests are based on [riscv-test-env](https://github.com/riscv/riscv-test-env/) and are integrated into the VM boot code to simplify testing, since only machine and supervisor modes can modify the stateen-related CSRs configurations.

Note: The `env` submodule has been modified and must be cloned as well.

The extensions are not enabled by default.