### PR TITLE
Move `effectivePrivilege` from `riscv_sys_regs` to `riscv_sys_control`.

### DIFF
--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -8,6 +8,11 @@
 
 /* Machine-mode and supervisor-mode functionality. */
 
+function effectivePrivilege(t : AccessType(ext_access_type), m : Mstatus, priv : Privilege) -> Privilege =
+  if   t != InstructionFetch() & m[MPRV] == 0b1
+  then privLevel_of_bits(m[MPP])
+  else priv
+
 /* CSR access control */
 
 function csrAccess(csr : csreg) -> csrRW = csr[11..10]

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -196,11 +196,6 @@ bitfield Mstatus : bits(64) = {
   SIE  : 1,
 }
 
-function effectivePrivilege(t : AccessType(ext_access_type), m : Mstatus, priv : Privilege) -> Privilege =
-  if   t != InstructionFetch() & m[MPRV] == 0b1
-  then privLevel_of_bits(m[MPP])
-  else priv
-
 function get_mstatus_SXL(m : Mstatus) -> arch_xlen = {
   if   xlen == 32
   then architecture(RV32)


### PR DESCRIPTION
For Sdext, the effective privilege is also governed by the `dcsr` CSR.  However, Sdext itself needs access to `riscv_sys_regs`.  This move resolves the dependencies.