### PR TITLE
Generate more accurate ISA information for device tree.

### DIFF
--- a/model/riscv_device_tree.sail
+++ b/model/riscv_device_tree.sail
@@ -19,6 +19,156 @@ function mmu_type() -> string = {
   }
 }
 
+// Generators for Device-Tree source corresponding to the model
+// configuration.
+// NOTE: These assume a valid model configuration.
+
+// Generates the value for the "riscv,isa-base" property.
+function generate_isa_base() -> string = {
+  "rv" ^ dec_str(xlen) ^ "i"
+}
+
+/* Some notes from the "ISA Extension Naming Convections" section of
+   the manual:
+
+  . The first letter following the "Z" conventionally indicates the
+    most closely related alphabetical extension category,
+    IMAFDQLCBKJTPVH.  If multiple "Z" extensions are named, they
+    should be ordered first by category, then alphabetically within a
+    category—for example, "Zicsr_Zifencei_Ztso".
+
+  . All multi-letter extensions, including those with the "Z" prefix, must be
+    separated from other multi-letter extensions by an underscore, e.g.,
+    "RV32IMACZicsr_Zifencei".
+
+  . Standard supervisor-level extensions (prefixed with either 'Ss' or
+    'Sv') should be listed after standard unprivileged extensions, and
+    like other multi-letter extensions, must be separated from other
+    multi-letter extensions by an underscore. If multiple
+    supervisor-level extensions are listed, they should be ordered
+    alphabetically.
+
+  . Standard machine-level extensions (prefixed with the letters "Sm")
+    should be listed after standard lesser-privileged extensions, and
+    like other multi-letter extensions, must be separated from other
+    multi-letter extensions by an underscore. If multiple
+    machine-level extensions are listed, they should be ordered
+    alphabetically.
+
+  Once the Sail configuration supports extension version numbers, we could
+  add them to the generated isa string.
+
+  The device-tree specification for the ISA string is at:
+  https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/devicetree/bindings/riscv/extensions.yaml
+
+  As the above document uses lower-case, the generator below does too.
+*/
+
+// Generates the value for the "riscv,isa-extensions" property
+// (if `as_isa_ext == false`) or the "riscv,isa" property (otherwise).
+// NOTE: The "riscv,isa" property is marked deprecated but is probably
+// still widely used.
+
+function dt_wrap(s : string, as_isa_ext : bool) -> string = {
+  if   as_isa_ext
+  then ", \"" ^ s ^ "\""
+  // In "riscv,isa", single letter extensions are concatenated
+  // without a separator.
+  else if string_length(s) == 1
+  then s
+  else "_" ^ s
+}
+
+function generate_isa_string(as_isa_ext : bool) -> string = {
+  (if   as_isa_ext
+   then "\"i\""
+   else "rv" ^ dec_str(xlen) ^ "i")
+
+// First append the single letter extensions.
+
+^ (if hartSupports(Ext_M) then dt_wrap("m", as_isa_ext) else "")
+^ (if hartSupports(Ext_A) then dt_wrap("a", as_isa_ext) else "")
+^ (if hartSupports(Ext_F) then dt_wrap("f", as_isa_ext) else "")
+^ (if hartSupports(Ext_D) then dt_wrap("d", as_isa_ext) else "")
+^ (if hartSupports(Ext_C) then dt_wrap("c", as_isa_ext) else "")
+  // 'b' does not appear in the above device-tree spec for "riscv,isa-extensions".
+^ (if hartSupports(Ext_B) & not(as_isa_ext) then "b"   else "")
+^ (if hartSupports(Ext_V) then dt_wrap("v", as_isa_ext) else "")
+// S and U are not valid extensions in the device-tree, whereas H is.
+
+// Append the Z extensions, ordered by category and then alphabetically.
+
+^ (if hartSupports(Ext_Zicbom) then dt_wrap("zicbom", as_isa_ext) else "")
+^ (if hartSupports(Ext_Zicboz) then dt_wrap("zicboz", as_isa_ext) else "")
+^ (if hartSupports(Ext_Zicntr) then dt_wrap("zicntr", as_isa_ext) else "")
+^ (if hartSupports(Ext_Zicond) then dt_wrap("zicond", as_isa_ext) else "")
+^ (if hartSupports(Ext_Zicsr)  then dt_wrap("zicsr", as_isa_ext)  else "")
+^ (if hartSupports(Ext_Zifencei) then dt_wrap("zifencei", as_isa_ext)  else "")
+^ (if hartSupports(Ext_Zihpm)  then dt_wrap("zihpm", as_isa_ext)  else "")
+^ (if hartSupports(Ext_Zimop)  then dt_wrap("zimop", as_isa_ext)  else "")
+
+// Zmmul is not a device-tree extension.
+
+^ (if hartSupports(Ext_Zaamo)  then dt_wrap("zaamo", as_isa_ext)  else "")
+^ (if hartSupports(Ext_Zabha)  then dt_wrap("zabha", as_isa_ext)  else "")
+^ (if hartSupports(Ext_Zalrsc) then dt_wrap("zalrsc", as_isa_ext) else "")
+^ (if hartSupports(Ext_Zawrs)  then dt_wrap("zawrs", as_isa_ext)  else "")
+
+^ (if hartSupports(Ext_Zfa)    then dt_wrap("zfa", as_isa_ext)    else "")
+^ (if hartSupports(Ext_Zfh)    then dt_wrap("zfh", as_isa_ext)    else "")
+^ (if hartSupports(Ext_Zfhmin) then dt_wrap("zfhmin", as_isa_ext) else "")
+^ (if hartSupports(Ext_Zfinx)  then dt_wrap("zfinx", as_isa_ext)  else "")
+
+// Zdinx and Zhinx{,min} are not extensions in device-tree.
+
+^ (if hartSupports(Ext_Zca)    then dt_wrap("zca", as_isa_ext)    else "")
+^ (if hartSupports(Ext_Zcb)    then dt_wrap("zcb", as_isa_ext)    else "")
+^ (if hartSupports(Ext_Zcd)    then dt_wrap("zcd", as_isa_ext)    else "")
+^ (if hartSupports(Ext_Zcf)    then dt_wrap("zcf", as_isa_ext)    else "")
+^ (if hartSupports(Ext_Zcmop)  then dt_wrap("zcmop", as_isa_ext)  else "")
+
+^ (if hartSupports(Ext_Zba)    then dt_wrap("zba", as_isa_ext)    else "")
+^ (if hartSupports(Ext_Zbb)    then dt_wrap("zbb", as_isa_ext)    else "")
+^ (if hartSupports(Ext_Zbc)    then dt_wrap("zbc", as_isa_ext)    else "")
+^ (if hartSupports(Ext_Zbkb)   then dt_wrap("zbkb", as_isa_ext)   else "")
+^ (if hartSupports(Ext_Zbkc)   then dt_wrap("zbkc", as_isa_ext)   else "")
+^ (if hartSupports(Ext_Zbkx)   then dt_wrap("zbkx", as_isa_ext)   else "")
+^ (if hartSupports(Ext_Zbs)    then dt_wrap("zbs", as_isa_ext)    else "")
+
+^ (if hartSupports(Ext_Zknd)   then dt_wrap("zknd", as_isa_ext)   else "")
+^ (if hartSupports(Ext_Zkne)   then dt_wrap("zkne", as_isa_ext)   else "")
+^ (if hartSupports(Ext_Zknh)   then dt_wrap("zknh", as_isa_ext)   else "")
+^ (if hartSupports(Ext_Zkr)    then dt_wrap("zkr", as_isa_ext)    else "")
+^ (if hartSupports(Ext_Zksed)  then dt_wrap("zksed", as_isa_ext)  else "")
+^ (if hartSupports(Ext_Zksh)   then dt_wrap("zksh", as_isa_ext)   else "")
+
+^ (if hartSupports(Ext_Zvbb)   then dt_wrap("zvbb", as_isa_ext)   else "")
+^ (if hartSupports(Ext_Zvbc)   then dt_wrap("zvbc", as_isa_ext)   else "")
+^ (if hartSupports(Ext_Zvkb)   then dt_wrap("zvkb", as_isa_ext)   else "")
+^ (if hartSupports(Ext_Zvkg)   then dt_wrap("zvkg", as_isa_ext)   else "")
+^ (if hartSupports(Ext_Zvkned) then dt_wrap("zvkned", as_isa_ext) else "")
+^ (if hartSupports(Ext_Zvknha) then dt_wrap("zvknha", as_isa_ext) else "")
+^ (if hartSupports(Ext_Zvknhb) then dt_wrap("zvknhb", as_isa_ext) else "")
+^ (if hartSupports(Ext_Zvksh)  then dt_wrap("zvksh", as_isa_ext)  else "")
+
+// Append the Supervisor extensions, ordered alphabetically.
+
+^ (if hartSupports(Ext_Sscofpmf)  then dt_wrap("sscofpmf", as_isa_ext)  else "")
+^ (if hartSupports(Ext_Sstc)      then dt_wrap("sstc", as_isa_ext)      else "")
+// Handle svade and svadu here when ready.
+^ (if hartSupports(Ext_Svinval)   then dt_wrap("svinval", as_isa_ext)   else "")
+^ (if hartSupports(Ext_Svnapot)   then dt_wrap("svnapot", as_isa_ext)   else "")
+^ (if hartSupports(Ext_Svpbmt)    then dt_wrap("svpbmt", as_isa_ext)    else "")
+
+// Append the Hypervisor extensions, ordered alphabetically.
+
+// Append the Machine mode extensions, ordered alphabetically.
+
+// Smcntrpmf is not a device-tree extension.
+}
+
+// Generates the full Device-Tree configuration for the model.
+
 function generate_dts() -> string = {
   let clock_freq : int = config platform.clock_frequency;
   let ram_base_hi = unsigned(plat_ram_base >> 32);
@@ -29,7 +179,6 @@ function generate_dts() -> string = {
   let clint_base_lo = unsigned(plat_clint_base[31 .. 0]);
   let clint_size_hi = unsigned(plat_clint_size >> 32);
   let clint_size_lo = unsigned(plat_clint_size[31 .. 0]);
-  let isa_string : string = "imafdc_zicntr_zihpm"; // Default, should be adjusted based on config.
 
   // `hex_str` is used for the unit-addresses of the `memory@` and `clint@` nodes
   // instead of `hex_bits_str` since they cannot have leading zeros.  These addresses
@@ -51,7 +200,9 @@ function generate_dts() -> string = {
 ^ "      reg = <0>;\n"
 ^ "      status = \"okay\";\n"
 ^ "      compatible = \"riscv\";\n"
-^ "      riscv,isa = \"" ^ "rv" ^ dec_str(xlen) ^ isa_string ^ "\";\n"
+^ "      riscv,isa-base = \"" ^ generate_isa_base() ^ "\";\n"
+^ "      riscv,isa = \"" ^ generate_isa_string(false) ^ "\";\n"
+^ "      riscv,isa-extensions = " ^ generate_isa_string(true) ^ ";\n"
 ^ "      mmu-type = \"riscv," ^ mmu_type() ^ "\";\n"
 ^ "      clock-frequency = <" ^ dec_str(clock_freq) ^ ">;\n"
 ^ "      CPU0_intc: interrupt-controller {\n"

--- a/model/riscv_device_tree.sail
+++ b/model/riscv_device_tree.sail
@@ -30,9 +30,7 @@ function generate_isa_base() -> string = {
 
 // Generates an ISA string in the appropriate format.
 
-// NOTE: The "riscv,isa" property is marked deprecated but is probably
-// still widely used.
-enum ISA_Format = {DeviceTree_ISA, DeviceTree_ISA_Extensions}
+enum ISA_Format = {Canonical_Lowercase, DeviceTree_ISA_Extensions}
 
 /* Some notes from the "ISA Extension Naming Convections" section of
    the manual:
@@ -74,9 +72,8 @@ function ext_wrap(ext : extension, fmt : ISA_Format) -> string = {
   if not(hartSupports(ext)) then return "";
   let s = extensionName(ext);
   match fmt {
-    DeviceTree_ISA =>
-      // In "riscv,isa", single letter extensions are concatenated
-      // without a separator.
+    Canonical_Lowercase =>
+      // Single letter extensions are concatenated without a separator.
       if string_length(s) == 1 then s else "_" ^ s,
     DeviceTree_ISA_Extensions =>
       ", \"" ^ s ^ "\"",
@@ -87,9 +84,9 @@ function generate_isa_string(fmt : ISA_Format) -> string = {
   // The Sail compiler blows up if this string is constructed in one go.
   // Build it up in pieces.
   let prefix : string = match fmt {
-    DeviceTree_ISA => "rv" ^ dec_str(xlen) ^ "i",
+    Canonical_Lowercase => "rv" ^ dec_str(xlen) ^ "i",
     DeviceTree_ISA_Extensions => "\"i\"",
-   };
+  };
 
   // First append the single letter extensions.
 
@@ -126,9 +123,10 @@ function generate_isa_string(fmt : ISA_Format) -> string = {
   ^ ext_wrap(Ext_Zfa, fmt)
   ^ ext_wrap(Ext_Zfh, fmt)
   ^ ext_wrap(Ext_Zfhmin, fmt)
-  ^ ext_wrap(Ext_Zfinx, fmt);
-
-  // Zdinx and Zhinx{,min} are not extensions in device-tree.
+  ^ ext_wrap(Ext_Zfinx, fmt)
+  ^ ext_wrap(Ext_Zdinx, fmt)
+  ^ ext_wrap(Ext_Zhinx, fmt)
+  ^ ext_wrap(Ext_Zhinxmin, fmt);
 
   let zc_exts = ""
   ^ ext_wrap(Ext_Zca, fmt)
@@ -220,7 +218,9 @@ function generate_dts() -> string = {
 ^ "      status = \"okay\";\n"
 ^ "      compatible = \"riscv\";\n"
 ^ "      riscv,isa-base = \"" ^ generate_isa_base() ^ "\";\n"
-^ "      riscv,isa = \"" ^ generate_isa_string(DeviceTree_ISA) ^ "\";\n"
+         // NOTE: The "riscv,isa" property is marked deprecated but is
+         // probably still widely used.
+^ "      riscv,isa = \"" ^ generate_isa_string(Canonical_Lowercase) ^ "\";\n"
 ^ "      riscv,isa-extensions = " ^ generate_isa_string(DeviceTree_ISA_Extensions) ^ ";\n"
 ^ "      mmu-type = \"riscv," ^ mmu_type() ^ "\";\n"
 ^ "      clock-frequency = <" ^ dec_str(clock_freq) ^ ">;\n"

--- a/model/riscv_device_tree.sail
+++ b/model/riscv_device_tree.sail
@@ -28,6 +28,12 @@ function generate_isa_base() -> string = {
   "rv" ^ dec_str(xlen) ^ "i"
 }
 
+// Generates an ISA string in the appropriate format.
+
+// NOTE: The "riscv,isa" property is marked deprecated but is probably
+// still widely used.
+enum ISA_Format = {DeviceTree_ISA, DeviceTree_ISA_Extensions}
+
 /* Some notes from the "ISA Extension Naming Convections" section of
    the manual:
 
@@ -64,109 +70,120 @@ function generate_isa_base() -> string = {
   As the above document uses lower-case, the generator below does too.
 */
 
-// Generates the value for the "riscv,isa-extensions" property
-// (if `as_isa_ext == false`) or the "riscv,isa" property (otherwise).
-// NOTE: The "riscv,isa" property is marked deprecated but is probably
-// still widely used.
-
-function dt_wrap(ext : extension, as_isa_ext : bool) -> string = {
+function ext_wrap(ext : extension, fmt : ISA_Format) -> string = {
   if not(hartSupports(ext)) then return "";
   let s = extensionName(ext);
-  if   as_isa_ext
-  then ", \"" ^ s ^ "\""
-  // In "riscv,isa", single letter extensions are concatenated
-  // without a separator.
-  else if string_length(s) == 1
-  then s
-  else "_" ^ s
+  match fmt {
+    DeviceTree_ISA =>
+      // In "riscv,isa", single letter extensions are concatenated
+      // without a separator.
+      if string_length(s) == 1 then s else "_" ^ s,
+    DeviceTree_ISA_Extensions =>
+      ", \"" ^ s ^ "\"",
+  }
 }
 
-function generate_isa_string(as_isa_ext : bool) -> string = {
-  (if   as_isa_ext
-   then "\"i\""
-   else "rv" ^ dec_str(xlen) ^ "i")
+function generate_isa_string(fmt : ISA_Format) -> string = {
+  // The Sail compiler blows up if this string is constructed in one go.
+  // Build it up in pieces.
+  let prefix : string = match fmt {
+    DeviceTree_ISA => "rv" ^ dec_str(xlen) ^ "i",
+    DeviceTree_ISA_Extensions => "\"i\"",
+   };
 
-// First append the single letter extensions.
+  // First append the single letter extensions.
 
-^ dt_wrap(Ext_M, as_isa_ext)
-^ dt_wrap(Ext_A, as_isa_ext)
-^ dt_wrap(Ext_F, as_isa_ext)
-^ dt_wrap(Ext_D, as_isa_ext)
-^ dt_wrap(Ext_C, as_isa_ext)
-  // 'b' does not appear in the above device-tree spec for "riscv,isa-extensions".
-^ (if as_isa_ext then "" else dt_wrap(Ext_B, false))
-^ dt_wrap(Ext_V, as_isa_ext)
-// S and U are not valid extensions in the device-tree, whereas H is.
+  let singles = ""
+  ^ ext_wrap(Ext_M, fmt)
+  ^ ext_wrap(Ext_A, fmt)
+  ^ ext_wrap(Ext_F, fmt)
+  ^ ext_wrap(Ext_D, fmt)
+  ^ ext_wrap(Ext_C, fmt)
+  ^ ext_wrap(Ext_B, fmt)
+  ^ ext_wrap(Ext_V, fmt);
+  // S and U are not valid extensions in the device-tree, whereas H is.
 
-// Append the Z extensions, ordered by category and then alphabetically.
+  // Append the Z extensions, ordered by category and then alphabetically.
+  let zi_exts = ""
+  ^ ext_wrap(Ext_Zicbom, fmt)
+  ^ ext_wrap(Ext_Zicboz, fmt)
+  ^ ext_wrap(Ext_Zicntr, fmt)
+  ^ ext_wrap(Ext_Zicond, fmt)
+  ^ ext_wrap(Ext_Zicsr, fmt)
+  ^ ext_wrap(Ext_Zifencei, fmt)
+  ^ ext_wrap(Ext_Zihpm, fmt)
+  ^ ext_wrap(Ext_Zimop, fmt)
 
-^ dt_wrap(Ext_Zicbom, as_isa_ext)
-^ dt_wrap(Ext_Zicboz, as_isa_ext)
-^ dt_wrap(Ext_Zicntr, as_isa_ext)
-^ dt_wrap(Ext_Zicond, as_isa_ext)
-^ dt_wrap(Ext_Zicsr, as_isa_ext)
-^ dt_wrap(Ext_Zifencei, as_isa_ext)
-^ dt_wrap(Ext_Zihpm, as_isa_ext)
-^ dt_wrap(Ext_Zimop, as_isa_ext)
+  ^ ext_wrap(Ext_Zmmul, fmt);
 
-// Zmmul is not a device-tree extension.
+  let za_exts = ""
+  ^ ext_wrap(Ext_Zaamo, fmt)
+  ^ ext_wrap(Ext_Zabha, fmt)
+  ^ ext_wrap(Ext_Zalrsc, fmt)
+  ^ ext_wrap(Ext_Zawrs, fmt);
 
-^ dt_wrap(Ext_Zaamo, as_isa_ext)
-^ dt_wrap(Ext_Zabha, as_isa_ext)
-^ dt_wrap(Ext_Zalrsc, as_isa_ext)
-^ dt_wrap(Ext_Zawrs, as_isa_ext)
+  let zf_exts = ""
+  ^ ext_wrap(Ext_Zfa, fmt)
+  ^ ext_wrap(Ext_Zfh, fmt)
+  ^ ext_wrap(Ext_Zfhmin, fmt)
+  ^ ext_wrap(Ext_Zfinx, fmt);
 
-^ dt_wrap(Ext_Zfa, as_isa_ext)
-^ dt_wrap(Ext_Zfh, as_isa_ext)
-^ dt_wrap(Ext_Zfhmin, as_isa_ext)
-^ dt_wrap(Ext_Zfinx, as_isa_ext)
+  // Zdinx and Zhinx{,min} are not extensions in device-tree.
 
-// Zdinx and Zhinx{,min} are not extensions in device-tree.
+  let zc_exts = ""
+  ^ ext_wrap(Ext_Zca, fmt)
+  ^ ext_wrap(Ext_Zcb, fmt)
+  ^ ext_wrap(Ext_Zcd, fmt)
+  ^ ext_wrap(Ext_Zcf, fmt)
+  ^ ext_wrap(Ext_Zcmop, fmt);
 
-^ dt_wrap(Ext_Zca, as_isa_ext)
-^ dt_wrap(Ext_Zcb, as_isa_ext)
-^ dt_wrap(Ext_Zcd, as_isa_ext)
-^ dt_wrap(Ext_Zcf, as_isa_ext)
-^ dt_wrap(Ext_Zcmop, as_isa_ext)
+  let zb_exts = ""
+  ^ ext_wrap(Ext_Zba, fmt)
+  ^ ext_wrap(Ext_Zbb, fmt)
+  ^ ext_wrap(Ext_Zbc, fmt)
+  ^ ext_wrap(Ext_Zbkb, fmt)
+  ^ ext_wrap(Ext_Zbkc, fmt)
+  ^ ext_wrap(Ext_Zbkx, fmt)
+  ^ ext_wrap(Ext_Zbs, fmt);
 
-^ dt_wrap(Ext_Zba, as_isa_ext)
-^ dt_wrap(Ext_Zbb, as_isa_ext)
-^ dt_wrap(Ext_Zbc, as_isa_ext)
-^ dt_wrap(Ext_Zbkb, as_isa_ext)
-^ dt_wrap(Ext_Zbkc, as_isa_ext)
-^ dt_wrap(Ext_Zbkx, as_isa_ext)
-^ dt_wrap(Ext_Zbs, as_isa_ext)
+  let zk_exts = ""
+  ^ ext_wrap(Ext_Zknd, fmt)
+  ^ ext_wrap(Ext_Zkne, fmt)
+  ^ ext_wrap(Ext_Zknh, fmt)
+  ^ ext_wrap(Ext_Zkr, fmt)
+  ^ ext_wrap(Ext_Zksed, fmt)
+  ^ ext_wrap(Ext_Zksh, fmt);
 
-^ dt_wrap(Ext_Zknd, as_isa_ext)
-^ dt_wrap(Ext_Zkne, as_isa_ext)
-^ dt_wrap(Ext_Zknh, as_isa_ext)
-^ dt_wrap(Ext_Zkr, as_isa_ext)
-^ dt_wrap(Ext_Zksed, as_isa_ext)
-^ dt_wrap(Ext_Zksh, as_isa_ext)
+  let zv_exts = ""
+  ^ ext_wrap(Ext_Zvbb, fmt)
+  ^ ext_wrap(Ext_Zvbc, fmt)
+  ^ ext_wrap(Ext_Zvkb, fmt)
+  ^ ext_wrap(Ext_Zvkg, fmt)
+  ^ ext_wrap(Ext_Zvkned, fmt)
+  ^ ext_wrap(Ext_Zvknha, fmt)
+  ^ ext_wrap(Ext_Zvknhb, fmt)
+  ^ ext_wrap(Ext_Zvksh, fmt);
 
-^ dt_wrap(Ext_Zvbb, as_isa_ext)
-^ dt_wrap(Ext_Zvbc, as_isa_ext)
-^ dt_wrap(Ext_Zvkb, as_isa_ext)
-^ dt_wrap(Ext_Zvkg, as_isa_ext)
-^ dt_wrap(Ext_Zvkned, as_isa_ext)
-^ dt_wrap(Ext_Zvknha, as_isa_ext)
-^ dt_wrap(Ext_Zvknhb, as_isa_ext)
-^ dt_wrap(Ext_Zvksh, as_isa_ext)
+  // Append the Supervisor extensions, ordered alphabetically.
 
-// Append the Supervisor extensions, ordered alphabetically.
+  let s_exts = ""
+  ^ ext_wrap(Ext_Sscofpmf, fmt)
+  ^ ext_wrap(Ext_Sstc, fmt)
+  // Handle svade and svadu here when ready.
+  ^ ext_wrap(Ext_Svinval, fmt)
+  ^ ext_wrap(Ext_Svnapot, fmt)
+  ^ ext_wrap(Ext_Svpbmt, fmt);
 
-^ dt_wrap(Ext_Sscofpmf, as_isa_ext)
-^ dt_wrap(Ext_Sstc, as_isa_ext)
-// Handle svade and svadu here when ready.
-^ dt_wrap(Ext_Svinval, as_isa_ext)
-^ dt_wrap(Ext_Svnapot, as_isa_ext)
-^ dt_wrap(Ext_Svpbmt, as_isa_ext)
+  // Append the Hypervisor extensions, ordered alphabetically.
 
-// Append the Hypervisor extensions, ordered alphabetically.
+  // Append the Machine mode extensions, ordered alphabetically.
 
-// Append the Machine mode extensions, ordered alphabetically.
+  let m_exts = ""
+  ^ ext_wrap(Ext_Smcntrpmf, fmt);
 
-// Smcntrpmf is not a device-tree extension.
+  prefix ^ singles
+  ^ zi_exts ^ za_exts ^ zf_exts ^ zc_exts ^ zb_exts ^ zk_exts ^ zv_exts
+  ^ s_exts ^ m_exts
 }
 
 // Generates the full Device-Tree configuration for the model.
@@ -203,8 +220,8 @@ function generate_dts() -> string = {
 ^ "      status = \"okay\";\n"
 ^ "      compatible = \"riscv\";\n"
 ^ "      riscv,isa-base = \"" ^ generate_isa_base() ^ "\";\n"
-^ "      riscv,isa = \"" ^ generate_isa_string(false) ^ "\";\n"
-^ "      riscv,isa-extensions = " ^ generate_isa_string(true) ^ ";\n"
+^ "      riscv,isa = \"" ^ generate_isa_string(DeviceTree_ISA) ^ "\";\n"
+^ "      riscv,isa-extensions = " ^ generate_isa_string(DeviceTree_ISA_Extensions) ^ ";\n"
 ^ "      mmu-type = \"riscv," ^ mmu_type() ^ "\";\n"
 ^ "      clock-frequency = <" ^ dec_str(clock_freq) ^ ">;\n"
 ^ "      CPU0_intc: interrupt-controller {\n"

--- a/model/riscv_device_tree.sail
+++ b/model/riscv_device_tree.sail
@@ -69,7 +69,9 @@ function generate_isa_base() -> string = {
 // NOTE: The "riscv,isa" property is marked deprecated but is probably
 // still widely used.
 
-function dt_wrap(s : string, as_isa_ext : bool) -> string = {
+function dt_wrap(ext : extension, as_isa_ext : bool) -> string = {
+  if not(hartSupports(ext)) then return "";
+  let s = extensionName(ext);
   if   as_isa_ext
   then ", \"" ^ s ^ "\""
   // In "riscv,isa", single letter extensions are concatenated
@@ -86,79 +88,79 @@ function generate_isa_string(as_isa_ext : bool) -> string = {
 
 // First append the single letter extensions.
 
-^ (if hartSupports(Ext_M) then dt_wrap("m", as_isa_ext) else "")
-^ (if hartSupports(Ext_A) then dt_wrap("a", as_isa_ext) else "")
-^ (if hartSupports(Ext_F) then dt_wrap("f", as_isa_ext) else "")
-^ (if hartSupports(Ext_D) then dt_wrap("d", as_isa_ext) else "")
-^ (if hartSupports(Ext_C) then dt_wrap("c", as_isa_ext) else "")
+^ dt_wrap(Ext_M, as_isa_ext)
+^ dt_wrap(Ext_A, as_isa_ext)
+^ dt_wrap(Ext_F, as_isa_ext)
+^ dt_wrap(Ext_D, as_isa_ext)
+^ dt_wrap(Ext_C, as_isa_ext)
   // 'b' does not appear in the above device-tree spec for "riscv,isa-extensions".
-^ (if hartSupports(Ext_B) & not(as_isa_ext) then "b"   else "")
-^ (if hartSupports(Ext_V) then dt_wrap("v", as_isa_ext) else "")
+^ (if as_isa_ext then "" else dt_wrap(Ext_B, false))
+^ dt_wrap(Ext_V, as_isa_ext)
 // S and U are not valid extensions in the device-tree, whereas H is.
 
 // Append the Z extensions, ordered by category and then alphabetically.
 
-^ (if hartSupports(Ext_Zicbom) then dt_wrap("zicbom", as_isa_ext) else "")
-^ (if hartSupports(Ext_Zicboz) then dt_wrap("zicboz", as_isa_ext) else "")
-^ (if hartSupports(Ext_Zicntr) then dt_wrap("zicntr", as_isa_ext) else "")
-^ (if hartSupports(Ext_Zicond) then dt_wrap("zicond", as_isa_ext) else "")
-^ (if hartSupports(Ext_Zicsr)  then dt_wrap("zicsr", as_isa_ext)  else "")
-^ (if hartSupports(Ext_Zifencei) then dt_wrap("zifencei", as_isa_ext)  else "")
-^ (if hartSupports(Ext_Zihpm)  then dt_wrap("zihpm", as_isa_ext)  else "")
-^ (if hartSupports(Ext_Zimop)  then dt_wrap("zimop", as_isa_ext)  else "")
+^ dt_wrap(Ext_Zicbom, as_isa_ext)
+^ dt_wrap(Ext_Zicboz, as_isa_ext)
+^ dt_wrap(Ext_Zicntr, as_isa_ext)
+^ dt_wrap(Ext_Zicond, as_isa_ext)
+^ dt_wrap(Ext_Zicsr, as_isa_ext)
+^ dt_wrap(Ext_Zifencei, as_isa_ext)
+^ dt_wrap(Ext_Zihpm, as_isa_ext)
+^ dt_wrap(Ext_Zimop, as_isa_ext)
 
 // Zmmul is not a device-tree extension.
 
-^ (if hartSupports(Ext_Zaamo)  then dt_wrap("zaamo", as_isa_ext)  else "")
-^ (if hartSupports(Ext_Zabha)  then dt_wrap("zabha", as_isa_ext)  else "")
-^ (if hartSupports(Ext_Zalrsc) then dt_wrap("zalrsc", as_isa_ext) else "")
-^ (if hartSupports(Ext_Zawrs)  then dt_wrap("zawrs", as_isa_ext)  else "")
+^ dt_wrap(Ext_Zaamo, as_isa_ext)
+^ dt_wrap(Ext_Zabha, as_isa_ext)
+^ dt_wrap(Ext_Zalrsc, as_isa_ext)
+^ dt_wrap(Ext_Zawrs, as_isa_ext)
 
-^ (if hartSupports(Ext_Zfa)    then dt_wrap("zfa", as_isa_ext)    else "")
-^ (if hartSupports(Ext_Zfh)    then dt_wrap("zfh", as_isa_ext)    else "")
-^ (if hartSupports(Ext_Zfhmin) then dt_wrap("zfhmin", as_isa_ext) else "")
-^ (if hartSupports(Ext_Zfinx)  then dt_wrap("zfinx", as_isa_ext)  else "")
+^ dt_wrap(Ext_Zfa, as_isa_ext)
+^ dt_wrap(Ext_Zfh, as_isa_ext)
+^ dt_wrap(Ext_Zfhmin, as_isa_ext)
+^ dt_wrap(Ext_Zfinx, as_isa_ext)
 
 // Zdinx and Zhinx{,min} are not extensions in device-tree.
 
-^ (if hartSupports(Ext_Zca)    then dt_wrap("zca", as_isa_ext)    else "")
-^ (if hartSupports(Ext_Zcb)    then dt_wrap("zcb", as_isa_ext)    else "")
-^ (if hartSupports(Ext_Zcd)    then dt_wrap("zcd", as_isa_ext)    else "")
-^ (if hartSupports(Ext_Zcf)    then dt_wrap("zcf", as_isa_ext)    else "")
-^ (if hartSupports(Ext_Zcmop)  then dt_wrap("zcmop", as_isa_ext)  else "")
+^ dt_wrap(Ext_Zca, as_isa_ext)
+^ dt_wrap(Ext_Zcb, as_isa_ext)
+^ dt_wrap(Ext_Zcd, as_isa_ext)
+^ dt_wrap(Ext_Zcf, as_isa_ext)
+^ dt_wrap(Ext_Zcmop, as_isa_ext)
 
-^ (if hartSupports(Ext_Zba)    then dt_wrap("zba", as_isa_ext)    else "")
-^ (if hartSupports(Ext_Zbb)    then dt_wrap("zbb", as_isa_ext)    else "")
-^ (if hartSupports(Ext_Zbc)    then dt_wrap("zbc", as_isa_ext)    else "")
-^ (if hartSupports(Ext_Zbkb)   then dt_wrap("zbkb", as_isa_ext)   else "")
-^ (if hartSupports(Ext_Zbkc)   then dt_wrap("zbkc", as_isa_ext)   else "")
-^ (if hartSupports(Ext_Zbkx)   then dt_wrap("zbkx", as_isa_ext)   else "")
-^ (if hartSupports(Ext_Zbs)    then dt_wrap("zbs", as_isa_ext)    else "")
+^ dt_wrap(Ext_Zba, as_isa_ext)
+^ dt_wrap(Ext_Zbb, as_isa_ext)
+^ dt_wrap(Ext_Zbc, as_isa_ext)
+^ dt_wrap(Ext_Zbkb, as_isa_ext)
+^ dt_wrap(Ext_Zbkc, as_isa_ext)
+^ dt_wrap(Ext_Zbkx, as_isa_ext)
+^ dt_wrap(Ext_Zbs, as_isa_ext)
 
-^ (if hartSupports(Ext_Zknd)   then dt_wrap("zknd", as_isa_ext)   else "")
-^ (if hartSupports(Ext_Zkne)   then dt_wrap("zkne", as_isa_ext)   else "")
-^ (if hartSupports(Ext_Zknh)   then dt_wrap("zknh", as_isa_ext)   else "")
-^ (if hartSupports(Ext_Zkr)    then dt_wrap("zkr", as_isa_ext)    else "")
-^ (if hartSupports(Ext_Zksed)  then dt_wrap("zksed", as_isa_ext)  else "")
-^ (if hartSupports(Ext_Zksh)   then dt_wrap("zksh", as_isa_ext)   else "")
+^ dt_wrap(Ext_Zknd, as_isa_ext)
+^ dt_wrap(Ext_Zkne, as_isa_ext)
+^ dt_wrap(Ext_Zknh, as_isa_ext)
+^ dt_wrap(Ext_Zkr, as_isa_ext)
+^ dt_wrap(Ext_Zksed, as_isa_ext)
+^ dt_wrap(Ext_Zksh, as_isa_ext)
 
-^ (if hartSupports(Ext_Zvbb)   then dt_wrap("zvbb", as_isa_ext)   else "")
-^ (if hartSupports(Ext_Zvbc)   then dt_wrap("zvbc", as_isa_ext)   else "")
-^ (if hartSupports(Ext_Zvkb)   then dt_wrap("zvkb", as_isa_ext)   else "")
-^ (if hartSupports(Ext_Zvkg)   then dt_wrap("zvkg", as_isa_ext)   else "")
-^ (if hartSupports(Ext_Zvkned) then dt_wrap("zvkned", as_isa_ext) else "")
-^ (if hartSupports(Ext_Zvknha) then dt_wrap("zvknha", as_isa_ext) else "")
-^ (if hartSupports(Ext_Zvknhb) then dt_wrap("zvknhb", as_isa_ext) else "")
-^ (if hartSupports(Ext_Zvksh)  then dt_wrap("zvksh", as_isa_ext)  else "")
+^ dt_wrap(Ext_Zvbb, as_isa_ext)
+^ dt_wrap(Ext_Zvbc, as_isa_ext)
+^ dt_wrap(Ext_Zvkb, as_isa_ext)
+^ dt_wrap(Ext_Zvkg, as_isa_ext)
+^ dt_wrap(Ext_Zvkned, as_isa_ext)
+^ dt_wrap(Ext_Zvknha, as_isa_ext)
+^ dt_wrap(Ext_Zvknhb, as_isa_ext)
+^ dt_wrap(Ext_Zvksh, as_isa_ext)
 
 // Append the Supervisor extensions, ordered alphabetically.
 
-^ (if hartSupports(Ext_Sscofpmf)  then dt_wrap("sscofpmf", as_isa_ext)  else "")
-^ (if hartSupports(Ext_Sstc)      then dt_wrap("sstc", as_isa_ext)      else "")
+^ dt_wrap(Ext_Sscofpmf, as_isa_ext)
+^ dt_wrap(Ext_Sstc, as_isa_ext)
 // Handle svade and svadu here when ready.
-^ (if hartSupports(Ext_Svinval)   then dt_wrap("svinval", as_isa_ext)   else "")
-^ (if hartSupports(Ext_Svnapot)   then dt_wrap("svnapot", as_isa_ext)   else "")
-^ (if hartSupports(Ext_Svpbmt)    then dt_wrap("svpbmt", as_isa_ext)    else "")
+^ dt_wrap(Ext_Svinval, as_isa_ext)
+^ dt_wrap(Ext_Svnapot, as_isa_ext)
+^ dt_wrap(Ext_Svpbmt, as_isa_ext)
 
 // Append the Hypervisor extensions, ordered alphabetically.
 

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -9,6 +9,12 @@
 // Enum with all extensions possibly supported by the model.
 scattered enum extension
 
+// Name of extension.  The current primary consumer of these names is
+// the device tree support, which uses lower case.  Since the ISA
+// naming strings are case-insensitive anyway, the names are lowercase.
+val extensionName : extension <-> string
+scattered mapping extensionName
+
 // Function used to determine if an extension is supported in the current configuration.
 val hartSupports : extension -> bool
 scattered function hartSupports
@@ -29,102 +35,133 @@ scattered function currentlyEnabled
 
 // Integer Multiplication and Division; not Machine!
 enum clause extension = Ext_M
+mapping clause extensionName = Ext_M <-> "m"
 function clause hartSupports(Ext_M) = config extensions.M.supported
 // Atomic Instructions
 enum clause extension = Ext_A
+mapping clause extensionName = Ext_A <-> "a"
 function clause hartSupports(Ext_A) = config extensions.A.supported
 // Single-Precision Floating-Point
 enum clause extension = Ext_F
+mapping clause extensionName = Ext_F <-> "f"
 function clause hartSupports(Ext_F) = config extensions.FD.supported
 // Double-Precision Floating-Point
 enum clause extension = Ext_D
+mapping clause extensionName = Ext_D <-> "d"
 function clause hartSupports(Ext_D) = config extensions.FD.supported // TODO: Separate F and D supported flags
 // Bit Manipulation
 enum clause extension = Ext_B
+mapping clause extensionName = Ext_B <-> "b"
 function clause hartSupports(Ext_B) = config extensions.B.supported
 // Vector Operations
 enum clause extension = Ext_V
+mapping clause extensionName = Ext_V <-> "v"
 function clause hartSupports(Ext_V) = config extensions.V.supported
 // Supervisor
 enum clause extension = Ext_S
+mapping clause extensionName = Ext_S <-> "s"
 function clause hartSupports(Ext_S) = config extensions.S.supported
 // User
 enum clause extension = Ext_U
+mapping clause extensionName = Ext_U <-> "u"
 function clause hartSupports(Ext_U) = config extensions.U.supported
 
 // Cache-Block Management Instructions
 enum clause extension = Ext_Zicbom
+mapping clause extensionName = Ext_Zicbom <-> "zicbom"
 function clause hartSupports(Ext_Zicbom) = config extensions.Zicbom.supported
 // Cache-Block Zero Instructions
 enum clause extension = Ext_Zicboz
+mapping clause extensionName = Ext_Zicboz <-> "zicboz"
 function clause hartSupports(Ext_Zicboz) = config extensions.Zicboz.supported
 // Base Counters and Timers
 enum clause extension = Ext_Zicntr
+mapping clause extensionName = Ext_Zicntr <-> "zicntr"
 function clause hartSupports(Ext_Zicntr) = config extensions.Zicntr.supported
 // Integer Conditional Operations
 enum clause extension = Ext_Zicond
+mapping clause extensionName = Ext_Zicond <-> "zicond"
 function clause hartSupports(Ext_Zicond) = config extensions.Zicond.supported
 // Extension for Control and Status Register (CSR) Instructions
 enum clause extension = Ext_Zicsr
+mapping clause extensionName = Ext_Zicsr <-> "zicsr"
 function clause hartSupports(Ext_Zicsr) = config extensions.Zicsr.supported
 // Instruction-Fetch Fence
 enum clause extension = Ext_Zifencei
+mapping clause extensionName = Ext_Zifencei <-> "zifencei"
 function clause hartSupports(Ext_Zifencei) = config extensions.Zifencei.supported
 // Hardware Performance Counters
 enum clause extension = Ext_Zihpm
+mapping clause extensionName = Ext_Zihpm <-> "zihpm"
 function clause hartSupports(Ext_Zihpm) = config extensions.Zihpm.supported
 // May-Be-Operations
 enum clause extension = Ext_Zimop
+mapping clause extensionName = Ext_Zimop <-> "zimop"
 function clause hartSupports(Ext_Zimop) = config extensions.Zimop.supported
 
 // Multiplication and Division: Multiplication only
 enum clause extension = Ext_Zmmul
+mapping clause extensionName = Ext_Zmmul <-> "zmmul"
 function clause hartSupports(Ext_Zmmul) = config extensions.Zmmul.supported
 
 // Atomic Memory Operations
 enum clause extension = Ext_Zaamo
+mapping clause extensionName = Ext_Zaamo <-> "zaamo"
 function clause hartSupports(Ext_Zaamo) = config extensions.Zaamo.supported
 // Byte and Halfword Atomic Memory Operations
 enum clause extension = Ext_Zabha
+mapping clause extensionName = Ext_Zabha <-> "zabha"
 function clause hartSupports(Ext_Zabha) = config extensions.Zabha.supported
 // Load-Reserved/Store-Conditional Instructions
 enum clause extension = Ext_Zalrsc
+mapping clause extensionName = Ext_Zalrsc <-> "zalrsc"
 function clause hartSupports(Ext_Zalrsc) = config extensions.Zalrsc.supported
 // Wait-On-Reservation-Set
 enum clause extension = Ext_Zawrs
+mapping clause extensionName = Ext_Zawrs <-> "zawrs"
 function clause hartSupports(Ext_Zawrs) = config extensions.Zawrs.supported
 
 // Additional Floating-Point Instructions
 enum clause extension = Ext_Zfa
+mapping clause extensionName = Ext_Zfa <-> "zfa"
 function clause hartSupports(Ext_Zfa) = config extensions.Zfa.supported
 // Half-Precision Floating-Point
 enum clause extension = Ext_Zfh
+mapping clause extensionName = Ext_Zfh <-> "zfh"
 function clause hartSupports(Ext_Zfh) = config extensions.Zfh.supported
 // Minimal Half-Precision Floating-Point
 enum clause extension = Ext_Zfhmin
+mapping clause extensionName = Ext_Zfhmin <-> "zfhmin"
 function clause hartSupports(Ext_Zfhmin) = config extensions.Zfhmin.supported
 // Floating-Point in Integer Registers (single precision)
 enum clause extension = Ext_Zfinx
+mapping clause extensionName = Ext_Zfinx <-> "zfinx"
 function clause hartSupports(Ext_Zfinx) = config extensions.Zfinx.supported
 
 // Floating-Point in Integer Registers (double precision)
 enum clause extension = Ext_Zdinx
+mapping clause extensionName = Ext_Zdinx <-> "zdinx"
 function clause hartSupports(Ext_Zdinx) = config extensions.Zfinx.supported // TODO: Separate Zfinx and Zdinx supported flags
 
 // Code Size Reduction: compressed instructions excluding floating point loads and stores
 enum clause extension = Ext_Zca
+mapping clause extensionName = Ext_Zca <-> "zca"
 function clause hartSupports(Ext_Zca) = config extensions.Zca.supported
 // Code Size Reduction: additional 16-bit aliases
 enum clause extension = Ext_Zcb
+mapping clause extensionName = Ext_Zcb <-> "zcb"
 function clause hartSupports(Ext_Zcb) = config extensions.Zcb.supported
 // Code Size Reduction: compressed double precision floating point loads and stores
 enum clause extension = Ext_Zcd
+mapping clause extensionName = Ext_Zcd <-> "zcd"
 function clause hartSupports(Ext_Zcd) = config extensions.Zcd.supported
 // Code Size Reduction: compressed single precision floating point loads and stores
 enum clause extension = Ext_Zcf
+mapping clause extensionName = Ext_Zcf <-> "zcf"
 function clause hartSupports(Ext_Zcf) = config extensions.Zcf.supported : bool & (xlen == 32)
 // Compressed May-Be-Operations
 enum clause extension = Ext_Zcmop
+mapping clause extensionName = Ext_Zcmop <-> "zcmop"
 function clause hartSupports(Ext_Zcmop) = config extensions.Zcmop.supported
 // Compressed Instructions
 // C is supported if all of the following are true:
@@ -132,109 +169,144 @@ function clause hartSupports(Ext_Zcmop) = config extensions.Zcmop.supported
 //   - Zcf is supported if F is supported (on rv32)
 //   - Zcd is supported if D is supported
 enum clause extension = Ext_C
+mapping clause extensionName = Ext_C <-> "c"
 function clause hartSupports(Ext_C) = hartSupports(Ext_Zca) & (hartSupports(Ext_Zcf) | not(hartSupports(Ext_F)) | xlen != 32) & (hartSupports(Ext_Zcd) | not(hartSupports(Ext_D)))
 
 // Bit Manipulation: Address generation
 enum clause extension = Ext_Zba
+mapping clause extensionName = Ext_Zba <-> "zba"
 function clause hartSupports(Ext_Zba) = config extensions.Zba.supported
 // Bit Manipulation: Basic bit-manipulation
 enum clause extension = Ext_Zbb
+mapping clause extensionName = Ext_Zbb <-> "zbb"
 function clause hartSupports(Ext_Zbb) = config extensions.Zbb.supported
 // Bit Manipulation: Carry-less multiplication
 enum clause extension = Ext_Zbc
+mapping clause extensionName = Ext_Zbc <-> "zbc"
 function clause hartSupports(Ext_Zbc) = config extensions.Zbc.supported
 // Bit Manipulation: Bit-manipulation for Cryptography
 enum clause extension = Ext_Zbkb
+mapping clause extensionName = Ext_Zbkb <-> "zbkb"
 function clause hartSupports(Ext_Zbkb) = config extensions.Zbkb.supported
 // Bit Manipulation: Carry-less multiplication for Cryptography
 enum clause extension = Ext_Zbkc
+mapping clause extensionName = Ext_Zbkc <-> "zbkc"
 function clause hartSupports(Ext_Zbkc) = config extensions.Zbkc.supported
 // Bit Manipulation: Crossbar permutations
 enum clause extension = Ext_Zbkx
+mapping clause extensionName = Ext_Zbkx <-> "zbkx"
 function clause hartSupports(Ext_Zbkx) = config extensions.Zbkx.supported
 // Bit Manipulation: Single-bit instructions
 enum clause extension = Ext_Zbs
+mapping clause extensionName = Ext_Zbs <-> "zbs"
 function clause hartSupports(Ext_Zbs) = config extensions.Zbs.supported
 
 // Scalar & Entropy Source Instructions: NIST Suite: AES Decryption
 enum clause extension = Ext_Zknd
+mapping clause extensionName = Ext_Zknd <-> "zknd"
 function clause hartSupports(Ext_Zknd) = config extensions.Zknd.supported
 // Scalar & Entropy Source Instructions: NIST Suite: AES Encryption
 enum clause extension = Ext_Zkne
+mapping clause extensionName = Ext_Zkne <-> "zkne"
 function clause hartSupports(Ext_Zkne) = config extensions.Zkne.supported
 // Scalar & Entropy Source Instructions: NIST Suite: Hash Function Instructions
 enum clause extension = Ext_Zknh
+mapping clause extensionName = Ext_Zknh <-> "zknh"
 function clause hartSupports(Ext_Zknh) = config extensions.Zknh.supported
 // Scalar & Entropy Source Instructions: Entropy Source Extension
 enum clause extension = Ext_Zkr
+mapping clause extensionName = Ext_Zkr <-> "zkr"
 function clause hartSupports(Ext_Zkr) = config extensions.Zkr.supported
 // Scalar & Entropy Source Instructions: ShangMi Suite: SM4 Block Cipher Instructions
 enum clause extension = Ext_Zksed
+mapping clause extensionName = Ext_Zksed <-> "zksed"
 function clause hartSupports(Ext_Zksed) = config extensions.Zksed.supported
 // Scalar & Entropy Source Instructions: ShangMi Suite: SM3 Hash Cipher Instructions
 enum clause extension = Ext_Zksh
+mapping clause extensionName = Ext_Zksh <-> "zksh"
 function clause hartSupports(Ext_Zksh) = config extensions.Zksh.supported
 
 // Floating-Point in Integer Registers (half precision)
 enum clause extension = Ext_Zhinx
+mapping clause extensionName = Ext_Zhinx <-> "zhinx"
 function clause hartSupports(Ext_Zhinx) = config extensions.Zhinx.supported
 // Floating-Point in Integer Registers (minimal half precision)
 enum clause extension = Ext_Zhinxmin
+mapping clause extensionName = Ext_Zhinxmin <-> "zhinxmin"
 function clause hartSupports(Ext_Zhinxmin) = config extensions.Zhinxmin.supported
 
 // Vector Basic Bit-manipulation
 enum clause extension = Ext_Zvbb
+mapping clause extensionName = Ext_Zvbb <-> "zvbb"
 function clause hartSupports(Ext_Zvbb) = config extensions.Zvbb.supported
 // Vector Carryless Multiplication
 enum clause extension = Ext_Zvbc
+mapping clause extensionName = Ext_Zvbc <-> "zvbc"
 function clause hartSupports(Ext_Zvbc) = config extensions.Zvbc.supported
 // Vector Cryptography Bit-manipulation
 enum clause extension = Ext_Zvkb
+mapping clause extensionName = Ext_Zvkb <-> "zvkb"
 function clause hartSupports(Ext_Zvkb) = config extensions.Zvkb.supported
 // Vector GCM/GMAC
 enum clause extension = Ext_Zvkg
+mapping clause extensionName = Ext_Zvkg <-> "zvkg"
 function clause hartSupports(Ext_Zvkg) = config extensions.Zvkg.supported
 // NIST Suite: Vector AES Block Cipher
 enum clause extension = Ext_Zvkned
+mapping clause extensionName = Ext_Zvkned <-> "zvkned"
 function clause hartSupports(Ext_Zvkned) = config extensions.Zvkned.supported
 // NIST Suite: Vector SHA-2 Secure Hash (SHA-256 only)
 enum clause extension = Ext_Zvknha
+mapping clause extensionName = Ext_Zvknha <-> "zvknha"
 function clause hartSupports(Ext_Zvknha) = config extensions.Zvknha.supported
 // NIST Suite: Vector SHA-2 Secure Hash (SHA-256 and SHA-512)
 enum clause extension = Ext_Zvknhb
+mapping clause extensionName = Ext_Zvknhb <-> "zvknhb"
 function clause hartSupports(Ext_Zvknhb) = config extensions.Zvknhb.supported
 // ShangMi Suite: SM3 Secure Hash
 enum clause extension = Ext_Zvksh
+mapping clause extensionName = Ext_Zvksh <-> "zvksh"
 function clause hartSupports(Ext_Zvksh) = config extensions.Zvksh.supported
 
 // Count Overflow and Mode-Based Filtering
 enum clause extension = Ext_Sscofpmf
+mapping clause extensionName = Ext_Sscofpmf <-> "sscofpmf"
 function clause hartSupports(Ext_Sscofpmf) = config extensions.Sscofpmf.supported
 // Supervisor-mode Timer Interrupts
 enum clause extension = Ext_Sstc
+mapping clause extensionName = Ext_Sstc <-> "sstc"
 function clause hartSupports(Ext_Sstc) = config extensions.Sstc.supported
 // Fine-Grained Address-Translation Cache Invalidation
 enum clause extension = Ext_Svinval
+mapping clause extensionName = Ext_Svinval <-> "svinval"
 function clause hartSupports(Ext_Svinval) = config extensions.Svinval.supported
 // NAPOT Translation Contiguity
 enum clause extension = Ext_Svnapot
+mapping clause extensionName = Ext_Svnapot <-> "svnapot"
 function clause hartSupports(Ext_Svnapot) = false // Not supported yet
 // Page-Based Memory Types
 enum clause extension = Ext_Svpbmt
+mapping clause extensionName = Ext_Svpbmt <-> "svpbmt"
 function clause hartSupports(Ext_Svpbmt) = false // Not supported yet
 
 // Supervisor-Level Address Translation Modes
 enum clause extension = Ext_Svbare
+mapping clause extensionName = Ext_Svbare <-> "svbare"
 function clause hartSupports(Ext_Svbare) = config extensions.Svbare.supported
 enum clause extension = Ext_Sv32
+mapping clause extensionName = Ext_Sv32 <-> "sv32"
 function clause hartSupports(Ext_Sv32) = config extensions.Sv32.supported : bool & (xlen == 32)
 enum clause extension = Ext_Sv39
+mapping clause extensionName = Ext_Sv39 <-> "sv39"
 function clause hartSupports(Ext_Sv39) = config extensions.Sv39.supported : bool & (xlen == 64)
 enum clause extension = Ext_Sv48
+mapping clause extensionName = Ext_Sv48 <-> "sv48"
 function clause hartSupports(Ext_Sv48) = config extensions.Sv48.supported : bool & (xlen == 64)
 enum clause extension = Ext_Sv57
+mapping clause extensionName = Ext_Sv57 <-> "sv57"
 function clause hartSupports(Ext_Sv57) = config extensions.Sv57.supported : bool & (xlen == 64)
 
 // Cycle and Instret Privilege Mode Filtering
 enum clause extension = Ext_Smcntrpmf
+mapping clause extensionName = Ext_Smcntrpmf <-> "smcntrpmf"
 function clause hartSupports(Ext_Smcntrpmf) = config extensions.Smcntrpmf.supported

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -185,22 +185,22 @@ function clause hartSupports(Ext_Zhinxmin) = config extensions.Zhinxmin.supporte
 // Vector Basic Bit-manipulation
 enum clause extension = Ext_Zvbb
 function clause hartSupports(Ext_Zvbb) = config extensions.Zvbb.supported
-// Vector Cryptography Bit-manipulation
-enum clause extension = Ext_Zvkb
-function clause hartSupports(Ext_Zvkb) = config extensions.Zvkb.supported
 // Vector Carryless Multiplication
 enum clause extension = Ext_Zvbc
 function clause hartSupports(Ext_Zvbc) = config extensions.Zvbc.supported
+// Vector Cryptography Bit-manipulation
+enum clause extension = Ext_Zvkb
+function clause hartSupports(Ext_Zvkb) = config extensions.Zvkb.supported
 // Vector GCM/GMAC
 enum clause extension = Ext_Zvkg
 function clause hartSupports(Ext_Zvkg) = config extensions.Zvkg.supported
 // NIST Suite: Vector AES Block Cipher
 enum clause extension = Ext_Zvkned
 function clause hartSupports(Ext_Zvkned) = config extensions.Zvkned.supported
-// NIST Suite: Vector SHA-2 Secure Hash
+// NIST Suite: Vector SHA-2 Secure Hash (SHA-256 only)
 enum clause extension = Ext_Zvknha
 function clause hartSupports(Ext_Zvknha) = config extensions.Zvknha.supported
-
+// NIST Suite: Vector SHA-2 Secure Hash (SHA-256 and SHA-512)
 enum clause extension = Ext_Zvknhb
 function clause hartSupports(Ext_Zvknhb) = config extensions.Zvknhb.supported
 // ShangMi Suite: SM3 Secure Hash
@@ -234,6 +234,7 @@ enum clause extension = Ext_Sv48
 function clause hartSupports(Ext_Sv48) = config extensions.Sv48.supported : bool & (xlen == 64)
 enum clause extension = Ext_Sv57
 function clause hartSupports(Ext_Sv57) = config extensions.Sv57.supported : bool & (xlen == 64)
+
 // Cycle and Instret Privilege Mode Filtering
 enum clause extension = Ext_Smcntrpmf
 function clause hartSupports(Ext_Smcntrpmf) = config extensions.Smcntrpmf.supported

--- a/model/riscv_insts_end.sail
+++ b/model/riscv_insts_end.sail
@@ -28,6 +28,7 @@ mapping clause assembly = C_ILLEGAL(s) <-> "c.illegal" ^ spc() ^ hex_bits_16(s)
 
 /* End definitions */
 end extension
+end extensionName
 end hartSupports
 end currentlyEnabled
 end ast


### PR DESCRIPTION
- Add the `riscv,isa-base` and `riscv,isa-extensions` properties, and make the value of `riscv,isa` more accurate.

- Introduce an extensionName mapping for extensions, and use it in ISA string generation.

- Add a formatting enum for generation that could be extended for other formats of the ISA string.

- While here, do a minor cleanup of `riscv_extensions.sail` to fix ordering and comments.

Fixes #992.