### PR TITLE
Run Lean CI on push in addition to PRs

### DIFF
--- a/.github/workflows/compile-lean.yml
+++ b/.github/workflows/compile-lean.yml
@@ -1,6 +1,6 @@
 name: Build and test Lean backend
 
-on: [pull_request, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   OPAMVERBOSE: 1


### PR DESCRIPTION
Caches are only reused if they are from the same branch or the master branch. Currently this never gets run on master, so the opam cache is not shared across PRs.