### PR TITLE
Add Zkt and Zvkt extensions for device tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ For booting operating system images, see the information under the
 - Zbkb, Zbkc, and Zbkx extensions for bit manipulation for cryptography, v1.0
 - Zkn (Zknd, Zkne, Zknh) and Zks (Zksed, Zksh) extensions for scalar cryptography, v1.0.1
 - Zkr extension for entropy source, v1.0
+- Zkt extension for data independent execution latency, v1.0 (no impact on model)
 - V extension for vector operations, v1.0
 - Zvbb extension for vector basic bit-manipulation, v1.0
 - Zvbc extension for vector carryless multiplication, v1.0
@@ -112,6 +113,7 @@ For booting operating system images, see the information under the
 - Zvkned extension for vector cryptography NIST Suite: Vector AES Block Cipher, v1.0
 - Zvknha and Zvknhb extensions for vector cryptography NIST Suite: Vector SHA-2 Secure Hash, v1.0
 - Zvksh extension for vector cryptography ShangMi Suite: SM3 Secure Hash, v1.0
+- Zvkt extension for vector data independent execution latency, v1.0 (no impact on model)
 - Machine, Supervisor, and User modes
 - Smcntrpmf extension for cycle and instret privilege mode filtering, v1.0
 - Sscofpmf extension for Count Overflow and Mode-Based Filtering, v1.0

--- a/config/default.json
+++ b/config/default.json
@@ -182,6 +182,9 @@
     "Zksh": {
       "supported": true
     },
+    "Zkt": {
+      "supported": true
+    },
     "Zhinx": {
       "supported": false
     },
@@ -210,6 +213,9 @@
       "supported": true
     },
     "Zvksh": {
+      "supported": true
+    },
+    "Zvkt": {
       "supported": true
     },
     "Sscofpmf": {

--- a/model/riscv_device_tree.sail
+++ b/model/riscv_device_tree.sail
@@ -150,7 +150,8 @@ function generate_isa_string(fmt : ISA_Format) -> string = {
   ^ ext_wrap(Ext_Zknh, fmt)
   ^ ext_wrap(Ext_Zkr, fmt)
   ^ ext_wrap(Ext_Zksed, fmt)
-  ^ ext_wrap(Ext_Zksh, fmt);
+  ^ ext_wrap(Ext_Zksh, fmt)
+  ^ ext_wrap(Ext_Zkt, fmt);
 
   let zv_exts = ""
   ^ ext_wrap(Ext_Zvbb, fmt)
@@ -160,7 +161,8 @@ function generate_isa_string(fmt : ISA_Format) -> string = {
   ^ ext_wrap(Ext_Zvkned, fmt)
   ^ ext_wrap(Ext_Zvknha, fmt)
   ^ ext_wrap(Ext_Zvknhb, fmt)
-  ^ ext_wrap(Ext_Zvksh, fmt);
+  ^ ext_wrap(Ext_Zvksh, fmt)
+  ^ ext_wrap(Ext_Zvkt, fmt);
 
   // Append the Supervisor extensions, ordered alphabetically.
 

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -225,6 +225,11 @@ function clause hartSupports(Ext_Zksed) = config extensions.Zksed.supported
 enum clause extension = Ext_Zksh
 mapping clause extensionName = Ext_Zksh <-> "zksh"
 function clause hartSupports(Ext_Zksh) = config extensions.Zksh.supported
+// Data Independent Execution Latency
+enum clause extension = Ext_Zkt
+mapping clause extensionName = Ext_Zkt <-> "zkt"
+function clause hartSupports(Ext_Zkt) = config extensions.Zkt.supported
+function clause currentlyEnabled(Ext_Zkt) = hartSupports(Ext_Zkt)
 
 // Floating-Point in Integer Registers (half precision)
 enum clause extension = Ext_Zhinx
@@ -267,6 +272,11 @@ function clause hartSupports(Ext_Zvknhb) = config extensions.Zvknhb.supported
 enum clause extension = Ext_Zvksh
 mapping clause extensionName = Ext_Zvksh <-> "zvksh"
 function clause hartSupports(Ext_Zvksh) = config extensions.Zvksh.supported
+// Vector Data Independent Execution Latency
+enum clause extension = Ext_Zvkt
+mapping clause extensionName = Ext_Zkt <-> "zvkt"
+function clause hartSupports(Ext_Zvkt) = config extensions.Zvkt.supported
+function clause currentlyEnabled(Ext_Zvkt) = hartSupports(Ext_Zvkt)
 
 // Count Overflow and Mode-Based Filtering
 enum clause extension = Ext_Sscofpmf


### PR DESCRIPTION
These extensions have no impact on the model itself (they are about data-independent execution latency), but if we want to be able to generate a complete device tree, we need to support them.