### PR TITLE
Update CI to run in merge queue

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch, merge_group]
 
 jobs:
   build:


### PR DESCRIPTION
Turns out the `merge_group` hook is required for CI jobs that are supposed to run in the merge queue. Otherwise the queue will just wait for the job to complete but never actually start it.