### PR TITLE
Move the `get_config_` function out of `riscv_sim.cpp`.

### DIFF
--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -14,6 +14,8 @@ set(EMULATOR_COMMON_SRCS
     riscv_sim.cpp
     riscv_softfloat.c
     riscv_softfloat.h
+    config_utils.h
+    config_utils.cpp
 )
 
 foreach (xlen IN ITEMS 32 64)

--- a/c_emulator/config_utils.cpp
+++ b/c_emulator/config_utils.cpp
@@ -1,0 +1,37 @@
+#include <string>
+#include <iostream>
+
+#include "sail_config.h"
+#include "config_utils.h"
+
+uint64_t get_config_uint64(std::vector<const char *> keypath)
+{
+  sail_config_json json = sail_config_get(keypath.size(), keypath.data());
+
+  if (!json) {
+    std::cerr << "Failed to find configuration option '";
+    for (auto part : keypath) {
+      std::cerr << "." << part;
+    }
+    std::cerr << "'.\n";
+    exit(1);
+  }
+
+  sail_int big_n;
+  uint64_t n;
+
+  if (!sail_config_is_int(json)) {
+    std::cerr << "Configuration option '";
+    for (auto part : keypath) {
+      std::cerr << "." << part;
+    }
+    std::cerr << "' could not be parsed as an integer.\n";
+    exit(1);
+  }
+
+  CREATE(sail_int)(&big_n);
+  sail_config_unwrap_int(&big_n, json);
+  n = sail_int_get_ui(big_n);
+  KILL(sail_int)(&big_n);
+  return n;
+}

--- a/c_emulator/config_utils.h
+++ b/c_emulator/config_utils.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <vector>
+#include "sail.h"
+
+uint64_t get_config_uint64(std::vector<const char *> keypath);

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -28,6 +28,7 @@
 #include "riscv_sail.h"
 #include "rvfi_dii.h"
 #include "default_config.h"
+#include "config_utils.h"
 
 enum {
   OPT_TRACE_OUTPUT = 1000,
@@ -359,38 +360,6 @@ uint64_t load_sail(char *f, bool main_file)
     mem_sig_end = end_sig;
   }
   return entry;
-}
-
-uint64_t get_config_uint64(std::vector<const char *> keypath)
-{
-  sail_config_json json = sail_config_get(keypath.size(), keypath.data());
-
-  if (!json) {
-    std::cerr << "Failed to find configuration option '";
-    for (auto part : keypath) {
-      std::cerr << "." << part;
-    }
-    std::cerr << "'.\n";
-    exit(1);
-  }
-
-  sail_int big_n;
-  uint64_t n;
-
-  if (!sail_config_is_int(json)) {
-    std::cerr << "Configuration option '";
-    for (auto part : keypath) {
-      std::cerr << "." << part;
-    }
-    std::cerr << "' could not be parsed as an integer.\n";
-    exit(1);
-  }
-
-  CREATE(sail_int)(&big_n);
-  sail_config_unwrap_int(&big_n, json);
-  n = sail_int_get_ui(big_n);
-  KILL(sail_int)(&big_n);
-  return n;
 }
 
 void init_sail_reset_vector(uint64_t entry)


### PR DESCRIPTION
This helps re-use from other files that might need it.