### PR TITLE
Update Sail RISC-V Tests download URL

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake options for test downloads
-set(TEST_DOWNLOAD_URL "https://github.com/nadime15/riscv-sail-tests/releases/download" CACHE STRING "Base URL to download precompiled riscv-tests and riscv-vector-tests from")
-set(TEST_DOWNLOAD_VERSION "2025-06-22" CACHE STRING "Version of precompiled tests to download")
+set(TEST_DOWNLOAD_URL "https://github.com/riscv-software-src/sail-riscv-tests/releases/download" CACHE STRING "Base URL to download precompiled riscv-tests and riscv-vector-tests from")
+set(TEST_DOWNLOAD_VERSION "2025-07-16" CACHE STRING "Version of precompiled tests to download")
 
 # Function to download and extract test files
 function(download_riscv_tests DOWNLOAD_PATH TARBALL_NAME DOWNLOAD_URL)

--- a/test/README.md
+++ b/test/README.md
@@ -2,9 +2,9 @@
 
 The simulator supports multiple test suites that are downloaded on-demand during the CMake configure step:
 
-- **Standard RISC-V Tests** from the [`riscv-tests`](https://github.com/riscv-software-src/riscv-tests) repository: Basic pre-compiled ELFs with fundamental ISA tests. Enabled by default (can be disabled with `-DENABLE_RISCV_TESTS=OFF`). Precompiled binaries are downloaded from [riscv-sail-tests releases](https://github.com/nadime15/riscv-sail-tests/releases/).
+- **Standard RISC-V Tests** from the [`riscv-tests`](https://github.com/riscv-software-src/riscv-tests) repository: Basic pre-compiled ELFs with fundamental ISA tests. Enabled by default (can be disabled with `-DENABLE_RISCV_TESTS=OFF`). Precompiled binaries are downloaded from [sail-riscv-tests releases](https://github.com/riscv-software-src/sail-riscv-tests/releases/).
 
-- **RISC-V Vector Extension Tests** from the [`riscv-vector-tests`](https://github.com/chipsalliance/riscv-vector-tests) repository: Comprehensive vector extension tests enabled with CMake options like `-DENABLE_RISCV_VECTOR_TESTS_V256_E32=ON` for specific VLEN/ELEN configurations (supported combinations: V128_E32, V128_E64, V256_E32, V256_E64, V512_E32, V512_E64). Precompiled binaries are downloaded from [riscv-sail-tests releases](https://github.com/nadime15/riscv-sail-tests/releases/).
+- **RISC-V Vector Extension Tests** from the [`riscv-vector-tests`](https://github.com/chipsalliance/riscv-vector-tests) repository: Comprehensive vector extension tests enabled with CMake options like `-DENABLE_RISCV_VECTOR_TESTS_V256_E32=ON` for specific VLEN/ELEN configurations (supported combinations: V128_E32, V128_E64, V256_E32, V256_E64, V512_E32, V512_E64). Precompiled binaries are downloaded from [sail-riscv-tests releases](https://github.com/riscv-software-src/sail-riscv-tests/releases).
 
 ## Local Test Directory
 


### PR DESCRIPTION
Update Sail RISC-V Tests URL and version to use the official https://github.com/riscv-software-src/sail-riscv-tests repository. 

The new Sail RISC-V Tests release adds two tests covering LMUL=8 for widening reduction instructions.