### PR TITLE
Fix number of defined `pmpcfg` CSRs

### DIFF
--- a/model/riscv_pmp_regs.sail
+++ b/model/riscv_pmp_regs.sail
@@ -236,7 +236,7 @@ mapping clause csr_name_map = 0x3EE  <-> "pmpaddr62"
 mapping clause csr_name_map = 0x3EF  <-> "pmpaddr63"
 
 // pmpcfgN
-function clause is_CSR_defined(0x3A) @ idx : bits(4) = sys_pmp_count > unsigned(idx) & (idx[0] == bitzero | xlen == 32)
+function clause is_CSR_defined(0x3A) @ idx : bits(4) = sys_pmp_count > 4 * unsigned(idx) & (idx[0] == bitzero | xlen == 32)
 function clause read_CSR(0x3A @ idx : bits(4) if idx[0] == bitzero | xlen == 32) = pmpReadCfgReg(unsigned(idx))
 function clause write_CSR((0x3A @ idx : bits(4), value) if idx[0] == bitzero | xlen == 32) = {
   let idx = unsigned(idx);


### PR DESCRIPTION
According to the spec, an implementation can implement 0, 16 or 64 PMP entries, which is controlled by `sys_pmp_count`. One entry consists in one `pmpaddr` register and 8 bits of configuration.

Therefore, there should be 0, 4 or 16 `pmpcfg` registers, as each hold 4 configuration entries. However, if `sys_pmp_count` is 16 the current Sail model defines 16 `pmpaddr` and 16 `pmpcfg` registers, i.e. there are more configurations than there are `pmpaddr`.

0 PMP entries -> 0 `pmpaddr`, 0 `pmpcfg`
16 PMP entries -> 16 `pmpaddr`, 16 `pmpcfg` <-- the problem is here
64 PMP entries -> 64 `pmpaddr`, 16 `pmpcfg`

This fixes the model to have 4 `pmpcfg` registers in that case.