### PR TITLE
Allow LMUL=8 for widening reduction instruction

### DIFF
--- a/model/riscv_insts_vext_fp_red.sail
+++ b/model/riscv_insts_vext_fp_red.sail
@@ -70,13 +70,12 @@ function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_po
   RETIRE_SUCCESS
 }
 
-val process_rfvv_widen : (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, nat1, sew_bitsize, range(-3, 3)) -> ExecutionResult
-function process_rfvv_widen(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {
+val process_rfvv_widening_reduction : (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, nat1, sew_bitsize, range(-3, 3)) -> ExecutionResult
+function process_rfvv_widening_reduction(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {
   let rm_3b          = fcsr[FRM];
   let SEW_widen      = SEW * 2;
-  let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_fp_reduction_widen(SEW, rm_3b, SEW_widen, LMUL_pow_widen) then return Illegal_Instruction();
+  if illegal_fp_widening_reduction(SEW, rm_3b, SEW_widen) then return Illegal_Instruction();
   assert(SEW >= 16 & SEW_widen <= 64);
 
   let num_elem_vd = get_num_elem(0, SEW_widen); /* vd regardless of LMUL setting */
@@ -117,7 +116,7 @@ function clause execute(RFVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let num_elem_vs = get_num_elem(LMUL_pow, SEW);
 
   if funct6 == FVV_VFWREDOSUM | funct6 == FVV_VFWREDUSUM then
-    process_rfvv_widen(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow)
+    process_rfvv_widening_reduction(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow)
   else
     process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow)
 }

--- a/model/riscv_insts_vext_fp_utils.sail
+++ b/model/riscv_insts_vext_fp_utils.sail
@@ -54,10 +54,11 @@ function illegal_fp_reduction(SEW, rm_3b) = {
 }
 
 /* f. Variable width check for floating-point widening reduction instructions */
-val illegal_fp_reduction_widen : (sew_bitsize, bits(3), int, int) -> bool
-function illegal_fp_reduction_widen(SEW, rm_3b, SEW_widen, LMUL_pow_widen) = {
+val illegal_fp_widening_reduction : (sew_bitsize, bits(3), int) -> bool
+function illegal_fp_widening_reduction(SEW, rm_3b, EEW) = {
+  let ELEN = 2 ^ ELEN_pow;
   not(valid_vtype()) | not(assert_vstart(0)) | not(valid_fp_op(SEW, rm_3b)) |
-  not(valid_eew_emul(SEW_widen, LMUL_pow_widen))
+  not(EEW >= 8 & EEW <= ELEN)
 }
 
 /* Floating point classification functions */

--- a/model/riscv_insts_vext_red.sail
+++ b/model/riscv_insts_vext_red.sail
@@ -26,10 +26,9 @@ mapping clause encdec = RIVVTYPE(funct6, vm, vs2, vs1, vd)
 function clause execute(RIVVTYPE(funct6, vm, vs2, vs1, vd)) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
-  let SEW_widen      = SEW * 2;
-  let LMUL_pow_widen = LMUL_pow + 1;
+  let SEW_widen = SEW * 2;
 
-  if illegal_reduction_widen(SEW_widen, LMUL_pow_widen) then return Illegal_Instruction();
+  if illegal_widening_reduction(SEW_widen) then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
 

--- a/model/riscv_insts_vext_utils.sail
+++ b/model/riscv_insts_vext_utils.sail
@@ -120,6 +120,7 @@ function illegal_vd_unmasked() = {
 /* d. Variable width check for:
  *  1. integer/fixed-point widening/narrowing instructions
  *  2. vector integer extension: vzext, vsext
+ *  3. vector crypto extension: zvbb
  */
 val illegal_variable_width : (vregidx, bits(1), int, int) -> bool
 function illegal_variable_width(vd, vm, SEW_new, LMUL_pow_new) = {
@@ -136,9 +137,10 @@ function illegal_reduction() = {
 }
 
 /* f. Variable width check for widening reduction instructions */
-val illegal_reduction_widen : (int, int) -> bool
-function illegal_reduction_widen(SEW_widen, LMUL_pow_widen) = {
-  not(valid_vtype()) | not(assert_vstart(0)) | not(valid_eew_emul(SEW_widen, LMUL_pow_widen))
+val illegal_widening_reduction : (int) -> bool
+function illegal_widening_reduction(EEW) = {
+  let ELEN = 2 ^ ELEN_pow;
+  not(valid_vtype()) | not(assert_vstart(0)) | not(EEW >= 8 & EEW <= ELEN)
 }
 
 /* g. Non-indexed load instruction check */

--- a/model/riscv_insts_zvbb.sail
+++ b/model/riscv_insts_zvbb.sail
@@ -520,7 +520,10 @@ function clause execute (VWSLL_VV(vm, vs2, vs1, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_reduction_widen(SEW_widen, LMUL_pow_widen) then return Illegal_Instruction();
+  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
+      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
 
@@ -568,7 +571,9 @@ function clause execute (VWSLL_VX(vm, vs2, rs1, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_reduction_widen(SEW_widen, LMUL_pow_widen) then return Illegal_Instruction();
+  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
 
@@ -615,7 +620,9 @@ function clause execute (VWSLL_VI(vm, vs2, uimm, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_reduction_widen(SEW_widen, LMUL_pow_widen) then return Illegal_Instruction();
+  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
 


### PR DESCRIPTION
This fixes issue #1135 by allowing LMUL=8 for widening reduction instructions.

I also fixed `vwsll.[vv,vx,vi]`, which were using the widening reduction validation function and replaced them with `illegal_variable_width()`.