### PR TITLE
Enable match_bv for Lean

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -492,6 +492,7 @@ foreach (xlen IN ITEMS 32 64)
                         --require-version ${SAIL_REQUIRED_VER}
                         --lean-output-dir ${CMAKE_CURRENT_BINARY_DIR}
                         --lean-force-output
+                        --lean-matchbv
                         --lean-noncomputable
                         --lean-noncomputable-function encdec_forwards
                         --lean-noncomputable-function encdec_backwards


### PR DESCRIPTION
This will make matching on bitvector pattern a lot more readable.

This is still in draft stage, as one last sail bug prevents us from using this option.