### PR TITLE
Use newtype cfregidx for compressed floating point register indices

### DIFF
--- a/model/riscv_fdext_regs.sail
+++ b/model/riscv_fdext_regs.sail
@@ -54,12 +54,14 @@ function nan_unbox(m, x) = if 'n == 'm then x else (
 
 newtype fregidx = Fregidx : bits(5)
 newtype fregno = Fregno : range(0, 31)
+// identifiers in RVC floating-point instructions
+newtype cfregidx = Cfregidx : bits(3)
 
 function fregidx_bits(Fregidx(r) : fregidx) -> bits(5) = r
 
-// TODO: We should have a separate Cfregidx type for compressed float registers.
-function cregidx_to_fregidx (Cregidx(b) : cregidx) -> fregidx = Fregidx(0b01 @ b)
+function cfregidx_to_fregidx (Cfregidx(b) : cfregidx) -> fregidx = Fregidx(0b01 @ b)
 
+mapping encdec_cfreg : cfregidx <-> bits(3) = { Cfregidx(r) <-> r }
 /*
  * TODO: This is not quite right for having both Zfinx and E, but at least it
  * marks the places we need to consider it
@@ -410,7 +412,7 @@ mapping freg_or_reg_name : fregidx <-> string = {
   f <-> freg_name(f)
 }
 
-mapping cfreg_name : cregidx <-> string = { Cregidx(i) <-> freg_name(Fregidx(0b01 @ i)) }
+mapping cfreg_name : cfregidx <-> string = { Cfregidx(i) <-> freg_name(Fregidx(0b01 @ i)) }
 
 /* **************************************************************** */
 /* Floating Point CSR                                               */

--- a/model/riscv_insts_zcd.sail
+++ b/model/riscv_insts_zcd.sail
@@ -20,9 +20,7 @@ function clause execute (C_FLDSP(uimm, rd)) = {
 }
 
 mapping clause assembly = C_FLDSP(uimm, rd)
-      if (xlen == 32 | xlen == 64)
   <-> "c.fldsp" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_9(uimm @ 0b000) ^ "(" ^ sp_reg_name() ^ ")"
-      if (xlen == 32 | xlen == 64)
 
 /* ****************************************************************** */
 union clause instruction = C_FSDSP : (bits(6), fregidx)
@@ -37,44 +35,38 @@ function clause execute (C_FSDSP(uimm, rs2)) = {
 }
 
 mapping clause assembly = C_FSDSP(uimm, rs2)
-      if (xlen == 32 | xlen == 64)
   <-> "c.fsdsp" ^ spc() ^ freg_name(rs2) ^ sep() ^ hex_bits_9(uimm @ 0b000) ^ "(" ^ sp_reg_name() ^ ")"
-      if (xlen == 32 | xlen == 64)
 
 /* ****************************************************************** */
-union clause instruction = C_FLD : (bits(5), cregidx, cregidx)
+union clause instruction = C_FLD : (bits(5), cregidx, cfregidx)
 
 mapping clause encdec_compressed = C_FLD(ui76 @ ui53, rs1, rd)
-  <-> 0b001 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_creg(rd) @ 0b00
+  <-> 0b001 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_cfreg(rd) @ 0b00
   when currentlyEnabled(Ext_Zcd)
 
 function clause execute (C_FLD(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
-  let rd = cregidx_to_fregidx(rdc);
+  let rd = cfregidx_to_fregidx(rdc);
   let rs = creg2reg_idx(rsc);
   execute(LOAD_FP(imm, rs, rd, 8))
 }
 
 mapping clause assembly = C_FLD(uimm, rsc, rdc)
-      if (xlen == 32 | xlen == 64)
   <-> "c.fld" ^ spc() ^ cfreg_name(rdc) ^ sep() ^ hex_bits_8(uimm @ 0b000) ^ "(" ^ creg_name(rsc) ^ ")"
-      if (xlen == 32 | xlen == 64)
 
 /* ****************************************************************** */
-union clause instruction = C_FSD : (bits(5), cregidx, cregidx)
+union clause instruction = C_FSD : (bits(5), cregidx, cfregidx)
 
 mapping clause encdec_compressed = C_FSD(ui76 @ ui53, rs1, rs2)
-  <-> 0b101 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_creg(rs2) @ 0b00
+  <-> 0b101 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_cfreg(rs2) @ 0b00
   when currentlyEnabled(Ext_Zcd)
 
 function clause execute (C_FSD(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
   let rs1 = creg2reg_idx(rsc1);
-  let rs2 = cregidx_to_fregidx(rsc2);
+  let rs2 = cfregidx_to_fregidx(rsc2);
   execute(STORE_FP(imm, rs2, rs1, 8))
 }
 
 mapping clause assembly = C_FSD(uimm, rsc1, rsc2)
-      if (xlen == 32 | xlen == 64)
   <-> "c.fsd" ^ spc() ^ cfreg_name(rsc2) ^ sep() ^ hex_bits_8(uimm @ 0b000) ^ "(" ^ creg_name(rsc1) ^ ")"
-      if (xlen == 32 | xlen == 64)

--- a/model/riscv_insts_zcf.sail
+++ b/model/riscv_insts_zcf.sail
@@ -40,15 +40,15 @@ mapping clause assembly = C_FSWSP(uimm, rs2)
   when xlen == 32
 
 /* ****************************************************************** */
-union clause instruction = C_FLW : (bits(5), cregidx, cregidx)
+union clause instruction = C_FLW : (bits(5), cregidx, cfregidx)
 
 mapping clause encdec_compressed = C_FLW(ui6 @ ui53 @ ui2, rs1, rd)
-  <-> 0b011 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_creg(rd) @ 0b00
+  <-> 0b011 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_cfreg(rd) @ 0b00
   when currentlyEnabled(Ext_Zcf)
 
 function clause execute (C_FLW(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
-  let rd = cregidx_to_fregidx(rdc);
+  let rd = cfregidx_to_fregidx(rdc);
   let rs = creg2reg_idx(rsc);
   execute(LOAD_FP(imm, rs, rd, 4))
 }
@@ -58,16 +58,16 @@ mapping clause assembly = C_FLW(uimm, rsc, rdc)
   when xlen == 32
 
 /* ****************************************************************** */
-union clause instruction = C_FSW : (bits(5), cregidx, cregidx)
+union clause instruction = C_FSW : (bits(5), cregidx, cfregidx)
 
 mapping clause encdec_compressed = C_FSW(ui6 @ ui53 @ ui2, rs1, rs2)
-  <-> 0b111 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_creg(rs2) @ 0b00
+  <-> 0b111 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_cfreg(rs2) @ 0b00
   when currentlyEnabled(Ext_Zcf)
 
 function clause execute (C_FSW(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   let rs1 = creg2reg_idx(rsc1);
-  let rs2 = cregidx_to_fregidx(rsc2);
+  let rs2 = cfregidx_to_fregidx(rsc2);
   execute(STORE_FP(imm, rs2, rs1, 4))
 }
 


### PR DESCRIPTION
Add `newtype cfregidx` so that we don't need to use `cregidx` for compressed floating point register indices.

Fixes #1052