### PR TITLE
Change register bit-width of vstart from 16 to xlen

### DIFF
--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -111,7 +111,7 @@ function clause execute VSETVLI(ma, ta, sew, lmul, rs1, rd) = {
 
   csr_write_callback("vtype", vtype.bits);
   csr_write_callback("vl", vl);
-  csr_write_callback("vstart", zero_extend(vstart));
+  csr_write_callback("vstart", vstart);
 
   RETIRE_SUCCESS
 }
@@ -161,7 +161,7 @@ function clause execute VSETVL(rs2, rs1, rd) = {
 
   csr_write_callback("vtype", vtype.bits);
   csr_write_callback("vl", vl);
-  csr_write_callback("vstart", zero_extend(vstart));
+  csr_write_callback("vstart", vstart);
 
   RETIRE_SUCCESS
 }
@@ -196,7 +196,7 @@ function clause execute VSETIVLI(ma, ta, sew, lmul, uimm, rd) = {
 
   csr_write_callback("vtype", vtype.bits);
   csr_write_callback("vl", vl);
-  csr_write_callback("vstart", zero_extend(vstart));
+  csr_write_callback("vstart", vstart);
 
   RETIRE_SUCCESS
 }

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -904,7 +904,7 @@ val get_16_random_bits = impure {
 } : unit -> bits(16)
 
 /* vector csrs */
-register vstart : bits(16) /* use the largest possible length of vstart */
+register vstart : xlenbits
 register vl     : xlenbits
 
 let VLENB : xlenbits =

--- a/model/riscv_vext_control.sail
+++ b/model/riscv_vext_control.sail
@@ -15,7 +15,7 @@ function clause currentlyEnabled(Ext_V) = hartSupports(Ext_V) & (misa[V] == 0b1)
 function set_vstart(value : bits(16)) -> unit = {
   dirty_v_context();
   vstart = zero_extend(value[(VLEN_pow - 1) .. 0]);
-  csr_write_callback("vstart", zero_extend(vstart));
+  csr_write_callback("vstart", vstart);
 }
 
 mapping clause csr_name_map = 0x008  <-> "vstart"
@@ -34,7 +34,7 @@ function clause is_CSR_defined (0xC20) = currentlyEnabled(Ext_V) // vl
 function clause is_CSR_defined (0xC21) = currentlyEnabled(Ext_V) // vtype
 function clause is_CSR_defined (0xC22) = currentlyEnabled(Ext_V) // vlenb
 
-function clause read_CSR(0x008) = zero_extend(vstart)
+function clause read_CSR(0x008) = vstart
 function clause read_CSR(0x009) = zero_extend(vcsr[vxsat])
 function clause read_CSR(0x00A) = zero_extend(vcsr[vxrm])
 function clause read_CSR(0x00F) = zero_extend(vcsr.bits)
@@ -42,7 +42,7 @@ function clause read_CSR(0xC20) = vl
 function clause read_CSR(0xC21) = vtype.bits
 function clause read_CSR(0xC22) = VLENB
 
-function clause write_CSR(0x008, value) = { set_vstart(value[15 .. 0]); zero_extend(vstart) }
+function clause write_CSR(0x008, value) = { set_vstart(value[15 .. 0]); vstart }
 function clause write_CSR(0x009, value) = { ext_write_vcsr (vcsr[vxrm], value[0 .. 0]); zero_extend(vcsr[vxsat]) }
 function clause write_CSR(0x00A, value) = { ext_write_vcsr (value[1 .. 0], vcsr[vxsat]); zero_extend(vcsr[vxrm]) }
 function clause write_CSR(0x00F, value) = { ext_write_vcsr (value [2 .. 1], value [0 .. 0]); zero_extend(vcsr.bits) }


### PR DESCRIPTION
The spec says that `vstart` is XLEN bits wide so this changes the underlying value to `xlenbits`. This allows removing various `zero_extend()`s. It still only allows writing the lowest VLEN_pow bits.