### PR TITLE
Remove regidx_to_regno functions etc.

### DIFF
--- a/model/riscv_fdext_regs.sail
+++ b/model/riscv_fdext_regs.sail
@@ -54,9 +54,7 @@ function nan_unbox(m, x) = if 'n == 'm then x else (
 
 newtype fregidx = Fregidx : bits(5)
 newtype fregno = Fregno : range(0, 31)
-function fregidx_to_fregno (Fregidx(b) : fregidx) -> fregno = Fregno(unsigned(b))
-function fregno_to_fregidx (Fregno(b) : fregno) -> fregidx = Fregidx(to_bits(5, b))
-function fregidx_offset(Fregidx(r) : fregidx, o : bits(5)) -> fregidx = Fregidx(r + o)
+
 function fregidx_bits(Fregidx(r) : fregidx) -> bits(5) = r
 
 function cregidx_to_fregidx (Cregidx(b) : cregidx) -> fregidx = Fregidx(0b01 @ b)
@@ -195,17 +193,16 @@ function wF (Fregno(r) : fregno, in_v : flenbits) -> unit = {
     29 => f29 = v,
     30 => f30 = v,
     31 => f31 = v,
-    _  => assert(false, "invalid floating point register number")
   };
 
-  freg_write_callback(fregno_to_fregidx(Fregno(r)), in_v);
+  freg_write_callback(Fregidx(to_bits(r)), in_v);
   dirty_fd_context();
 }
 
-function rF_bits(i: fregidx) -> flenbits = rF(fregidx_to_fregno(i))
+function rF_bits(Fregidx(i) : fregidx) -> flenbits = rF(Fregno(unsigned(i)))
 
-function wF_bits(i: fregidx, data: flenbits) -> unit = {
-  wF(fregidx_to_fregno(i)) = data
+function wF_bits(Fregidx(i) : fregidx, data: flenbits) -> unit = {
+  wF(Fregno(unsigned(i))) = data
 }
 
 overload F = {rF_bits, wF_bits, rF, wF}

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -101,7 +101,7 @@ mapping creg_name_raw : bits(3) <-> string = {
 
 mapping creg_name : cregidx <-> string = { Cregidx(i) <-> creg_name_raw(i) }
 
-function xreg_write_callback(reg: regidx, value : xlenbits) -> unit = {
+function xreg_write_callback(reg : regidx, value : xlenbits) -> unit = {
   let name = reg_name(reg);
   xreg_full_write_callback(name, reg, value);
 }
@@ -175,7 +175,6 @@ function rX (Regno(r) : regno) -> xlenbits = {
       29 => x29,
       30 => x30,
       31 => x31,
-      _  => {assert(false, "invalid register number"); zero_reg}
     };
   regval_from_reg(v)
 }
@@ -215,15 +214,14 @@ function wX (Regno(r) : regno, in_v : xlenbits) -> unit = {
     29 => x29 = v,
     30 => x30 = v,
     31 => x31 = v,
-    _  => assert(false, "invalid register number")
   };
-  if (r != 0) then xreg_write_callback(regno_to_regidx(Regno(r)), in_v)
+  if r != 0 then xreg_write_callback(Regidx(to_bits(r)), in_v)
 }
 
-function rX_bits(i: regidx) -> xlenbits = rX(regidx_to_regno(i))
+function rX_bits(Regidx(i) : regidx) -> xlenbits = rX(Regno(unsigned(i)))
 
-function wX_bits(i: regidx, data: xlenbits) -> unit = {
-  wX(regidx_to_regno(i)) = data
+function wX_bits(Regidx(i) : regidx, data : xlenbits) -> unit = {
+  wX(Regno(unsigned(i))) = data
 }
 
 overload X = {rX_bits, wX_bits, rX, wX}

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -27,14 +27,11 @@ newtype cregidx = Cregidx : bits(3) /* identifiers in RVC instructions */
 type csreg = bits(12)  /* CSR addressing */
 
 function regidx_offset(Regidx(r) : regidx, o : bits(5)) -> regidx = Regidx(r + o)
-function regidx_bits (Regidx(b) : regidx) -> bits(5) = b
+function regidx_bits(Regidx(b) : regidx) -> bits(5) = b
 
 /* register file indexing */
 
 newtype regno = Regno : range(0, 31)
-
-function regidx_to_regno (Regidx(b) : regidx) -> regno = Regno(unsigned(b))
-function regno_to_regidx (Regno(b) : regno) -> regidx = Regidx(to_bits(5, b))
 
 /* mapping RVC register indices into normal indices */
 val creg2reg_idx : cregidx -> regidx


### PR DESCRIPTION
I was going to change these functions to a mapping, but I think we don't really need them at all.

I also removed some redundant `assert()`s for invalid register numbers.