### PR TITLE
Fix to_bits_unsafe() in crypto extension

### DIFF
--- a/model/riscv_types_kext.sail
+++ b/model/riscv_types_kext.sail
@@ -213,8 +213,8 @@ function aes_subword_inv(x) = {
 val sm4_sbox : bits(8) -> bits(8)
 function sm4_sbox(x) = sbox_lookup(x, sm4_sbox_table)
 
-val aes_get_column : (bits(128), nat) -> bits(32)
-function aes_get_column(state,c) = (state >> (to_bits_unsafe(7, 32 * c)))[31..0]
+function aes_get_column(state : bits(128), c : range(0, 3)) -> bits(32) =
+  state[32 * c + 31 .. 32 * c]
 
 /* 64-bit to 64-bit function which applies the AES forward sbox to each byte
  * in a 64-bit word.
@@ -250,8 +250,8 @@ function aes_apply_inv_sbox_to_each_byte(x) = {
  * AES full-round transformation functions.
  */
 
-val getbyte : (bits(64), int) -> bits(8)
-function getbyte(x, i) = (x >> to_bits_unsafe(6, i * 8))[7..0]
+function getbyte(x : bits(64), i : range(0, 7)) -> bits(8) =
+  x[8 * i + 7 .. 8 * i]
 
 val aes_rv64_shiftrows_fwd : (bits(64), bits(64)) -> bits(64)
 function aes_rv64_shiftrows_fwd(rs2, rs1) = {


### PR DESCRIPTION
There was no need for using `to_bits()` in the first place - we can do it simpler just by accessing the bits directly.