### PR TITLE
Only set CMP0135 if it is supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,9 @@ cmake_policy(VERSION 3.20...3.31)
 # this requires `makeinfo` which we don't want to require.
 # TODO: Remove this when we bump the minimum CMake version to 3.24 and
 # instead add DOWNLOAD_EXTRACT_TIMESTAMP TRUE to ExternalProject_Add().
-cmake_policy(SET CMP0135 OLD)
+if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 OLD)
+endif()
 
 project(sail_riscv)
 


### PR DESCRIPTION
Check if CMP0135 is supported by the version of CMake being used before setting it. If it isn't supported the old behavior is used anyway.