### PR TITLE
Lean CI: use the latest version of sail

### DIFF
--- a/.github/workflows/compile-lean.yml
+++ b/.github/workflows/compile-lean.yml
@@ -30,6 +30,7 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.version }}
 
       - name: Setup opam
+        if: steps.cache-opam-restore.outputs.cache-hit != 'true'
         run: |
           opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
           opam install dune

--- a/.github/workflows/compile-lean.yml
+++ b/.github/workflows/compile-lean.yml
@@ -30,13 +30,11 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.version }}
 
       - name: Setup opam
-        if: steps.cache-opam-restore.outputs.cache-hit != 'true'
         run: |
           opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
           opam install dune
 
       - name: Install Sail
-        if: steps.cache-opam-restore.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/rems-project/sail.git
           eval $(opam env)
@@ -44,7 +42,6 @@ jobs:
           (cd sail; make install)
 
       - name: Save cached opam
-        if: steps.cache-opam-restore.outputs.cache-hit != 'true'
         id: cache-opam-save
         uses: actions/cache/save@v4
         with:


### PR DESCRIPTION
Before this change, we skipped sail build & install when hitting the `.opam` cache. As a result, some random partially outdated sail version was used, instead of the intended latest tip-of-tree of sail. This PR continues to cache opam and sail, but does not skip the sail build & install on a cache hit, but executes them, trusting that the cache will accelerate them. As a result, we get the best of both worlds, fast builds and always the latest sail version.

