### PR TITLE
Fix printf in first party test

### DIFF
--- a/test/first_party/src/common/runtime.c
+++ b/test/first_party/src/common/runtime.c
@@ -6,7 +6,7 @@ int printf(const char *fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
-  int rc = npf_pprintf(&htif_putc, NULL, fmt, ap);
+  int rc = npf_vpprintf(&htif_putc, NULL, fmt, ap);
   va_end(ap);
   return rc;
 }


### PR DESCRIPTION
fix #944 

Passing va to ... is invalid, but I didn't find an offical doc
