### PR TITLE
Reduce duplication in Zba

### DIFF
--- a/model/riscv_insts_zba.sail
+++ b/model/riscv_insts_zba.sail
@@ -25,73 +25,44 @@ function clause execute (SLLIUW(shamt, rs1, rd)) = {
 }
 
 /* ****************************************************************** */
-union clause instruction = ZBA_RTYPEUW : (regidx, regidx, regidx, bropw_zba)
+union clause instruction = ZBA_RTYPEUW : (regidx, regidx, regidx, shamt_zba)
 
-mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, ADDUW)
-  <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0111011
+mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, shamt)
+  <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ shamt @ 0b0 @ encdec_reg(rd) @ 0b0111011
   when currentlyEnabled(Ext_Zba) & xlen == 64
 
-mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, SH1ADDUW)
-  <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0111011
-  when currentlyEnabled(Ext_Zba) & xlen == 64
-
-mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, SH2ADDUW)
-  <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0111011
-  when currentlyEnabled(Ext_Zba) & xlen == 64
-
-mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, SH3ADDUW)
-  <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0111011
-  when currentlyEnabled(Ext_Zba) & xlen == 64
-
-mapping zba_rtypeuw_mnemonic : bropw_zba <-> string = {
-  ADDUW    <-> "add.uw",
-  SH1ADDUW <-> "sh1add.uw",
-  SH2ADDUW <-> "sh2add.uw",
-  SH3ADDUW <-> "sh3add.uw",
+mapping zba_rtypeuw_mnemonic : shamt_zba <-> string = {
+  0b00 <-> "add.uw",
+  0b01 <-> "sh1add.uw",
+  0b10 <-> "sh2add.uw",
+  0b11 <-> "sh3add.uw",
 }
 
-mapping clause assembly = ZBA_RTYPEUW(rs2, rs1, rd, op)
-  <-> zba_rtypeuw_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
+mapping clause assembly = ZBA_RTYPEUW(rs2, rs1, rd, shamt)
+  <-> zba_rtypeuw_mnemonic(shamt) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (ZBA_RTYPEUW(rs2, rs1, rd, op)) = {
-  let shamt : bits(2) = match op {
-    ADDUW    => 0b00,
-    SH1ADDUW => 0b01,
-    SH2ADDUW => 0b10,
-    SH3ADDUW => 0b11,
-  };
+function clause execute (ZBA_RTYPEUW(rs2, rs1, rd, shamt)) = {
   X(rd) = (zero_extend(X(rs1)[31..0]) << shamt) + X(rs2);
   RETIRE_SUCCESS
 }
 
 /* ****************************************************************** */
-union clause instruction = ZBA_RTYPE : (regidx, regidx, regidx, brop_zba)
+union clause instruction = ZBA_RTYPE : (regidx, regidx, regidx, shamt_zba)
 
-mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, SH1ADD)
-  <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011
-  when currentlyEnabled(Ext_Zba)
-mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, SH2ADD)
-  <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
-  when currentlyEnabled(Ext_Zba)
-mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, SH3ADD)
-  <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011
-  when currentlyEnabled(Ext_Zba)
+mapping clause encdec = ZBA_RTYPE(rs2, rs1, rd, shamt)
+  <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ shamt @ 0b0 @ encdec_reg(rd) @ 0b0110011
+  when shamt != 0b00 & currentlyEnabled(Ext_Zba)
 
-mapping zba_rtype_mnemonic : brop_zba <-> string = {
-  SH1ADD <-> "sh1add",
-  SH2ADD <-> "sh2add",
-  SH3ADD <-> "sh3add",
+mapping zba_rtype_mnemonic : shamt_zba <-> string = {
+  0b01 <-> "sh1add",
+  0b10 <-> "sh2add",
+  0b11 <-> "sh3add",
 }
 
-mapping clause assembly = ZBA_RTYPE(rs2, rs1, rd, op)
-  <-> zba_rtype_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
+mapping clause assembly = ZBA_RTYPE(rs2, rs1, rd, shamt)
+  <-> zba_rtype_mnemonic(shamt) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (ZBA_RTYPE(rs2, rs1, rd, op)) = {
-  let shamt : bits(2) = match op {
-    SH1ADD => 0b01,
-    SH2ADD => 0b10,
-    SH3ADD => 0b11,
-  };
+function clause execute (ZBA_RTYPE(rs2, rs1, rd, shamt)) = {
   X(rd) = (X(rs1) << shamt) + X(rs2);
   RETIRE_SUCCESS
 }

--- a/model/riscv_insts_zcb.sail
+++ b/model/riscv_insts_zcb.sail
@@ -174,7 +174,7 @@ mapping clause assembly = C_ZEXT_W(rsdc) <->
 
 function clause execute C_ZEXT_W(rsdc) = {
   let rsd = creg2reg_idx(rsdc);
-  execute (ZBA_RTYPEUW(zreg, rsd, rsd, ADDUW))
+  execute (ZBA_RTYPEUW(zreg, rsd, rsd, 0b00))
 }
 
 /* ****************************************************************** */

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -279,15 +279,13 @@ enum csrop = {CSRRW, CSRRS, CSRRC}                    /* CSR ops */
 
 enum cbop_zicbom = {CBO_CLEAN, CBO_FLUSH, CBO_INVAL}  /* Zicbom ops */
 
-enum brop_zba = {SH1ADD, SH2ADD, SH3ADD}
+type shamt_zba = bits(2)
 
 enum brop_zbb = {ANDN, ORN, XNOR, MAX, MAXU, MIN, MINU, ROL, ROR}
 
 enum brop_zbkb = {PACK, PACKH}
 
 enum brop_zbs = {BCLR, BEXT, BINV, BSET}
-
-enum bropw_zba = {ADDUW, SH1ADDUW, SH2ADDUW, SH3ADDUW}
 
 enum bropw_zbb = {ROLW, RORW}
 


### PR DESCRIPTION
The shift amount for these instructions is pretty clearly part of the opcode, so we can decode it directly and avoid so much repetition. The only slightly awkward part is that a shift of 0 is not allowed for `ZBA_RTYPE`. That's handled with `when shamt != 0b00`.