### PR TITLE
Make `try_step` return whether the hart is waiting, instead of whether it stepped.

### DIFF
--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -543,7 +543,7 @@ void flush_logs(void)
 
 void run_sail(void)
 {
-  bool stepped;
+  bool is_waiting;
   bool exit_wait = true;
   bool diverged = false;
 
@@ -578,7 +578,7 @@ void run_sail(void)
       sail_int sail_step;
       CREATE(sail_int)(&sail_step);
       CONVERT_OF(sail_int, mach_int)(&sail_step, step_no);
-      stepped = ztry_step(sail_step, exit_wait);
+      is_waiting = ztry_step(sail_step, exit_wait);
       if (have_exception)
         goto step_exception;
       flush_logs();
@@ -587,7 +587,7 @@ void run_sail(void)
         rvfi->send_trace(config_print_rvfi);
       }
     }
-    if (stepped) {
+    if (!is_waiting) {
       if (config_print_step) {
         fprintf(trace_log, "\n");
       }

--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -142,9 +142,9 @@ function wait_is_nop(wr : WaitReason) -> bool =
 // A "step" is a full execution of an instruction, resulting either
 // in its retirement or a trap. WFI and WRS instructions can cause
 // the model to wait (hart_state is HART_WAITING), in which case
-// a step has not happened and `try_step()` returns false. Otherwise
-// it returns true. Equivalently, it returns whether the model is now
-// in an active state (HART_ACTIVE).
+// a step has not happened and `try_step()` returns true. Otherwise
+// it returns false. Equivalently, it returns whether the model is now
+// in a waiting state (HART_WAITING).
 //
 // * step_no: the current step number; this is maintained by by the
 //            non-Sail harness and is incremented when `try_step()`
@@ -212,7 +212,7 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
   };
 
   match hart_state {
-    HART_WAITING(_) => false,
+    HART_WAITING(_) => true,
     HART_ACTIVE() => {
       tick_pc();
 
@@ -238,8 +238,8 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
 
       // For step extensions
       ext_post_step_hook();
-      // Return that we have stepped and are active.
-      true
+      // Return that we have stepped and are not waiting.
+      false
     }
   }
 }


### PR DESCRIPTION
For Sdext, `try_step` will also need to return whether the hart entered debug mode (i.e. halted) or experienced an error in debug mode.  The `stepped` case will then hold if nothing unusual happened (e.g. is not waiting and not in debug mode).

This is a step towards the API for Sdext.