### PR TITLE
Fix signed immediates in vector assembly

### DIFF
--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -941,7 +941,7 @@ mapping vitype_mnemonic : vifunct6 <-> string = {
 }
 
 mapping clause assembly = VITYPE(funct6, vm, vs2, simm, vd)
-  <-> vitype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ maybe_vmask(vm)
+  <-> vitype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_signed_5(simm) ^ maybe_vmask(vm)
 
 /* ************************** OPIVI (WITYPE Narrowing) *************************** */
 /* ************** Vector Narrowing Integer Right Shift Instructions ************** */
@@ -1011,7 +1011,7 @@ mapping nistype_mnemonic : nisfunct6 <-> string = {
 }
 
 mapping clause assembly = NISTYPE(funct6, vm, vs2, simm, vd)
-  <-> nistype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ maybe_vmask(vm)
+  <-> nistype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_signed_5(simm) ^ maybe_vmask(vm)
 
 /* ************************** OPIVI (WITYPE Narrowing) *************************** */
 /* *************** Vector Narrowing Fixed-Point Clip Instructions **************** */
@@ -1082,7 +1082,7 @@ mapping nitype_mnemonic : nifunct6 <-> string = {
 }
 
 mapping clause assembly = NITYPE(funct6, vm, vs2, simm, vd)
-  <-> nitype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ maybe_vmask(vm)
+  <-> nitype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_signed_5(simm) ^ maybe_vmask(vm)
 
 /* ***************** OPIVI (Vector Slide & Gather Instructions) ****************** */
 /* Slide and gather instructions extend rs1/imm to XLEN instead of SEW bits */
@@ -1154,7 +1154,7 @@ mapping visg_mnemonic : visgfunct6 <-> string = {
 }
 
 mapping clause assembly = VISG(funct6, vm, vs2, simm, vd)
-  <-> visg_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ maybe_vmask(vm)
+  <-> visg_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_signed_5(simm) ^ maybe_vmask(vm)
 
 /* ********************** OPIVI (Integer Merge Instruction) ********************** */
 union clause ast = MASKTYPEI : (vregidx, bits(5), vregidx)
@@ -1206,7 +1206,7 @@ function clause execute(MASKTYPEI(vs2, simm, vd)) = {
 }
 
 mapping clause assembly = MASKTYPEI(vs2, simm, vd)
-  <-> "vmerge.vim" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ sep() ^ "v0"
+  <-> "vmerge.vim" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_signed_5(simm) ^ sep() ^ "v0"
 
 /* ********************** OPIVI (Integer Move Instruction) *********************** */
 union clause ast = MOVETYPEI : (vregidx, bits(5))
@@ -1245,7 +1245,7 @@ function clause execute(MOVETYPEI(vd, simm)) = {
 }
 
 mapping clause assembly = MOVETYPEI(vd, simm)
-  <-> "vmv.v.i" ^ spc() ^ vreg_name(vd) ^ sep() ^ hex_bits_5(simm)
+  <-> "vmv.v.i" ^ spc() ^ vreg_name(vd) ^ sep() ^ hex_bits_signed_5(simm)
 
 /* ********************* OPIVI (Whole Vector Register Move) ********************** */
 union clause ast = VMVRTYPE : (vregidx, bits(5), vregidx)

--- a/model/riscv_insts_vext_vm.sail
+++ b/model/riscv_insts_vext_vm.sail
@@ -565,7 +565,7 @@ mapping vimtype_mnemonic : vimfunct6 <-> string = {
 }
 
 mapping clause assembly = VIMTYPE(funct6, vs2, simm, vd)
-  <-> vimtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ sep() ^ "v0"
+  <-> vimtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_signed_5(simm) ^ sep() ^ "v0"
 
 /* ****************************** OPIVI (VIMCTYPE) ******************************* */
 /* VIMC instructions' destination is a mask register (e.g. carry out) */
@@ -620,7 +620,7 @@ mapping vimctype_mnemonic : vimcfunct6 <-> string = {
 }
 
 mapping clause assembly = VIMCTYPE(funct6, vs2, simm, vd)
-  <-> vimctype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm)
+  <-> vimctype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_signed_5(simm)
 
 /* ****************************** OPIVI (VIMSTYPE) ******************************* */
 /* VIMS instructions' destination is a vector register (e.g. actual sum) */
@@ -678,7 +678,7 @@ mapping vimstype_mnemonic : vimsfunct6 <-> string = {
 }
 
 mapping clause assembly = VIMSTYPE(funct6, vs2, simm, vd)
-  <-> vimstype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ sep() ^ "v0"
+  <-> vimstype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_signed_5(simm) ^ sep() ^ "v0"
 
 /* ***************** OPIVI (Vector Integer Compare Instructions) ***************** */
 /* VICMP instructions' destination is a mask register */
@@ -747,4 +747,4 @@ mapping vicmptype_mnemonic : vicmpfunct6 <-> string = {
 }
 
 mapping clause assembly = VICMPTYPE(funct6, vm, vs2, simm, vd)
-  <-> vicmptype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(simm) ^ maybe_vmask(vm)
+  <-> vicmptype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_signed_5(simm) ^ maybe_vmask(vm)


### PR DESCRIPTION
These instructions were printing signed immediates as unsigned numbers, which leads to errors when assembling them with GAS like

    Error: bad value for vector immediate field, value must be -16...15