### PR TITLE
Add missing riscv_sstc.sail to CMake build

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -179,6 +179,7 @@ foreach (xlen IN ITEMS 32 64)
                 ${sail_sys_srcs}
                 "riscv_inst_retire.sail"
                 "riscv_platform.sail"
+                "riscv_sstc.sail"
                 "riscv_mem.sail"
                 ${sail_vm_srcs}
                 # Shared/common code for the cryptography extension.


### PR DESCRIPTION
This was not included when moving over to the CMake build system and resulted in a kernel panic when trying to boot linux (#889)