### PR TITLE
fix: Correct a few compressed load/store assembly

### DIFF
--- a/model/riscv_insts_zca.sail
+++ b/model/riscv_insts_zca.sail
@@ -418,7 +418,7 @@ function clause execute (C_LWSP(uimm, rd)) = {
 }
 
 mapping clause assembly = C_LWSP(uimm, rd)
-  <-> "c.lwsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name(Regidx(0b00010)) ^ ")"
+  <-> "c.lwsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name_func(sp) ^ ")"
   when rd != zreg
 
 /* ****************************************************************** */
@@ -434,7 +434,7 @@ function clause execute (C_LDSP(uimm, rd)) = {
 }
 
 mapping clause assembly = C_LDSP(uimm, rd)
-  <-> "c.ldsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name(Regidx(0b00010)) ^ ")"
+  <-> "c.ldsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name_func(sp) ^ ")"
   when rd != zreg & xlen == 64
 
 /* ****************************************************************** */
@@ -450,7 +450,7 @@ function clause execute (C_SWSP(uimm, rs2)) = {
 }
 
 mapping clause assembly = C_SWSP(uimm, rs2)
-  <-> "c.swsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name(Regidx(0b00010)) ^ ")"
+  <-> "c.swsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name_func(sp) ^ ")"
 
 /* ****************************************************************** */
 union clause ast = C_SDSP : (bits(6), regidx)
@@ -465,7 +465,7 @@ function clause execute (C_SDSP(uimm, rs2)) = {
 }
 
 mapping clause assembly = C_SDSP(uimm, rs2)
-  <-> "c.sdsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name(Regidx(0b00010)) ^ ")"
+  <-> "c.sdsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name_func(sp) ^ ")"
   when xlen == 64
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zca.sail
+++ b/model/riscv_insts_zca.sail
@@ -418,7 +418,7 @@ function clause execute (C_LWSP(uimm, rd)) = {
 }
 
 mapping clause assembly = C_LWSP(uimm, rd)
-  <-> "c.lwsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name_func(sp) ^ ")"
+  <-> "c.lwsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ sp_reg_name() ^ ")"
   when rd != zreg
 
 /* ****************************************************************** */
@@ -434,7 +434,7 @@ function clause execute (C_LDSP(uimm, rd)) = {
 }
 
 mapping clause assembly = C_LDSP(uimm, rd)
-  <-> "c.ldsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name_func(sp) ^ ")"
+  <-> "c.ldsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ sp_reg_name() ^ ")"
   when rd != zreg & xlen == 64
 
 /* ****************************************************************** */
@@ -450,7 +450,7 @@ function clause execute (C_SWSP(uimm, rs2)) = {
 }
 
 mapping clause assembly = C_SWSP(uimm, rs2)
-  <-> "c.swsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name_func(sp) ^ ")"
+  <-> "c.swsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ sp_reg_name() ^ ")"
 
 /* ****************************************************************** */
 union clause ast = C_SDSP : (bits(6), regidx)
@@ -465,7 +465,7 @@ function clause execute (C_SDSP(uimm, rs2)) = {
 }
 
 mapping clause assembly = C_SDSP(uimm, rs2)
-  <-> "c.sdsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name_func(sp) ^ ")"
+  <-> "c.sdsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ sp_reg_name() ^ ")"
   when xlen == 64
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zca.sail
+++ b/model/riscv_insts_zca.sail
@@ -418,7 +418,7 @@ function clause execute (C_LWSP(uimm, rd)) = {
 }
 
 mapping clause assembly = C_LWSP(uimm, rd)
-  <-> "c.lwsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm)
+  <-> "c.lwsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name(Regidx(0b00010)) ^ ")"
   when rd != zreg
 
 /* ****************************************************************** */
@@ -434,7 +434,7 @@ function clause execute (C_LDSP(uimm, rd)) = {
 }
 
 mapping clause assembly = C_LDSP(uimm, rd)
-  <-> "c.ldsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm)
+  <-> "c.ldsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name(Regidx(0b00010)) ^ ")"
   when rd != zreg & xlen == 64
 
 /* ****************************************************************** */
@@ -450,7 +450,7 @@ function clause execute (C_SWSP(uimm, rs2)) = {
 }
 
 mapping clause assembly = C_SWSP(uimm, rs2)
-  <-> "c.swsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm)
+  <-> "c.swsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name(Regidx(0b00010)) ^ ")"
 
 /* ****************************************************************** */
 union clause ast = C_SDSP : (bits(6), regidx)
@@ -465,7 +465,7 @@ function clause execute (C_SDSP(uimm, rs2)) = {
 }
 
 mapping clause assembly = C_SDSP(uimm, rs2)
-  <-> "c.sdsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm)
+  <-> "c.sdsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name(Regidx(0b00010)) ^ ")"
   when xlen == 64
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zcd.sail
+++ b/model/riscv_insts_zcd.sail
@@ -21,7 +21,7 @@ function clause execute (C_FLDSP(uimm, rd)) = {
 
 mapping clause assembly = C_FLDSP(uimm, rd)
       if (xlen == 32 | xlen == 64)
-  <-> "c.fldsp" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_6(uimm)
+  <-> "c.fldsp" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name(Regidx(0b00010)) ^ ")"
       if (xlen == 32 | xlen == 64)
 
 /* ****************************************************************** */
@@ -38,7 +38,7 @@ function clause execute (C_FSDSP(uimm, rs2)) = {
 
 mapping clause assembly = C_FSDSP(uimm, rs2)
       if (xlen == 32 | xlen == 64)
-  <-> "c.fsdsp" ^ spc() ^ freg_name(rs2) ^ sep() ^ hex_bits_6(uimm)
+  <-> "c.fsdsp" ^ spc() ^ freg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name(Regidx(0b00010)) ^ ")"
       if (xlen == 32 | xlen == 64)
 
 /* ****************************************************************** */
@@ -57,7 +57,7 @@ function clause execute (C_FLD(uimm, rsc, rdc)) = {
 
 mapping clause assembly = C_FLD(uimm, rsc, rdc)
       if (xlen == 32 | xlen == 64)
-  <-> "c.fld" ^ spc() ^ creg_name(rdc) ^ sep() ^ creg_name(rsc) ^ sep() ^ hex_bits_8(uimm @ 0b000)
+  <-> "c.fld" ^ spc() ^ creg_name(rdc) ^ sep() ^ hex_bits_8(uimm @ 0b000) ^ "(" ^ creg_name(rsc) ^ ")"
       if (xlen == 32 | xlen == 64)
 
 /* ****************************************************************** */
@@ -76,5 +76,5 @@ function clause execute (C_FSD(uimm, rsc1, rsc2)) = {
 
 mapping clause assembly = C_FSD(uimm, rsc1, rsc2)
       if (xlen == 32 | xlen == 64)
-  <-> "c.fsd" ^ spc() ^ creg_name(rsc1) ^ sep() ^ creg_name(rsc2) ^ sep() ^ hex_bits_8(uimm @ 0b000)
+  <-> "c.fsd" ^ spc() ^ creg_name(rsc1) ^ sep() ^ hex_bits_8(uimm @ 0b000) ^ "(" ^ creg_name(rsc2) ^ ")"
       if (xlen == 32 | xlen == 64)

--- a/model/riscv_insts_zcd.sail
+++ b/model/riscv_insts_zcd.sail
@@ -21,7 +21,7 @@ function clause execute (C_FLDSP(uimm, rd)) = {
 
 mapping clause assembly = C_FLDSP(uimm, rd)
       if (xlen == 32 | xlen == 64)
-  <-> "c.fldsp" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name(Regidx(0b00010)) ^ ")"
+  <-> "c.fldsp" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name_func(sp) ^ ")"
       if (xlen == 32 | xlen == 64)
 
 /* ****************************************************************** */
@@ -38,7 +38,7 @@ function clause execute (C_FSDSP(uimm, rs2)) = {
 
 mapping clause assembly = C_FSDSP(uimm, rs2)
       if (xlen == 32 | xlen == 64)
-  <-> "c.fsdsp" ^ spc() ^ freg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name(Regidx(0b00010)) ^ ")"
+  <-> "c.fsdsp" ^ spc() ^ freg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name_func(sp) ^ ")"
       if (xlen == 32 | xlen == 64)
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zcd.sail
+++ b/model/riscv_insts_zcd.sail
@@ -76,5 +76,5 @@ function clause execute (C_FSD(uimm, rsc1, rsc2)) = {
 
 mapping clause assembly = C_FSD(uimm, rsc1, rsc2)
       if (xlen == 32 | xlen == 64)
-  <-> "c.fsd" ^ spc() ^ creg_name(rsc1) ^ sep() ^ hex_bits_8(uimm @ 0b000) ^ "(" ^ creg_name(rsc2) ^ ")"
+  <-> "c.fsd" ^ spc() ^ creg_name(rsc2) ^ sep() ^ hex_bits_8(uimm @ 0b000) ^ "(" ^ creg_name(rsc1) ^ ")"
       if (xlen == 32 | xlen == 64)

--- a/model/riscv_insts_zcd.sail
+++ b/model/riscv_insts_zcd.sail
@@ -21,7 +21,7 @@ function clause execute (C_FLDSP(uimm, rd)) = {
 
 mapping clause assembly = C_FLDSP(uimm, rd)
       if (xlen == 32 | xlen == 64)
-  <-> "c.fldsp" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name_func(sp) ^ ")"
+  <-> "c.fldsp" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ sp_reg_name() ^ ")"
       if (xlen == 32 | xlen == 64)
 
 /* ****************************************************************** */
@@ -38,7 +38,7 @@ function clause execute (C_FSDSP(uimm, rs2)) = {
 
 mapping clause assembly = C_FSDSP(uimm, rs2)
       if (xlen == 32 | xlen == 64)
-  <-> "c.fsdsp" ^ spc() ^ freg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name_func(sp) ^ ")"
+  <-> "c.fsdsp" ^ spc() ^ freg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ sp_reg_name() ^ ")"
       if (xlen == 32 | xlen == 64)
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zcf.sail
+++ b/model/riscv_insts_zcf.sail
@@ -20,7 +20,7 @@ function clause execute (C_FLWSP(imm, rd)) = {
 }
 
 mapping clause assembly = C_FLWSP(imm, rd)
-  <-> "c.flwsp" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_6(imm) ^ "(" ^ reg_name_func(sp) ^ ")"
+  <-> "c.flwsp" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_6(imm) ^ "(" ^ sp_reg_name() ^ ")"
   when xlen == 32
 
 /* ****************************************************************** */
@@ -36,7 +36,7 @@ function clause execute (C_FSWSP(uimm, rs2)) = {
 }
 
 mapping clause assembly = C_FSWSP(uimm, rs2)
-  <-> "c.fswsp" ^ spc() ^ freg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name_func(sp) ^ ")"
+  <-> "c.fswsp" ^ spc() ^ freg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ sp_reg_name() ^ ")"
   when xlen == 32
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zcf.sail
+++ b/model/riscv_insts_zcf.sail
@@ -20,7 +20,7 @@ function clause execute (C_FLWSP(imm, rd)) = {
 }
 
 mapping clause assembly = C_FLWSP(imm, rd)
-  <-> "c.flwsp" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_6(imm) ^ "(" ^ reg_name(Regidx(0b00010)) ^ ")"
+  <-> "c.flwsp" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_6(imm) ^ "(" ^ reg_name_func(sp) ^ ")"
   when xlen == 32
 
 /* ****************************************************************** */
@@ -36,7 +36,7 @@ function clause execute (C_FSWSP(uimm, rs2)) = {
 }
 
 mapping clause assembly = C_FSWSP(uimm, rs2)
-  <-> "c.fswsp" ^ spc() ^ freg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name(Regidx(0b00010)) ^ ")"
+  <-> "c.fswsp" ^ spc() ^ freg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name_func(sp) ^ ")"
   when xlen == 32
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zcf.sail
+++ b/model/riscv_insts_zcf.sail
@@ -20,7 +20,7 @@ function clause execute (C_FLWSP(imm, rd)) = {
 }
 
 mapping clause assembly = C_FLWSP(imm, rd)
-  <-> "c.flwsp" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_6(imm)
+  <-> "c.flwsp" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_6(imm) ^ "(" ^ reg_name(Regidx(0b00010)) ^ ")"
   when xlen == 32
 
 /* ****************************************************************** */
@@ -36,7 +36,7 @@ function clause execute (C_FSWSP(uimm, rs2)) = {
 }
 
 mapping clause assembly = C_FSWSP(uimm, rs2)
-  <-> "c.fswsp" ^ spc() ^ freg_name(rs2) ^ sep() ^ hex_bits_6(uimm)
+  <-> "c.fswsp" ^ spc() ^ freg_name(rs2) ^ sep() ^ hex_bits_6(uimm) ^ "(" ^ reg_name(Regidx(0b00010)) ^ ")"
   when xlen == 32
 
 /* ****************************************************************** */
@@ -54,7 +54,7 @@ function clause execute (C_FLW(uimm, rsc, rdc)) = {
 }
 
 mapping clause assembly = C_FLW(uimm, rsc, rdc)
-  <-> "c.flw" ^ spc() ^ creg_name(rdc) ^ sep() ^ creg_name(rsc) ^ sep() ^ hex_bits_7(uimm @ 0b00)
+  <-> "c.flw" ^ spc() ^ creg_name(rdc) ^ sep() ^ hex_bits_7(uimm @ 0b00) ^ "(" ^ creg_name(rsc) ^ ")"
   when xlen == 32
 
 /* ****************************************************************** */
@@ -72,5 +72,5 @@ function clause execute (C_FSW(uimm, rsc1, rsc2)) = {
 }
 
 mapping clause assembly = C_FSW(uimm, rsc1, rsc2)
-  <-> "c.fsw" ^ spc() ^ creg_name(rsc1) ^ sep() ^ creg_name(rsc2) ^ sep() ^ hex_bits_7(uimm @ 0b00)
+  <-> "c.fsw" ^ spc() ^ creg_name(rsc1) ^ sep() ^ hex_bits_7(uimm @ 0b00) ^ "(" ^ creg_name(rsc2) ^ ")"
   when xlen == 32

--- a/model/riscv_insts_zcf.sail
+++ b/model/riscv_insts_zcf.sail
@@ -72,5 +72,5 @@ function clause execute (C_FSW(uimm, rsc1, rsc2)) = {
 }
 
 mapping clause assembly = C_FSW(uimm, rsc1, rsc2)
-  <-> "c.fsw" ^ spc() ^ creg_name(rsc1) ^ sep() ^ hex_bits_7(uimm @ 0b00) ^ "(" ^ creg_name(rsc2) ^ ")"
+  <-> "c.fsw" ^ spc() ^ creg_name(rsc2) ^ sep() ^ hex_bits_7(uimm @ 0b00) ^ "(" ^ creg_name(rsc1) ^ ")"
   when xlen == 32

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -88,6 +88,8 @@ mapping reg_name : regidx <-> string = {
   Regidx(i) if not(get_config_use_abi_names()) <-> reg_arch_name_raw(i),
 }
 
+function reg_name_func(reg: regidx) -> string = reg_name(reg)
+
 mapping creg_name_raw : bits(3) <-> string = {
   0b000 <-> "s0",
   0b001 <-> "s1",

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -91,8 +91,8 @@ mapping reg_name : regidx <-> string = {
 // Special mapping for the sp register for use in assembly for sp-relative
 // instructions where the argument *must* be `sp` (or `x2`).
 mapping sp_reg_name : unit <-> string = {
-  () if get_config_use_abi_names() <-> "sp" ,
-  () if not(get_config_use_abi_names()) <-> "x2" ,
+  () if get_config_use_abi_names() <-> "sp",
+  () if not(get_config_use_abi_names()) <-> "x2",
 }
 
 mapping creg_name_raw : bits(3) <-> string = {

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -88,7 +88,12 @@ mapping reg_name : regidx <-> string = {
   Regidx(i) if not(get_config_use_abi_names()) <-> reg_arch_name_raw(i),
 }
 
-function reg_name_func(reg: regidx) -> string = reg_name(reg)
+// Special mapping for the sp register for use in assembly for sp-relative
+// instructions where the argument *must* be `sp` (or `x2`).
+mapping sp_reg_name : unit <-> string = {
+  () if get_config_use_abi_names() <-> "sp" ,
+  () if not(get_config_use_abi_names()) <-> "x2" ,
+}
 
 mapping creg_name_raw : bits(3) <-> string = {
   0b000 <-> "s0",


### PR DESCRIPTION
Assembly for load/store instructions need a base register in the form:
```
instruction destination,offset(base)
```

Within that set, stack-based instructions need to explicitly specify
the stack pointer (even though it is ignored in encoding).

Also, `fsd`, `fsw` have reversed operands.