### PR TITLE
Split the Zaamo and Zalrsc extensions into separate files

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -56,7 +56,8 @@ foreach (xlen IN ITEMS 32 64)
             set(sail_default_inst
                 "riscv_insts_base.sail"
                 "riscv_insts_zifencei.sail"
-                "riscv_insts_aext.sail"
+                "riscv_insts_zaamo.sail"
+                "riscv_insts_zalrsc.sail"
                 "riscv_insts_zca.sail"
                 "riscv_insts_mext.sail"
                 "riscv_insts_zicsr.sail"

--- a/model/riscv_insts_zaamo.sail
+++ b/model/riscv_insts_zaamo.sail
@@ -6,36 +6,12 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-/* ****************************************************************** */
-/* This file specifies the atomic instructions in the 'A' extension.  */
-
-/* ****************************************************************** */
-
-function clause currentlyEnabled(Ext_A) = hartSupports(Ext_A) & misa[A] == 0b1
+function clause currentlyEnabled(Ext_A) = hartSupports(Ext_A) & misa[A] == 0b1 // TODO: Move currentlyEnabled(Ext_A) to a more central file
+function clause currentlyEnabled(Ext_Zaamo) = hartSupports(Ext_Zaamo) | currentlyEnabled(Ext_A)
 function clause currentlyEnabled(Ext_Zabha) = hartSupports(Ext_Zabha) & currentlyEnabled(Ext_Zaamo)
 
-// Some print utils for lr/sc.
-
-function aqrl_str(aq : bool, rl : bool) -> string =
-  match (aq, rl) {
-    (false, false) => "",
-    (false, true)  => ".rl",
-    (true, false)  => ".aq",
-    (true, true)   => ".aqrl"
-  }
-
-/**
- * RISC-V A-extension defines LR / SC / AMOs for word and double
- * RISC-V Zabha extension defines AMOs for byte and halfword
- */
-function lrsc_width_valid(size : word_width) -> bool = {
-  match size {
-    WORD   => true,
-    DOUBLE => xlen >= 64,
-    _      => false
-  }
-}
-
+// Zaamo defines AMOs for word and double
+// Zabha defines AMOs for byte and halfword
 function amo_width_valid(size : word_width) -> bool = {
   match size {
     BYTE   => currentlyEnabled(Ext_Zabha),
@@ -46,83 +22,6 @@ function amo_width_valid(size : word_width) -> bool = {
 }
 
 /* ****************************************************************** */
-function clause currentlyEnabled(Ext_Zalrsc) = hartSupports(Ext_Zalrsc) | currentlyEnabled(Ext_A)
-
-union clause ast = LOADRES : (bool, bool, regidx, word_width, regidx)
-
-mapping clause encdec = LOADRES(aq, rl, rs1, size, rd)
-  <-> 0b00010 @ bool_bits(aq) @ bool_bits(rl) @ 0b00000 @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ encdec_reg(rd) @ 0b0101111
-  when currentlyEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
-
-/* We could set load-reservations on physical or virtual addresses.
- * However most chips (especially multi-core) will use physical addresses.
- * Additionally, matching on physical addresses allows as many SC's to
- * succeed as the spec allows. This simplifies verification against real chips
- * since you can force spurious failures from a DUT into the Sail model and
- * then compare the result (a kind of one-way waiver). Using virtual addresses
- * requires cancelling the reservation in some additional places, e.g. xRET, and
- * that will break comparison with a DUT that doesn't require cancellation there.
- */
-
-function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
-  let width_bytes = size_bytes(width);
-
-  // This is checked during decoding.
-  assert(width_bytes <= xlen_bytes);
-
-  match vmem_read(rs1, zeros(), width_bytes, Read(Data), aq, aq & rl, true) {
-    Ok(data) => {
-      X(rd) = sign_extend(data);
-      RETIRE_SUCCESS
-    },
-    Err(e) => e,
-  }
-}
-
-mapping clause assembly = LOADRES(aq, rl, rs1, size, rd)
-  <-> "lr." ^ size_mnemonic(size) ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
-
-/* ****************************************************************** */
-union clause ast = STORECON : (bool, bool, regidx, regidx, word_width, regidx)
-
-mapping clause encdec = STORECON(aq, rl, rs2, rs1, size, rd)
-  <-> 0b00011 @ bool_bits(aq) @ bool_bits(rl) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ encdec_reg(rd) @ 0b0101111
-  when currentlyEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
-
-/* NOTE: Currently, we only EA if address translation is successful. This may need revisiting. */
-function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
-  let width_bytes = size_bytes(width);
-
-  // This is checked during decoding.
-  assert(width_bytes <= xlen_bytes);
-
-  if speculate_conditional() == false then {
-    /* should only happen in RMEM
-     * RMEM: allow SC to fail very early
-     */
-    X(rd) = zero_extend(0b1);
-    return RETIRE_SUCCESS
-  };
-
-  /* normal non-rmem case
-   * RMEM: SC is allowed to succeed (but might fail later)
-   */
-  let data = X(rs2)[width_bytes * 8 - 1 .. 0];
-  match vmem_write(rs1, zeros(), width_bytes, data, Write(Data), aq & rl, rl, true) {
-    Ok(b) => {
-      X(rd) = zero_extend(bool_bits(~(b)));
-      cancel_reservation();
-      RETIRE_SUCCESS
-    },
-    Err(e) => e,
-  }
-}
-
-mapping clause assembly = STORECON(aq, rl, rs2, rs1, size, rd)
-  <-> "sc." ^ size_mnemonic(size) ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs2) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
-
-/* ****************************************************************** */
-function clause currentlyEnabled(Ext_Zaamo) = hartSupports(Ext_Zaamo) | currentlyEnabled(Ext_A)
 
 union clause ast = AMO : (amoop, bool, bool, regidx, regidx, word_width, regidx)
 

--- a/model/riscv_insts_zalrsc.sail
+++ b/model/riscv_insts_zalrsc.sail
@@ -1,0 +1,94 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+function clause currentlyEnabled(Ext_Zalrsc) = hartSupports(Ext_Zalrsc) | currentlyEnabled(Ext_A)
+
+// Zalrsc defines LR/SC for word and double
+function lrsc_width_valid(size : word_width) -> bool = {
+  match size {
+    WORD   => true,
+    DOUBLE => xlen >= 64,
+    _      => false
+  }
+}
+
+/* ****************************************************************** */
+
+union clause ast = LOADRES : (bool, bool, regidx, word_width, regidx)
+
+mapping clause encdec = LOADRES(aq, rl, rs1, size, rd)
+  <-> 0b00010 @ bool_bits(aq) @ bool_bits(rl) @ 0b00000 @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ encdec_reg(rd) @ 0b0101111
+  when currentlyEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
+
+/* We could set load-reservations on physical or virtual addresses.
+ * However most chips (especially multi-core) will use physical addresses.
+ * Additionally, matching on physical addresses allows as many SC's to
+ * succeed as the spec allows. This simplifies verification against real chips
+ * since you can force spurious failures from a DUT into the Sail model and
+ * then compare the result (a kind of one-way waiver). Using virtual addresses
+ * requires cancelling the reservation in some additional places, e.g. xRET, and
+ * that will break comparison with a DUT that doesn't require cancellation there.
+ */
+
+function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
+  let width_bytes = size_bytes(width);
+
+  // This is checked during decoding.
+  assert(width_bytes <= xlen_bytes);
+
+  match vmem_read(rs1, zeros(), width_bytes, Read(Data), aq, aq & rl, true) {
+    Ok(data) => {
+      X(rd) = sign_extend(data);
+      RETIRE_SUCCESS
+    },
+    Err(e) => e,
+  }
+}
+
+mapping clause assembly = LOADRES(aq, rl, rs1, size, rd)
+  <-> "lr." ^ size_mnemonic(size) ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
+
+/* ****************************************************************** */
+
+union clause ast = STORECON : (bool, bool, regidx, regidx, word_width, regidx)
+
+mapping clause encdec = STORECON(aq, rl, rs2, rs1, size, rd)
+  <-> 0b00011 @ bool_bits(aq) @ bool_bits(rl) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ encdec_reg(rd) @ 0b0101111
+  when currentlyEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
+
+/* NOTE: Currently, we only EA if address translation is successful. This may need revisiting. */
+function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
+  let width_bytes = size_bytes(width);
+
+  // This is checked during decoding.
+  assert(width_bytes <= xlen_bytes);
+
+  if speculate_conditional() == false then {
+    /* should only happen in RMEM
+     * RMEM: allow SC to fail very early
+     */
+    X(rd) = zero_extend(0b1);
+    return RETIRE_SUCCESS
+  };
+
+  /* normal non-rmem case
+   * RMEM: SC is allowed to succeed (but might fail later)
+   */
+  let data = X(rs2)[width_bytes * 8 - 1 .. 0];
+  match vmem_write(rs1, zeros(), width_bytes, data, Write(Data), aq & rl, rl, true) {
+    Ok(b) => {
+      X(rd) = zero_extend(bool_bits(~(b)));
+      cancel_reservation();
+      RETIRE_SUCCESS
+    },
+    Err(e) => e,
+  }
+}
+
+mapping clause assembly = STORECON(aq, rl, rs2, rs1, size, rd)
+  <-> "sc." ^ size_mnemonic(size) ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs2) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"


### PR DESCRIPTION
Zaamo and Zalrsc are separate extensions (even if both are included in A), so by our convention they should be in separate files. They also have suprisingly little overlap, so it is a very clean split.