### PR TITLE
Add current virtualization mode register

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -161,6 +161,7 @@ foreach (xlen IN ITEMS 32 64)
                 "riscv_regs.sail"
                 "riscv_pc_access.sail"
                 "riscv_sys_regs.sail"
+                "riscv_hext_regs.sail"
                 "riscv_pmp_regs.sail"
                 "riscv_pmp_control.sail"
                 "riscv_ext_regs.sail"
@@ -175,6 +176,7 @@ foreach (xlen IN ITEMS 32 64)
                 "riscv_types_common.sail"
                 "riscv_types_ext.sail"
                 "riscv_types.sail"
+                "riscv_types_hext.sail"
                 "riscv_vmem_types.sail"
                 ${sail_regs_srcs}
                 ${sail_sys_srcs}

--- a/model/riscv_hext_regs.sail
+++ b/model/riscv_hext_regs.sail
@@ -1,0 +1,10 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+/* current virtualization mode */
+register cur_virtualization : Virtualization

--- a/model/riscv_types_hext.sail
+++ b/model/riscv_types_hext.sail
@@ -1,0 +1,30 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+// The current virtualization mode
+// indicates whether the hart is currently executing in a guest
+enum Virtualization = { V0, V1 }
+
+function virt_priv_to_str(priv : Privilege, virt: Virtualization) -> string = {
+  match (priv, virt) {
+    (User      , V0) => "U",  // User mode
+    (Supervisor, V0) => "HS", // Hypervisor-extended supervisor mode
+    (Machine   , V0) => "M",  // Machine mode
+    (User      , V1) => "VU", // Virtual user mode
+    (Supervisor, V1) => "VS", // Virtual supervisor mode
+    (Machine   , V1) => internal_error(__FILE__, __LINE__, "illegal privilege mode"),
+  }
+}
+overload to_str = {virt_priv_to_str}
+
+function two_stage_translation_enabled(priv : Privilege, virt : Virtualization) -> bool = {
+  match (priv, virt) {
+    (priv, V1) if priv != Machine => true,
+    _ => false,
+  }
+}


### PR DESCRIPTION
Add current virtualization mode register

- Add new enum `Virtualization`
- Add new register `cur_virtualization`
- Add `virt_priv_to_str `and `two_stage_translation_enabled `function

---

I deleted the `type virt_mode = bits(1)` and related functions defined in the original commit, because they were not actually used

reference:

- spec from [privileged 21.1.(0)](https://riscv.github.io/riscv-isa-manual/snapshot/privileged/#_privilege_modes)
- splite from the first commit [Setup for hypervisor extension](https://github.com/riscv/sail-riscv/pull/612/commits/b2e56bbbc3216eedae0907308bab3fde5a014e8f) of #612 

> I will try to align the PR with the specific spec sections for easier review
