### PR TITLE
Use `0` for empty pred/succ set in fence assembly

### DIFF
--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -497,7 +497,11 @@ mapping bit_maybe_o : bits(1) <-> string = {
 }
 
 mapping fence_bits : bits(4) <-> string = {
-  i : bits(1) @ o : bits(1) @ r : bits(1) @ w : bits(1) <-> bit_maybe_i(i) ^ bit_maybe_o(o) ^ bit_maybe_r(r) ^ bit_maybe_w(w)
+  // Fences with empty predecessor or successor sets are nops.
+  // Clang/LLVM's assembly supports using `0` for these.
+  // Binutils/GAS does not so you would have to use `.insn` to encode these.
+  0b0000 <-> "0",
+  i : bits(1) @ o : bits(1) @ r : bits(1) @ w : bits(1) <-> bit_maybe_i(i) ^ bit_maybe_o(o) ^ bit_maybe_r(r) ^ bit_maybe_w(w),
 }
 
 mapping clause assembly = FENCE(pred, succ)


### PR DESCRIPTION
It's legal (but not very useful) to have a fence with an empty predecessor or successor set. These are executed as nops. Currently we disassemble them to e.g. `fence , rw` which is not valid. This improves the disassembly to `fence 0, rw` which is accepted by LLVM, but unfortunately not GAS.