### PR TITLE
Improve typing of division and modulo

### DIFF
--- a/model/prelude.sail
+++ b/model/prelude.sail
@@ -49,12 +49,14 @@ val sub_vec_int = pure {c: "sub_bits_int", lean: "BitVec.subInt", _: "sub_vec_in
 overload operator - = {sub_vec, sub_vec_int}
 
 val quot_positive_round_zero = pure {interpreter: "quot_round_zero", lem: "hardware_quot", lean: "Int.tdiv", c: "tdiv_int", coq: "Z.quot"} : forall 'n 'm, 'n >= 0 & 'm > 0. (int('n), int('m)) -> int(div('n, 'm))
+val quot_round_zero = pure {interpreter: "quot_round_zero", lem: "hardware_quot", c: "tdiv_int", coq: "Z.quot", lean: "Int.tdiv"} : forall 'm, 'm != 0 . (int, int('m)) -> int
 
-val quot_round_zero = pure {interpreter: "quot_round_zero", lem: "hardware_quot", c: "tdiv_int", coq: "Z.quot", lean: "Int.tdiv"} : (int, int) -> int
-val rem_round_zero = pure {interpreter: "rem_round_zero", lem: "hardware_mod", c: "tmod_int", coq: "Z.rem", lean: "Int.tmod"} : (int, int) -> int
+val rem_positive_round_zero = pure {interpreter: "rem_round_zero", lem: "hardware_mod", c: "tmod_int", coq: "Z.rem", lean: "Int.tmod"} : forall 'n 'm, 'n >= 0 & 'm > 0. (int('n), int('m)) -> int(mod('n, 'm))
+val rem_round_zero = pure {interpreter: "rem_round_zero", lem: "hardware_mod", c: "tmod_int", coq: "Z.rem", lean: "Int.tmod"} : forall 'm, 'm != 0 . (int, int('m)) -> int
 
-/* The following defines % as euclidean modulus */
-overload operator % = {emod_int}
+// For working with division / modulus we require the divisor to be >= 1.
+// This type describes that.
+type nat1 = {'n, 'n > 0. int('n)}
 
 overload min = {min_int}
 overload max = {max_int}
@@ -211,8 +213,13 @@ function reverse_bits (xs)  = {
   ys
 }
 
-overload operator / = {quot_positive_round_zero, quot_round_zero}
 overload operator * = {mult_atom, mult_int}
+// quot_round_zero and rem_round_zero are deliberately not
+// added to these overloads to avoid accidentally doing
+// division or modulo with negative numbers which is almost
+// always a mistake in this context.
+overload operator / = {quot_positive_round_zero}
+overload operator % = {rem_positive_round_zero}
 
 /* helper for vector extension
  * 1. EEW between 8 and 64
@@ -256,5 +263,5 @@ val sys_enable_experimental_extensions = pure "sys_enable_experimental_extension
 // Print a bit vector in hex. If it is not a multiple of 4
 // bits in length zero extend it so it is (bits_str() prints
 // bit vectors that aren't a multiple of 4 bits in binary).
-function hex_bits_str forall 'n . (x : bits('n)) -> string =
+function hex_bits_str forall 'n, 'n >= 0 . (x : bits('n)) -> string =
   bits_str(zero_extend((3 - (('n + 3) % 4)) + 'n, x))

--- a/model/riscv_device_tree.sail
+++ b/model/riscv_device_tree.sail
@@ -101,7 +101,7 @@ function generate_isa_string(fmt : ISA_Format) -> string = {
 // Generates the full Device-Tree configuration for the model.
 
 function generate_dts() -> string = {
-  let clock_freq : int = config platform.clock_frequency;
+  let clock_freq : nat = config platform.clock_frequency;
   let ram_base_hi = unsigned(plat_ram_base >> 32);
   let ram_base_lo = unsigned(plat_ram_base[31 .. 0]);
   let ram_size_hi = unsigned(plat_ram_size >> 32);

--- a/model/riscv_insts_vext_fp_red.sail
+++ b/model/riscv_insts_vext_fp_red.sail
@@ -27,7 +27,7 @@ mapping clause encdec = RFVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_rfvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_V)
 
-val process_rfvv_single: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, int('n), int('m), int('p)) -> ExecutionResult
+val process_rfvv_single : (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, nat1, sew_bitsize, range(-3, 3)) -> ExecutionResult
 function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {
   let rm_3b = fcsr[FRM];
   let num_elem_vd = get_num_elem(0, SEW); /* vd regardless of LMUL setting */
@@ -70,7 +70,7 @@ function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_po
   RETIRE_SUCCESS
 }
 
-val process_rfvv_widen: forall 'n 'm 'p, 'n > 0 & 'm in {8, 16, 32, 64}. (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, int('n), int('m), int('p)) -> ExecutionResult
+val process_rfvv_widen : (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, nat1, sew_bitsize, range(-3, 3)) -> ExecutionResult
 function process_rfvv_widen(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {
   let rm_3b          = fcsr[FRM];
   let SEW_widen      = SEW * 2;

--- a/model/riscv_insts_vext_fp_utils.sail
+++ b/model/riscv_insts_vext_fp_utils.sail
@@ -14,7 +14,7 @@
  *  1. Valid element width of floating-point numbers
  *  2. Valid floating-point rounding mode
  */
-val valid_fp_op : ({8, 16, 32, 64}, bits(3)) -> bool
+val valid_fp_op : (sew_bitsize, bits(3)) -> bool
 function valid_fp_op(SEW, rm_3b) = {
   /* 128-bit floating-point values will be supported in future extensions */
   let valid_sew = (SEW >= 16 & SEW <= 128);
@@ -23,38 +23,38 @@ function valid_fp_op(SEW, rm_3b) = {
 }
 
 /* a. Normal check for floating-point instructions */
-val illegal_fp_normal : (vregidx, bits(1), {8, 16, 32, 64}, bits(3)) -> bool
+val illegal_fp_normal : (vregidx, bits(1), sew_bitsize, bits(3)) -> bool
 function illegal_fp_normal(vd, vm, SEW, rm_3b) = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b))
 }
 
 /* b. Masked check for floating-point instructions encoded with vm = 0 */
-val illegal_fp_vd_masked : (vregidx, {8, 16, 32, 64}, bits(3)) -> bool
+val illegal_fp_vd_masked : (vregidx, sew_bitsize, bits(3)) -> bool
 function illegal_fp_vd_masked(vd, SEW, rm_3b) = {
   not(valid_vtype()) | vd == zvreg | not(valid_fp_op(SEW, rm_3b))
 }
 
 /* c. Unmasked check for floating-point instructions encoded with vm = 1 */
-val illegal_fp_vd_unmasked : ({8, 16, 32, 64}, bits(3)) -> bool
+val illegal_fp_vd_unmasked : (sew_bitsize, bits(3)) -> bool
 function illegal_fp_vd_unmasked(SEW, rm_3b) = {
   not(valid_vtype()) | not(valid_fp_op(SEW, rm_3b))
 }
 
 /* d. Variable width check for floating-point widening/narrowing instructions */
-val illegal_fp_variable_width : (vregidx, bits(1), {8, 16, 32, 64}, bits(3), int, int) -> bool
+val illegal_fp_variable_width : (vregidx, bits(1), sew_bitsize, bits(3), int, int) -> bool
 function illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_new, LMUL_pow_new) = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) |
   not(valid_eew_emul(SEW_new, LMUL_pow_new))
 }
 
 /* e. Normal check for floating-point reduction instructions */
-val illegal_fp_reduction : ({8, 16, 32, 64}, bits(3)) -> bool
+val illegal_fp_reduction : (sew_bitsize, bits(3)) -> bool
 function illegal_fp_reduction(SEW, rm_3b) = {
   not(valid_vtype()) | not(assert_vstart(0)) | not(valid_fp_op(SEW, rm_3b))
 }
 
 /* f. Variable width check for floating-point widening reduction instructions */
-val illegal_fp_reduction_widen : ({8, 16, 32, 64}, bits(3), int, int) -> bool
+val illegal_fp_reduction_widen : (sew_bitsize, bits(3), int, int) -> bool
 function illegal_fp_reduction_widen(SEW, rm_3b, SEW_widen, LMUL_pow_widen) = {
   not(valid_vtype()) | not(assert_vstart(0)) | not(valid_fp_op(SEW, rm_3b)) |
   not(valid_eew_emul(SEW_widen, LMUL_pow_widen))
@@ -450,12 +450,11 @@ function riscv_f32ToUi16 (rm, v) = {
 
 val rsqrt7 : forall 'm, 'm in {16, 32, 64}. (bits('m), bool) -> bits_D
 function rsqrt7 (v, sub) = {
-  let (sig, exp, sign, e, s) : (bits(64), bits(64), bits(1), nat, nat) = match 'm {
+  let (sig, exp, sign, e, s) : (bits(64), bits(64), bits(1), {5, 8, 11}, {10, 23, 52}) = match 'm {
     16 => (zero_extend(64, v[9 .. 0]), zero_extend(64, v[14 .. 10]), [v[15]], 5, 10),
     32 => (zero_extend(64, v[22 .. 0]), zero_extend(64, v[30 .. 23]), [v[31]], 8, 23),
     64 => (zero_extend(64, v[51 .. 0]), zero_extend(64, v[62 .. 52]), [v[63]], 11, 52)
   };
-  assert(s == 10 & e == 5 | s == 23 & e == 8 | s == 52 & e == 11);
   let table : vector(128, int) = [
       52, 51, 50, 48, 47, 46, 44, 43,
       42, 41, 40, 39, 38, 36, 35, 34,
@@ -490,7 +489,7 @@ function rsqrt7 (v, sub) = {
   };
   assert(idx >= 0 & idx < 128);
   let out_sig = to_bits_unsafe(s, table[(127 - idx)]) << (s - 7);
-  let out_exp = to_bits_unsafe(e, (3 * (2 ^ (e - 1) - 1) - 1 - signed(normalized_exp)) / 2);
+  let out_exp = to_bits_unsafe(e, quot_round_zero(3 * (2 ^ (e - 1) - 1) - 1 - signed(normalized_exp), 2));
   zero_extend(64, sign @ out_exp @ out_sig)
 }
 

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -84,7 +84,7 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
   let vd_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
 
   let 'm = nf * load_width_bytes * 8;
-  let (result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val) {
+  let (result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, 'm, EMUL_pow, vd_seg, vm_val) {
     Ok(v)   => v,
     Err(()) => return Illegal_Instruction()
   };

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -185,7 +185,7 @@ val get_velem_quad : forall 'n 'm 'p, 'n > 0 & 'm > 0 & 'p >= 0 & 4 * 'p + 3 < '
 function get_velem_quad(v, i) = v[4 * i + 3] @ v[4 * i + 2] @ v[4 * i + 1] @ v[4 * i]
 
 /* Divide the input bitvector into 4 equal slices and store them in vd starting at position 4*i */
-val write_velem_quad : forall 'p 'n 'm, 8 <= 'n <= 64 & 'm > 0 & 'p >= 0. (vregidx, int('n), bits('m), int('p)) -> unit
+val write_velem_quad : forall 'n, 'n > 0 . (vregidx, sew_bitsize, bits('n), nat) -> unit
 function write_velem_quad(vd, SEW, input, i) = {
   foreach(j from 0 to 3)
     write_single_element(SEW, 4 * i + j, vd, slice(input, j * SEW, SEW));
@@ -198,7 +198,7 @@ val get_velem_oct_vec : forall 'n 'm 'p, 'n > 0 & 8 <= 'm <= 64 & 'p >= 0 & 8 * 
 function get_velem_oct_vec(n, v, i) = [ v[8 * i + 7], v[8 * i + 6], v[8 * i + 5], v[8 * i + 4], v[8 * i + 3], v[8 * i + 2], v[8 * i + 1], v[8 * i] ]
 
 /* Writes each of the 8 elements from the input vector to the vector register vd, starting at position 8 * i */
-val write_velem_oct_vec : forall 'p 'n, 8 <= 'n <= 64 & 'p >= 0. (vregidx, int('n), vector(8, bits('n)), int('p)) -> unit
+val write_velem_oct_vec : forall 'n, 'n in {8, 16, 32, 64}. (vregidx, int('n), vector(8, bits('n)), nat) -> unit
 function write_velem_oct_vec(vd, SEW, input, i) = {
   foreach(j from 0 to 7)
     write_single_element(SEW, 8 * i + j, vd, input[j]);
@@ -209,7 +209,7 @@ val get_velem_quad_vec : forall 'n 'm 'p, 'n > 0 & 8 <= 'm <= 64  & 'p >= 0 & 4 
 function get_velem_quad_vec(v, i) = [ v[4 * i + 3], v[4 * i + 2], v[4 * i + 1], v[4 * i] ]
 
 /* Writes each of the 4 elements from the input vector to the vector register vd, starting at position 4 * i */
-val write_velem_quad_vec : forall 'p 'n, 8 <= 'n <= 64 & 'p >= 0. (vregidx, int('n), vector(4, bits('n)), int('p)) -> unit
+val write_velem_quad_vec : forall 'p 'n, 'n in {8, 16, 32, 64} & 'p >= 0. (vregidx, int('n), vector(4, bits('n)), int('p)) -> unit
 function write_velem_quad_vec(vd, SEW, input, i) = {
   foreach(j from 0 to 3)
     write_single_element(SEW, 4 * i + j, vd, input[j]);
@@ -243,8 +243,8 @@ function get_end_element() = unsigned(vl) - 1
  *   vector2 is a "mask" vector that is true for an element if the corresponding element
  *     in the result vector should be updated by the calling instruction
  */
-val init_masked_result : forall 'n 'm 'p, 'n >= 0 & 'm >= 0. (int('n), int('m), int('p), vector('n, bits('m)), bits('n)) -> result((vector('n, bits('m)), bits('n)), unit)
-function init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
+val init_masked_result : forall 'n 'm 'p, 'n >= 0 . (int('n), int('m), int('p), vector('n, bits('m)), bits('n)) -> result((vector('n, bits('m)), bits('n)), unit)
+function init_masked_result(num_elem, EEW, LMUL_pow, vd_val, vm_val) = {
   let start_element : nat = match get_start_element() {
     Ok(v)   => v,
     Err(()) => return Err(())
@@ -336,8 +336,8 @@ function init_masked_source(num_elem, LMUL_pow, vm_val) = {
 
 /* Mask handling for carry functions that use masks as input/output */
 /* Only prestart and tail elements are masked in a mask value */
-val init_masked_result_carry : forall 'n 'm 'p, 'n >= 0. (int('n), int('m), int('p), bits('n)) -> result((bits('n), bits('n)), unit)
-function init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) = {
+val init_masked_result_carry : forall 'n, 'n >= 0 . (int('n), sew_bitsize, int, bits('n)) -> result((bits('n), bits('n)), unit)
+function init_masked_result_carry(num_elem, EEW, LMUL_pow, vd_val) = {
   let start_element : nat = match get_start_element() {
     Ok(v)   => v,
     Err(()) => return Err(())
@@ -375,8 +375,8 @@ function init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) = {
 }
 
 /* Mask handling for cmp functions that use masks as output */
-val init_masked_result_cmp : forall 'n 'm 'p, 'n >= 0. (int('n), int('m), int('p), bits('n), bits('n)) -> result((bits('n), bits('n)), unit)
-function init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
+val init_masked_result_cmp : forall 'n, 'n >= 0 . (int('n), sew_bitsize, int, bits('n), bits('n)) -> result((bits('n), bits('n)), unit)
+function init_masked_result_cmp(num_elem, EEW, LMUL_pow, vd_val, vm_val) = {
   let start_element : nat = match get_start_element() {
     Ok(v)   => v,
     Err(()) => return Err(())
@@ -425,7 +425,7 @@ function init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) = {
  *   Read multiple register groups and concatenate them in parallel
  *   The whole segments with the same element index are combined together
  */
-val read_vreg_seg : forall 'n 'm 'p 'q, 'n >= 0 & 'm >= 0 & nfields_range('q). (int('n), int('m), int('p), int('q), vregidx) -> vector('n, bits('q * 'm))
+val read_vreg_seg : forall 'n 'm 'p 'q, 'n >= 0 & 'm in {8, 16, 32, 64} & nfields_range('q). (int('n), int('m), int('p), int('q), vregidx) -> vector('n, bits('q * 'm))
 function read_vreg_seg(num_elem, SEW, LMUL_pow, nf, vrid) = {
   let LMUL_reg : int = if LMUL_pow <= 0 then 1 else 2 ^ LMUL_pow;
   var vreg_list : vector('q, vector('n, bits('m))) = vector_init(vector_init(zeros()));
@@ -443,7 +443,7 @@ function read_vreg_seg(num_elem, SEW, LMUL_pow, nf, vrid) = {
 }
 
 /* Shift amounts */
-val get_shift_amount : forall 'n 'm, 0 <= 'n & 'm in {8, 16, 32, 64}. (bits('n), int('m)) -> nat
+val get_shift_amount : forall 'n, 0 <= 'n . (bits('n), sew_bitsize) -> nat
 function get_shift_amount(bit_val, SEW) = {
   let lowlog2bits = log2(SEW);
   assert(0 < lowlog2bits & lowlog2bits < 'n);

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -198,7 +198,7 @@ val get_velem_oct_vec : forall 'n 'm 'p, 'n > 0 & 8 <= 'm <= 64 & 'p >= 0 & 8 * 
 function get_velem_oct_vec(n, v, i) = [ v[8 * i + 7], v[8 * i + 6], v[8 * i + 5], v[8 * i + 4], v[8 * i + 3], v[8 * i + 2], v[8 * i + 1], v[8 * i] ]
 
 /* Writes each of the 8 elements from the input vector to the vector register vd, starting at position 8 * i */
-val write_velem_oct_vec : forall 'n, 'n in {8, 16, 32, 64}. (vregidx, int('n), vector(8, bits('n)), nat) -> unit
+val write_velem_oct_vec : forall 'n, is_sew_bitsize('n) . (vregidx, int('n), vector(8, bits('n)), nat) -> unit
 function write_velem_oct_vec(vd, SEW, input, i) = {
   foreach(j from 0 to 7)
     write_single_element(SEW, 8 * i + j, vd, input[j]);
@@ -209,7 +209,7 @@ val get_velem_quad_vec : forall 'n 'm 'p, 'n > 0 & 8 <= 'm <= 64  & 'p >= 0 & 4 
 function get_velem_quad_vec(v, i) = [ v[4 * i + 3], v[4 * i + 2], v[4 * i + 1], v[4 * i] ]
 
 /* Writes each of the 4 elements from the input vector to the vector register vd, starting at position 4 * i */
-val write_velem_quad_vec : forall 'p 'n, 'n in {8, 16, 32, 64} & 'p >= 0. (vregidx, int('n), vector(4, bits('n)), int('p)) -> unit
+val write_velem_quad_vec : forall 'p 'n, is_sew_bitsize('n) & 'p >= 0. (vregidx, int('n), vector(4, bits('n)), int('p)) -> unit
 function write_velem_quad_vec(vd, SEW, input, i) = {
   foreach(j from 0 to 3)
     write_single_element(SEW, 4 * i + j, vd, input[j]);
@@ -425,7 +425,7 @@ function init_masked_result_cmp(num_elem, EEW, LMUL_pow, vd_val, vm_val) = {
  *   Read multiple register groups and concatenate them in parallel
  *   The whole segments with the same element index are combined together
  */
-val read_vreg_seg : forall 'n 'm 'p 'q, 'n >= 0 & 'm in {8, 16, 32, 64} & nfields_range('q). (int('n), int('m), int('p), int('q), vregidx) -> vector('n, bits('q * 'm))
+val read_vreg_seg : forall 'n 'm 'p 'q, 'n >= 0 & is_sew_bitsize('m) & nfields_range('q). (int('n), int('m), int('p), int('q), vregidx) -> vector('n, bits('q * 'm))
 function read_vreg_seg(num_elem, SEW, LMUL_pow, nf, vrid) = {
   let LMUL_reg : int = if LMUL_pow <= 0 then 1 else 2 ^ LMUL_pow;
   var vreg_list : vector('q, vector('n, bits('m))) = vector_init(vector_init(zeros()));

--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -39,10 +39,10 @@
  *   is_aligned_addr - checks for alignment of a physical or virtual address
  */
 
-function is_aligned_paddr forall 'n. (Physaddr(addr) : physaddr, width : int('n)) -> bool =
+function is_aligned_paddr(Physaddr(addr) : physaddr, width : nat1) -> bool =
   unsigned(addr) % width == 0
 
-function is_aligned_vaddr forall 'n. (Virtaddr(addr) : virtaddr, width : int('n)) -> bool =
+function is_aligned_vaddr(Virtaddr(addr) : virtaddr, width : nat1) -> bool =
   unsigned(addr) % width == 0
 
 function is_aligned_bits(vaddr : xlenbits, width : word_width) -> bool =

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -118,7 +118,7 @@ function within_htif_readable forall 'n, 0 < 'n <= max_mem_access . (Physaddr(ad
 
 /* CLINT (Core Local Interruptor), based on Spike. */
 
-let plat_insns_per_tick : int = config platform.instructions_per_tick
+let plat_insns_per_tick : nat1 = config platform.instructions_per_tick
 
 // Each hart has a memory-mapped mtimecmp register. Typically these are
 // exposed as an array in CLINT. The CLINT implementation here is currently

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -1004,8 +1004,11 @@ function get_sew_pow() -> SEW_pow = {
   sew_pow_val(sew_pow)
 }
 
+// Valid SEW sizes in bits.
+type sew_bitsize = {8, 16, 32, 64}
+
 /* this returns the actual value of SEW */
-function get_sew() -> {8, 16, 32, 64} =
+function get_sew() -> sew_bitsize =
   2 ^ get_sew_pow()
 
 /* this returns the value of SEW in bytes */

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -1006,6 +1006,7 @@ function get_sew_pow() -> SEW_pow = {
 
 // Valid SEW sizes in bits.
 type sew_bitsize = {8, 16, 32, 64}
+type is_sew_bitsize('n) -> Bool = 'n in {8, 16, 32, 64}
 
 /* this returns the actual value of SEW */
 function get_sew() -> sew_bitsize =

--- a/model/riscv_vext_regs.sail
+++ b/model/riscv_vext_regs.sail
@@ -237,23 +237,22 @@ function ext_write_vcsr (vxrm_val, vxsat_val) = {
 }
 
 /* num_elem means max(VLMAX,VLEN/SEW)) according to Section 5.4 of RVV spec */
-val get_num_elem : (int, int) -> {'n, 'n > 0. int('n)}
+val get_num_elem : (int, sew_bitsize) -> nat1
 function get_num_elem(LMUL_pow, SEW) = {
   let LMUL_pow_reg = if LMUL_pow < 0 then 0 else LMUL_pow;
   /* Ignore lmul < 1 so that the entire vreg is read, allowing all masking to
    * be handled in init_masked_result */
-  let num_elem = 2 ^ LMUL_pow_reg * VLEN / SEW;
+  let num_elem = (2 ^ LMUL_pow_reg) * VLEN / SEW;
   assert(num_elem > 0);
   num_elem
 }
 
 /* Reads a single vreg into multiple elements */
-val read_single_vreg : forall 'n 'm, 'n >= 0 & 'm >= 0. (int('n), int('m), vregidx) -> vector('n, bits('m))
+val read_single_vreg : forall 'n 'm, 'n >= 0 & 'm in {8, 16, 32, 64} . (int('n), int('m), vregidx) -> vector('n, bits('m))
 function read_single_vreg(num_elem, SEW, vrid) = {
   let bv     : vregtype                  = V(vrid);
   var result : vector('n, bits('m)) = vector_init(zeros());
 
-  assert(8 <= SEW & SEW <= 64);
   foreach (i from 0 to (num_elem - 1)) {
     let start_index = i * SEW;
     result[i] = slice(bv, start_index, SEW);
@@ -263,11 +262,10 @@ function read_single_vreg(num_elem, SEW, vrid) = {
 }
 
 /* Writes multiple elements into a single vreg */
-val write_single_vreg : forall 'n 'm, 'n >= 0. (int('n), int('m), vregidx, vector('n, bits('m))) -> unit
+val write_single_vreg : forall 'n 'm, 'n >= 0 & 'm in {8, 16, 32, 64} . (int('n), int('m), vregidx, vector('n, bits('m))) -> unit
 function write_single_vreg(num_elem, SEW, vrid, v) = {
   var r : vregtype = zeros();
 
-  assert(8 <= SEW & SEW <= 64);
   foreach (i from (num_elem - 1) downto 0) {
     r = r << SEW;
     r = r | zero_extend(v[i]);
@@ -277,7 +275,7 @@ function write_single_vreg(num_elem, SEW, vrid, v) = {
 }
 
 /* The general vreg reading operation with num_elem as max(VLMAX,VLEN/SEW)) */
-val read_vreg : forall 'n 'm 'p, 'n >= 0 & 'm >= 0. (int('n), int('m), int('p), vregidx) -> vector('n, bits('m))
+val read_vreg : forall 'n 'm 'p, 'n >= 0 & 'm in {8, 16, 32, 64} . (int('n), int('m), int('p), vregidx) -> vector('n, bits('m))
 function read_vreg(num_elem, SEW, LMUL_pow, vrid) = {
   let vrid_val = unsigned(vregidx_bits(vrid));
   var result : vector('n, bits('m)) = vector_init(zeros());
@@ -294,7 +292,7 @@ function read_vreg(num_elem, SEW, LMUL_pow, vrid) = {
     if LMUL_pow < 0 then {
       result = read_single_vreg('n, SEW, vrid);
     } else {
-      let 'num_elem_single : int = VLEN / SEW;
+      let 'num_elem_single = VLEN / SEW;
       assert('num_elem_single >= 0);
       foreach (i_lmul from 0 to (2 ^ LMUL_pow_reg - 1)) {
         let r_start_i : int = i_lmul * 'num_elem_single;
@@ -315,11 +313,11 @@ function read_vreg(num_elem, SEW, LMUL_pow, vrid) = {
 }
 
 /* Single element reading operation */
-val read_single_element : forall 'm 'x, 8 <= 'm <= 128. (int('m), int('x), vregidx) -> bits('m)
+val read_single_element : forall 'm, 'm in {8, 16, 32, 64} . (int('m), nat, vregidx) -> bits('m)
 function read_single_element(EEW, index, vrid) = {
   assert(VLEN >= EEW);
-  let 'elem_per_reg : int = VLEN / EEW;
-  assert('elem_per_reg >= 0);
+  let 'elem_per_reg = VLEN / EEW;
+  assert('elem_per_reg > 0);
   let real_vrid  : vregidx = vregidx_offset(vrid, to_bits_unsafe(5, index / 'elem_per_reg));
   let real_index : int    = index % 'elem_per_reg;
   let vrid_val : vector('elem_per_reg, bits('m)) = read_single_vreg('elem_per_reg, EEW, real_vrid);
@@ -328,7 +326,7 @@ function read_single_element(EEW, index, vrid) = {
 }
 
 /* The general vreg writing operation with num_elem as max(VLMAX,VLEN/SEW)) */
-val write_vreg : forall 'n 'm 'p, 'n >= 0 & 'm >= 0. (int('n), int('m), int('p), vregidx, vector('n, bits('m))) -> unit
+val write_vreg : forall 'n 'm 'p, 'n >= 0 & 'm in {8, 16, 32, 64} . (int('n), int('m), int('p), vregidx, vector('n, bits('m))) -> unit
 function write_vreg(num_elem, SEW, LMUL_pow, vrid, vec) = {
   let LMUL_pow_reg = if LMUL_pow < 0 then 0 else LMUL_pow;
 
@@ -350,10 +348,10 @@ function write_vreg(num_elem, SEW, LMUL_pow, vrid, vec) = {
 }
 
 /* Single element writing operation */
-val write_single_element : forall 'm 'x, 8 <= 'm <= 128. (int('m), int('x), vregidx, bits('m)) -> unit
+val write_single_element : forall 'm, 'm in {8, 16, 32, 64}. (int('m), nat, vregidx, bits('m)) -> unit
 function write_single_element(EEW, index, vrid, value) = {
-  let 'elem_per_reg : int = VLEN / EEW;
-  assert('elem_per_reg >= 0);
+  let 'elem_per_reg = VLEN / EEW;
+  assert('elem_per_reg > 0);
   let real_vrid  : vregidx = vregidx_offset(vrid, to_bits_unsafe(5, index / 'elem_per_reg));
   let real_index : int    = index % 'elem_per_reg;
 

--- a/model/riscv_vext_regs.sail
+++ b/model/riscv_vext_regs.sail
@@ -248,7 +248,7 @@ function get_num_elem(LMUL_pow, SEW) = {
 }
 
 /* Reads a single vreg into multiple elements */
-val read_single_vreg : forall 'n 'm, 'n >= 0 & 'm in {8, 16, 32, 64} . (int('n), int('m), vregidx) -> vector('n, bits('m))
+val read_single_vreg : forall 'n 'm, 'n >= 0 & is_sew_bitsize('m) . (int('n), int('m), vregidx) -> vector('n, bits('m))
 function read_single_vreg(num_elem, SEW, vrid) = {
   let bv     : vregtype                  = V(vrid);
   var result : vector('n, bits('m)) = vector_init(zeros());
@@ -262,7 +262,7 @@ function read_single_vreg(num_elem, SEW, vrid) = {
 }
 
 /* Writes multiple elements into a single vreg */
-val write_single_vreg : forall 'n 'm, 'n >= 0 & 'm in {8, 16, 32, 64} . (int('n), int('m), vregidx, vector('n, bits('m))) -> unit
+val write_single_vreg : forall 'n 'm, 'n >= 0 & is_sew_bitsize('m) . (int('n), int('m), vregidx, vector('n, bits('m))) -> unit
 function write_single_vreg(num_elem, SEW, vrid, v) = {
   var r : vregtype = zeros();
 
@@ -275,7 +275,7 @@ function write_single_vreg(num_elem, SEW, vrid, v) = {
 }
 
 /* The general vreg reading operation with num_elem as max(VLMAX,VLEN/SEW)) */
-val read_vreg : forall 'n 'm 'p, 'n >= 0 & 'm in {8, 16, 32, 64} . (int('n), int('m), int('p), vregidx) -> vector('n, bits('m))
+val read_vreg : forall 'n 'm 'p, 'n >= 0 & is_sew_bitsize('m) . (int('n), int('m), int('p), vregidx) -> vector('n, bits('m))
 function read_vreg(num_elem, SEW, LMUL_pow, vrid) = {
   let vrid_val = unsigned(vregidx_bits(vrid));
   var result : vector('n, bits('m)) = vector_init(zeros());
@@ -313,7 +313,7 @@ function read_vreg(num_elem, SEW, LMUL_pow, vrid) = {
 }
 
 /* Single element reading operation */
-val read_single_element : forall 'm, 'm in {8, 16, 32, 64} . (int('m), nat, vregidx) -> bits('m)
+val read_single_element : forall 'm, is_sew_bitsize('m) . (int('m), nat, vregidx) -> bits('m)
 function read_single_element(EEW, index, vrid) = {
   assert(VLEN >= EEW);
   let 'elem_per_reg = VLEN / EEW;
@@ -326,7 +326,7 @@ function read_single_element(EEW, index, vrid) = {
 }
 
 /* The general vreg writing operation with num_elem as max(VLMAX,VLEN/SEW)) */
-val write_vreg : forall 'n 'm 'p, 'n >= 0 & 'm in {8, 16, 32, 64} . (int('n), int('m), int('p), vregidx, vector('n, bits('m))) -> unit
+val write_vreg : forall 'n 'm 'p, 'n >= 0 & is_sew_bitsize('m) . (int('n), int('m), int('p), vregidx, vector('n, bits('m))) -> unit
 function write_vreg(num_elem, SEW, LMUL_pow, vrid, vec) = {
   let LMUL_pow_reg = if LMUL_pow < 0 then 0 else LMUL_pow;
 
@@ -348,7 +348,7 @@ function write_vreg(num_elem, SEW, LMUL_pow, vrid, vec) = {
 }
 
 /* Single element writing operation */
-val write_single_element : forall 'm, 'm in {8, 16, 32, 64}. (int('m), nat, vregidx, bits('m)) -> unit
+val write_single_element : forall 'm, is_sew_bitsize('m) . (int('m), nat, vregidx, bits('m)) -> unit
 function write_single_element(EEW, index, vrid, value) = {
   let 'elem_per_reg = VLEN / EEW;
   assert('elem_per_reg > 0);

--- a/model/riscv_zvk_utils.sail
+++ b/model/riscv_zvk_utils.sail
@@ -14,7 +14,7 @@ function zvk_valid_reg_overlap(rs, rd, emul_pow) = {
   (rs_int + reg_group_size <= rd_int) | (rd_int + reg_group_size <= rs_int)
 }
 
-function zvk_check_encdec(EGW: int, EGS: int) -> bool = (unsigned(vl) % EGS == 0) & (unsigned(vstart) % EGS == 0) & (2 ^ get_lmul_pow() * VLEN) >= EGW
+function zvk_check_encdec(EGW : nat, EGS : nat1) -> bool = (unsigned(vl) % EGS == 0) & (unsigned(vstart) % EGS == 0) & (2 ^ get_lmul_pow() * VLEN) >= EGW
 
 /*
  * Utility functions for Zvknh[ab]


### PR DESCRIPTION
This changes the definition of `%` and `/` to *only* work with positive numbers and also require the divisor to be non-zero.

The very few number of places that need signed division can call `quot_round_zero`/`rem_round_zero` directly. These don't require positive arguments, but they do still require a non-zero divisor.

Making this change required updating a load of other code which didn't have sufficiently accurate types, so it's a quite a large commit but not easy to split up.