### PR TITLE
Fix encoding for `ZBA_RTYPEUW``

### DIFF
--- a/model/riscv_insts_zba.sail
+++ b/model/riscv_insts_zba.sail
@@ -27,8 +27,14 @@ function clause execute (SLLIUW(shamt, rs1, rd)) = {
 /* ****************************************************************** */
 union clause instruction = ZBA_RTYPEUW : (regidx, regidx, regidx, shamt_zba)
 
+// add.uw
+mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, 0b00)
+  <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b00 @ 0b0 @ encdec_reg(rd) @ 0b0111011
+  when currentlyEnabled(Ext_Zba) & xlen == 64
+
+// sh#add.uw
 mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, shamt)
-  <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ shamt @ 0b0 @ encdec_reg(rd) @ 0b0111011
+  <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ shamt @ 0b0 @ encdec_reg(rd) @ 0b0111011
   when currentlyEnabled(Ext_Zba) & xlen == 64
 
 mapping zba_rtypeuw_mnemonic : shamt_zba <-> string = {


### PR DESCRIPTION
PR #1119 broke `sh#add.uw` instruction decoding. This splits the `encdec` clauses for `add.uw` and `sh#add.uw` to fix the encoding.