### PR TITLE
Remove speculate_conditional

### DIFF
--- a/c_emulator/riscv_platform.cpp
+++ b/c_emulator/riscv_platform.cpp
@@ -24,17 +24,17 @@ mach_bits plat_get_16_random_bits(unit)
   return rv_16_random_bits();
 }
 
+// Note: Store-Conditionals are allowed to spuriously fail. If you want
+// that to happen you can spuriously set `reservation_valid = false`
+// either directly in `load_reservation()` or by callling
+// `cancel_reservation()`.
+
 unit load_reservation(mach_bits addr)
 {
   reservation = addr;
   reservation_valid = true;
   RESERVATION_DBG("reservation <- %0" PRIx64 "\n", reservation);
   return UNIT;
-}
-
-bool speculate_conditional(unit)
-{
-  return true;
 }
 
 static mach_bits check_mask()

--- a/c_emulator/riscv_platform.h
+++ b/c_emulator/riscv_platform.h
@@ -8,7 +8,6 @@ extern "C" {
 // Provides entropy for the scalar cryptography extension.
 mach_bits plat_get_16_random_bits(unit);
 
-bool speculate_conditional(unit);
 unit load_reservation(mach_bits);
 bool match_reservation(mach_bits);
 unit cancel_reservation(unit);

--- a/handwritten_support/RiscvExtras.lean
+++ b/handwritten_support/RiscvExtras.lean
@@ -70,8 +70,6 @@ axiom valid_reservation : Unit → Bool
 
 axiom get_16_random_bits : Unit → SailM (BitVec 16)
 
-axiom speculate_conditional : Unit → SailM Bool
-
 end Effectful
 
 -- Floats

--- a/handwritten_support/RiscvExtrasExecutable.lean
+++ b/handwritten_support/RiscvExtrasExecutable.lean
@@ -71,8 +71,6 @@ def valid_reservation : Unit → Bool := λ _ => false
 
 def get_16_random_bits : Unit → SailM (BitVec 16) := λ _ => panic "TODO"
 
-def speculate_conditional : Unit → SailM Bool := λ _ => panic "TODO"
-
 end Effectful
 
 -- Floats

--- a/handwritten_support/riscv_extras.lem
+++ b/handwritten_support/riscv_extras.lem
@@ -81,9 +81,6 @@ type bitvector = list Sail2_values.bitU
 val load_reservation : forall 'abort 'barrier 'cache_op 'fault 'pa 'tlb_op 'translation_summary 'trans_start 'trans_end 'arch_ak 'rv 'e. bitvector -> monad 'abort 'barrier 'cache_op 'fault 'pa 'tlb_op 'translation_summary 'trans_start 'trans_end 'arch_ak 'rv unit 'e
 let load_reservation addr = return ()
 
-val speculate_conditional_success : forall 'abort 'barrier 'cache_op 'fault 'pa 'tlb_op 'translation_summary 'trans_start 'trans_end 'arch_ak 'rv 'e. unit -> monad 'abort 'barrier 'cache_op 'fault 'pa 'tlb_op 'translation_summary 'trans_start 'trans_end 'arch_ak 'rv bool 'e
-let speculate_conditional_success () = return true
-
 let match_reservation _ = true
 let cancel_reservation () = return ()
 let valid_reservation () = false

--- a/handwritten_support/riscv_extras_sequential.lem
+++ b/handwritten_support/riscv_extras_sequential.lem
@@ -132,8 +132,6 @@ let read_ram addrsize size hexRAM address =
 val load_reservation : forall 'a. Size 'a => bitvector 'a -> unit
 let load_reservation addr = ()
 
-let speculate_conditional_success () = excl_result ()
-
 let match_reservation _ = true
 let cancel_reservation () = ()
 let valid_reservation () = false

--- a/model/riscv_insts_zalrsc.sail
+++ b/model/riscv_insts_zalrsc.sail
@@ -68,14 +68,6 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
   // This is checked during decoding.
   assert(width_bytes <= xlen_bytes);
 
-  if speculate_conditional() == false then {
-    /* should only happen in RMEM
-     * RMEM: allow SC to fail very early
-     */
-    X(rd) = zero_extend(0b1);
-    return RETIRE_SUCCESS
-  };
-
   /* normal non-rmem case
    * RMEM: SC is allowed to succeed (but might fail later)
    */

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -92,8 +92,6 @@ function check_CSR(csr : csreg, p : Privilege, isWrite : bool) -> bool =
  * where cancellation can be performed.
  */
 
-val speculate_conditional = impure {interpreter: "excl_res", c: "speculate_conditional", lem: "speculate_conditional_success"} : unit -> bool
-
 val load_reservation = impure {interpreter: "Platform.load_reservation", c: "load_reservation", lem: "load_reservation"} : physaddrbits -> unit
 val match_reservation = pure {interpreter: "Platform.match_reservation", lem: "match_reservation", c: "match_reservation"} : physaddrbits -> bool
 val cancel_reservation = impure {interpreter: "Platform.cancel_reservation", c: "cancel_reservation", lem: "cancel_reservation"} : unit -> unit


### PR DESCRIPTION
I've previously used this to inject sprurious Store-Conditional failures, however it required some tweaking because it's called very early before various exceptions can happen.

A better solution is to spuriously cancel the reservation directly in `load_reservation()` or by calling `cancel_reservation()`.

This change doesn't actually do that but I added notes explaining that you can. In future when we provide a library interface we can do it like that.