### PR TITLE
Rename `ast` to `instruction`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,11 @@ These are verbatim excerpts from the model file containing the base instructions
 ### ITYPE (or ADDI)
 
 ```
-/* the assembly abstract syntax tree (AST) clause for the ITYPE instructions */
+/* the instruction clause for the ITYPE instructions */
 
-union clause ast = ITYPE : (bits(12), regidx, regidx, iop)
+union clause instruction = ITYPE : (bits(12), regidx, regidx, iop)
 
-/* the encode/decode mapping between AST elements and 32-bit words */
+/* the encode/decode mapping between instruction elements and 32-bit words */
 
 mapping encdec_iop : iop <-> bits(3) = {
   ADDI  <-> 0b000,
@@ -160,7 +160,7 @@ function clause execute (ITYPE (imm, rs1, rd, op)) = {
   RETIRE_SUCCESS
 }
 
-/* the assembly/disassembly mapping between AST elements and strings */
+/* the assembly/disassembly mapping between instruction elements and strings */
 
 mapping itype_mnemonic : iop <-> string = {
   ADDI  <-> "addi",
@@ -178,7 +178,7 @@ mapping clause assembly = ITYPE(imm, rs1, rd, op)
 ### SRET
 
 ```
-union clause ast = SRET : unit
+union clause instruction = SRET : unit
 
 mapping clause encdec = SRET()
   <-> 0b0001000 @ 0b00010 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011

--- a/doc/ReadingGuide.md
+++ b/doc/ReadingGuide.md
@@ -102,7 +102,7 @@ such as the platform memory map.
   definitions and their assembly language formats. Each file contains
   the instructions for an extension, with `riscv_insts_base.sail` containing
   the base integer instruction set. Each instruction is represented
-  as a variant clause of the `ast` type, and its execution semantics
+  as a variant clause of the `instruction` type, and its execution semantics
   are represented as a clause of the `execute` function. `mapping`
   clauses specify the encoding and decoding of each instruction to and
   from their binary representations and assembly language formats.

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -481,7 +481,7 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
                     --memo-z3
                     --lean-output-dir ${CMAKE_CURRENT_BINARY_DIR}
                     --lean-force-output
-                    --lean-non-beq-type ast
+                    --lean-non-beq-type instruction
                 )
                 set(lean_sail_default
                     --lean-noncomputable

--- a/model/riscv_decode_ext.sail
+++ b/model/riscv_decode_ext.sail
@@ -11,8 +11,8 @@
   hooks, the default implementation of which is provided below.
  */
 
-val ext_decode_compressed : bits(16) -> ast
+val ext_decode_compressed : bits(16) -> instruction
 function ext_decode_compressed(bv) = encdec_compressed(bv)
 
-val ext_decode : bits(32) -> ast
+val ext_decode : bits(32) -> instruction
 function ext_decode(bv) = encdec(bv)

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -13,7 +13,7 @@ function clause currentlyEnabled(Ext_C) = hartSupports(Ext_C) & misa[C] == 0b1
 function clause currentlyEnabled(Ext_Zca) = hartSupports(Ext_Zca) & (currentlyEnabled(Ext_C) | not(hartSupports(Ext_C)))
 
 /* ****************************************************************** */
-union clause ast = UTYPE : (bits(20), regidx, uop)
+union clause instruction = UTYPE : (bits(20), regidx, uop)
 
 mapping encdec_uop : uop <-> bits(7) = {
   LUI   <-> 0b0110111,
@@ -41,7 +41,7 @@ mapping clause assembly = UTYPE(imm, rd, op)
   <-> utype_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_signed_20(imm)
 
 /* ****************************************************************** */
-union clause ast = JAL : (bits(21), regidx)
+union clause instruction = JAL : (bits(21), regidx)
 
 mapping clause encdec = JAL(imm_19 @ imm_7_0 @ imm_8 @ imm_18_13 @ imm_12_9 @ 0b0, rd)
   <-> imm_19 : bits(1) @ imm_18_13 : bits(6) @ imm_12_9 : bits(4) @ imm_8 : bits(1) @ imm_7_0 : bits(8) @ encdec_reg(rd) @ 0b1101111
@@ -83,7 +83,7 @@ mapping clause assembly = JAL(imm, rd)
   <-> "jal" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_signed_21(imm)
 
 /* ****************************************************************** */
-union clause ast = JALR : (bits(12), regidx, regidx)
+union clause instruction = JALR : (bits(12), regidx, regidx)
 
 mapping clause encdec = JALR(imm, rs1, rd)
   <-> imm @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b1100111
@@ -94,7 +94,7 @@ mapping clause assembly = JALR(imm, rs1, rd)
 /* see riscv_jalr_seq.sail or riscv_jalr_rmem.sail for the execute clause. */
 
 /* ****************************************************************** */
-union clause ast = BTYPE : (bits(13), regidx, regidx, bop)
+union clause instruction = BTYPE : (bits(13), regidx, regidx, bop)
 
 mapping encdec_bop : bop <-> bits(3) = {
   BEQ  <-> 0b000,
@@ -148,7 +148,7 @@ mapping clause assembly = BTYPE(imm, rs2, rs1, op)
   <-> btype_mnemonic(op) ^ spc() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_signed_13(imm)
 
 /* ****************************************************************** */
-union clause ast = ITYPE : (bits(12), regidx, regidx, iop)
+union clause instruction = ITYPE : (bits(12), regidx, regidx, iop)
 
 mapping encdec_iop : iop <-> bits(3) = {
   ADDI  <-> 0b000,
@@ -188,7 +188,7 @@ mapping clause assembly = ITYPE(imm, rs1, rd, op)
   <-> itype_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_signed_12(imm)
 
 /* ****************************************************************** */
-union clause ast = SHIFTIOP : (bits(6), regidx, regidx, sop)
+union clause instruction = SHIFTIOP : (bits(6), regidx, regidx, sop)
 
 mapping encdec_sop : sop <-> bits(3) = {
   SLLI <-> 0b001,
@@ -226,7 +226,7 @@ mapping clause assembly = SHIFTIOP(shamt, rs1, rd, op)
   <-> shiftiop_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_6(shamt)
 
 /* ****************************************************************** */
-union clause ast = RTYPE : (regidx, regidx, regidx, rop)
+union clause instruction = RTYPE : (regidx, regidx, regidx, rop)
 
 mapping clause encdec = RTYPE(rs2, rs1, rd, ADD)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
 mapping clause encdec = RTYPE(rs2, rs1, rd, SLT)  <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011
@@ -272,7 +272,7 @@ mapping clause assembly = RTYPE(rs2, rs1, rd, op)
   <-> rtype_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
 /* ****************************************************************** */
-union clause ast = LOAD : (bits(12), regidx, regidx, bool, word_width)
+union clause instruction = LOAD : (bits(12), regidx, regidx, bool, word_width)
 
 /* unsigned loads are only present for widths strictly less than xlen,
    signed loads also present for widths equal to xlen */
@@ -310,7 +310,7 @@ mapping clause assembly = LOAD(imm, rs1, rd, is_unsigned, width)
   <-> "l" ^ size_mnemonic(width) ^ maybe_u(is_unsigned) ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_signed_12(imm) ^ "(" ^ reg_name(rs1) ^ ")"
 
 /* ****************************************************************** */
-union clause ast = STORE : (bits(12), regidx, regidx, word_width)
+union clause instruction = STORE : (bits(12), regidx, regidx, word_width)
 
 mapping clause encdec = STORE(imm7 @ imm5, rs2, rs1, width)
   <-> imm7 : bits(7) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(width) @ imm5 : bits(5) @ 0b0100011
@@ -333,7 +333,7 @@ mapping clause assembly = STORE(imm, rs2, rs1, width)
   <-> "s" ^ size_mnemonic(width) ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_signed_12(imm) ^ opt_spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
 
 /* ****************************************************************** */
-union clause ast = ADDIW : (bits(12), regidx, regidx)
+union clause instruction = ADDIW : (bits(12), regidx, regidx)
 
 mapping clause encdec = ADDIW(imm, rs1, rd)
   <-> imm @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0011011
@@ -350,7 +350,7 @@ mapping clause assembly = ADDIW(imm, rs1, rd)
   when xlen == 64
 
 /* ****************************************************************** */
-union clause ast = RTYPEW : (regidx, regidx, regidx, ropw)
+union clause instruction = RTYPEW : (regidx, regidx, regidx, ropw)
 
 mapping clause encdec = RTYPEW(rs2, rs1, rd, ADDW)
   <-> 0b0000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0111011
@@ -395,7 +395,7 @@ mapping clause assembly = RTYPEW(rs2, rs1, rd, op)
   when xlen == 64
 
 /* ****************************************************************** */
-union clause ast = SHIFTIWOP : (bits(5), regidx, regidx, sopw)
+union clause instruction = SHIFTIWOP : (bits(5), regidx, regidx, sopw)
 
 mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, SLLIW)
   <-> 0b0000000 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
@@ -429,7 +429,7 @@ mapping clause assembly = SHIFTIWOP(shamt, rs1, rd, op)
   when xlen == 64
 
 /* ****************************************************************** */
-union clause ast = FENCE : (bits(4), bits(4))
+union clause instruction = FENCE : (bits(4), bits(4))
 
 mapping clause encdec = FENCE(pred, succ)
   <-> 0b0000 @ pred @ succ @ 0b00000 @ 0b000 @ 0b00000 @ 0b0001111
@@ -499,7 +499,7 @@ mapping clause assembly = FENCE(pred, succ)
   <-> "fence" ^ spc() ^ fence_bits(pred) ^ sep() ^ fence_bits(succ)
 
 /* ****************************************************************** */
-union clause ast = FENCE_TSO : unit
+union clause instruction = FENCE_TSO : unit
 
 mapping clause encdec = FENCE_TSO()
   <-> 0b1000 @ 0b0011 @ 0b0011 @ 0b00000 @ 0b000 @ 0b00000 @ 0b0001111
@@ -513,7 +513,7 @@ mapping clause assembly = FENCE_TSO()
   <-> "fence.tso"
 
 /* ****************************************************************** */
-union clause ast = ECALL : unit
+union clause instruction = ECALL : unit
 
 mapping clause encdec = ECALL()
   <-> 0b000000000000 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
@@ -533,7 +533,7 @@ function clause execute ECALL() = {
 mapping clause assembly = ECALL() <-> "ecall"
 
 /* ****************************************************************** */
-union clause ast = MRET : unit
+union clause instruction = MRET : unit
 
 mapping clause encdec = MRET()
   <-> 0b0011000 @ 0b00010 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
@@ -552,7 +552,7 @@ function clause execute MRET() = {
 mapping clause assembly = MRET() <-> "mret"
 
 /* ****************************************************************** */
-union clause ast = SRET : unit
+union clause instruction = SRET : unit
 
 mapping clause encdec = SRET()
   <-> 0b0001000 @ 0b00010 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
@@ -576,7 +576,7 @@ function clause execute SRET() = {
 mapping clause assembly = SRET() <-> "sret"
 
 /* ****************************************************************** */
-union clause ast = EBREAK : unit
+union clause instruction = EBREAK : unit
 
 mapping clause encdec = EBREAK()
   <-> 0b000000000001 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
@@ -587,7 +587,7 @@ function clause execute EBREAK() =
 mapping clause assembly = EBREAK() <-> "ebreak"
 
 /* ****************************************************************** */
-union clause ast = WFI : unit
+union clause instruction = WFI : unit
 
 mapping clause encdec = WFI()
   <-> 0b000100000101 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
@@ -604,7 +604,7 @@ function clause execute WFI() =
 mapping clause assembly = WFI() <-> "wfi"
 
 /* ****************************************************************** */
-union clause ast = SFENCE_VMA : (regidx, regidx)
+union clause instruction = SFENCE_VMA : (regidx, regidx)
 
 mapping clause encdec = SFENCE_VMA(rs1, rs2)
   <-> 0b0001001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ 0b00000 @ 0b1110011

--- a/model/riscv_insts_begin.sail
+++ b/model/riscv_insts_begin.sail
@@ -11,26 +11,26 @@
  * This includes decoding, execution, and assembly parsing and printing.
  */
 
-scattered union ast
+scattered union instruction
 
 /* returns whether an instruction was retired, used for computing minstret */
-val execute : ast -> ExecutionResult
+val execute : instruction -> ExecutionResult
 scattered function execute
 
-val assembly : ast <-> string
+val assembly : instruction <-> string
 scattered mapping assembly
 
-val encdec : ast <-> bits(32)
+val encdec : instruction <-> bits(32)
 scattered mapping encdec
 
-val encdec_compressed : ast <-> bits(16)
+val encdec_compressed : instruction <-> bits(16)
 scattered mapping encdec_compressed
 
 /*
- * We declare the ILLEGAL/C_ILLEGAL ast clauses here instead of in
+ * We declare the ILLEGAL/C_ILLEGAL instruction clauses here instead of in
  * riscv_insts_end, so that model extensions can make use of them.
  * However, the encdec mapping must come last to ensure that all
  * unmatched encodings decode to an illegal instruction.
  */
-union clause ast = ILLEGAL : word
-union clause ast = C_ILLEGAL : half
+union clause instruction = ILLEGAL : word
+union clause instruction = C_ILLEGAL : half

--- a/model/riscv_insts_dext.sail
+++ b/model/riscv_insts_dext.sail
@@ -251,11 +251,11 @@ function validDoubleRegs(n, regs) = {
 /* ****************************************************************** */
 /* Fused multiply-add */
 
-/* AST */
+/* instruction */
 
-union clause ast = F_MADD_TYPE_D : (fregidx, fregidx, fregidx, rounding_mode, fregidx, f_madd_op_D)
+union clause instruction = F_MADD_TYPE_D : (fregidx, fregidx, fregidx, rounding_mode, fregidx, f_madd_op_D)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FMADD_D)
   <-> encdec_freg(rs3) @ 0b01 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b100_0011
@@ -298,7 +298,7 @@ function clause execute (F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, op)) = {
   }
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping f_madd_type_mnemonic_D : f_madd_op_D <-> string = {
     FMADD_D  <-> "fmadd.d",
@@ -318,11 +318,11 @@ mapping clause assembly = F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, op)
 /* ****************************************************************** */
 /* Binary ops with rounding mode */
 
-/* AST */
+/* instruction */
 
-union clause ast = F_BIN_RM_TYPE_D : (fregidx, fregidx, rounding_mode, fregidx, f_bin_rm_op_D)
+union clause instruction = F_BIN_RM_TYPE_D : (fregidx, fregidx, rounding_mode, fregidx, f_bin_rm_op_D)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FADD_D)
   <-> 0b000_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011
@@ -362,7 +362,7 @@ function clause execute (F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, op)) = {
   }
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping f_bin_rm_type_mnemonic_D : f_bin_rm_op_D <-> string = {
   FADD_D  <-> "fadd.d",
@@ -381,13 +381,13 @@ mapping clause assembly = F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, op)
 /* ****************************************************************** */
 /* Unary with rounding mode */
 
-/* AST */
+/* instruction */
 
-union clause ast = F_UN_RM_FF_TYPE_D : (fregidx, rounding_mode, fregidx, f_un_rm_ff_op_D)
-union clause ast = F_UN_RM_XF_TYPE_D : (regidx, rounding_mode, fregidx, f_un_rm_xf_op_D)
-union clause ast = F_UN_RM_FX_TYPE_D : (fregidx, rounding_mode, regidx, f_un_rm_fx_op_D)
+union clause instruction = F_UN_RM_FF_TYPE_D : (fregidx, rounding_mode, fregidx, f_un_rm_ff_op_D)
+union clause instruction = F_UN_RM_XF_TYPE_D : (regidx, rounding_mode, fregidx, f_un_rm_xf_op_D)
+union clause instruction = F_UN_RM_FX_TYPE_D : (fregidx, rounding_mode, regidx, f_un_rm_fx_op_D)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = F_UN_RM_FF_TYPE_D(rs1, rm, rd, FSQRT_D)
   <-> 0b010_1101 @ 0b00000 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011
@@ -606,7 +606,7 @@ function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_LU)) = {
   }
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping f_un_rm_ff_type_mnemonic_D : f_un_rm_ff_op_D <-> string = {
     FSQRT_D   <-> "fsqrt.d",
@@ -649,12 +649,12 @@ mapping clause assembly = F_UN_RM_XF_TYPE_D(rs1, rm, rd, op)
 /* ****************************************************************** */
 /* Binary, no rounding mode */
 
-/* AST */
+/* instruction */
 
-union clause ast = F_BIN_F_TYPE_D : (fregidx, fregidx, fregidx, f_bin_f_op_D)
-union clause ast = F_BIN_X_TYPE_D : (fregidx, fregidx, regidx, f_bin_x_op_D)
+union clause instruction = F_BIN_F_TYPE_D : (fregidx, fregidx, fregidx, f_bin_f_op_D)
+union clause instruction = F_BIN_X_TYPE_D : (fregidx, fregidx, regidx, f_bin_x_op_D)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = F_BIN_F_TYPE_D(rs2, rs1, rd, FSGNJ_D)
                     <-> 0b001_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011
@@ -800,7 +800,7 @@ function clause execute (F_BIN_X_TYPE_D(rs2, rs1, rd, FLE_D)) = {
   RETIRE_SUCCESS
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping f_bin_f_type_mnemonic_D : f_bin_f_op_D <-> string = {
     FSGNJ_D  <-> "fsgnj.d",
@@ -831,10 +831,10 @@ mapping clause assembly = F_BIN_X_TYPE_D(rs2, rs1, rd, op)
 /* ****************************************************************** */
 /* Unary, no rounding mode */
 
-union clause ast = F_UN_X_TYPE_D : (fregidx, regidx, f_un_x_op_D)
-union clause ast = F_UN_F_TYPE_D : (regidx, fregidx, f_un_f_op_D)
+union clause instruction = F_UN_X_TYPE_D : (fregidx, regidx, f_un_x_op_D)
+union clause instruction = F_UN_F_TYPE_D : (regidx, fregidx, f_un_f_op_D)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = F_UN_X_TYPE_D(rs1, rd, FCLASS_D)
                     <-> 0b111_0001 @ 0b00000 @ encdec_freg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011
@@ -884,7 +884,7 @@ function clause execute (F_UN_F_TYPE_D(rs1, rd, FMV_D_X)) = {
   RETIRE_SUCCESS
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping f_un_x_type_mnemonic_D : f_un_x_op_D <-> string = {
     FMV_X_D  <-> "fmv.x.d",

--- a/model/riscv_insts_end.sail
+++ b/model/riscv_insts_end.sail
@@ -31,13 +31,13 @@ end extension
 end extensionName
 end hartSupports
 end currentlyEnabled
-end ast
+end instruction
 end execute
 end assembly
 end encdec
 end encdec_compressed
 
-val print_insn : ast -> string
+val print_insn : instruction -> string
 function print_insn insn = assembly(insn)
 
 overload to_str = {print_insn}

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -267,12 +267,12 @@ function haveSingleFPU() -> bool = currentlyEnabled(Ext_F) | currentlyEnabled(Ex
 /* ****************************************************************** */
 /* Floating-point loads                                               */
 
-/* AST */
+/* instruction */
 /* FLH, FLW and FLD; H/W/D is encoded in 'word_width' */
 
-union clause ast = LOAD_FP : (bits(12), regidx, fregidx, word_width)
+union clause instruction = LOAD_FP : (bits(12), regidx, fregidx, word_width)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = LOAD_FP(imm, rs1, rd, 2)
   <-> imm @ encdec_reg(rs1) @ 0b001 @ encdec_freg(rd) @ 0b000_0111
@@ -299,7 +299,7 @@ function clause execute(LOAD_FP(imm, rs1, rd, width)) = {
   }
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping clause assembly = LOAD_FP(imm, rs1, rd, width)
                       <-> "fl" ^ size_mnemonic(width)
@@ -310,12 +310,12 @@ mapping clause assembly = LOAD_FP(imm, rs1, rd, width)
 /* ****************************************************************** */
 /* Floating-point stores                                              */
 
-/* AST */
+/* instruction */
 /* FSH, FSW and FSD; H/W/D is encoded in 'word_width' */
 
-union clause ast = STORE_FP : (bits(12), fregidx, regidx, word_width)
+union clause instruction = STORE_FP : (bits(12), fregidx, regidx, word_width)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, 2)
   <-> imm7 : bits(7) @ encdec_freg(rs2) @ encdec_reg(rs1) @ 0b001 @ imm5 : bits(5) @ 0b010_0111
@@ -344,7 +344,7 @@ function clause execute (STORE_FP(imm, rs2, rs1, width)) = {
   }
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping clause assembly = STORE_FP(imm, rs2, rs1, width)
                       <-> "fs" ^ size_mnemonic(width)
@@ -355,11 +355,11 @@ mapping clause assembly = STORE_FP(imm, rs2, rs1, width)
 /* ****************************************************************** */
 /* Fused multiply-add */
 
-/* AST */
+/* instruction */
 
-union clause ast = F_MADD_TYPE_S : (fregidx, fregidx, fregidx, rounding_mode, fregidx, f_madd_op_S)
+union clause instruction = F_MADD_TYPE_S : (fregidx, fregidx, fregidx, rounding_mode, fregidx, f_madd_op_S)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FMADD_S)
   <-> encdec_freg(rs3) @ 0b00 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b100_0011
@@ -401,7 +401,7 @@ function clause execute (F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, op)) = {
   }
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping f_madd_type_mnemonic_S : f_madd_op_S <-> string = {
     FMADD_S  <-> "fmadd.s",
@@ -421,11 +421,11 @@ mapping clause assembly = F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, op)
 /* ****************************************************************** */
 /* Binary ops with rounding mode */
 
-/* AST */
+/* instruction */
 
-union clause ast = F_BIN_RM_TYPE_S : (fregidx, fregidx, rounding_mode, fregidx, f_bin_rm_op_S)
+union clause instruction = F_BIN_RM_TYPE_S : (fregidx, fregidx, rounding_mode, fregidx, f_bin_rm_op_S)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FADD_S)
   <-> 0b000_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011
@@ -465,7 +465,7 @@ function clause execute (F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, op)) = {
   }
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping f_bin_rm_type_mnemonic_S : f_bin_rm_op_S <-> string = {
   FADD_S  <-> "fadd.s",
@@ -484,13 +484,13 @@ mapping clause assembly = F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, op)
 /* ****************************************************************** */
 /* Unary with rounding mode */
 
-/* AST */
+/* instruction */
 
-union clause ast = F_UN_RM_FF_TYPE_S : (fregidx, rounding_mode, fregidx, f_un_rm_ff_op_S)
-union clause ast = F_UN_RM_FX_TYPE_S : (fregidx, rounding_mode, regidx, f_un_rm_fx_op_S)
-union clause ast = F_UN_RM_XF_TYPE_S : (regidx, rounding_mode, fregidx, f_un_rm_xf_op_S)
+union clause instruction = F_UN_RM_FF_TYPE_S : (fregidx, rounding_mode, fregidx, f_un_rm_ff_op_S)
+union clause instruction = F_UN_RM_FX_TYPE_S : (fregidx, rounding_mode, regidx, f_un_rm_fx_op_S)
+union clause instruction = F_UN_RM_XF_TYPE_S : (regidx, rounding_mode, fregidx, f_un_rm_xf_op_S)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = F_UN_RM_FF_TYPE_S(rs1, rm, rd, FSQRT_S)
   <-> 0b010_1100 @ 0b00000 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011
@@ -671,7 +671,7 @@ function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_LU)) = {
   }
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping clause assembly = F_UN_RM_FF_TYPE_S(rs1, rm, rd, FSQRT_S)
                       <-> "fsqrt.s"
@@ -709,12 +709,12 @@ mapping clause assembly = F_UN_RM_XF_TYPE_S(rs1, rm, rd, op)
 /* ****************************************************************** */
 /* Binary, no rounding mode */
 
-/* AST */
+/* instruction */
 
-union clause ast = F_BIN_TYPE_F_S : (fregidx, fregidx, fregidx, f_bin_op_f_S)
-union clause ast = F_BIN_TYPE_X_S : (fregidx, fregidx, regidx, f_bin_op_x_S)
+union clause instruction = F_BIN_TYPE_F_S : (fregidx, fregidx, fregidx, f_bin_op_f_S)
+union clause instruction = F_BIN_TYPE_X_S : (fregidx, fregidx, regidx, f_bin_op_x_S)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = F_BIN_TYPE_F_S(rs2, rs1, rd, FSGNJ_S)
                     <-> 0b001_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011
@@ -859,7 +859,7 @@ function clause execute (F_BIN_TYPE_X_S(rs2, rs1, rd, FLE_S)) = {
   RETIRE_SUCCESS
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping f_bin_type_mnemonic_f_S : f_bin_op_f_S <-> string = {
     FSGNJ_S  <-> "fsgnj.s",
@@ -890,10 +890,10 @@ mapping clause assembly = F_BIN_TYPE_X_S(rs2, rs1, rd, op)
 /* ****************************************************************** */
 /* Unary, no rounding mode */
 
-union clause ast = F_UN_TYPE_F_S : (regidx, fregidx, f_un_op_f_S)
-union clause ast = F_UN_TYPE_X_S : (fregidx, regidx, f_un_op_x_S)
+union clause instruction = F_UN_TYPE_F_S : (regidx, fregidx, f_un_op_f_S)
+union clause instruction = F_UN_TYPE_X_S : (fregidx, regidx, f_un_op_x_S)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = F_UN_TYPE_X_S(rs1, rd, FCLASS_S)
                     <-> 0b111_0000 @ 0b00000 @ encdec_freg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011
@@ -939,7 +939,7 @@ function clause execute (F_UN_TYPE_F_S(rs1, rd, FMV_W_X)) = {
   RETIRE_SUCCESS
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping f_un_type_mnemonic_x_S : f_un_op_x_S <-> string = {
     FCLASS_S <-> "fclass.s",

--- a/model/riscv_insts_mext.sail
+++ b/model/riscv_insts_mext.sail
@@ -13,7 +13,7 @@
 function clause currentlyEnabled(Ext_M) = hartSupports(Ext_M) & misa[M] == 0b1
 function clause currentlyEnabled(Ext_Zmmul) = hartSupports(Ext_Zmmul) | currentlyEnabled(Ext_M)
 
-union clause ast = MUL : (regidx, regidx, regidx, mul_op)
+union clause instruction = MUL : (regidx, regidx, regidx, mul_op)
 
 mapping encdec_mul_op : mul_op <-> bits(3) = {
   struct { high = false, signed_rs1 = true,  signed_rs2 = true  } <-> 0b000,
@@ -50,7 +50,7 @@ mapping clause assembly = MUL(rs2, rs1, rd, mul_op)
   <-> mul_mnemonic(mul_op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
 /* ****************************************************************** */
-union clause ast = DIV : (regidx, regidx, regidx, bool)
+union clause instruction = DIV : (regidx, regidx, regidx, bool)
 
 mapping clause encdec = DIV(rs2, rs1, rd, is_unsigned)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b10 @ bool_bits(is_unsigned) @ encdec_reg(rd) @ 0b0110011
@@ -73,7 +73,7 @@ mapping clause assembly = DIV(rs2, rs1, rd, is_unsigned)
   <-> "div" ^ maybe_u(is_unsigned) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
 /* ****************************************************************** */
-union clause ast = REM : (regidx, regidx, regidx, bool)
+union clause instruction = REM : (regidx, regidx, regidx, bool)
 
 mapping clause encdec = REM(rs2, rs1, rd, is_unsigned)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b11 @ bool_bits(is_unsigned) @ encdec_reg(rd) @ 0b0110011
@@ -95,7 +95,7 @@ mapping clause assembly = REM(rs2, rs1, rd, is_unsigned)
   <-> "rem" ^ maybe_u(is_unsigned) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
 /* ****************************************************************** */
-union clause ast = MULW : (regidx, regidx, regidx)
+union clause instruction = MULW : (regidx, regidx, regidx)
 
 mapping clause encdec = MULW(rs2, rs1, rd)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0111011
@@ -117,7 +117,7 @@ mapping clause assembly = MULW(rs2, rs1, rd)
   when xlen == 64
 
 /* ****************************************************************** */
-union clause ast = DIVW : (regidx, regidx, regidx, bool)
+union clause instruction = DIVW : (regidx, regidx, regidx, bool)
 
 mapping clause encdec = DIVW(rs2, rs1, rd, is_unsigned)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b10 @ bool_bits(is_unsigned) @ encdec_reg(rd) @ 0b0111011
@@ -141,7 +141,7 @@ mapping clause assembly = DIVW(rs2, rs1, rd, is_unsigned)
   when xlen == 64
 
 /* ****************************************************************** */
-union clause ast = REMW : (regidx, regidx, regidx, bool)
+union clause instruction = REMW : (regidx, regidx, regidx, bool)
 
 mapping clause encdec = REMW(rs2, rs1, rd, is_unsigned)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b11 @ bool_bits(is_unsigned) @ encdec_reg(rd) @ 0b0111011

--- a/model/riscv_insts_reserved_fence.sail
+++ b/model/riscv_insts_reserved_fence.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-union clause ast = FENCE_RESERVED : (bits(4), bits(4), bits(4), regidx, regidx)
+union clause instruction = FENCE_RESERVED : (bits(4), bits(4), bits(4), regidx, regidx)
 
 mapping clause encdec = FENCE_RESERVED(fm, pred, succ, rs, rd)
   <-> fm : bits(4) @ pred : bits(4) @ succ : bits(4) @ encdec_reg(rs) @ 0b000 @ encdec_reg(rd) @ 0b0001111
@@ -20,7 +20,7 @@ mapping clause assembly = FENCE_RESERVED(fm, pred, succ, rs, rd)
       when (fm != 0b0000 & fm != 0b1000) | rs != zreg | rd != zreg
 
 /* ****************************************************************** */
-union clause ast = FENCEI_RESERVED : (bits(12), regidx, regidx)
+union clause instruction = FENCEI_RESERVED : (bits(12), regidx, regidx)
 
 mapping clause encdec = FENCEI_RESERVED(imm, rs, rd)
   <-> imm : bits(12) @ encdec_reg(rs) @ 0b001 @ encdec_reg(rd) @ 0b0001111

--- a/model/riscv_insts_rmem.sail
+++ b/model/riscv_insts_rmem.sail
@@ -11,7 +11,7 @@
 
 /* ****************************************************************** */
 
-union clause ast = STOP_FETCHING : unit
+union clause instruction = STOP_FETCHING : unit
 
 /* RMEM stop fetching sentinel, using RISCV encoding space custom-0 */
 mapping clause encdec = STOP_FETCHING()
@@ -21,7 +21,7 @@ function clause execute (STOP_FETCHING()) = RETIRE_SUCCESS
 
 mapping clause assembly = STOP_FETCHING() <-> "stop_fetching"
 
-union clause ast = THREAD_START : unit
+union clause instruction = THREAD_START : unit
 
 /* RMEM thread start sentinel, using RISCV encoding space custom-0 */
 mapping clause encdec = THREAD_START()

--- a/model/riscv_insts_svinval.sail
+++ b/model/riscv_insts_svinval.sail
@@ -8,7 +8,7 @@
 
 function clause currentlyEnabled(Ext_Svinval) = hartSupports(Ext_Svinval)
 
-union clause ast = SINVAL_VMA : (regidx, regidx)
+union clause instruction = SINVAL_VMA : (regidx, regidx)
 
 mapping clause encdec = SINVAL_VMA(rs1, rs2)
   <-> 0b0001011 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ 0b00000 @ 0b1110011
@@ -23,7 +23,7 @@ mapping clause assembly = SINVAL_VMA(rs1, rs2)
 
 /* ****************************************************************** */
 
-union clause ast = SFENCE_W_INVAL : unit
+union clause instruction = SFENCE_W_INVAL : unit
 
 mapping clause encdec = SFENCE_W_INVAL()
   <-> 0b0001100 @ 0b00000 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
@@ -39,7 +39,7 @@ mapping clause assembly = SFENCE_W_INVAL() <-> "sfence.w.inval"
 
 /* ****************************************************************** */
 
-union clause ast = SFENCE_INVAL_IR : unit
+union clause instruction = SFENCE_INVAL_IR : unit
 
 mapping clause encdec = SFENCE_INVAL_IR()
   <-> 0b0001100 @ 0b00001 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011

--- a/model/riscv_insts_vext_arith.sail
+++ b/model/riscv_insts_vext_arith.sail
@@ -14,7 +14,7 @@
 /* ******************************************************************************* */
 
 /* ******************************* OPIVV (VVTYPE) ******************************** */
-union clause ast = VVTYPE : (vvfunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = VVTYPE : (vvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_vvfunct6 : vvfunct6 <-> bits(6) = {
   VV_VADD          <-> 0b000000,
@@ -169,7 +169,7 @@ mapping clause assembly = VVTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ************************** OPIVV (WVTYPE Narrowing) *************************** */
 /* ************** Vector Narrowing Integer Right Shift Instructions ************** */
-union clause ast = NVSTYPE : (nvsfunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = NVSTYPE : (nvsfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_nvsfunct6 : nvsfunct6 <-> bits(6) = {
   NVS_VNSRL       <-> 0b101100,
@@ -240,7 +240,7 @@ mapping clause assembly = NVSTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ************************** OPIVV (WVTYPE Narrowing) *************************** */
 /* *************** Vector Narrowing Fixed-Point Clip Instructions **************** */
-union clause ast = NVTYPE : (nvfunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = NVTYPE : (nvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_nvfunct6 : nvfunct6 <-> bits(6) = {
   NV_VNCLIPU     <-> 0b101110,
@@ -311,7 +311,7 @@ mapping clause assembly = NVTYPE(funct6, vm, vs2, vs1, vd)
   <-> nvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
 /* ********************** OPIVV (Integer Merge Instruction) ********************** */
-union clause ast = MASKTYPEV : (vregidx, vregidx, vregidx)
+union clause instruction = MASKTYPEV : (vregidx, vregidx, vregidx)
 
 mapping clause encdec = MASKTYPEV (vs2, vs1,  vd)
   <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
@@ -363,7 +363,7 @@ mapping clause assembly = MASKTYPEV(vs2, vs1, vd)
 <-> "vmerge.vvm" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ sep() ^ "v0"
 
 /* ********************** OPIVV (Integer Move Instruction) *********************** */
-union clause ast = MOVETYPEV : (vregidx, vregidx)
+union clause instruction = MOVETYPEV : (vregidx, vregidx)
 
 mapping clause encdec = MOVETYPEV (vs1, vd)
   <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
@@ -402,7 +402,7 @@ mapping clause assembly = MOVETYPEV(vs1, vd)
   <-> "vmv.v.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1)
 
 /* ******************************* OPIVX (VXTYPE) ******************************** */
-union clause ast = VXTYPE : (vxfunct6, bits(1), vregidx, regidx, vregidx)
+union clause instruction = VXTYPE : (vxfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_vxfunct6 : vxfunct6 <-> bits(6) = {
   VX_VADD       <-> 0b000000,
@@ -539,7 +539,7 @@ mapping clause assembly = VXTYPE(funct6, vm, vs2, rs1, vd)
 
 /* ************************** OPIVX (WXTYPE Narrowing) *************************** */
 /* ************** Vector Narrowing Integer Right Shift Instructions ************** */
-union clause ast = NXSTYPE : (nxsfunct6, bits(1), vregidx, regidx, vregidx)
+union clause instruction = NXSTYPE : (nxsfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_nxsfunct6 : nxsfunct6 <-> bits(6) = {
   NXS_VNSRL       <-> 0b101100,
@@ -610,7 +610,7 @@ mapping clause assembly = NXSTYPE(funct6, vm, vs2, rs1, vd)
 
 /* ************************** OPIVX (WXTYPE Narrowing) *************************** */
 /* *************** Vector Narrowing Fixed-Point Clip Instructions **************** */
-union clause ast = NXTYPE : (nxfunct6, bits(1), vregidx, regidx, vregidx)
+union clause instruction = NXTYPE : (nxfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_nxfunct6 : nxfunct6 <-> bits(6) = {
   NX_VNCLIPU     <-> 0b101110,
@@ -682,7 +682,7 @@ mapping clause assembly = NXTYPE(funct6, vm, vs2, rs1, vd)
 
 /* ***************** OPIVX (Vector Slide & Gather Instructions) ****************** */
 /* Slide and gather instructions extend rs1/imm to XLEN instead of SEW bits */
-union clause ast = VXSG : (vxsgfunct6, bits(1), vregidx, regidx, vregidx)
+union clause instruction = VXSG : (vxsgfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_vxsgfunct6 : vxsgfunct6 <-> bits(6) = {
   VX_VSLIDEUP     <-> 0b001110,
@@ -753,7 +753,7 @@ mapping clause assembly = VXSG(funct6, vm, vs2, rs1, vd)
   <-> vxsg_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
 
 /* ********************** OPIVX (Integer Merge Instruction) ********************** */
-union clause ast = MASKTYPEX : (vregidx, regidx, vregidx)
+union clause instruction = MASKTYPEX : (vregidx, regidx, vregidx)
 
 mapping clause encdec = MASKTYPEX(vs2, rs1, vd)
   <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
@@ -805,7 +805,7 @@ mapping clause assembly = MASKTYPEX(vs2, rs1, vd)
   <-> "vmerge.vxm" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ sep() ^ "v0"
 
 /* ********************** OPIVX (Integer Move Instruction) *********************** */
-union clause ast = MOVETYPEX : (regidx, vregidx)
+union clause instruction = MOVETYPEX : (regidx, vregidx)
 
 mapping clause encdec = MOVETYPEX (rs1, vd)
   <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
@@ -844,7 +844,7 @@ mapping clause assembly = MOVETYPEX(rs1, vd)
   <-> "vmv.v.x" ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1)
 
 /* ******************************* OPIVI (VITYPE) ******************************** */
-union clause ast = VITYPE : (vifunct6, bits(1), vregidx, bits(5), vregidx)
+union clause instruction = VITYPE : (vifunct6, bits(1), vregidx, bits(5), vregidx)
 
 mapping encdec_vifunct6 : vifunct6 <-> bits(6) = {
   VI_VADD       <-> 0b000000,
@@ -949,7 +949,7 @@ mapping clause assembly = VITYPE(funct6, vm, vs2, simm, vd)
 
 /* ************************** OPIVI (WITYPE Narrowing) *************************** */
 /* ************** Vector Narrowing Integer Right Shift Instructions ************** */
-union clause ast = NISTYPE : (nisfunct6, bits(1), vregidx, bits(5), vregidx)
+union clause instruction = NISTYPE : (nisfunct6, bits(1), vregidx, bits(5), vregidx)
 
 mapping encdec_nisfunct6 : nisfunct6 <-> bits(6) = {
   NIS_VNSRL       <-> 0b101100,
@@ -1020,7 +1020,7 @@ mapping clause assembly = NISTYPE(funct6, vm, vs2, simm, vd)
 
 /* ************************** OPIVI (WITYPE Narrowing) *************************** */
 /* *************** Vector Narrowing Fixed-Point Clip Instructions **************** */
-union clause ast = NITYPE : (nifunct6, bits(1), vregidx, bits(5), vregidx)
+union clause instruction = NITYPE : (nifunct6, bits(1), vregidx, bits(5), vregidx)
 
 mapping encdec_nifunct6 : nifunct6 <-> bits(6) = {
   NI_VNCLIPU     <-> 0b101110,
@@ -1092,7 +1092,7 @@ mapping clause assembly = NITYPE(funct6, vm, vs2, simm, vd)
 
 /* ***************** OPIVI (Vector Slide & Gather Instructions) ****************** */
 /* Slide and gather instructions extend rs1/imm to XLEN instead of SEW bits */
-union clause ast = VISG : (visgfunct6, bits(1), vregidx, bits(5), vregidx)
+union clause instruction = VISG : (visgfunct6, bits(1), vregidx, bits(5), vregidx)
 
 mapping encdec_visgfunct6 : visgfunct6 <-> bits(6) = {
   VI_VSLIDEUP     <-> 0b001110,
@@ -1163,7 +1163,7 @@ mapping clause assembly = VISG(funct6, vm, vs2, simm, vd)
   <-> visg_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_signed_5(simm) ^ maybe_vmask(vm)
 
 /* ********************** OPIVI (Integer Merge Instruction) ********************** */
-union clause ast = MASKTYPEI : (vregidx, bits(5), vregidx)
+union clause instruction = MASKTYPEI : (vregidx, bits(5), vregidx)
 
 mapping clause encdec = MASKTYPEI(vs2, simm, vd)
   <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
@@ -1215,7 +1215,7 @@ mapping clause assembly = MASKTYPEI(vs2, simm, vd)
   <-> "vmerge.vim" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_signed_5(simm) ^ sep() ^ "v0"
 
 /* ********************** OPIVI (Integer Move Instruction) *********************** */
-union clause ast = MOVETYPEI : (vregidx, bits(5))
+union clause instruction = MOVETYPEI : (vregidx, bits(5))
 
 mapping clause encdec = MOVETYPEI (vd, simm)
   <-> 0b010111 @ 0b1 @ 0b00000 @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
@@ -1254,7 +1254,7 @@ mapping clause assembly = MOVETYPEI(vd, simm)
   <-> "vmv.v.i" ^ spc() ^ vreg_name(vd) ^ sep() ^ hex_bits_signed_5(simm)
 
 /* ********************* OPIVI (Whole Vector Register Move) ********************** */
-union clause ast = VMVRTYPE : (vregidx, {1, 2, 4, 8}, vregidx)
+union clause instruction = VMVRTYPE : (vregidx, {1, 2, 4, 8}, vregidx)
 
 // "The number of vector registers to copy is encoded in the low three
 // bits of the simm field (simm[2:0]) using the same encoding as the nf[2:0]
@@ -1312,7 +1312,7 @@ mapping clause assembly = VMVRTYPE(vs2, nreg, vd)
   <-> "vmv" ^ nreg_string(nreg) ^ "r.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)
 
 /* ******************************* OPMVV (VVTYPE) ******************************** */
-union clause ast = MVVTYPE : (mvvfunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = MVVTYPE : (mvvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_mvvfunct6 : mvvfunct6 <-> bits(6) = {
   MVV_VAADDU      <-> 0b001000,
@@ -1440,7 +1440,7 @@ mapping clause assembly = MVVTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ************************* OPMVV (VVtype Multiply-Add) ************************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast = MVVMATYPE : (mvvmafunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = MVVMATYPE : (mvvmafunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_mvvmafunct6 : mvvmafunct6 <-> bits(6) = {
   MVV_VMACC       <-> 0b101101,
@@ -1501,7 +1501,7 @@ mapping clause assembly = MVVMATYPE(funct6, vm, vs2, vs1, vd)
   <-> mvvmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* *************************** OPMVV (VVTYPE Widening) *************************** */
-union clause ast = WVVTYPE : (wvvfunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = WVVTYPE : (wvvfunct6, bits(1), vregidx, vregidx, vregidx)
 mapping encdec_wvvfunct6 : wvvfunct6 <-> bits(6) = {
   WVV_VADD       <-> 0b110001,
   WVV_VSUB       <-> 0b110011,
@@ -1578,7 +1578,7 @@ mapping clause assembly = WVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> wvvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
 /* *************************** OPMVV (WVTYPE Widening) *************************** */
-union clause ast = WVTYPE : (wvfunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = WVTYPE : (wvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_wvfunct6 : wvfunct6 <-> bits(6) = {
   WV_VADD       <-> 0b110101,
@@ -1647,7 +1647,7 @@ mapping clause assembly = WVTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ******************** OPMVV (VVtype Widening Multiply-Add) ********************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast = WMVVTYPE : (wmvvfunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = WMVVTYPE : (wmvvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_wmvvfunct6 : wmvvfunct6 <-> bits(6) = {
   WMVV_VWMACCU   <-> 0b111100,
@@ -1714,7 +1714,7 @@ mapping clause assembly = WMVVTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ****************************** OPMVV (VXUNARY0) ******************************* */
 /* ******************* Vector Integer Extension (SEW/2 source) ******************* */
-union clause ast = VEXTTYPE : (vextfunct6, bits(1), vregidx, vregidx)
+union clause instruction = VEXTTYPE : (vextfunct6, bits(1), vregidx, vregidx)
 
 mapping vext_vs1 : vextfunct6 <-> bits(5) = {
   VEXT2_ZVF2  <-> 0b00110,
@@ -1795,7 +1795,7 @@ mapping clause assembly = VEXTTYPE(funct6, vm, vs2, vd)
   <-> vexttype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************ OPMVV (vmv.x.s in VWXUNARY0) ************************* */
-union clause ast = VMVXS : (vregidx, regidx)
+union clause instruction = VMVXS : (vregidx, regidx)
 
 mapping clause encdec = VMVXS(vs2, rd)
   <-> 0b010000 @ 0b1 @ encdec_vreg(vs2) @ 0b00000 @ 0b010 @ encdec_reg(rd) @ 0b1010111
@@ -1824,7 +1824,7 @@ mapping clause assembly = VMVXS(vs2, rd)
   <-> "vmv.x.s" ^ spc() ^ reg_name(rd) ^ sep() ^ vreg_name(vs2)
 
 /* ********************* OPMVV (Vector Compress Instruction) ********************* */
-union clause ast = MVVCOMPRESS : (vregidx, vregidx, vregidx)
+union clause instruction = MVVCOMPRESS : (vregidx, vregidx, vregidx)
 
 mapping clause encdec = MVVCOMPRESS(vs2, vs1, vd)
   <-> 0b010111 @ 0b1 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
@@ -1885,7 +1885,7 @@ mapping clause assembly = MVVCOMPRESS(vs2, vs1, vd)
   <-> "vcompress.vm" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1)
 
 /* ******************************* OPMVX (VXTYPE) ******************************** */
-union clause ast = MVXTYPE : (mvxfunct6, bits(1), vregidx, regidx, vregidx)
+union clause instruction = MVXTYPE : (mvxfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_mvxfunct6 : mvxfunct6 <-> bits(6) = {
   MVX_VAADDU        <-> 0b001000,
@@ -2026,7 +2026,7 @@ mapping clause assembly = MVXTYPE(funct6, vm, vs2, rs1, vd)
 
 /* ************************* OPMVX (VXtype Multiply-Add) ************************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast = MVXMATYPE : (mvxmafunct6, bits(1), vregidx, regidx, vregidx)
+union clause instruction = MVXMATYPE : (mvxmafunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_mvxmafunct6 : mvxmafunct6 <-> bits(6) = {
   MVX_VMACC         <-> 0b101101,
@@ -2087,7 +2087,7 @@ mapping clause assembly = MVXMATYPE(funct6, vm, vs2, rs1, vd)
   <-> mvxmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* *************************** OPMVX (VXTYPE Widening) *************************** */
-union clause ast = WVXTYPE : (wvxfunct6, bits(1), vregidx, regidx, vregidx)
+union clause instruction = WVXTYPE : (wvxfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_wvxfunct6 : wvxfunct6 <-> bits(6) = {
   WVX_VADD       <-> 0b110001,
@@ -2164,7 +2164,7 @@ mapping clause assembly = WVXTYPE(funct6, vm, vs2, rs1, vd)
   <-> wvxtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
 
 /* *************************** OPMVX (WXTYPE Widening) *************************** */
-union clause ast = WXTYPE : (wxfunct6, bits(1), vregidx, regidx, vregidx)
+union clause instruction = WXTYPE : (wxfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_wxfunct6 : wxfunct6 <-> bits(6) = {
   WX_VADD       <-> 0b110101,
@@ -2232,7 +2232,7 @@ mapping clause assembly = WXTYPE(funct6, vm, vs2, rs1, vd)
 
 /* ******************** OPMVX (VXtype Widening Multiply-Add) ********************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast =  WMVXTYPE : (wmvxfunct6, bits(1), vregidx, regidx, vregidx)
+union clause instruction =  WMVXTYPE : (wmvxfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_wmvxfunct6 : wmvxfunct6 <-> bits(6) = {
   WMVX_VWMACCU    <-> 0b111100,
@@ -2300,7 +2300,7 @@ mapping clause assembly = WMVXTYPE(funct6, vm, vs2, rs1, vd)
   <-> wmvxtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ reg_name(rs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ****************************** OPMVX (VRXUNARY0) ****************************** */
-union clause ast = VMVSX : (regidx, vregidx)
+union clause instruction = VMVSX : (regidx, vregidx)
 
 mapping clause encdec = VMVSX(rs1, vd)
   <-> 0b010000 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111

--- a/model/riscv_insts_vext_fp.sail
+++ b/model/riscv_insts_vext_fp.sail
@@ -13,7 +13,7 @@
 /* ******************************************************************************* */
 
 /* ******************************* OPFVV (VVTYPE) ******************************** */
-union clause ast = FVVTYPE : (fvvfunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = FVVTYPE : (fvvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_fvvfunct6 : fvvfunct6 <-> bits(6) = {
   FVV_VADD       <-> 0b000000,
@@ -92,7 +92,7 @@ mapping clause assembly = FVVTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ************************* OPFVV (VVtype Multiply-Add) ************************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast = FVVMATYPE : (fvvmafunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = FVVMATYPE : (fvvmafunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_fvvmafunct6 : fvvmafunct6 <-> bits(6) = {
   FVV_VMADD      <-> 0b101000,
@@ -167,7 +167,7 @@ mapping clause assembly = FVVMATYPE(funct6, vm, vs2, vs1, vd)
   <-> fvvmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* *************************** OPFVV (VVTYPE Widening) *************************** */
-union clause ast = FWVVTYPE : (fwvvfunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = FWVVTYPE : (fwvvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_fwvvfunct6 : fwvvfunct6 <-> bits(6) = {
   FWVV_VADD       <-> 0b110000,
@@ -234,7 +234,7 @@ mapping clause assembly = FWVVTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ******************** OPFVV (VVtype Widening Multiply-Add) ********************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast = FWVVMATYPE : (fwvvmafunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = FWVVMATYPE : (fwvvmafunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_fwvvmafunct6 : fwvvmafunct6 <-> bits(6) = {
   FWVV_VMACC      <-> 0b111100,
@@ -303,7 +303,7 @@ mapping clause assembly = FWVVMATYPE(funct6, vm, vs1, vs2, vd)
   <-> fwvvmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* *************************** OPFVV (WVTYPE Widening) *************************** */
-union clause ast = FWVTYPE : (fwvfunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = FWVTYPE : (fwvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_fwvfunct6 : fwvfunct6 <-> bits(6) = {
   FWV_VADD       <-> 0b110100,
@@ -365,7 +365,7 @@ mapping clause assembly = FWVTYPE(funct6, vm, vs2, vs1, vd)
   <-> fwvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
 /* ****************************** OPFVV (VFUNARY0) ******************************* */
-union clause ast = VFUNARY0 : (bits(1), vregidx, vfunary0, vregidx)
+union clause instruction = VFUNARY0 : (bits(1), vregidx, vfunary0, vregidx)
 
 mapping encdec_vfunary0_vs1 : vfunary0 <-> bits(5) = {
   FV_CVT_XU_F       <-> 0b00000,
@@ -481,7 +481,7 @@ mapping clause assembly = VFUNARY0(vm, vs2, vfunary0, vd)
   <-> vfunary0_mnemonic(vfunary0) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************** OPFVV (VFUNARY0 Widening) ************************** */
-union clause ast = VFWUNARY0 : (bits(1), vregidx, vfwunary0, vregidx)
+union clause instruction = VFWUNARY0 : (bits(1), vregidx, vfwunary0, vregidx)
 
 mapping encdec_vfwunary0_vs1 : vfwunary0 <-> bits(5) = {
   FWV_CVT_XU_F      <-> 0b01000,
@@ -613,7 +613,7 @@ mapping clause assembly = VFWUNARY0(vm, vs2, vfwunary0, vd)
   <-> vfwunary0_mnemonic(vfwunary0) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************* OPFVV (VFUNARY0 Narrowing) ************************** */
-union clause ast = VFNUNARY0 : (bits(1), vregidx, vfnunary0, vregidx)
+union clause instruction = VFNUNARY0 : (bits(1), vregidx, vfnunary0, vregidx)
 
 mapping encdec_vfnunary0_vs1 : vfnunary0 <-> bits(5) = {
   FNV_CVT_XU_F      <-> 0b10000,
@@ -756,7 +756,7 @@ mapping clause assembly = VFNUNARY0(vm, vs2, vfnunary0, vd)
   <-> vfnunary0_mnemonic(vfnunary0) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ****************************** OPFVV (VFUNARY1) ******************************* */
-union clause ast = VFUNARY1 : (bits(1), vregidx, vfunary1, vregidx)
+union clause instruction = VFUNARY1 : (bits(1), vregidx, vfunary1, vregidx)
 
 mapping encdec_vfunary1_vs1 : vfunary1 <-> bits(5) = {
   FVV_VSQRT       <-> 0b00000,
@@ -842,7 +842,7 @@ mapping clause assembly = VFUNARY1(vm, vs2, vfunary1, vd)
   <-> vfunary1_mnemonic(vfunary1) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ****************************** OPFVV (VWFUNARY0) ****************************** */
-union clause ast = VFMVFS : (vregidx, fregidx)
+union clause instruction = VFMVFS : (vregidx, fregidx)
 
 mapping clause encdec = VFMVFS(vs2, rd)
   <-> 0b010000 @ 0b1 @ encdec_vreg(vs2) @ 0b00000 @ 0b001 @ encdec_freg(rd) @ 0b1010111
@@ -875,7 +875,7 @@ mapping clause assembly = VFMVFS(vs2, rd)
   <-> "vfmv.f.s" ^ spc() ^ freg_name(rd) ^ sep() ^ vreg_name(vs2)
 
 /* ******************************* OPFVF (VFtype) ******************************** */
-union clause ast = FVFTYPE : (fvffunct6, bits(1), vregidx, fregidx, vregidx)
+union clause instruction = FVFTYPE : (fvffunct6, bits(1), vregidx, fregidx, vregidx)
 
 mapping encdec_fvffunct6 : fvffunct6 <-> bits(6) = {
   VF_VADD          <-> 0b000000,
@@ -973,7 +973,7 @@ mapping clause assembly = FVFTYPE(funct6, vm, vs2, rs1, vd)
 
 /* ************************* OPFVF (VFtype Multiply-Add) ************************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast = FVFMATYPE : (fvfmafunct6, bits(1), vregidx, fregidx, vregidx)
+union clause instruction = FVFMATYPE : (fvfmafunct6, bits(1), vregidx, fregidx, vregidx)
 
 mapping encdec_fvfmafunct6 : fvfmafunct6 <-> bits(6) = {
   VF_VMADD      <-> 0b101000,
@@ -1048,7 +1048,7 @@ mapping clause assembly = FVFMATYPE(funct6, vm, vs2, rs1, vd)
   <-> fvfmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ freg_name(rs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* *************************** OPFVF (VFTYPE Widening) *************************** */
-union clause ast = FWVFTYPE : (fwvffunct6, bits(1), vregidx, fregidx, vregidx)
+union clause instruction = FWVFTYPE : (fwvffunct6, bits(1), vregidx, fregidx, vregidx)
 
 mapping encdec_fwvffunct6 : fwvffunct6 <-> bits(6) = {
   FWVF_VADD       <-> 0b110000,
@@ -1114,7 +1114,7 @@ mapping clause assembly = FWVFTYPE(funct6, vm, vs2, rs1, vd)
 
 /* ******************** OPFVF (VFtype Widening Multiply-Add) ********************* */
 /* Multiply-Add instructions switch the order of source operands in assembly (vs1/rs1 before vs2) */
-union clause ast = FWVFMATYPE : (fwvfmafunct6, bits(1), fregidx, vregidx, vregidx)
+union clause instruction = FWVFMATYPE : (fwvfmafunct6, bits(1), fregidx, vregidx, vregidx)
 
 mapping encdec_fwvfmafunct6 : fwvfmafunct6 <-> bits(6) = {
   FWVF_VMACC      <-> 0b111100,
@@ -1182,7 +1182,7 @@ mapping clause assembly = FWVFMATYPE(funct6, vm, rs1, vs2, vd)
   <-> fwvfmatype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ freg_name(rs1) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* *************************** OPFVF (WFTYPE Widening) *************************** */
-union clause ast = FWFTYPE : (fwffunct6, bits(1), vregidx, fregidx, vregidx)
+union clause instruction = FWFTYPE : (fwffunct6, bits(1), vregidx, fregidx, vregidx)
 
 mapping encdec_fwffunct6 : fwffunct6 <-> bits(6) = {
   FWF_VADD       <-> 0b110100,
@@ -1244,7 +1244,7 @@ mapping clause assembly = FWFTYPE(funct6, vm, vs2, rs1, vd)
 
 /* ************************** OPFVF (Merge Instruction) ************************** */
 /* This instruction operates on all body elements regardless of mask value */
-union clause ast = VFMERGE : (vregidx, fregidx, vregidx)
+union clause instruction = VFMERGE : (vregidx, fregidx, vregidx)
 
 mapping clause encdec = VFMERGE(vs2, rs1, vd)
   <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
@@ -1299,7 +1299,7 @@ mapping clause assembly = VFMERGE(vs2, rs1, vd)
 
 /* ************************** OPFVF (Move Instruction) *************************** */
 /* This instruction shares the encoding with vfmerge.vfm, but with vm=1 and vs2=v0 */
-union clause ast = VFMV : (fregidx, vregidx)
+union clause instruction = VFMV : (fregidx, vregidx)
 
 mapping clause encdec = VFMV(rs1, vd)
   <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
@@ -1340,7 +1340,7 @@ mapping clause assembly = VFMV(rs1, vd)
   <-> "vfmv.v.f" ^ spc() ^ vreg_name(vd) ^ sep() ^ freg_name(rs1)
 
 /* ****************************** OPFVF (VRFUNARY0) ****************************** */
-union clause ast = VFMVSF : (fregidx, vregidx)
+union clause instruction = VFMVSF : (fregidx, vregidx)
 
 mapping clause encdec = VFMVSF(rs1, vd)
   <-> 0b010000 @ 0b1 @ 0b00000 @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111

--- a/model/riscv_insts_vext_fp_red.sail
+++ b/model/riscv_insts_vext_fp_red.sail
@@ -12,7 +12,7 @@
 /* ******************************************************************************* */
 
 /* ********************** OPFVV (Floating-Point Reduction) *********************** */
-union clause ast = RFVVTYPE : (rfvvfunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = RFVVTYPE : (rfvvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_rfvvfunct6 : rfvvfunct6 <-> bits(6) = {
   FVV_VFREDOSUM   <-> 0b000011,

--- a/model/riscv_insts_vext_fp_vm.sail
+++ b/model/riscv_insts_vext_fp_vm.sail
@@ -13,7 +13,7 @@
 
 /* ******************************* OPFVV (VVMTYPE) ******************************* */
 /* FVVM instructions' destination is a mask register */
-union clause ast = FVVMTYPE : (fvvmfunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = FVVMTYPE : (fvvmfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_fvvmfunct6 : fvvmfunct6 <-> bits(6) = {
   FVVM_VMFEQ      <-> 0b011000,
@@ -78,7 +78,7 @@ mapping clause assembly = FVVMTYPE(funct6, vm, vs2, vs1, vd)
 
 /* ******************************* OPFVF (VFMTYPE) ******************************* */
 /* VFM instructions' destination is a mask register */
-union clause ast = FVFMTYPE : (fvfmfunct6, bits(1), vregidx, fregidx, vregidx)
+union clause instruction = FVFMTYPE : (fvfmfunct6, bits(1), vregidx, fregidx, vregidx)
 
 mapping encdec_fvfmfunct6 : fvfmfunct6 <-> bits(6) = {
   VFM_VMFEQ      <-> 0b011000,

--- a/model/riscv_insts_vext_mask.sail
+++ b/model/riscv_insts_vext_mask.sail
@@ -12,7 +12,7 @@
 /* ******************************************************************************* */
 
 /* ******************************* OPMVV (MMTYPE) ******************************** */
-union clause ast = MMTYPE : (mmfunct6, vregidx, vregidx, vregidx)
+union clause instruction = MMTYPE : (mmfunct6, vregidx, vregidx, vregidx)
 
 mapping encdec_mmfunct6 : mmfunct6 <-> bits(6) = {
   MM_VMAND     <-> 0b011001,
@@ -84,7 +84,7 @@ mapping clause assembly = MMTYPE(funct6, vs2, vs1, vd)
   <-> mmtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1)
 
 /* ************************* OPMVV (vcpop in VWXUNARY0) ************************** */
-union clause ast = VCPOP_M : (bits(1), vregidx, regidx)
+union clause instruction = VCPOP_M : (bits(1), vregidx, regidx)
 
 mapping clause encdec = VCPOP_M(vm, vs2, rd)
   <-> 0b010000 @ vm @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_reg(rd) @ 0b1010111
@@ -122,7 +122,7 @@ mapping clause assembly = VCPOP_M(vm, vs2, rd)
   <-> "vcpop.m" ^ spc() ^ reg_name(rd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************* OPMVV (vfirst in VWXUNARY0) ************************* */
-union clause ast = VFIRST_M : (bits(1), vregidx, regidx)
+union clause instruction = VFIRST_M : (bits(1), vregidx, regidx)
 
 mapping clause encdec = VFIRST_M(vm, vs2, rd)
   <-> 0b010000 @ vm @ encdec_vreg(vs2) @ 0b10001 @ 0b010 @ encdec_reg(rd) @ 0b1010111
@@ -162,7 +162,7 @@ mapping clause assembly = VFIRST_M(vm, vs2, rd)
   <-> "vfirst.m" ^ spc() ^ reg_name(rd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************** OPMVV (vmsbf in VMUNARY0) ************************** */
-union clause ast = VMSBF_M : (bits(1), vregidx, vregidx)
+union clause instruction = VMSBF_M : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VMSBF_M(vm, vs2, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ 0b00001 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
@@ -206,7 +206,7 @@ mapping clause assembly = VMSBF_M(vm, vs2, vd)
   <-> "vmsbf.m" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************** OPMVV (vmsif in VMUNARY0) ************************** */
-union clause ast = VMSIF_M : (bits(1), vregidx, vregidx)
+union clause instruction = VMSIF_M : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VMSIF_M(vm, vs2, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ 0b00011 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
@@ -250,7 +250,7 @@ mapping clause assembly = VMSIF_M(vm, vs2, vd)
   <-> "vmsif.m" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************** OPMVV (vmsof in VMUNARY0) ************************** */
-union clause ast = VMSOF_M : (bits(1), vregidx, vregidx)
+union clause instruction = VMSOF_M : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VMSOF_M(vm, vs2, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ 0b00010 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
@@ -298,7 +298,7 @@ mapping clause assembly = VMSOF_M(vm, vs2, vd)
   <-> "vmsof.m" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************** OPMVV (viota in VMUNARY0) ************************** */
-union clause ast = VIOTA_M : (bits(1), vregidx, vregidx)
+union clause instruction = VIOTA_M : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VIOTA_M(vm, vs2, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
@@ -342,7 +342,7 @@ mapping clause assembly = VIOTA_M(vm, vs2, vd)
   <-> "viota.m" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* *************************** OPMVV (vid in VMUNARY0) *************************** */
-union clause ast = VID_V : (bits(1), vregidx)
+union clause instruction = VID_V : (bits(1), vregidx)
 
 mapping clause encdec = VID_V(vm, vd)
   <-> 0b010100 @ vm @ 0b00000 @ 0b10001 @ 0b010 @ encdec_vreg(vd) @ 0b1010111

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -70,7 +70,7 @@ mapping vlewidth_pow : vlewidth <-> {3, 4, 5, 6} = {
 }
 
 /* ******************** Vector Load Unit-Stride Normal & Segment (mop=0b00, lumop=0b00000) ********************* */
-union clause ast = VLSEGTYPE : (bits(3), bits(1), regidx, vlewidth, vregidx)
+union clause instruction = VLSEGTYPE : (bits(3), bits(1), regidx, vlewidth, vregidx)
 
 mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
@@ -131,7 +131,7 @@ mapping clause assembly = VLSEGTYPE(nf, vm, rs1, width, vd)
   <-> "vl" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ maybe_vmask(vm)
 
 /* ************ Vector Load Unit-Stride Normal & Segment Fault-Only-First (mop=0b00, lumop=0b10000) ************ */
-union clause ast = VLSEGFFTYPE : (bits(3), bits(1), regidx, vlewidth, vregidx)
+union clause instruction = VLSEGFFTYPE : (bits(3), bits(1), regidx, vlewidth, vregidx)
 
 mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b10000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
@@ -209,7 +209,7 @@ mapping clause assembly = VLSEGFFTYPE(nf, vm, rs1, width, vd)
   <-> "vl" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ "ff.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ maybe_vmask(vm)
 
 /* ******************** Vector Store Unit-Stride Normal & Segment (mop=0b00, sumop=0b00000) ******************** */
-union clause ast = VSSEGTYPE : (bits(3), bits(1), regidx, vlewidth, vregidx)
+union clause instruction = VSSEGTYPE : (bits(3), bits(1), regidx, vlewidth, vregidx)
 
 mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b00 @ vm @ 0b00000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
@@ -267,7 +267,7 @@ mapping clause assembly = VSSEGTYPE(nf, vm, rs1, width, vs3)
   <-> "vs" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ maybe_vmask(vm)
 
 /* ****************************** Vector Load Strided Normal & Segment (mop=0b10) ****************************** */
-union clause ast = VLSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, vregidx)
+union clause instruction = VLSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, vregidx)
 
 mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
   <-> nf @ 0b0 @ 0b10 @ vm @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
@@ -329,7 +329,7 @@ mapping clause assembly = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
   <-> "vls" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(rs2) ^ maybe_vmask(vm)
 
 /* ***************************** Vector Store Strided Normal & Segment (mop=0b10) ****************************** */
-union clause ast = VSSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, vregidx)
+union clause instruction = VSSSEGTYPE : (bits(3), bits(1), regidx, regidx, vlewidth, vregidx)
 
 mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b10 @ vm @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
@@ -388,7 +388,7 @@ mapping clause assembly = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
   <-> "vss" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ reg_name(rs2) ^ maybe_vmask(vm)
 
 /* ************************* Vector Load Indexed Unordered Normal & Segment (mop=0b01) ************************* */
-union clause ast = VLUXSEGTYPE : (bits(3), bits(1), vregidx, regidx, vlewidth, vregidx)
+union clause instruction = VLUXSEGTYPE : (bits(3), bits(1), vregidx, regidx, vlewidth, vregidx)
 
 mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   <-> nf @ 0b0 @ 0b01 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
@@ -452,7 +452,7 @@ mapping clause assembly = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   <-> "vlux" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************** Vector Load Indexed Ordered Normal & Segment (mop=0b11) ************************** */
-union clause ast = VLOXSEGTYPE : (bits(3), bits(1), vregidx, regidx, vlewidth, vregidx)
+union clause instruction = VLOXSEGTYPE : (bits(3), bits(1), vregidx, regidx, vlewidth, vregidx)
 
 mapping clause encdec = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   <-> nf @ 0b0 @ 0b11 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
@@ -480,7 +480,7 @@ mapping clause assembly = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   <-> "vlox" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************ Vector Store Indexed Unordered Normal & Segment (mop=0b01) ************************* */
-union clause ast = VSUXSEGTYPE : (bits(3), bits(1), vregidx, regidx, vlewidth, vregidx)
+union clause instruction = VSUXSEGTYPE : (bits(3), bits(1), vregidx, regidx, vlewidth, vregidx)
 
 mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b01 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
@@ -541,7 +541,7 @@ mapping clause assembly = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   <-> "vsux" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ************************* Vector Store Indexed Ordered Normal & Segment (mop=0b11) ************************** */
-union clause ast = VSOXSEGTYPE : (bits(3), bits(1), vregidx, regidx, vlewidth, vregidx)
+union clause instruction = VSOXSEGTYPE : (bits(3), bits(1), vregidx, regidx, vlewidth, vregidx)
 
 mapping clause encdec = VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   <-> nf @ 0b0 @ 0b11 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
@@ -569,7 +569,7 @@ mapping clause assembly = VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   <-> "vsox" ^ nfields_string(nf) ^ "ei" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")" ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 /* ***************** Vector Load Unit-Stride Whole Register (vm=0b1, mop=0b00, lumop=0b01000) ****************** */
-union clause ast = VLRETYPE : (bits(3), regidx, vlewidth, vregidx)
+union clause instruction = VLRETYPE : (bits(3), regidx, vlewidth, vregidx)
 
 mapping clause encdec = VLRETYPE(nf, rs1, width, vd)
   <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
@@ -631,7 +631,7 @@ mapping clause assembly = VLRETYPE(nf, rs1, width, vd)
   <-> "vl" ^ nfields_int_string(nf) ^ "re" ^ vlewidth_bitsnumberstr(width) ^ ".v" ^ spc() ^ vreg_name(vd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
 
 /* ***************** Vector Store Unit-Stride Whole Register (vm=0b1, mop=0b00, lumop=0b01000) ***************** */
-union clause ast = VSRETYPE : (bits(3), regidx, vregidx)
+union clause instruction = VSRETYPE : (bits(3), regidx, vregidx)
 
 mapping clause encdec = VSRETYPE(nf, rs1, vs3)
   <-> nf @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ encdec_reg(rs1) @ 0b000 @ encdec_vreg(vs3) @ 0b0100111
@@ -698,7 +698,7 @@ mapping clause assembly = VSRETYPE(nf, rs1, vs3)
   <-> "vs" ^ nfields_int_string(nf) ^ "r.v" ^ spc() ^ vreg_name(vs3) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
 
 /* ************** Vector Mask Load/Store Unit-Stride (nf=0b000, mop=0b00, lumop or sumop=0b01011) ************** */
-union clause ast = VMTYPE : (regidx, vregidx, vmlsop)
+union clause instruction = VMTYPE : (regidx, vregidx, vmlsop)
 
 mapping encdec_lsop : vmlsop <-> bits(7) = {
   VLM      <-> 0b0000111,

--- a/model/riscv_insts_vext_red.sail
+++ b/model/riscv_insts_vext_red.sail
@@ -12,7 +12,7 @@
 /* ******************************************************************************* */
 
 /* ********************* OPIVV (Widening Integer Reduction) ********************** */
-union clause ast = RIVVTYPE : (rivvfunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = RIVVTYPE : (rivvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_rivvfunct6 : rivvfunct6 <-> bits(6) = {
   IVV_VWREDSUMU   <-> 0b110000,
@@ -78,7 +78,7 @@ mapping clause assembly = RIVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> rivvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
 /* ******************* OPMVV (Single-Width Integer Reduction) ******************** */
-union clause ast = RMVVTYPE : (rmvvfunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = RMVVTYPE : (rmvvfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_rmvvfunct6 : rmvvfunct6 <-> bits(6) = {
   MVV_VREDSUM     <-> 0b000000,

--- a/model/riscv_insts_vext_vm.sail
+++ b/model/riscv_insts_vext_vm.sail
@@ -15,7 +15,7 @@
 /* VVM instructions' destination is a mask register (e.g. carry out) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VVMTYPE : (vvmfunct6, vregidx, vregidx, vregidx)
+union clause instruction = VVMTYPE : (vvmfunct6, vregidx, vregidx, vregidx)
 
 mapping encdec_vvmfunct6 : vvmfunct6 <-> bits(6) = {
   VVM_VMADC    <-> 0b010001, /* carry in, carry out */
@@ -74,7 +74,7 @@ mapping clause assembly = VVMTYPE(funct6, vs2, vs1, vd)
 /* VVMC instructions' destination is a mask register (e.g. carry out) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VVMCTYPE : (vvmcfunct6, vregidx, vregidx, vregidx)
+union clause instruction = VVMCTYPE : (vvmcfunct6, vregidx, vregidx, vregidx)
 
 mapping encdec_vvmcfunct6 : vvmcfunct6 <-> bits(6) = {
   VVMC_VMADC    <-> 0b010001, /* no carry in, carry out */
@@ -132,7 +132,7 @@ mapping clause assembly = VVMCTYPE(funct6, vs2, vs1, vd)
 /* VVMS instructions' destination is a vector register (e.g. actual sum) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VVMSTYPE : (vvmsfunct6, vregidx, vregidx, vregidx)
+union clause instruction = VVMSTYPE : (vvmsfunct6, vregidx, vregidx, vregidx)
 
 mapping encdec_vvmsfunct6 : vvmsfunct6 <-> bits(6) = {
   VVMS_VADC     <-> 0b010000, /* carry in, no carry out */
@@ -191,7 +191,7 @@ mapping clause assembly = VVMSTYPE(funct6, vs2, vs1, vd)
 
 /* ***************** OPIVV (Vector Integer Compare Instructions) ***************** */
 /* VVCMP instructions' destination is a mask register */
-union clause ast = VVCMPTYPE : (vvcmpfunct6, bits(1), vregidx, vregidx, vregidx)
+union clause instruction = VVCMPTYPE : (vvcmpfunct6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_vvcmpfunct6 : vvcmpfunct6 <-> bits(6) = {
   VVCMP_VMSEQ    <-> 0b011000,
@@ -262,7 +262,7 @@ mapping clause assembly = VVCMPTYPE(funct6, vm, vs2, vs1, vd)
 /* VXM instructions' destination is a mask register (e.g. carry out) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VXMTYPE : (vxmfunct6, vregidx, regidx, vregidx)
+union clause instruction = VXMTYPE : (vxmfunct6, vregidx, regidx, vregidx)
 
 mapping encdec_vxmfunct6 : vxmfunct6 <-> bits(6) = {
   VXM_VMADC    <-> 0b010001, /* carry in, carry out */
@@ -321,7 +321,7 @@ mapping clause assembly = VXMTYPE(funct6, vs2, rs1, vd)
 /* VXMC instructions' destination is a mask register (e.g. carry out) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VXMCTYPE : (vxmcfunct6, vregidx, regidx, vregidx)
+union clause instruction = VXMCTYPE : (vxmcfunct6, vregidx, regidx, vregidx)
 
 mapping encdec_vxmcfunct6 : vxmcfunct6 <-> bits(6) = {
   VXMC_VMADC    <-> 0b010001, /* carry in, carry out */
@@ -379,7 +379,7 @@ mapping clause assembly = VXMCTYPE(funct6, vs2, rs1, vd)
 /* VXMS instructions' destination is a vector register (e.g. actual sum) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VXMSTYPE : (vxmsfunct6, vregidx, regidx, vregidx)
+union clause instruction = VXMSTYPE : (vxmsfunct6, vregidx, regidx, vregidx)
 
 mapping encdec_vxmsfunct6 : vxmsfunct6 <-> bits(6) = {
   VXMS_VADC     <-> 0b010000, /* carry in, no carry out */
@@ -438,7 +438,7 @@ mapping clause assembly = VXMSTYPE(funct6, vs2, rs1, vd)
 
 /* ***************** OPIVX (Vector Integer Compare Instructions) ***************** */
 /* VXCMP instructions' destination is a mask register */
-union clause ast = VXCMPTYPE : (vxcmpfunct6, bits(1), vregidx, regidx, vregidx)
+union clause instruction = VXCMPTYPE : (vxcmpfunct6, bits(1), vregidx, regidx, vregidx)
 
 mapping encdec_vxcmpfunct6 : vxcmpfunct6 <-> bits(6) = {
   VXCMP_VMSEQ    <-> 0b011000,
@@ -515,7 +515,7 @@ mapping clause assembly = VXCMPTYPE(funct6, vm, vs2, rs1, vd)
 /* VIM instructions' destination is a mask register (e.g. carry out) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VIMTYPE : (vimfunct6, vregidx, bits(5), vregidx)
+union clause instruction = VIMTYPE : (vimfunct6, vregidx, bits(5), vregidx)
 
 mapping encdec_vimfunct6 : vimfunct6 <-> bits(6) = {
   VIM_VMADC    <-> 0b010001 /* carry in, carry out */
@@ -571,7 +571,7 @@ mapping clause assembly = VIMTYPE(funct6, vs2, simm, vd)
 /* VIMC instructions' destination is a mask register (e.g. carry out) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VIMCTYPE : (vimcfunct6, vregidx, bits(5), vregidx)
+union clause instruction = VIMCTYPE : (vimcfunct6, vregidx, bits(5), vregidx)
 
 mapping encdec_vimcfunct6 : vimcfunct6 <-> bits(6) = {
   VIMC_VMADC    <-> 0b010001 /* carry in, carry out */
@@ -626,7 +626,7 @@ mapping clause assembly = VIMCTYPE(funct6, vs2, simm, vd)
 /* VIMS instructions' destination is a vector register (e.g. actual sum) */
 /* Instructions with no carry out will set mask result to current mask value */
 /* May or may not read from source mask register (e.g. carry in) */
-union clause ast = VIMSTYPE : (vimsfunct6, vregidx, bits(5), vregidx)
+union clause instruction = VIMSTYPE : (vimsfunct6, vregidx, bits(5), vregidx)
 
 mapping encdec_vimsfunct6 : vimsfunct6 <-> bits(6) = {
   VIMS_VADC     <-> 0b010000 /* Carry in, no carry out */
@@ -682,7 +682,7 @@ mapping clause assembly = VIMSTYPE(funct6, vs2, simm, vd)
 
 /* ***************** OPIVI (Vector Integer Compare Instructions) ***************** */
 /* VICMP instructions' destination is a mask register */
-union clause ast = VICMPTYPE : (vicmpfunct6, bits(1), vregidx, bits(5), vregidx)
+union clause instruction = VICMPTYPE : (vicmpfunct6, bits(1), vregidx, bits(5), vregidx)
 
 mapping encdec_vicmpfunct6 : vicmpfunct6 <-> bits(6) = {
   VICMP_VMSEQ    <-> 0b011000,

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -74,7 +74,7 @@ function calculate_new_vl(AVL : int, VLMAX : int) -> xlenbits = {
 }
 
 /* *********************************** vsetvli *********************************** */
-union clause ast = VSETVLI : (bits(1), bits(1), bits(3), bits(3), regidx, regidx)
+union clause instruction = VSETVLI : (bits(1), bits(1), bits(3), bits(3), regidx, regidx)
 
 mapping clause encdec = VSETVLI(ma, ta, sew, lmul, rs1, rd)
   <-> 0b0000 @ ma @ ta @ sew @ lmul @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b1010111
@@ -128,7 +128,7 @@ mapping clause assembly = VSETVLI(ma, ta, sew, lmul, rs1, rd)
   <-> "vsetvli" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ sew_flag(sew) ^ maybe_lmul_flag(lmul) ^ ta_flag(ta) ^ ma_flag(ma)
 
 /* *********************************** vsetvl ************************************ */
-union clause ast = VSETVL : (regidx, regidx, regidx)
+union clause instruction = VSETVL : (regidx, regidx, regidx)
 
 mapping clause encdec = VSETVL(rs2, rs1, rd)
   <-> 0b1000000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b1010111
@@ -192,7 +192,7 @@ mapping clause assembly = VSETVL(rs2, rs1, rd)
   <-> "vsetvl" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
 /* ********************************** vsetivli *********************************** */
-union clause ast = VSETIVLI : ( bits(1), bits(1), bits(3), bits(3), bits(5), regidx)
+union clause instruction = VSETIVLI : ( bits(1), bits(1), bits(3), bits(3), bits(5), regidx)
 
 mapping clause encdec = VSETIVLI(ma, ta, sew, lmul, uimm, rd)
   <-> 0b1100 @ ma @ ta @ sew @ lmul @ uimm @ 0b111 @ encdec_reg(rd) @ 0b1010111

--- a/model/riscv_insts_zaamo.sail
+++ b/model/riscv_insts_zaamo.sail
@@ -23,7 +23,7 @@ function amo_width_valid(size : word_width) -> bool = {
 
 /* ****************************************************************** */
 
-union clause ast = AMO : (amoop, bool, bool, regidx, regidx, word_width, regidx)
+union clause instruction = AMO : (amoop, bool, bool, regidx, regidx, word_width, regidx)
 
 mapping encdec_amoop : amoop <-> bits(5) = {
   AMOSWAP <-> 0b00001,

--- a/model/riscv_insts_zalrsc.sail
+++ b/model/riscv_insts_zalrsc.sail
@@ -19,7 +19,7 @@ function lrsc_width_valid(size : word_width) -> bool = {
 
 /* ****************************************************************** */
 
-union clause ast = LOADRES : (bool, bool, regidx, word_width, regidx)
+union clause instruction = LOADRES : (bool, bool, regidx, word_width, regidx)
 
 mapping clause encdec = LOADRES(aq, rl, rs1, size, rd)
   <-> 0b00010 @ bool_bits(aq) @ bool_bits(rl) @ 0b00000 @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ encdec_reg(rd) @ 0b0101111
@@ -53,7 +53,7 @@ mapping clause assembly = LOADRES(aq, rl, rs1, size, rd)
 
 /* ****************************************************************** */
 
-union clause ast = STORECON : (bool, bool, regidx, regidx, word_width, regidx)
+union clause instruction = STORECON : (bool, bool, regidx, regidx, word_width, regidx)
 
 mapping clause encdec = STORECON(aq, rl, rs2, rs1, size, rd)
   <-> 0b00011 @ bool_bits(aq) @ bool_bits(rl) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ encdec_reg(rd) @ 0b0101111

--- a/model/riscv_insts_zawrs.sail
+++ b/model/riscv_insts_zawrs.sail
@@ -12,7 +12,7 @@ function clause currentlyEnabled(Ext_Zawrs) = hartSupports(Ext_Zawrs)
 
 /* ****************************************************************** */
 
-union clause ast = WRS : (wrsop)
+union clause instruction = WRS : (wrsop)
 mapping encdec_wrsop : wrsop <-> bits(12) = {
   WRS_STO <-> 0b000000011101,
   WRS_NTO <-> 0b000000001101,

--- a/model/riscv_insts_zba.sail
+++ b/model/riscv_insts_zba.sail
@@ -10,7 +10,7 @@ function clause currentlyEnabled(Ext_B) = hartSupports(Ext_B) & misa[B] == 0b1
 function clause currentlyEnabled(Ext_Zba) = hartSupports(Ext_Zba) | currentlyEnabled(Ext_B)
 
 /* ****************************************************************** */
-union clause ast = SLLIUW : (bits(6), regidx, regidx)
+union clause instruction = SLLIUW : (bits(6), regidx, regidx)
 
 mapping clause encdec = SLLIUW(shamt, rs1, rd)
   <-> 0b000010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
@@ -25,7 +25,7 @@ function clause execute (SLLIUW(shamt, rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = ZBA_RTYPEUW : (regidx, regidx, regidx, bropw_zba)
+union clause instruction = ZBA_RTYPEUW : (regidx, regidx, regidx, bropw_zba)
 
 mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, ADDUW)
   <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0111011
@@ -65,7 +65,7 @@ function clause execute (ZBA_RTYPEUW(rs2, rs1, rd, op)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = ZBA_RTYPE : (regidx, regidx, regidx, brop_zba)
+union clause instruction = ZBA_RTYPE : (regidx, regidx, regidx, brop_zba)
 
 mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, SH1ADD)
   <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011

--- a/model/riscv_insts_zbb.sail
+++ b/model/riscv_insts_zbb.sail
@@ -10,7 +10,7 @@ function clause currentlyEnabled(Ext_Zbb) = hartSupports(Ext_Zbb) | currentlyEna
 function clause currentlyEnabled(Ext_Zbkb) = hartSupports(Ext_Zbkb)
 
 /* ****************************************************************** */
-union clause ast = RORIW : (bits(5), regidx, regidx)
+union clause instruction = RORIW : (bits(5), regidx, regidx)
 
 mapping clause encdec = RORIW(shamt, rs1, rd)
   <-> 0b0110000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0011011
@@ -25,7 +25,7 @@ function clause execute (RORIW(shamt, rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = RORI : (bits(6), regidx, regidx)
+union clause instruction = RORI : (bits(6), regidx, regidx)
 
 mapping clause encdec = RORI(shamt, rs1, rd)
   <-> 0b011000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
@@ -41,7 +41,7 @@ function clause execute (RORI(shamt, rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = ZBB_RTYPEW : (regidx, regidx, regidx, bropw_zbb)
+union clause instruction = ZBB_RTYPEW : (regidx, regidx, regidx, bropw_zbb)
 
 mapping clause encdec = ZBB_RTYPEW(rs2, rs1, rd, ROLW)
   <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0111011
@@ -71,7 +71,7 @@ function clause execute (ZBB_RTYPEW(rs2, rs1, rd, op)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = ZBB_RTYPE : (regidx, regidx, regidx, brop_zbb)
+union clause instruction = ZBB_RTYPE : (regidx, regidx, regidx, brop_zbb)
 
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, ANDN)
   <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
@@ -143,7 +143,7 @@ function clause execute (ZBB_RTYPE(rs2, rs1, rd, op)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = ZBB_EXTOP : (regidx, regidx, extop_zbb)
+union clause instruction = ZBB_EXTOP : (regidx, regidx, extop_zbb)
 
 mapping clause encdec = ZBB_EXTOP(rs1, rd, SEXTB)
   <-> 0b0110000 @ 0b00100 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
@@ -182,7 +182,7 @@ function clause execute (ZBB_EXTOP(rs1, rd, op)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = REV8 : (regidx, regidx)
+union clause instruction = REV8 : (regidx, regidx)
 
 mapping clause encdec = REV8(rs1, rd)
   <-> 0b011010011000 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
@@ -201,7 +201,7 @@ function clause execute (REV8(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = ORCB : (regidx, regidx)
+union clause instruction = ORCB : (regidx, regidx)
 
 mapping clause encdec = ORCB(rs1, rd)
   <-> 0b001010000111 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
@@ -222,7 +222,7 @@ function clause execute (ORCB(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = CPOP : (regidx, regidx)
+union clause instruction = CPOP : (regidx, regidx)
 
 mapping clause encdec = CPOP(rs1, rd)
   <-> 0b011000000010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
@@ -237,7 +237,7 @@ function clause execute (CPOP(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = CPOPW : (regidx, regidx)
+union clause instruction = CPOPW : (regidx, regidx)
 
 mapping clause encdec = CPOPW(rs1, rd)
   <-> 0b011000000010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
@@ -252,7 +252,7 @@ function clause execute (CPOPW(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = CLZ : (regidx, regidx)
+union clause instruction = CLZ : (regidx, regidx)
 
 mapping clause encdec = CLZ(rs1, rd)
   <-> 0b011000000000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
@@ -267,7 +267,7 @@ function clause execute (CLZ(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = CLZW : (regidx, regidx)
+union clause instruction = CLZW : (regidx, regidx)
 
 mapping clause encdec = CLZW(rs1, rd)
   <-> 0b011000000000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
@@ -282,7 +282,7 @@ function clause execute (CLZW(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = CTZ : (regidx, regidx)
+union clause instruction = CTZ : (regidx, regidx)
 
 mapping clause encdec = CTZ(rs1, rd)
   <-> 0b011000000001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
@@ -297,7 +297,7 @@ function clause execute (CTZ(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = CTZW : (regidx, regidx)
+union clause instruction = CTZW : (regidx, regidx)
 
 mapping clause encdec = CTZW(rs1, rd)
   <-> 0b011000000001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011

--- a/model/riscv_insts_zbc.sail
+++ b/model/riscv_insts_zbc.sail
@@ -10,7 +10,7 @@ function clause currentlyEnabled(Ext_Zbc) = hartSupports(Ext_Zbc)
 function clause currentlyEnabled(Ext_Zbkc) = hartSupports(Ext_Zbkc)
 
 /* ****************************************************************** */
-union clause ast = CLMUL : (regidx, regidx, regidx)
+union clause instruction = CLMUL : (regidx, regidx, regidx)
 
 mapping clause encdec = CLMUL(rs2, rs1, rd)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
@@ -26,7 +26,7 @@ function clause execute (CLMUL(rs2, rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = CLMULH : (regidx, regidx, regidx)
+union clause instruction = CLMULH : (regidx, regidx, regidx)
 
 mapping clause encdec = CLMULH(rs2, rs1, rd)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b011 @ encdec_reg(rd) @ 0b0110011
@@ -42,7 +42,7 @@ function clause execute (CLMULH(rs2, rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = CLMULR : (regidx, regidx, regidx)
+union clause instruction = CLMULR : (regidx, regidx, regidx)
 
 mapping clause encdec = CLMULR(rs2, rs1, rd)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011

--- a/model/riscv_insts_zbkb.sail
+++ b/model/riscv_insts_zbkb.sail
@@ -7,7 +7,7 @@
 /*=======================================================================================*/
 
 /* ****************************************************************** */
-union clause ast = ZBKB_RTYPE : (regidx, regidx, regidx, brop_zbkb)
+union clause instruction = ZBKB_RTYPE : (regidx, regidx, regidx, brop_zbkb)
 
 mapping clause encdec = ZBKB_RTYPE(rs2, rs1, rd, PACK)
   <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
@@ -37,7 +37,7 @@ function clause execute (ZBKB_RTYPE(rs2, rs1, rd, op)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = ZBKB_PACKW : (regidx, regidx, regidx)
+union clause instruction = ZBKB_PACKW : (regidx, regidx, regidx)
 
 mapping clause encdec = ZBKB_PACKW(rs2, rs1, rd)
   <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0111011
@@ -56,7 +56,7 @@ function clause execute (ZBKB_PACKW(rs2, rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = ZIP : (regidx, regidx)
+union clause instruction = ZIP : (regidx, regidx)
 
 mapping clause encdec = ZIP(rs1, rd)
   <-> 0b000010001111 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
@@ -78,7 +78,7 @@ function clause execute (ZIP(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = UNZIP : (regidx, regidx)
+union clause instruction = UNZIP : (regidx, regidx)
 
 mapping clause encdec = UNZIP(rs1, rd)
   <-> 0b000010001111 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
@@ -100,7 +100,7 @@ function clause execute (UNZIP(rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = BREV8 : (regidx, regidx)
+union clause instruction = BREV8 : (regidx, regidx)
 
 mapping clause encdec = BREV8(rs1, rd)
   <-> 0b011010000111 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011

--- a/model/riscv_insts_zbkx.sail
+++ b/model/riscv_insts_zbkx.sail
@@ -9,7 +9,7 @@
 function clause currentlyEnabled(Ext_Zbkx) = hartSupports(Ext_Zbkx)
 
 /* ****************************************************************** */
-union clause ast = XPERM8 : (regidx, regidx, regidx)
+union clause instruction = XPERM8 : (regidx, regidx, regidx)
 
 mapping clause encdec = XPERM8(rs2, rs1, rd)
   <-> 0b0010100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
@@ -33,7 +33,7 @@ function clause execute (XPERM8(rs2, rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = XPERM4 : (regidx, regidx, regidx)
+union clause instruction = XPERM4 : (regidx, regidx, regidx)
 
 mapping clause encdec = XPERM4(rs2, rs1, rd)
   <-> 0b0010100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011

--- a/model/riscv_insts_zbs.sail
+++ b/model/riscv_insts_zbs.sail
@@ -9,7 +9,7 @@
 function clause currentlyEnabled(Ext_Zbs) = hartSupports(Ext_Zbs) | currentlyEnabled(Ext_B)
 
 /* ****************************************************************** */
-union clause ast = ZBS_IOP : (bits(6), regidx, regidx, biop_zbs)
+union clause instruction = ZBS_IOP : (bits(6), regidx, regidx, biop_zbs)
 
 mapping clause encdec = ZBS_IOP(shamt, rs1, rd, BCLRI)
   <-> 0b010010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
@@ -53,7 +53,7 @@ function clause execute (ZBS_IOP(shamt, rs1, rd, op)) = {
 }
 
 /* ****************************************************************** */
-union clause ast = ZBS_RTYPE : (regidx, regidx, regidx, brop_zbs)
+union clause instruction = ZBS_RTYPE : (regidx, regidx, regidx, brop_zbs)
 
 mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, BCLR)
   <-> 0b0100100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011

--- a/model/riscv_insts_zca.sail
+++ b/model/riscv_insts_zca.sail
@@ -14,7 +14,7 @@
  */
 
 /* ****************************************************************** */
-union clause ast = C_NOP : (bits(6))
+union clause instruction = C_NOP : (bits(6))
 
 mapping clause encdec_compressed = C_NOP(imm5 @ imm40)
   <-> 0b000 @ imm5 : bits(1) @ 0b00000 @ imm40 : bits(5) @ 0b01
@@ -31,7 +31,7 @@ mapping clause assembly = C_NOP(imm)
   when imm != zeros()
 
 /* ****************************************************************** */
-union clause ast = C_ADDI4SPN : (cregidx, bits(8))
+union clause instruction = C_ADDI4SPN : (cregidx, bits(8))
 
 mapping clause encdec_compressed = C_ADDI4SPN(rd, nz96 @ nz54 @ nz3 @ nz2)
   <-> 0b000 @ nz54 : bits(2) @ nz96 : bits(4) @ nz2 : bits(1) @ nz3 : bits(1) @ encdec_creg(rd) @ 0b00
@@ -49,7 +49,7 @@ mapping clause assembly = C_ADDI4SPN(rdc, nzimm)
       if nzimm != 0b00000000
 
 /* ****************************************************************** */
-union clause ast = C_LW : (bits(5), cregidx, cregidx)
+union clause instruction = C_LW : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_LW(ui6 @ ui53 @ ui2, rs1, rd)
   <-> 0b010 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_creg(rd) @ 0b00
@@ -66,7 +66,7 @@ mapping clause assembly = C_LW(uimm, rsc, rdc)
   <-> "c.lw" ^ spc() ^ creg_name(rdc) ^ sep() ^ hex_bits_7(uimm @ 0b00) ^ "(" ^ creg_name(rsc) ^ ")"
 
 /* ****************************************************************** */
-union clause ast = C_LD : (bits(5), cregidx, cregidx)
+union clause instruction = C_LD : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_LD(ui76 @ ui53, rs1, rd)
   <-> 0b011 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_creg(rd) @ 0b00
@@ -84,7 +84,7 @@ mapping clause assembly = C_LD(uimm, rsc, rdc)
   when xlen == 64
 
 /* ****************************************************************** */
-union clause ast = C_SW : (bits(5), cregidx, cregidx)
+union clause instruction = C_SW : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SW(ui6 @ ui53 @ ui2, rs1, rs2)
   <-> 0b110 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_creg(rs2) @ 0b00
@@ -101,7 +101,7 @@ mapping clause assembly = C_SW(uimm, rsc1, rsc2)
   <-> "c.sw" ^ spc() ^ creg_name(rsc2) ^ sep() ^ hex_bits_7(uimm @ 0b00) ^ "(" ^ creg_name(rsc1) ^ ")"
 
 /* ****************************************************************** */
-union clause ast = C_SD : (bits(5), cregidx, cregidx)
+union clause instruction = C_SD : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SD(ui76 @ ui53, rs1, rs2)
       if xlen == 64 & currentlyEnabled(Ext_Zca)
@@ -121,7 +121,7 @@ mapping clause assembly = C_SD(uimm, rsc1, rsc2)
       if xlen == 64
 
 /* ****************************************************************** */
-union clause ast = C_ADDI : (bits(6), regidx)
+union clause instruction = C_ADDI : (bits(6), regidx)
 
 // Code points with rsd=x0 are c.nop.
 // c.addi with imm=0 are hints.
@@ -139,7 +139,7 @@ mapping clause assembly = C_ADDI(imm, rsd)
   when rsd != zreg
 
 /* ****************************************************************** */
-union clause ast = C_JAL : (bits(11))
+union clause instruction = C_JAL : (bits(11))
 
 mapping clause encdec_compressed = C_JAL(i11 @ i10 @ i98 @ i7 @ i6 @ i5 @ i4 @ i31)
   <-> 0b001 @ i11 : bits(1) @ i4 : bits(1) @ i98 : bits(2) @ i10 : bits(1) @ i6 : bits(1) @ i7 : bits(1) @ i31 : bits(3) @ i5 : bits(1) @ 0b01
@@ -153,7 +153,7 @@ mapping clause assembly = C_JAL(imm)
   when xlen == 32
 
 /* ****************************************************************** */
-union clause ast = C_ADDIW : (bits(6), regidx)
+union clause instruction = C_ADDIW : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_ADDIW(imm5 @ imm40, rsd)
   <-> 0b001 @ imm5 : bits(1) @ encdec_reg(rsd) @ imm40 : bits(5) @ 0b01
@@ -167,7 +167,7 @@ mapping clause assembly = C_ADDIW(imm, rsd)
   when xlen == 64
 
 /* ****************************************************************** */
-union clause ast = C_LI : (bits(6), regidx)
+union clause instruction = C_LI : (bits(6), regidx)
 
 // c.li with rd=x0 are hints.
 mapping clause encdec_compressed = C_LI(imm5 @ imm40, rd)
@@ -183,7 +183,7 @@ mapping clause assembly = C_LI(imm, rd)
   <-> "c.li" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_signed_6(imm)
 
 /* ****************************************************************** */
-union clause ast = C_ADDI16SP : (bits(6))
+union clause instruction = C_ADDI16SP : (bits(6))
 
 mapping clause encdec_compressed = C_ADDI16SP(nzi9 @ nzi87 @ nzi6 @ nzi5 @ nzi4)
   <-> 0b011 @ nzi9 : bits(1) @ /* x2 */ 0b00010 @ nzi4 : bits(1) @ nzi6 : bits(1) @ nzi87 : bits(2) @ nzi5 : bits(1) @ 0b01
@@ -199,7 +199,7 @@ mapping clause assembly = C_ADDI16SP(imm)
   when imm != 0b000000
 
 /* ****************************************************************** */
-union clause ast = C_LUI : (bits(6), regidx)
+union clause instruction = C_LUI : (bits(6), regidx)
 
 // c.lui with rd=x0 are hints.
 // Code points with rd=x2 are c.addi16sp.
@@ -218,7 +218,7 @@ mapping clause assembly = C_LUI(imm, rd)
   when rd != sp & imm != 0b000000
 
 /* ****************************************************************** */
-union clause ast = C_SRLI : (bits(6), cregidx)
+union clause instruction = C_SRLI : (bits(6), cregidx)
 
 // c.srli with shamt=0 are hints.
 mapping clause encdec_compressed = C_SRLI(shamt5 @ shamt40, rsd)
@@ -234,7 +234,7 @@ mapping clause assembly = C_SRLI(shamt, rsd)
   <-> "c.srli" ^ spc() ^ creg_name(rsd) ^ sep() ^ hex_bits_6(shamt)
 
 /* ****************************************************************** */
-union clause ast = C_SRAI : (bits(6), cregidx)
+union clause instruction = C_SRAI : (bits(6), cregidx)
 
 // c.srai with shamt=0 are hints.
 mapping clause encdec_compressed = C_SRAI(shamt5 @ shamt40, rsd)
@@ -250,7 +250,7 @@ mapping clause assembly = C_SRAI(shamt, rsd)
   <-> "c.srai" ^ spc() ^ creg_name(rsd) ^ sep() ^ hex_bits_6(shamt)
 
 /* ****************************************************************** */
-union clause ast = C_ANDI : (bits(6), cregidx)
+union clause instruction = C_ANDI : (bits(6), cregidx)
 
 mapping clause encdec_compressed = C_ANDI(i5 @ i40, rsd)
   <-> 0b100 @ i5 : bits(1) @ 0b10 @ encdec_creg(rsd) @ i40 : bits(5) @ 0b01
@@ -265,7 +265,7 @@ mapping clause assembly = C_ANDI(imm, rsd)
   <-> "c.andi" ^ spc() ^ creg_name(rsd) ^ sep() ^ hex_bits_signed_6(imm)
 
 /* ****************************************************************** */
-union clause ast = C_SUB : (cregidx, cregidx)
+union clause instruction = C_SUB : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SUB(rsd, rs2)
   <-> 0b100 @ 0b0 @ 0b11 @ encdec_creg(rsd) @ 0b00 @ encdec_creg(rs2) @ 0b01
@@ -281,7 +281,7 @@ mapping clause assembly = C_SUB(rsd, rs2)
   <-> "c.sub" ^ spc() ^ creg_name(rsd) ^ sep() ^ creg_name(rs2)
 
 /* ****************************************************************** */
-union clause ast = C_XOR : (cregidx, cregidx)
+union clause instruction = C_XOR : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_XOR(rsd, rs2)
   <-> 0b100 @ 0b0 @ 0b11 @ encdec_creg(rsd) @ 0b01 @ encdec_creg(rs2) @ 0b01
@@ -297,7 +297,7 @@ mapping clause assembly = C_XOR(rsd, rs2)
   <-> "c.xor" ^ spc() ^ creg_name(rsd) ^ sep() ^ creg_name(rs2)
 
 /* ****************************************************************** */
-union clause ast = C_OR : (cregidx, cregidx)
+union clause instruction = C_OR : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_OR(rsd, rs2)
   <-> 0b100 @ 0b0 @ 0b11 @ encdec_creg(rsd) @ 0b10 @ encdec_creg(rs2) @ 0b01
@@ -313,7 +313,7 @@ mapping clause assembly = C_OR(rsd, rs2)
   <-> "c.or" ^ spc() ^ creg_name(rsd) ^ sep() ^ creg_name(rs2)
 
 /* ****************************************************************** */
-union clause ast = C_AND : (cregidx, cregidx)
+union clause instruction = C_AND : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_AND(rsd, rs2)
   <-> 0b100 @ 0b0 @ 0b11 @ encdec_creg(rsd) @ 0b11 @ encdec_creg(rs2) @ 0b01
@@ -329,7 +329,7 @@ mapping clause assembly = C_AND(rsd, rs2)
   <-> "c.and" ^ spc() ^ creg_name(rsd) ^ sep() ^ creg_name(rs2)
 
 /* ****************************************************************** */
-union clause ast = C_SUBW : (cregidx, cregidx)
+union clause instruction = C_SUBW : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SUBW(rsd, rs2)
   <-> 0b100 @ 0b1 @ 0b11 @ encdec_creg(rsd) @ 0b00 @ encdec_creg(rs2) @ 0b01
@@ -346,7 +346,7 @@ mapping clause assembly = C_SUBW(rsd, rs2)
   when xlen == 64
 
 /* ****************************************************************** */
-union clause ast = C_ADDW : (cregidx, cregidx)
+union clause instruction = C_ADDW : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_ADDW(rsd, rs2)
   <-> 0b100 @ 0b1 @ 0b11 @ encdec_creg(rsd) @ 0b01 @ encdec_creg(rs2) @ 0b01
@@ -363,7 +363,7 @@ mapping clause assembly = C_ADDW(rsd, rs2)
   when xlen == 64
 
 /* ****************************************************************** */
-union clause ast = C_J : (bits(11))
+union clause instruction = C_J : (bits(11))
 
 mapping clause encdec_compressed = C_J(i11 @ i10 @ i98 @ i7 @ i6 @ i5 @ i4 @ i31)
   <-> 0b101 @ i11 : bits(1) @ i4 : bits(1) @ i98 : bits(2) @ i10 : bits(1) @ i6 : bits(1) @ i7 : bits(1) @ i31 : bits(3) @ i5 : bits(1) @ 0b01
@@ -376,7 +376,7 @@ mapping clause assembly = C_J(imm)
   <-> "c.j" ^ spc() ^ hex_bits_signed_12(imm @ 0b0)
 
 /* ****************************************************************** */
-union clause ast = C_BEQZ : (bits(8), cregidx)
+union clause instruction = C_BEQZ : (bits(8), cregidx)
 
 mapping clause encdec_compressed = C_BEQZ(i8 @ i76 @ i5 @ i43 @ i21, rs)
   <-> 0b110 @ i8 : bits(1) @ i43 : bits(2) @ encdec_creg(rs) @ i76 : bits(2) @ i21 : bits(2) @ i5 : bits(1) @ 0b01
@@ -389,7 +389,7 @@ mapping clause assembly = C_BEQZ(imm, rs)
   <-> "c.beqz" ^ spc() ^ creg_name(rs) ^ sep() ^ hex_bits_signed_9(imm @ 0b0)
 
 /* ****************************************************************** */
-union clause ast = C_BNEZ : (bits(8), cregidx)
+union clause instruction = C_BNEZ : (bits(8), cregidx)
 
 mapping clause encdec_compressed = C_BNEZ(i8 @ i76 @ i5 @ i43 @ i21, rs)
   <-> 0b111 @ i8 : bits(1) @ i43 : bits(2) @ encdec_creg(rs) @ i76 : bits(2) @ i21 : bits(2) @ i5 : bits(1) @ 0b01
@@ -402,7 +402,7 @@ mapping clause assembly = C_BNEZ(imm, rs)
   <-> "c.bnez" ^ spc() ^ creg_name(rs) ^ sep() ^ hex_bits_signed_9(imm @ 0b0)
 
 /* ****************************************************************** */
-union clause ast = C_SLLI : (bits(6), regidx)
+union clause instruction = C_SLLI : (bits(6), regidx)
 
 // c.slli with shamt=0 or rsd=x0 are hints.
 mapping clause encdec_compressed = C_SLLI(shamt5 @ shamt40, rsd)
@@ -416,7 +416,7 @@ mapping clause assembly = C_SLLI(shamt, rsd)
   <-> "c.slli" ^ spc() ^ reg_name(rsd) ^ sep() ^ hex_bits_6(shamt)
 
 /* ****************************************************************** */
-union clause ast = C_LWSP : (bits(6), regidx)
+union clause instruction = C_LWSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_LWSP(ui76 @ ui5 @ ui42, rd)
   <-> 0b010 @ ui5 : bits(1) @ encdec_reg(rd) @ ui42 : bits(3) @ ui76 : bits(2) @ 0b10
@@ -432,7 +432,7 @@ mapping clause assembly = C_LWSP(uimm, rd)
   when rd != zreg
 
 /* ****************************************************************** */
-union clause ast = C_LDSP : (bits(6), regidx)
+union clause instruction = C_LDSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_LDSP(ui86 @ ui5 @ ui43, rd)
   <-> 0b011 @ ui5 : bits(1) @ encdec_reg(rd) @ ui43 : bits(2) @ ui86 : bits(3) @ 0b10
@@ -448,7 +448,7 @@ mapping clause assembly = C_LDSP(uimm, rd)
   when rd != zreg & xlen == 64
 
 /* ****************************************************************** */
-union clause ast = C_SWSP : (bits(6), regidx)
+union clause instruction = C_SWSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_SWSP(ui76 @ ui52, rs2)
   <-> 0b110 @ ui52 : bits(4) @ ui76 : bits(2) @ encdec_reg(rs2) @ 0b10
@@ -463,7 +463,7 @@ mapping clause assembly = C_SWSP(uimm, rs2)
   <-> "c.swsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_8(uimm @ 0b00) ^ "(" ^ sp_reg_name() ^ ")"
 
 /* ****************************************************************** */
-union clause ast = C_SDSP : (bits(6), regidx)
+union clause instruction = C_SDSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_SDSP(ui86 @ ui53, rs2)
   <-> 0b111 @ ui53 : bits(3) @ ui86 : bits(3) @ encdec_reg(rs2) @ 0b10
@@ -479,7 +479,7 @@ mapping clause assembly = C_SDSP(uimm, rs2)
   when xlen == 64
 
 /* ****************************************************************** */
-union clause ast = C_JR : (regidx)
+union clause instruction = C_JR : (regidx)
 
 mapping clause encdec_compressed = C_JR(rs1)
   <-> 0b100 @ 0b0 @ encdec_reg(rs1) @ 0b00000 @ 0b10
@@ -493,7 +493,7 @@ mapping clause assembly = C_JR(rs1)
   when rs1 != zreg
 
 /* ****************************************************************** */
-union clause ast = C_JALR : (regidx)
+union clause instruction = C_JALR : (regidx)
 
 mapping clause encdec_compressed = C_JALR(rs1)
   <-> 0b100 @ 0b1 @ encdec_reg(rs1) @ 0b00000 @ 0b10
@@ -507,7 +507,7 @@ mapping clause assembly = C_JALR(rs1)
   when rs1 != zreg
 
 /* ****************************************************************** */
-union clause ast = C_MV : (regidx, regidx)
+union clause instruction = C_MV : (regidx, regidx)
 
 // Code points with rs2=0 are c.jr.
 // c.mv with rd=x0 are hints.
@@ -523,7 +523,7 @@ mapping clause assembly = C_MV(rd, rs2)
   when rs2 != zreg
 
 /* ****************************************************************** */
-union clause ast = C_EBREAK : unit
+union clause instruction = C_EBREAK : unit
 
 mapping clause encdec_compressed = C_EBREAK()
   <-> 0b100 @ 0b1 @ 0b00000 @ 0b00000 @ 0b10
@@ -535,7 +535,7 @@ function clause execute C_EBREAK() =
 mapping clause assembly = C_EBREAK() <-> "c.ebreak"
 
 /* ****************************************************************** */
-union clause ast = C_ADD : (regidx, regidx)
+union clause instruction = C_ADD : (regidx, regidx)
 
 // Code points with rs2=x0 are c.jalr/c.ebreak.
 // c.add with rsd=x0 are hints.

--- a/model/riscv_insts_zcb.sail
+++ b/model/riscv_insts_zcb.sail
@@ -8,7 +8,7 @@
 
 function clause currentlyEnabled(Ext_Zcb) = hartSupports(Ext_Zcb) & currentlyEnabled(Ext_Zca)
 
-union clause ast = C_LBU : (bits(2), cregidx, cregidx)
+union clause instruction = C_LBU : (bits(2), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_LBU(uimm1 @ uimm0, rdc, rsc1)
   <-> 0b100 @ 0b000 @ encdec_creg(rsc1) @ uimm0 : bits(1) @ uimm1 : bits(1) @ encdec_creg(rdc) @ 0b00
@@ -26,7 +26,7 @@ function clause execute C_LBU(uimm, rdc, rsc1) = {
 
 /* ****************************************************************** */
 
-union clause ast = C_LHU : (bits(2), cregidx, cregidx)
+union clause instruction = C_LHU : (bits(2), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_LHU(uimm1 @ 0b0, rdc, rsc1)
   <-> 0b100 @ 0b001 @ encdec_creg(rsc1) @ 0b0 @ uimm1 : bits(1) @ encdec_creg(rdc) @ 0b00
@@ -44,7 +44,7 @@ function clause execute C_LHU(uimm, rdc, rsc1) = {
 
 /* ****************************************************************** */
 
-union clause ast = C_LH : (bits(2), cregidx, cregidx)
+union clause instruction = C_LH : (bits(2), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_LH(uimm1 @ 0b0, rdc, rsc1)
   <-> 0b100 @ 0b001 @ encdec_creg(rsc1) @ 0b1 @ uimm1 : bits(1) @ encdec_creg(rdc) @ 0b00
@@ -62,7 +62,7 @@ function clause execute C_LH(uimm, rdc, rsc1) = {
 
 /* ****************************************************************** */
 
-union clause ast = C_SB : (bits(2), cregidx, cregidx)
+union clause instruction = C_SB : (bits(2), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SB(uimm1 @ uimm0, rsc1, rsc2)
   <-> 0b100 @ 0b010 @ encdec_creg(rsc1) @ uimm0 : bits(1) @ uimm1 : bits(1) @ encdec_creg(rsc2) @ 0b00
@@ -80,7 +80,7 @@ function clause execute C_SB(uimm, rsc1, rsc2) = {
 
 /* ****************************************************************** */
 
-union clause ast = C_SH : (bits(2), cregidx, cregidx)
+union clause instruction = C_SH : (bits(2), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SH(uimm1 @ 0b0, rsc1, rsc2)
   <-> 0b100 @ 0b011 @ encdec_creg(rsc1) @ 0b0 @ uimm1 : bits(1) @ encdec_creg(rsc2) @ 0b00
@@ -98,7 +98,7 @@ function clause execute C_SH(uimm, rsc1, rsc2) = {
 
 /* ****************************************************************** */
 
-union clause ast = C_ZEXT_B : (cregidx)
+union clause instruction = C_ZEXT_B : (cregidx)
 
 mapping clause encdec_compressed = C_ZEXT_B(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b000 @ 0b01
@@ -115,7 +115,7 @@ function clause execute C_ZEXT_B(rsdc) = {
 
 /* ****************************************************************** */
 
-union clause ast = C_SEXT_B : (cregidx)
+union clause instruction = C_SEXT_B : (cregidx)
 
 mapping clause encdec_compressed = C_SEXT_B(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b001 @ 0b01
@@ -131,7 +131,7 @@ function clause execute C_SEXT_B(rsdc) = {
 
 /* ****************************************************************** */
 
-union clause ast = C_ZEXT_H : (cregidx)
+union clause instruction = C_ZEXT_H : (cregidx)
 
 mapping clause encdec_compressed = C_ZEXT_H(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b010 @ 0b01
@@ -147,7 +147,7 @@ function clause execute C_ZEXT_H(rsdc) = {
 
 /* ****************************************************************** */
 
-union clause ast = C_SEXT_H : (cregidx)
+union clause instruction = C_SEXT_H : (cregidx)
 
 mapping clause encdec_compressed = C_SEXT_H(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b011 @ 0b01
@@ -163,7 +163,7 @@ function clause execute C_SEXT_H(rsdc) = {
 
 /* ****************************************************************** */
 
-union clause ast = C_ZEXT_W : (cregidx)
+union clause instruction = C_ZEXT_W : (cregidx)
 
 mapping clause encdec_compressed = C_ZEXT_W(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b100 @ 0b01
@@ -179,7 +179,7 @@ function clause execute C_ZEXT_W(rsdc) = {
 
 /* ****************************************************************** */
 
-union clause ast = C_NOT : (cregidx)
+union clause instruction = C_NOT : (cregidx)
 
 mapping clause encdec_compressed = C_NOT(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b101 @ 0b01
@@ -196,7 +196,7 @@ function clause execute C_NOT(rsdc) = {
 
 /* ****************************************************************** */
 
-union clause ast = C_MUL : (cregidx, cregidx)
+union clause instruction = C_MUL : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_MUL(rsdc, rsc2)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b10 @ encdec_creg(rsc2) @ 0b01

--- a/model/riscv_insts_zcd.sail
+++ b/model/riscv_insts_zcd.sail
@@ -8,7 +8,7 @@
 
 function clause currentlyEnabled(Ext_Zcd) = hartSupports(Ext_Zcd) & currentlyEnabled(Ext_D) & currentlyEnabled(Ext_Zca) & (currentlyEnabled(Ext_C) | not(hartSupports(Ext_C)))
 
-union clause ast = C_FLDSP : (bits(6), fregidx)
+union clause instruction = C_FLDSP : (bits(6), fregidx)
 
 mapping clause encdec_compressed = C_FLDSP(ui86 @ ui5 @ ui43, rd)
   <-> 0b001 @ ui5 : bits(1) @ encdec_freg(rd) @ ui43 : bits(2) @ ui86 : bits(3) @ 0b10
@@ -25,7 +25,7 @@ mapping clause assembly = C_FLDSP(uimm, rd)
       if (xlen == 32 | xlen == 64)
 
 /* ****************************************************************** */
-union clause ast = C_FSDSP : (bits(6), fregidx)
+union clause instruction = C_FSDSP : (bits(6), fregidx)
 
 mapping clause encdec_compressed = C_FSDSP(ui86 @ ui53, rs2)
   <-> 0b101 @ ui53 : bits(3) @ ui86 : bits(3) @ encdec_freg(rs2) @ 0b10
@@ -42,7 +42,7 @@ mapping clause assembly = C_FSDSP(uimm, rs2)
       if (xlen == 32 | xlen == 64)
 
 /* ****************************************************************** */
-union clause ast = C_FLD : (bits(5), cregidx, cregidx)
+union clause instruction = C_FLD : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_FLD(ui76 @ ui53, rs1, rd)
   <-> 0b001 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_creg(rd) @ 0b00
@@ -61,7 +61,7 @@ mapping clause assembly = C_FLD(uimm, rsc, rdc)
       if (xlen == 32 | xlen == 64)
 
 /* ****************************************************************** */
-union clause ast = C_FSD : (bits(5), cregidx, cregidx)
+union clause instruction = C_FSD : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_FSD(ui76 @ ui53, rs1, rs2)
   <-> 0b101 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_creg(rs2) @ 0b00

--- a/model/riscv_insts_zcf.sail
+++ b/model/riscv_insts_zcf.sail
@@ -8,7 +8,7 @@
 
 function clause currentlyEnabled(Ext_Zcf) = hartSupports(Ext_Zcf) & currentlyEnabled(Ext_F) & currentlyEnabled(Ext_Zca) & (currentlyEnabled(Ext_C) | not(hartSupports(Ext_C)))
 
-union clause ast = C_FLWSP : (bits(6), fregidx)
+union clause instruction = C_FLWSP : (bits(6), fregidx)
 
 mapping clause encdec_compressed = C_FLWSP(ui76 @ ui5 @ ui42, rd)
   <-> 0b011 @ ui5 : bits(1) @ encdec_freg(rd) @ ui42 : bits(3) @ ui76 : bits(2) @ 0b10
@@ -24,7 +24,7 @@ mapping clause assembly = C_FLWSP(imm, rd)
   when xlen == 32
 
 /* ****************************************************************** */
-union clause ast = C_FSWSP : (bits(6), fregidx)
+union clause instruction = C_FSWSP : (bits(6), fregidx)
 
 mapping clause encdec_compressed = C_FSWSP(ui76 @ ui52, rs2)
   <-> 0b111 @ ui52 : bits(4) @ ui76 : bits(2) @ encdec_freg(rs2) @ 0b10
@@ -40,7 +40,7 @@ mapping clause assembly = C_FSWSP(uimm, rs2)
   when xlen == 32
 
 /* ****************************************************************** */
-union clause ast = C_FLW : (bits(5), cregidx, cregidx)
+union clause instruction = C_FLW : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_FLW(ui6 @ ui53 @ ui2, rs1, rd)
   <-> 0b011 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_creg(rd) @ 0b00
@@ -58,7 +58,7 @@ mapping clause assembly = C_FLW(uimm, rsc, rdc)
   when xlen == 32
 
 /* ****************************************************************** */
-union clause ast = C_FSW : (bits(5), cregidx, cregidx)
+union clause instruction = C_FSW : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_FSW(ui6 @ ui53 @ ui2, rs1, rs2)
   <-> 0b111 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_creg(rs2) @ 0b00

--- a/model/riscv_insts_zcmop.sail
+++ b/model/riscv_insts_zcmop.sail
@@ -8,7 +8,7 @@
 
 function clause currentlyEnabled(Ext_Zcmop) = hartSupports(Ext_Zcmop) & currentlyEnabled(Ext_Zca)
 
-union clause ast = ZCMOP : (bits(3))
+union clause instruction = ZCMOP : (bits(3))
 
 mapping clause encdec_compressed = ZCMOP(mop)
   <-> 0b01100 @ mop : bits(3) @ 0b100000 @ 0b01

--- a/model/riscv_insts_zfa.sail
+++ b/model/riscv_insts_zfa.sail
@@ -10,7 +10,7 @@ function clause currentlyEnabled(Ext_Zfa) = hartSupports(Ext_Zfa) & currentlyEna
 
 /* FLI.H */
 
-union clause ast = FLI_H : (bits(5), fregidx)
+union clause instruction = FLI_H : (bits(5), fregidx)
 
 mapping clause encdec = FLI_H(constantidx, rd)
   <-> 0b111_1010 @ 0b00001 @ constantidx @ 0b000 @ encdec_freg(rd) @ 0b101_0011
@@ -60,7 +60,7 @@ function clause execute (FLI_H(constantidx, rd)) = {
 
 /* FLI.S */
 
-union clause ast = FLI_S : (bits(5), fregidx)
+union clause instruction = FLI_S : (bits(5), fregidx)
 
 mapping clause encdec = FLI_S(constantidx, rd)
   <-> 0b111_1000 @ 0b00001 @ constantidx @ 0b000 @ encdec_freg(rd) @ 0b101_0011
@@ -110,7 +110,7 @@ function clause execute (FLI_S(constantidx, rd)) = {
 
 /* FLI.D */
 
-union clause ast = FLI_D : (bits(5), fregidx)
+union clause instruction = FLI_D : (bits(5), fregidx)
 
 mapping clause encdec = FLI_D(constantidx, rd)
   <-> 0b111_1001 @ 0b00001 @ constantidx @ 0b000 @ encdec_freg(rd) @ 0b101_0011
@@ -160,7 +160,7 @@ function clause execute (FLI_D(constantidx, rd)) = {
 
 /* FMINM.H */
 
-union clause ast = FMINM_H : (fregidx, fregidx, fregidx)
+union clause instruction = FMINM_H : (fregidx, fregidx, fregidx)
 
 mapping clause encdec = FMINM_H(rs2, rs1, rd)
   <-> 0b001_0110 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b101_0011
@@ -191,7 +191,7 @@ function clause execute (FMINM_H(rs2, rs1, rd)) = {
 
 /* FMAXM.H */
 
-union clause ast = FMAXM_H : (fregidx, fregidx, fregidx)
+union clause instruction = FMAXM_H : (fregidx, fregidx, fregidx)
 
 mapping clause encdec = FMAXM_H(rs2, rs1, rd)
   <-> 0b001_0110 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b011 @ encdec_freg(rd) @ 0b101_0011
@@ -222,7 +222,7 @@ function clause execute (FMAXM_H(rs2, rs1, rd)) = {
 
 /* FMINM.S */
 
-union clause ast = FMINM_S : (fregidx, fregidx, fregidx)
+union clause instruction = FMINM_S : (fregidx, fregidx, fregidx)
 
 mapping clause encdec = FMINM_S(rs2, rs1, rd)
   <-> 0b001_0100 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b101_0011
@@ -253,7 +253,7 @@ function clause execute (FMINM_S(rs2, rs1, rd)) = {
 
 /* FMAXM.S */
 
-union clause ast = FMAXM_S : (fregidx, fregidx, fregidx)
+union clause instruction = FMAXM_S : (fregidx, fregidx, fregidx)
 
 mapping clause encdec = FMAXM_S(rs2, rs1, rd)
   <-> 0b001_0100 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b011 @ encdec_freg(rd) @ 0b101_0011
@@ -284,7 +284,7 @@ function clause execute (FMAXM_S(rs2, rs1, rd)) = {
 
 /* FMINM.D */
 
-union clause ast = FMINM_D : (fregidx, fregidx, fregidx)
+union clause instruction = FMINM_D : (fregidx, fregidx, fregidx)
 
 mapping clause encdec = FMINM_D(rs2, rs1, rd)
   <-> 0b001_0101 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b101_0011
@@ -315,7 +315,7 @@ function clause execute (FMINM_D(rs2, rs1, rd)) = {
 
 /* FMAXM.D */
 
-union clause ast = FMAXM_D : (fregidx, fregidx, fregidx)
+union clause instruction = FMAXM_D : (fregidx, fregidx, fregidx)
 
 mapping clause encdec = FMAXM_D(rs2, rs1, rd)
   <-> 0b001_0101 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b011 @ encdec_freg(rd) @ 0b101_0011
@@ -346,7 +346,7 @@ function clause execute (FMAXM_D(rs2, rs1, rd)) = {
 
 /* FROUND.H */
 
-union clause ast = FROUND_H : (fregidx, rounding_mode, fregidx)
+union clause instruction = FROUND_H : (fregidx, rounding_mode, fregidx)
 
 mapping clause encdec = FROUND_H(rs1, rm, rd)
   <-> 0b010_0010 @ 0b00100 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
@@ -375,7 +375,7 @@ function clause execute (FROUND_H(rs1, rm, rd)) = {
 
 /* FROUNDNX.H */
 
-union clause ast = FROUNDNX_H : (fregidx, rounding_mode, fregidx)
+union clause instruction = FROUNDNX_H : (fregidx, rounding_mode, fregidx)
 
 mapping clause encdec = FROUNDNX_H(rs1, rm, rd)
   <-> 0b010_0010 @ 0b00101 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
@@ -404,7 +404,7 @@ function clause execute (FROUNDNX_H(rs1, rm, rd)) = {
 
 /* FROUND.S */
 
-union clause ast = FROUND_S : (fregidx, rounding_mode, fregidx)
+union clause instruction = FROUND_S : (fregidx, rounding_mode, fregidx)
 
 mapping clause encdec = FROUND_S(rs1, rm, rd)
   <-> 0b010_0000 @ 0b00100 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
@@ -433,7 +433,7 @@ function clause execute (FROUND_S(rs1, rm, rd)) = {
 
 /* FROUNDNX.S */
 
-union clause ast = FROUNDNX_S : (fregidx, rounding_mode, fregidx)
+union clause instruction = FROUNDNX_S : (fregidx, rounding_mode, fregidx)
 
 mapping clause encdec = FROUNDNX_S(rs1, rm, rd)
   <-> 0b010_0000 @ 0b00101 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
@@ -462,7 +462,7 @@ function clause execute (FROUNDNX_S(rs1, rm, rd)) = {
 
 /* FROUND.D */
 
-union clause ast = FROUND_D : (fregidx, rounding_mode, fregidx)
+union clause instruction = FROUND_D : (fregidx, rounding_mode, fregidx)
 
 mapping clause encdec = FROUND_D(rs1, rm, rd)
   <-> 0b010_0001 @ 0b00100 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
@@ -491,7 +491,7 @@ function clause execute (FROUND_D(rs1, rm, rd)) = {
 
 /* FROUNDNX.D */
 
-union clause ast = FROUNDNX_D : (fregidx, rounding_mode, fregidx)
+union clause instruction = FROUNDNX_D : (fregidx, rounding_mode, fregidx)
 
 mapping clause encdec = FROUNDNX_D(rs1, rm, rd)
   <-> 0b010_0001 @ 0b00101 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b101_0011
@@ -520,7 +520,7 @@ function clause execute (FROUNDNX_D(rs1, rm, rd)) = {
 
 /* FMVH.X.D */
 
-union clause ast = FMVH_X_D : (fregidx, regidx)
+union clause instruction = FMVH_X_D : (fregidx, regidx)
 
 mapping clause encdec   = FMVH_X_D(rs1, rd)
   <-> 0b111_0001 @ 0b00001 @ encdec_freg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b101_0011
@@ -539,7 +539,7 @@ function clause execute (FMVH_X_D(rs1, rd)) = {
 
 /* FMVP.X.D */
 
-union clause ast = FMVP_D_X : (regidx, regidx, fregidx)
+union clause instruction = FMVP_D_X : (regidx, regidx, fregidx)
 
 mapping clause encdec = FMVP_D_X(rs2, rs1, rd)
   <-> 0b101_1001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011
@@ -567,7 +567,7 @@ function clause execute (FMVP_D_X(rs2, rs1, rd)) = {
 
 /* FLEQ.H */
 
-union clause ast = FLEQ_H : (fregidx, fregidx, regidx)
+union clause instruction = FLEQ_H : (fregidx, fregidx, regidx)
 
 mapping clause encdec = FLEQ_H(rs2, rs1, rd)
   <-> 0b101_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011
@@ -592,7 +592,7 @@ function clause execute(FLEQ_H(rs2, rs1, rd)) = {
 
 /* FLTQ.H */
 
-union clause ast = FLTQ_H : (fregidx, fregidx, regidx)
+union clause instruction = FLTQ_H : (fregidx, fregidx, regidx)
 
 mapping clause encdec = FLTQ_H(rs2, rs1, rd)
   <-> 0b101_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011
@@ -617,7 +617,7 @@ function clause execute(FLTQ_H(rs2, rs1, rd)) = {
 
 /* FLEQ.S */
 
-union clause ast = FLEQ_S : (fregidx, fregidx, regidx)
+union clause instruction = FLEQ_S : (fregidx, fregidx, regidx)
 
 mapping clause encdec = FLEQ_S(rs2, rs1, rd)
   <-> 0b101_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011
@@ -642,7 +642,7 @@ function clause execute(FLEQ_S(rs2, rs1, rd)) = {
 
 /* FLTQ.S */
 
-union clause ast = FLTQ_S : (fregidx, fregidx, regidx)
+union clause instruction = FLTQ_S : (fregidx, fregidx, regidx)
 
 mapping clause encdec = FLTQ_S(rs2, rs1, rd)
   <-> 0b101_0000 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011
@@ -668,7 +668,7 @@ function clause execute(FLTQ_S(rs2, rs1, rd)) = {
 
 /* FLEQ.D */
 
-union clause ast = FLEQ_D : (fregidx, fregidx, regidx)
+union clause instruction = FLEQ_D : (fregidx, fregidx, regidx)
 
 mapping clause encdec = FLEQ_D(rs2, rs1, rd)
   <-> 0b101_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b101_0011
@@ -693,7 +693,7 @@ function clause execute(FLEQ_D(rs2, rs1, rd)) = {
 
 /* FLTQ.D */
 
-union clause ast = FLTQ_D : (fregidx, fregidx, regidx)
+union clause instruction = FLTQ_D : (fregidx, fregidx, regidx)
 
 mapping clause encdec = FLTQ_D(rs2, rs1, rd)
   <-> 0b101_0001 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b101_0011
@@ -781,7 +781,7 @@ function fcvtmod_helper(x64) = {
   }
 }
 
-union clause ast = FCVTMOD_W_D : (fregidx, regidx)
+union clause instruction = FCVTMOD_W_D : (fregidx, regidx)
 
 /* We need rounding mode to be explicitly specified to RTZ(0b001) */
 mapping clause encdec = FCVTMOD_W_D(rs1, rd)

--- a/model/riscv_insts_zfh.sail
+++ b/model/riscv_insts_zfh.sail
@@ -180,11 +180,11 @@ function haveHalfMin() -> bool = haveHalfFPU() | currentlyEnabled(Ext_Zfhmin) | 
 
 /* Binary ops with rounding mode */
 
-/* AST */
+/* instruction */
 
-union clause ast = F_BIN_RM_TYPE_H : (fregidx, fregidx, rounding_mode, fregidx, f_bin_rm_op_H)
+union clause instruction = F_BIN_RM_TYPE_H : (fregidx, fregidx, rounding_mode, fregidx, f_bin_rm_op_H)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FADD_H)
 <-> 0b000_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011
@@ -224,7 +224,7 @@ function clause execute (F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, op)) = {
   }
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping f_bin_rm_type_mnemonic_H : f_bin_rm_op_H <-> string = {
   FADD_H  <-> "fadd.h",
@@ -243,11 +243,11 @@ mapping clause assembly = F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, op)
 /* ****************************************************************** */
 /* Fused multiply-add */
 
-/* AST */
+/* instruction */
 
-union clause ast = F_MADD_TYPE_H : (fregidx, fregidx, fregidx, rounding_mode, fregidx, f_madd_op_H)
+union clause instruction = F_MADD_TYPE_H : (fregidx, fregidx, fregidx, rounding_mode, fregidx, f_madd_op_H)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FMADD_H)
 <-> encdec_freg(rs3) @ 0b10 @ encdec_freg(rs2) @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b100_0011
@@ -289,7 +289,7 @@ function clause execute (F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, op)) = {
   }
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping f_madd_type_mnemonic_H : f_madd_op_H <-> string = {
     FMADD_H  <-> "fmadd.h",
@@ -309,12 +309,12 @@ mapping clause assembly = F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, op)
 /* ****************************************************************** */
 /* Binary, no rounding mode */
 
-/* AST */
+/* instruction */
 
-union clause ast = F_BIN_F_TYPE_H : (fregidx, fregidx, fregidx, f_bin_f_op_H)
-union clause ast = F_BIN_X_TYPE_H : (fregidx, fregidx, regidx, f_bin_x_op_H)
+union clause instruction = F_BIN_F_TYPE_H : (fregidx, fregidx, fregidx, f_bin_f_op_H)
+union clause instruction = F_BIN_X_TYPE_H : (fregidx, fregidx, regidx, f_bin_x_op_H)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = F_BIN_F_TYPE_H(rs2, rs1, rd, FSGNJ_H)
   <-> 0b001_0010 @ encdec_freg(rs2) @ encdec_freg(rs1) @ 0b000 @ encdec_freg(rd) @ 0b101_0011
@@ -459,7 +459,7 @@ function clause execute (F_BIN_X_TYPE_H(rs2, rs1, rd, FLE_H)) = {
   RETIRE_SUCCESS
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping f_bin_f_type_mnemonic_H : f_bin_f_op_H <-> string = {
     FSGNJ_H  <-> "fsgnj.h",
@@ -490,13 +490,13 @@ mapping clause assembly = F_BIN_X_TYPE_H(rs2, rs1, rd, op)
 /* ****************************************************************** */
 /* Unary with rounding mode */
 
-/* AST */
+/* instruction */
 
-union clause ast = F_UN_RM_FF_TYPE_H : (fregidx, rounding_mode, fregidx, f_un_rm_ff_op_H)
-union clause ast = F_UN_RM_FX_TYPE_H : (fregidx, rounding_mode, regidx, f_un_rm_fx_op_H)
-union clause ast = F_UN_RM_XF_TYPE_H : (regidx, rounding_mode, fregidx, f_un_rm_xf_op_H)
+union clause instruction = F_UN_RM_FF_TYPE_H : (fregidx, rounding_mode, fregidx, f_un_rm_ff_op_H)
+union clause instruction = F_UN_RM_FX_TYPE_H : (fregidx, rounding_mode, regidx, f_un_rm_fx_op_H)
+union clause instruction = F_UN_RM_XF_TYPE_H : (regidx, rounding_mode, fregidx, f_un_rm_xf_op_H)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = F_UN_RM_FF_TYPE_H(rs1, rm, rd, FSQRT_H)
 <-> 0b010_1110 @ 0b00000 @ encdec_freg(rs1) @ encdec_rounding_mode (rm) @ encdec_freg(rd) @ 0b101_0011
@@ -756,7 +756,7 @@ function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_LU)) = {
   }
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping f_un_rm_ff_type_mnemonic_H : f_un_rm_ff_op_H <-> string = {
     FSQRT_H   <-> "fsqrt.h",
@@ -801,10 +801,10 @@ mapping clause assembly = F_UN_RM_XF_TYPE_H(rs1, rm, rd, op)
 /* ****************************************************************** */
 /* Unary, no rounding mode */
 
-union clause ast = F_UN_F_TYPE_H : (regidx, fregidx, f_un_f_op_H)
-union clause ast = F_UN_X_TYPE_H : (fregidx, regidx, f_un_x_op_H)
+union clause instruction = F_UN_F_TYPE_H : (regidx, fregidx, f_un_f_op_H)
+union clause instruction = F_UN_X_TYPE_H : (fregidx, regidx, f_un_x_op_H)
 
-/* AST <-> Binary encoding ================================ */
+/* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = F_UN_X_TYPE_H(rs1, rd, FCLASS_H)
   <-> 0b111_0010 @ 0b00000 @ encdec_freg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b101_0011
@@ -854,7 +854,7 @@ function clause execute (F_UN_F_TYPE_H(rs1, rd, FMV_H_X)) = {
   RETIRE_SUCCESS
 }
 
-/* AST -> Assembly notation ================================ */
+/* instruction -> Assembly notation ================================ */
 
 mapping f_un_f_type_mnemonic_H : f_un_f_op_H <-> string = {
     FMV_H_X  <-> "fmv.h.x"

--- a/model/riscv_insts_zicbom.sail
+++ b/model/riscv_insts_zicbom.sail
@@ -13,7 +13,7 @@ function clause currentlyEnabled(Ext_Zicbom) = hartSupports(Ext_Zicbom)
 function cbo_clean_flush_enabled(p : Privilege) -> bool = feature_enabled_for_priv(p, menvcfg[CBCFE][0], senvcfg[CBCFE][0])
 
 /* ****************************************************************** */
-union clause ast = ZICBOM : (cbop_zicbom, regidx)
+union clause instruction = ZICBOM : (cbop_zicbom, regidx)
 
 mapping encdec_cbop : cbop_zicbom <-> bits(12) = {
   CBO_CLEAN <-> 0b000000000001,

--- a/model/riscv_insts_zicboz.sail
+++ b/model/riscv_insts_zicboz.sail
@@ -13,7 +13,7 @@ function clause currentlyEnabled(Ext_Zicboz) = hartSupports(Ext_Zicboz)
 function cbo_zero_enabled(p : Privilege) -> bool = feature_enabled_for_priv(p, menvcfg[CBZE][0], senvcfg[CBZE][0])
 
 /* ****************************************************************** */
-union clause ast = ZICBOZ : (regidx)
+union clause instruction = ZICBOZ : (regidx)
 
 mapping clause encdec = ZICBOZ(rs1)
   <-> 0b000000000100 @ encdec_reg(rs1) @ 0b010 @ 0b00000 @ 0b0001111

--- a/model/riscv_insts_zicond.sail
+++ b/model/riscv_insts_zicond.sail
@@ -8,7 +8,7 @@
 
 function clause currentlyEnabled(Ext_Zicond) = hartSupports(Ext_Zicond)
 
-union clause ast = ZICOND_RTYPE : (regidx, regidx, regidx, zicondop)
+union clause instruction = ZICOND_RTYPE : (regidx, regidx, regidx, zicondop)
 
 mapping clause encdec = ZICOND_RTYPE(rs2, rs1, rd, CZERO_EQZ)
   <-> 0b0000111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011

--- a/model/riscv_insts_zicsr.sail
+++ b/model/riscv_insts_zicsr.sail
@@ -11,8 +11,8 @@
 /* ****************************************************************** */
 function clause currentlyEnabled(Ext_Zicsr) = hartSupports(Ext_Zicsr)
 
-union clause ast = CSRReg  : (csreg, regidx, regidx, csrop)
-union clause ast = CSRImm  : (csreg, bits(5), regidx, csrop)
+union clause instruction = CSRReg  : (csreg, regidx, regidx, csrop)
+union clause instruction = CSRImm  : (csreg, bits(5), regidx, csrop)
 
 mapping encdec_csrop : csrop <-> bits(2) = {
   CSRRW <-> 0b01,

--- a/model/riscv_insts_zifencei.sail
+++ b/model/riscv_insts_zifencei.sail
@@ -13,7 +13,7 @@
 
 function clause currentlyEnabled(Ext_Zifencei) = hartSupports(Ext_Zifencei)
 
-union clause ast = FENCEI : unit
+union clause instruction = FENCEI : unit
 
 mapping clause encdec = FENCEI()
   <-> 0b000000000000 @ 0b00000 @ 0b001 @ 0b00000 @ 0b0001111

--- a/model/riscv_insts_zimop.sail
+++ b/model/riscv_insts_zimop.sail
@@ -8,8 +8,8 @@
 
 function clause currentlyEnabled(Ext_Zimop) = hartSupports(Ext_Zimop)
 
-union clause ast = ZIMOP_MOP_R : (bits(5), regidx, regidx)
-union clause ast = ZIMOP_MOP_RR : (bits(3), regidx, regidx, regidx)
+union clause instruction = ZIMOP_MOP_R : (bits(5), regidx, regidx)
+union clause instruction = ZIMOP_MOP_RR : (bits(3), regidx, regidx, regidx)
 
 mapping clause encdec = ZIMOP_MOP_R(mop_30 @ mop_27_26 @ mop_21_20, rs1, rd)
   <-> 0b1 @ mop_30 : bits(1) @ 0b00 @ mop_27_26 : bits(2) @ 0b0111 @ mop_21_20 : bits(2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b1110011

--- a/model/riscv_insts_zkn.sail
+++ b/model/riscv_insts_zkn.sail
@@ -13,10 +13,10 @@
 
 function clause currentlyEnabled(Ext_Zknh) = hartSupports(Ext_Zknh)
 
-union clause ast = SHA256SIG0 : (regidx, regidx)
-union clause ast = SHA256SIG1 : (regidx, regidx)
-union clause ast = SHA256SUM0 : (regidx, regidx)
-union clause ast = SHA256SUM1 : (regidx, regidx)
+union clause instruction = SHA256SIG0 : (regidx, regidx)
+union clause instruction = SHA256SIG1 : (regidx, regidx)
+union clause instruction = SHA256SUM0 : (regidx, regidx)
+union clause instruction = SHA256SUM1 : (regidx, regidx)
 
 mapping clause encdec = SHA256SUM0 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
@@ -81,7 +81,7 @@ function clause execute (SHA256SUM1(rs1, rd)) = {
 
 function clause currentlyEnabled(Ext_Zkne) = hartSupports(Ext_Zkne)
 
-union clause ast = AES32ESMI : (bits(2), regidx, regidx, regidx)
+union clause instruction = AES32ESMI : (bits(2), regidx, regidx, regidx)
 
 mapping clause encdec = AES32ESMI (bs, rs2, rs1, rd)
   <-> bs @ 0b10011 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
@@ -100,7 +100,7 @@ function clause execute (AES32ESMI (bs, rs2, rs1, rd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = AES32ESI : (bits(2), regidx, regidx, regidx)
+union clause instruction = AES32ESI : (bits(2), regidx, regidx, regidx)
 
 mapping clause encdec = AES32ESI (bs, rs2, rs1, rd)
   <-> bs @ 0b10001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
@@ -125,7 +125,7 @@ function clause execute (AES32ESI (bs, rs2, rs1, rd)) = {
 
 function clause currentlyEnabled(Ext_Zknd) = hartSupports(Ext_Zknd)
 
-union clause ast = AES32DSMI : (bits(2), regidx, regidx, regidx)
+union clause instruction = AES32DSMI : (bits(2), regidx, regidx, regidx)
 
 mapping clause encdec = AES32DSMI (bs, rs2, rs1, rd)
   <-> bs @ 0b10111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
@@ -144,7 +144,7 @@ function clause execute (AES32DSMI (bs, rs2, rs1, rd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = AES32DSI  : (bits(2), regidx, regidx, regidx)
+union clause instruction = AES32DSI  : (bits(2), regidx, regidx, regidx)
 
 mapping clause encdec = AES32DSI (bs, rs2, rs1, rd)
   <-> bs @ 0b10101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
@@ -167,12 +167,12 @@ function clause execute (AES32DSI (bs, rs2, rs1, rd)) = {
  * ----------------------------------------------------------------------
  */
 
-union clause ast = SHA512SIG0L : (regidx, regidx, regidx)
-union clause ast = SHA512SIG0H : (regidx, regidx, regidx)
-union clause ast = SHA512SIG1L : (regidx, regidx, regidx)
-union clause ast = SHA512SIG1H : (regidx, regidx, regidx)
-union clause ast = SHA512SUM0R : (regidx, regidx, regidx)
-union clause ast = SHA512SUM1R : (regidx, regidx, regidx)
+union clause instruction = SHA512SIG0L : (regidx, regidx, regidx)
+union clause instruction = SHA512SIG0H : (regidx, regidx, regidx)
+union clause instruction = SHA512SIG1L : (regidx, regidx, regidx)
+union clause instruction = SHA512SIG1H : (regidx, regidx, regidx)
+union clause instruction = SHA512SUM0R : (regidx, regidx, regidx)
+union clause instruction = SHA512SUM1R : (regidx, regidx, regidx)
 
 mapping clause encdec = SHA512SUM0R (rs2, rs1, rd)
   <-> 0b01 @ 0b01000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
@@ -257,13 +257,13 @@ function clause execute (SHA512SUM1R(rs2, rs1, rd)) = {
  * ----------------------------------------------------------------------
  */
 
-union clause ast = AES64KS1I : (bits(4), regidx, regidx)
-union clause ast = AES64KS2  : (regidx, regidx, regidx)
-union clause ast = AES64IM   : (regidx, regidx)
-union clause ast = AES64ESM  : (regidx, regidx, regidx)
-union clause ast = AES64ES   : (regidx, regidx, regidx)
-union clause ast = AES64DSM  : (regidx, regidx, regidx)
-union clause ast = AES64DS   : (regidx, regidx, regidx)
+union clause instruction = AES64KS1I : (bits(4), regidx, regidx)
+union clause instruction = AES64KS2  : (regidx, regidx, regidx)
+union clause instruction = AES64IM   : (regidx, regidx)
+union clause instruction = AES64ESM  : (regidx, regidx, regidx)
+union clause instruction = AES64ES   : (regidx, regidx, regidx)
+union clause instruction = AES64DSM  : (regidx, regidx, regidx)
+union clause instruction = AES64DS   : (regidx, regidx, regidx)
 
 mapping clause encdec = AES64KS1I (rnum, rs1, rd)
   <-> 0b00 @ 0b11000 @ 0b1 @ rnum @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
@@ -382,10 +382,10 @@ function clause execute (AES64DS(rs2, rs1, rd)) = {
  * ----------------------------------------------------------------------
  */
 
-union clause ast = SHA512SIG0 : (regidx, regidx)
-union clause ast = SHA512SIG1 : (regidx, regidx)
-union clause ast = SHA512SUM0 : (regidx, regidx)
-union clause ast = SHA512SUM1 : (regidx, regidx)
+union clause instruction = SHA512SIG0 : (regidx, regidx)
+union clause instruction = SHA512SIG1 : (regidx, regidx)
+union clause instruction = SHA512SUM0 : (regidx, regidx)
+union clause instruction = SHA512SUM1 : (regidx, regidx)
 
 mapping clause encdec = SHA512SUM0 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00100 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011

--- a/model/riscv_insts_zks.sail
+++ b/model/riscv_insts_zks.sail
@@ -13,8 +13,8 @@
 
 function clause currentlyEnabled(Ext_Zksh) = hartSupports(Ext_Zksh)
 
-union clause ast = SM3P0 : (regidx, regidx)
-union clause ast = SM3P1 : (regidx, regidx)
+union clause instruction = SM3P0 : (regidx, regidx)
+union clause instruction = SM3P1 : (regidx, regidx)
 
 mapping clause encdec = SM3P0 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b01000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
@@ -51,8 +51,8 @@ function clause execute (SM3P1(rs1, rd)) = {
 
 function clause currentlyEnabled(Ext_Zksed) = hartSupports(Ext_Zksed)
 
-union clause ast = SM4ED : (bits(2), regidx, regidx, regidx)
-union clause ast = SM4KS : (bits(2), regidx, regidx, regidx)
+union clause instruction = SM4ED : (bits(2), regidx, regidx, regidx)
+union clause instruction = SM4KS : (bits(2), regidx, regidx, regidx)
 
 mapping clause encdec = SM4ED (bs, rs2, rs1, rd)
   <-> bs @ 0b11000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011

--- a/model/riscv_insts_zvbb.sail
+++ b/model/riscv_insts_zvbb.sail
@@ -9,7 +9,7 @@
 function clause currentlyEnabled(Ext_Zvbb) = hartSupports(Ext_Zvbb) & currentlyEnabled(Ext_V)
 function clause currentlyEnabled(Ext_Zvkb) = (hartSupports(Ext_Zvkb) | currentlyEnabled(Ext_Zvbb)) & currentlyEnabled(Ext_V)
 
-union clause ast = VANDN_VV : (bits(1), vregidx, vregidx, vregidx)
+union clause instruction = VANDN_VV : (bits(1), vregidx, vregidx, vregidx)
 
 mapping clause encdec = VANDN_VV(vm, vs1, vs2, vd)
   <-> 0b000001 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
@@ -46,7 +46,7 @@ function clause execute (VANDN_VV(vm, vs1, vs2, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VANDN_VX : (bits(1), vregidx, regidx, vregidx)
+union clause instruction = VANDN_VX : (bits(1), vregidx, regidx, vregidx)
 
 mapping clause encdec = VANDN_VX(vm, vs2, rs1, vd)
   <-> 0b000001 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
@@ -83,7 +83,7 @@ function clause execute (VANDN_VX(vm, vs2, rs1, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VBREV_V : (bits(1), vregidx, vregidx)
+union clause instruction = VBREV_V : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VBREV_V(vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01010 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
@@ -123,7 +123,7 @@ function clause execute (VBREV_V(vm, vs2, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VBREV8_V : (bits(1), vregidx, vregidx)
+union clause instruction = VBREV8_V : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VBREV8_V(vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01000 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
@@ -160,7 +160,7 @@ function clause execute (VBREV8_V(vm, vs2, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VREV8_V : (bits(1), vregidx, vregidx)
+union clause instruction = VREV8_V : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VREV8_V(vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01001 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
@@ -197,7 +197,7 @@ function clause execute (VREV8_V(vm, vs2, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VCLZ_V : (bits(1), vregidx, vregidx)
+union clause instruction = VCLZ_V : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VCLZ_V (vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01100 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
@@ -235,7 +235,7 @@ function clause execute (VCLZ_V(vm, vs2, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VCTZ_V : (bits(1), vregidx, vregidx)
+union clause instruction = VCTZ_V : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VCTZ_V (vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01101 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
@@ -273,7 +273,7 @@ function clause execute (VCTZ_V(vm, vs2, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VCPOP_V : (bits(1), vregidx, vregidx)
+union clause instruction = VCPOP_V : (bits(1), vregidx, vregidx)
 
 mapping clause encdec = VCPOP_V (vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01110 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
@@ -314,7 +314,7 @@ function clause execute (VCPOP_V(vm, vs2, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VROL_VV : (bits(1), vregidx, vregidx, vregidx)
+union clause instruction = VROL_VV : (bits(1), vregidx, vregidx, vregidx)
 
 mapping clause encdec = VROL_VV(vm, vs1, vs2, vd)
   <-> 0b010101 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
@@ -352,7 +352,7 @@ function clause execute (VROL_VV(vm, vs1, vs2, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VROL_VX : (bits(1), vregidx, regidx, vregidx)
+union clause instruction = VROL_VX : (bits(1), vregidx, regidx, vregidx)
 
 mapping clause encdec = VROL_VX(vm, vs2, rs1, vd)
   <-> 0b010101 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
@@ -390,7 +390,7 @@ function clause execute (VROL_VX(vm, vs2, rs1, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VROR_VV : (bits(1), vregidx, vregidx, vregidx)
+union clause instruction = VROR_VV : (bits(1), vregidx, vregidx, vregidx)
 
 mapping clause encdec = VROR_VV(vm, vs1, vs2, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
@@ -428,7 +428,7 @@ function clause execute (VROR_VV(vm, vs1, vs2, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VROR_VX : (bits(1), vregidx, regidx, vregidx)
+union clause instruction = VROR_VX : (bits(1), vregidx, regidx, vregidx)
 
 mapping clause encdec = VROR_VX(vm, vs2, rs1, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
@@ -466,7 +466,7 @@ function clause execute (VROR_VX(vm, vs2, rs1, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VROR_VI : (bits(1), vregidx, bits(6), vregidx)
+union clause instruction = VROR_VI : (bits(1), vregidx, bits(6), vregidx)
 
 mapping clause encdec = VROR_VI(vm, vs2, uimm5 @ uimm40, vd)
   <-> 0b01010 @ uimm5 @ vm @ encdec_vreg(vs2) @ uimm40 : bits(5) @ 0b011 @ encdec_vreg(vd) @ 0b1010111
@@ -504,7 +504,7 @@ function clause execute (VROR_VI(vm, vs2, uimm, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VWSLL_VV : (bits(1), vregidx, vregidx, vregidx)
+union clause instruction = VWSLL_VV : (bits(1), vregidx, vregidx, vregidx)
 
 mapping clause encdec = VWSLL_VV (vm, vs2, vs1, vd)
   <-> 0b110101 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
@@ -552,7 +552,7 @@ function clause execute (VWSLL_VV(vm, vs2, vs1, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VWSLL_VX : (bits(1), vregidx, regidx, vregidx)
+union clause instruction = VWSLL_VX : (bits(1), vregidx, regidx, vregidx)
 
 mapping clause encdec = VWSLL_VX (vm, vs2, rs1, vd)
   <-> 0b110101 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
@@ -599,7 +599,7 @@ function clause execute (VWSLL_VX(vm, vs2, rs1, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VWSLL_VI : (bits(1), vregidx, bits(5), vregidx)
+union clause instruction = VWSLL_VI : (bits(1), vregidx, bits(5), vregidx)
 
 mapping clause encdec = VWSLL_VI (vm, vs2, uimm, vd)
   <-> 0b110101 @ vm @ encdec_vreg(vs2) @ uimm @ 0b011 @ encdec_vreg(vd) @ 0b1010111

--- a/model/riscv_insts_zvbc.sail
+++ b/model/riscv_insts_zvbc.sail
@@ -8,7 +8,7 @@
 
 function clause currentlyEnabled(Ext_Zvbc) = hartSupports(Ext_Zvbc) & currentlyEnabled(Ext_V)
 
-union clause ast = VCLMUL_VV : (bits(1), vregidx, vregidx, vregidx)
+union clause instruction = VCLMUL_VV : (bits(1), vregidx, vregidx, vregidx)
 
 mapping clause encdec = VCLMUL_VV (vm, vs2, vs1, vd)
   <-> 0b001100 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
@@ -46,7 +46,7 @@ function clause execute (VCLMUL_VV(vm, vs2, vs1, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VCLMUL_VX : (bits(1), vregidx, regidx, vregidx)
+union clause instruction = VCLMUL_VX : (bits(1), vregidx, regidx, vregidx)
 
 mapping clause encdec = VCLMUL_VX (vm, vs2, rs1, vd)
   <-> 0b001100 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
@@ -85,7 +85,7 @@ function clause execute (VCLMUL_VX(vm, vs2, rs1, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VCLMULH_VV : (bits(1), vregidx, vregidx, vregidx)
+union clause instruction = VCLMULH_VV : (bits(1), vregidx, vregidx, vregidx)
 
 mapping clause encdec = VCLMULH_VV (vm, vs2, vs1, vd)
   <-> 0b001101 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
@@ -123,7 +123,7 @@ function clause execute (VCLMULH_VV(vm, vs2, vs1, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = VCLMULH_VX : (bits(1), vregidx, regidx, vregidx)
+union clause instruction = VCLMULH_VX : (bits(1), vregidx, regidx, vregidx)
 
 mapping clause encdec = VCLMULH_VX (vm, vs2, rs1, vd)
   <-> 0b001101 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111

--- a/model/riscv_insts_zvkg.sail
+++ b/model/riscv_insts_zvkg.sail
@@ -8,7 +8,7 @@
 
 function clause currentlyEnabled(Ext_Zvkg) = hartSupports(Ext_Zvkg) & currentlyEnabled(Ext_V)
 
-union clause ast = VGHSH_VV : (vregidx, vregidx, vregidx)
+union clause instruction = VGHSH_VV : (vregidx, vregidx, vregidx)
 
 mapping clause encdec = VGHSH_VV(vs2, vs1, vd)
   <-> 0b1011001 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1110111
@@ -56,7 +56,7 @@ function clause execute (VGHSH_VV(vs2, vs1, vd)) = {
 mapping clause assembly = VGHSH_VV(vs2, vs1, vd)
   <-> "vghsh.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1)
 
-union clause ast = VGMUL_VV : (vregidx, vregidx)
+union clause instruction = VGMUL_VV : (vregidx, vregidx)
 
 mapping clause encdec = VGMUL_VV(vs2, vd)
   <-> 0b1010001 @ encdec_vreg(vs2) @ 0b10001 @ 0b010 @ encdec_vreg(vd) @ 0b1110111

--- a/model/riscv_insts_zvkned.sail
+++ b/model/riscv_insts_zvkned.sail
@@ -8,7 +8,7 @@
 
 function clause currentlyEnabled(Ext_Zvkned) = hartSupports(Ext_Zvkned) & currentlyEnabled(Ext_V)
 
-union clause ast = VAESDF : (zvk_vaesdf_funct6, vregidx, vregidx)
+union clause instruction = VAESDF : (zvk_vaesdf_funct6, vregidx, vregidx)
 
 mapping encdec_vaesdf : zvk_vaesdf_funct6 <-> bits(6) = {
   ZVK_VAESDF_VV <-> 0b101000,
@@ -60,7 +60,7 @@ mapping vaesdf_mnemonic : zvk_vaesdf_funct6 <-> string = {
 mapping clause assembly = VAESDF(funct6, vs2, vd)
   <-> vaesdf_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)
 
-union clause ast = VAESDM : (zvk_vaesdm_funct6, vregidx, vregidx)
+union clause instruction = VAESDM : (zvk_vaesdm_funct6, vregidx, vregidx)
 
 mapping encdec_vaesdm : zvk_vaesdm_funct6 <-> bits(6) = {
   ZVK_VAESDM_VV <-> 0b101000,
@@ -113,7 +113,7 @@ mapping vaesdm_mnemonic : zvk_vaesdm_funct6 <-> string = {
 mapping clause assembly = VAESDM(funct6, vs2, vd)
   <-> vaesdm_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)
 
-union clause ast = VAESEF : (zvk_vaesef_funct6, vregidx, vregidx)
+union clause instruction = VAESEF : (zvk_vaesef_funct6, vregidx, vregidx)
 
 mapping encdec_vaesef : zvk_vaesef_funct6 <-> bits(6) = {
   ZVK_VAESEF_VV <-> 0b101000,
@@ -165,7 +165,7 @@ mapping vaesef_mnemonic : zvk_vaesef_funct6 <-> string = {
 mapping clause assembly = VAESEF(funct6, vs2, vd)
   <-> vaesef_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)
 
-union clause ast = VAESEM : (zvk_vaesem_funct6, vregidx, vregidx)
+union clause instruction = VAESEM : (zvk_vaesem_funct6, vregidx, vregidx)
 
 mapping encdec_vaesem : zvk_vaesem_funct6 <-> bits(6) = {
   ZVK_VAESEM_VV <-> 0b101000,
@@ -218,7 +218,7 @@ mapping vaesem_mnemonic : zvk_vaesem_funct6 <-> string = {
 mapping clause assembly = VAESEM(funct6, vs2, vd)
   <-> vaesem_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2)
 
-union clause ast = VAESKF1_VI : (vregidx, bits(5), vregidx)
+union clause instruction = VAESKF1_VI : (vregidx, bits(5), vregidx)
 
 mapping clause encdec = VAESKF1_VI(vs2, rnd, vd)
   <-> 0b1000101 @ encdec_vreg(vs2) @ rnd @ 0b010 @ encdec_vreg(vd) @ 0b1110111
@@ -267,7 +267,7 @@ function clause execute (VAESKF1_VI(vs2, rnd, vd)) = {
 mapping clause assembly = VAESKF1_VI(vs2, rnd, vd)
   <-> "vaeskf1.vi" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(rnd)
 
-union clause ast = VAESKF2_VI : (vregidx, bits(5), vregidx)
+union clause instruction = VAESKF2_VI : (vregidx, bits(5), vregidx)
 
 mapping clause encdec = VAESKF2_VI(vs2, rnd, vd)
   <-> 0b1010101 @ encdec_vreg(vs2) @ rnd @ 0b010 @ encdec_vreg(vd) @ 0b1110111
@@ -317,7 +317,7 @@ function clause execute (VAESKF2_VI(vs2, rnd, vd)) = {
 mapping clause assembly = VAESKF2_VI(vs2, rnd, vd)
   <-> "vaeskf2.vi" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(rnd)
 
-union clause ast = VAESZ_VS : (vregidx, vregidx)
+union clause instruction = VAESZ_VS : (vregidx, vregidx)
 
 mapping clause encdec = VAESZ_VS(vs2, vd)
   <-> 0b1010011 @ encdec_vreg(vs2) @ 0b00111 @ 0b010 @ encdec_vreg(vd) @ 0b1110111

--- a/model/riscv_insts_zvknhab.sail
+++ b/model/riscv_insts_zvknhab.sail
@@ -9,7 +9,7 @@
 function clause currentlyEnabled(Ext_Zvknha) = hartSupports(Ext_Zvknha) & currentlyEnabled(Ext_V)
 function clause currentlyEnabled(Ext_Zvknhb) = hartSupports(Ext_Zvknhb) & currentlyEnabled(Ext_V)
 
-union clause ast = VSHA2MS_VV : (vregidx, vregidx, vregidx)
+union clause instruction = VSHA2MS_VV : (vregidx, vregidx, vregidx)
 
 mapping clause encdec = VSHA2MS_VV(vs2, vs1, vd)
   <-> 0b1011011 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1110111
@@ -66,7 +66,7 @@ function clause execute (VSHA2MS_VV(vs2, vs1, vd)) = {
   RETIRE_SUCCESS
 }
 
-union clause ast = ZVKSHA2TYPE : (zvk_vsha2_funct6, vregidx, vregidx, vregidx)
+union clause instruction = ZVKSHA2TYPE : (zvk_vsha2_funct6, vregidx, vregidx, vregidx)
 
 mapping encdec_vsha2 : zvk_vsha2_funct6 <-> bits(6) = {
   ZVK_VSHA2CH_VV <-> 0b101110,

--- a/model/riscv_insts_zvksed.sail
+++ b/model/riscv_insts_zvksed.sail
@@ -8,7 +8,7 @@
 
 function clause currentlyEnabled(Ext_Zvksed) = hartSupports(Ext_Zvksed) & currentlyEnabled(Ext_V)
 
-union clause ast = VSM4K_VI : (vregidx, bits(5), vregidx)
+union clause instruction = VSM4K_VI : (vregidx, bits(5), vregidx)
 
 mapping clause encdec = VSM4K_VI(vs2, uimm, vd)
   <-> 0b1000011 @ encdec_vreg(vs2) @ uimm @ 0b010 @ encdec_vreg(vd) @ 0b1110111
@@ -61,7 +61,7 @@ function clause execute (VSM4K_VI(vs2, uimm, vd)) = {
 mapping clause assembly = VSM4K_VI(vs2, uimm, vd)
   <-> "vsm4k.vi" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(uimm)
 
-union clause ast = ZVKSM4RTYPE : (zvk_vsm4r_funct6, vregidx, vregidx)
+union clause instruction = ZVKSM4RTYPE : (zvk_vsm4r_funct6, vregidx, vregidx)
 
 mapping clause encdec = ZVKSM4RTYPE(ZVK_VSM4R_VV, vs2, vd)
   <-> 0b1010001 @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_vreg(vd) @ 0b1110111

--- a/model/riscv_insts_zvksh.sail
+++ b/model/riscv_insts_zvksh.sail
@@ -8,7 +8,7 @@
 
 function clause currentlyEnabled(Ext_Zvksh) = hartSupports(Ext_Zvksh) & currentlyEnabled(Ext_V)
 
-union clause ast = VSM3ME_VV : (vregidx, vregidx, vregidx)
+union clause instruction = VSM3ME_VV : (vregidx, vregidx, vregidx)
 
 mapping clause encdec = VSM3ME_VV(vs2, vs1, vd)
   <-> 0b1000001 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1110111
@@ -51,7 +51,7 @@ function clause execute (VSM3ME_VV(vs2, vs1, vd)) = {
 mapping clause assembly = VSM3ME_VV(vs2, vs1, vd)
   <-> "vsm3me.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1)
 
-union clause ast = VSM3C_VI : (vregidx, bits(5), vregidx)
+union clause instruction = VSM3C_VI : (vregidx, bits(5), vregidx)
 
 mapping clause encdec = VSM3C_VI(vs2, uimm, vd)
   <-> 0b1010111 @ encdec_vreg(vs2) @ uimm @ 0b010 @ encdec_vreg(vd) @ 0b1110111

--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -98,15 +98,15 @@ function run_hart_active(step_no: nat) -> Step = {
       F_RVC(h) => {
         sail_instr_announce(h);
         let instbits : instbits = zero_extend(h);
-        let ast = ext_decode_compressed(h);
+        let instruction = ext_decode_compressed(h);
         if   get_config_print_instr()
         then {
-          print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ BitStr(PC) ^ " (" ^ BitStr(h) ^ ") " ^ to_str(ast));
+          print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ BitStr(PC) ^ " (" ^ BitStr(h) ^ ") " ^ to_str(instruction));
         };
         /* check for RVC once here instead of every RVC execute clause. */
         if currentlyEnabled(Ext_Zca) then {
           nextPC = PC + 2;
-          let r = execute(ast);
+          let r = execute(instruction);
           Step_Execute(r, instbits)
         } else {
           Step_Execute(Illegal_Instruction(), instbits)
@@ -115,13 +115,13 @@ function run_hart_active(step_no: nat) -> Step = {
       F_Base(w) => {
         sail_instr_announce(w);
         let instbits : instbits = zero_extend(w);
-        let ast = ext_decode(w);
+        let instruction = ext_decode(w);
         if   get_config_print_instr()
         then {
-          print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ BitStr(PC) ^ " (" ^ BitStr(w) ^ ") " ^ to_str(ast));
+          print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ BitStr(PC) ^ " (" ^ BitStr(w) ^ ") " ^ to_str(instruction));
         };
         nextPC = PC + 4;
-        let r = execute(ast);
+        let r = execute(instruction);
         Step_Execute(r, instbits)
       }
     }

--- a/model/riscv_termination.sail
+++ b/model/riscv_termination.sail
@@ -6,7 +6,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                                */
 /*=======================================================================================*/
 
-val compressed_measure : ast -> int
+val compressed_measure : instruction -> int
 function compressed_measure(instr) =
   match instr {
     C_ADDI4SPN (rdc,nzimm) => 1,


### PR DESCRIPTION
Fixes #1018.

Should go along with an accompanying update to the Sail manual, but not a prerequisite to merging this.