### PR TITLE
Explicitly use get_bits_truncate() for multiplications

### DIFF
--- a/model/riscv_insts_mext.sail
+++ b/model/riscv_insts_mext.sail
@@ -30,9 +30,9 @@ mapping clause encdec = MUL(rs2, rs1, rd, mul_op)
 function clause execute (MUL(rs2, rs1, rd, mul_op)) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
-  let rs1_int : int = if mul_op.signed_rs1 then signed(rs1_val) else unsigned(rs1_val);
-  let rs2_int : int = if mul_op.signed_rs2 then signed(rs2_val) else unsigned(rs2_val);
-  let result_wide = to_bits_unsafe(2 * xlen, rs1_int * rs2_int);
+  let rs1_int = if mul_op.signed_rs1 then signed(rs1_val) else unsigned(rs1_val);
+  let rs2_int = if mul_op.signed_rs2 then signed(rs2_val) else unsigned(rs2_val);
+  let result_wide : bits(2 * xlen) = to_bits_truncate(rs1_int * rs2_int);
   let result = if   mul_op.high
                then result_wide[(2 * xlen - 1) .. xlen]
                else result_wide[(xlen - 1) .. 0];
@@ -65,7 +65,7 @@ function clause execute (DIV(rs2, rs1, rd, s)) = {
   let q : int = if rs2_int == 0 then -1 else quot_round_zero(rs1_int, rs2_int);
   /* check for signed overflow */
   let q': int = if s & q > xlen_max_signed then xlen_min_signed else q;
-  X(rd) = to_bits_unsafe(xlen, q');
+  X(rd) = to_bits_truncate(q');
   RETIRE_SUCCESS
 }
 
@@ -91,7 +91,7 @@ function clause execute (REM(rs2, rs1, rd, s)) = {
   let rs2_int : int = if s then signed(rs2_val) else unsigned(rs2_val);
   let r : int = if rs2_int == 0 then rs1_int else rem_round_zero(rs1_int, rs2_int);
   /* signed overflow case returns zero naturally as required due to -1 divisor */
-  X(rd) = to_bits_unsafe(xlen, r);
+  X(rd) = to_bits_truncate(r);
   RETIRE_SUCCESS
 }
 
@@ -110,8 +110,7 @@ function clause execute (MULW(rs2, rs1, rd)) = {
   let rs2_val = X(rs2)[31..0];
   let rs1_int : int = signed(rs1_val);
   let rs2_int : int = signed(rs2_val);
-  /* to_bits_unsafe requires expansion to 64 bits followed by truncation */
-  let result32 = to_bits_unsafe(64, rs1_int * rs2_int)[31..0];
+  let result32 : bits(32) = to_bits_truncate(rs1_int * rs2_int);
   let result : xlenbits = sign_extend(result32);
   X(rd) = result;
   RETIRE_SUCCESS
@@ -136,7 +135,7 @@ function clause execute (DIVW(rs2, rs1, rd, s)) = {
   let q : int = if rs2_int == 0 then -1 else quot_round_zero(rs1_int, rs2_int);
   /* check for signed overflow */
   let q': int = if s & q > (2 ^ 31 - 1) then  (0 - (2 ^ 31)) else q;
-  X(rd) = sign_extend(to_bits_unsafe(32, q'));
+  X(rd) = sign_extend(to_bits_truncate(32, q'));
   RETIRE_SUCCESS
 }
 
@@ -158,7 +157,7 @@ function clause execute (REMW(rs2, rs1, rd, s)) = {
   let rs2_int : int = if s then signed(rs2_val) else unsigned(rs2_val);
   let r : int = if rs2_int == 0 then rs1_int else rem_round_zero(rs1_int, rs2_int);
   /* signed overflow case returns zero naturally as required due to -1 divisor */
-  X(rd) = sign_extend(to_bits_unsafe(32, r));
+  X(rd) = sign_extend(to_bits_truncate(32, r));
   RETIRE_SUCCESS
 }
 


### PR DESCRIPTION
This is one place where we explicitly do want to truncate the result.