### PR TITLE
Use integers for access sizes instead of an enum

### DIFF
--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -277,7 +277,7 @@ union clause ast = LOAD : (bits(12), regidx, regidx, bool, word_width)
 /* unsigned loads are only present for widths strictly less than xlen,
    signed loads also present for widths equal to xlen */
 function valid_load_encdec(width : word_width, is_unsigned : bool) -> bool =
-  (size_bytes(width) < xlen_bytes) | (not(is_unsigned) & size_bytes(width) <= xlen_bytes)
+  (width < xlen_bytes) | (not(is_unsigned) & width <= xlen_bytes)
 
 val extend_value : forall 'n, 0 < 'n <= xlen. (bool, bits('n)) -> xlenbits
 function extend_value(is_unsigned, value) = if is_unsigned then zero_extend(value) else sign_extend(value)
@@ -288,12 +288,11 @@ mapping clause encdec = LOAD(imm, rs1, rd, is_unsigned, width)
 
 function clause execute (LOAD(imm, rs1, rd, is_unsigned, width)) = {
   let offset : xlenbits = sign_extend(imm);
-  let width_bytes = size_bytes(width);
 
   // This is checked during decoding.
-  assert(width_bytes <= xlen_bytes);
+  assert(width <= xlen_bytes);
 
-  match vmem_read(rs1, offset, width_bytes, Read(Data), false, false, false) {
+  match vmem_read(rs1, offset, width, Read(Data), false, false, false) {
     Ok(data) => {
       X(rd) = extend_value(is_unsigned, data);
       RETIRE_SUCCESS
@@ -315,17 +314,16 @@ union clause ast = STORE : (bits(12), regidx, regidx, word_width)
 
 mapping clause encdec = STORE(imm7 @ imm5, rs2, rs1, width)
   <-> imm7 : bits(7) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(width) @ imm5 : bits(5) @ 0b0100011
-  when size_bytes(width) <= xlen_bytes
+  when width <= xlen_bytes
 
 function clause execute (STORE(imm, rs2, rs1, width)) = {
   let offset : xlenbits = sign_extend(imm);
-  let width_bytes = size_bytes(width);
 
   // This is checked during decoding.
-  assert(width_bytes <= xlen_bytes);
+  assert(width <= xlen_bytes);
 
-  let data = X(rs2)[width_bytes * 8 - 1 .. 0];
-  match vmem_write(rs1, offset, width_bytes, data, Write(Data), false, false, false) {
+  let data = X(rs2)[width * 8 - 1 .. 0];
+  match vmem_write(rs1, offset, width, data, Write(Data), false, false, false) {
     Ok(_) => RETIRE_SUCCESS,
     Err(e) => e,
   }

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -274,28 +274,26 @@ union clause ast = LOAD_FP : (bits(12), regidx, fregidx, word_width)
 
 /* AST <-> Binary encoding ================================ */
 
-mapping clause encdec = LOAD_FP(imm, rs1, rd, HALF)
+mapping clause encdec = LOAD_FP(imm, rs1, rd, 2)
   <-> imm @ encdec_reg(rs1) @ 0b001 @ encdec_freg(rd) @ 0b000_0111
   when currentlyEnabled(Ext_Zfhmin)
 
-mapping clause encdec = LOAD_FP(imm, rs1, rd, WORD)
+mapping clause encdec = LOAD_FP(imm, rs1, rd, 4)
   <-> imm @ encdec_reg(rs1) @ 0b010 @ encdec_freg(rd) @ 0b000_0111
   when currentlyEnabled(Ext_F)
 
-mapping clause encdec = LOAD_FP(imm, rs1, rd, DOUBLE)
+mapping clause encdec = LOAD_FP(imm, rs1, rd, 8)
   <-> imm @ encdec_reg(rs1) @ 0b011 @ encdec_freg(rd) @ 0b000_0111
   when currentlyEnabled(Ext_D)
 
 /* Execution semantics ================================ */
 
 function clause execute(LOAD_FP(imm, rs1, rd, width)) = {
-  let width_bytes = size_bytes(width);
-
   // This is checked during decoding.
-  assert(width_bytes <= flen_bytes);
+  assert(width <= flen_bytes);
 
   let offset : xlenbits = sign_extend(imm);
-  match vmem_read(rs1, offset, width_bytes, Read(Data), false, false, false) {
+  match vmem_read(rs1, offset, width, Read(Data), false, false, false) {
     Ok(result) => { F(rd) = nan_box(result); RETIRE_SUCCESS },
     Err(e)     => e,
   }
@@ -319,29 +317,27 @@ union clause ast = STORE_FP : (bits(12), fregidx, regidx, word_width)
 
 /* AST <-> Binary encoding ================================ */
 
-mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, HALF)
+mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, 2)
   <-> imm7 : bits(7) @ encdec_freg(rs2) @ encdec_reg(rs1) @ 0b001 @ imm5 : bits(5) @ 0b010_0111
   when currentlyEnabled(Ext_Zfhmin)
 
-mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, WORD)
+mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, 4)
   <-> imm7 : bits(7) @ encdec_freg(rs2) @ encdec_reg(rs1) @ 0b010 @ imm5 : bits(5) @ 0b010_0111
   when currentlyEnabled(Ext_F)
 
-mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, DOUBLE)
+mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, 8)
   <-> imm7 : bits(7) @ encdec_freg(rs2) @ encdec_reg(rs1) @ 0b011 @ imm5 : bits(5) @ 0b010_0111
   when currentlyEnabled(Ext_D)
 
 /* Execution semantics ================================ */
 
 function clause execute (STORE_FP(imm, rs2, rs1, width)) = {
-  let width_bytes = size_bytes(width);
-
   // This is checked during decoding.
-  assert(width_bytes <= flen_bytes);
+  assert(width <= flen_bytes);
 
   let offset : xlenbits = sign_extend(imm);
-  let data = F(rs2)[width_bytes * 8 - 1 ..  0];
-  match vmem_write(rs1, offset, width_bytes, data, Write(Data), false, false, false) {
+  let data = F(rs2)[width * 8 - 1 ..  0];
+  match vmem_write(rs1, offset, width, data, Write(Data), false, false, false) {
     Ok(true)  => RETIRE_SUCCESS,
     Ok(false) => internal_error(__FILE__, __LINE__, "store got false from vmem_write"),
     Err(e)    => e,

--- a/model/riscv_insts_vext_mem.sail
+++ b/model/riscv_insts_vext_mem.sail
@@ -79,7 +79,6 @@ mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd)
 val process_vlseg : forall 'f 'b 'n 'p, nfields_range('f) & is_mem_width('b) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> ExecutionResult
 function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
-  let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vd_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
 
@@ -141,7 +140,6 @@ mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd)
 val process_vlsegff : forall 'f 'b 'n 'p, nfields_range('f) & is_mem_width('b) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> ExecutionResult
 function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
-  let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vd_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
   let tail_ag : agtype = get_vtype_vta();
@@ -220,7 +218,6 @@ mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3)
 val process_vsseg : forall 'f 'b 'n 'p, nfields_range('f) & is_mem_width('b) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, int('p), int('n)) -> ExecutionResult
 function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
-  let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs3_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
 
@@ -279,7 +276,6 @@ mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
 val process_vlsseg : forall 'f 'b 'n 'p, nfields_range('f) & is_mem_width('b) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, regidx, int('p), int('n)) -> ExecutionResult
 function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
-  let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vd_seg  : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
   let rs2_val : int = unsigned(get_scalar(rs2, xlen));
@@ -342,7 +338,6 @@ mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
 val process_vssseg : forall 'f 'b 'n 'p, nfields_range('f) & is_mem_width('b) & ('n > 0). (int('f), bits(1), vregidx, int('b), regidx, regidx, int('p), int('n)) -> ExecutionResult
 function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
   let EMUL_reg : int = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
-  let width_type : word_width = size_bytes(load_width_bytes);
   let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs3_seg : vector('n, bits('f * 'b * 8)) = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
   let rs2_val : int = unsigned(get_scalar(rs2, xlen));
@@ -402,7 +397,6 @@ mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
 val process_vlxseg : forall 'f 'ib 'db 'ip 'dp 'n, nfields_range('f) & is_mem_width('ib) & is_mem_width('db) & ('n > 0). (int('f), bits(1), vregidx, int('ib), int('db), int('ip), int('dp), regidx, vregidx, int('n), int) -> ExecutionResult
 function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
-  let width_type : word_width = size_bytes(EEW_data_bytes);
   let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vd_seg  : vector('n, bits('f * 'db * 8)) = read_vreg_seg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, nf, vd);
   let vs2_val : vector('n, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
@@ -495,7 +489,6 @@ mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
 val process_vsxseg : forall 'f 'ib 'db 'ip 'dp 'n, nfields_range('f) & is_mem_width('ib) & is_mem_width('db) & ('n > 0). (int('f), bits(1), vregidx, int('ib), int('db), int('ip), int('dp), regidx, vregidx, int('n), int) -> ExecutionResult
 function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
   let EMUL_data_reg : int = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
-  let width_type : word_width = size_bytes(EEW_data_bytes);
   let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs3_seg : vector('n, bits('f * 'db * 8)) = read_vreg_seg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, nf, vs3);
   let vs2_val : vector('n, bits('ib * 8)) = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
@@ -584,7 +577,6 @@ mapping clause encdec = VLRETYPE(nf, rs1, width, vd)
 
 val process_vlre : forall 'f 'b 'n, nfields_range_pow2('f) & is_mem_width('b) & ('n >= 0). (int('f), vregidx, int('b), regidx, int('n)) -> ExecutionResult
 function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
-  let width_type : word_width = size_bytes(load_width_bytes);
   let start_element : nat = match get_start_element() {
     Ok(v)   => v,
     Err(()) => return Illegal_Instruction()
@@ -647,7 +639,6 @@ mapping clause encdec = VSRETYPE(nf, rs1, vs3)
 
 val process_vsre : forall 'f 'b 'n, nfields_range_pow2('f) & is_mem_width('b) & ('n >= 0). (int('f), int('b), regidx, vregidx, int('n)) -> ExecutionResult
 function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
-  let width_type : word_width = BYTE;
   let start_element : nat = match get_start_element() {
     Ok(v)   => v,
     Err(()) => return Illegal_Instruction()
@@ -720,7 +711,6 @@ mapping clause encdec = VMTYPE(rs1, vd_or_vs3, op)
 
 val process_vm : forall 'n 'l, ('n >= 0 & 'l >= 0). (vregidx, regidx, int('n), int('l), vmlsop) -> ExecutionResult
 function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
-  let width_type : word_width = BYTE;
   let start_element : nat = match get_start_element() {
     Ok(v)   => v,
     Err(()) => return Illegal_Instruction()

--- a/model/riscv_insts_zaamo.sail
+++ b/model/riscv_insts_zaamo.sail
@@ -14,10 +14,10 @@ function clause currentlyEnabled(Ext_Zabha) = hartSupports(Ext_Zabha) & currentl
 // Zabha defines AMOs for byte and halfword
 function amo_width_valid(size : word_width) -> bool = {
   match size {
-    BYTE   => currentlyEnabled(Ext_Zabha),
-    HALF   => currentlyEnabled(Ext_Zabha),
-    WORD   => true,
-    DOUBLE => xlen >= 64,
+    1 => currentlyEnabled(Ext_Zabha),
+    2 => currentlyEnabled(Ext_Zabha),
+    4 => true,
+    8 => xlen >= 64,
   }
 }
 
@@ -44,15 +44,15 @@ mapping clause encdec = AMO(op, aq, rl, rs2, rs1, size, rd)
 /* NOTE: Currently, we only EA if address translation is successful.
    This may need revisiting. */
 function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
-  let 'width_bytes = size_bytes(width);
+  let 'width = width;
 
   // This is checked during decoding.
-  assert(width_bytes <= xlen_bytes);
+  assert(width <= xlen_bytes);
 
   /* Get the address, X(rs1) (no offset).
     * Some extensions perform additional checks on address validity.
     */
-  match ext_data_get_addr(rs1, zeros(), ReadWrite(Data, Data), width_bytes) {
+  match ext_data_get_addr(rs1, zeros(), ReadWrite(Data, Data), width) {
     Ext_DataAddr_Error(e)  => Ext_DataAddr_Check_Failure(e),
     Ext_DataAddr_OK(vaddr) => {
       if not(is_aligned_addr(bits_of(vaddr), width))
@@ -60,14 +60,14 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
       else match translateAddr(vaddr, ReadWrite(Data, Data)) {
         Err(e, _) => Memory_Exception(vaddr, e),
         Ok(addr, _) => {
-          let rs2_val = X(rs2)[width_bytes * 8 - 1 .. 0];
-          match mem_write_ea(addr, width_bytes, aq & rl, rl, true) {
+          let rs2_val = X(rs2)[width * 8 - 1 .. 0];
+          match mem_write_ea(addr, width, aq & rl, rl, true) {
             Err(e) => Memory_Exception(vaddr, e),
             Ok(_) => {
-              match mem_read(ReadWrite(Data, Data), addr, width_bytes, aq, aq & rl, true) {
+              match mem_read(ReadWrite(Data, Data), addr, width, aq, aq & rl, true) {
                 Err(e)     => Memory_Exception(vaddr, e),
                 Ok(loaded) => {
-                  let result : bits('width_bytes * 8) =
+                  let result : bits('width * 8) =
                     match op {
                       AMOSWAP => rs2_val,
                       AMOADD  => rs2_val + loaded,
@@ -79,7 +79,7 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
                       AMOMINU => if rs2_val <_u loaded then rs2_val else loaded,
                       AMOMAXU => if rs2_val >_u loaded then rs2_val else loaded,
                     };
-                  match mem_write_value(addr, width_bytes, sign_extend(result), aq & rl, rl, true) {
+                  match mem_write_value(addr, width, sign_extend(result), aq & rl, rl, true) {
                     Ok(true)  => { X(rd) = sign_extend(loaded); RETIRE_SUCCESS },
                     Ok(false) => { internal_error(__FILE__, __LINE__, "AMO got false from mem_write_value") },
                     Err(e)    => Memory_Exception(vaddr, e),

--- a/model/riscv_insts_zalrsc.sail
+++ b/model/riscv_insts_zalrsc.sail
@@ -11,9 +11,9 @@ function clause currentlyEnabled(Ext_Zalrsc) = hartSupports(Ext_Zalrsc) | curren
 // Zalrsc defines LR/SC for word and double
 function lrsc_width_valid(size : word_width) -> bool = {
   match size {
-    WORD   => true,
-    DOUBLE => xlen >= 64,
-    _      => false
+    4 => true,
+    8 => xlen >= 64,
+    _ => false,
   }
 }
 
@@ -36,12 +36,10 @@ mapping clause encdec = LOADRES(aq, rl, rs1, size, rd)
  */
 
 function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
-  let width_bytes = size_bytes(width);
-
   // This is checked during decoding.
-  assert(width_bytes <= xlen_bytes);
+  assert(width <= xlen_bytes);
 
-  match vmem_read(rs1, zeros(), width_bytes, Read(Data), aq, aq & rl, true) {
+  match vmem_read(rs1, zeros(), width, Read(Data), aq, aq & rl, true) {
     Ok(data) => {
       X(rd) = sign_extend(data);
       RETIRE_SUCCESS
@@ -63,16 +61,14 @@ mapping clause encdec = STORECON(aq, rl, rs2, rs1, size, rd)
 
 /* NOTE: Currently, we only EA if address translation is successful. This may need revisiting. */
 function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
-  let width_bytes = size_bytes(width);
-
   // This is checked during decoding.
-  assert(width_bytes <= xlen_bytes);
+  assert(width <= xlen_bytes);
 
   /* normal non-rmem case
    * RMEM: SC is allowed to succeed (but might fail later)
    */
-  let data = X(rs2)[width_bytes * 8 - 1 .. 0];
-  match vmem_write(rs1, zeros(), width_bytes, data, Write(Data), aq & rl, rl, true) {
+  let data = X(rs2)[width * 8 - 1 .. 0];
+  match vmem_write(rs1, zeros(), width, data, Write(Data), aq & rl, rl, true) {
     Ok(b) => {
       X(rd) = zero_extend(bool_bits(~(b)));
       cancel_reservation();

--- a/model/riscv_insts_zca.sail
+++ b/model/riscv_insts_zca.sail
@@ -59,7 +59,7 @@ function clause execute (C_LW(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   let rd = creg2reg_idx(rdc);
   let rs = creg2reg_idx(rsc);
-  execute(LOAD(imm, rs, rd, false, WORD))
+  execute(LOAD(imm, rs, rd, false, 4))
 }
 
 mapping clause assembly = C_LW(uimm, rsc, rdc)
@@ -76,7 +76,7 @@ function clause execute (C_LD(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
   let rd = creg2reg_idx(rdc);
   let rs = creg2reg_idx(rsc);
-  execute(LOAD(imm, rs, rd, false, DOUBLE))
+  execute(LOAD(imm, rs, rd, false, 8))
 }
 
 mapping clause assembly = C_LD(uimm, rsc, rdc)
@@ -94,7 +94,7 @@ function clause execute (C_SW(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   let rs1 = creg2reg_idx(rsc1);
   let rs2 = creg2reg_idx(rsc2);
-  execute(STORE(imm, rs2, rs1, WORD))
+  execute(STORE(imm, rs2, rs1, 4))
 }
 
 mapping clause assembly = C_SW(uimm, rsc1, rsc2)
@@ -112,7 +112,7 @@ function clause execute (C_SD(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
   let rs1 = creg2reg_idx(rsc1);
   let rs2 = creg2reg_idx(rsc2);
-  execute(STORE(imm, rs2, rs1, DOUBLE))
+  execute(STORE(imm, rs2, rs1, 8))
 }
 
 mapping clause assembly = C_SD(uimm, rsc1, rsc2)
@@ -424,7 +424,7 @@ mapping clause encdec_compressed = C_LWSP(ui76 @ ui5 @ ui42, rd)
 
 function clause execute (C_LWSP(uimm, rd)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
-  execute(LOAD(imm, sp, rd, false, WORD))
+  execute(LOAD(imm, sp, rd, false, 4))
 }
 
 mapping clause assembly = C_LWSP(uimm, rd)
@@ -440,7 +440,7 @@ mapping clause encdec_compressed = C_LDSP(ui86 @ ui5 @ ui43, rd)
 
 function clause execute (C_LDSP(uimm, rd)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
-  execute(LOAD(imm, sp, rd, false, DOUBLE))
+  execute(LOAD(imm, sp, rd, false, 8))
 }
 
 mapping clause assembly = C_LDSP(uimm, rd)
@@ -456,7 +456,7 @@ mapping clause encdec_compressed = C_SWSP(ui76 @ ui52, rs2)
 
 function clause execute (C_SWSP(uimm, rs2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
-  execute(STORE(imm, rs2, sp, WORD))
+  execute(STORE(imm, rs2, sp, 4))
 }
 
 mapping clause assembly = C_SWSP(uimm, rs2)
@@ -471,7 +471,7 @@ mapping clause encdec_compressed = C_SDSP(ui86 @ ui53, rs2)
 
 function clause execute (C_SDSP(uimm, rs2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
-  execute(STORE(imm, rs2, sp, DOUBLE))
+  execute(STORE(imm, rs2, sp, 8))
 }
 
 mapping clause assembly = C_SDSP(uimm, rs2)

--- a/model/riscv_insts_zcb.sail
+++ b/model/riscv_insts_zcb.sail
@@ -21,7 +21,7 @@ function clause execute C_LBU(uimm, rdc, rsc1) = {
   let imm : bits(12) = zero_extend(uimm);
   let rd = creg2reg_idx(rdc);
   let rs1 = creg2reg_idx(rsc1);
-  execute(LOAD(imm, rs1, rd, true, BYTE))
+  execute(LOAD(imm, rs1, rd, true, 1))
 }
 
 /* ****************************************************************** */
@@ -39,7 +39,7 @@ function clause execute C_LHU(uimm, rdc, rsc1) = {
   let imm : bits(12) = zero_extend(uimm);
   let rd = creg2reg_idx(rdc);
   let rs1 = creg2reg_idx(rsc1);
-  execute(LOAD(imm, rs1, rd, true, HALF))
+  execute(LOAD(imm, rs1, rd, true, 2))
 }
 
 /* ****************************************************************** */
@@ -57,7 +57,7 @@ function clause execute C_LH(uimm, rdc, rsc1) = {
   let imm : bits(12) = zero_extend(uimm);
   let rd = creg2reg_idx(rdc);
   let rs1 = creg2reg_idx(rsc1);
-  execute(LOAD(imm, rs1, rd, false, HALF))
+  execute(LOAD(imm, rs1, rd, false, 2))
 }
 
 /* ****************************************************************** */
@@ -75,7 +75,7 @@ function clause execute C_SB(uimm, rsc1, rsc2) = {
   let imm : bits(12) = zero_extend(uimm);
   let rs1 = creg2reg_idx(rsc1);
   let rs2 = creg2reg_idx(rsc2);
-  execute(STORE(imm, rs2, rs1, BYTE))
+  execute(STORE(imm, rs2, rs1, 1))
 }
 
 /* ****************************************************************** */
@@ -93,7 +93,7 @@ function clause execute C_SH(uimm, rsc1, rsc2) = {
   let imm : bits(12) = zero_extend(uimm);
   let rs1 = creg2reg_idx(rsc1);
   let rs2 = creg2reg_idx(rsc2);
-  execute(STORE(imm, rs2, rs1, HALF))
+  execute(STORE(imm, rs2, rs1, 2))
 }
 
 /* ****************************************************************** */

--- a/model/riscv_insts_zcd.sail
+++ b/model/riscv_insts_zcd.sail
@@ -16,7 +16,7 @@ mapping clause encdec_compressed = C_FLDSP(ui86 @ ui5 @ ui43, rd)
 
 function clause execute (C_FLDSP(uimm, rd)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
-  execute(LOAD_FP(imm, sp, rd, DOUBLE))
+  execute(LOAD_FP(imm, sp, rd, 8))
 }
 
 mapping clause assembly = C_FLDSP(uimm, rd)
@@ -33,7 +33,7 @@ mapping clause encdec_compressed = C_FSDSP(ui86 @ ui53, rs2)
 
 function clause execute (C_FSDSP(uimm, rs2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
-  execute(STORE_FP(imm, rs2, sp, DOUBLE))
+  execute(STORE_FP(imm, rs2, sp, 8))
 }
 
 mapping clause assembly = C_FSDSP(uimm, rs2)
@@ -52,7 +52,7 @@ function clause execute (C_FLD(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
   let rd = cregidx_to_fregidx(rdc);
   let rs = creg2reg_idx(rsc);
-  execute(LOAD_FP(imm, rs, rd, DOUBLE))
+  execute(LOAD_FP(imm, rs, rd, 8))
 }
 
 mapping clause assembly = C_FLD(uimm, rsc, rdc)
@@ -71,7 +71,7 @@ function clause execute (C_FSD(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
   let rs1 = creg2reg_idx(rsc1);
   let rs2 = cregidx_to_fregidx(rsc2);
-  execute(STORE_FP(imm, rs2, rs1, DOUBLE))
+  execute(STORE_FP(imm, rs2, rs1, 8))
 }
 
 mapping clause assembly = C_FSD(uimm, rsc1, rsc2)

--- a/model/riscv_insts_zcf.sail
+++ b/model/riscv_insts_zcf.sail
@@ -16,7 +16,7 @@ mapping clause encdec_compressed = C_FLWSP(ui76 @ ui5 @ ui42, rd)
 
 function clause execute (C_FLWSP(imm, rd)) = {
   let imm : bits(12) = zero_extend(imm @ 0b00);
-  execute(LOAD_FP(imm, sp, rd, WORD))
+  execute(LOAD_FP(imm, sp, rd, 4))
 }
 
 mapping clause assembly = C_FLWSP(imm, rd)
@@ -32,7 +32,7 @@ mapping clause encdec_compressed = C_FSWSP(ui76 @ ui52, rs2)
 
 function clause execute (C_FSWSP(uimm, rs2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
-  execute(STORE_FP(imm, rs2, sp, WORD))
+  execute(STORE_FP(imm, rs2, sp, 4))
 }
 
 mapping clause assembly = C_FSWSP(uimm, rs2)
@@ -50,7 +50,7 @@ function clause execute (C_FLW(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   let rd = cregidx_to_fregidx(rdc);
   let rs = creg2reg_idx(rsc);
-  execute(LOAD_FP(imm, rs, rd, WORD))
+  execute(LOAD_FP(imm, rs, rd, 4))
 }
 
 mapping clause assembly = C_FLW(uimm, rsc, rdc)
@@ -68,7 +68,7 @@ function clause execute (C_FSW(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   let rs1 = creg2reg_idx(rsc1);
   let rs2 = cregidx_to_fregidx(rsc2);
-  execute(STORE_FP(imm, rs2, rs1, WORD))
+  execute(STORE_FP(imm, rs2, rs1, 4))
 }
 
 mapping clause assembly = C_FSW(uimm, rsc1, rsc2)

--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -47,10 +47,10 @@ function is_aligned_vaddr(Virtaddr(addr) : virtaddr, width : nat1) -> bool =
 
 function is_aligned_bits(vaddr : xlenbits, width : word_width) -> bool =
   match width {
-    BYTE   => true,
-    HALF   => vaddr[0..0] == zeros(),
-    WORD   => vaddr[1..0] == zeros(),
-    DOUBLE => vaddr[2..0] == zeros(),
+    1 => true,
+    2 => vaddr[0..0] == zeros(),
+    4 => vaddr[1..0] == zeros(),
+    8 => vaddr[2..0] == zeros(),
   }
 
 overload is_aligned_addr = {is_aligned_paddr, is_aligned_vaddr, is_aligned_bits}

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -85,7 +85,7 @@ union AccessType ('a : Type) = {
   InstructionFetch : unit
 }
 
-enum word_width = {BYTE, HALF, WORD, DOUBLE}
+type word_width = {1, 2, 4, 8}
 
 type is_mem_width('w) = 'w in {1, 2, 4, 8}
 
@@ -310,24 +310,17 @@ overload to_str = {wait_name}
 
 // Get the bit encoding of word_width.
 mapping size_enc : word_width <-> bits(2) = {
-  BYTE   <-> 0b00,
-  HALF   <-> 0b01,
-  WORD   <-> 0b10,
-  DOUBLE <-> 0b11
+  1 <-> 0b00,
+  2 <-> 0b01,
+  4 <-> 0b10,
+  8 <-> 0b11,
 }
 
 mapping size_mnemonic : word_width <-> string = {
-  BYTE   <-> "b",
-  HALF   <-> "h",
-  WORD   <-> "w",
-  DOUBLE <-> "d"
-}
-
-mapping size_bytes : word_width <-> {1, 2, 4, 8} = {
-  BYTE   <-> 1,
-  HALF   <-> 2,
-  WORD   <-> 4,
-  DOUBLE <-> 8,
+  1 <-> "b",
+  2 <-> "h",
+  4 <-> "w",
+  8 <-> "d",
 }
 
 struct mul_op = {

--- a/model/riscv_vmem_utils.sail
+++ b/model/riscv_vmem_utils.sail
@@ -169,7 +169,7 @@ function check_misaligned(vaddr : virtaddr, width : word_width) -> bool = {
   if plat_enable_misaligned_access then {
     false
   } else {
-    not(is_aligned_addr(vaddr, size_bytes(width)))
+    not(is_aligned_addr(vaddr, width))
   }
 }
 
@@ -194,7 +194,7 @@ function vmem_read(rs, offset, width, acc, aq, rl, res) = {
     if   not(is_aligned_addr(vaddr, width))
     then return Err(Memory_Exception(vaddr, E_Load_Addr_Align()));
   } else {
-    if check_misaligned(vaddr, size_bytes(width))
+    if check_misaligned(vaddr, width)
     then return Err(Memory_Exception(vaddr, E_Load_Addr_Align()));
   };
 
@@ -251,7 +251,7 @@ function vmem_write(rs_addr, offset, width, data, acc, aq, rl, res) = {
     Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
   };
 
-  if   check_misaligned(vaddr, size_bytes(width))
+  if   check_misaligned(vaddr, width)
   then return Err(Memory_Exception(vaddr, E_SAMO_Addr_Align()));
 
   vmem_write_addr(vaddr, width, data, acc, aq, rl, res)


### PR DESCRIPTION
For instructions that can access power-of-two sizes (1, 2, 4, 8 bytes), switch to using integers for the sizes instead of an enum. This will allow more elegant support for 16-byte accesses in future, and is slightly nicer already.

There are more possible improvements:

1. Merge some of the repeated encdec clauses.
2. Use power of two instead of bytes, i.e. `range(0, 3)` instead of `{1, 2, 4, 8}`.

However this keeps the change fairly minimal.