### PR TITLE
Add option to print abi or architectural register names in trace and disassembly

### DIFF
--- a/c_emulator/riscv_callbacks.cpp
+++ b/c_emulator/riscv_callbacks.cpp
@@ -62,11 +62,17 @@ unit mem_exception_callback(uint64_t paddr, uint64_t num_of_exception)
   return UNIT;
 }
 
-unit xreg_write_callback(unsigned reg, uint64_t value)
+unit xreg_full_write_callback(const_sail_string abi_name, unsigned reg,
+                              uint64_t value)
 {
   if (config_print_reg) {
-    fprintf(trace_log, "x%d <- 0x%0*" PRIX64 "\n", reg,
-            static_cast<int>(zxlen / 4), value);
+    if (config_use_abi_names) {
+      fprintf(trace_log, "%s <- 0x%0*" PRIX64 "\n", abi_name,
+              static_cast<int>(zxlen / 4), value);
+    } else {
+      fprintf(trace_log, "x%d <- 0x%0*" PRIX64 "\n", reg,
+              static_cast<int>(zxlen / 4), value);
+    }
   }
   if (config_enable_rvfi) {
     zrvfi_wX(reg, value);

--- a/c_emulator/riscv_callbacks.h
+++ b/c_emulator/riscv_callbacks.h
@@ -10,7 +10,8 @@ unit mem_write_callback(const char *type, uint64_t paddr, uint64_t width,
 unit mem_read_callback(const char *type, uint64_t paddr, uint64_t width,
                        lbits value);
 unit mem_exception_callback(uint64_t paddr, uint64_t num_of_exception);
-unit xreg_write_callback(unsigned reg, uint64_t value);
+unit xreg_full_write_callback(const_sail_string abi_name, unsigned reg,
+                              uint64_t value);
 unit freg_write_callback(unsigned reg, uint64_t value);
 // `full` indicates that the name and index of the CSR are provided.
 // 64 bit CSRs use a long_csr_write_callback Sail function that automatically

--- a/c_emulator/riscv_config.h
+++ b/c_emulator/riscv_config.h
@@ -7,3 +7,4 @@ extern bool config_print_reg;
 extern bool config_print_mem_access;
 extern bool config_print_platform;
 extern bool config_enable_rvfi;
+extern bool config_use_abi_names;

--- a/c_emulator/riscv_prelude.cpp
+++ b/c_emulator/riscv_prelude.cpp
@@ -43,3 +43,8 @@ bool get_config_rvfi(unit)
 {
   return config_enable_rvfi;
 }
+
+bool get_config_use_abi_names(unit)
+{
+  return config_use_abi_names;
+}

--- a/c_emulator/riscv_prelude.h
+++ b/c_emulator/riscv_prelude.h
@@ -16,6 +16,7 @@ unit print_platform(sail_string s);
 bool get_config_print_instr(unit);
 bool get_config_print_platform(unit);
 bool get_config_rvfi(unit);
+bool get_config_use_abi_names(unit);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -55,6 +55,7 @@ bool config_print_instr = true;
 bool config_print_reg = true;
 bool config_print_mem_access = true;
 bool config_print_platform = true;
+bool config_use_abi_names = false;
 bool config_print_rvfi = false;
 bool config_print_step = false;
 bool config_enable_rvfi = false;
@@ -71,6 +72,8 @@ void set_config_print(char *var, bool val)
     config_print_instr = val;
   } else if (strcmp("reg", var) == 0) {
     config_print_reg = val;
+  } else if (strcmp("abi", var) == 0) {
+    config_use_abi_names = val;
   } else if (strcmp("mem", var) == 0) {
     config_print_mem_access = val;
   } else if (strcmp("rvfi", var) == 0) {

--- a/model/prelude.sail
+++ b/model/prelude.sail
@@ -70,10 +70,12 @@ function print_step() = ()
 val get_config_print_instr = pure {c:"get_config_print_instr"} : unit -> bool
 val get_config_print_platform = pure {c:"get_config_print_platform"} : unit -> bool
 val get_config_rvfi = pure {c:"get_config_rvfi"} : unit -> bool
+val get_config_use_abi_names = pure {c:"get_config_use_abi_names"} : unit -> bool
 // defaults for other backends
 function get_config_print_instr () = false
 function get_config_print_platform () = false
 function get_config_rvfi () = false
+function get_config_use_abi_names () = false
 
 val sign_extend : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)
 val zero_extend : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)

--- a/model/riscv_callbacks.sail
+++ b/model/riscv_callbacks.sail
@@ -19,8 +19,8 @@ function mem_exception_callback(_) = ()
 val pc_write_callback = pure {c: "pc_write_callback"} : xlenbits -> unit
 function pc_write_callback(_) = ()
 
-val xreg_write_callback = pure {c: "xreg_write_callback"} : (regidx, xlenbits) -> unit
-function xreg_write_callback(_) = ()
+val xreg_full_write_callback = pure {c: "xreg_full_write_callback"} : (string, regidx, xlenbits) -> unit
+function xreg_full_write_callback(_) = ()
 
 val csr_full_write_callback = pure {c: "csr_full_write_callback"} : (string, csreg, xlenbits) -> unit
 function csr_full_write_callback(_) = ()

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -11,6 +11,101 @@
 register PC       : xlenbits
 register nextPC   : xlenbits
 
+/* mappings for assembly */
+
+mapping reg_abi_name_raw : bits(5) <-> string = {
+    0b00000 <-> "zero",
+    0b00001 <-> "ra",
+    0b00010 <-> "sp",
+    0b00011 <-> "gp",
+    0b00100 <-> "tp",
+    0b00101 <-> "t0",
+    0b00110 <-> "t1",
+    0b00111 <-> "t2",
+    0b01000 <-> "fp",
+    0b01001 <-> "s1",
+    0b01010 <-> "a0",
+    0b01011 <-> "a1",
+    0b01100 <-> "a2",
+    0b01101 <-> "a3",
+    0b01110 <-> "a4",
+    0b01111 <-> "a5",
+    0b10000 <-> "a6",
+    0b10001 <-> "a7",
+    0b10010 <-> "s2",
+    0b10011 <-> "s3",
+    0b10100 <-> "s4",
+    0b10101 <-> "s5",
+    0b10110 <-> "s6",
+    0b10111 <-> "s7",
+    0b11000 <-> "s8",
+    0b11001 <-> "s9",
+    0b11010 <-> "s10",
+    0b11011 <-> "s11",
+    0b11100 <-> "t3",
+    0b11101 <-> "t4",
+    0b11110 <-> "t5",
+    0b11111 <-> "t6",
+}
+
+mapping reg_arch_name_raw : bits(5) <-> string = {
+    0b00000 <-> "x0",
+    0b00001 <-> "x1",
+    0b00010 <-> "x2",
+    0b00011 <-> "x3",
+    0b00100 <-> "x4",
+    0b00101 <-> "x5",
+    0b00110 <-> "x6",
+    0b00111 <-> "x7",
+    0b01000 <-> "x8",
+    0b01001 <-> "x9",
+    0b01010 <-> "x10",
+    0b01011 <-> "x11",
+    0b01100 <-> "x12",
+    0b01101 <-> "x13",
+    0b01110 <-> "x14",
+    0b01111 <-> "x15",
+    0b10000 <-> "x16",
+    0b10001 <-> "x17",
+    0b10010 <-> "x18",
+    0b10011 <-> "x19",
+    0b10100 <-> "x20",
+    0b10101 <-> "x21",
+    0b10110 <-> "x22",
+    0b10111 <-> "x23",
+    0b11000 <-> "x24",
+    0b11001 <-> "x25",
+    0b11010 <-> "x26",
+    0b11011 <-> "x27",
+    0b11100 <-> "x28",
+    0b11101 <-> "x29",
+    0b11110 <-> "x30",
+    0b11111 <-> "x31",
+}
+
+mapping reg_name : regidx <-> string = {
+  Regidx(i) if get_config_use_abi_names()      <-> reg_abi_name_raw(i),
+  Regidx(i) if not(get_config_use_abi_names()) <-> reg_arch_name_raw(i),
+}
+
+mapping creg_name_raw : bits(3) <-> string = {
+  0b000 <-> "s0",
+  0b001 <-> "s1",
+  0b010 <-> "a0",
+  0b011 <-> "a1",
+  0b100 <-> "a2",
+  0b101 <-> "a3",
+  0b110 <-> "a4",
+  0b111 <-> "a5",
+}
+
+mapping creg_name : cregidx <-> string = { Cregidx(i) <-> creg_name_raw(i) }
+
+function xreg_write_callback(reg: regidx, value : xlenbits) -> unit = {
+  let name = reg_name(reg);
+  xreg_full_write_callback(name, reg, value);
+}
+
 /* register file and accessors */
 
 register x1  : regtype
@@ -132,58 +227,6 @@ function wX_bits(i: regidx, data: xlenbits) -> unit = {
 }
 
 overload X = {rX_bits, wX_bits, rX, wX}
-
-/* mappings for assembly */
-
-mapping reg_name_raw : bits(5) <-> string = {
-    0b00000 <-> "zero",
-    0b00001 <-> "ra",
-    0b00010 <-> "sp",
-    0b00011 <-> "gp",
-    0b00100 <-> "tp",
-    0b00101 <-> "t0",
-    0b00110 <-> "t1",
-    0b00111 <-> "t2",
-    0b01000 <-> "fp",
-    0b01001 <-> "s1",
-    0b01010 <-> "a0",
-    0b01011 <-> "a1",
-    0b01100 <-> "a2",
-    0b01101 <-> "a3",
-    0b01110 <-> "a4",
-    0b01111 <-> "a5",
-    0b10000 <-> "a6",
-    0b10001 <-> "a7",
-    0b10010 <-> "s2",
-    0b10011 <-> "s3",
-    0b10100 <-> "s4",
-    0b10101 <-> "s5",
-    0b10110 <-> "s6",
-    0b10111 <-> "s7",
-    0b11000 <-> "s8",
-    0b11001 <-> "s9",
-    0b11010 <-> "s10",
-    0b11011 <-> "s11",
-    0b11100 <-> "t3",
-    0b11101 <-> "t4",
-    0b11110 <-> "t5",
-    0b11111 <-> "t6"
-}
-
-mapping reg_name : regidx <-> string = { Regidx(i) <-> reg_name_raw(i) }
-
-mapping creg_name_raw : bits(3) <-> string = {
-  0b000 <-> "s0",
-  0b001 <-> "s1",
-  0b010 <-> "a0",
-  0b011 <-> "a1",
-  0b100 <-> "a2",
-  0b101 <-> "a3",
-  0b110 <-> "a4",
-  0b111 <-> "a5"
-}
-
-mapping creg_name : cregidx <-> string = { Cregidx(i) <-> creg_name_raw(i) }
 
 /* Mappings for encoding */
 


### PR DESCRIPTION
Fixes #909 