### PR TITLE
replace "size" names with "width" in instruction operate

### DIFF
--- a/model/riscv_addr_checks.sail
+++ b/model/riscv_addr_checks.sail
@@ -63,8 +63,8 @@ function ext_handle_data_check_error(err : ext_data_addr_error) -> unit =
   ()
 
 /* Default implementations of these hooks permit all accesses.  */
-function ext_check_phys_mem_read (access_type, paddr, size, acquire, release, reserved, read_meta) =
+function ext_check_phys_mem_read (access_type, paddr, width, acquire, release, reserved, read_meta) =
   Ext_PhysAddr_OK ()
 
-function ext_check_phys_mem_write(write_kind, paddr, size, data, metadata) =
+function ext_check_phys_mem_write(write_kind, paddr, width, data, metadata) =
   Ext_PhysAddr_OK ()

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -283,7 +283,7 @@ val extend_value : forall 'n, 0 < 'n <= xlen. (bool, bits('n)) -> xlenbits
 function extend_value(is_unsigned, value) = if is_unsigned then zero_extend(value) else sign_extend(value)
 
 mapping clause encdec = LOAD(imm, rs1, rd, is_unsigned, width)
-  <-> imm @ encdec_reg(rs1) @ bool_bits(is_unsigned) @ size_enc(width) @ encdec_reg(rd) @ 0b0000011
+  <-> imm @ encdec_reg(rs1) @ bool_bits(is_unsigned) @ width_enc(width) @ encdec_reg(rd) @ 0b0000011
   when valid_load_encdec(width, is_unsigned)
 
 function clause execute (LOAD(imm, rs1, rd, is_unsigned, width)) = {
@@ -307,13 +307,13 @@ mapping maybe_u : bool <-> string = {
 }
 
 mapping clause assembly = LOAD(imm, rs1, rd, is_unsigned, width)
-  <-> "l" ^ size_mnemonic(width) ^ maybe_u(is_unsigned) ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_signed_12(imm) ^ "(" ^ reg_name(rs1) ^ ")"
+  <-> "l" ^ width_mnemonic(width) ^ maybe_u(is_unsigned) ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_signed_12(imm) ^ "(" ^ reg_name(rs1) ^ ")"
 
 /* ****************************************************************** */
 union clause instruction = STORE : (bits(12), regidx, regidx, word_width)
 
 mapping clause encdec = STORE(imm7 @ imm5, rs2, rs1, width)
-  <-> imm7 : bits(7) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(width) @ imm5 : bits(5) @ 0b0100011
+  <-> imm7 : bits(7) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ width_enc(width) @ imm5 : bits(5) @ 0b0100011
   when width <= xlen_bytes
 
 function clause execute (STORE(imm, rs2, rs1, width)) = {
@@ -330,7 +330,7 @@ function clause execute (STORE(imm, rs2, rs1, width)) = {
 }
 
 mapping clause assembly = STORE(imm, rs2, rs1, width)
-  <-> "s" ^ size_mnemonic(width) ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_signed_12(imm) ^ opt_spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
+  <-> "s" ^ width_mnemonic(width) ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_signed_12(imm) ^ opt_spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
 
 /* ****************************************************************** */
 union clause instruction = ADDIW : (bits(12), regidx, regidx)

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -283,7 +283,7 @@ union clause instruction = LOAD_FP : (bits(12), regidx, fregidx, word_width)
 /* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = LOAD_FP(imm, rs1, rd, width)
-  <-> imm @ encdec_reg(rs1) @ 0b0 @ size_enc(width) @ encdec_freg(rd) @ 0b000_0111
+  <-> imm @ encdec_reg(rs1) @ 0b0 @ width_enc(width) @ encdec_freg(rd) @ 0b000_0111
   when float_load_store_width_supported(width)
 
 /* Execution semantics ================================ */
@@ -302,7 +302,7 @@ function clause execute(LOAD_FP(imm, rs1, rd, width)) = {
 /* instruction -> Assembly notation ================================ */
 
 mapping clause assembly = LOAD_FP(imm, rs1, rd, width)
-                      <-> "fl" ^ size_mnemonic(width)
+                      <-> "fl" ^ width_mnemonic(width)
                           ^ spc() ^ freg_or_reg_name(rd)
                           ^ sep() ^ hex_bits_signed_12(imm)
                           ^ opt_spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
@@ -318,7 +318,7 @@ union clause instruction = STORE_FP : (bits(12), fregidx, regidx, word_width)
 /* instruction <-> Binary encoding ================================ */
 
 mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, width)
-  <-> imm7 : bits(7) @ encdec_freg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(width) @ imm5 : bits(5) @ 0b010_0111
+  <-> imm7 : bits(7) @ encdec_freg(rs2) @ encdec_reg(rs1) @ 0b0 @ width_enc(width) @ imm5 : bits(5) @ 0b010_0111
   when float_load_store_width_supported(width)
 
 /* Execution semantics ================================ */
@@ -339,7 +339,7 @@ function clause execute (STORE_FP(imm, rs2, rs1, width)) = {
 /* instruction -> Assembly notation ================================ */
 
 mapping clause assembly = STORE_FP(imm, rs2, rs1, width)
-                      <-> "fs" ^ size_mnemonic(width)
+                      <-> "fs" ^ width_mnemonic(width)
                           ^ spc() ^ freg_name(rs2)
                           ^ sep() ^ hex_bits_signed_12(imm)
                           ^ opt_spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"

--- a/model/riscv_insts_zaamo.sail
+++ b/model/riscv_insts_zaamo.sail
@@ -12,8 +12,8 @@ function clause currentlyEnabled(Ext_Zabha) = hartSupports(Ext_Zabha) & currentl
 
 // Zaamo defines AMOs for word and double
 // Zabha defines AMOs for byte and halfword
-function amo_width_valid(size : word_width) -> bool = {
-  match size {
+function amo_width_valid(width : word_width) -> bool = {
+  match width {
     1 => currentlyEnabled(Ext_Zabha),
     2 => currentlyEnabled(Ext_Zabha),
     4 => true,
@@ -37,9 +37,9 @@ mapping encdec_amoop : amoop <-> bits(5) = {
   AMOMAXU <-> 0b11100
 }
 
-mapping clause encdec = AMO(op, aq, rl, rs2, rs1, size, rd)
-  <-> encdec_amoop(op) @ bool_bits(aq) @ bool_bits(rl) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ encdec_reg(rd) @ 0b0101111
-  when currentlyEnabled(Ext_Zaamo) & amo_width_valid(size)
+mapping clause encdec = AMO(op, aq, rl, rs2, rs1, width, rd)
+  <-> encdec_amoop(op) @ bool_bits(aq) @ bool_bits(rl) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ width_enc(width) @ encdec_reg(rd) @ 0b0101111
+  when currentlyEnabled(Ext_Zaamo) & amo_width_valid(width)
 
 /* NOTE: Currently, we only EA if address translation is successful.
    This may need revisiting. */
@@ -114,4 +114,4 @@ mapping maybe_aqrl : (bool, bool) <-> string = {
 }
 
 mapping clause assembly = AMO(op, aq, rl, rs2, rs1, width, rd)
-  <-> amo_mnemonic(op) ^ "." ^ size_mnemonic(width) ^ maybe_aqrl(aq, rl) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs2) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
+  <-> amo_mnemonic(op) ^ "." ^ width_mnemonic(width) ^ maybe_aqrl(aq, rl) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs2) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"

--- a/model/riscv_insts_zalrsc.sail
+++ b/model/riscv_insts_zalrsc.sail
@@ -9,8 +9,8 @@
 function clause currentlyEnabled(Ext_Zalrsc) = hartSupports(Ext_Zalrsc) | currentlyEnabled(Ext_A)
 
 // Zalrsc defines LR/SC for word and double
-function lrsc_width_valid(size : word_width) -> bool = {
-  match size {
+function lrsc_width_valid(width : word_width) -> bool = {
+  match width {
     4 => true,
     8 => xlen >= 64,
     _ => false,
@@ -21,9 +21,9 @@ function lrsc_width_valid(size : word_width) -> bool = {
 
 union clause instruction = LOADRES : (bool, bool, regidx, word_width, regidx)
 
-mapping clause encdec = LOADRES(aq, rl, rs1, size, rd)
-  <-> 0b00010 @ bool_bits(aq) @ bool_bits(rl) @ 0b00000 @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ encdec_reg(rd) @ 0b0101111
-  when currentlyEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
+mapping clause encdec = LOADRES(aq, rl, rs1, width, rd)
+  <-> 0b00010 @ bool_bits(aq) @ bool_bits(rl) @ 0b00000 @ encdec_reg(rs1) @ 0b0 @ width_enc(width) @ encdec_reg(rd) @ 0b0101111
+  when currentlyEnabled(Ext_Zalrsc) & lrsc_width_valid(width)
 
 /* We could set load-reservations on physical or virtual addresses.
  * However most chips (especially multi-core) will use physical addresses.
@@ -48,16 +48,16 @@ function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
   }
 }
 
-mapping clause assembly = LOADRES(aq, rl, rs1, size, rd)
-  <-> "lr." ^ size_mnemonic(size) ^ maybe_aqrl(aq, rl) ^ spc() ^ reg_name(rd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
+mapping clause assembly = LOADRES(aq, rl, rs1, width, rd)
+  <-> "lr." ^ width_mnemonic(width) ^ maybe_aqrl(aq, rl) ^ spc() ^ reg_name(rd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
 
 /* ****************************************************************** */
 
 union clause instruction = STORECON : (bool, bool, regidx, regidx, word_width, regidx)
 
-mapping clause encdec = STORECON(aq, rl, rs2, rs1, size, rd)
-  <-> 0b00011 @ bool_bits(aq) @ bool_bits(rl) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ size_enc(size) @ encdec_reg(rd) @ 0b0101111
-  when currentlyEnabled(Ext_Zalrsc) & lrsc_width_valid(size)
+mapping clause encdec = STORECON(aq, rl, rs2, rs1, width, rd)
+  <-> 0b00011 @ bool_bits(aq) @ bool_bits(rl) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ width_enc(width) @ encdec_reg(rd) @ 0b0101111
+  when currentlyEnabled(Ext_Zalrsc) & lrsc_width_valid(width)
 
 /* NOTE: Currently, we only EA if address translation is successful. This may need revisiting. */
 function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
@@ -78,5 +78,5 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
   }
 }
 
-mapping clause assembly = STORECON(aq, rl, rs2, rs1, size, rd)
-  <-> "sc." ^ size_mnemonic(size) ^ maybe_aqrl(aq, rl) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs2) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
+mapping clause assembly = STORECON(aq, rl, rs2, rs1, width, rd)
+  <-> "sc." ^ width_mnemonic(width) ^ maybe_aqrl(aq, rl) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs2) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -307,14 +307,14 @@ mapping wait_name : WaitReason <-> string = {
 overload to_str = {wait_name}
 
 // Get the bit encoding of word_width.
-mapping size_enc : word_width <-> bits(2) = {
+mapping width_enc : word_width <-> bits(2) = {
   1 <-> 0b00,
   2 <-> 0b01,
   4 <-> 0b10,
   8 <-> 0b11,
 }
 
-mapping size_mnemonic : word_width <-> string = {
+mapping width_mnemonic : word_width <-> string = {
   1 <-> "b",
   2 <-> "h",
   4 <-> "w",

--- a/model/riscv_vmem.sail
+++ b/model/riscv_vmem.sail
@@ -47,17 +47,17 @@ type PTW_Result('v : Int), is_sv_mode('v) = result((PTW_Output('v), ext_ptw), (P
 // Write a Page Table Entry.
 function write_pte forall 'n, 'n in {4, 8} . (
   paddr    : physaddr,
-  pte_size : int('n),
+  pte_width : int('n),
   pte      : bits('n * 8),
 ) -> MemoryOpResult(bool) =
-  mem_write_value_priv(paddr, pte_size, pte, Supervisor, false, false, false)
+  mem_write_value_priv(paddr, pte_width, pte, Supervisor, false, false, false)
 
 // Read a Page Table Entry.
 function read_pte forall 'n, 'n in {4, 8} . (
   paddr    : physaddr,
-  pte_size : int('n),
+  pte_width : int('n),
 ) -> MemoryOpResult(bits(8 * 'n)) =
-  mem_read_priv(Read(Data), Supervisor, paddr, pte_size, false, false, false)
+  mem_read_priv(Read(Data), Supervisor, paddr, pte_width, false, false, false)
 
 // PRIVATE
 // 'v is the virtual address size.
@@ -88,12 +88,12 @@ function pt_walk(
   ext_ptw,
 ) = {
   // Extract the PPN component for this level; 10 bits on Sv32, otherwise 9.
-  let 'vpn_i_size = if 'v == 32 then 10 else 9;
-  let vpn_i = vpn[(level + 1) * vpn_i_size - 1 .. level * vpn_i_size];
-  let 'log_pte_size_bytes = if 'v == 32 then 2 else 3;
+  let 'vpn_i_width = if 'v == 32 then 10 else 9;
+  let vpn_i = vpn[(level + 1) * vpn_i_width - 1 .. level * vpn_i_width];
+  let 'log_pte_width_bytes = if 'v == 32 then 2 else 3;
 
   // Address of PTE in page table. This is 34 bits for Sv32, otherwise 56 bits.
-  let pte_addr = pt_base @ vpn_i @ zeros('log_pte_size_bytes);
+  let pte_addr = pt_base @ vpn_i @ zeros('log_pte_width_bytes);
 
 
   // Convert to a physical address (34 bits for RV32, 64 bits to RV64).
@@ -104,7 +104,7 @@ function pt_walk(
   let pte_addr = Physaddr(zero_extend(pte_addr));
 
   // Read this-level PTE from mem (Step 2 of VATP)
-  match read_pte(pte_addr, 2 ^ log_pte_size_bytes) {
+  match read_pte(pte_addr, 2 ^ log_pte_width_bytes) {
     Err(_)  => Err(PTW_Access(), ext_ptw),
     Ok(pte) => {
       let pte_flags = Mk_PTE_Flags(pte[7 .. 0]);
@@ -127,10 +127,10 @@ function pt_walk(
             Err(PTW_Invalid_PTE(), ext_ptw)
         } else {
           // Leaf PTE (Step 5 of VATP).
-          let ppn_size_bits = if 'v == 32 then 10 else 9;
+          let ppn_width_bits = if 'v == 32 then 10 else 9;
           if level > 0 then {
             // Check for misaligned superpage.
-            let low_bits = ppn_size_bits * level;
+            let low_bits = ppn_width_bits * level;
             if   ppn[low_bits - 1 .. 0] != zeros()
             then return Err(PTW_Misaligned(), ext_ptw);
           };
@@ -142,7 +142,7 @@ function pt_walk(
               let ppn = if level > 0 then {
                 // Compose final PA in superpage:
                 // Superpage PPN @ lower VPNs @ page-offset
-                let low_bits = ppn_size_bits * level;
+                let low_bits = ppn_width_bits * level;
                 ppn[length(ppn) - 1 .. low_bits] @ vpn[low_bits - 1 .. 0]
               } else {
                 ppn

--- a/model/riscv_vmem_pte.sail
+++ b/model/riscv_vmem_pte.sail
@@ -42,14 +42,14 @@ bitfield PTE_Ext : pte_ext_bits = {
 let default_sv32_ext_pte : pte_ext_bits = zeros()
 
 // PRIVATE: extract ext bits of PTE above the PPN.
-val ext_bits_of_PTE : forall 'pte_size, 'pte_size in {32, 64}. bits('pte_size) -> PTE_Ext
+val ext_bits_of_PTE : forall 'pte_width, 'pte_width in {32, 64}. bits('pte_width) -> PTE_Ext
 function ext_bits_of_PTE(pte) =
-  Mk_PTE_Ext(if 'pte_size == 64 then pte[63 .. 54] else default_sv32_ext_pte)
+  Mk_PTE_Ext(if 'pte_width == 64 then pte[63 .. 54] else default_sv32_ext_pte)
 
 // PRIVATE: extract full PPN from a PTE
-val PPN_of_PTE : forall 'pte_size, 'pte_size in {32, 64}.
-  bits('pte_size) -> bits(if 'pte_size == 32 then 22 else 44)
-function PPN_of_PTE(pte) = if 'pte_size == 32 then pte[31 .. 10] else pte[53 .. 10]
+val PPN_of_PTE : forall 'pte_width, 'pte_width in {32, 64}.
+  bits('pte_width) -> bits(if 'pte_width == 32 then 22 else 44)
+function PPN_of_PTE(pte) = if 'pte_width == 32 then pte[31 .. 10] else pte[53 .. 10]
 
 // PRIVATE: 8 LSBs of PTEs in Sv32, Sv39, Sv48 and Sv57
 bitfield PTE_Flags : pte_flags_bits = {
@@ -137,10 +137,10 @@ function check_PTE_permission(ac        : AccessType(ext_access_type),
 
 // Update PTE bits if needed; return new PTE if updated
 // PRIVATE
-function update_PTE_Bits forall 'pte_size, 'pte_size in {32, 64} . (
-  pte : bits('pte_size),
+function update_PTE_Bits forall 'pte_width, 'pte_width in {32, 64} . (
+  pte : bits('pte_width),
   a   : AccessType(ext_access_type),
-) -> option(bits('pte_size)) = {
+) -> option(bits('pte_width)) = {
   let pte_flags = Mk_PTE_Flags(pte[7 .. 0]);
 
   // Update 'dirty' bit?


### PR DESCRIPTION
For #1116

Sort out the `size` name, mainly include:
- paddr width 
- Load and Store width
- encode mapping name
- pte, vpn, ppn width

The `width` in sail code for the above entries was consistently named `size`, hence the modification.