### PR TITLE
Improve the C++ get_config API for the Sail config.

### DIFF
--- a/c_emulator/config_utils.cpp
+++ b/c_emulator/config_utils.cpp
@@ -4,7 +4,7 @@
 #include "sail_config.h"
 #include "config_utils.h"
 
-uint64_t get_config_uint64(std::vector<const char *> keypath)
+uint64_t get_config_uint64(const std::vector<const char *> &keypath)
 {
   sail_config_json json = sail_config_get(keypath.size(), keypath.data());
 

--- a/c_emulator/config_utils.h
+++ b/c_emulator/config_utils.h
@@ -3,4 +3,4 @@
 #include <vector>
 #include "sail.h"
 
-uint64_t get_config_uint64(std::vector<const char *> keypath);
+uint64_t get_config_uint64(const std::vector<const char *> &keypath);


### PR DESCRIPTION
This uses a more idiomatic signature.