### PR TITLE
Include climits in riscv_sim.cpp

### DIFF
--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -1,4 +1,5 @@
 #include <ctype.h>
+#include <climits>
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
`ULLONG_MAX` is defined in `climits`, so it should be explicitly included.

Ran into a build failure with an older compiler without this include. I think sometimes `iostream` includes it, but we shouldn't rely on that.