### PR TITLE
Add 0x prefix to vector callback printed value

### DIFF
--- a/c_emulator/riscv_callbacks.cpp
+++ b/c_emulator/riscv_callbacks.cpp
@@ -115,7 +115,7 @@ unit csr_full_read_callback(const_sail_string csr_name, unsigned reg,
 unit vreg_write_callback(unsigned reg, lbits value)
 {
   if (config_print_reg) {
-    fprintf(trace_log, "v%d <- ", reg);
+    fprintf(trace_log, "v%d <- 0x", reg);
     // TODO: the width of `value` is currently `vlenmax` bits which can be much
     // greater than VLEN. In future we will remove `vlenmax`, then we can remove
     // the `zVLEN / 8` argument here.


### PR DESCRIPTION
Seems like this was just forgotten. The vector callback prints the value in hex but doesn't prefix if with `0x` like all of the other callbacks.