### PR TITLE
Refactor ISA string generation and improve type checking performance

### DIFF
--- a/model/riscv_device_tree.sail
+++ b/model/riscv_device_tree.sail
@@ -86,110 +86,16 @@ function ext_wrap(ext : extension, fmt : ISA_Format) -> string = {
 }
 
 function generate_isa_string(fmt : ISA_Format) -> string = {
-  // The Sail compiler blows up if this string is constructed in one go.
-  // Build it up in pieces.
-  let prefix : string = match fmt {
+  var isa_string : string = match fmt {
     Canonical_Lowercase => "rv" ^ dec_str(xlen) ^ "i",
     DeviceTree_ISA_Extensions => "\"i\"",
   };
 
-  // First append the single letter extensions.
+  // The default Order dec means we start from the end
+  foreach (i from (length(extensions_ordered_for_isa_string) - 1) downto 0)
+    isa_string = isa_string ^ ext_wrap(extensions_ordered_for_isa_string[i], fmt);
 
-  let singles = ""
-  ^ ext_wrap(Ext_M, fmt)
-  ^ ext_wrap(Ext_A, fmt)
-  ^ ext_wrap(Ext_F, fmt)
-  ^ ext_wrap(Ext_D, fmt)
-  ^ ext_wrap(Ext_C, fmt)
-  ^ ext_wrap(Ext_B, fmt)
-  ^ ext_wrap(Ext_V, fmt)
-  // S and U are not valid extensions in the device-tree, whereas H is.
-  ^ ext_wrap(Ext_H, fmt);
-
-  // Append the Z extensions, ordered by category and then alphabetically.
-  let zi_exts = ""
-  ^ ext_wrap(Ext_Zicbom, fmt)
-  ^ ext_wrap(Ext_Zicboz, fmt)
-  ^ ext_wrap(Ext_Zicntr, fmt)
-  ^ ext_wrap(Ext_Zicond, fmt)
-  ^ ext_wrap(Ext_Zicsr, fmt)
-  ^ ext_wrap(Ext_Zifencei, fmt)
-  ^ ext_wrap(Ext_Zihpm, fmt)
-  ^ ext_wrap(Ext_Zimop, fmt)
-
-  ^ ext_wrap(Ext_Zmmul, fmt);
-
-  let za_exts = ""
-  ^ ext_wrap(Ext_Zaamo, fmt)
-  ^ ext_wrap(Ext_Zabha, fmt)
-  ^ ext_wrap(Ext_Zalrsc, fmt)
-  ^ ext_wrap(Ext_Zawrs, fmt);
-
-  let zf_exts = ""
-  ^ ext_wrap(Ext_Zfa, fmt)
-  ^ ext_wrap(Ext_Zfh, fmt)
-  ^ ext_wrap(Ext_Zfhmin, fmt)
-  ^ ext_wrap(Ext_Zfinx, fmt)
-  ^ ext_wrap(Ext_Zdinx, fmt)
-  ^ ext_wrap(Ext_Zhinx, fmt)
-  ^ ext_wrap(Ext_Zhinxmin, fmt);
-
-  let zc_exts = ""
-  ^ ext_wrap(Ext_Zca, fmt)
-  ^ ext_wrap(Ext_Zcb, fmt)
-  ^ ext_wrap(Ext_Zcd, fmt)
-  ^ ext_wrap(Ext_Zcf, fmt)
-  ^ ext_wrap(Ext_Zcmop, fmt);
-
-  let zb_exts = ""
-  ^ ext_wrap(Ext_Zba, fmt)
-  ^ ext_wrap(Ext_Zbb, fmt)
-  ^ ext_wrap(Ext_Zbc, fmt)
-  ^ ext_wrap(Ext_Zbkb, fmt)
-  ^ ext_wrap(Ext_Zbkc, fmt)
-  ^ ext_wrap(Ext_Zbkx, fmt)
-  ^ ext_wrap(Ext_Zbs, fmt);
-
-  let zk_exts = ""
-  ^ ext_wrap(Ext_Zknd, fmt)
-  ^ ext_wrap(Ext_Zkne, fmt)
-  ^ ext_wrap(Ext_Zknh, fmt)
-  ^ ext_wrap(Ext_Zkr, fmt)
-  ^ ext_wrap(Ext_Zksed, fmt)
-  ^ ext_wrap(Ext_Zksh, fmt)
-  ^ ext_wrap(Ext_Zkt, fmt);
-
-  let zv_exts = ""
-  ^ ext_wrap(Ext_Zvbb, fmt)
-  ^ ext_wrap(Ext_Zvbc, fmt)
-  ^ ext_wrap(Ext_Zvkb, fmt)
-  ^ ext_wrap(Ext_Zvkg, fmt)
-  ^ ext_wrap(Ext_Zvkned, fmt)
-  ^ ext_wrap(Ext_Zvknha, fmt)
-  ^ ext_wrap(Ext_Zvknhb, fmt)
-  ^ ext_wrap(Ext_Zvksh, fmt)
-  ^ ext_wrap(Ext_Zvkt, fmt);
-
-  // Append the Supervisor extensions, ordered alphabetically.
-
-  let s_exts = ""
-  ^ ext_wrap(Ext_Sscofpmf, fmt)
-  ^ ext_wrap(Ext_Sstc, fmt)
-  // Handle svade and svadu here when ready.
-  ^ ext_wrap(Ext_Svinval, fmt)
-  ^ ext_wrap(Ext_Svnapot, fmt)
-  ^ ext_wrap(Ext_Svpbmt, fmt);
-
-  // Append the Hypervisor extensions, ordered alphabetically.
-
-  // Append the Machine mode extensions, ordered alphabetically.
-
-  let m_exts = ""
-  ^ ext_wrap(Ext_Smcntrpmf, fmt);
-
-  prefix ^ singles
-  ^ zi_exts ^ za_exts ^ zf_exts ^ zc_exts ^ zb_exts ^ zk_exts ^ zv_exts
-  ^ s_exts ^ m_exts
+  isa_string
 }
 
 // Generates the full Device-Tree configuration for the model.

--- a/model/riscv_extensions.sail
+++ b/model/riscv_extensions.sail
@@ -324,3 +324,98 @@ function clause hartSupports(Ext_Sv57) = config extensions.Sv57.supported : bool
 enum clause extension = Ext_Smcntrpmf
 mapping clause extensionName = Ext_Smcntrpmf <-> "smcntrpmf"
 function clause hartSupports(Ext_Smcntrpmf) = config extensions.Smcntrpmf.supported
+
+let extensions_ordered_for_isa_string = [
+  // Single letter extensions.
+  Ext_M,
+  Ext_A,
+  Ext_F,
+  Ext_D,
+  // Ext_G,
+  // Ext_Q,
+  Ext_C,
+  Ext_B,
+  // Ext_P,
+  Ext_V,
+  Ext_H,
+  // S and U are not valid extensions in the device-tree, whereas H is.
+
+  // Z extensions, ordered by category and then alphabetically.
+  // Zi
+  Ext_Zicbom,
+  Ext_Zicboz,
+  Ext_Zicntr,
+  Ext_Zicond,
+  Ext_Zicsr,
+  Ext_Zifencei,
+  Ext_Zihpm,
+  Ext_Zimop,
+
+  // Zm
+  Ext_Zmmul,
+
+  // Za
+  Ext_Zaamo,
+  Ext_Zabha,
+  Ext_Zalrsc,
+  Ext_Zawrs,
+
+  // Zf, Zd, and Zq
+  Ext_Zfa,
+  Ext_Zfh,
+  Ext_Zfhmin,
+  Ext_Zfinx,
+  Ext_Zdinx,
+  Ext_Zhinx,
+  Ext_Zhinxmin,
+
+  // Zc
+  Ext_Zca,
+  Ext_Zcb,
+  Ext_Zcd,
+  Ext_Zcf,
+  Ext_Zcmop,
+
+  // Zb
+  Ext_Zba,
+  Ext_Zbb,
+  Ext_Zbc,
+  Ext_Zbkb,
+  Ext_Zbkc,
+  Ext_Zbkx,
+  Ext_Zbs,
+
+  // Zk
+  Ext_Zknd,
+  Ext_Zkne,
+  Ext_Zknh,
+  Ext_Zkr,
+  Ext_Zksed,
+  Ext_Zksh,
+  Ext_Zkt,
+
+  // Zv
+  Ext_Zvbb,
+  Ext_Zvbc,
+  Ext_Zvkb,
+  Ext_Zvkg,
+  Ext_Zvkned,
+  Ext_Zvknha,
+  Ext_Zvknhb,
+  Ext_Zvksh,
+  Ext_Zvkt,
+
+  // Supervisor extensions, ordered alphabetically.
+  Ext_Sscofpmf,
+  Ext_Sstc,
+  // Ext_Svade,
+  // Ext_Svadu,
+  Ext_Svinval,
+  Ext_Svnapot,
+  Ext_Svpbmt,
+
+  // Hypervisor extensions, ordered alphabetically.
+
+  // Machine mode extensions, ordered alphabetically.
+  Ext_Smcntrpmf,
+]


### PR DESCRIPTION
Simplify the ISA string generation code using a loop over a vector. This also avoids slow type checking performance in the Sail compiler when expressions contain many overloaded operations, particularly when the existing heuristics for speeding this process up do not fire.