### PR TITLE
Remove int annotations from M extension

### DIFF
--- a/model/riscv_insts_mext.sail
+++ b/model/riscv_insts_mext.sail
@@ -30,8 +30,8 @@ mapping clause encdec = MUL(rs2, rs1, rd, mul_op)
 function clause execute (MUL(rs2, rs1, rd, mul_op)) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
-  let rs1_int : int = if mul_op.signed_rs1 then signed(rs1_val) else unsigned(rs1_val);
-  let rs2_int : int = if mul_op.signed_rs2 then signed(rs2_val) else unsigned(rs2_val);
+  let rs1_int = if mul_op.signed_rs1 then signed(rs1_val) else unsigned(rs1_val);
+  let rs2_int = if mul_op.signed_rs2 then signed(rs2_val) else unsigned(rs2_val);
   let result_wide = to_bits_unsafe(2 * xlen, rs1_int * rs2_int);
   let result = if   mul_op.high
                then result_wide[(2 * xlen - 1) .. xlen]
@@ -60,11 +60,11 @@ mapping clause encdec = DIV(rs2, rs1, rd, s)
 function clause execute (DIV(rs2, rs1, rd, s)) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
-  let rs1_int : int = if s then signed(rs1_val) else unsigned(rs1_val);
-  let rs2_int : int = if s then signed(rs2_val) else unsigned(rs2_val);
-  let q : int = if rs2_int == 0 then -1 else quot_round_zero(rs1_int, rs2_int);
+  let rs1_int = if s then signed(rs1_val) else unsigned(rs1_val);
+  let rs2_int = if s then signed(rs2_val) else unsigned(rs2_val);
+  let q = if rs2_int == 0 then -1 else quot_round_zero(rs1_int, rs2_int);
   /* check for signed overflow */
-  let q': int = if s & q >= 2 ^ (xlen - 1) then negate(2 ^ (xlen - 1)) else q;
+  let q' = if s & q >= 2 ^ (xlen - 1) then negate(2 ^ (xlen - 1)) else q;
   X(rd) = to_bits_unsafe(xlen, q');
   RETIRE_SUCCESS
 }
@@ -87,9 +87,9 @@ mapping clause encdec = REM(rs2, rs1, rd, s)
 function clause execute (REM(rs2, rs1, rd, s)) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
-  let rs1_int : int = if s then signed(rs1_val) else unsigned(rs1_val);
-  let rs2_int : int = if s then signed(rs2_val) else unsigned(rs2_val);
-  let r : int = if rs2_int == 0 then rs1_int else rem_round_zero(rs1_int, rs2_int);
+  let rs1_int = if s then signed(rs1_val) else unsigned(rs1_val);
+  let rs2_int = if s then signed(rs2_val) else unsigned(rs2_val);
+  let r = if rs2_int == 0 then rs1_int else rem_round_zero(rs1_int, rs2_int);
   /* signed overflow case returns zero naturally as required due to -1 divisor */
   X(rd) = to_bits_unsafe(xlen, r);
   RETIRE_SUCCESS
@@ -108,8 +108,8 @@ mapping clause encdec = MULW(rs2, rs1, rd)
 function clause execute (MULW(rs2, rs1, rd)) = {
   let rs1_val = X(rs1)[31..0];
   let rs2_val = X(rs2)[31..0];
-  let rs1_int : int = signed(rs1_val);
-  let rs2_int : int = signed(rs2_val);
+  let rs1_int = signed(rs1_val);
+  let rs2_int = signed(rs2_val);
   /* to_bits_unsafe requires expansion to 64 bits followed by truncation */
   let result32 = to_bits_unsafe(64, rs1_int * rs2_int)[31..0];
   let result : xlenbits = sign_extend(result32);
@@ -131,11 +131,11 @@ mapping clause encdec = DIVW(rs2, rs1, rd, s)
 function clause execute (DIVW(rs2, rs1, rd, s)) = {
   let rs1_val = X(rs1)[31..0];
   let rs2_val = X(rs2)[31..0];
-  let rs1_int : int = if s then signed(rs1_val) else unsigned(rs1_val);
-  let rs2_int : int = if s then signed(rs2_val) else unsigned(rs2_val);
-  let q : int = if rs2_int == 0 then -1 else quot_round_zero(rs1_int, rs2_int);
+  let rs1_int = if s then signed(rs1_val) else unsigned(rs1_val);
+  let rs2_int = if s then signed(rs2_val) else unsigned(rs2_val);
+  let q = if rs2_int == 0 then -1 else quot_round_zero(rs1_int, rs2_int);
   /* check for signed overflow */
-  let q': int = if s & q > (2 ^ 31 - 1) then  (0 - (2 ^ 31)) else q;
+  let q' = if s & q > (2 ^ 31 - 1) then  (0 - (2 ^ 31)) else q;
   X(rd) = sign_extend(to_bits_unsafe(32, q'));
   RETIRE_SUCCESS
 }
@@ -154,9 +154,9 @@ mapping clause encdec = REMW(rs2, rs1, rd, s)
 function clause execute (REMW(rs2, rs1, rd, s)) = {
   let rs1_val = X(rs1)[31..0];
   let rs2_val = X(rs2)[31..0];
-  let rs1_int : int = if s then signed(rs1_val) else unsigned(rs1_val);
-  let rs2_int : int = if s then signed(rs2_val) else unsigned(rs2_val);
-  let r : int = if rs2_int == 0 then rs1_int else rem_round_zero(rs1_int, rs2_int);
+  let rs1_int = if s then signed(rs1_val) else unsigned(rs1_val);
+  let rs2_int = if s then signed(rs2_val) else unsigned(rs2_val);
+  let r = if rs2_int == 0 then rs1_int else rem_round_zero(rs1_int, rs2_int);
   /* signed overflow case returns zero naturally as required due to -1 divisor */
   X(rd) = sign_extend(to_bits_unsafe(32, r));
   RETIRE_SUCCESS


### PR DESCRIPTION
These are unnecessary and also erase important type checking information.