### PR TITLE
Add config option to trap on sfence.vma if virt mem not supported

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -215,7 +215,8 @@
       "supported": true
     },
     "Svbare": {
-      "supported": true
+      "supported": true,
+      "sfence_vma_illegal_if_svbare_only": true
     },
     "Sv32": {
       "supported": true

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -625,6 +625,7 @@ union clause ast = SFENCE_VMA : (regidx, regidx)
 
 mapping clause encdec = SFENCE_VMA(rs1, rs2)
   <-> 0b0001001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ 0b00000 @ 0b1110011
+  when virtual_memory_supported() | not(config extensions.Svbare.sfence_vma_illegal_if_svbare_only : bool)
 
 function clause execute SFENCE_VMA(rs1, rs2) = {
   let addr = if rs1 != zreg then Some(X(rs1)) else None();


### PR DESCRIPTION
From section 12.2.1 of the priv spec:
> For implementations that make satp.MODE read-only zero (always Bare), attempts to execute an SFENCE.VMA instruction might raise an illegal-instruction exception.