### PR TITLE
Add README.md for berkeley-softfloat-3 library

### DIFF
--- a/dependencies/softfloat/berkeley-softfloat-3/README.md
+++ b/dependencies/softfloat/berkeley-softfloat-3/README.md
@@ -1,0 +1,23 @@
+
+Package Overview for Berkeley SoftFloat Release 3e
+==================================================
+
+John R. Hauser<br>
+2018 January 20
+
+
+Berkeley SoftFloat is a software implementation of binary floating-point
+that conforms to the IEEE Standard for Floating-Point Arithmetic.  SoftFloat
+is distributed in the form of C source code.  Building the SoftFloat sources
+generates a library file (typically `softfloat.a` or `libsoftfloat.a`)
+containing the floating-point subroutines.
+
+
+The SoftFloat package is documented in the following files in the `doc`
+subdirectory:
+
+* [SoftFloat.html](http://www.jhauser.us/arithmetic/SoftFloat-3/doc/SoftFloat.html) Documentation for using the SoftFloat functions.
+* [SoftFloat-source.html](http://www.jhauser.us/arithmetic/SoftFloat-3/doc/SoftFloat-source.html) Documentation for building SoftFloat.
+* [SoftFloat-history.html](http://www.jhauser.us/arithmetic/SoftFloat-3/doc/SoftFloat-history.html) History of the major changes to SoftFloat.
+
+Other files in the package comprise the source code for SoftFloat.


### PR DESCRIPTION
GitHub did not render README.txt or README.html, so this adds a README.md.