### PR TITLE
Add --always flag to git describe

### DIFF
--- a/cmake/project_version.cmake
+++ b/cmake/project_version.cmake
@@ -5,10 +5,12 @@ set(sail_riscv_release_version "0.7")
 find_package(Git)
 
 if (Git_FOUND)
-  # We could remove --tags if we started annotating the release tags.
-  # --broken allows building in a corrupt git repo.
+  # --tags     Search for lightweight tags as well as annotated ones.
+  # --always   If there are no tags use the git hash instead of failing.
+  # --dirty    Append '-dirty' if the working tree has local modifications.
+  # --broken   Append '-broken' if the repo is corrupt instead of failing.
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --tags --dirty --broken
+    COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty --broken
     RESULT_VARIABLE git_error
     OUTPUT_VARIABLE git_describe
     OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
This provides more useful information and avoids an ugly error if you don't have any tags at all.