### PR TITLE
Allow `write_CSR` to indicate an illegal instruction trap.

### DIFF
--- a/model/riscv_csr_begin.sail
+++ b/model/riscv_csr_begin.sail
@@ -16,15 +16,15 @@ val csr_name : csreg -> string
 function csr_name(csr) = csr_name_map(csr)
 overload to_str = {csr_name}
 
-/* returns whether a CSR exists
- */
+// returns whether a CSR exists
 val is_CSR_defined : (csreg) -> bool
 scattered function is_CSR_defined
 
-/* returns the value of the CSR if it is defined */
+// returns the value of the CSR if it is defined
 val read_CSR : csreg -> xlenbits
 scattered function read_CSR
 
-/* returns new value (after legalisation) if the CSR is defined */
-val write_CSR : (csreg, xlenbits) -> xlenbits
+// returns new value (after legalisation) if the CSR is defined,
+// otherwise a unit value indicating an illegal instruction.
+val write_CSR : (csreg, xlenbits) -> result(xlenbits, unit)
 scattered function write_CSR

--- a/model/riscv_fdext_control.sail
+++ b/model/riscv_fdext_control.sail
@@ -32,8 +32,8 @@ function clause read_CSR (0x001) = zero_extend(fcsr[FFLAGS])
 function clause read_CSR (0x002) = zero_extend(fcsr[FRM])
 function clause read_CSR (0x003) = zero_extend(fcsr.bits)
 
-function clause write_CSR (0x001, value) = { write_fcsr(fcsr[FRM], value[4..0]); zero_extend(fcsr[FFLAGS]) }
-function clause write_CSR (0x002, value) = { write_fcsr(value[2..0], fcsr[FFLAGS]); zero_extend(fcsr[FRM]) }
-function clause write_CSR (0x003, value) = { write_fcsr(value[7..5], value[4..0]); zero_extend(fcsr.bits) }
+function clause write_CSR (0x001, value) = { write_fcsr(fcsr[FRM], value[4..0]); Ok(zero_extend(fcsr[FFLAGS])) }
+function clause write_CSR (0x002, value) = { write_fcsr(value[2..0], fcsr[FFLAGS]); Ok(zero_extend(fcsr[FRM])) }
+function clause write_CSR (0x003, value) = { write_fcsr(value[7..5], value[4..0]); Ok(zero_extend(fcsr.bits)) }
 
 /* **************************************************************** */

--- a/model/riscv_insts_zicsr.sail
+++ b/model/riscv_insts_zicsr.sail
@@ -43,13 +43,19 @@ function doCSR(csr : csreg, rs1_val : xlenbits, rd : regidx, op : csrop, is_CSR_
         CSRRS => csr_val | rs1_val,
         CSRRC => csr_val & ~(rs1_val)
       };
-      let final_val = write_CSR(csr, new_val);
-      csr_write_callback(csr, final_val);
+      match write_CSR(csr, new_val) {
+        Ok(final_val) => {
+          csr_write_callback(csr, final_val);
+          X(rd) = csr_val;
+          RETIRE_SUCCESS
+        },
+        Err(()) => Illegal_Instruction()
+      }
     } else {
       csr_read_callback(csr, csr_val);
-    };
-    X(rd) = csr_val;
-    RETIRE_SUCCESS
+      X(rd) = csr_val;
+      RETIRE_SUCCESS
+    }
   }
 }
 

--- a/model/riscv_pmp_regs.sail
+++ b/model/riscv_pmp_regs.sail
@@ -241,7 +241,7 @@ function clause read_CSR(0x3A @ idx : bits(4) if idx[0] == bitzero | xlen == 32)
 function clause write_CSR((0x3A @ idx : bits(4), value) if idx[0] == bitzero | xlen == 32) = {
   let idx = unsigned(idx);
   pmpWriteCfgReg(idx, value);
-  pmpReadCfgReg(idx)
+  Ok(pmpReadCfgReg(idx))
 }
 
 // pmpaddrN. Unfortunately the PMP index does not nicely align with the CSR index bits.
@@ -255,7 +255,7 @@ function clause read_CSR(0x3C @ idx : bits(4)) = pmpReadAddrReg(unsigned(0b01 @ 
 function clause read_CSR(0x3D @ idx : bits(4)) = pmpReadAddrReg(unsigned(0b10 @ idx))
 function clause read_CSR(0x3E @ idx : bits(4)) = pmpReadAddrReg(unsigned(0b11 @ idx))
 
-function clause write_CSR(0x3B @ idx : bits(4), value) = { let idx = unsigned(0b00 @ idx); pmpWriteAddrReg(idx, value); pmpReadAddrReg(idx) }
-function clause write_CSR(0x3C @ idx : bits(4), value) = { let idx = unsigned(0b01 @ idx); pmpWriteAddrReg(idx, value); pmpReadAddrReg(idx) }
-function clause write_CSR(0x3D @ idx : bits(4), value) = { let idx = unsigned(0b10 @ idx); pmpWriteAddrReg(idx, value); pmpReadAddrReg(idx) }
-function clause write_CSR(0x3E @ idx : bits(4), value) = { let idx = unsigned(0b11 @ idx); pmpWriteAddrReg(idx, value); pmpReadAddrReg(idx) }
+function clause write_CSR(0x3B @ idx : bits(4), value) = { let idx = unsigned(0b00 @ idx); pmpWriteAddrReg(idx, value); Ok(pmpReadAddrReg(idx)) }
+function clause write_CSR(0x3C @ idx : bits(4), value) = { let idx = unsigned(0b01 @ idx); pmpWriteAddrReg(idx, value); Ok(pmpReadAddrReg(idx)) }
+function clause write_CSR(0x3D @ idx : bits(4), value) = { let idx = unsigned(0b10 @ idx); pmpWriteAddrReg(idx, value); Ok(pmpReadAddrReg(idx)) }
+function clause write_CSR(0x3E @ idx : bits(4), value) = { let idx = unsigned(0b11 @ idx); pmpWriteAddrReg(idx, value); Ok(pmpReadAddrReg(idx)) }

--- a/model/riscv_smcntrpmf.sail
+++ b/model/riscv_smcntrpmf.sail
@@ -38,12 +38,12 @@ function clause read_CSR(0x721 if xlen == 32) = mcyclecfg.bits[63 .. 32]
 function clause read_CSR(0x322) = minstretcfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x722 if xlen == 32) = minstretcfg.bits[63 .. 32]
 
-function clause write_CSR((0x321, value) if xlen == 64) = { mcyclecfg = legalize_smcntrpmf(mcyclecfg, value); mcyclecfg.bits }
-function clause write_CSR((0x321, value) if xlen == 32) = { mcyclecfg = legalize_smcntrpmf(mcyclecfg, mcyclecfg.bits[63 .. 32] @ value); mcyclecfg.bits[xlen - 1 .. 0] }
-function clause write_CSR((0x721, value) if xlen == 32) = { mcyclecfg = legalize_smcntrpmf(mcyclecfg, value @ mcyclecfg.bits[31 .. 0]); mcyclecfg.bits[63 .. 32] }
-function clause write_CSR((0x322, value) if xlen == 64) = { minstretcfg = legalize_smcntrpmf(minstretcfg, value); minstretcfg.bits[xlen - 1 .. 0] }
-function clause write_CSR((0x322, value) if xlen == 32) = { minstretcfg = legalize_smcntrpmf(minstretcfg, minstretcfg.bits[63 .. 32] @ value); minstretcfg.bits[xlen - 1 .. 0] }
-function clause write_CSR((0x722, value) if xlen == 32) = { minstretcfg = legalize_smcntrpmf(minstretcfg, value @ minstretcfg.bits[31 .. 0]); minstretcfg.bits[63 .. 32] }
+function clause write_CSR((0x321, value) if xlen == 64) = { mcyclecfg = legalize_smcntrpmf(mcyclecfg, value); Ok(mcyclecfg.bits) }
+function clause write_CSR((0x321, value) if xlen == 32) = { mcyclecfg = legalize_smcntrpmf(mcyclecfg, mcyclecfg.bits[63 .. 32] @ value); Ok(mcyclecfg.bits[xlen - 1 .. 0]) }
+function clause write_CSR((0x721, value) if xlen == 32) = { mcyclecfg = legalize_smcntrpmf(mcyclecfg, value @ mcyclecfg.bits[31 .. 0]); Ok(mcyclecfg.bits[63 .. 32]) }
+function clause write_CSR((0x322, value) if xlen == 64) = { minstretcfg = legalize_smcntrpmf(minstretcfg, value); Ok(minstretcfg.bits[xlen - 1 .. 0]) }
+function clause write_CSR((0x322, value) if xlen == 32) = { minstretcfg = legalize_smcntrpmf(minstretcfg, minstretcfg.bits[63 .. 32] @ value); Ok(minstretcfg.bits[xlen - 1 .. 0]) }
+function clause write_CSR((0x722, value) if xlen == 32) = { minstretcfg = legalize_smcntrpmf(minstretcfg, value @ minstretcfg.bits[31 .. 0]); Ok(minstretcfg.bits[63 .. 32]) }
 
 function counter_priv_filter_bit(reg : CountSmcntrpmf, priv : Privilege) -> bits(1) =
   // When all xINH bits are zero, event counting is enabled in all modes.

--- a/model/riscv_sscofpmf.sail
+++ b/model/riscv_sscofpmf.sail
@@ -53,7 +53,7 @@ function clause read_CSR(0b0111001 /* 0x720 */ @ index : bits(5) if xlen == 32 &
 function clause write_CSR((0b0111001 /* 0x720 */ @ index : bits(5), value) if xlen == 32 & unsigned(index) >= 3) = {
   let index = hpmidx_from_bits(index);
   write_mhpmeventh(index, value);
-  read_mhpmeventh(index)
+  Ok(read_mhpmeventh(index))
 }
 
 // scountovf collates the OF (overflow) bit for each event.

--- a/model/riscv_sstc.sail
+++ b/model/riscv_sstc.sail
@@ -16,5 +16,5 @@ function clause is_CSR_defined(0x15D) = currentlyEnabled(Ext_S) & currentlyEnabl
 function clause read_CSR(0x14D) = stimecmp[xlen - 1 .. 0]
 function clause read_CSR(0x15D if xlen == 32) = stimecmp[63 .. 32]
 
-function clause write_CSR(0x14D, value) = { stimecmp[(xlen - 1) .. 0] = value; stimecmp[xlen - 1 ..0] }
-function clause write_CSR((0x15D, value) if xlen == 32) = { stimecmp[63 ..32] = value; stimecmp[63 .. 32] }
+function clause write_CSR(0x14D, value) = { stimecmp[(xlen - 1) .. 0] = value; Ok(stimecmp[xlen - 1 ..0]) }
+function clause write_CSR((0x15D, value) if xlen == 32) = { stimecmp[63 ..32] = value; Ok(stimecmp[63 .. 32]) }

--- a/model/riscv_sys_exceptions.sail
+++ b/model/riscv_sys_exceptions.sail
@@ -93,7 +93,7 @@ function clause read_CSR(0x141) = get_xepc(Supervisor)
 function clause read_CSR(0x305) = get_mtvec()
 function clause read_CSR(0x341) = get_xepc(Machine)
 
-function clause write_CSR(0x105, value) = { set_stvec(value) }
-function clause write_CSR(0x141, value) = { set_xepc(Supervisor, value) }
-function clause write_CSR(0x305, value) = { set_mtvec(value) }
-function clause write_CSR(0x341, value) = { set_xepc(Machine, value) }
+function clause write_CSR(0x105, value) = { Ok(set_stvec(value)) }
+function clause write_CSR(0x141, value) = { Ok(set_xepc(Supervisor, value)) }
+function clause write_CSR(0x305, value) = { Ok(set_mtvec(value)) }
+function clause write_CSR(0x341, value) = { Ok(set_xepc(Machine, value)) }

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -125,7 +125,7 @@ function legalize_misa(m : Misa, v : xlenbits) -> Misa = {
 mapping clause csr_name_map = 0x301  <-> "misa"
 function clause is_CSR_defined(0x301) = true // misa
 function clause read_CSR(0x301) = misa.bits
-function clause write_CSR(0x301, value) = { misa = legalize_misa(misa, value); misa.bits }
+function clause write_CSR(0x301, value) = { misa = legalize_misa(misa, value); Ok(misa.bits) }
 
 // Are supervisor/user mode currently enabled? Although
 // unlikely and not currently supported by the model,
@@ -280,9 +280,9 @@ function clause is_CSR_defined(0x310) = xlen == 32 // mstatush
 function clause read_CSR(0x300) = mstatus.bits[xlen - 1 .. 0]
 function clause read_CSR(0x310 if xlen == 32) = mstatus.bits[63 .. 32]
 
-function clause write_CSR((0x300, value) if xlen == 64) = { mstatus = legalize_mstatus(mstatus, value); mstatus.bits }
-function clause write_CSR((0x300, value) if xlen == 32) = { mstatus = legalize_mstatus(mstatus, mstatus.bits[63 .. 32] @ value); mstatus.bits[31 .. 0] }
-function clause write_CSR((0x310, value) if xlen == 32) = { mstatus = legalize_mstatus(mstatus, value @ mstatus.bits[31 .. 0]); mstatus.bits[63 .. 32] }
+function clause write_CSR((0x300, value) if xlen == 64) = { mstatus = legalize_mstatus(mstatus, value); Ok(mstatus.bits) }
+function clause write_CSR((0x300, value) if xlen == 32) = { mstatus = legalize_mstatus(mstatus, mstatus.bits[63 .. 32] @ value); Ok(mstatus.bits[31 .. 0]) }
+function clause write_CSR((0x310, value) if xlen == 32) = { mstatus = legalize_mstatus(mstatus, value @ mstatus.bits[31 .. 0]); Ok(mstatus.bits[63 .. 32]) }
 
 /* architecture and extension checks */
 
@@ -338,15 +338,15 @@ function clause read_CSR(0x757 if xlen == 32) = mseccfg.bits[63 .. 32]
 
 function clause write_CSR((0x747, value) if xlen == 32) = {
   mseccfg = legalize_mseccfg(mseccfg, mseccfg.bits[63 .. 32] @ value);
-  mseccfg.bits[31 .. 0]
+  Ok(mseccfg.bits[31 .. 0])
 }
 function clause write_CSR((0x747, value) if xlen == 64) = {
   mseccfg = legalize_mseccfg(mseccfg, value);
-  mseccfg.bits
+  Ok(mseccfg.bits)
 }
 function clause write_CSR((0x757, value) if xlen == 32) = {
   mseccfg = legalize_mseccfg(mseccfg, value @ mseccfg.bits[31 .. 0]);
-  mseccfg.bits[63 .. 32]
+  Ok(mseccfg.bits[63 .. 32])
 }
 
 
@@ -422,10 +422,10 @@ function clause read_CSR(0x30A) = menvcfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x31A if xlen == 32) = menvcfg.bits[63 .. 32]
 function clause read_CSR(0x10A) = senvcfg.bits[xlen - 1 .. 0]
 
-function clause write_CSR((0x30A, value) if xlen == 32) = { menvcfg = legalize_menvcfg(menvcfg, menvcfg.bits[63 .. 32] @ value); menvcfg.bits[31 .. 0] }
-function clause write_CSR((0x30A, value) if xlen == 64) = { menvcfg = legalize_menvcfg(menvcfg, value); menvcfg.bits }
-function clause write_CSR((0x31A, value) if xlen == 32) = { menvcfg = legalize_menvcfg(menvcfg, value @ menvcfg.bits[31 .. 0]); menvcfg.bits[63 .. 32] }
-function clause write_CSR(0x10A, value) = { senvcfg = legalize_senvcfg(senvcfg, zero_extend(value)); senvcfg.bits[xlen - 1 .. 0] }
+function clause write_CSR((0x30A, value) if xlen == 32) = { menvcfg = legalize_menvcfg(menvcfg, menvcfg.bits[63 .. 32] @ value); Ok(menvcfg.bits[31 .. 0]) }
+function clause write_CSR((0x30A, value) if xlen == 64) = { menvcfg = legalize_menvcfg(menvcfg, value); Ok(menvcfg.bits) }
+function clause write_CSR((0x31A, value) if xlen == 32) = { menvcfg = legalize_menvcfg(menvcfg, value @ menvcfg.bits[31 .. 0]); Ok(menvcfg.bits[63 .. 32]) }
+function clause write_CSR(0x10A, value) = { senvcfg = legalize_senvcfg(senvcfg, zero_extend(value)); Ok(senvcfg.bits[xlen - 1 .. 0]) }
 
 // Return whether or not FIOM is currently active, based on the current
 // privilege and the menvcfg/senvcfg settings. This means that I/O fences
@@ -529,12 +529,12 @@ function clause read_CSR(0x302) = medeleg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x312 if xlen == 32) = medeleg.bits[63 .. 32]
 function clause read_CSR(0x303) = mideleg.bits
 
-function clause write_CSR(0x304, value) = { mie = legalize_mie(mie, value); mie.bits }
-function clause write_CSR(0x344, value) = { mip = legalize_mip(mip, value); mip.bits }
-function clause write_CSR((0x302, value) if xlen == 64) = { medeleg = legalize_medeleg(medeleg, value); medeleg.bits }
-function clause write_CSR((0x302, value) if xlen == 32) = { medeleg = legalize_medeleg(medeleg, medeleg.bits[63 .. 32] @ value); medeleg.bits[31 .. 0] }
-function clause write_CSR((0x312, value) if xlen == 32) = { medeleg = legalize_medeleg(medeleg, value @ medeleg.bits[31 .. 0]); medeleg.bits[63 .. 32] }
-function clause write_CSR(0x303, value) = { mideleg = legalize_mideleg(mideleg, value); mideleg.bits }
+function clause write_CSR(0x304, value) = { mie = legalize_mie(mie, value); Ok(mie.bits) }
+function clause write_CSR(0x344, value) = { mip = legalize_mip(mip, value); Ok(mip.bits) }
+function clause write_CSR((0x302, value) if xlen == 64) = { medeleg = legalize_medeleg(medeleg, value); Ok(medeleg.bits) }
+function clause write_CSR((0x302, value) if xlen == 32) = { medeleg = legalize_medeleg(medeleg, medeleg.bits[63 .. 32] @ value); Ok(medeleg.bits[31 .. 0]) }
+function clause write_CSR((0x312, value) if xlen == 32) = { medeleg = legalize_medeleg(medeleg, value @ medeleg.bits[31 .. 0]); Ok(medeleg.bits[63 .. 32]) }
+function clause write_CSR(0x303, value) = { mideleg = legalize_mideleg(mideleg, value); Ok(mideleg.bits) }
 
 /* registers for trap handling */
 
@@ -561,7 +561,7 @@ register mcause : Mcause
 mapping clause csr_name_map = 0x342  <-> "mcause"
 function clause is_CSR_defined(0x342) = true // mcause
 function clause read_CSR(0x342) = mcause.bits
-function clause write_CSR(0x342, value) = { mcause.bits = value; mcause.bits }
+function clause write_CSR(0x342, value) = { mcause.bits = value; Ok(mcause.bits) }
 
 /* Interpreting the trap-vector address */
 function tvec_addr(m : Mtvec, c : Mcause) -> option(xlenbits) = {
@@ -609,8 +609,8 @@ function clause is_CSR_defined(0x340) = true // mscratch
 function clause read_CSR(0x343) = mtval
 function clause read_CSR(0x340) = mscratch
 
-function clause write_CSR(0x343, value) = { mtval = value; mtval }
-function clause write_CSR(0x340, value) = { mscratch = value; mscratch }
+function clause write_CSR(0x343, value) = { mtval = value; Ok(mtval) }
+function clause write_CSR(0x340, value) = { mscratch = value; Ok(mscratch) }
 
 /* counters */
 
@@ -631,7 +631,7 @@ register scounteren : Counteren
 mapping clause csr_name_map = 0x106  <-> "scounteren"
 function clause is_CSR_defined(0x106) = currentlyEnabled(Ext_S) // scounteren
 function clause read_CSR(0x106) = zero_extend(scounteren.bits)
-function clause write_CSR(0x106, value) = { scounteren = legalize_scounteren(scounteren, value); zero_extend(scounteren.bits) }
+function clause write_CSR(0x106, value) = { scounteren = legalize_scounteren(scounteren, value); Ok(zero_extend(scounteren.bits)) }
 
 // mcounteren
 function legalize_mcounteren(c : Counteren, v : xlenbits) -> Counteren = {
@@ -643,7 +643,7 @@ register mcounteren : Counteren
 mapping clause csr_name_map = 0x306  <-> "mcounteren"
 function clause is_CSR_defined(0x306) = currentlyEnabled(Ext_U) // mcounteren
 function clause read_CSR(0x306) = zero_extend(mcounteren.bits)
-function clause write_CSR(0x306, value) = { mcounteren = legalize_mcounteren(mcounteren, value); zero_extend(mcounteren.bits) }
+function clause write_CSR(0x306, value) = { mcounteren = legalize_mcounteren(mcounteren, value); Ok(zero_extend(mcounteren.bits)) }
 
 
 // mcountinhibit
@@ -663,7 +663,7 @@ register mcountinhibit : Counterin
 mapping clause csr_name_map = 0x320  <-> "mcountinhibit"
 function clause is_CSR_defined(0x320) = true // mcountinhibit
 function clause read_CSR(0x320) = zero_extend(mcountinhibit.bits)
-function clause write_CSR(0x320, value) = { mcountinhibit = legalize_mcountinhibit(mcountinhibit, value); zero_extend(mcountinhibit.bits) }
+function clause write_CSR(0x320, value) = { mcountinhibit = legalize_mcountinhibit(mcountinhibit, value); Ok(zero_extend(mcountinhibit.bits)) }
 
 register mcycle : bits(64)
 register mtime : bits(64)
@@ -776,7 +776,7 @@ function legalize_sstatus(m : Mstatus, v : xlenbits) -> Mstatus = {
 mapping clause csr_name_map = 0x100  <-> "sstatus"
 function clause is_CSR_defined(0x100) = currentlyEnabled(Ext_S) // sstatus
 function clause read_CSR(0x100) = lower_mstatus(mstatus).bits[xlen - 1 .. 0]
-function clause write_CSR(0x100, value) = { mstatus = legalize_sstatus(mstatus, value); lower_mstatus(mstatus).bits[xlen - 1 .. 0] }
+function clause write_CSR(0x100, value) = { mstatus = legalize_sstatus(mstatus, value); Ok(lower_mstatus(mstatus).bits[xlen - 1 .. 0]) }
 
 
 bitfield Sinterrupts : xlenbits = {
@@ -824,7 +824,7 @@ function legalize_sip(m : Minterrupts, d : Minterrupts, v : xlenbits) -> Minterr
 mapping clause csr_name_map = 0x144  <-> "sip"
 function clause is_CSR_defined(0x144) = currentlyEnabled(Ext_S) // sip
 function clause read_CSR(0x144) = lower_mip(mip, mideleg).bits
-function clause write_CSR(0x144, value) = { mip = legalize_sip(mip, mideleg, value); lower_mip(mip, mideleg).bits }
+function clause write_CSR(0x144, value) = { mip = legalize_sip(mip, mideleg, value); Ok(lower_mip(mip, mideleg).bits) }
 
 
 // sie
@@ -846,7 +846,7 @@ function legalize_sie(m : Minterrupts, d : Minterrupts, v : xlenbits) -> Minterr
 mapping clause csr_name_map = 0x104  <-> "sie"
 function clause is_CSR_defined(0x104) = currentlyEnabled(Ext_S) // sie
 function clause read_CSR(0x104) = lower_mie(mie, mideleg).bits
-function clause write_CSR(0x104, value) = { mie = legalize_sie(mie, mideleg, value); lower_mie(mie, mideleg).bits }
+function clause write_CSR(0x104, value) = { mie = legalize_sie(mie, mideleg, value); Ok(lower_mie(mie, mideleg).bits) }
 
 
 /* other non-VM related supervisor state */
@@ -868,9 +868,9 @@ function clause read_CSR(0x140) = sscratch
 function clause read_CSR(0x142) = scause.bits
 function clause read_CSR(0x143) = stval
 
-function clause write_CSR(0x140, value) = { sscratch = value; sscratch }
-function clause write_CSR(0x142, value) = { scause.bits = value; scause.bits }
-function clause write_CSR(0x143, value) = { stval = value; stval }
+function clause write_CSR(0x140, value) = { sscratch = value; Ok(sscratch) }
+function clause write_CSR(0x142, value) = { scause.bits = value; Ok(scause.bits) }
+function clause write_CSR(0x143, value) = { stval = value; Ok(stval) }
 
 /*
  * S-mode address translation and protection (satp) layout.
@@ -933,7 +933,7 @@ mapping clause csr_name_map = 0x7a3  <-> "tdata3"
 
 function clause is_CSR_defined(0x7a0) = true
 function clause read_CSR(0x7a0) = ~(tselect)  /* this indicates we don't have any trigger support */
-function clause write_CSR(0x7a0, value) = { tselect = value; tselect }
+function clause write_CSR(0x7a0, value) = { tselect = value; Ok(tselect) }
 
 /*
  * Entropy Source - Platform access to random bits.

--- a/model/riscv_vext_control.sail
+++ b/model/riscv_vext_control.sail
@@ -9,8 +9,7 @@
 function clause currentlyEnabled(Ext_V) = hartSupports(Ext_V) & (misa[V] == 0b1) & (mstatus[VS] != 0b00) & currentlyEnabled(Ext_Zicsr)
 
 // Note: The spec recommends trapping if vstart is out of bounds but the
-// current implementation does not do that because write_CSR() doesn't
-// allow traps.
+// current implementation does yet do that.
 
 function set_vstart(value : bits(16)) -> unit = {
   dirty_v_context();
@@ -42,7 +41,7 @@ function clause read_CSR(0xC20) = vl
 function clause read_CSR(0xC21) = vtype.bits
 function clause read_CSR(0xC22) = VLENB
 
-function clause write_CSR(0x008, value) = { set_vstart(value[15 .. 0]); vstart }
-function clause write_CSR(0x009, value) = { ext_write_vcsr (vcsr[vxrm], value[0 .. 0]); zero_extend(vcsr[vxsat]) }
-function clause write_CSR(0x00A, value) = { ext_write_vcsr (value[1 .. 0], vcsr[vxsat]); zero_extend(vcsr[vxrm]) }
-function clause write_CSR(0x00F, value) = { ext_write_vcsr (value [2 .. 1], value [0 .. 0]); zero_extend(vcsr.bits) }
+function clause write_CSR(0x008, value) = { set_vstart(value[15 .. 0]); Ok(vstart) }
+function clause write_CSR(0x009, value) = { ext_write_vcsr (vcsr[vxrm], value[0 .. 0]); Ok(zero_extend(vcsr[vxsat])) }
+function clause write_CSR(0x00A, value) = { ext_write_vcsr (value[1 .. 0], vcsr[vxsat]); Ok(zero_extend(vcsr[vxrm])) }
+function clause write_CSR(0x00F, value) = { ext_write_vcsr (value [2 .. 1], value [0 .. 0]); Ok(zero_extend(vcsr.bits)) }

--- a/model/riscv_vmem.sail
+++ b/model/riscv_vmem.sail
@@ -164,7 +164,7 @@ register satp : xlenbits
 mapping clause csr_name_map = 0x180  <-> "satp"
 function clause is_CSR_defined(0x180) = currentlyEnabled(Ext_S)
 function clause read_CSR(0x180) = satp
-function clause write_CSR(0x180, value) = { satp = legalize_satp(cur_architecture(), satp, value); satp }
+function clause write_CSR(0x180, value) = { satp = legalize_satp(cur_architecture(), satp, value); Ok(satp) }
 
 // ----------------
 // Fields of SATP

--- a/model/riscv_zicntr_control.sail
+++ b/model/riscv_zicntr_control.sail
@@ -46,7 +46,7 @@ function clause read_CSR(0xB02) = minstret[(xlen - 1) .. 0]
 function clause read_CSR(0xB80 if xlen == 32)= mcycle[63 .. 32]
 function clause read_CSR(0xB82 if xlen == 32) = minstret[63 .. 32]
 
-function clause write_CSR(0xB00, value) = { mcycle[(xlen - 1) .. 0] = value; value }
-function clause write_CSR(0xB02, value) = { minstret[(xlen - 1) .. 0] = value; minstret_increment = false; value }
-function clause write_CSR((0xB80, value) if xlen == 32) = { mcycle[63 .. 32] = value; value }
-function clause write_CSR((0xB82, value) if xlen == 32) = { minstret[63 .. 32] = value; minstret_increment = false; value }
+function clause write_CSR(0xB00, value) = { mcycle[(xlen - 1) .. 0] = value; Ok(value) }
+function clause write_CSR(0xB02, value) = { minstret[(xlen - 1) .. 0] = value; minstret_increment = false; Ok(value) }
+function clause write_CSR((0xB80, value) if xlen == 32) = { mcycle[63 .. 32] = value; Ok(value) }
+function clause write_CSR((0xB82, value) if xlen == 32) = { minstret[63 .. 32] = value; minstret_increment = false; Ok(value) }

--- a/model/riscv_zihpm.sail
+++ b/model/riscv_zihpm.sail
@@ -229,7 +229,7 @@ function clause read_CSR(0b0011001 /* 0x320 */ @ index : bits(5) if unsigned(ind
 function clause write_CSR((0b0011001 /* 0x320 */ @ index : bits(5), value) if unsigned(index) >= 3) = {
   let index = hpmidx_from_bits(index);
   write_mhpmevent(index, value);
-  read_mhpmevent(index)
+  Ok(read_mhpmevent(index))
 }
 
 /* Hardware Performance Monitoring machine mode counters */
@@ -242,12 +242,12 @@ function clause read_CSR(0b1011100 /* 0xB80 */ @ index : bits(5) if xlen == 32 &
 function clause write_CSR((0b1011000 /* 0xB00 */ @ index : bits(5), value) if unsigned(index) >= 3) = {
   let index = hpmidx_from_bits(index);
   write_mhpmcounter(index, value);
-  read_mhpmcounter(index)
+  Ok(read_mhpmcounter(index))
 }
 function clause write_CSR((0b1011100 /* 0xB80 */ @ index : bits(5), value) if xlen == 32 & unsigned(index) >= 3) = {
   let index = hpmidx_from_bits(index);
   write_mhpmcounterh(index, value);
-  read_mhpmcounterh(index)
+  Ok(read_mhpmcounterh(index))
 }
 
 /* Hardware Performance Monitoring user mode counters */

--- a/model/riscv_zkr_control.sail
+++ b/model/riscv_zkr_control.sail
@@ -44,4 +44,4 @@ function write_seed_csr () -> xlenbits = zeros()
 mapping clause csr_name_map = 0x015  <-> "seed"
 function clause is_CSR_defined(0x015) = currentlyEnabled(Ext_Zkr)
 function clause read_CSR(0x015) = read_seed_csr()
-function clause write_CSR(0x015, value) = write_seed_csr()
+function clause write_CSR(0x015, value) = Ok(write_seed_csr())


### PR DESCRIPTION
This enables data-dependent illegal instruction traps on CSR writes, such as on out-of-bounds values for vstart.

Indicating other kinds of traps would need a bigger refactor, but this should suffice for now.