### PR TITLE
Use correct register prefix in `freg_write_callback`

### DIFF
--- a/c_emulator/riscv_callbacks.cpp
+++ b/c_emulator/riscv_callbacks.cpp
@@ -86,7 +86,7 @@ unit freg_write_callback(unsigned reg, uint64_t value)
   if (config_print_reg) {
     // TODO: Might need to change from PRIX64 to PRIX128 once the "Q" extension
     // is supported
-    fprintf(trace_log, "x%d <- 0x%0*" PRIX64 "\n", reg,
+    fprintf(trace_log, "f%d <- 0x%0*" PRIX64 "\n", reg,
             static_cast<int>(zflen / 4), value);
   }
   return UNIT;


### PR DESCRIPTION
This is seemingly a silly copy-paste typo from 90de2d05.

Example of erroneous logs:

```
[0] [M]: 0x0000000000210868 (0xF4068CD3) fmv.h.x fs9, a3
x25 <- 0xFFFFFFFFFFFF463F
```

Here `x25` should be `f25`.