### PR TITLE
Use existing bit counting functions

### DIFF
--- a/model/arithmetic.sail
+++ b/model/arithmetic.sail
@@ -48,3 +48,16 @@ function rev8(input) = {
   };
   output
 }
+
+val count_ones : forall 'n, 'n >= 0. (bits('n)) -> range(0, 'n)
+function count_ones(x) = {
+  var count : range(0, 'n) = 0;
+  foreach (i from 0 to ('n - 1)) {
+    if x[i] == bitone then {
+      let new_count = count + 1;
+      assert(new_count <= 'n);
+      count = new_count;
+    }
+  };
+  count
+}

--- a/model/riscv_insts_vext_fp_utils.sail
+++ b/model/riscv_insts_vext_fp_utils.sail
@@ -476,7 +476,7 @@ function rsqrt7 (v, sub) = {
 
   let (normalized_exp, normalized_sig) =
       if sub then {
-        let nr_leadingzeros = count_leadingzeros(sig, s);
+        let nr_leadingzeros = count_leading_zeros(sig[s - 1 .. 0]);
         assert(nr_leadingzeros >= 0);
         (to_bits_unsafe(64, (0 - nr_leadingzeros)), zero_extend(64, sig[(s - 1) .. 0] << (1 + nr_leadingzeros)))
       } else {
@@ -544,12 +544,11 @@ function riscv_f64Rsqrte7 (rm, v) = {
 
 val recip7 : forall 'm, 'm in {16, 32, 64}. (bits('m), bits(3), bool) -> (bool, bits_D)
 function recip7 (v, rm_3b, sub) = {
-  let (sig, exp, sign, e, s) : (bits(64), bits(64), bits(1), nat, nat) = match 'm {
+  let (sig, exp, sign, e, s) : (bits(64), bits(64), bits(1), {5, 8, 11}, {10, 23, 52}) = match 'm {
     16 => (zero_extend(64, v[9 .. 0]), zero_extend(64, v[14 .. 10]), [v[15]], 5, 10),
     32 => (zero_extend(64, v[22 .. 0]), zero_extend(64, v[30 .. 23]), [v[31]], 8, 23),
     64 => (zero_extend(64, v[51 .. 0]), zero_extend(64, v[62 .. 52]), [v[63]], 11, 52)
   };
-  assert(s == 10 & e == 5 | s == 23 & e == 8 | s == 52 & e == 11);
   let table : vector(128, int) = [
       127, 125, 123, 121, 119, 117, 116, 114,
       112, 110, 109, 107, 105, 104, 102, 100,
@@ -568,7 +567,7 @@ function recip7 (v, rm_3b, sub) = {
       8, 8, 7, 7, 6, 5, 5, 4,
       4, 3, 3, 2, 2, 1, 1, 0];
 
-  let nr_leadingzeros = count_leadingzeros(sig, s);
+  let nr_leadingzeros = count_leading_zeros(sig[s - 1 .. 0]);
   assert(nr_leadingzeros >= 0);
   let (normalized_exp, normalized_sig) =
       if sub then {

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -493,16 +493,6 @@ function signed_saturation(len, elem) = {
   };
 }
 
-val count_leadingzeros : (bits(64), int) -> int
-function count_leadingzeros (sig, len) = {
-  var idx : int = -1;
-  assert(len == 10 | len == 23 | len == 52);
-  foreach (i from 0 to (len - 1)) {
-    if sig[i] == bitone then idx = i;
-  };
-  len - idx - 1
-}
-
 /* The parameter m is implicit to help proof the proof assistant backends infer its value. */
 val vrev8 : forall 'n 'm, 'n >= 0 & 'm >= 0. (implicit('m), vector('n, bits('m * 8))) -> vector('n, bits('m * 8))
 function vrev8(m, input) = {

--- a/model/riscv_insts_zbb.sail
+++ b/model/riscv_insts_zbb.sail
@@ -245,11 +245,7 @@ mapping clause assembly = CPOP(rs1, rd)
   <-> "cpop" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
 function clause execute (CPOP(rs1, rd)) = {
-  let rs1_val = X(rs1);
-  var result : nat = 0;
-  foreach (i from 0 to (xlen - 1))
-    if rs1_val[i] == bitone then result = result + 1;
-  X(rd) = to_bits_unsafe(xlen, result);
+  X(rd) = to_bits(count_ones(X(rs1)));
   RETIRE_SUCCESS
 }
 
@@ -264,11 +260,7 @@ mapping clause assembly = CPOPW(rs1, rd)
   <-> "cpopw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
 function clause execute (CPOPW(rs1, rd)) = {
-  let rs1_val = X(rs1);
-  var result : nat = 0;
-  foreach (i from 0 to 31)
-    if rs1_val[i] == bitone then result = result + 1;
-  X(rd) = to_bits_unsafe(xlen, result);
+  X(rd) = to_bits(count_ones(X(rs1)[31 .. 0]));
   RETIRE_SUCCESS
 }
 
@@ -283,14 +275,7 @@ mapping clause assembly = CLZ(rs1, rd)
   <-> "clz" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
 function clause execute (CLZ(rs1, rd)) = {
-  let rs1_val = X(rs1);
-  var result : nat = 0;
-  var done : bool = false;
-  foreach (i from (xlen - 1) downto 0)
-    if not(done) then if rs1_val[i] == bitzero
-                    then result = result + 1
-                    else done = true;
-  X(rd) = to_bits_unsafe(xlen, result);
+  X(rd) = to_bits(count_leading_zeros(X(rs1)));
   RETIRE_SUCCESS
 }
 
@@ -305,14 +290,7 @@ mapping clause assembly = CLZW(rs1, rd)
   <-> "clzw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
 function clause execute (CLZW(rs1, rd)) = {
-  let rs1_val = X(rs1);
-  var result : nat = 0;
-  var done : bool = false;
-  foreach (i from 31 downto 0)
-    if not(done) then if rs1_val[i] == bitzero
-                    then result = result + 1
-                    else done = true;
-  X(rd) = to_bits_unsafe(xlen, result);
+  X(rd) = to_bits(count_leading_zeros(X(rs1)[31 .. 0]));
   RETIRE_SUCCESS
 }
 
@@ -327,14 +305,7 @@ mapping clause assembly = CTZ(rs1, rd)
   <-> "ctz" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
 function clause execute (CTZ(rs1, rd)) = {
-  let rs1_val = X(rs1);
-  var result : nat = 0;
-  var done : bool = false;
-  foreach (i from 0 to (xlen - 1))
-    if not(done) then if rs1_val[i] == bitzero
-                    then result = result + 1
-                    else done = true;
-  X(rd) = to_bits_unsafe(xlen, result);
+  X(rd) = to_bits(count_trailing_zeros(X(rs1)));
   RETIRE_SUCCESS
 }
 
@@ -349,13 +320,6 @@ mapping clause assembly = CTZW(rs1, rd)
   <-> "ctzw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
 function clause execute (CTZW(rs1, rd)) = {
-  let rs1_val = X(rs1);
-  var result : nat = 0;
-  var done : bool = false;
-  foreach (i from 0 to 31)
-    if not(done) then if rs1_val[i] == bitzero
-                    then result = result + 1
-                    else done = true;
-  X(rd) = to_bits_unsafe(xlen, result);
+  X(rd) = to_bits(count_trailing_zeros(X(rs1)[31 .. 0]));
   RETIRE_SUCCESS
 }


### PR DESCRIPTION
Use the existing bit counting functions, and add `count_ones()`.

One downside is that `count_leading_zeros()` is not implemented in Sail, so it makes the inclusion in the ISA manual less helpful.

However given the difficulties of actually getting Sail code into the ISA manual it's probably ok for now. Also `count_leading_zeros()` is a standard operation and has obvious semantics.