### PR TITLE
Fix to_bits_unsafe() in Zvk

### DIFF
--- a/model/riscv_zvk_utils.sail
+++ b/model/riscv_zvk_utils.sail
@@ -29,23 +29,23 @@ function zvknhab_check_encdec(vs2: vregidx, vs1: vregidx, vd: vregidx) -> bool =
   zvk_check_encdec(SEW, 4) & zvk_valid_reg_overlap(vs1, vd, LMUL_pow) & zvk_valid_reg_overlap(vs2, vd, LMUL_pow);
 }
 
-val zvk_sig0 : forall 'n 'm, 'n == 'm & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
+val zvk_sig0 : forall 'n, 'n in {32, 64} . (bits('n), int('n)) -> bits('n)
 function zvk_sig0(x, SEW) = {
   match SEW {
-    32 => ((x >>> 7) ^ (x >>> 18) ^ (x >> to_bits_unsafe('n, 3))),
-    64 => ((x >>> 1) ^ (x >>>  8) ^ (x >> to_bits_unsafe('n, 7))),
+    32 => ((x >>> 7) ^ (x >>> 18) ^ (x >> 3)),
+    64 => ((x >>> 1) ^ (x >>>  8) ^ (x >> 7)),
   }
 }
 
-val zvk_sig1 : forall 'n 'm, 'n == 'm & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
+val zvk_sig1 : forall 'n, 'n in {32, 64} . (bits('n), int('n)) -> bits('n)
 function zvk_sig1(x, SEW) = {
   match SEW {
-    32 => ((x >>> 17) ^ (x >>> 19) ^ (x >> to_bits_unsafe('n, 10))),
-    64 => ((x >>> 19) ^ (x >>> 61) ^ (x >> to_bits_unsafe('n,  6))),
+    32 => ((x >>> 17) ^ (x >>> 19) ^ (x >> 10)),
+    64 => ((x >>> 19) ^ (x >>> 61) ^ (x >>  6)),
   }
 }
 
-val zvk_sum0 : forall 'n 'm, 'n == 'm & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
+val zvk_sum0 : forall 'n, 'n in {32, 64} . (bits('n), int('n)) -> bits('n)
 function zvk_sum0(x, SEW) = {
   match SEW {
     32 => ((x >>>  2) ^ (x >>> 13) ^ (x >>> 22)),
@@ -53,7 +53,7 @@ function zvk_sum0(x, SEW) = {
   }
 }
 
-val zvk_sum1 : forall 'n 'm, 'n == 'm & ('m == 32 | 'm == 64). (bits('n), int('m)) -> bits('n)
+val zvk_sum1 : forall 'n, 'n in {32, 64} . (bits('n), int('n)) -> bits('n)
 function zvk_sum1(x, SEW) = {
   match SEW {
     32 => ((x >>>  6) ^ (x >>> 11) ^ (x >>> 25)),


### PR DESCRIPTION
Don't convert to bits, and also remove the redundant '`m` type parameter which is always constrained to equal `'n'` anyway.