### PR TITLE
Minor Zba style improvements

### DIFF
--- a/model/riscv_insts_zba.sail
+++ b/model/riscv_insts_zba.sail
@@ -20,9 +20,7 @@ mapping clause assembly = SLLIUW(shamt, rs1, rd)
   <-> "slli.uw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_6(shamt)
 
 function clause execute (SLLIUW(shamt, rs1, rd)) = {
-  let rs1_val = X(rs1);
-  let result : xlenbits = zero_extend(rs1_val[31..0]) << shamt;
-  X(rd) = result;
+  X(rd) = zero_extend(X(rs1)[31..0]) << shamt;
   RETIRE_SUCCESS
 }
 
@@ -49,23 +47,20 @@ mapping zba_rtypeuw_mnemonic : bropw_zba <-> string = {
   ADDUW    <-> "add.uw",
   SH1ADDUW <-> "sh1add.uw",
   SH2ADDUW <-> "sh2add.uw",
-  SH3ADDUW <-> "sh3add.uw"
+  SH3ADDUW <-> "sh3add.uw",
 }
 
 mapping clause assembly = ZBA_RTYPEUW(rs2, rs1, rd, op)
   <-> zba_rtypeuw_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
 function clause execute (ZBA_RTYPEUW(rs2, rs1, rd, op)) = {
-  let rs1_val = X(rs1);
-  let rs2_val = X(rs2);
   let shamt : bits(2) = match op {
     ADDUW    => 0b00,
     SH1ADDUW => 0b01,
     SH2ADDUW => 0b10,
-    SH3ADDUW => 0b11
+    SH3ADDUW => 0b11,
   };
-  let result : xlenbits = (zero_extend(rs1_val[31..0]) << shamt) + rs2_val;
-  X(rd) = result;
+  X(rd) = (zero_extend(X(rs1)[31..0]) << shamt) + X(rs2);
   RETIRE_SUCCESS
 }
 
@@ -85,21 +80,18 @@ mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, SH3ADD)
 mapping zba_rtype_mnemonic : brop_zba <-> string = {
   SH1ADD <-> "sh1add",
   SH2ADD <-> "sh2add",
-  SH3ADD <-> "sh3add"
+  SH3ADD <-> "sh3add",
 }
 
 mapping clause assembly = ZBA_RTYPE(rs2, rs1, rd, op)
   <-> zba_rtype_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
 function clause execute (ZBA_RTYPE(rs2, rs1, rd, op)) = {
-  let rs1_val = X(rs1);
-  let rs2_val = X(rs2);
   let shamt : bits(2) = match op {
     SH1ADD => 0b01,
     SH2ADD => 0b10,
-    SH3ADD => 0b11
+    SH3ADD => 0b11,
   };
-  let result : xlenbits = (rs1_val << shamt) + rs2_val;
-  X(rd) = result;
+  X(rd) = (X(rs1) << shamt) + X(rs2);
   RETIRE_SUCCESS
 }


### PR DESCRIPTION
Remove some unnecessary intermediate variables. Add trailing commas.