### PR TITLE
Add config flags to control PMP address mode support

### DIFF
--- a/config/rv32d.json
+++ b/config/rv32d.json
@@ -12,7 +12,10 @@
   "memory": {
     "pmp": {
       "grain": 0,
-      "count": 16
+      "count": 16,
+      "tor_supported": true,
+      "na4_supported": true,
+      "napot_supported": true
     },
     "misaligned": {
       "supported": true,

--- a/config/rv64d.json
+++ b/config/rv64d.json
@@ -12,7 +12,10 @@
   "memory": {
     "pmp": {
       "grain": 0,
-      "count": 16
+      "count": 16,
+      "tor_supported": true,
+      "na4_supported": true,
+      "napot_supported": true
     },
     "misaligned": {
       "supported": true,

--- a/model/riscv_pmp_control.sail
+++ b/model/riscv_pmp_control.sail
@@ -47,7 +47,7 @@ function pmpMatchAddr(
 ) -> pmpAddrMatch = {
   let addr = unsigned(addr);
   let width = unsigned(width);
-  match pmpAddrMatchType_of_bits(ent[A]) {
+  match pmpAddrMatchType_encdec(ent[A]) {
     OFF => PMP_NoMatch,
     TOR => {
       // "If PMP entry [i]'s A field is set to TOR, the entry matches
@@ -119,6 +119,6 @@ function reset_pmp() -> unit = {
   foreach (i from 0 to 63) {
     // On reset the PMP register's A and L bits are set to 0 unless the platform
     // mandates a different value.
-    pmpcfg_n[i] = [pmpcfg_n[i] with A = pmpAddrMatchType_to_bits(OFF), L = 0b0];
+    pmpcfg_n[i] = [pmpcfg_n[i] with A = pmpAddrMatchType_encdec(OFF), L = 0b0];
   };
 }

--- a/model/riscv_pmp_regs.sail
+++ b/model/riscv_pmp_regs.sail
@@ -19,24 +19,11 @@ let sys_pmp_grain : range(0, 63) = config memory.pmp.grain
 
 enum PmpAddrMatchType = {OFF, TOR, NA4, NAPOT}
 
-val pmpAddrMatchType_of_bits : bits(2) -> PmpAddrMatchType
-function pmpAddrMatchType_of_bits(bs) = {
-  match bs {
-    0b00 => OFF,
-    0b01 => TOR,
-    0b10 => NA4,
-    0b11 => NAPOT
-  }
-}
-
-val pmpAddrMatchType_to_bits : PmpAddrMatchType -> bits(2)
-function pmpAddrMatchType_to_bits(bs) = {
-  match bs {
-    OFF   => 0b00,
-    TOR   => 0b01,
-    NA4   => 0b10,
-    NAPOT => 0b11
-  }
+mapping pmpAddrMatchType_encdec : PmpAddrMatchType <-> bits(2) = {
+  OFF   <-> 0b00,
+  TOR   <-> 0b01,
+  NA4   <-> 0b10,
+  NAPOT <-> 0b11,
 }
 
 bitfield Pmpcfg_ent : bits(8) = {
@@ -102,7 +89,7 @@ function pmpLocked(cfg: Pmpcfg_ent) -> bool =
    cfg[L] == 0b1
 
 function pmpTORLocked(cfg: Pmpcfg_ent) -> bool =
-   (cfg[L] == 0b1) & (pmpAddrMatchType_of_bits(cfg[A]) == TOR)
+   (cfg[L] == 0b1) & (pmpAddrMatchType_encdec(cfg[A]) == TOR)
 
 function pmpWriteCfg(n: range(0, 63), cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent =
   if pmpLocked(cfg) then cfg
@@ -115,12 +102,21 @@ function pmpWriteCfg(n: range(0, 63), cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent
     // This is the least risky option from a security perspective.
     let cfg = if cfg[W] == 0b1 & cfg[R] == 0b0 then [cfg with X = 0b0, W = 0b0, R = 0b0] else cfg;
 
-    // "When G >= 1, the NA4 mode is not selectable."
-    // In this implementation we set it to OFF if NA4 is selected.
+    // We support disabling all modes globally, which is allowed since this
+    // is a WARL field.
+    let mode_supported : bool = match pmpAddrMatchType_encdec(cfg[A]) {
+      OFF   => true,
+      TOR   => config memory.pmp.tor_supported,
+      // "When G >= 1, the NA4 mode is not selectable."
+      NA4   => (config memory.pmp.na4_supported : bool) & sys_pmp_grain == 0,
+      NAPOT => config memory.pmp.napot_supported,
+    };
+
+    // In this implementation we set the mode to OFF if an unsupported mode is selected.
     // This is the least risky option from a security perspective.
-    let cfg = if sys_pmp_grain >= 1 & pmpAddrMatchType_of_bits(cfg[A]) == NA4
-              then [cfg with A = pmpAddrMatchType_to_bits(OFF)]
-              else cfg;
+    let cfg = if mode_supported
+              then cfg
+              else [cfg with A = pmpAddrMatchType_encdec(OFF)];
 
     cfg
   }

--- a/model/riscv_validate_config.sail
+++ b/model/riscv_validate_config.sail
@@ -99,9 +99,20 @@ function check_mem_layout() -> bool = {
   valid
 }
 
+function check_pmp() -> bool = {
+  var valid : bool = true;
+  if (config memory.pmp.na4_supported : bool) & sys_pmp_grain != 0
+  then {
+    valid = false;
+    print_endline("NA4 is not supported if the PMP grain G is non-zero.");
+  };
+  valid
+}
+
 function config_is_valid() -> bool = {
     check_privs()
   & check_mmu_config()
   & check_mem_layout()
   & check_vlen_elen()
+  & check_pmp()
 }


### PR DESCRIPTION
This adds config flags to allow marking PMP address matching modes as not supported. If software tries to write an unsupported mode it will get set to OFF instead.

For NA4 mode it is required that the grain G is 0. If it isn't then that mode is unsupported. This is also checked in `config_is_valid()` which is redundant... but I think that's ok for now. Another option would be to print a warning like `Warning: NA4 is marked as supported but G > 0 so it has been disabled`.

Fixes #1109 