### PR TITLE
Add Remote Bitbang protocol support for GDB/OpenOCD integration

### DIFF
--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -16,6 +16,10 @@ set(EMULATOR_COMMON_SRCS
     riscv_softfloat.h
     config_utils.h
     config_utils.cpp
+    jtag_dtm.cpp
+    jtag_dtm.h
+    remote_bitbang.cpp
+    remote_bitbang.h
 )
 
 add_executable(sail_riscv_sim

--- a/c_emulator/jtag_dtm.cpp
+++ b/c_emulator/jtag_dtm.cpp
@@ -1,0 +1,276 @@
+#include <stdio.h>
+#include "jtag_dtm.h"
+#include "remote_bitbang.h"
+#include "riscv_sail.h"
+#include "sail.h"
+
+#if 0
+#define D(x) x
+#else
+#define D(x)
+#endif
+
+enum { IR_IDCODE = 1, IR_DTMCONTROL = 0x10, IR_DBUS = 0x11, IR_BYPASS = 0x1f };
+
+#define DTMCONTROL_VERSION 0xf
+#define DTMCONTROL_ABITS (0x3f << 4)
+#define DTMCONTROL_DMISTAT (3 << 10)
+#define DTMCONTROL_IDLE (7 << 12)
+#define DTMCONTROL_DMIRESET (1 << 16)
+#define DTMCONTROL_DMIHARDRESET (1 << 17)
+
+#define DTM_DTMCS_ABITS_OFFSET 4ULL
+
+#define DMI_OP 3
+#define DMI_DATA (0xffffffffLL << 2)
+#define DMI_ADDRESS ((1LL << (abits + 34)) - (1LL << 34))
+
+#define DMI_OP_STATUS_SUCCESS 0
+#define DMI_OP_STATUS_RESERVED 1
+#define DMI_OP_STATUS_FAILED 2
+#define DMI_OP_STATUS_BUSY 3
+
+#define DMI_OP_NOP 0
+#define DMI_OP_READ 1
+#define DMI_OP_WRITE 2
+#define DMI_OP_RESERVED 3
+
+#define DTM_DMI_OP_OFFSET 0ULL
+#define DTM_DMI_OP_LENGTH 2ULL
+#define DTM_DMI_OP 3ULL
+
+jtag_dtm_t::jtag_dtm_t(unsigned required_rti_cycles)
+    : required_rti_cycles(required_rti_cycles)
+    , _tck(false)
+    , _tms(false)
+    , _tdi(false)
+    , _tdo(false)
+    , dtmcontrol((abits << DTM_DTMCS_ABITS_OFFSET) | 1)
+    , dmi(DMI_OP_STATUS_SUCCESS << DTM_DMI_OP_OFFSET)
+    , bypass(0)
+    , _state(TEST_LOGIC_RESET)
+{
+}
+
+void jtag_dtm_t::reset()
+{
+  _state = TEST_LOGIC_RESET;
+  busy_stuck = false;
+  rti_remaining = 0;
+  dmi = 0;
+}
+
+void jtag_dtm_t::set_pins(bool tck, bool tms, bool tdi)
+{
+  const jtag_state_t next[16][2] = {
+      /* TEST_LOGIC_RESET */ {RUN_TEST_IDLE, TEST_LOGIC_RESET},
+      /* RUN_TEST_IDLE */
+      {RUN_TEST_IDLE, SELECT_DR_SCAN  },
+      /* SELECT_DR_SCAN */
+      {CAPTURE_DR,    SELECT_IR_SCAN  },
+      /* CAPTURE_DR */
+      {SHIFT_DR,      EXIT1_DR        },
+      /* SHIFT_DR */
+      {SHIFT_DR,      EXIT1_DR        },
+      /* EXIT1_DR */
+      {PAUSE_DR,      UPDATE_DR       },
+      /* PAUSE_DR */
+      {PAUSE_DR,      EXIT2_DR        },
+      /* EXIT2_DR */
+      {SHIFT_DR,      UPDATE_DR       },
+      /* UPDATE_DR */
+      {RUN_TEST_IDLE, SELECT_DR_SCAN  },
+      /* SELECT_IR_SCAN */
+      {CAPTURE_IR,    TEST_LOGIC_RESET},
+      /* CAPTURE_IR */
+      {SHIFT_IR,      EXIT1_IR        },
+      /* SHIFT_IR */
+      {SHIFT_IR,      EXIT1_IR        },
+      /* EXIT1_IR */
+      {PAUSE_IR,      UPDATE_IR       },
+      /* PAUSE_IR */
+      {PAUSE_IR,      EXIT2_IR        },
+      /* EXIT2_IR */
+      {SHIFT_IR,      UPDATE_IR       },
+      /* UPDATE_IR */
+      {RUN_TEST_IDLE, SELECT_DR_SCAN  }
+  };
+
+  if (!_tck && tck) {
+    // Positive clock edge. TMS and TDI are sampled
+    // on the rising edge of TCK by Target.
+    switch (_state) {
+    case SHIFT_DR:
+      dr >>= 1;
+      dr |= (uint64_t)_tdi << (dr_length - 1);
+      break;
+    case SHIFT_IR:
+      ir >>= 1;
+      ir |= _tdi << (ir_length - 1);
+      break;
+    default:
+      break;
+    }
+    _state = next[_state][_tms];
+
+  } else {
+    // Negative clock edge. TDO is updated.
+    switch (_state) {
+    case RUN_TEST_IDLE:
+      if (rti_remaining > 0)
+        rti_remaining--;
+      // dm->run_test_idle();
+      break;
+    case TEST_LOGIC_RESET:
+      ir = IR_IDCODE;
+      break;
+    case CAPTURE_DR:
+      capture_dr();
+      break;
+    case SHIFT_DR:
+      _tdo = dr & 1;
+      break;
+    case UPDATE_DR:
+      update_dr();
+      break;
+    case SHIFT_IR:
+      _tdo = ir & 1;
+      break;
+    default:
+      break;
+    }
+  }
+
+  D(fprintf(stderr,
+            "state=%2d, tdi=%d, tdo=%d, tms=%d, tck=%d, ir=0x%02x, "
+            "dr=0x%lx\n",
+            _state, _tdi, _tdo, _tms, _tck, ir, dr));
+
+  _tck = tck;
+  _tms = tms;
+  _tdi = tdi;
+}
+
+void jtag_dtm_t::capture_dr()
+{
+  switch (ir) {
+  case IR_IDCODE:
+    dr = idcode;
+    dr_length = 32;
+    break;
+  case IR_DTMCONTROL:
+    dr = dtmcontrol;
+    dr_length = 32;
+    break;
+  case IR_DBUS:
+    if (rti_remaining > 0 || busy_stuck) {
+      dr = DMI_OP_STATUS_BUSY;
+      busy_stuck = true;
+    } else {
+      dr = dmi;
+    }
+    dr_length = abits + 34;
+    break;
+  case IR_BYPASS:
+    dr = bypass;
+    dr_length = 1;
+    break;
+  default:
+    D(fprintf(stderr, "Unsupported IR: 0x%x\n", ir));
+    break;
+  }
+  D(fprintf(stderr, "Capture DR; IR=0x%x, DR=0x%lx (%d bits)\n", ir, dr,
+            dr_length));
+}
+
+void jtag_dtm_t::update_dr()
+{
+  D(fprintf(stderr, "Update DR; IR=0x%x, DR=0x%lx (%d bits)\n", ir, dr,
+            dr_length));
+
+  if (ir == IR_DTMCONTROL) {
+    if (dr & DTMCONTROL_DMIRESET)
+      busy_stuck = false;
+    if (dr & DTMCONTROL_DMIHARDRESET)
+      reset();
+  } else if (ir == IR_BYPASS) {
+    bypass = dr;
+  } else if (ir == IR_DBUS && !busy_stuck) {
+    unsigned op = dr & DMI_OP;
+
+    uint32_t data = (dr & DMI_DATA) >> 2;
+    sail_int sail_data;
+    CREATE(sail_int)(&sail_data);
+    CONVERT_OF(sail_int, mach_int)(&sail_data, data);
+
+    uint32_t address = (dr & DMI_ADDRESS) >> 34;
+    sail_int sail_address;
+    CREATE(sail_int)(&sail_address);
+    CONVERT_OF(sail_int, mach_int)(&sail_address, address);
+
+    D(fprintf(stderr, "OP: %u\n", op));
+
+    dmi = dr;
+
+    bool success = true;
+    if (op == DMI_OP_READ) {
+      // NOTE: If the interface of dmi_read() stays the same, are
+      // these struct names always deterministic and don't change?
+      // NOTE: The following struct consists of a bool and a sail_int
+      struct ztuple_z8z5boolzCz0z5iz9 dmi_read_result;
+      CREATE(sail_int)(&dmi_read_result.ztup1);
+
+      zdmi_read(&dmi_read_result, sail_address);
+
+      success = dmi_read_result.ztup0;
+
+      if (success) {
+        uint32_t value = CONVERT_OF(mach_int, sail_int)(dmi_read_result.ztup1);
+
+        dmi &= ~DMI_DATA;
+        dmi |= ((uint64_t)value << 2) & DMI_DATA;
+      }
+      KILL(sail_int)(&dmi_read_result.ztup1);
+    } else if (op == DMI_OP_WRITE) {
+      success = zdmi_write(sail_address, sail_data);
+    }
+
+    if (success) {
+      dmi = (dmi & ~0x3) | DMI_OP_STATUS_SUCCESS;
+    } else {
+      dmi = (dmi & ~0x3) | DMI_OP_STATUS_FAILED;
+    }
+
+    D(fprintf(stderr, "dmi=0x%lx\n", dmi));
+
+    rti_remaining = required_rti_cycles;
+
+    KILL(sail_int)(&sail_address);
+    KILL(sail_int)(&sail_data);
+  }
+}
+
+static bool debug_enabled = false;
+static jtag_dtm_t *jtag_dtm = nullptr;
+static remote_bitbang_t *remote_bitbang = nullptr;
+
+void init_debug_interface(uint16_t rbb_port)
+{
+  if (!jtag_dtm) {
+    debug_enabled = true;
+    unsigned required_rti_cycles = 0;
+    // TODO: Add command-line option to set required_rti_cycles at runtime
+    jtag_dtm = new jtag_dtm_t(required_rti_cycles);
+    remote_bitbang = new remote_bitbang_t(rbb_port, jtag_dtm);
+  }
+}
+
+bool is_debug_enabled()
+{
+  return debug_enabled;
+}
+
+remote_bitbang_t *get_remote_bitbang()
+{
+  return remote_bitbang;
+}

--- a/c_emulator/jtag_dtm.h
+++ b/c_emulator/jtag_dtm.h
@@ -1,0 +1,79 @@
+#ifndef JTAG_DTM_H
+#define JTAG_DTM_H
+
+#include <stdint.h>
+
+typedef enum {
+  TEST_LOGIC_RESET,
+  RUN_TEST_IDLE,
+  SELECT_DR_SCAN,
+  CAPTURE_DR,
+  SHIFT_DR,
+  EXIT1_DR,
+  PAUSE_DR,
+  EXIT2_DR,
+  UPDATE_DR,
+  SELECT_IR_SCAN,
+  CAPTURE_IR,
+  SHIFT_IR,
+  EXIT1_IR,
+  PAUSE_IR,
+  EXIT2_IR,
+  UPDATE_IR
+} jtag_state_t;
+
+class jtag_dtm_t {
+  static const unsigned idcode = 0xdeadbeef;
+
+public:
+  jtag_dtm_t(unsigned required_rti_cycles);
+  void reset();
+
+  void set_pins(bool tck, bool tms, bool tdi);
+
+  bool tdo() const
+  {
+    return _tdo;
+  }
+
+  jtag_state_t state() const
+  {
+    return _state;
+  }
+
+private:
+  // The number of Run-Test/Idle cycles required
+  // before a DMI access is complete.
+  unsigned required_rti_cycles;
+  bool _tck, _tms, _tdi, _tdo;
+  uint32_t ir;
+  const unsigned ir_length = 5;
+  uint64_t dr;
+  unsigned dr_length;
+
+  // abits must come before dtmcontrol so it can
+  // easily be used in the constructor.
+  // From RISC-V Debug Spec (both 0.13.2 and 1.0):
+  // The DMI uses between 7 and 32 address bits.
+  const unsigned abits = 7;
+  uint32_t dtmcontrol;
+  uint64_t dmi;
+  unsigned bypass;
+  // Number of Run-Test/Idle cycles needed before
+  // we call this access complete.
+  unsigned rti_remaining;
+  bool busy_stuck;
+
+  jtag_state_t _state;
+
+  void capture_dr();
+  void update_dr();
+};
+
+class remote_bitbang_t;
+
+void init_debug_interface(uint16_t rbb_port);
+bool is_debug_enabled();
+remote_bitbang_t *get_remote_bitbang();
+
+#endif

--- a/c_emulator/remote_bitbang.cpp
+++ b/c_emulator/remote_bitbang.cpp
@@ -1,0 +1,207 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <arpa/inet.h>
+#ifndef AF_INET
+#include <sys/socket.h>
+#endif
+#ifndef INADDR_ANY
+#include <netinet/in.h>
+#endif
+
+#include "jtag_dtm.h"
+#include "remote_bitbang.h"
+
+remote_bitbang_t::remote_bitbang_t(uint16_t port, jtag_dtm_t *tap)
+    : tap(tap)
+    , socket_fd(-1)
+    , client_fd(-1)
+    , recv_start(0)
+    , recv_end(0)
+{
+  // Create socket
+  socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (socket_fd == -1) {
+    fprintf(stderr, "remote_bitbang failed to create socket: %s (%d)\n",
+            strerror(errno), errno);
+    exit(EXIT_FAILURE);
+  }
+
+  if (fcntl(socket_fd, F_SETFL, O_NONBLOCK) == -1) {
+    fprintf(stderr, "remote_bitbang failed to set non-blocking: %s (%d)\n",
+            strerror(errno), errno);
+    exit(EXIT_FAILURE);
+  }
+
+  int reuseaddr = 1;
+  if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &reuseaddr, sizeof(int))
+      == -1) {
+    fprintf(stderr, "remote_bitbang failed setsockopt: %s (%d)\n",
+            strerror(errno), errno);
+    exit(EXIT_FAILURE);
+  }
+
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = INADDR_ANY;
+  addr.sin_port = htons(port);
+
+  if (bind(socket_fd, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
+    fprintf(stderr, "remote_bitbang failed to bind socket: %s (%d)\n",
+            strerror(errno), errno);
+    exit(EXIT_FAILURE);
+  }
+
+  if (listen(socket_fd, 1) == -1) {
+    fprintf(stderr, "remote_bitbang failed to listen on socket: %s (%d)\n",
+            strerror(errno), errno);
+    exit(EXIT_FAILURE);
+  }
+
+  socklen_t addrlen = sizeof(addr);
+  if (getsockname(socket_fd, (struct sockaddr *)&addr, &addrlen) == -1) {
+    fprintf(stderr, "remote_bitbang getsockname failed: %s (%d)\n",
+            strerror(errno), errno);
+    exit(EXIT_FAILURE);
+  }
+
+  printf("Listening for remote bitbang connection on port %d.\n",
+         ntohs(addr.sin_port));
+  fflush(stdout);
+}
+
+void remote_bitbang_t::accept()
+{
+  client_fd = ::accept(socket_fd, NULL, NULL);
+  if (client_fd == -1) {
+    if (errno == EAGAIN) {
+      // No client waiting to connect right now.
+    } else {
+      fprintf(stderr, "failed to accept on socket: %s (%d)\n", strerror(errno),
+              errno);
+      exit(EXIT_FAILURE);
+    }
+  } else {
+    fcntl(client_fd, F_SETFL, O_NONBLOCK);
+  }
+}
+
+void remote_bitbang_t::tick()
+{
+  if (client_fd > 0) {
+    execute_commands();
+  } else {
+    this->accept();
+  }
+}
+
+void remote_bitbang_t::execute_commands()
+{
+  unsigned total_processed = 0;
+  bool quit = false;
+  bool in_rti = tap->state() == RUN_TEST_IDLE;
+  bool entered_rti = false;
+  while (1) {
+    if (recv_start < recv_end) {
+      unsigned send_offset = 0;
+      while (recv_start < recv_end) {
+        uint8_t command = recv_buf[recv_start];
+
+        switch (command) {
+        case 'B':
+          break;
+        case 'b':
+          break;
+        case 'r':
+          tap->reset();
+          break;
+        case '0':
+          tap->set_pins(0, 0, 0);
+          break;
+        case '1':
+          tap->set_pins(0, 0, 1);
+          break;
+        case '2':
+          tap->set_pins(0, 1, 0);
+          break;
+        case '3':
+          tap->set_pins(0, 1, 1);
+          break;
+        case '4':
+          tap->set_pins(1, 0, 0);
+          break;
+        case '5':
+          tap->set_pins(1, 0, 1);
+          break;
+        case '6':
+          tap->set_pins(1, 1, 0);
+          break;
+        case '7':
+          tap->set_pins(1, 1, 1);
+          break;
+        case 'R':
+          send_buf[send_offset++] = tap->tdo() ? '1' : '0';
+          break;
+        case 'Q':
+          quit = true;
+          break;
+        default:
+          fprintf(stderr, "remote_bitbang got unsupported command '%c'\n",
+                  command);
+        }
+        recv_start++;
+        total_processed++;
+        if (!in_rti && tap->state() == RUN_TEST_IDLE) {
+          entered_rti = true;
+          break;
+        }
+        in_rti = false;
+      }
+      unsigned sent = 0;
+      while (sent < send_offset) {
+        ssize_t bytes = write(client_fd, send_buf + sent, send_offset);
+        if (bytes == -1) {
+          fprintf(stderr, "failed to write to socket: %s (%d)\n",
+                  strerror(errno), errno);
+          exit(EXIT_FAILURE);
+        }
+        sent += bytes;
+      }
+    }
+
+    if (total_processed > buf_size || quit || entered_rti) {
+      // Don't go forever, because that could starve the main simulation.
+      break;
+    }
+
+    recv_start = 0;
+    recv_end = read(client_fd, recv_buf, buf_size);
+
+    if (recv_end == -1) {
+      if (errno == EAGAIN) {
+        break;
+      } else {
+        fprintf(stderr, "remote_bitbang failed to read on socket: %s (%d)\n",
+                strerror(errno), errno);
+        exit(EXIT_FAILURE);
+      }
+    }
+
+    if (quit) {
+      fprintf(stderr, "Remote Bitbang received 'Q'\n");
+    }
+
+    if (recv_end == 0 || quit) {
+      // The remote disconnected.
+      fprintf(stderr, "Received nothing. Quitting.\n");
+      close(client_fd);
+      client_fd = 0;
+      break;
+    }
+  }
+}

--- a/c_emulator/remote_bitbang.h
+++ b/c_emulator/remote_bitbang.h
@@ -1,0 +1,31 @@
+#ifndef REMOTE_BITBANG_H
+#define REMOTE_BITBANG_H
+
+#include <stdint.h>
+
+class jtag_dtm_t;
+
+class remote_bitbang_t {
+public:
+  remote_bitbang_t(uint16_t port, jtag_dtm_t *tap);
+
+  void tick();
+
+private:
+  jtag_dtm_t *tap;
+
+  int socket_fd;
+  int client_fd;
+
+  static const ssize_t buf_size = 64 * 1024;
+  char send_buf[buf_size];
+  char recv_buf[buf_size];
+  ssize_t recv_start, recv_end;
+
+  // Check for a client connecting, and accept if there is one.
+  void accept();
+  // Execute any commands the client has for us.
+  void execute_commands();
+};
+
+#endif

--- a/c_emulator/riscv_callbacks.cpp
+++ b/c_emulator/riscv_callbacks.cpp
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <vector>
 #include <inttypes.h>
+#include "jtag_dtm.h"
+#include "remote_bitbang.h"
 
 void print_lbits_hex(lbits val, int length = 0)
 {
@@ -134,6 +136,23 @@ unit trap_callback(unit)
 {
   if (config_enable_rvfi) {
     zrvfi_trap(UNIT);
+  }
+  return UNIT;
+}
+
+unit jtag_dtm_tick(unit)
+{
+  if (is_debug_enabled()) {
+    // NOTE: This is a temporary solution and needs to be redone
+    // we want to avoid the simulation ending too early
+    // so we keep polling to see if the debugger has sent more data
+    int max_ticks = 10000000;
+    int ticks = 0;
+    auto remote_bitbang = get_remote_bitbang();
+    while (ticks < max_ticks) {
+      remote_bitbang->tick();
+      ticks++;
+    }
   }
   return UNIT;
 }

--- a/c_emulator/riscv_callbacks.h
+++ b/c_emulator/riscv_callbacks.h
@@ -23,6 +23,7 @@ unit csr_full_read_callback(const_sail_string csr_name, unsigned reg,
 unit vreg_write_callback(unsigned reg, lbits value);
 unit pc_write_callback(sbits value);
 unit trap_callback(unit);
+unit jtag_dtm_tick(unit);
 
 // TODO: Move these implementations to C.
 unit zrvfi_write(sbits paddr, int64_t width, lbits value);

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -27,6 +27,7 @@
 #include "rvfi_dii.h"
 #include "default_config.h"
 #include "config_utils.h"
+#include "jtag_dtm.h"
 
 enum {
   OPT_TRACE_OUTPUT = 1000,
@@ -220,6 +221,7 @@ static int process_args(int argc, char **argv)
   while (true) {
     c = getopt_long(argc, argv,
                     "a"
+                    "d:"
                     "p"
                     "b:"
                     "t:"
@@ -235,6 +237,15 @@ static int process_args(int argc, char **argv)
     if (c == -1)
       break;
     switch (c) {
+    case 'd': {
+      fprintf(
+          stderr,
+          "Enable debugging and waits for OpenOCD to connect, opens port at "
+          "provided argument\n");
+      uint16_t rbb_port = atoi(optarg);
+      init_debug_interface(rbb_port);
+      break;
+    }
     case 'p':
       fprintf(stderr, "will show execution times on completion.\n");
       do_show_times = true;
@@ -445,6 +456,7 @@ void init_sail_reset_vector(uint64_t entry)
 
 void init_sail(uint64_t elf_entry, const char *config_file)
 {
+
   zinit_model(config_file != nullptr ? config_file : "");
   if (rvfi) {
     /*

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -147,6 +147,7 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
     set(sail_regs_srcs
         "riscv_csr_begin.sail"
         "riscv_callbacks.sail"
+        "riscv_debug_module_interface.sail"
         "riscv_reg_type.sail"
         "riscv_freg_type.sail"
         "riscv_regs.sail"
@@ -268,6 +269,8 @@ foreach (variant IN ITEMS "" "smt" "rocq" "rmem" "lean" "lem" "isabelle")
                 --c-preserve generate_dts
                 --c-preserve config_is_valid
                 --c-preserve generate_canonical_isa_string
+                --c-preserve dmi_read
+                --c-preserve dmi_write
                 # Preserve RVFI functions.
                 --c-preserve rvfi_set_instr_packet
                 --c-preserve rvfi_get_cmd

--- a/model/riscv_callbacks.sail
+++ b/model/riscv_callbacks.sail
@@ -31,6 +31,9 @@ function csr_full_read_callback(_) = ()
 val trap_callback = pure {c: "trap_callback"} : unit -> unit
 function trap_callback(_) = ()
 
+val jtag_dtm_tick = pure {c: "jtag_dtm_tick"} : unit -> unit
+function jtag_dtm_tick(_) = ()
+
 // Overloads for easier use of callbacks
 function csr_name_write_callback(name : string, value : xlenbits) -> unit = {
   let csr = csr_name_map(name);

--- a/model/riscv_debug_module_interface.sail
+++ b/model/riscv_debug_module_interface.sail
@@ -1,0 +1,26 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+// The DMI read/write interfaces connect the Debug Transport Module to the Debug Module,
+// bridging external debuggers like GDB (via OpenOCD) with internal components.
+// These interfaces are just one of many options and can be replaced by simple handshake
+// protocols or more complex bus protocols like AMBA to simulate hardware behavior.
+
+// Debug module interface read
+// Returns success status and 32-bit data read from the given 32-bit address
+function dmi_read(address : nat) -> (bool, nat) = {
+  // TODO
+  (true, 1)
+}
+
+// Debug module interface write
+// Returns success status after writing 32-bit value to the given 32-bit address
+function dmi_write(address : nat, value : nat) -> bool = {
+  // TODO
+  true
+}

--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -163,6 +163,10 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
   /* for step extensions */
   ext_pre_step_hook();
 
+  // If enabled, advances the bitbanging protocol and sends
+  // data to the debugger (over OpenOCD) or reads from it
+  jtag_dtm_tick();
+
   /*
    * This records whether or not minstret should be incremented when
    * the instruction is retired. Since retirement occurs before CSR


### PR DESCRIPTION
This PR adds the Remote Bitbang protocol (mainly code from Spike), which is one of three components required to enable remote debugging (Remote Bitbang, the Debug Module and the Sdext Extension).

With this protocol in place, it's now possible to connect OpenOCD (compiled with Remote Bitbang support) to the simulator. OpenOCD will successfully initiate communication but will not complete the initialization process yet, as the Debug Module is still missing. That module will provide internal registers and support for accessing general-purpose registers and CSRs, both of which are not yet implemented.

To enable remote debugging, this PR also adds a new (internal for now) command-line option to Sail:

`./build/c_emulator/sail_riscv_sim -d 9824 ./test/riscv-tests/rv64ui-p-jal.elf`

The `-d <PORT>` option sets the port for OpenOCD to connect to. Sail will wait for an incoming connection, but will continue the simulation slowly.