### PR TITLE
fix: fcvtmod.w.d requires explicit "rtz"

### DIFF
--- a/model/riscv_insts_zfa.sail
+++ b/model/riscv_insts_zfa.sail
@@ -789,7 +789,7 @@ mapping clause encdec = FCVTMOD_W_D(rs1, rd)
   when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = FCVTMOD_W_D(rs1, rd)
-  <-> "fcvtmod.w.d" ^ spc() ^ reg_name(rd) ^ sep() ^ freg_name(rs1)
+  <-> "fcvtmod.w.d" ^ spc() ^ reg_name(rd) ^ sep() ^ freg_name(rs1) ^ ",rtz"
 
 function clause execute(FCVTMOD_W_D(rs1, rd)) = {
   let rs1_val_D = F_D(rs1);

--- a/model/riscv_insts_zfa.sail
+++ b/model/riscv_insts_zfa.sail
@@ -789,7 +789,7 @@ mapping clause encdec = FCVTMOD_W_D(rs1, rd)
   when currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zfa)
 
 mapping clause assembly = FCVTMOD_W_D(rs1, rd)
-  <-> "fcvtmod.w.d" ^ spc() ^ reg_name(rd) ^ sep() ^ freg_name(rs1) ^ ",rtz"
+  <-> "fcvtmod.w.d" ^ spc() ^ reg_name(rd) ^ sep() ^ freg_name(rs1) ^ sep() ^ "rtz"
 
 function clause execute(FCVTMOD_W_D(rs1, rd)) = {
   let rs1_val_D = F_D(rs1);


### PR DESCRIPTION
Per The RISC-V Instruction Set Manual, Volume I: Unprivileged Architecture, Version 20250508, 25.4 Modular Convert-to-Integer Instruction:
> The assembly syntax requires the RTZ rounding mode to be explicitly
> specified, i.e., `fcvtmod.w.d rd, rs1, rtz`.

But, the Sail code does not accept that third "rtz" operand.

Add the explicit third operand to `fcvtmod.w.d`.