### PR TITLE
Add assembly for WRS instructions

### DIFF
--- a/model/riscv_insts_zawrs.sail
+++ b/model/riscv_insts_zawrs.sail
@@ -27,3 +27,6 @@ function clause execute (WRS(WRS_STO)) =
 
 function clause execute (WRS(WRS_NTO)) =
   Enter_Wait(WAIT_WRS_NTO)
+
+mapping clause assembly = WRS(WRS_STO) <-> "wrs.sto"
+mapping clause assembly = WRS(WRS_NTO) <-> "wrs.nto"


### PR DESCRIPTION
This was missing. I verified that GAS accepts both of these and it doesn't accept just `wrs`.