### PR TITLE
adapt isla_footprint to the init_model signature change

### DIFF
--- a/model/main.sail
+++ b/model/main.sail
@@ -66,7 +66,7 @@ val isla_footprint : forall 'n, 'n in {16, 32}. bits('n) -> bool
 
 function isla_footprint(opcode) = {
   try {
-    init_model();
+    init_model("");
     isla_footprint_no_init(opcode)
   } catch {
     _ => false


### PR DESCRIPTION
using isla-sail on the current RISC-V model is broken, because `init_model` now takes a string, but the call to `init_model` in `isla_footprint` only passes unit. fix this by passing the empty string (isla doesn't support loading configuration files at runtime, as far as I understand. Therefore it will anyway always use the default config).