### PR TITLE
Remove the use of function wrappers to initialize config parameters.

### DIFF
--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -48,7 +48,7 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW_pow  = get_sew_pow();
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let VLEN_pow = get_vlen_pow();
+  let VLEN_pow = get_vlen_pow;
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) then return Illegal_Instruction();
@@ -695,7 +695,7 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let SEW_pow  = get_sew_pow();
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let VLEN_pow = get_vlen_pow();
+  let VLEN_pow = get_vlen_pow;
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) then return Illegal_Instruction();
@@ -1104,7 +1104,7 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let SEW_pow  = get_sew_pow();
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let VLEN_pow = get_vlen_pow();
+  let VLEN_pow = get_vlen_pow;
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) then return Illegal_Instruction();

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -48,7 +48,6 @@ function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW_pow  = get_sew_pow();
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let VLEN_pow = get_vlen_pow;
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) then return Illegal_Instruction();
@@ -695,7 +694,6 @@ function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
   let SEW_pow  = get_sew_pow();
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let VLEN_pow = get_vlen_pow;
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) then return Illegal_Instruction();
@@ -1104,7 +1102,6 @@ function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
   let SEW_pow  = get_sew_pow();
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let VLEN_pow = get_vlen_pow;
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_normal(vd, vm) then return Illegal_Instruction();

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -30,7 +30,7 @@ mapping maybe_vmask : string <-> bits(1) = {
  */
 val valid_eew_emul : (int, int) -> bool
 function valid_eew_emul(EEW, EMUL_pow) = {
-  let ELEN = 2 ^ get_elen_pow();
+  let ELEN = 2 ^ get_elen_pow;
   EEW >= 8 & EEW <= ELEN & EMUL_pow >= -3 & EMUL_pow <= 3
 }
 
@@ -219,7 +219,7 @@ function write_velem_quad_vec(vd, SEW, input, i) = {
 val get_start_element : unit -> result(nat, unit)
 function get_start_element() = {
   let start_element = unsigned(vstart);
-  let VLEN_pow = get_vlen_pow();
+  let VLEN_pow = get_vlen_pow;
   let SEW_pow = get_sew_pow();
   /* The use of vstart values greater than the largest element
    * index for the current SEW setting is reserved.

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -30,7 +30,7 @@ mapping maybe_vmask : string <-> bits(1) = {
  */
 val valid_eew_emul : (int, int) -> bool
 function valid_eew_emul(EEW, EMUL_pow) = {
-  let ELEN = 2 ^ get_elen_pow;
+  let ELEN = 2 ^ ELEN_pow;
   EEW >= 8 & EEW <= ELEN & EMUL_pow >= -3 & EMUL_pow <= 3
 }
 
@@ -219,7 +219,6 @@ function write_velem_quad_vec(vd, SEW, input, i) = {
 val get_start_element : unit -> result(nat, unit)
 function get_start_element() = {
   let start_element = unsigned(vstart);
-  let VLEN_pow = get_vlen_pow;
   let SEW_pow = get_sew_pow();
   /* The use of vstart values greater than the largest element
    * index for the current SEW setting is reserved.

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -52,7 +52,7 @@ function handle_illegal_vtype() = {
   csr_write_callback("vl", vl);
 }
 
-function vl_use_ceil() -> bool = config extensions.V.vl_use_ceil
+let vl_use_ceil : bool = config extensions.V.vl_use_ceil
 
 function calculate_new_vl(AVL : int, VLMAX : int) -> xlenbits = {
   // See "Constraints on Setting vl" in the vector spec.
@@ -62,7 +62,7 @@ function calculate_new_vl(AVL : int, VLMAX : int) -> xlenbits = {
       // If VLMAX < AVL < 2 * VLMAX then we can use any value
       // such that ceil(AVL / 2) <= vl <= VLMAX. Here we provide
       // two options: ceil(AVL / 2) or VLMAX.
-      if vl_use_ceil() then (AVL + 1) / 2 else VLMAX
+      if vl_use_ceil then (AVL + 1) / 2 else VLMAX
     }
     else VLMAX;
 
@@ -85,8 +85,8 @@ function clause execute VSETVLI(ma, ta, sew, lmul, rs1, rd) = {
   vtype.bits = 0b0 @ zeros(xlen - 9) @ ma @ ta @ sew @ lmul;
 
   /* check new SEW and LMUL are legal and calculate VLMAX */
-  let VLEN_pow     = get_vlen_pow();
-  let ELEN_pow     = get_elen_pow();
+  let VLEN_pow     = get_vlen_pow;
+  let ELEN_pow     = get_elen_pow;
   let LMUL_pow_new = get_lmul_pow();
   let SEW_pow_new  = get_sew_pow();
   if SEW_pow_new > (LMUL_pow_new + ELEN_pow) then { handle_illegal_vtype(); return RETIRE_SUCCESS };
@@ -137,8 +137,8 @@ function clause execute VSETVL(rs2, rs1, rd) = {
   vtype.bits = X(rs2);
 
   /* check new SEW and LMUL are legal and calculate VLMAX */
-  let VLEN_pow     = get_vlen_pow();
-  let ELEN_pow     = get_elen_pow();
+  let VLEN_pow     = get_vlen_pow;
+  let ELEN_pow     = get_elen_pow;
   let LMUL_pow_new = get_lmul_pow();
   let SEW_pow_new  = get_sew_pow();
   if SEW_pow_new > (LMUL_pow_new + ELEN_pow) then { handle_illegal_vtype(); return RETIRE_SUCCESS };
@@ -185,8 +185,8 @@ function clause execute VSETIVLI(ma, ta, sew, lmul, uimm, rd) = {
   vtype.bits = 0b0 @ zeros(xlen - 9) @ ma @ ta @ sew @ lmul;
 
   /* check new SEW and LMUL are legal and calculate VLMAX */
-  let VLEN_pow     = get_vlen_pow();
-  let ELEN_pow     = get_elen_pow();
+  let VLEN_pow     = get_vlen_pow;
+  let ELEN_pow     = get_elen_pow;
   let LMUL_pow_new = get_lmul_pow();
   let SEW_pow_new  = get_sew_pow();
   if SEW_pow_new > (LMUL_pow_new + ELEN_pow) then { handle_illegal_vtype(); return RETIRE_SUCCESS };

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -85,8 +85,6 @@ function clause execute VSETVLI(ma, ta, sew, lmul, rs1, rd) = {
   vtype.bits = 0b0 @ zeros(xlen - 9) @ ma @ ta @ sew @ lmul;
 
   /* check new SEW and LMUL are legal and calculate VLMAX */
-  let VLEN_pow     = get_vlen_pow;
-  let ELEN_pow     = get_elen_pow;
   let LMUL_pow_new = get_lmul_pow();
   let SEW_pow_new  = get_sew_pow();
   if SEW_pow_new > (LMUL_pow_new + ELEN_pow) then { handle_illegal_vtype(); return RETIRE_SUCCESS };
@@ -137,8 +135,6 @@ function clause execute VSETVL(rs2, rs1, rd) = {
   vtype.bits = X(rs2);
 
   /* check new SEW and LMUL are legal and calculate VLMAX */
-  let VLEN_pow     = get_vlen_pow;
-  let ELEN_pow     = get_elen_pow;
   let LMUL_pow_new = get_lmul_pow();
   let SEW_pow_new  = get_sew_pow();
   if SEW_pow_new > (LMUL_pow_new + ELEN_pow) then { handle_illegal_vtype(); return RETIRE_SUCCESS };
@@ -185,8 +181,6 @@ function clause execute VSETIVLI(ma, ta, sew, lmul, uimm, rd) = {
   vtype.bits = 0b0 @ zeros(xlen - 9) @ ma @ ta @ sew @ lmul;
 
   /* check new SEW and LMUL are legal and calculate VLMAX */
-  let VLEN_pow     = get_vlen_pow;
-  let ELEN_pow     = get_elen_pow;
   let LMUL_pow_new = get_lmul_pow();
   let SEW_pow_new  = get_sew_pow();
   if SEW_pow_new > (LMUL_pow_new + ELEN_pow) then { handle_illegal_vtype(); return RETIRE_SUCCESS };

--- a/model/riscv_insts_zicbom.sail
+++ b/model/riscv_insts_zicbom.sail
@@ -66,12 +66,11 @@ function cbop_priv_check(p: Privilege) -> checked_cbop = {
 val process_clean_inval : (regidx, cbop_zicbom) -> ExecutionResult
 function process_clean_inval(rs1, cbop) = {
   let rs1_val = X(rs1);
-  let cache_block_size_exp = plat_cache_block_size_exp();
-  let cache_block_size = 2 ^ cache_block_size_exp;
+  let cache_block_size = 2 ^ plat_cache_block_size_exp;
 
   // Offset from rs1 to the beginning of the cache block. This is 0 if rs1
   // is aligned to the cache block, or negative if rs1 is misaligned.
-  let negative_offset = (rs1_val & ~(zero_extend(ones(cache_block_size_exp)))) - rs1_val;
+  let negative_offset = (rs1_val & ~(zero_extend(ones(plat_cache_block_size_exp)))) - rs1_val;
 
   // TODO: This is incorrect since CHERI only requires at least one byte
   // to be in bounds here, whereas `ext_data_get_addr()` checks that all bytes

--- a/model/riscv_insts_zicboz.sail
+++ b/model/riscv_insts_zicboz.sail
@@ -25,12 +25,11 @@ mapping clause assembly = ZICBOZ(rs1)
 function clause execute(ZICBOZ(rs1)) = {
   if cbo_zero_enabled(cur_privilege) then {
     let rs1_val = X(rs1);
-    let cache_block_size_exp = plat_cache_block_size_exp();
-    let cache_block_size = 2 ^ cache_block_size_exp;
+    let cache_block_size = 2 ^ plat_cache_block_size_exp;
 
     // Offset from rs1 to the beginning of the cache block. This is 0 if rs1
     // is aligned to the cache block, or negative if rs1 is misaligned.
-    let negative_offset = (rs1_val & ~(zero_extend(ones(cache_block_size_exp)))) - rs1_val;
+    let negative_offset = (rs1_val & ~(zero_extend(ones(plat_cache_block_size_exp)))) - rs1_val;
 
     match ext_data_get_addr(rs1, negative_offset, Write(Data), cache_block_size) {
       Ext_DataAddr_Error(e) => Ext_DataAddr_Check_Failure(e),

--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -97,7 +97,7 @@ function phys_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext
 // Check if access is permitted according to PMPs and PMAs.
 val phys_access_check : forall 'n, 0 < 'n <= max_mem_access . (AccessType(ext_access_type), Privilege, physaddr, int('n)) -> option(ExceptionType)
 function phys_access_check (t, p, paddr, width) = {
-  let pmpError : option(ExceptionType) = if sys_pmp_count() == 0 then None() else pmpCheck(paddr, width, t, p);
+  let pmpError : option(ExceptionType) = if sys_pmp_count == 0 then None() else pmpCheck(paddr, width, t, p);
   // TODO: Also check PMAs and select the highest priority fault.
   pmpError
 }

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -28,30 +28,30 @@ val elf_entry = pure {
 // Cache block size is 2^cache_block_size_exp. Max is `max_mem_access` (4096)
 // because this model performs `cbo.zero` with a single write, and the behaviour
 // with cache blocks larger than a page is not clearly defined.
-function plat_cache_block_size_exp() -> range(0, 12) = config platform.cache_block_size_exp
+let plat_cache_block_size_exp : range(0, 12) = config platform.cache_block_size_exp
 
 /* Main memory */
-function plat_ram_base() -> physaddrbits = to_bits_checked(config platform.ram.base : int)
-function plat_ram_size() -> physaddrbits = to_bits_checked(config platform.ram.size : int)
+register plat_ram_base : physaddrbits = to_bits_checked(config platform.ram.base : int)
+register plat_ram_size : physaddrbits = to_bits_checked(config platform.ram.size : int)
 
 /* whether the MMU should update dirty bits in PTEs */
-function plat_enable_dirty_update() -> bool = config memory.translation.dirty_update
+let plat_enable_dirty_update : bool = config memory.translation.dirty_update
 
 /* whether the platform supports misaligned accesses without trapping to M-mode. if false,
  * misaligned loads/stores are trapped to Machine mode.
  */
-function plat_enable_misaligned_access() -> bool = config memory.misaligned.supported
+let plat_enable_misaligned_access : bool = config memory.misaligned.supported
 
 /* whether mtval stores the bits of a faulting instruction on illegal instruction exceptions */
-function plat_mtval_has_illegal_inst_bits() -> bool = config base.mtval_has_illegal_instruction_bits
+let plat_mtval_has_illegal_inst_bits : bool = config base.mtval_has_illegal_instruction_bits
 
 /* ROM holding reset vector and device-tree DTB */
-function plat_rom_base() -> physaddrbits = to_bits_checked(config platform.rom.base : int)
-function plat_rom_size() -> physaddrbits = to_bits_checked(config platform.rom.size : int)
+register plat_rom_base : physaddrbits = to_bits_checked(config platform.rom.base : int)
+register plat_rom_size : physaddrbits = to_bits_checked(config platform.rom.size : int)
 
 /* Location of clock-interface, which should match with the spec in the DTB */
-function plat_clint_base() -> physaddrbits = to_bits_checked(config platform.clint.base : int)
-function plat_clint_size() -> physaddrbits = to_bits_checked(config platform.clint.size : int)
+register plat_clint_base : physaddrbits = to_bits_checked(config platform.clint.base : int)
+register plat_clint_size : physaddrbits = to_bits_checked(config platform.clint.size : int)
 
 // Whether HTIF (Host Target InterFace) is enabled. This is used for
 // console output and signalling the end of tests.
@@ -59,7 +59,7 @@ val plat_enable_htif = pure "plat_enable_htif" : unit -> bool
 
 /* Location of HTIF ports */
 val plat_htif_tohost = pure {c: "plat_htif_tohost", lem: "plat_htif_tohost"} : unit -> physaddrbits
-function plat_htif_tohost () = to_bits_checked(elf_tohost())
+function plat_htif_tohost () = zeros()
 // todo: fromhost
 
 /* Physical memory map predicates */
@@ -70,10 +70,10 @@ function within_phys_mem forall 'n, 'n <= max_mem_access. (Physaddr(addr) : phys
    * on unsigned unbounded integers.
    */
   let addr_int     = unsigned(addr);
-  let ram_base_int = unsigned(plat_ram_base ());
-  let rom_base_int = unsigned(plat_rom_base ());
-  let ram_size_int = unsigned(plat_ram_size ());
-  let rom_size_int = unsigned(plat_rom_size ());
+  let ram_base_int = unsigned(plat_ram_base);
+  let rom_base_int = unsigned(plat_rom_base);
+  let ram_size_int = unsigned(plat_ram_size);
+  let rom_size_int = unsigned(plat_rom_size);
 
   /* todo: iterate over segment list */
   if      (  ram_base_int <= addr_int
@@ -84,10 +84,10 @@ function within_phys_mem forall 'n, 'n <= max_mem_access. (Physaddr(addr) : phys
   then    true
   else {
     print_platform("within_phys_mem: " ^ BitStr(addr) ^ " not within phys-mem:");
-    print_platform("  plat_rom_base: " ^ BitStr(plat_rom_base ()));
-    print_platform("  plat_rom_size: " ^ BitStr(plat_rom_size ()));
-    print_platform("  plat_ram_base: " ^ BitStr(plat_ram_base ()));
-    print_platform("  plat_ram_size: " ^ BitStr(plat_ram_size ()));
+    print_platform("  plat_rom_base: " ^ BitStr(plat_rom_base));
+    print_platform("  plat_rom_size: " ^ BitStr(plat_rom_size));
+    print_platform("  plat_ram_base: " ^ BitStr(plat_ram_base));
+    print_platform("  plat_ram_size: " ^ BitStr(plat_ram_size));
     false
   }
 }
@@ -98,8 +98,8 @@ function within_clint forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : ph
    * on unsigned unbounded integers.
    */
   let addr_int       = unsigned(addr);
-  let clint_base_int = unsigned(plat_clint_base ());
-  let clint_size_int = unsigned(plat_clint_size ());
+  let clint_base_int = unsigned(plat_clint_base);
+  let clint_size_int = unsigned(plat_clint_size);
     clint_base_int <= addr_int
   & (addr_int + sizeof('n)) <= (clint_base_int + clint_size_int)
 }
@@ -112,7 +112,7 @@ function within_htif_readable forall 'n, 0 < 'n <= max_mem_access . (Physaddr(ad
 
 /* CLINT (Core Local Interruptor), based on Spike. */
 
-function plat_insns_per_tick() -> int = config platform.instructions_per_tick
+let plat_insns_per_tick : int = config platform.instructions_per_tick
 
 // Each hart has a memory-mapped mtimecmp register. Typically these are
 // exposed as an array in CLINT. The CLINT implementation here is currently
@@ -144,7 +144,7 @@ let MTIME_BASE_HI    : physaddrbits = zero_extend(0x0bffc)
 
 val clint_load : forall 'n, 'n > 0. (AccessType(ext_access_type), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
 function clint_load(t, Physaddr(addr), width) = {
-  let addr = addr - plat_clint_base ();
+  let addr = addr - plat_clint_base;
   /* FIXME: For now, only allow exact aligned access. */
   if addr == MSIP_BASE & ('n == 8 | 'n == 4)
   then {
@@ -214,7 +214,7 @@ function clint_dispatch() -> unit = {
 
 val clint_store: forall 'n, 'n > 0. (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
 function clint_store(Physaddr(addr), width, data) = {
-  let addr = addr - plat_clint_base ();
+  let addr = addr - plat_clint_base;
   if addr == MSIP_BASE & ('n == 8 | 'n == 4) then {
     if   get_config_print_platform()
     then print_platform("clint[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mip.MSI <- " ^ BitStr(data[0]) ^ ")");
@@ -431,7 +431,7 @@ function init_platform() -> unit = {
 /* Platform-specific handling of instruction faults */
 
 function handle_illegal(instbits : instbits) -> unit = {
-  let info = if plat_mtval_has_illegal_inst_bits()
+  let info = if   plat_mtval_has_illegal_inst_bits
              then Some(zero_extend(xlen, instbits))
              else None();
   let t : sync_exception = struct { trap    = E_Illegal_Instr(),

--- a/model/riscv_pmp_control.sail
+++ b/model/riscv_pmp_control.sail
@@ -59,7 +59,7 @@ function pmpMatchAddr(
     },
     NA4 => {
       // NA4 is not selectable when the PMP grain G >= 1. See pmpWriteCfg().
-      assert(sys_pmp_grain() < 1, "NA4 cannot be selected when PMP grain G >= 1.");
+      assert(sys_pmp_grain < 1, "NA4 cannot be selected when PMP grain G >= 1.");
       // Match a 4-byte region.
       let begin = unsigned(pmpaddr) * 4;
       pmpRangeMatch(begin, begin + 4, addr, width)
@@ -123,11 +123,6 @@ function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
 }
 
 function reset_pmp() -> unit = {
-  assert(
-    sys_pmp_count() == 0 | sys_pmp_count() == 16 | sys_pmp_count() == 64,
-    "sys_pmp_count() must be 0, 16, or 64"
-  );
-
   foreach (i from 0 to 63) {
     // On reset the PMP register's A and L bits are set to 0 unless the platform
     // mandates a different value.

--- a/model/riscv_pmp_regs.sail
+++ b/model/riscv_pmp_regs.sail
@@ -6,6 +6,15 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
+/* Platform configuration */
+
+/* How many PMP entries are implemented. This must be 0, 16 or 64 (this is checked at runtime). */
+let sys_pmp_count : {0, 16, 64} = config memory.pmp.count
+
+/* G parameter that specifies the PMP grain size. The grain size is 2^(G+2), e.g.
+   G=0 -> 4 bytes, G=10 -> 4096 bytes. */
+let sys_pmp_grain : range(0, 63) = config memory.pmp.grain
+
 /* PMP configuration entries */
 
 enum PmpAddrMatchType = {OFF, TOR, NA4, NAPOT}
@@ -67,7 +76,7 @@ function pmpReadCfgReg(n : range(0, 15)) -> xlenbits = {
 }
 
 function pmpReadAddrReg(n : range(0, 63)) -> xlenbits = {
-  let G = sys_pmp_grain();
+  let G = sys_pmp_grain;
   let match_type = pmpcfg_n[n][A];
   let addr = pmpaddr_n[n];
 
@@ -109,7 +118,7 @@ function pmpWriteCfg(n: range(0, 63), cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent
     // "When G >= 1, the NA4 mode is not selectable."
     // In this implementation we set it to OFF if NA4 is selected.
     // This is the least risky option from a security perspective.
-    let cfg = if sys_pmp_grain() >= 1 & pmpAddrMatchType_of_bits(cfg[A]) == NA4
+    let cfg = if sys_pmp_grain >= 1 & pmpAddrMatchType_of_bits(cfg[A]) == NA4
               then [cfg with A = pmpAddrMatchType_to_bits(OFF)]
               else cfg;
 
@@ -231,7 +240,7 @@ mapping clause csr_name_map = 0x3EE  <-> "pmpaddr62"
 mapping clause csr_name_map = 0x3EF  <-> "pmpaddr63"
 
 // pmpcfgN
-function clause is_CSR_defined(0x3A) @ idx : bits(4) = sys_pmp_count() > unsigned(idx) & (idx[0] == bitzero | xlen == 32)
+function clause is_CSR_defined(0x3A) @ idx : bits(4) = sys_pmp_count > unsigned(idx) & (idx[0] == bitzero | xlen == 32)
 function clause read_CSR(0x3A @ idx : bits(4) if idx[0] == bitzero | xlen == 32) = pmpReadCfgReg(unsigned(idx))
 function clause write_CSR((0x3A @ idx : bits(4), value) if idx[0] == bitzero | xlen == 32) = {
   let idx = unsigned(idx);
@@ -240,10 +249,10 @@ function clause write_CSR((0x3A @ idx : bits(4), value) if idx[0] == bitzero | x
 }
 
 // pmpaddrN. Unfortunately the PMP index does not nicely align with the CSR index bits.
-function clause is_CSR_defined(0x3B) @ idx : bits(4) = sys_pmp_count() > unsigned(0b00 @ idx)
-function clause is_CSR_defined(0x3C) @ idx : bits(4) = sys_pmp_count() > unsigned(0b01 @ idx)
-function clause is_CSR_defined(0x3D) @ idx : bits(4) = sys_pmp_count() > unsigned(0b10 @ idx)
-function clause is_CSR_defined(0x3E) @ idx : bits(4) = sys_pmp_count() > unsigned(0b11 @ idx)
+function clause is_CSR_defined(0x3B) @ idx : bits(4) = sys_pmp_count > unsigned(0b00 @ idx)
+function clause is_CSR_defined(0x3C) @ idx : bits(4) = sys_pmp_count > unsigned(0b01 @ idx)
+function clause is_CSR_defined(0x3D) @ idx : bits(4) = sys_pmp_count > unsigned(0b10 @ idx)
+function clause is_CSR_defined(0x3E) @ idx : bits(4) = sys_pmp_count > unsigned(0b11 @ idx)
 
 function clause read_CSR(0x3B @ idx : bits(4)) = pmpReadAddrReg(unsigned(0b00 @ idx))
 function clause read_CSR(0x3C @ idx : bits(4)) = pmpReadAddrReg(unsigned(0b01 @ idx))

--- a/model/riscv_sscofpmf.sail
+++ b/model/riscv_sscofpmf.sail
@@ -44,7 +44,7 @@ mapping clause csr_name_map = 0xDA0  <-> "scountovf"
 function read_mhpmeventh(index : hpmidx) -> bits(32) = mhpmevent[index].bits[63 .. 32]
 
 function write_mhpmeventh(index : hpmidx, value : bits(32)) -> unit =
-  if sys_writable_hpm_counters()[index] == bitone then
+  if sys_writable_hpm_counters[index] == bitone then
   mhpmevent[index] = legalize_hpmevent(Mk_HpmEvent(value @ mhpmevent[index].bits[31 .. 0]))
 
 // mhpmevent3..31h

--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -245,7 +245,6 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
 }
 
 function loop () : unit -> unit = {
-  let insns_per_tick = plat_insns_per_tick();
   var i : nat = 0;
   var step_no : nat = 0;
   while not(htif_done) do {
@@ -268,7 +267,7 @@ function loop () : unit -> unit = {
     } else {
       /* update time */
       i = i + 1;
-      if i == insns_per_tick then {
+      if i == plat_insns_per_tick then {
         tick_clock();
         i = 0;
       }

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -907,8 +907,8 @@ val get_16_random_bits = impure {
 register vstart : bits(16) /* use the largest possible length of vstart */
 register vl     : xlenbits
 
-let get_vlenb : xlenbits =
-  to_bits(2 ^ get_vlen_pow / 8)
+let VLENB : xlenbits =
+  to_bits(2 ^ VLEN_pow / 8)
 
 bitfield Vtype  : xlenbits = {
   vill      : xlen - 1,

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -83,21 +83,14 @@ register misa : Misa =
   ]
 
 /* whether misa is R/W */
-function sys_enable_writable_misa() -> bool = config base.writable_misa
+let sys_enable_writable_misa : bool = config base.writable_misa
 
 /* Whether FIOM bit of menvcfg/senvcfg is enabled. It must be enabled if
    supervisor mode is implemented and non-bare addressing modes are supported. */
-function sys_enable_writable_fiom() -> bool = config base.writable_fiom
-
-/* How many PMP entries are implemented. This must be 0, 16 or 64 (this is checked at runtime). */
-function sys_pmp_count() -> {0, 16, 64} = config memory.pmp.count
-
-/* G parameter that specifies the PMP grain size. The grain size is 2^(G+2), e.g.
-   G=0 -> 4 bytes, G=10 -> 4096 bytes. */
-function sys_pmp_grain() -> range(0, 63) = config memory.pmp.grain
+let sys_enable_writable_fiom : bool = config base.writable_fiom
 
 /* Which HPM counters are supported (as a bit mask). Bits [2 .. 0] are ignored. */
-function sys_writable_hpm_counters() -> bits(32) = config base.writable_hpm_counters
+let sys_writable_hpm_counters : bits(32) = config base.writable_hpm_counters
 
 // Supervisor timecmp
 function clause currentlyEnabled(Ext_Sstc) = hartSupports(Ext_Sstc)
@@ -110,7 +103,7 @@ val ext_veto_disable_C : unit -> bool
 function legalize_misa(m : Misa, v : xlenbits) -> Misa = {
   let v = Mk_Misa(v);
   /* Suppress updates to MISA if MISA is not writable or if by disabling C next PC would become misaligned or an extension vetoes */
-  if   not(sys_enable_writable_misa()) | (v[C] == 0b0 & (nextPC[1] == bitone | ext_veto_disable_C()))
+  if   not(sys_enable_writable_misa) | (v[C] == 0b0 & (nextPC[1] == bitone | ext_veto_disable_C()))
   then m
   else [m with
     A = if hartSupports(Ext_A) then v[A] else 0b0,
@@ -348,7 +341,7 @@ bitfield SEnvcfg : xlenbits = {
 function legalize_menvcfg(o : MEnvcfg, v : bits(64)) -> MEnvcfg = {
   let v = Mk_MEnvcfg(v);
   [o with
-    FIOM = if sys_enable_writable_fiom() then v[FIOM] else 0b0,
+    FIOM = if sys_enable_writable_fiom then v[FIOM] else 0b0,
     CBZE = if currentlyEnabled(Ext_Zicboz) then v[CBZE] else 0b0,
     CBCFE = if currentlyEnabled(Ext_Zicbom) then v[CBCFE] else 0b0,
     CBIE = if currentlyEnabled(Ext_Zicbom) then (if v[CBIE] != 0b10 then v[CBIE] else 0b00) else 0b00,
@@ -360,7 +353,7 @@ function legalize_menvcfg(o : MEnvcfg, v : bits(64)) -> MEnvcfg = {
 function legalize_senvcfg(o : SEnvcfg, v : xlenbits) -> SEnvcfg = {
   let v = Mk_SEnvcfg(v);
   [o with
-    FIOM = if sys_enable_writable_fiom() then v[FIOM] else 0b0,
+    FIOM = if sys_enable_writable_fiom then v[FIOM] else 0b0,
     CBZE = if currentlyEnabled(Ext_Zicboz) then v[CBZE] else 0b0,
     CBCFE = if currentlyEnabled(Ext_Zicbom) then v[CBCFE] else 0b0,
     CBIE = if currentlyEnabled(Ext_Zicbom) then (if v[CBIE] != 0b10 then v[CBIE] else 0b00) else 0b00,
@@ -585,7 +578,7 @@ bitfield Counteren : bits(32) = {
 
 // scounteren
 function legalize_scounteren(c : Counteren, v : xlenbits) -> Counteren = {
-  let supported_counters = sys_writable_hpm_counters()[31 .. 3] @ 0b111;
+  let supported_counters = sys_writable_hpm_counters[31 .. 3] @ 0b111;
   Mk_Counteren(v[31 .. 0] & supported_counters)
 }
 
@@ -597,7 +590,7 @@ function clause write_CSR(0x106, value) = { scounteren = legalize_scounteren(sco
 
 // mcounteren
 function legalize_mcounteren(c : Counteren, v : xlenbits) -> Counteren = {
-  let supported_counters = sys_writable_hpm_counters()[31 .. 3] @ 0b111;
+  let supported_counters = sys_writable_hpm_counters[31 .. 3] @ 0b111;
   Mk_Counteren(v[31 .. 0] & supported_counters)
 }
 
@@ -617,7 +610,7 @@ bitfield Counterin : bits(32) = {
 
 function legalize_mcountinhibit(c : Counterin, v : xlenbits) -> Counterin = {
   // Note the 0 in 0b101 is because the mtimer counter can't be paused.
-  let supported_counters = sys_writable_hpm_counters()[31 .. 3] @ 0b101;
+  let supported_counters = sys_writable_hpm_counters[31 .. 3] @ 0b101;
   Mk_Counterin(v[31 .. 0] & supported_counters)
 }
 
@@ -914,8 +907,8 @@ val get_16_random_bits = impure {
 register vstart : bits(16) /* use the largest possible length of vstart */
 register vl     : xlenbits
 
-function get_vlenb() -> xlenbits =
-  to_bits(2 ^ (get_vlen_pow()) / 8)
+let get_vlenb : xlenbits =
+  to_bits(2 ^ get_vlen_pow / 8)
 
 bitfield Vtype  : xlenbits = {
   vill      : xlen - 1,

--- a/model/riscv_vext_control.sail
+++ b/model/riscv_vext_control.sail
@@ -14,7 +14,7 @@ function clause currentlyEnabled(Ext_V) = hartSupports(Ext_V) & (misa[V] == 0b1)
 
 function set_vstart(value : bits(16)) -> unit = {
   dirty_v_context();
-  let vstart_length = get_vlen_pow();
+  let vstart_length = get_vlen_pow;
   vstart = zero_extend(value[(vstart_length - 1) .. 0]);
   csr_write_callback("vstart", zero_extend(vstart));
 }
@@ -41,7 +41,7 @@ function clause read_CSR(0x00A) = zero_extend(vcsr[vxrm])
 function clause read_CSR(0x00F) = zero_extend(vcsr.bits)
 function clause read_CSR(0xC20) = vl
 function clause read_CSR(0xC21) = vtype.bits
-function clause read_CSR(0xC22) = get_vlenb()
+function clause read_CSR(0xC22) = get_vlenb
 
 function clause write_CSR(0x008, value) = { set_vstart(value[15 .. 0]); zero_extend(vstart) }
 function clause write_CSR(0x009, value) = { ext_write_vcsr (vcsr[vxrm], value[0 .. 0]); zero_extend(vcsr[vxsat]) }

--- a/model/riscv_vext_control.sail
+++ b/model/riscv_vext_control.sail
@@ -14,8 +14,7 @@ function clause currentlyEnabled(Ext_V) = hartSupports(Ext_V) & (misa[V] == 0b1)
 
 function set_vstart(value : bits(16)) -> unit = {
   dirty_v_context();
-  let vstart_length = get_vlen_pow;
-  vstart = zero_extend(value[(vstart_length - 1) .. 0]);
+  vstart = zero_extend(value[(VLEN_pow - 1) .. 0]);
   csr_write_callback("vstart", zero_extend(vstart));
 }
 
@@ -41,7 +40,7 @@ function clause read_CSR(0x00A) = zero_extend(vcsr[vxrm])
 function clause read_CSR(0x00F) = zero_extend(vcsr.bits)
 function clause read_CSR(0xC20) = vl
 function clause read_CSR(0xC21) = vtype.bits
-function clause read_CSR(0xC22) = get_vlenb
+function clause read_CSR(0xC22) = VLENB
 
 function clause write_CSR(0x008, value) = { set_vstart(value[15 .. 0]); zero_extend(vstart) }
 function clause write_CSR(0x009, value) = { ext_write_vcsr (vcsr[vxrm], value[0 .. 0]); zero_extend(vcsr[vxsat]) }

--- a/model/riscv_vlen.sail
+++ b/model/riscv_vlen.sail
@@ -6,15 +6,15 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-function get_elen_pow() -> range(3, 16) = config extensions.V.elen_exp
+let get_elen_pow : range(3, 16) = config extensions.V.elen_exp
 
 /* Note: ELEN=32 requires a different encoding of the CSR vtype.
  * The current version of vtype implementation corresponds to the ELEN=64 configuration.
  * TODO: the configurarion of ELEN and its corresponding vtype implementations.
  */
 
-function get_vlen_pow() -> range(3, 16) = config extensions.V.vlen_exp
+let get_vlen_pow : range(3, 16) = config extensions.V.vlen_exp
 
 type vlenmax : Int = 65536
 
-let VLEN = 2 ^ get_vlen_pow()
+let VLEN = 2 ^ get_vlen_pow

--- a/model/riscv_vlen.sail
+++ b/model/riscv_vlen.sail
@@ -6,15 +6,15 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-let get_elen_pow : range(3, 16) = config extensions.V.elen_exp
+let ELEN_pow : range(3, 16) = config extensions.V.elen_exp
 
 /* Note: ELEN=32 requires a different encoding of the CSR vtype.
  * The current version of vtype implementation corresponds to the ELEN=64 configuration.
  * TODO: the configurarion of ELEN and its corresponding vtype implementations.
  */
 
-let get_vlen_pow : range(3, 16) = config extensions.V.vlen_exp
+let VLEN_pow : range(3, 16) = config extensions.V.vlen_exp
 
 type vlenmax : Int = 65536
 
-let VLEN = 2 ^ get_vlen_pow
+let VLEN = 2 ^ VLEN_pow

--- a/model/riscv_vmem.sail
+++ b/model/riscv_vmem.sail
@@ -245,7 +245,7 @@ function translate_TLB_hit forall 'v, is_sv_mode('v) . (
         None()     => TR_Address(tlb_get_ppn(sv_width, ent, vpn), ext_ptw),
         Some(pte') =>
           // Step 9 of VATP. See riscv_platform.sail.
-          if not(plat_enable_dirty_update()) then
+          if not(plat_enable_dirty_update) then
             // pte needs dirty/accessed update but that is not enabled
             TR_Failure(PTW_PTE_Update(), ext_ptw)
           else {
@@ -293,7 +293,7 @@ function translate_TLB_miss forall 'v, is_sv_mode('v) . (
         },
         Some(pte) =>
           // Step 9 of VATP. See riscv_platform.sail.
-          if not(plat_enable_dirty_update()) then
+          if not(plat_enable_dirty_update) then
             // pte needs dirty/accessed update but that is not enabled
             TR_Failure(PTW_PTE_Update(), ext_ptw)
           else {

--- a/model/riscv_vmem_utils.sail
+++ b/model/riscv_vmem_utils.sail
@@ -29,14 +29,14 @@
 /* This is a external option that controls the order in which the model
  * performs misaligned accesses.
  */
-function sys_misaligned_order_decreasing() -> bool = config memory.misaligned.order_decreasing
+let sys_misaligned_order_decreasing : bool = config memory.misaligned.order_decreasing
 
 /* This is an external option that, when true, causes all misaligned accesses
  * to be split into single byte operations.  Otherwise, misaligned accesses
  * are split into multiple accesses of smaller widths such that each of the latter
  * accesses is aligned.
  */
-function sys_misaligned_byte_by_byte() -> bool = config memory.misaligned.byte_by_byte
+let sys_misaligned_byte_by_byte : bool = config memory.misaligned.byte_by_byte
 
 /* This is an external option that returns an integer N, such that
  * when N is greater than zero, misaligned accesses to physical memory
@@ -44,7 +44,7 @@ function sys_misaligned_byte_by_byte() -> bool = config memory.misaligned.byte_b
  * naturally aligned 2^N byte region.  This region must be smaller than
  * the page size (i.e. 2^12 = 4096 bytes).
  */
-function sys_misaligned_allowed_within_exp() -> range(0, 11) = config memory.misaligned.allowed_within_exp
+let sys_misaligned_allowed_within_exp : range(0, 11) = config memory.misaligned.allowed_within_exp
 
 /* Check if an 'n byte access for an address is within an aligned 2^'r byte region */
 val access_within : forall 'width 'n 'r, 0 <= 'r <= 'width & 1 <= 'n <= 2^'r.
@@ -73,7 +73,7 @@ function prop_access_within_single(addr : bits(32)) -> bool = {
 val allowed_misaligned : forall 'width, 'width > 0. (xlenbits, int('width)) -> bool
 
 function allowed_misaligned(vaddr, width) = {
-  let region_width_exp = sys_misaligned_allowed_within_exp();
+  let region_width_exp = sys_misaligned_allowed_within_exp;
   let region_width = 2 ^ region_width_exp;
 
   if width > region_width then return false;
@@ -87,7 +87,7 @@ val split_misaligned : forall 'width, 'width > 0.
 function split_misaligned(vaddr, width) = {
   let vaddr_bits = bits_of(vaddr);
   if is_aligned_addr(vaddr, width) | allowed_misaligned(vaddr_bits, width) then (1, width)
-  else if sys_misaligned_byte_by_byte() then (width, 1)
+  else if sys_misaligned_byte_by_byte then (width, 1)
   else {
     let bytes_per_access = 2 ^ count_trailing_zeros(vaddr_bits);
     let num_accesses = width / bytes_per_access;
@@ -104,7 +104,7 @@ val misaligned_order : forall 'n.
   int('n) -> {'first 'last 'step, valid_misaligned_order('n, 'first, 'last, 'step). (int('first), int('last), int('step))}
 
 function misaligned_order(n) = {
-  if sys_misaligned_order_decreasing() then {
+  if sys_misaligned_order_decreasing then {
     (n - 1, 0, -1)
   } else {
     (0, n - 1, 1)
@@ -166,7 +166,7 @@ function vmem_write_addr(vaddr, width, data, acc, aq, rl, res) = {
 /****    External API    ****/
 
 function check_misaligned(vaddr : virtaddr, width : word_width) -> bool = {
-  if plat_enable_misaligned_access() then {
+  if plat_enable_misaligned_access then {
     false
   } else {
     not(is_aligned_addr(vaddr, size_bytes(width)))

--- a/model/riscv_zihpm.sail
+++ b/model/riscv_zihpm.sail
@@ -210,13 +210,13 @@ function read_mhpmevent(index : hpmidx) -> xlenbits = mhpmevent[index].bits[(xle
 
 // Write the HPM CSRs. These return the new value of the CSR, for use in writeCSR.
 function write_mhpmcounter(index : hpmidx, value : xlenbits) -> unit =
-  if sys_writable_hpm_counters()[index] == bitone then mhpmcounter[index][(xlen - 1) .. 0] = value
+  if sys_writable_hpm_counters[index] == bitone then mhpmcounter[index][(xlen - 1) .. 0] = value
 
 function write_mhpmcounterh(index : hpmidx, value : bits(32)) -> unit =
-  if sys_writable_hpm_counters()[index] == bitone then mhpmcounter[index][63 .. 32] = value
+  if sys_writable_hpm_counters[index] == bitone then mhpmcounter[index][63 .. 32] = value
 
 function write_mhpmevent(index : hpmidx, value : xlenbits) -> unit =
-  if sys_writable_hpm_counters()[index] == bitone then
+  if sys_writable_hpm_counters[index] == bitone then
   mhpmevent[index] = legalize_hpmevent(Mk_HpmEvent(match xlen {
     32 => mhpmevent[index].bits[63 .. 32] @ value,
     64 => value,


### PR DESCRIPTION
This was a legacy of the configuration via cli option approach.
    
Parameters initialized via `to_bits_checked()` are set to `register` values, since top-level `let` bindings seem to require pure initializers and the assert in `to_bits_checked()` is not pure.

PMP config parameters were moved to`riscv_pmp_regs.sail` from `riscv_sys_regs.sail`, and a now redundant assert was removed from `reset_pmp()`.

Rename the vector config parameters since they are not `get_` functions anymore. This results in a slight simplification of vector code using these parameters.
