### PR TITLE
Fix a few issues in the `vset{i}vl{i}` instructions.

### DIFF
--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -81,12 +81,11 @@ function clause execute VSETVLI(ma, ta, sew, lmul, rs1, rd) = {
   let SEW_pow_ori   = get_sew_pow();
   let ratio_pow_ori = SEW_pow_ori - LMUL_pow_ori;
 
-  /* set vtype */
-  vtype.bits = 0b0 @ zeros(xlen - 9) @ ma @ ta @ sew @ lmul;
-
   /* check new SEW and LMUL are legal and calculate VLMAX */
-  let LMUL_pow_new = get_lmul_pow();
-  let SEW_pow_new  = get_sew_pow();
+  let (LMUL_pow_new, SEW_pow_new) : (LMUL_pow, SEW_pow) = match (lmul_pow_of_bits(lmul), sew_pow_of_bits(sew)) {
+    (Some(lmul_pow), Some(sew_pow)) => (lmul_pow, sew_pow),
+    (_, _) => { handle_illegal_vtype(); return RETIRE_SUCCESS },
+  };
   if SEW_pow_new > (LMUL_pow_new + ELEN_pow) then { handle_illegal_vtype(); return RETIRE_SUCCESS };
   let VLMAX = 2 ^ (VLEN_pow + LMUL_pow_new - SEW_pow_new);
 
@@ -105,6 +104,9 @@ function clause execute VSETVLI(ma, ta, sew, lmul, rs1, rd) = {
     let ratio_pow_new = SEW_pow_new - LMUL_pow_new;
     if (ratio_pow_new != ratio_pow_ori) then { handle_illegal_vtype(); return RETIRE_SUCCESS }
   };
+
+  /* set vtype */
+  vtype.bits = 0b0 @ zeros(xlen - 9) @ ma @ ta @ sew @ lmul;
 
   /* reset vstart to 0 */
   set_vstart(zeros());
@@ -131,12 +133,17 @@ function clause execute VSETVL(rs2, rs1, rd) = {
   let SEW_pow_ori   = get_sew_pow();
   let ratio_pow_ori = SEW_pow_ori - LMUL_pow_ori;
 
-  /* set vtype */
-  vtype.bits = X(rs2);
+  let vtype_new = Mk_Vtype(X(rs2));
+  let ma   = vtype_new[vma];
+  let ta   = vtype_new[vta];
+  let sew  = vtype_new[vsew];
+  let lmul = vtype_new[vlmul];
 
   /* check new SEW and LMUL are legal and calculate VLMAX */
-  let LMUL_pow_new = get_lmul_pow();
-  let SEW_pow_new  = get_sew_pow();
+  let (LMUL_pow_new, SEW_pow_new) : (LMUL_pow, SEW_pow) = match (lmul_pow_of_bits(lmul), sew_pow_of_bits(sew)) {
+    (Some(lmul_pow), Some(sew_pow)) => (lmul_pow, sew_pow),
+    (_, _) => { handle_illegal_vtype(); return RETIRE_SUCCESS },
+  };
   if SEW_pow_new > (LMUL_pow_new + ELEN_pow) then { handle_illegal_vtype(); return RETIRE_SUCCESS };
   let VLMAX = 2 ^ (VLEN_pow + LMUL_pow_new - SEW_pow_new);
 
@@ -155,6 +162,9 @@ function clause execute VSETVL(rs2, rs1, rd) = {
     let ratio_pow_new = SEW_pow_new - LMUL_pow_new;
     if (ratio_pow_new != ratio_pow_ori) then { handle_illegal_vtype(); return RETIRE_SUCCESS }
   };
+
+  /* set vtype */
+  vtype.bits = 0b0 @ zeros(xlen - 9) @ ma @ ta @ sew @ lmul;
 
   /* reset vstart to 0 */
   set_vstart(zeros());
@@ -177,12 +187,11 @@ mapping clause encdec = VSETIVLI(ma, ta, sew, lmul, uimm, rd)
   when currentlyEnabled(Ext_V)
 
 function clause execute VSETIVLI(ma, ta, sew, lmul, uimm, rd) = {
-  /* set vtype */
-  vtype.bits = 0b0 @ zeros(xlen - 9) @ ma @ ta @ sew @ lmul;
-
   /* check new SEW and LMUL are legal and calculate VLMAX */
-  let LMUL_pow_new = get_lmul_pow();
-  let SEW_pow_new  = get_sew_pow();
+  let (LMUL_pow_new, SEW_pow_new) : (LMUL_pow, SEW_pow) = match (lmul_pow_of_bits(lmul), sew_pow_of_bits(sew)) {
+    (Some(lmul_pow), Some(sew_pow)) => (lmul_pow, sew_pow),
+    (_, _) => { handle_illegal_vtype(); return RETIRE_SUCCESS },
+  };
   if SEW_pow_new > (LMUL_pow_new + ELEN_pow) then { handle_illegal_vtype(); return RETIRE_SUCCESS };
   let VLMAX = 2 ^ (VLEN_pow + LMUL_pow_new - SEW_pow_new);
 
@@ -190,6 +199,9 @@ function clause execute VSETIVLI(ma, ta, sew, lmul, uimm, rd) = {
   let AVL = unsigned(uimm); /* AVL is encoded as 5-bit zero-extended imm in the rs1 field */
   vl = calculate_new_vl(AVL, VLMAX);
   X(rd) = vl;
+
+  /* set vtype */
+  vtype.bits = 0b0 @ zeros(xlen - 9) @ ma @ ta @ sew @ lmul;
 
   /* reset vstart to 0 */
   set_vstart(zeros());

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -920,15 +920,37 @@ bitfield Vtype  : xlenbits = {
 }
 register vtype : Vtype
 
+type SEW_pow = range(3, 6)
+
+function sew_pow_of_bits(sew : bits(3)) -> option(SEW_pow) =
+  match sew {
+    0b000 => Some(3),
+    0b001 => Some(4),
+    0b010 => Some(5),
+    0b011 => Some(6),
+    _     => None(),
+  }
+
+type LMUL_pow = range(-3, 3)
+
+function lmul_pow_of_bits(lmul : bits(3)) -> option(LMUL_pow) =
+  match lmul {
+    0b101 => Some(-3),
+    0b110 => Some(-2),
+    0b111 => Some(-1),
+    0b000 => Some(0),
+    0b001 => Some(1),
+    0b010 => Some(2),
+    0b011 => Some(3),
+    _     => None(),
+  }
+
 /* the dynamic selected element width (SEW) */
 /* this returns the power of 2 for SEW */
-function get_sew_pow() -> {3, 4, 5, 6} =
-  match vtype[vsew] {
-    0b000 => 3,
-    0b001 => 4,
-    0b010 => 5,
-    0b011 => 6,
-    _     => {assert(false, "invalid vsew field in vtype"); 0}
+function get_sew_pow() -> SEW_pow =
+  match sew_pow_of_bits(vtype[vsew]) {
+    Some(p) => p,
+    None()  => {assert(false, "invalid vsew field in vtype"); 0}
   }
 
 /* this returns the actual value of SEW */
@@ -941,19 +963,12 @@ function get_sew_bytes() -> {1, 2, 4, 8} =
 
 /* the vector register group multiplier (LMUL) */
 /* this returns the power of 2 for LMUL */
-val get_lmul_pow : unit -> {-3, -2, -1, 0, 1, 2, 3}
-function get_lmul_pow() = {
-  match vtype[vlmul] {
-    0b101 => -3,
-    0b110 => -2,
-    0b111 => -1,
-    0b000 => 0,
-    0b001 => 1,
-    0b010 => 2,
-    0b011 => 3,
-    _     => {assert(false, "invalid vlmul field in vtype"); 0}
+val get_lmul_pow : unit -> LMUL_pow
+function get_lmul_pow() =
+  match lmul_pow_of_bits(vtype[vlmul]) {
+    Some(p) => p,
+    None()  => {assert(false, "invalid vlmul field in vtype"); 0},
   }
-}
 
 enum agtype = { UNDISTURBED, AGNOSTIC }
 


### PR DESCRIPTION
- Check for reserved values of `vsew` and `vlmul` in the proposed `vtype` before setting `vtype`.  If reserved values are present, set `vtype.vill` instead of asserting (as was the case for all three instructions).

- Ensure that the reserved bits of `vtype` are zeroed as required instead of blindly copying them from the proposed `vtype` (as was the case for `vsetvl`).