### PR TITLE
Fix CSR trace output to print correct width based on XLEN

### DIFF
--- a/c_emulator/riscv_callbacks.cpp
+++ b/c_emulator/riscv_callbacks.cpp
@@ -96,8 +96,8 @@ unit csr_full_write_callback(const_sail_string csr_name, unsigned reg,
                              sbits value)
 {
   if (config_print_reg) {
-    fprintf(trace_log, "CSR %s (0x%03X) <- 0x%016" PRIX64 "\n", csr_name, reg,
-            value.bits);
+    fprintf(trace_log, "CSR %s (0x%03X) <- 0x%0*" PRIX64 "\n", csr_name, reg,
+            static_cast<int>(zxlen / 4), value.bits);
   }
   return UNIT;
 }
@@ -106,8 +106,8 @@ unit csr_full_read_callback(const_sail_string csr_name, unsigned reg,
                             sbits value)
 {
   if (config_print_reg) {
-    fprintf(trace_log, "CSR %s (0x%03X) -> 0x%016" PRIX64 "\n", csr_name, reg,
-            value.bits);
+    fprintf(trace_log, "CSR %s (0x%03X) -> 0x%0*" PRIX64 "\n", csr_name, reg,
+            static_cast<int>(zxlen / 4), value.bits);
   }
   return UNIT;
 }

--- a/c_emulator/riscv_callbacks.cpp
+++ b/c_emulator/riscv_callbacks.cpp
@@ -97,7 +97,7 @@ unit csr_full_write_callback(const_sail_string csr_name, unsigned reg,
 {
   if (config_print_reg) {
     fprintf(trace_log, "CSR %s (0x%03X) <- 0x%0*" PRIX64 "\n", csr_name, reg,
-            static_cast<int>(zxlen / 4), value.bits);
+            static_cast<int>(value.len / 4), value.bits);
   }
   return UNIT;
 }
@@ -107,7 +107,7 @@ unit csr_full_read_callback(const_sail_string csr_name, unsigned reg,
 {
   if (config_print_reg) {
     fprintf(trace_log, "CSR %s (0x%03X) -> 0x%0*" PRIX64 "\n", csr_name, reg,
-            static_cast<int>(zxlen / 4), value.bits);
+            static_cast<int>(value.len / 4), value.bits);
   }
   return UNIT;
 }


### PR DESCRIPTION
This fixes #1094, where CSR values were incorrectly logged as 64-bit when running in RV32 mode.