### PR TITLE
Adding support for (project) fast track extension Zvkgs

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -200,6 +200,9 @@
     "Zvkg": {
       "supported": true
     },
+    "Zvkgs": {
+      "supported": true
+    },
     "Zvkned": {
       "supported": true
     },

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -206,6 +206,9 @@ function clause hartSupports(Ext_Zvknhb) = config extensions.Zvknhb.supported
 // ShangMi Suite: SM3 Secure Hash
 enum clause extension = Ext_Zvksh
 function clause hartSupports(Ext_Zvksh) = config extensions.Zvksh.supported
+// Vector-Scalar GCM/GMAC
+enum clause extension = Ext_Zvkgs
+function clause hartSupports(Ext_Zvkgs) = config extensions.Zvkgs.supported
 
 // Count Overflow and Mode-Based Filtering
 enum clause extension = Ext_Sscofpmf

--- a/model/riscv_insts_zvkg.sail
+++ b/model/riscv_insts_zvkg.sail
@@ -8,13 +8,21 @@
 
 function clause currentlyEnabled(Ext_Zvkg) = hartSupports(Ext_Zvkg) & currentlyEnabled(Ext_V)
 
-union clause ast = VGHSH_VV : (vregidx, vregidx, vregidx)
+function clause currentlyEnabled(Ext_Zvkgs) = hartSupports(Ext_Zvkgs) & currentlyEnabled(Ext_V)
 
-mapping clause encdec = VGHSH_VV(vs2, vs1, vd)
-  <-> 0b1011001 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1110111
-  when currentlyEnabled(Ext_Zvkg) & get_sew() == 32 & zvk_check_encdec(128, 4)
+union clause ast = VGHSH : (zvk_vghsh_funct6, vregidx, vregidx, vregidx)
 
-function clause execute (VGHSH_VV(vs2, vs1, vd)) = {
+mapping encdec_vghsh : zvk_vghsh_funct6 <-> bits(6) = {
+  ZVKG_VGHSH_VV <-> 0b101100,
+  ZVKGS_VGHSH_VS <-> 0b100011,
+}
+
+mapping clause encdec = VGHSH(funct6, vs2, vs1, vd)
+  <-> encdec_vghsh(funct6) @ 0b1 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  when (currentlyEnabled(Ext_Zvkg) & funct6 == ZVKG_VGHSH_VV | currentlyEnabled(Ext_Zvkgs) & funct6 == ZVKGS_VGHSH_VS) &
+   get_sew() == 32 & zvk_check_encdec(128, 4)
+
+function clause execute (VGHSH(funct6, vs2, vs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -33,7 +41,10 @@ function clause execute (VGHSH_VV(vs2, vs1, vd)) = {
 
     let Y : bits(128) = get_velem_quad(vd_val, i);
     let X : bits(128) = get_velem_quad(vs1_val, i);
-    var H : bits(128) = brev8(get_velem_quad(vs2_val, i));
+    var H : bits(128) = match funct6 {
+      ZVKG_VGHSH_VV => brev8(get_velem_quad(vs2_val, i)),
+      ZVKGS_VGHSH_VS => brev8(get_velem_quad(vs2_val, 0)),
+    };
 
     var Z : bits(128) = zeros();
     let S : bits(128) = brev8(Y ^ X);
@@ -53,16 +64,27 @@ function clause execute (VGHSH_VV(vs2, vs1, vd)) = {
   RETIRE_SUCCESS
 }
 
-mapping clause assembly = VGHSH_VV(vs2, vs1, vd)
-  <-> "vghsh.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1)
+mapping vghsh_mnemonic : zvk_vghsh_funct6 <-> string = {
+  ZVKG_VGHSH_VV <-> "vghsh.vv",
+  ZVKGS_VGHSH_VS <-> "vghsh.vs", 
+}
 
-union clause ast = VGMUL_VV : (vregidx, vregidx)
+mapping clause assembly = VGHSH(funct6, vs2, vs1, vd)
+  <-> vghsh_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1)
 
-mapping clause encdec = VGMUL_VV(vs2, vd)
-  <-> 0b1010001 @ encdec_vreg(vs2) @ 0b10001 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
-  when currentlyEnabled(Ext_Zvkg) & get_sew() == 32 & zvk_check_encdec(128, 4)
+union clause ast = VGMUL : (zvk_vgmul_funct6, vregidx, vregidx)
 
-function clause execute (VGMUL_VV(vs2, vd)) = {
+mapping encdec_vgmul : zvk_vgmul_funct6 <-> bits(6) = {
+  ZVKG_VGMUL_VV <-> 0b101000,
+  ZVKGS_VGMUL_VS <-> 0b101001,
+}
+
+mapping clause encdec = VGMUL(funct6, vs2, vd)
+  <-> encdec_vgmul(funct6) @ 0b1 @ encdec_vreg(vs2) @ 0b10001 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  when (currentlyEnabled(Ext_Zvkg) & funct6 == ZVKG_VGMUL_VV | currentlyEnabled(Ext_Zvkgs) & funct6 == ZVKGS_VGMUL_VS) &
+   get_sew() == 32 & zvk_check_encdec(128, 4)
+
+function clause execute (VGMUL(funct6, vs2, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -79,7 +101,10 @@ function clause execute (VGMUL_VV(vs2, vd)) = {
     assert(i * 4 + 3 < num_elem);
 
     let Y : bits(128) = brev8(get_velem_quad(vd_val, i));
-    var H : bits(128) = brev8(get_velem_quad(vs2_val, i));
+    var H : bits(128) = match funct6 {
+      ZVKG_VGMUL_VV => brev8(get_velem_quad(vs2_val, i)),
+      ZVKGS_VGMUL_VS => brev8(get_velem_quad(vs2_val, 0)),
+    };
     var Z : bits(128) = zeros();
 
     foreach (b from 0 to 127) {
@@ -97,5 +122,10 @@ function clause execute (VGMUL_VV(vs2, vd)) = {
   RETIRE_SUCCESS
 }
 
-mapping clause assembly = VGMUL_VV(vs2, vd)
-  <-> "vgmul.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)
+mapping vgmul_mnemonic : zvk_vgmul_funct6 <-> string = {
+  ZVKG_VGMUL_VV <-> "vgmul.vv",
+  ZVKGS_VGMUL_VS <-> "vgmul.vs",
+}
+
+mapping clause assembly = VGMUL(funct6, vs2, vd)
+  <-> vgmul_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)

--- a/model/riscv_zvk_utils.sail
+++ b/model/riscv_zvk_utils.sail
@@ -127,3 +127,11 @@ enum zvk_vaesdf_funct6 = {ZVK_VAESDF_VV, ZVK_VAESDF_VS}
 enum zvk_vaesdm_funct6 = {ZVK_VAESDM_VV, ZVK_VAESDM_VS}
 enum zvk_vaesef_funct6 = {ZVK_VAESEF_VV, ZVK_VAESEF_VS}
 enum zvk_vaesem_funct6 = {ZVK_VAESEM_VV, ZVK_VAESEM_VS}
+
+/*
+ * Utility function for Zvkg/Zvkgs
+ * ----------------------------------------------------------------------
+ */
+ enum zvk_vghsh_funct6 = {ZVKG_VGHSH_VV, ZVKGS_VGHSH_VS}
+
+ enum zvk_vgmul_funct6 = {ZVKG_VGMUL_VV, ZVKGS_VGMUL_VS}


### PR DESCRIPTION
This PR is a sibling to https://github.com/riscv/sail-riscv/pull/931
It aims at adding support for the other extension part of the vector-crypto fast track project: **Zvkgs** (Vector-Scalar VGHSH and VGMUL instructions `vghsh.vs` and `vgmul.vs`).

The fast track effort is tracked here: https://github.com/riscv/riscv-isa-manual/pull/1306.
Opcodes used in this PR are from https://github.com/riscv/riscv-opcodes/pull/270/files.

This is very much a work in progress at this point.

* Modifying zvkg description to support both Zvkg and Zvkgs
* Enabling Zvkgs in default configuration

I tried to reuse existing code by inserting the new support in `model/riscv_insts_zvkg.sail` and mimicking what was done for other vector-scalar variants (in particular from Zvkned).

Any feedback appreciated on the general syntax, naming, correctness (it builds "locally" but I have not done anything more to test yet) ...