### PR TITLE
Rename xlen to mxlen in the config.

### DIFF
--- a/config/rv32d.json
+++ b/config/rv32d.json
@@ -1,6 +1,6 @@
 {
   "base": {
-    "xlen": 32,
+    "mxlen": 32,
     "writable_misa": true,
     "writable_fiom": true,
     "writable_hpm_counters": {

--- a/config/rv64d.json
+++ b/config/rv64d.json
@@ -1,6 +1,6 @@
 {
   "base": {
-    "xlen": 64,
+    "mxlen": 64,
     "writable_misa": true,
     "writable_fiom": true,
     "writable_hpm_counters": {

--- a/model/riscv_xlen.sail
+++ b/model/riscv_xlen.sail
@@ -10,7 +10,7 @@
 // This is done using the smallest/most logarithmic possible value since Sail's
 // type system works well for multiply and 2^ but not divide and log2.
 
-type xlen : Int = config base.xlen
+type xlen : Int = config base.mxlen
 constraint xlen in {32, 64}
 
 type log2_xlen  : Int = if xlen == 32 then 5 else 6


### PR DESCRIPTION
MXLEN is the architectural constant, so use it in user-exposed name in the config.