### PR TITLE
Inline xlen_min_signed etc.

### DIFF
--- a/model/riscv_insts_mext.sail
+++ b/model/riscv_insts_mext.sail
@@ -64,7 +64,7 @@ function clause execute (DIV(rs2, rs1, rd, s)) = {
   let rs2_int : int = if s then signed(rs2_val) else unsigned(rs2_val);
   let q : int = if rs2_int == 0 then -1 else quot_round_zero(rs1_int, rs2_int);
   /* check for signed overflow */
-  let q': int = if s & q > xlen_max_signed then xlen_min_signed else q;
+  let q': int = if s & q >= 2 ^ (xlen - 1) then 0 - 2 ^ (xlen - 1) else q;
   X(rd) = to_bits_unsafe(xlen, q');
   RETIRE_SUCCESS
 }

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -7,9 +7,6 @@
 /*=======================================================================================*/
 
 /* Basic type and function definitions used pervasively in the model. */
-let xlen_max_unsigned = 2 ^ xlen - 1
-let xlen_max_signed = 2 ^ (xlen - 1) - 1
-let xlen_min_signed = 0 - 2 ^ (xlen - 1)
 
 type half = bits(16)
 type word = bits(32)


### PR DESCRIPTION
These are only used once and `xlen_max_unsigned` as completely unused. The `0 -` is slightly unfortunate.