### PR TITLE
Fix float register names in compressed float load/stores

### DIFF
--- a/model/riscv_fdext_regs.sail
+++ b/model/riscv_fdext_regs.sail
@@ -371,6 +371,8 @@ mapping freg_or_reg_name : fregidx <-> string = {
   f <-> freg_name(f)
 }
 
+mapping cfreg_name : cregidx <-> string = { Cregidx(i) <-> freg_name(Fregidx(0b01 @ i)) }
+
 /* **************************************************************** */
 /* Floating Point CSR                                               */
 /*     fflags    address 0x001    same as fcrs [4..0]               */

--- a/model/riscv_insts_zcd.sail
+++ b/model/riscv_insts_zcd.sail
@@ -57,7 +57,7 @@ function clause execute (C_FLD(uimm, rsc, rdc)) = {
 
 mapping clause assembly = C_FLD(uimm, rsc, rdc)
       if (xlen == 32 | xlen == 64)
-  <-> "c.fld" ^ spc() ^ creg_name(rdc) ^ sep() ^ hex_bits_8(uimm @ 0b000) ^ "(" ^ creg_name(rsc) ^ ")"
+  <-> "c.fld" ^ spc() ^ cfreg_name(rdc) ^ sep() ^ hex_bits_8(uimm @ 0b000) ^ "(" ^ creg_name(rsc) ^ ")"
       if (xlen == 32 | xlen == 64)
 
 /* ****************************************************************** */
@@ -76,5 +76,5 @@ function clause execute (C_FSD(uimm, rsc1, rsc2)) = {
 
 mapping clause assembly = C_FSD(uimm, rsc1, rsc2)
       if (xlen == 32 | xlen == 64)
-  <-> "c.fsd" ^ spc() ^ creg_name(rsc2) ^ sep() ^ hex_bits_8(uimm @ 0b000) ^ "(" ^ creg_name(rsc1) ^ ")"
+  <-> "c.fsd" ^ spc() ^ cfreg_name(rsc2) ^ sep() ^ hex_bits_8(uimm @ 0b000) ^ "(" ^ creg_name(rsc1) ^ ")"
       if (xlen == 32 | xlen == 64)

--- a/model/riscv_insts_zcf.sail
+++ b/model/riscv_insts_zcf.sail
@@ -54,7 +54,7 @@ function clause execute (C_FLW(uimm, rsc, rdc)) = {
 }
 
 mapping clause assembly = C_FLW(uimm, rsc, rdc)
-  <-> "c.flw" ^ spc() ^ creg_name(rdc) ^ sep() ^ hex_bits_7(uimm @ 0b00) ^ "(" ^ creg_name(rsc) ^ ")"
+  <-> "c.flw" ^ spc() ^ cfreg_name(rdc) ^ sep() ^ hex_bits_7(uimm @ 0b00) ^ "(" ^ creg_name(rsc) ^ ")"
   when xlen == 32
 
 /* ****************************************************************** */
@@ -72,5 +72,5 @@ function clause execute (C_FSW(uimm, rsc1, rsc2)) = {
 }
 
 mapping clause assembly = C_FSW(uimm, rsc1, rsc2)
-  <-> "c.fsw" ^ spc() ^ creg_name(rsc2) ^ sep() ^ hex_bits_7(uimm @ 0b00) ^ "(" ^ creg_name(rsc1) ^ ")"
+  <-> "c.fsw" ^ spc() ^ cfreg_name(rsc2) ^ sep() ^ hex_bits_7(uimm @ 0b00) ^ "(" ^ creg_name(rsc1) ^ ")"
   when xlen == 32


### PR DESCRIPTION
These instructions were using the integer register names which is not correct and not accepted by Clang.