### PR TITLE
fix: c.sh has operands reversed

### DIFF
--- a/model/riscv_insts_zcb.sail
+++ b/model/riscv_insts_zcb.sail
@@ -87,7 +87,7 @@ mapping clause encdec_compressed = C_SH(uimm1 @ 0b0, rs1c, rs2c)
   when currentlyEnabled(Ext_Zcb)
 
 mapping clause assembly = C_SH(uimm, rs1c, rs2c) <->
-  "c.sh" ^ spc() ^ creg_name(rs1c) ^ sep() ^ hex_bits_2(uimm) ^ opt_spc() ^ "(" ^ opt_spc() ^ creg_name(rs2c) ^ opt_spc() ^ ")"
+  "c.sh" ^ spc() ^ creg_name(rs2c) ^ sep() ^ hex_bits_2(uimm) ^ opt_spc() ^ "(" ^ opt_spc() ^ creg_name(rs1c) ^ opt_spc() ^ ")"
 
 function clause execute C_SH(uimm, rs1c, rs2c) = {
   let imm : bits(12) = zero_extend(uimm);


### PR DESCRIPTION
Per The RISC-V Instruction Set Manual, Volume I: Unprivileged Architecture, Version 20250508, the assembly syntax for `c.sh` is:
```
c.sh rs2', uimm(rs1')
```

But, the Sail code has (edited for brevity):
```
"c.sh" ^ spc() ^ creg_name(rs1c) ^ sep() ^ (uimm) ^ "(" ^ creg_name(rs2c) ^ ")"
```

Reverse the fields in the Sail code to match the spec.