### PR TITLE
Add Lean back to CI for each PR but don't require it to pass

### DIFF
--- a/.github/workflows/compile-lean.yml
+++ b/.github/workflows/compile-lean.yml
@@ -1,6 +1,6 @@
 name: Build and test Lean backend
 
-on: [workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 env:
   OPAMVERBOSE: 1


### PR DESCRIPTION
Now that we have a "ci_pass" job, we can reenable the Lean CI job for each PR but not add it as a dependency of that job. This way, we will know if Lean is broken by a new change and can hopefully get it fixed without bogging down developers who aren't familiar with the theorem prover backends.