### PR TITLE
Replace rv_16_random_bits implemention with cpp std mt19937

### DIFF
--- a/c_emulator/riscv_platform_impl.cpp
+++ b/c_emulator/riscv_platform_impl.cpp
@@ -3,10 +3,19 @@
 #include <stdio.h>
 #include <random>
 
+static std::optional<uint64_t> rng_seed;
+
+// Must be called before rv_16_random_bits().
+void rv_set_rng_seed(std::optional<uint64_t> seed)
+{
+  rng_seed = seed;
+}
+
 // Provides entropy for the scalar cryptography extension.
 uint64_t rv_16_random_bits(void)
 {
-  static std::mt19937_64 rng(0);
+  static std::mt19937_64 rng(rng_seed.has_value() ? *rng_seed
+                                                  : std::random_device {}());
   return static_cast<uint16_t>(rng());
 }
 

--- a/c_emulator/riscv_platform_impl.cpp
+++ b/c_emulator/riscv_platform_impl.cpp
@@ -1,20 +1,13 @@
 #include "riscv_platform_impl.h"
 #include <unistd.h>
 #include <stdio.h>
+#include <random>
 
 // Provides entropy for the scalar cryptography extension.
 uint64_t rv_16_random_bits(void)
 {
-  // This function can be changed to support deterministic sequences of
-  // pseudo-random bytes. This is useful for testing.
-  const char *name = "/dev/urandom";
-  FILE *f = fopen(name, "rb");
-  uint16_t val;
-  if (fread(&val, 2, 1, f) != 1) {
-    fprintf(stderr, "Unable to read 2 bytes from %s\n", name);
-  }
-  fclose(f);
-  return (uint64_t)val;
+  static std::mt19937_64 rng(0);
+  return static_cast<uint16_t>(rng());
 }
 
 bool rv_enable_experimental_extensions = false;

--- a/c_emulator/riscv_platform_impl.h
+++ b/c_emulator/riscv_platform_impl.h
@@ -3,7 +3,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <optional>
 
+void rv_set_rng_seed(std::optional<uint64_t> seed);
 // Provides entropy for the scalar cryptography extension.
 extern uint64_t rv_16_random_bits(void);
 

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -82,6 +82,8 @@ bool config_enable_rvfi = false;
 struct timeval init_start, init_end, run_end;
 uint64_t total_insns = 0;
 uint64_t insn_limit = 0;
+std::optional<uint64_t> rng_seed;
+
 #ifdef SAILCOV
 char *sailcov_file = nullptr;
 #endif
@@ -163,6 +165,7 @@ static void setup_options(CLI::App &app)
       ->option_text("<int> (within [1 - 65535])");
   app.add_option("--inst-limit", insn_limit, "Instruction limit")
       ->option_text("<uint>");
+  app.add_option("--rng-seed", rng_seed, "RNG seed")->option_text("<uint>");
 #ifdef SAILCOV
   app.add_option("--sailcov-file", sailcov_file, "Sail coverage output file")
       ->option_text("<file>");
@@ -597,6 +600,8 @@ int inner_main(int argc, char **argv)
   } else {
     sail_config_set_string(get_default_config());
   }
+
+  rv_set_rng_seed(rng_seed);
 
   // Initialize platform.
   init_platform_constants();


### PR DESCRIPTION
For #1126. Since Sail is currently running on a single core, I think using global `static` is still acceptable.