### PR TITLE
Add support for local counter-overflow interrupts

### DIFF
--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -102,13 +102,14 @@ function exception_delegatee(e : ExceptionType, p : Privilege) -> Privilege = {
  */
 function findPendingInterrupt(ip : xlenbits) -> option(InterruptType) = {
   let ip = Mk_Minterrupts(ip);
-  if      ip[MEI] == 0b1 then Some(I_M_External)
-  else if ip[MSI] == 0b1 then Some(I_M_Software)
-  else if ip[MTI] == 0b1 then Some(I_M_Timer)
-  else if ip[SEI] == 0b1 then Some(I_S_External)
-  else if ip[SSI] == 0b1 then Some(I_S_Software)
-  else if ip[STI] == 0b1 then Some(I_S_Timer)
-  else                        None()
+  if      ip[MEI]   == 0b1 then Some(I_M_External)
+  else if ip[MSI]   == 0b1 then Some(I_M_Software)
+  else if ip[MTI]   == 0b1 then Some(I_M_Timer)
+  else if ip[SEI]   == 0b1 then Some(I_S_External)
+  else if ip[SSI]   == 0b1 then Some(I_S_Software)
+  else if ip[STI]   == 0b1 then Some(I_S_Timer)
+  else if ip[LCOFI] == 0b1 then Some(I_L_Counter_Overflow)
+  else                          None()
 }
 
 /* Given the current privilege level, return the pending set

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -441,13 +441,15 @@ function is_fiom_active() -> bool = {
 /* interrupt processing state */
 
 bitfield Minterrupts : xlenbits = {
-  MEI : 11, /* external interrupts */
+  LCOFI : 13, // local counter overflow interrupts
+
+  MEI : 11, // external interrupts
   SEI : 9,
 
-  MTI : 7,  /* timers interrupts */
+  MTI : 7,  // timers interrupts
   STI : 5,
 
-  MSI : 3,  /* software interrupts */
+  MSI : 3,  // software interrupts
   SSI : 1,
 }
 
@@ -455,6 +457,7 @@ function legalize_mip(o : Minterrupts, v : xlenbits) -> Minterrupts = {
   // The only writable bits are the S-mode bits.
   let v = Mk_Minterrupts(v);
   [o with
+    LCOFI = if currentlyEnabled(Ext_Sscofpmf) then v[LCOFI] else 0b0,
     SEI = if currentlyEnabled(Ext_S) then v[SEI] else 0b0,
     SSI = if currentlyEnabled(Ext_S) then v[SSI] else 0b0,
     STI = if currentlyEnabled(Ext_S) then (
@@ -467,6 +470,7 @@ function legalize_mip(o : Minterrupts, v : xlenbits) -> Minterrupts = {
 function legalize_mie(o : Minterrupts, v : xlenbits) -> Minterrupts = {
   let v = Mk_Minterrupts(v);
   [o with
+    LCOFI = if currentlyEnabled(Ext_Sscofpmf) then v[LCOFI] else 0b0,
     MEI = v[MEI],
     MTI = v[MTI],
     MSI = v[MSI],
@@ -780,11 +784,13 @@ function clause write_CSR(0x100, value) = { mstatus = legalize_sstatus(mstatus, 
 
 
 bitfield Sinterrupts : xlenbits = {
-  SEI : 9,  /* external interrupts */
+  LCOFI : 13, // local counter overflow interrupts
 
-  STI : 5,  /* timers interrupts */
+  SEI : 9,  // external interrupts
 
-  SSI : 1,  /* software interrupts */
+  STI : 5,  // timers interrupts
+
+  SSI : 1,  // software interrupts
 }
 
 // sip
@@ -793,6 +799,7 @@ function lower_mip(m : Minterrupts, d : Minterrupts) -> Sinterrupts = {
   let s : Sinterrupts = Mk_Sinterrupts(zeros());
 
   [s with
+    LCOFI = m[LCOFI] & d[LCOFI],
     SEI = m[SEI] & d[SEI],
     STI = m[STI] & d[STI],
     SSI = m[SSI] & d[SSI],
@@ -804,6 +811,7 @@ function lower_mie(m : Minterrupts, d : Minterrupts) -> Sinterrupts = {
   let s : Sinterrupts = Mk_Sinterrupts(zeros());
 
   [s with
+    LCOFI = m[LCOFI] & d[LCOFI],
     SEI = m[SEI] & d[SEI],
     STI = m[STI] & d[STI],
     SSI = m[SSI] & d[SSI],
@@ -812,9 +820,10 @@ function lower_mie(m : Minterrupts, d : Minterrupts) -> Sinterrupts = {
 
 /* Returns the new value of mip from the previous mip (o) and the written sip (s) as delegated by mideleg (d). */
 function lift_sip(o : Minterrupts, d : Minterrupts, s : Sinterrupts) -> Minterrupts = {
-  let m : Minterrupts = o;
-  let m = if d[SSI] == 0b1 then [m with SSI = s[SSI]] else m;
-  m
+  [o with
+    LCOFI = if d[LCOFI] == 0b1 then s[LCOFI] else o[LCOFI],
+    SSI = if d[SSI] == 0b1 then s[SSI] else o[SSI],
+  ]
 }
 
 function legalize_sip(m : Minterrupts, d : Minterrupts, v : xlenbits) -> Minterrupts = {
@@ -832,6 +841,7 @@ function clause write_CSR(0x144, value) = { mip = legalize_sip(mip, mideleg, val
 function lift_sie(o : Minterrupts, d : Minterrupts, s : Sinterrupts) -> Minterrupts = {
   let m : Minterrupts = o;
   [m with
+    LCOFI = if d[LCOFI] == 0b1 then s[LCOFI] else m[LCOFI],
     SEI = if d[SEI] == 0b1 then s[SEI] else m[SEI],
     STI = if d[STI] == 0b1 then s[STI] else m[STI],
     SSI = if d[SSI] == 0b1 then s[SSI] else m[SSI],

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -100,21 +100,23 @@ enum InterruptType = {
   I_M_Timer,
   I_U_External,
   I_S_External,
-  I_M_External
+  I_M_External,
+  I_L_Counter_Overflow,
 }
 
 val interruptType_to_bits : InterruptType -> exc_code
 function interruptType_to_bits (i) =
   match (i) {
-    I_U_Software => 0x00,
-    I_S_Software => 0x01,
-    I_M_Software => 0x03,
-    I_U_Timer    => 0x04,
-    I_S_Timer    => 0x05,
-    I_M_Timer    => 0x07,
-    I_U_External => 0x08,
-    I_S_External => 0x09,
-    I_M_External => 0x0b
+    I_U_Software         => 0x00,
+    I_S_Software         => 0x01,
+    I_M_Software         => 0x03,
+    I_U_Timer            => 0x04,
+    I_S_Timer            => 0x05,
+    I_M_Timer            => 0x07,
+    I_U_External         => 0x08,
+    I_S_External         => 0x09,
+    I_M_External         => 0x0b,
+    I_L_Counter_Overflow => 0x0d,
   }
 
 /* architectural exception definitions */


### PR DESCRIPTION
If the Sscofpmf extension is not implemented, xip.LCOFIP and xie.LCOFIE are read-only zeros.