### PR TITLE
Add VU and VS privilege level

### DIFF
--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -525,7 +525,8 @@ function clause execute ECALL() = {
     struct { trap = match (cur_privilege) {
                       User       => E_U_EnvCall(),
                       Supervisor => E_S_EnvCall(),
-                      Machine    => E_M_EnvCall()
+                      Machine    => E_M_EnvCall(),
+                      _          => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported yet"),
                     },
              excinfo = (None() : option(xlenbits)),
              ext     = None() };
@@ -563,7 +564,8 @@ function clause execute SRET() = {
   let sret_illegal : bool = match cur_privilege {
     User       => true,
     Supervisor => not(currentlyEnabled(Ext_S)) | mstatus[TSR] == 0b1,
-    Machine    => not(currentlyEnabled(Ext_S))
+    Machine    => not(currentlyEnabled(Ext_S)),
+    _          => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported yet"),
   };
   if   sret_illegal
   then Illegal_Instruction()
@@ -600,7 +602,8 @@ function clause execute WFI() =
     Supervisor => if   mstatus[TW] == 0b1
                   then Illegal_Instruction()
                   else Enter_Wait(WAIT_WFI),
-    User       => Illegal_Instruction()
+    User       => Illegal_Instruction(),
+    _          => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported yet"),
   }
 
 mapping clause assembly = WFI() <-> "wfi"
@@ -624,7 +627,8 @@ function clause execute SFENCE_VMA(rs1, rs2) = {
                     0b1 => Illegal_Instruction(),
                     0b0 => { flush_TLB(asid, addr); RETIRE_SUCCESS },
                   },
-    Machine    => { flush_TLB(asid, addr); RETIRE_SUCCESS }
+    Machine    => { flush_TLB(asid, addr); RETIRE_SUCCESS },
+    _          => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported yet"),
   }
 }
 

--- a/model/riscv_smcntrpmf.sail
+++ b/model/riscv_smcntrpmf.sail
@@ -15,8 +15,8 @@ function legalize_smcntrpmf(c : CountSmcntrpmf, value : bits(64)) -> CountSmcntr
     MINH  = v[MINH],
     SINH  = if currentlyEnabled(Ext_S) then v[SINH] else 0b0,
     UINH  = if currentlyEnabled(Ext_U) then v[UINH] else 0b0,
-    // VSINH = v[VSINH],
-    // VUINH = v[VUINH],
+    VSINH = if currentlyEnabled(Ext_S) & currentlyEnabled(Ext_H) then v[VSINH] else 0b0,
+    VUINH = if currentlyEnabled(Ext_U) & currentlyEnabled(Ext_H) then v[VUINH] else 0b0,
   ]
 }
 
@@ -48,10 +48,11 @@ function clause write_CSR((0x722, value) if xlen == 32) = { minstretcfg = legali
 function counter_priv_filter_bit(reg : CountSmcntrpmf, priv : Privilege) -> bits(1) =
   // When all xINH bits are zero, event counting is enabled in all modes.
   match priv {
-    Machine    => reg[MINH],
-    Supervisor => reg[SINH],
-    User       => reg[UINH],
-    // TODO: VSINH, VUINH when those modes are defined
+    Machine           => reg[MINH],
+    Supervisor        => reg[SINH],
+    VirtualSupervisor => reg[VSINH],
+    User              => reg[UINH],
+    VirtualUser       => reg[VUINH],
   }
 
 function should_inc_mcycle(priv : Privilege) -> bool =

--- a/model/riscv_sscofpmf.sail
+++ b/model/riscv_sscofpmf.sail
@@ -72,6 +72,7 @@ function get_scountovf(priv : Privilege) -> bits(32) = {
     Machine => overflow,
     Supervisor => overflow & mcounteren.bits,
     User => internal_error(__FILE__, __LINE__, "scountovf not readable from User mode"),
+    _ => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported yet"),
   }
 }
 

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -30,6 +30,7 @@ function feature_enabled_for_priv(p : Privilege, machine_enable_bit : bit, super
   Machine => true,
   Supervisor => machine_enable_bit == bitone,
   User => machine_enable_bit == bitone & (not(currentlyEnabled(Ext_S)) | supervisor_enable_bit == bitone),
+  _ => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported yet"),
 }
 
 // Return true if the counter is enabled OR the CSR is not a counter.
@@ -64,6 +65,7 @@ function check_seed_CSR (csr : csreg, p : Privilege, isWrite : bool) -> bool = {
       Machine => true,
       Supervisor => false, /* TODO: base this on mseccfg */
       User => false, /* TODO: base this on mseccfg */
+      _ => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported yet"),
     }
   }
 }
@@ -216,6 +218,7 @@ function track_trap(p : Privilege) -> unit = {
       csr_write_callback("sepc", sepc);
     },
     User => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    _ => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported yet"),
   };
 }
 
@@ -258,7 +261,8 @@ function trap_handler(del_priv : Privilege, intr : bool, c : exc_code, pc : xlen
        mstatus[SPP]  = match cur_privilege {
                            User => 0b0,
                            Supervisor => 0b1,
-                           Machine => internal_error(__FILE__, __LINE__, "invalid privilege for s-mode trap")
+                           Machine => internal_error(__FILE__, __LINE__, "invalid privilege for s-mode trap"),
+                           _ => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported yet"),
                          };
        stval           = tval(info);
        sepc            = pc;
@@ -272,6 +276,7 @@ function trap_handler(del_priv : Privilege, intr : bool, c : exc_code, pc : xlen
        prepare_trap_vector(del_priv, scause)
     },
     User => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    _    => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported yet"),
   };
 }
 

--- a/model/riscv_sys_exceptions.sail
+++ b/model/riscv_sys_exceptions.sail
@@ -23,6 +23,7 @@ function prepare_trap_vector(p : Privilege, cause : Mcause) -> xlenbits = {
                        Machine    => mtvec,
                        Supervisor => stvec,
                        User       => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+                       _          => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported yet"),
                      };
   match tvec_addr(tvec, cause) {
     Some(epc) => epc,
@@ -43,6 +44,7 @@ function get_xepc(p) =
     Machine    => align_pc(mepc),
     Supervisor => align_pc(sepc),
     User       => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    _          => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported yet"),
   }
 
 val set_xepc : (Privilege, xlenbits) -> xlenbits
@@ -52,6 +54,7 @@ function set_xepc(p, value) = {
     Machine    => mepc = target,
     Supervisor => sepc = target,
     User       => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    _          => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported yet"),
   };
   target
 }

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -296,7 +296,8 @@ function cur_architecture() -> Architecture = {
     match cur_privilege {
       Machine    => misa[MXL],
       Supervisor => get_mstatus_SXL(mstatus),
-      User       => get_mstatus_UXL(mstatus)
+      User       => get_mstatus_UXL(mstatus),
+      _          => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported yet"),
     };
   architecture(a)
 }
@@ -390,6 +391,7 @@ function is_fiom_active() -> bool = {
     Machine => false,
     Supervisor => menvcfg[FIOM] == 0b1,
     User => (menvcfg[FIOM] | senvcfg[FIOM]) == 0b1,
+    _ => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported yet"),
   }
 }
 

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -58,23 +58,27 @@ mapping architecture : Architecture <-> arch_xlen = {
 /* privilege levels */
 
 type priv_level = bits(2)
-enum Privilege  = {User, Supervisor, Machine}
+enum Privilege  = {User, VirtualUser, Supervisor, VirtualSupervisor, Machine}
 
-mapping privLevel_bits : Privilege <-> priv_level = {
-  User       <-> 0b00,
-  Supervisor <-> 0b01,
-  Machine    <-> 0b11,
+mapping nominalPrivLevel_bits : Privilege <-> priv_level = {
+  User                       <-> 0b00,
+  forwards VirtualUser        => 0b00,
+  Supervisor                 <-> 0b01,
+  forwards VirtualSupervisor  => 0b01,
+  Machine                    <-> 0b11,
   backwards 0b10 => internal_error(__FILE__, __LINE__, "Invalid privilege level: " ^ BitStr(0b10))
 }
 
-function privLevel_to_bits(p : Privilege) -> priv_level = privLevel_bits(p)
-function privLevel_of_bits(b : priv_level) -> Privilege = privLevel_bits(b)
+function privLevel_to_bits(p : Privilege) -> priv_level = nominalPrivLevel_bits(p)
+function privLevel_of_bits(b : priv_level) -> Privilege = nominalPrivLevel_bits(b)
 
 function privLevel_to_str (p : Privilege) -> string =
   match (p) {
-    User       => "U",
-    Supervisor => "S",
-    Machine    => "M"
+    User              => "U",
+    VirtualUser       => "VU",
+    Supervisor        => "HS",
+    VirtualSupervisor => "VS",
+    Machine           => "M"
   }
 
 overload to_str = {privLevel_to_str}

--- a/model/riscv_vmem_pte.sail
+++ b/model/riscv_vmem_pte.sail
@@ -130,7 +130,8 @@ function check_PTE_permission(ac        : AccessType(ext_access_type),
                                           | ((pte_X == 0b1) & mxr)),
       (InstructionFetch(),Supervisor) => (pte_U == 0b0) & (pte_X == 0b1),
       (_,               Machine)    => internal_error(__FILE__, __LINE__,
-                                                      "m-mode mem perm check")};
+                                                      "m-mode mem perm check"),
+      _ => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported yet")};
   if success then PTE_Check_Success(())
   else            PTE_Check_Failure((), ())
 }


### PR DESCRIPTION
# Please ignore this repeated PR

- Add `VirtualUser` and `VirtualSupervisor` to the existing `Privilege` enum
- Rename `privLevel_bits` to `nominalPrivLevel_bits` and add conversions for VS and VU to bits
- Add placeholder to all `match cur_privilege` statements, mark VS and VU branches as unimplemented

---

link #1061 

I think this looks better than `match (cur_privilege, cur_virtualication)`.