### PR TITLE
Move privilege-based CSR access into scattered is_CSR_accessible function

### DIFF
--- a/model/riscv_csr_begin.sail
+++ b/model/riscv_csr_begin.sail
@@ -17,8 +17,8 @@ function csr_name(csr) = csr_name_map(csr)
 overload to_str = {csr_name}
 
 // returns whether a CSR exists
-val is_CSR_defined : (csreg) -> bool
-scattered function is_CSR_defined
+val is_CSR_accessible : (csreg, Privilege, bool) -> bool
+scattered function is_CSR_accessible
 
 // returns the value of the CSR if it is defined
 val read_CSR : csreg -> xlenbits

--- a/model/riscv_csr_end.sail
+++ b/model/riscv_csr_end.sail
@@ -9,17 +9,17 @@
 mapping clause csr_name_map = reg <-> hex_bits_12(reg)
 end csr_name_map
 
-function clause is_CSR_defined(_) = false
-end is_CSR_defined
+function clause is_CSR_accessible(_) = false
+end is_CSR_accessible
 
 function clause read_CSR(csr) = {
-   // This should be impossible because is_CSR_defined() should have returned false.
+   // This should be impossible because is_CSR_accessible() should have returned false.
    internal_error(__FILE__, __LINE__, "Read from CSR that does not exist: " ^ bits_str(csr));
 }
 end read_CSR
 
 function clause write_CSR(csr, _) = {
-   // This should be impossible because is_CSR_defined() should have returned false.
+   // This should be impossible because is_CSR_accessible() should have returned false.
    internal_error(__FILE__, __LINE__, "Write to CSR that does not exist: " ^ bits_str(csr));
 }
 end write_CSR

--- a/model/riscv_fdext_control.sail
+++ b/model/riscv_fdext_control.sail
@@ -24,9 +24,9 @@ mapping clause csr_name_map = 0x001  <-> "fflags"
 mapping clause csr_name_map = 0x002  <-> "frm"
 mapping clause csr_name_map = 0x003  <-> "fcsr"
 
-function clause is_CSR_defined (0x001) = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
-function clause is_CSR_defined (0x002) = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
-function clause is_CSR_defined (0x003) = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
+function clause is_CSR_accessible (0x001, _, _) = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
+function clause is_CSR_accessible (0x002, _, _) = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
+function clause is_CSR_accessible (0x003, _, _) = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
 
 function clause read_CSR (0x001) = zero_extend(fcsr[FFLAGS])
 function clause read_CSR (0x002) = zero_extend(fcsr[FRM])

--- a/model/riscv_pmp_regs.sail
+++ b/model/riscv_pmp_regs.sail
@@ -236,7 +236,7 @@ mapping clause csr_name_map = 0x3EE  <-> "pmpaddr62"
 mapping clause csr_name_map = 0x3EF  <-> "pmpaddr63"
 
 // pmpcfgN
-function clause is_CSR_defined(0x3A) @ idx : bits(4) = sys_pmp_count > 4 * unsigned(idx) & (idx[0] == bitzero | xlen == 32)
+function clause is_CSR_accessible(0x3A @ idx : bits(4), _, _) = sys_pmp_count > 4 * unsigned(idx) & (idx[0] == bitzero | xlen == 32)
 function clause read_CSR(0x3A @ idx : bits(4) if idx[0] == bitzero | xlen == 32) = pmpReadCfgReg(unsigned(idx))
 function clause write_CSR((0x3A @ idx : bits(4), value) if idx[0] == bitzero | xlen == 32) = {
   let idx = unsigned(idx);
@@ -245,10 +245,10 @@ function clause write_CSR((0x3A @ idx : bits(4), value) if idx[0] == bitzero | x
 }
 
 // pmpaddrN. Unfortunately the PMP index does not nicely align with the CSR index bits.
-function clause is_CSR_defined(0x3B) @ idx : bits(4) = sys_pmp_count > unsigned(0b00 @ idx)
-function clause is_CSR_defined(0x3C) @ idx : bits(4) = sys_pmp_count > unsigned(0b01 @ idx)
-function clause is_CSR_defined(0x3D) @ idx : bits(4) = sys_pmp_count > unsigned(0b10 @ idx)
-function clause is_CSR_defined(0x3E) @ idx : bits(4) = sys_pmp_count > unsigned(0b11 @ idx)
+function clause is_CSR_accessible(0x3B @ idx : bits(4), _, _) = sys_pmp_count > unsigned(0b00 @ idx)
+function clause is_CSR_accessible(0x3C @ idx : bits(4), _, _) = sys_pmp_count > unsigned(0b01 @ idx)
+function clause is_CSR_accessible(0x3D @ idx : bits(4), _, _) = sys_pmp_count > unsigned(0b10 @ idx)
+function clause is_CSR_accessible(0x3E @ idx : bits(4), _, _) = sys_pmp_count > unsigned(0b11 @ idx)
 
 function clause read_CSR(0x3B @ idx : bits(4)) = pmpReadAddrReg(unsigned(0b00 @ idx))
 function clause read_CSR(0x3C @ idx : bits(4)) = pmpReadAddrReg(unsigned(0b01 @ idx))

--- a/model/riscv_smcntrpmf.sail
+++ b/model/riscv_smcntrpmf.sail
@@ -28,10 +28,10 @@ mapping clause csr_name_map = 0x721  <-> "mcyclecfgh"
 mapping clause csr_name_map = 0x322  <-> "minstretcfg"
 mapping clause csr_name_map = 0x722  <-> "minstretcfgh"
 
-function clause is_CSR_defined(0x321) = currentlyEnabled(Ext_Smcntrpmf) // mcyclecfg
-function clause is_CSR_defined(0x721) = currentlyEnabled(Ext_Smcntrpmf) & xlen == 32 // mcyclecfgh
-function clause is_CSR_defined(0x322) = currentlyEnabled(Ext_Smcntrpmf) // minstretcfg
-function clause is_CSR_defined(0x722) = currentlyEnabled(Ext_Smcntrpmf) & xlen == 32 // minstretcfgh
+function clause is_CSR_accessible(0x321, _, _) = currentlyEnabled(Ext_Smcntrpmf) // mcyclecfg
+function clause is_CSR_accessible(0x721, _, _) = currentlyEnabled(Ext_Smcntrpmf) & xlen == 32 // mcyclecfgh
+function clause is_CSR_accessible(0x322, _, _) = currentlyEnabled(Ext_Smcntrpmf) // minstretcfg
+function clause is_CSR_accessible(0x722, _, _) = currentlyEnabled(Ext_Smcntrpmf) & xlen == 32 // minstretcfgh
 
 function clause read_CSR(0x321) = mcyclecfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x721 if xlen == 32) = mcyclecfg.bits[63 .. 32]

--- a/model/riscv_sscofpmf.sail
+++ b/model/riscv_sscofpmf.sail
@@ -48,7 +48,7 @@ function write_mhpmeventh(index : hpmidx, value : bits(32)) -> unit =
   mhpmevent[index] = legalize_hpmevent(Mk_HpmEvent(value @ mhpmevent[index].bits[31 .. 0]))
 
 // mhpmevent3..31h
-function clause is_CSR_defined(0b0111001 /* 0x720 */ @ index : bits(5) if unsigned(index) >= 3) = currentlyEnabled(Ext_Sscofpmf) & (xlen == 32)
+function clause is_CSR_accessible((0b0111001 /* 0x720 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Sscofpmf) & (xlen == 32)
 function clause read_CSR(0b0111001 /* 0x720 */ @ index : bits(5) if xlen == 32 & unsigned(index) >= 3) = read_mhpmeventh(hpmidx_from_bits(index))
 function clause write_CSR((0b0111001 /* 0x720 */ @ index : bits(5), value) if xlen == 32 & unsigned(index) >= 3) = {
   let index = hpmidx_from_bits(index);
@@ -76,6 +76,6 @@ function get_scountovf(priv : Privilege) -> bits(32) = {
 }
 
 // scountovf
-function clause is_CSR_defined(0xDA0) = currentlyEnabled(Ext_Sscofpmf) & currentlyEnabled(Ext_S)
+function clause is_CSR_accessible(0xDA0, _, _) = currentlyEnabled(Ext_Sscofpmf) & currentlyEnabled(Ext_S)
 function clause read_CSR(0xDA0) = zero_extend(get_scountovf(cur_privilege))
 // scountovf is read-only.

--- a/model/riscv_sstc.sail
+++ b/model/riscv_sstc.sail
@@ -10,8 +10,16 @@
 mapping clause csr_name_map = 0x14D  <-> "stimecmp"
 mapping clause csr_name_map = 0x15D  <-> "stimecmph"
 
-function clause is_CSR_defined(0x14D) = currentlyEnabled(Ext_S) & currentlyEnabled(Ext_Sstc)
-function clause is_CSR_defined(0x15D) = currentlyEnabled(Ext_S) & currentlyEnabled(Ext_Sstc) & xlen == 32
+function sstc_CSRs_accessible(priv : Privilege) -> bool =
+    priv == Machine | (priv == Supervisor & mcounteren[TM] == 0b1 & menvcfg[STCE] == 0b1)
+
+function clause is_CSR_accessible(0x14D, priv, _) =
+    currentlyEnabled(Ext_S) & currentlyEnabled(Ext_Sstc) &
+    sstc_CSRs_accessible(priv)
+
+function clause is_CSR_accessible(0x15D, priv, _) =
+    currentlyEnabled(Ext_S) & currentlyEnabled(Ext_Sstc) & xlen == 32 &
+    sstc_CSRs_accessible(priv)
 
 function clause read_CSR(0x14D) = stimecmp[xlen - 1 .. 0]
 function clause read_CSR(0x15D if xlen == 32) = stimecmp[63 .. 32]

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -26,64 +26,10 @@ function check_CSR_priv(csr : csreg, p : Privilege) -> bool =
 function check_CSR_access(csr : csreg, isWrite : bool) -> bool =
   not(isWrite & (csrAccess(csr) == 0b11))
 
-function check_TVM_SATP(csr : csreg, p : Privilege) -> bool =
-  not(csr == 0x180 & p == Supervisor & mstatus[TVM] == 0b1)
-
-// There are several features that are controlled by machine/supervisor enable
-// bits (m/senvcfg, m/scounteren, etc.). This abstracts that logic.
-function feature_enabled_for_priv(p : Privilege, machine_enable_bit : bit, supervisor_enable_bit : bit) -> bool = match p {
-  Machine => true,
-  Supervisor => machine_enable_bit == bitone,
-  User => machine_enable_bit == bitone & (not(currentlyEnabled(Ext_S)) | supervisor_enable_bit == bitone),
-}
-
-// Return true if the counter is enabled OR the CSR is not a counter.
-function check_Counteren(csr : csreg, p : Privilege) -> bool = {
-  // Check if it is not a counter.
-  if csr <_u 0xC00 | 0xC1F <_u csr then return true;
-
-  // Check the relevant bit in m/scounteren.
-  let index = unsigned(csr[4 .. 0]);
-  feature_enabled_for_priv(p, mcounteren.bits[index], scounteren.bits[index])
-}
-
-// Return true if the stimecmp[h] CSR is accessible OR the CSR is not stimecmp[h].
-function check_Stimecmp(csr : csreg, p : Privilege) -> bool = {
-  // Check if it is not stimecmp.
-  if csr != 0x14D & csr != 0x15D then return true;
-
-  p == Machine | (p == Supervisor & mcounteren[TM] == 0b1 & menvcfg[STCE] == 0b1)
-}
-
-/* Seed may only be accessed if we are doing a write, and access has been
- * allowed in the current priv mode
- */
-function check_seed_CSR (csr : csreg, p : Privilege, isWrite : bool) -> bool = {
-  if not(csr == 0x015) then {
-    true
-  } else if not(isWrite) then {
-    /* Read-only access to the seed CSR is not allowed */
-    false
-  } else {
-    match (p) {
-      Machine => true,
-      Supervisor => mseccfg[SSEED] == 0b1,
-      User => mseccfg[USEED] == 0b1,
-    }
-  }
-}
-
 function check_CSR(csr : csreg, p : Privilege, isWrite : bool) -> bool =
-    is_CSR_defined(csr)
-  & check_CSR_priv(csr, p)
+    check_CSR_priv(csr, p)
   & check_CSR_access(csr, isWrite)
-  // TODO: If we add `p` back to is_CSR_defined() we could move these three
-  // check_ functions back there. We should also rename is_CSR_defined()
-  // to is_CSR_accessible() or similar.
-  & check_TVM_SATP(csr, p)
-  & check_Counteren(csr, p)
-  & check_Stimecmp(csr, p)
-  & check_seed_CSR(csr, p, isWrite)
+  & is_CSR_accessible(csr, p, isWrite)
 
 /* Exception delegation: given an exception and the privilege at which
  * it occurred, returns the privilege at which it should be handled.

--- a/model/riscv_sys_exceptions.sail
+++ b/model/riscv_sys_exceptions.sail
@@ -83,10 +83,10 @@ mapping clause csr_name_map = 0x141  <-> "sepc"
 mapping clause csr_name_map = 0x305  <-> "mtvec"
 mapping clause csr_name_map = 0x341  <-> "mepc"
 
-function clause is_CSR_defined(0x105) = currentlyEnabled(Ext_S) // stvec
-function clause is_CSR_defined(0x141) = currentlyEnabled(Ext_S) // sepc
-function clause is_CSR_defined(0x305) = true // mtvec
-function clause is_CSR_defined(0x341) = true // mepc
+function clause is_CSR_accessible(0x105, _, _) = currentlyEnabled(Ext_S) // stvec
+function clause is_CSR_accessible(0x141, _, _) = currentlyEnabled(Ext_S) // sepc
+function clause is_CSR_accessible(0x305, _, _) = true // mtvec
+function clause is_CSR_accessible(0x341, _, _) = true // mepc
 
 function clause read_CSR(0x105) = get_stvec()
 function clause read_CSR(0x141) = get_xepc(Supervisor)

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -123,7 +123,7 @@ function legalize_misa(m : Misa, v : xlenbits) -> Misa = {
 }
 
 mapping clause csr_name_map = 0x301  <-> "misa"
-function clause is_CSR_defined(0x301) = true // misa
+function clause is_CSR_accessible(0x301, _, _) = true // misa
 function clause read_CSR(0x301) = misa.bits
 function clause write_CSR(0x301, value) = { misa = legalize_misa(misa, value); Ok(misa.bits) }
 
@@ -274,8 +274,8 @@ register mstatus : Mstatus = {
 mapping clause csr_name_map = 0x300  <-> "mstatus"
 mapping clause csr_name_map = 0x310  <-> "mstatush"
 
-function clause is_CSR_defined(0x300) = true // mstatus
-function clause is_CSR_defined(0x310) = xlen == 32 // mstatush
+function clause is_CSR_accessible(0x300, _, _) = true // mstatus
+function clause is_CSR_accessible(0x310, _, _) = xlen == 32 // mstatush
 
 function clause read_CSR(0x300) = mstatus.bits[xlen - 1 .. 0]
 function clause read_CSR(0x310 if xlen == 32) = mstatus.bits[63 .. 32]
@@ -330,8 +330,8 @@ mapping clause csr_name_map = 0x747  <-> "mseccfg"
 mapping clause csr_name_map = 0x757  <-> "mseccfgh"
 
 // "mseccfg exists if Zkr is implemented, or if it is required by other processor features."
-function clause is_CSR_defined(0x747) = currentlyEnabled(Ext_Zkr) // mseccfg
-function clause is_CSR_defined(0x757) = currentlyEnabled(Ext_Zkr) & xlen == 32 // mseccfgh
+function clause is_CSR_accessible(0x747, _, _) = currentlyEnabled(Ext_Zkr) // mseccfg
+function clause is_CSR_accessible(0x757, _, _) = currentlyEnabled(Ext_Zkr) & xlen == 32 // mseccfgh
 
 function clause read_CSR(0x747) = mseccfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x757 if xlen == 32) = mseccfg.bits[63 .. 32]
@@ -414,9 +414,9 @@ mapping clause csr_name_map = 0x30A  <-> "menvcfg"
 mapping clause csr_name_map = 0x31A  <-> "menvcfgh"
 mapping clause csr_name_map = 0x10A  <-> "senvcfg"
 
-function clause is_CSR_defined(0x30A) = currentlyEnabled(Ext_U) // menvcfg
-function clause is_CSR_defined(0x31A) = currentlyEnabled(Ext_U) & (xlen == 32) // menvcfgh
-function clause is_CSR_defined(0x10A) = currentlyEnabled(Ext_S) // senvcfg
+function clause is_CSR_accessible(0x30A, _, _) = currentlyEnabled(Ext_U) // menvcfg
+function clause is_CSR_accessible(0x31A, _, _) = currentlyEnabled(Ext_U) & (xlen == 32) // menvcfgh
+function clause is_CSR_accessible(0x10A, _, _) = currentlyEnabled(Ext_S) // senvcfg
 
 function clause read_CSR(0x30A) = menvcfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x31A if xlen == 32) = menvcfg.bits[63 .. 32]
@@ -517,11 +517,11 @@ mapping clause csr_name_map = 0x302  <-> "medeleg"
 mapping clause csr_name_map = 0x312  <-> "medelegh"
 mapping clause csr_name_map = 0x303  <-> "mideleg"
 
-function clause is_CSR_defined(0x304) = true // mie
-function clause is_CSR_defined(0x344) = true // mip
-function clause is_CSR_defined(0x302) = currentlyEnabled(Ext_S) // medeleg
-function clause is_CSR_defined(0x312) = currentlyEnabled(Ext_S) & xlen == 32 // medelegh
-function clause is_CSR_defined(0x303) = currentlyEnabled(Ext_S) // mideleg
+function clause is_CSR_accessible(0x304, _, _) = true // mie
+function clause is_CSR_accessible(0x344, _, _) = true // mip
+function clause is_CSR_accessible(0x302, _, _) = currentlyEnabled(Ext_S) // medeleg
+function clause is_CSR_accessible(0x312, _, _) = currentlyEnabled(Ext_S) & xlen == 32 // medelegh
+function clause is_CSR_accessible(0x303, _, _) = currentlyEnabled(Ext_S) // mideleg
 
 function clause read_CSR(0x304) = mie.bits
 function clause read_CSR(0x344) = mip.bits
@@ -559,7 +559,7 @@ bitfield Mcause : xlenbits = {
 }
 register mcause : Mcause
 mapping clause csr_name_map = 0x342  <-> "mcause"
-function clause is_CSR_defined(0x342) = true // mcause
+function clause is_CSR_accessible(0x342, _, _) = true // mcause
 function clause read_CSR(0x342) = mcause.bits
 function clause write_CSR(0x342, value) = { mcause.bits = value; Ok(mcause.bits) }
 
@@ -603,8 +603,8 @@ register mscratch : xlenbits
 mapping clause csr_name_map = 0x343  <-> "mtval"
 mapping clause csr_name_map = 0x340  <-> "mscratch"
 
-function clause is_CSR_defined(0x343) = true // mtval
-function clause is_CSR_defined(0x340) = true // mscratch
+function clause is_CSR_accessible(0x343, _, _) = true // mtval
+function clause is_CSR_accessible(0x340, _, _) = true // mscratch
 
 function clause read_CSR(0x343) = mtval
 function clause read_CSR(0x340) = mscratch
@@ -629,7 +629,7 @@ function legalize_scounteren(c : Counteren, v : xlenbits) -> Counteren = {
 
 register scounteren : Counteren
 mapping clause csr_name_map = 0x106  <-> "scounteren"
-function clause is_CSR_defined(0x106) = currentlyEnabled(Ext_S) // scounteren
+function clause is_CSR_accessible(0x106, _, _) = currentlyEnabled(Ext_S) // scounteren
 function clause read_CSR(0x106) = zero_extend(scounteren.bits)
 function clause write_CSR(0x106, value) = { scounteren = legalize_scounteren(scounteren, value); Ok(zero_extend(scounteren.bits)) }
 
@@ -641,7 +641,7 @@ function legalize_mcounteren(c : Counteren, v : xlenbits) -> Counteren = {
 
 register mcounteren : Counteren
 mapping clause csr_name_map = 0x306  <-> "mcounteren"
-function clause is_CSR_defined(0x306) = currentlyEnabled(Ext_U) // mcounteren
+function clause is_CSR_accessible(0x306, _, _) = currentlyEnabled(Ext_U) // mcounteren
 function clause read_CSR(0x306) = zero_extend(mcounteren.bits)
 function clause write_CSR(0x306, value) = { mcounteren = legalize_mcounteren(mcounteren, value); Ok(zero_extend(mcounteren.bits)) }
 
@@ -661,7 +661,7 @@ function legalize_mcountinhibit(c : Counterin, v : xlenbits) -> Counterin = {
 
 register mcountinhibit : Counterin
 mapping clause csr_name_map = 0x320  <-> "mcountinhibit"
-function clause is_CSR_defined(0x320) = true // mcountinhibit
+function clause is_CSR_accessible(0x320, _, _) = true // mcountinhibit
 function clause read_CSR(0x320) = zero_extend(mcountinhibit.bits)
 function clause write_CSR(0x320, value) = { mcountinhibit = legalize_mcountinhibit(mcountinhibit, value); Ok(zero_extend(mcountinhibit.bits)) }
 
@@ -698,11 +698,11 @@ mapping clause csr_name_map = 0xF13  <-> "mimpid"
 mapping clause csr_name_map = 0xF14  <-> "mhartid"
 mapping clause csr_name_map = 0xF15  <-> "mconfigptr"
 
-function clause is_CSR_defined(0xf11) = true // mvendorid
-function clause is_CSR_defined(0xf12) = true // marchdid
-function clause is_CSR_defined(0xf13) = true // mimpid
-function clause is_CSR_defined(0xf14) = true // mhartid
-function clause is_CSR_defined(0xf15) = true // mconfigptr
+function clause is_CSR_accessible(0xf11, _, _) = true // mvendorid
+function clause is_CSR_accessible(0xf12, _, _) = true // marchdid
+function clause is_CSR_accessible(0xf13, _, _) = true // mimpid
+function clause is_CSR_accessible(0xf14, _, _) = true // mhartid
+function clause is_CSR_accessible(0xf15, _, _) = true // mconfigptr
 
 function clause read_CSR(0xF11) = zero_extend(mvendorid)
 function clause read_CSR(0xF12) = marchid
@@ -774,7 +774,7 @@ function legalize_sstatus(m : Mstatus, v : xlenbits) -> Mstatus = {
 }
 
 mapping clause csr_name_map = 0x100  <-> "sstatus"
-function clause is_CSR_defined(0x100) = currentlyEnabled(Ext_S) // sstatus
+function clause is_CSR_accessible(0x100, _, _) = currentlyEnabled(Ext_S) // sstatus
 function clause read_CSR(0x100) = lower_mstatus(mstatus).bits[xlen - 1 .. 0]
 function clause write_CSR(0x100, value) = { mstatus = legalize_sstatus(mstatus, value); Ok(lower_mstatus(mstatus).bits[xlen - 1 .. 0]) }
 
@@ -822,7 +822,7 @@ function legalize_sip(m : Minterrupts, d : Minterrupts, v : xlenbits) -> Minterr
 }
 
 mapping clause csr_name_map = 0x144  <-> "sip"
-function clause is_CSR_defined(0x144) = currentlyEnabled(Ext_S) // sip
+function clause is_CSR_accessible(0x144, _, _) = currentlyEnabled(Ext_S) // sip
 function clause read_CSR(0x144) = lower_mip(mip, mideleg).bits
 function clause write_CSR(0x144, value) = { mip = legalize_sip(mip, mideleg, value); Ok(lower_mip(mip, mideleg).bits) }
 
@@ -844,7 +844,7 @@ function legalize_sie(m : Minterrupts, d : Minterrupts, v : xlenbits) -> Minterr
 
 
 mapping clause csr_name_map = 0x104  <-> "sie"
-function clause is_CSR_defined(0x104) = currentlyEnabled(Ext_S) // sie
+function clause is_CSR_accessible(0x104, _, _) = currentlyEnabled(Ext_S) // sie
 function clause read_CSR(0x104) = lower_mie(mie, mideleg).bits
 function clause write_CSR(0x104, value) = { mie = legalize_sie(mie, mideleg, value); Ok(lower_mie(mie, mideleg).bits) }
 
@@ -860,9 +860,9 @@ mapping clause csr_name_map = 0x140  <-> "sscratch"
 mapping clause csr_name_map = 0x142  <-> "scause"
 mapping clause csr_name_map = 0x143  <-> "stval"
 
-function clause is_CSR_defined(0x140) = currentlyEnabled(Ext_S) // sscratch
-function clause is_CSR_defined(0x142) = currentlyEnabled(Ext_S) // scause
-function clause is_CSR_defined(0x143) = currentlyEnabled(Ext_S) // stval
+function clause is_CSR_accessible(0x140, _, _) = currentlyEnabled(Ext_S) // sscratch
+function clause is_CSR_accessible(0x142, _, _) = currentlyEnabled(Ext_S) // scause
+function clause is_CSR_accessible(0x143, _, _) = currentlyEnabled(Ext_S) // stval
 
 function clause read_CSR(0x140) = sscratch
 function clause read_CSR(0x142) = scause.bits
@@ -931,7 +931,7 @@ mapping clause csr_name_map = 0x7a1  <-> "tdata1"
 mapping clause csr_name_map = 0x7a2  <-> "tdata2"
 mapping clause csr_name_map = 0x7a3  <-> "tdata3"
 
-function clause is_CSR_defined(0x7a0) = true
+function clause is_CSR_accessible(0x7a0, _, _) = true
 function clause read_CSR(0x7a0) = ~(tselect)  /* this indicates we don't have any trigger support */
 function clause write_CSR(0x7a0, value) = { tselect = value; Ok(tselect) }
 
@@ -947,3 +947,16 @@ val get_16_random_bits = impure {
     c: "plat_get_16_random_bits",
     lem: "plat_get_16_random_bits"
 } : unit -> bits(16)
+
+
+// There are several features that are controlled by machine/supervisor enable
+// bits (m/senvcfg, m/scounteren, etc.). This abstracts that logic.
+function feature_enabled_for_priv(p : Privilege, machine_enable_bit : bit, supervisor_enable_bit : bit) -> bool = match p {
+  Machine => true,
+  Supervisor => machine_enable_bit == bitone,
+  User => machine_enable_bit == bitone & (not(currentlyEnabled(Ext_S)) | supervisor_enable_bit == bitone),
+}
+
+// Return true if the counter is enabled.
+function counter_enabled(index: range(0, 31), priv : Privilege) -> bool =
+  feature_enabled_for_priv(priv, mcounteren.bits[index], scounteren.bits[index])

--- a/model/riscv_vext_regs.sail
+++ b/model/riscv_vext_regs.sail
@@ -326,13 +326,13 @@ mapping clause csr_name_map = 0xC20  <-> "vl"
 mapping clause csr_name_map = 0xC21  <-> "vtype"
 mapping clause csr_name_map = 0xC22  <-> "vlenb"
 
-function clause is_CSR_defined (0x008) = currentlyEnabled(Ext_V) // vstart
-function clause is_CSR_defined (0x009) = currentlyEnabled(Ext_V) // vxsat
-function clause is_CSR_defined (0x00A) = currentlyEnabled(Ext_V) // vxrm
-function clause is_CSR_defined (0x00F) = currentlyEnabled(Ext_V) // vcsr
-function clause is_CSR_defined (0xC20) = currentlyEnabled(Ext_V) // vl
-function clause is_CSR_defined (0xC21) = currentlyEnabled(Ext_V) // vtype
-function clause is_CSR_defined (0xC22) = currentlyEnabled(Ext_V) // vlenb
+function clause is_CSR_accessible(0x008, _, _) = currentlyEnabled(Ext_V) // vstart
+function clause is_CSR_accessible(0x009, _, _) = currentlyEnabled(Ext_V) // vxsat
+function clause is_CSR_accessible(0x00A, _, _) = currentlyEnabled(Ext_V) // vxrm
+function clause is_CSR_accessible(0x00F, _, _) = currentlyEnabled(Ext_V) // vcsr
+function clause is_CSR_accessible(0xC20, _, _) = currentlyEnabled(Ext_V) // vl
+function clause is_CSR_accessible(0xC21, _, _) = currentlyEnabled(Ext_V) // vtype
+function clause is_CSR_accessible(0xC22, _, _) = currentlyEnabled(Ext_V) // vlenb
 
 function clause read_CSR(0x008) = vstart
 function clause read_CSR(0x009) = zero_extend(vcsr[vxsat])

--- a/model/riscv_vmem.sail
+++ b/model/riscv_vmem.sail
@@ -162,7 +162,7 @@ function pt_walk(
 // PUBLIC: see also riscv_insts_zicsr.sail and other CSR-related files
 register satp : xlenbits
 mapping clause csr_name_map = 0x180  <-> "satp"
-function clause is_CSR_defined(0x180) = currentlyEnabled(Ext_S)
+function clause is_CSR_accessible(0x180, priv, _) = currentlyEnabled(Ext_S) & not(priv == Supervisor & mstatus[TVM] == 0b1)
 function clause read_CSR(0x180) = satp
 function clause write_CSR(0x180, value) = { satp = legalize_satp(cur_architecture(), satp, value); Ok(satp) }
 

--- a/model/riscv_zicntr_control.sail
+++ b/model/riscv_zicntr_control.sail
@@ -15,12 +15,12 @@ mapping clause csr_name_map = 0xC80  <-> "cycleh"
 mapping clause csr_name_map = 0xC81  <-> "timeh"
 mapping clause csr_name_map = 0xC82  <-> "instreth"
 
-function clause is_CSR_defined(0xC00) = currentlyEnabled(Ext_Zicntr) // cycle
-function clause is_CSR_defined(0xC01) = currentlyEnabled(Ext_Zicntr) // time
-function clause is_CSR_defined(0xC02) = currentlyEnabled(Ext_Zicntr) // instret
-function clause is_CSR_defined(0xC80) = currentlyEnabled(Ext_Zicntr) & (xlen == 32) // cycleh
-function clause is_CSR_defined(0xC81) = currentlyEnabled(Ext_Zicntr) & (xlen == 32) // timeh
-function clause is_CSR_defined(0xC82) = currentlyEnabled(Ext_Zicntr) & (xlen == 32) // instreth
+function clause is_CSR_accessible(0xC00, priv, _) = currentlyEnabled(Ext_Zicntr) & counter_enabled(0, priv) // cycle
+function clause is_CSR_accessible(0xC01, priv, _) = currentlyEnabled(Ext_Zicntr) & counter_enabled(1, priv) // time
+function clause is_CSR_accessible(0xC02, priv, _) = currentlyEnabled(Ext_Zicntr) & counter_enabled(2, priv) // instret
+function clause is_CSR_accessible(0xC80, priv, _) = currentlyEnabled(Ext_Zicntr) & xlen == 32 & counter_enabled(0, priv) // cycleh
+function clause is_CSR_accessible(0xC81, priv, _) = currentlyEnabled(Ext_Zicntr) & xlen == 32 & counter_enabled(1, priv) // timeh
+function clause is_CSR_accessible(0xC82, priv, _) = currentlyEnabled(Ext_Zicntr) & xlen == 32 & counter_enabled(2, priv) // instreth
 
 function clause read_CSR(0xC00) = mcycle[(xlen - 1) .. 0]
 function clause read_CSR(0xC01) = mtime[(xlen - 1) .. 0]
@@ -36,10 +36,10 @@ mapping clause csr_name_map = 0xB02  <-> "minstret"
 mapping clause csr_name_map = 0xB80  <-> "mcycleh"
 mapping clause csr_name_map = 0xB82  <-> "minstreth"
 
-function clause is_CSR_defined(0xB00) = currentlyEnabled(Ext_Zicntr) // mcycle
-function clause is_CSR_defined(0xB02) = currentlyEnabled(Ext_Zicntr) // minstret
-function clause is_CSR_defined(0xB80) = currentlyEnabled(Ext_Zicntr) & xlen == 32 // mcycleh
-function clause is_CSR_defined(0xB82) = currentlyEnabled(Ext_Zicntr) & xlen == 32 // minstreth
+function clause is_CSR_accessible(0xB00, _, _) = currentlyEnabled(Ext_Zicntr) // mcycle
+function clause is_CSR_accessible(0xB02, _, _) = currentlyEnabled(Ext_Zicntr) // minstret
+function clause is_CSR_accessible(0xB80, _, _) = currentlyEnabled(Ext_Zicntr) & xlen == 32 // mcycleh
+function clause is_CSR_accessible(0xB82, _, _) = currentlyEnabled(Ext_Zicntr) & xlen == 32 // minstreth
 
 function clause read_CSR(0xB00) = mcycle[(xlen - 1) .. 0]
 function clause read_CSR(0xB02) = minstret[(xlen - 1) .. 0]

--- a/model/riscv_zihpm.sail
+++ b/model/riscv_zihpm.sail
@@ -224,7 +224,7 @@ function write_mhpmevent(index : hpmidx, value : xlenbits) -> unit =
   }))
 
 /* Hardware Performance Monitoring event selection */
-function clause is_CSR_defined(0b0011001 /* 0x320 */ @ index : bits(5) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) // mhpmevent3..31
+function clause is_CSR_accessible((0b0011001 /* 0x320 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) // mhpmevent3..31
 function clause read_CSR(0b0011001 /* 0x320 */ @ index : bits(5) if unsigned(index) >= 3) = read_mhpmevent(hpmidx_from_bits(index))
 function clause write_CSR((0b0011001 /* 0x320 */ @ index : bits(5), value) if unsigned(index) >= 3) = {
   let index = hpmidx_from_bits(index);
@@ -233,8 +233,8 @@ function clause write_CSR((0b0011001 /* 0x320 */ @ index : bits(5), value) if un
 }
 
 /* Hardware Performance Monitoring machine mode counters */
-function clause is_CSR_defined(0b1011000 /* 0xB00 */ @ index : bits(5) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) // mhpmcounter3..31
-function clause is_CSR_defined(0b1011100 /* 0xB80 */ @ index : bits(5) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & (xlen == 32) // mhpmcounterh3..31
+function clause is_CSR_accessible((0b1011000 /* 0xB00 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) // mhpmcounter3..31
+function clause is_CSR_accessible((0b1011100 /* 0xB80 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & xlen == 32 // mhpmcounterh3..31
 
 function clause read_CSR(0b1011000 /* 0xB00 */ @ index : bits(5) if unsigned(index) >= 3) = read_mhpmcounter(hpmidx_from_bits(index))
 function clause read_CSR(0b1011100 /* 0xB80 */ @ index : bits(5) if xlen == 32 & unsigned(index) >= 3) = read_mhpmcounterh(hpmidx_from_bits(index))
@@ -251,8 +251,8 @@ function clause write_CSR((0b1011100 /* 0xB80 */ @ index : bits(5), value) if xl
 }
 
 /* Hardware Performance Monitoring user mode counters */
-function clause is_CSR_defined(0b1100000 /* 0xC00 */ @ index : bits(5) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & currentlyEnabled(Ext_U) // hpmcounter3..31
-function clause is_CSR_defined(0b1100100 /* 0xC80 */ @ index : bits(5) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & currentlyEnabled(Ext_U) & (xlen == 32) // hpmcounterh3..31
+function clause is_CSR_accessible((0b1100000 /* 0xC00 */ @ index : bits(5), priv, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & currentlyEnabled(Ext_U) & counter_enabled(unsigned(index), priv) // hpmcounter3..31
+function clause is_CSR_accessible((0b1100100 /* 0xC80 */ @ index : bits(5), priv, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & currentlyEnabled(Ext_U) & xlen == 32 & counter_enabled(unsigned(index), priv) // hpmcounterh3..31
 
 function clause read_CSR(0b1100000 /* 0xC00 */ @ index : bits(5) if unsigned(index) >= 3) = read_mhpmcounter(hpmidx_from_bits(index))
 function clause read_CSR(0b1100100 /* 0xC80 */ @ index : bits(5) if xlen == 32 & unsigned(index) >= 3) = read_mhpmcounterh(hpmidx_from_bits(index))

--- a/model/riscv_zkr_control.sail
+++ b/model/riscv_zkr_control.sail
@@ -42,6 +42,15 @@ function write_seed_csr () -> xlenbits = zeros()
 
 /* CSR mapping */
 mapping clause csr_name_map = 0x015  <-> "seed"
-function clause is_CSR_defined(0x015) = currentlyEnabled(Ext_Zkr)
+function clause is_CSR_accessible(0x015, priv, is_write) =
+  currentlyEnabled(Ext_Zkr) &
+  // Read-only access is not allowed.
+  is_write &
+  (match priv {
+    Machine => true,
+    Supervisor => mseccfg[SSEED] == 0b1,
+    User => mseccfg[USEED] == 0b1,
+  })
+
 function clause read_CSR(0x015) = read_seed_csr()
 function clause write_CSR(0x015, value) = Ok(write_seed_csr())


### PR DESCRIPTION
Instead of having special extra functions to check accessibility of CSRs that depend on the privilege mode, and `is_write`, just add those parameters to `is_CSR_defined` (and rename it to `is_CSR_accessible`).

This also fixes a bug (discovered by inspection when making this change) - the `check_Counteren` was not checking the `...h` registers for RV32.