### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Build simulators and JSON
         run: |
+          git config --global --add safe.directory '*'
           cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DSTATIC=TRUE -DENABLE_RISCV_TESTS=TRUE -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE
           cd build
           ninja all generated_sail_riscv_docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
         type: boolean
       draft:
         description: "Is this a draft release (not public; you can publish it later)?"
+        default: true
         required: false
         type: boolean
 
@@ -69,9 +70,9 @@ jobs:
 
       - name: Build simulators and JSON
         run: |
-          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DSTATIC=TRUE
+          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DSTATIC=TRUE -DENABLE_RISCV_TESTS=TRUE -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE
           cd build
-          ninja all generated_docs_rv64d
+          ninja all generated_sail_riscv_docs
           ctest
           cpack
 
@@ -80,8 +81,8 @@ jobs:
         with:
           name: release-${{ matrix.name }}
           path: |
-            build/sail_riscv-*
-            build/model/riscv_model_rv64d.json
+            build/sail-riscv-*
+            build/model/sail_riscv_model.json
           if-no-files-found: error
 
   release:
@@ -97,8 +98,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            release-linux-amd64/sail_riscv-Linux-x86_64.tar.gz
-            release-linux-amd64/model/riscv_model_rv64d.json
+            release-linux-amd64/sail-riscv-Linux-x86_64.tar.gz
+            release-linux-amd64/model/sail_riscv_model.json
           fail_on_unmatched_files: true
           tag_name: ${{ inputs.version }}
           body: ${{ inputs.notes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,8 @@ jobs:
               gcc \
               gcc-c++ \
               cmake \
-              ninja-build
+              ninja-build \
+              jq
           curl --location --output sail.tar.gz https://github.com/rems-project/sail/releases/download/$SAIL_VERSION-linux-binary/sail.tar.gz
           tar --directory=/usr/local --strip-components=1 --extract --file sail.tar.gz
 


### PR DESCRIPTION
Fix the release workflow in preparation for the upcoming release:
- Updated artifact names
- Add `jq` as a dependency for running tests
- Enable new tests as part of release CI since the existing ones have been deleted
- Treat cloned directory as safe for git so build information is properly generated (this is not the default inside of the docker container)