### PR TITLE
Move the functions guarding `mcycle` and `minstret` increments to `riscv_platform`.

### DIFF
--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -270,6 +270,14 @@ function clint_store(Physaddr(addr), width, data) = {
   }
 }
 
+/* Counters and timers are affected by Smcntrpmf (and the forthcoming Sdext extension). */
+
+function should_inc_mcycle(priv : Privilege) -> bool =
+  mcountinhibit[CY] == 0b0 & counter_priv_filter_bit(mcyclecfg, priv) == 0b0
+
+function should_inc_minstret(priv : Privilege) -> bool =
+  mcountinhibit[IR] == 0b0 & counter_priv_filter_bit(minstretcfg, priv) == 0b0
+
 val tick_clock : unit -> unit
 function tick_clock() = {
   if   should_inc_mcycle(cur_privilege)

--- a/model/riscv_smcntrpmf.sail
+++ b/model/riscv_smcntrpmf.sail
@@ -53,9 +53,3 @@ function counter_priv_filter_bit(reg : CountSmcntrpmf, priv : Privilege) -> bits
     User       => reg[UINH],
     // TODO: VSINH, VUINH when those modes are defined
   }
-
-function should_inc_mcycle(priv : Privilege) -> bool =
-  mcountinhibit[CY] == 0b0 & counter_priv_filter_bit(mcyclecfg, priv) == 0b0
-
-function should_inc_minstret(priv : Privilege) -> bool =
-  mcountinhibit[IR] == 0b0 & counter_priv_filter_bit(minstretcfg, priv) == 0b0


### PR DESCRIPTION
These will be affected by the Sdext extension and hence need to belong to a common file.

This also fixes #783.