### PR TITLE
Fix xepc interaction with compressed extensions

### DIFF
--- a/model/riscv_insts_zcf.sail
+++ b/model/riscv_insts_zcf.sail
@@ -6,15 +6,6 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-/* ********************************************************************* */
-/* This file specifies the compressed floating-point instructions.
- *
- * These instructions are only legal if misa[C] and misa[F]
- * are set.
- */
-
-/* ****************************************************************** */
-
 function clause currentlyEnabled(Ext_Zcf) = hartSupports(Ext_Zcf) & currentlyEnabled(Ext_F) & currentlyEnabled(Ext_Zca) & (currentlyEnabled(Ext_C) | not(hartSupports(Ext_C)))
 
 union clause ast = C_FLWSP : (bits(6), fregidx)

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -541,12 +541,10 @@ function tvec_addr(m : Mtvec, c : Mcause) -> option(xlenbits) = {
 
 register mepc : xlenbits
 
-/* The xepc legalization zeroes xepc[1:0] when misa.C is hardwired to 0.
- * When misa.C is writable, it zeroes only xepc[0].
- */
+// The xepc legalization zeroes xepc[1:0] when Zca is not supported.
+// When Zca is supported (whether it is enabled or not), it zeroes only xepc[0].
 function legalize_xepc(v : xlenbits) -> xlenbits = {
-  // allow writing xepc[1] only if misa.C is enabled or could be enabled.
-  if   hartSupports(Ext_C)
+  if   hartSupports(Ext_Zca)
   then [v with 0 = bitzero]
   else [v with 1..0 = zeros()]
 }
@@ -554,7 +552,7 @@ function legalize_xepc(v : xlenbits) -> xlenbits = {
 // Align value to min supported PC alignment. This is used to
 // legalize xepc reads.
 function align_pc(addr : xlenbits) -> xlenbits = {
-  if misa[C] == 0b1
+  if currentlyEnabled(Ext_Zca)
   then [addr with 0 = bitzero]
   else [addr with 1..0 = zeros()]
 }


### PR DESCRIPTION
When any compressed extension is supported (whether enabled or not), `xepc[1]` can be written.
When compressed instructions are disabled, `xepc[1]` is read as 0.

Both of these were checked based on `misa[C]`, but compressed instructions can be supported without setting `misa[C]` (e.g. an `RV32IF_Zca` hart).