### PR TITLE
fix: c.sw,c.sd have assembly operands reversed, missing parens

### DIFF
--- a/model/riscv_insts_zca.sail
+++ b/model/riscv_insts_zca.sail
@@ -58,7 +58,7 @@ function clause execute (C_LW(uimm, rsc, rdc)) = {
 }
 
 mapping clause assembly = C_LW(uimm, rsc, rdc)
-  <-> "c.lw" ^ spc() ^ creg_name(rdc) ^ sep() ^ creg_name(rsc) ^ sep() ^ hex_bits_7(uimm @ 0b00)
+  <-> "c.lw" ^ spc() ^ creg_name(rdc) ^ sep() ^ hex_bits_7(uimm @ 0b00) ^ "(" ^ creg_name(rsc) ^ ")"
 
 /* ****************************************************************** */
 union clause ast = C_LD : (bits(5), cregidx, cregidx)
@@ -75,7 +75,7 @@ function clause execute (C_LD(uimm, rsc, rdc)) = {
 }
 
 mapping clause assembly = C_LD(uimm, rsc, rdc)
-  <-> "c.ld" ^ spc() ^ creg_name(rdc) ^ sep() ^ creg_name(rsc) ^ sep() ^ hex_bits_8(uimm @ 0b000)
+  <-> "c.ld" ^ spc() ^ creg_name(rdc) ^ sep() ^ hex_bits_8(uimm @ 0b000) ^ "(" ^ creg_name(rsc) ^ ")"
   when xlen == 64
 
 /* ****************************************************************** */
@@ -93,7 +93,7 @@ function clause execute (C_SW(uimm, rsc1, rsc2)) = {
 }
 
 mapping clause assembly = C_SW(uimm, rsc1, rsc2)
-  <-> "c.sw" ^ spc() ^ creg_name(rsc1) ^ sep() ^ creg_name(rsc2) ^ sep() ^ hex_bits_7(uimm @ 0b00)
+  <-> "c.sw" ^ spc() ^ creg_name(rsc2) ^ sep() ^ hex_bits_7(uimm @ 0b00) ^ "(" ^ creg_name(rsc1) ^ ")"
 
 /* ****************************************************************** */
 union clause ast = C_SD : (bits(5), cregidx, cregidx)
@@ -112,7 +112,7 @@ function clause execute (C_SD(uimm, rsc1, rsc2)) = {
 
 mapping clause assembly = C_SD(uimm, rsc1, rsc2)
       if xlen == 64
-  <-> "c.sd" ^ spc() ^ creg_name(rsc1) ^ sep() ^ creg_name(rsc2) ^ sep() ^ hex_bits_8(uimm @ 0b000)
+  <-> "c.sd" ^ spc() ^ creg_name(rsc2) ^ sep() ^ hex_bits_8(uimm @ 0b000) ^ "(" ^ creg_name(rsc1) ^ ")"
       if xlen == 64
 
 /* ****************************************************************** */


### PR DESCRIPTION
Per The RISC-V Instruction Set Manual, Volume I: Unprivileged Architecture, Version 20250508, the assembly syntax for `c.sh` is:
```
c.sd rs2', offset(rs1')
```

But, the Sail code has:
```
"c.sd" ^ spc() ^ creg_name(rsc1) ^ sep() ^ creg_name(rsc2) ^ sep() ^ hex_bits_8(uimm @ 0b000)
```
Reverse the fields in the Sail code to match the spec.

Note also that syntax described by the Sail expression would be:
```
c.sd rs1',rs2',uimm
```

So, fix that to match the spec, also, in several places.