### PR TITLE
Fix build failure due to plat_enable_htif signature mismatch

### DIFF
--- a/c_emulator/riscv_platform.cpp
+++ b/c_emulator/riscv_platform.cpp
@@ -66,7 +66,7 @@ unit plat_term_write(mach_bits s)
   return UNIT;
 }
 
-bool plat_enable_htif()
+bool plat_enable_htif(unit)
 {
   return rv_enable_htif;
 }

--- a/c_emulator/riscv_platform.h
+++ b/c_emulator/riscv_platform.h
@@ -16,7 +16,7 @@ unit cancel_reservation(unit);
 unit plat_term_write(mach_bits);
 
 mach_bits plat_htif_tohost(unit);
-bool plat_enable_htif();
+bool plat_enable_htif(unit);
 
 bool sys_enable_experimental_extensions(unit);
 


### PR DESCRIPTION
We compile the model as C, and unlike C++, in C prior to C23 a function declaration with no parameters didn't mean that it was a function with no parameters; instead it meant it was a function with unknown parameters, so any would be allowed.

This was fixed in C23 and GCC 15 increased the minimum standard to C23, thus exposing this mistake.