### PR TITLE
Add VU and VS privilege level

### DIFF
--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -508,7 +508,7 @@ mapping clause encdec = ECALL()
   <-> 0b000000000000 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
 
 function clause execute ECALL() = {
-  let trap : ExceptionType = match (cur_privilege) {
+  let trap : ExceptionType = match cur_privilege {
     User              => E_U_EnvCall(),
     Supervisor        => E_S_EnvCall(),
     Machine           => E_M_EnvCall(),

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -508,14 +508,15 @@ mapping clause encdec = ECALL()
   <-> 0b000000000000 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
 
 function clause execute ECALL() = {
+  let trap : ExceptionType = match (cur_privilege) {
+    User              => E_U_EnvCall(),
+    Supervisor        => E_S_EnvCall(),
+    Machine           => E_M_EnvCall(),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+  };
   let t : sync_exception = struct {
-    trap = match (cur_privilege) {
-      User              => E_U_EnvCall(),
-      Supervisor        => E_S_EnvCall(),
-      Machine           => E_M_EnvCall(),
-      VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-      VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    },
+    trap    = trap,
     excinfo = (None() : option(xlenbits)),
     ext     = None(),
   };

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -508,14 +508,17 @@ mapping clause encdec = ECALL()
   <-> 0b000000000000 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
 
 function clause execute ECALL() = {
-  let t : sync_exception =
-    struct { trap = match (cur_privilege) {
-                      User       => E_U_EnvCall(),
-                      Supervisor => E_S_EnvCall(),
-                      Machine    => E_M_EnvCall()
-                    },
-             excinfo = (None() : option(xlenbits)),
-             ext     = None() };
+  let t : sync_exception = struct {
+    trap = match (cur_privilege) {
+      User              => E_U_EnvCall(),
+      Supervisor        => E_S_EnvCall(),
+      Machine           => E_M_EnvCall(),
+      VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+      VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    },
+    excinfo = (None() : option(xlenbits)),
+    ext     = None(),
+  };
   Trap(cur_privilege, CTL_TRAP(t), PC)
 }
 
@@ -548,9 +551,11 @@ mapping clause encdec = SRET()
 
 function clause execute SRET() = {
   let sret_illegal : bool = match cur_privilege {
-    User       => true,
-    Supervisor => not(currentlyEnabled(Ext_S)) | mstatus[TSR] == 0b1,
-    Machine    => not(currentlyEnabled(Ext_S))
+    User              => true,
+    Supervisor        => not(currentlyEnabled(Ext_S)) | mstatus[TSR] == 0b1,
+    Machine           => not(currentlyEnabled(Ext_S)),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   };
   if   sret_illegal
   then Illegal_Instruction()
@@ -583,11 +588,13 @@ mapping clause encdec = WFI()
 
 function clause execute WFI() =
   match cur_privilege {
-    Machine    => Enter_Wait(WAIT_WFI),
-    Supervisor => if   mstatus[TW] == 0b1
-                  then Illegal_Instruction()
-                  else Enter_Wait(WAIT_WFI),
-    User       => Illegal_Instruction()
+    Machine           => Enter_Wait(WAIT_WFI),
+    Supervisor        => if   mstatus[TW] == 0b1
+                         then Illegal_Instruction()
+                         else Enter_Wait(WAIT_WFI),
+    User              => Illegal_Instruction(),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   }
 
 mapping clause assembly = WFI() <-> "wfi"
@@ -606,12 +613,14 @@ function clause execute SFENCE_VMA(rs1, rs2) = {
   // is 9 but we always set it to 16 for RV64.
   let asid = if rs2 != zreg then Some(X(rs2)[asidlen - 1 .. 0]) else None();
   match cur_privilege {
-    User       => Illegal_Instruction(),
-    Supervisor => match mstatus[TVM] {
-                    0b1 => Illegal_Instruction(),
-                    0b0 => { flush_TLB(asid, addr); RETIRE_SUCCESS },
-                  },
-    Machine    => { flush_TLB(asid, addr); RETIRE_SUCCESS }
+    User              => Illegal_Instruction(),
+    Supervisor        => match mstatus[TVM] {
+                           0b1 => Illegal_Instruction(),
+                           0b0 => { flush_TLB(asid, addr); RETIRE_SUCCESS },
+                         },
+    Machine           => { flush_TLB(asid, addr); RETIRE_SUCCESS },
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   }
 }
 

--- a/model/riscv_insts_svinval.sail
+++ b/model/riscv_insts_svinval.sail
@@ -32,6 +32,7 @@ mapping clause encdec = SFENCE_W_INVAL()
 function clause execute SFENCE_W_INVAL() = {
   if cur_privilege == User
   then Illegal_Instruction()
+  // TODO: VU-mode raises a virtual-instruction exception
   else RETIRE_SUCCESS // Implemented as no-op as all memory operations are visible immediately the current Sail model
 }
 
@@ -48,7 +49,12 @@ mapping clause encdec = SFENCE_INVAL_IR()
 function clause execute SFENCE_INVAL_IR() = {
   if cur_privilege == User
   then Illegal_Instruction()
+  // TODO: VU-mode raises a virtual-instruction exception
   else RETIRE_SUCCESS // Implemented as no-op as all memory operations are visible immediately in current Sail model
 }
 
 mapping clause assembly = SFENCE_INVAL_IR() <-> "sfence.inval.ir"
+
+/* ****************************************************************** */
+
+// TODO: Implement HINVAL.VVMA amd HINVAL.GVMA

--- a/model/riscv_insts_zicbom.sail
+++ b/model/riscv_insts_zicbom.sail
@@ -50,7 +50,7 @@ enum checked_cbop = {CBOP_ILLEGAL, CBOP_ILLEGAL_VIRTUAL, CBOP_INVAL_FLUSH, CBOP_
 // Select the cbop to perform based on the privilege.
 function cbop_priv_check(p: Privilege) -> checked_cbop = {
   let mCBIE : cbie = encdec_cbie(menvcfg[CBIE]);
-  // TODO: check henvcfg after hyppervisor is implemented
+  // TODO: check henvcfg after hypervisor is implemented
   let sCBIE : cbie = if   currentlyEnabled(Ext_S)
                      then encdec_cbie(senvcfg[CBIE])
                      else encdec_cbie(menvcfg[CBIE]);

--- a/model/riscv_insts_zicbom.sail
+++ b/model/riscv_insts_zicbom.sail
@@ -50,10 +50,13 @@ enum checked_cbop = {CBOP_ILLEGAL, CBOP_ILLEGAL_VIRTUAL, CBOP_INVAL_FLUSH, CBOP_
 // Select the cbop to perform based on the privilege.
 function cbop_priv_check(p: Privilege) -> checked_cbop = {
   let mCBIE : cbie = encdec_cbie(menvcfg[CBIE]);
+  // TODO: check henvcfg after hyppervisor is implemented
   let sCBIE : cbie = if   currentlyEnabled(Ext_S)
                      then encdec_cbie(senvcfg[CBIE])
                      else encdec_cbie(menvcfg[CBIE]);
   match (p, mCBIE, sCBIE) {
+    (VirtualUser, _, _)       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    (VirtualSupervisor, _, _) => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
     (Machine, _,               _              ) => CBOP_INVAL_INVAL,
     (_,       CBIE_ILLEGAL,    _              ) => CBOP_ILLEGAL,      // (priv_mode != M) && mCBIE == 00
     (User,    _,               CBIE_ILLEGAL   ) => CBOP_ILLEGAL,      // (priv_mode == U) && sCBIE == 00

--- a/model/riscv_smcntrpmf.sail
+++ b/model/riscv_smcntrpmf.sail
@@ -15,8 +15,8 @@ function legalize_smcntrpmf(c : CountSmcntrpmf, value : bits(64)) -> CountSmcntr
     MINH  = v[MINH],
     SINH  = if currentlyEnabled(Ext_S) then v[SINH] else 0b0,
     UINH  = if currentlyEnabled(Ext_U) then v[UINH] else 0b0,
-    // VSINH = v[VSINH],
-    // VUINH = v[VUINH],
+    VSINH = if currentlyEnabled(Ext_H) then v[VSINH] else 0b0,
+    VUINH = if currentlyEnabled(Ext_H) then v[VUINH] else 0b0,
   ]
 }
 
@@ -48,8 +48,9 @@ function clause write_CSR((0x722, value) if xlen == 32) = { minstretcfg = legali
 function counter_priv_filter_bit(reg : CountSmcntrpmf, priv : Privilege) -> bits(1) =
   // When all xINH bits are zero, event counting is enabled in all modes.
   match priv {
-    Machine    => reg[MINH],
-    Supervisor => reg[SINH],
-    User       => reg[UINH],
-    // TODO: VSINH, VUINH when those modes are defined
+    Machine           => reg[MINH],
+    Supervisor        => reg[SINH],
+    VirtualSupervisor => reg[VSINH],
+    User              => reg[UINH],
+    VirtualUser       => reg[VUINH],
   }

--- a/model/riscv_sscofpmf.sail
+++ b/model/riscv_sscofpmf.sail
@@ -69,9 +69,11 @@ function get_scountovf(priv : Privilege) -> bits(32) = {
     mhpmevent[ 3][OF] @ 0b000;
 
   match priv {
-    Machine => overflow,
-    Supervisor => overflow & mcounteren.bits,
-    User => internal_error(__FILE__, __LINE__, "scountovf not readable from User mode"),
+    Machine           => overflow,
+    Supervisor        => overflow & mcounteren.bits,
+    User              => internal_error(__FILE__, __LINE__, "scountovf not readable from User mode"),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   }
 }
 

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -10,13 +10,13 @@
 
 function effectivePrivilege(t : AccessType(ext_access_type), m : Mstatus, priv : Privilege) -> Privilege =
   if   t != InstructionFetch() & m[MPRV] == 0b1
-  then privLevel_of_bits(m[MPP])
+  then privLevel_of_bits(m[MPP], bitzero) // TODO: use m[MPV] if hypervisor enabled
   else priv
 
 // CSR access control
 
 function csrAccess(csr : csreg) -> csrRW = csr[11..10]
-function csrPriv(csr : csreg) -> priv_level = csr[9..8]
+function csrPriv(csr : csreg) -> nom_priv_bits = csr[9..8]
 
 // Check that the CSR access is made with sufficient privilege.
 function check_CSR_priv(csr : csreg, p : Privilege) -> bool =
@@ -36,6 +36,7 @@ function check_CSR(csr : csreg, p : Privilege, isWrite : bool) -> bool =
 function exception_delegatee(e : ExceptionType, p : Privilege) -> Privilege = {
   let idx   = num_of_ExceptionType(e);
   let super = bit_to_bool(medeleg.bits[idx]);
+  // TODO: check VS/VU-mode if hypervisor extension enabled
   let deleg = if currentlyEnabled(Ext_S) & super then Supervisor else Machine;
   // We cannot transition to a less-privileged mode.
   if   privLevel_to_bits(deleg) <_u privLevel_to_bits(p)
@@ -62,6 +63,8 @@ function findPendingInterrupt(ip : xlenbits) -> option(InterruptType) = {
 // allows for example the M_Timer to be delegated to the S-mode.
 //
 // This is used when the hart is in the Active state.
+//
+// TODO: check hip/hie if hypervisor enabled.
 function getPendingSet(priv : Privilege) -> option((xlenbits, Privilege)) = {
   // mideleg can only be non-zero if we support Supervisor mode.
   assert(currentlyEnabled(Ext_S) | mideleg.bits == zeros());
@@ -142,7 +145,9 @@ function track_trap(p : Privilege) -> unit = {
       csr_write_callback("stval", stval);
       csr_write_callback("sepc", sepc);
     },
-    User => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    User              => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   };
 }
 
@@ -157,55 +162,61 @@ function trap_handler(del_priv : Privilege, intr : bool, c : exc_code, pc : xlen
 
   match (del_priv) {
     Machine => {
-       mcause[IsInterrupt] = bool_to_bits(intr);
-       mcause[Cause]       = zero_extend(c);
+      mcause[IsInterrupt] = bool_to_bits(intr);
+      mcause[Cause]       = zero_extend(c);
 
-       mstatus[MPIE] = mstatus[MIE];
-       mstatus[MIE]  = 0b0;
-       mstatus[MPP]  = privLevel_to_bits(cur_privilege);
-       mtval         = tval(info);
-       mepc          = pc;
+      mstatus[MPIE] = mstatus[MIE];
+      mstatus[MIE]  = 0b0;
+      mstatus[MPP]  = privLevel_to_bits(cur_privilege);
+      mtval         = tval(info);
+      mepc          = pc;
 
-       cur_privilege = del_priv;
+      cur_privilege = del_priv;
 
-       handle_trap_extension(del_priv, pc, ext);
+      handle_trap_extension(del_priv, pc, ext);
 
-       track_trap(del_priv);
+      track_trap(del_priv);
 
-       prepare_trap_vector(del_priv, mcause)
+      prepare_trap_vector(del_priv, mcause)
     },
     Supervisor => {
-       assert (currentlyEnabled(Ext_S), "no supervisor mode present for delegation");
+      assert (currentlyEnabled(Ext_S), "no supervisor mode present for delegation");
 
-       scause[IsInterrupt] = bool_to_bits(intr);
-       scause[Cause]       = zero_extend(c);
+      scause[IsInterrupt] = bool_to_bits(intr);
+      scause[Cause]       = zero_extend(c);
 
-       mstatus[SPIE] = mstatus[SIE];
-       mstatus[SIE]  = 0b0;
-       mstatus[SPP]  = match cur_privilege {
-                           User => 0b0,
-                           Supervisor => 0b1,
-                           Machine => internal_error(__FILE__, __LINE__, "invalid privilege for s-mode trap")
-                         };
-       stval         = tval(info);
-       sepc          = pc;
+      mstatus[SPIE] = mstatus[SIE];
+      mstatus[SIE]  = 0b0;
+      mstatus[SPP]  = match cur_privilege {
+        User              => 0b0,
+        Supervisor        => 0b1,
+        Machine           => internal_error(__FILE__, __LINE__, "invalid privilege for s-mode trap"),
+        VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+        VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+      };
+      stval           = tval(info);
+      sepc            = pc;
 
-       cur_privilege = del_priv;
+      cur_privilege   = del_priv;
 
-       handle_trap_extension(del_priv, pc, ext);
+      handle_trap_extension(del_priv, pc, ext);
 
-       track_trap(del_priv);
+      track_trap(del_priv);
 
-       prepare_trap_vector(del_priv, scause)
+      prepare_trap_vector(del_priv, scause)
     },
-    User => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    User              => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   };
 }
 
 function exception_handler(cur_priv : Privilege, ctl : ctl_result,
                            pc: xlenbits) -> xlenbits = {
-  match ctl {
-    CTL_TRAP(e) => {
+  match (cur_priv, ctl) {
+    (VirtualUser, _)       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    (VirtualSupervisor, _) => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    (_, CTL_TRAP(e)) => {
       let del_priv = exception_delegatee(e.trap, cur_priv);
       if   get_config_print_platform()
       then print_log("trapping from " ^ to_str(cur_priv) ^ " to " ^ to_str(del_priv)
@@ -216,7 +227,7 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
       let prev_priv = cur_privilege;
       mstatus[MIE]  = mstatus[MPIE];
       mstatus[MPIE] = 0b1;
-      cur_privilege = privLevel_of_bits(mstatus[MPP]);
+      cur_privilege   = privLevel_of_bits(mstatus[MPP], bitzero); // TODO: use mstatus[MPV] if hypervisor enabled
       mstatus[MPP]  = privLevel_to_bits(if currentlyEnabled(Ext_U) then User else Machine);
       if   cur_privilege != Machine
       then mstatus[MPRV] = 0b0;

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -10,7 +10,7 @@
 
 function effectivePrivilege(t : AccessType(ext_access_type), m : Mstatus, priv : Privilege) -> Privilege =
   if   t != InstructionFetch() & m[MPRV] == 0b1
-  then privLevel_of_bits(m[MPP], bitzero) // TODO: use m[MPV] if hypervisor enabled
+  then privLevel_bits(m[MPP], bitzero) // TODO: use m[MPV] if hypervisor enabled
   else priv
 
 // CSR access control
@@ -213,10 +213,8 @@ function trap_handler(del_priv : Privilege, intr : bool, c : exc_code, pc : xlen
 
 function exception_handler(cur_priv : Privilege, ctl : ctl_result,
                            pc: xlenbits) -> xlenbits = {
-  match (cur_priv, ctl) {
-    (VirtualUser, _)       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    (VirtualSupervisor, _) => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    (_, CTL_TRAP(e)) => {
+  match ctl {
+    CTL_TRAP(e) => {
       let del_priv = exception_delegatee(e.trap, cur_priv);
       if   get_config_print_platform()
       then print_log("trapping from " ^ to_str(cur_priv) ^ " to " ^ to_str(del_priv)
@@ -227,7 +225,7 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
       let prev_priv = cur_privilege;
       mstatus[MIE]  = mstatus[MPIE];
       mstatus[MPIE] = 0b1;
-      cur_privilege   = privLevel_of_bits(mstatus[MPP], bitzero); // TODO: use mstatus[MPV] if hypervisor enabled
+      cur_privilege = privLevel_bits(mstatus[MPP], bitzero); // TODO: use mstatus[MPV] if hypervisor enabled
       mstatus[MPP]  = privLevel_to_bits(if currentlyEnabled(Ext_U) then User else Machine);
       if   cur_privilege != Machine
       then mstatus[MPRV] = 0b0;

--- a/model/riscv_sys_exceptions.sail
+++ b/model/riscv_sys_exceptions.sail
@@ -20,10 +20,12 @@ function handle_trap_extension(p : Privilege, pc : xlenbits, u : option(unit)) -
 // used for traps and ECALL
 function prepare_trap_vector(p : Privilege, cause : Mcause) -> xlenbits = {
   let tvec : Mtvec = match p {
-                       Machine    => mtvec,
-                       Supervisor => stvec,
-                       User       => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
-                     };
+    Machine           => mtvec,
+    Supervisor        => stvec,
+    User              => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+  };
   match tvec_addr(tvec, cause) {
     Some(epc) => epc,
     None()    => internal_error(__FILE__, __LINE__, "Invalid tvec mode")
@@ -39,18 +41,22 @@ function prepare_trap_vector(p : Privilege, cause : Mcause) -> xlenbits = {
 val get_xepc : Privilege -> xlenbits
 function get_xepc(p) =
   match p {
-    Machine    => align_pc(mepc),
-    Supervisor => align_pc(sepc),
-    User       => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    Machine           => align_pc(mepc),
+    Supervisor        => align_pc(sepc),
+    User              => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   }
 
 val set_xepc : (Privilege, xlenbits) -> xlenbits
 function set_xepc(p, value) = {
   let target = legalize_xepc(value);
   match p {
-    Machine    => mepc = target,
-    Supervisor => sepc = target,
-    User       => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    Machine           => mepc = target,
+    Supervisor        => sepc = target,
+    User              => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   };
   target
 }

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -150,7 +150,7 @@ function virtual_memory_supported() -> bool = {
 function lowest_supported_privLevel() -> Privilege =
   if currentlyEnabled(Ext_U) then User else Machine
 
-function have_privLevel(priv : nom_priv_bits) -> bool =
+function have_nominal_privLevel(priv : nom_priv_bits) -> bool =
   match priv {
     0b00 => currentlyEnabled(Ext_U),
     0b01 => currentlyEnabled(Ext_S),
@@ -240,7 +240,7 @@ function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
     // but only if Zfinx isn't enabled.
     // FIXME: This should be made a platform parameter.
     FS = if hartSupports(Ext_Zfinx) then extStatus_to_bits(Off) else v[FS],
-    MPP = if have_privLevel(v[MPP]) then v[MPP] else privLevel_to_bits(lowest_supported_privLevel()),
+    MPP = if have_nominal_privLevel(v[MPP]) then v[MPP] else privLevel_to_bits(lowest_supported_privLevel()),
     SPP = if currentlyEnabled(Ext_S) then v[SPP] else 0b0,
     // TODO: make this configurable
     // If neither the v registers nor S-mode is implemented, then VS is
@@ -957,6 +957,8 @@ function feature_enabled_for_priv(p : Privilege, machine_enable_bit : bit, super
   Machine => true,
   Supervisor => machine_enable_bit == bitone,
   User => machine_enable_bit == bitone & (not(currentlyEnabled(Ext_S)) | supervisor_enable_bit == bitone),
+  VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+  VirtualUser => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
 }
 
 // Return true if the counter is enabled.

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -150,7 +150,7 @@ function virtual_memory_supported() -> bool = {
 function lowest_supported_privLevel() -> Privilege =
   if currentlyEnabled(Ext_U) then User else Machine
 
-function have_privLevel(priv : priv_level) -> bool =
+function have_privLevel(priv : nom_priv_bits) -> bool =
   match priv {
     0b00 => currentlyEnabled(Ext_U),
     0b01 => currentlyEnabled(Ext_S),
@@ -290,9 +290,11 @@ function clause write_CSR((0x310, value) if xlen == 32) = { mstatus = legalize_m
 function cur_architecture() -> Architecture = {
   let a : arch_xlen =
     match cur_privilege {
-      Machine    => misa[MXL],
-      Supervisor => get_mstatus_SXL(mstatus),
-      User       => get_mstatus_UXL(mstatus)
+      Machine           => misa[MXL],
+      Supervisor        => get_mstatus_SXL(mstatus),
+      User              => get_mstatus_UXL(mstatus),
+      VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+      VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
     };
   architecture(a)
 }
@@ -433,9 +435,11 @@ function clause write_CSR(0x10A, value) = { senvcfg = legalize_senvcfg(senvcfg, 
 // imply memory fence.
 function is_fiom_active() -> bool = {
   match cur_privilege {
-    Machine => false,
-    Supervisor => menvcfg[FIOM] == 0b1,
-    User => (menvcfg[FIOM] | senvcfg[FIOM]) == 0b1,
+    Machine           => false,
+    Supervisor        => menvcfg[FIOM] == 0b1,
+    User              => (menvcfg[FIOM] | senvcfg[FIOM]) == 0b1,
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   }
 }
 

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -79,7 +79,6 @@ mapping privLevel_bits : (nom_priv_bits, virt_mode_bit) <-> Privilege = {
 }
 
 function privLevel_to_bits(p : Privilege) -> nom_priv_bits = { let (p, _) = privLevel_bits(p); p }
-function privLevel_of_bits(p : nom_priv_bits, v : virt_mode_bit) -> Privilege = privLevel_bits((p, v))
 
 function privLevel_to_str (p : Privilege) -> string =
   match (p) {

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -61,26 +61,33 @@ mapping architecture : Architecture <-> arch_xlen = {
   backwards 0b00 => internal_error(__FILE__, __LINE__, "architecture(0b00) is invalid")
 }
 
-// privilege levels
+// nominal privilege levels
+type nom_priv_bits = bits(2)
 
-type priv_level = bits(2)
-enum Privilege  = {User, Supervisor, Machine}
+// virtualization modes
+type virt_mode_bit = bit
 
-mapping privLevel_bits : Privilege <-> priv_level = {
-  User       <-> 0b00,
-  Supervisor <-> 0b01,
-  Machine    <-> 0b11,
-  backwards 0b10 => internal_error(__FILE__, __LINE__, "Invalid privilege level: " ^ bits_str(0b10))
+enum Privilege  = {User, VirtualUser, Supervisor, VirtualSupervisor, Machine}
+
+mapping privLevel_bits : (nom_priv_bits, virt_mode_bit) <-> Privilege = {
+  (0b00, bitzero) <-> User,
+  (0b00, bitone ) <-> VirtualUser,
+  (0b01, bitzero) <-> Supervisor,
+  (0b01, bitone ) <-> VirtualSupervisor,
+  (0b11, bitzero) <-> Machine,
+  forwards _       => internal_error(__FILE__, __LINE__, "Invalid privilege level or virtual mode"),
 }
 
-function privLevel_to_bits(p : Privilege) -> priv_level = privLevel_bits(p)
-function privLevel_of_bits(b : priv_level) -> Privilege = privLevel_bits(b)
+function privLevel_to_bits(p : Privilege) -> nom_priv_bits = { let (p, _) = privLevel_bits(p); p }
+function privLevel_of_bits(p : nom_priv_bits, v : virt_mode_bit) -> Privilege = privLevel_bits((p, v))
 
 function privLevel_to_str (p : Privilege) -> string =
   match (p) {
-    User       => "U",
-    Supervisor => "S",
-    Machine    => "M"
+    User              => "U",
+    VirtualUser       => "VU",
+    Supervisor        => if currentlyEnabled(Ext_H) then "HS" else "S",
+    VirtualSupervisor => "VS",
+    Machine           => "M"
   }
 
 overload to_str = {privLevel_to_str}

--- a/model/riscv_vmem_pte.sail
+++ b/model/riscv_vmem_pte.sail
@@ -131,6 +131,8 @@ function check_PTE_permission(ac        : AccessType(ext_access_type),
     // loads and stores; not instruction fetch.
     Supervisor => not(pte_U) | (do_sum & is_load_store(ac)),
     Machine    => internal_error(__FILE__, __LINE__, "m-mode mem perm check"),
+    VirtualUser => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   };
 
   if access_ok & priv_ok then PTE_Check_Success(()) else PTE_Check_Failure((), ())

--- a/model/riscv_zkr_control.sail
+++ b/model/riscv_zkr_control.sail
@@ -49,6 +49,8 @@ function clause is_CSR_accessible(0x015, priv, is_write) =
     Machine => true,
     Supervisor => mseccfg[SSEED] == 0b1,
     User => mseccfg[USEED] == 0b1,
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualUser => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   })
 
 function clause read_CSR(0x015) = read_seed_csr()


### PR DESCRIPTION
- Add `VirtualUser` and `VirtualSupervisor` to the existing `Privilege` enum
- Rename `privLevel_bits` to `nominalPrivLevel_bits` and add conversions for VS and VU to bits
- Add placeholder to all `match cur_privilege` statements, mark VS and VU branches as unimplemented