### PR TITLE
Add empty stubs for the state-change callbacks

### DIFF
--- a/model/riscv_callbacks.sail
+++ b/model/riscv_callbacks.sail
@@ -8,13 +8,28 @@
 
 // Callbacks for state-changing events
 val mem_write_callback = pure {c: "mem_write_callback"} : forall 'n, 0 < 'n <= max_mem_access . (/* addr */ physaddrbits, /* width */ int('n), /* value */ bits(8 * 'n)) -> unit
+function mem_write_callback(_) = ()
+
 val mem_read_callback = pure {c: "mem_read_callback"} : forall 'n, 0 < 'n <= max_mem_access . (/* access type */ string, /* addr */ physaddrbits, /* width */ int('n), /* value */ bits(8 * 'n)) -> unit
+function mem_read_callback(_) = ()
+
 val mem_exception_callback = pure {c: "mem_exception_callback"} : forall 'n, 0 <= 'n < xlen . (/* addr */ physaddrbits, /* num_of_ExceptionType */ int('n)) -> unit
+function mem_exception_callback(_) = ()
+
 val pc_write_callback = pure {c: "pc_write_callback"} : xlenbits -> unit
+function pc_write_callback(_) = ()
+
 val xreg_write_callback = pure {c: "xreg_write_callback"} : (regidx, xlenbits) -> unit
+function xreg_write_callback(_) = ()
+
 val csr_full_write_callback = pure {c: "csr_full_write_callback"} : (string, csreg, xlenbits) -> unit
+function csr_full_write_callback(_) = ()
+
 val csr_full_read_callback = pure {c: "csr_full_read_callback"} : (string, csreg, xlenbits) -> unit
+function csr_full_read_callback(_) = ()
+
 val trap_callback = pure {c: "trap_callback"} : unit -> unit
+function trap_callback(_) = ()
 
 // Overloads for easier use of callbacks
 function csr_name_write_callback(name : string, value : xlenbits) -> unit = {

--- a/model/riscv_fdext_regs.sail
+++ b/model/riscv_fdext_regs.sail
@@ -71,6 +71,7 @@ function fregidx_to_regidx (Fregidx(b) : fregidx) -> regidx =
 mapping encdec_freg : fregidx <-> bits(5) = { Fregidx(r) <-> r }
 
 val freg_write_callback = pure {c: "freg_write_callback"} : (fregidx, flenbits) -> unit
+function freg_write_callback(_) = ()
 
 register f0  : fregtype
 register f1  : fregtype

--- a/model/riscv_vext_regs.sail
+++ b/model/riscv_vext_regs.sail
@@ -16,6 +16,7 @@ function vregidx_bits (Vregidx(b) : vregidx) -> bits(5) = b
 mapping encdec_vreg : vregidx <-> bits(5) = { Vregidx(r) <-> r }
 
 val vreg_write_callback = pure {c: "vreg_write_callback"} : (vregidx, vregtype) -> unit
+function vreg_write_callback(_) = ()
 
 let zvreg : vregidx = Vregidx(0b00000) /* v0, zero register  */
 


### PR DESCRIPTION
This should fix the builds for the the non-C backends.