### PR TITLE
build_simulators.sh: use /bin/sh

### DIFF
--- a/build_simulators.sh
+++ b/build_simulators.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 : "${DOWNLOAD_GMP:=TRUE}"


### PR DESCRIPTION
This file does not depend on any bash features, we can use POSIX sh.
