### PR TITLE
Add mstatush to csr_name_map

### DIFF
--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -284,6 +284,7 @@ register mstatus : Mstatus = {
 }
 
 mapping clause csr_name_map = 0x300  <-> "mstatus"
+mapping clause csr_name_map = 0x310  <-> "mstatush"
 
 function clause is_CSR_defined(0x300) = true // mstatus
 function clause is_CSR_defined(0x310) = xlen == 32 // mstatush


### PR DESCRIPTION
Add missing `mstatush` to the `csr_name_map` mapping. This was causing incorrect CSR log messages.

 