### PR TITLE
Remove `BitStr()`, `bit_str()` and use native `bits_str()` instead

### DIFF
--- a/model/prelude.sail
+++ b/model/prelude.sail
@@ -32,14 +32,6 @@ overload operator & = {and_vec}
 
 overload operator | = {or_vec}
 
-function bit_str(b: bit) -> string =
-  match b {
-    bitzero => "0b0",
-    bitone => "0b1"
-  }
-
-overload BitStr = {bits_str, bit_str}
-
 overload operator ^ = {xor_vec, concat_str}
 
 val sub_vec = pure {c: "sub_bits", lean: "_lean_sub", _: "sub_vec"} : forall 'n. (bits('n), bits('n)) -> bits('n)

--- a/model/riscv_freg_type.sail
+++ b/model/riscv_freg_type.sail
@@ -16,7 +16,7 @@ let zero_freg : fregtype = zeros()
 
 /* default register printer */
 val FRegStr : fregtype -> string
-function FRegStr(r) = BitStr(r)
+function FRegStr(r) = bits_str(r)
 
 /* conversions */
 

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -90,11 +90,11 @@ function within_phys_mem forall 'n, 'n <= max_mem_access. (Physaddr(addr) : phys
            & (addr_int + sizeof('n)) <= (rom_base_int + rom_size_int))
   then    true
   else {
-    print_platform("within_phys_mem: " ^ BitStr(addr) ^ " not within phys-mem:");
-    print_platform("  plat_rom_base: " ^ BitStr(plat_rom_base));
-    print_platform("  plat_rom_size: " ^ BitStr(plat_rom_size));
-    print_platform("  plat_ram_base: " ^ BitStr(plat_ram_base));
-    print_platform("  plat_ram_size: " ^ BitStr(plat_ram_size));
+    print_platform("within_phys_mem: " ^ bits_str(addr) ^ " not within phys-mem:");
+    print_platform("  plat_rom_base: " ^ bits_str(plat_rom_base));
+    print_platform("  plat_rom_size: " ^ bits_str(plat_rom_size));
+    print_platform("  plat_ram_base: " ^ bits_str(plat_ram_base));
+    print_platform("  plat_ram_size: " ^ bits_str(plat_ram_size));
     false
   }
 }
@@ -156,51 +156,51 @@ function clint_load(t, Physaddr(addr), width) = {
   if addr == MSIP_BASE & ('n == 8 | 'n == 4)
   then {
     if   get_config_print_platform()
-    then print_platform("clint[" ^ BitStr(addr) ^ "] -> " ^ BitStr(mip[MSI]));
+    then print_platform("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mip[MSI]));
     Ok(zero_extend(sizeof(8 * 'n), mip[MSI]))
   }
   else if addr == MTIMECMP_BASE & ('n == 4)
   then {
     if   get_config_print_platform()
-    then print_platform("clint<4>[" ^ BitStr(addr) ^ "] -> " ^ BitStr(mtimecmp[31..0]));
+    then print_platform("clint<4>[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtimecmp[31..0]));
     /* FIXME: Redundant zero_extend currently required by Lem backend */
     Ok(zero_extend(32, mtimecmp[31..0]))
   }
   else if addr == MTIMECMP_BASE & ('n == 8)
   then {
     if   get_config_print_platform()
-    then print_platform("clint<8>[" ^ BitStr(addr) ^ "] -> " ^ BitStr(mtimecmp));
+    then print_platform("clint<8>[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtimecmp));
     /* FIXME: Redundant zero_extend currently required by Lem backend */
     Ok(zero_extend(64, mtimecmp))
   }
   else if addr == MTIMECMP_BASE_HI & ('n == 4)
   then {
     if   get_config_print_platform()
-    then print_platform("clint-hi<4>[" ^ BitStr(addr) ^ "] -> " ^ BitStr(mtimecmp[63..32]));
+    then print_platform("clint-hi<4>[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtimecmp[63..32]));
     /* FIXME: Redundant zero_extend currently required by Lem backend */
     Ok(zero_extend(32, mtimecmp[63..32]))
   }
   else if addr == MTIME_BASE & ('n == 4)
   then {
     if   get_config_print_platform()
-    then print_platform("clint[" ^ BitStr(addr) ^ "] -> " ^ BitStr(mtime));
+    then print_platform("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtime));
     Ok(zero_extend(32, mtime[31..0]))
   }
   else if addr == MTIME_BASE & ('n == 8)
   then {
     if   get_config_print_platform()
-    then print_platform("clint[" ^ BitStr(addr) ^ "] -> " ^ BitStr(mtime));
+    then print_platform("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtime));
     Ok(zero_extend(64, mtime))
   }
   else if addr == MTIME_BASE_HI & ('n == 4)
   then {
     if   get_config_print_platform()
-    then print_platform("clint[" ^ BitStr(addr) ^ "] -> " ^ BitStr(mtime));
+    then print_platform("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtime));
     Ok(zero_extend(32, mtime[63..32]))
   }
   else {
     if   get_config_print_platform()
-    then print_platform("clint[" ^ BitStr(addr) ^ "] -> <not-mapped>");
+    then print_platform("clint[" ^ bits_str(addr) ^ "] -> <not-mapped>");
     match t {
       InstructionFetch() => Err(E_Fetch_Access_Fault()),
       Read(Data) => Err(E_Load_Access_Fault()),
@@ -215,8 +215,8 @@ function clint_dispatch() -> unit = {
     mip[STI] = bool_to_bits(stimecmp <=_u mtime);
   };
   if get_config_print_platform()
-  then print_platform("clint mtime " ^ BitStr(mtime) ^ " (mip.MTI <- " ^ BitStr(mip[MTI]) ^
-    (if currentlyEnabled(Ext_Sstc) then ", mip.STI <- " ^ BitStr(mip[STI]) else "") ^ ")");
+  then print_platform("clint mtime " ^ bits_str(mtime) ^ " (mip.MTI <- " ^ bits_str(mip[MTI]) ^
+    (if currentlyEnabled(Ext_Sstc) then ", mip.STI <- " ^ bits_str(mip[STI]) else "") ^ ")");
 }
 
 val clint_store: forall 'n, 'n > 0. (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
@@ -224,49 +224,49 @@ function clint_store(Physaddr(addr), width, data) = {
   let addr = addr - plat_clint_base;
   if addr == MSIP_BASE & ('n == 8 | 'n == 4) then {
     if   get_config_print_platform()
-    then print_platform("clint[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mip.MSI <- " ^ BitStr(data[0]) ^ ")");
+    then print_platform("clint[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mip.MSI <- " ^ bits_str(data[0..0]) ^ ")");
     mip[MSI] = [data[0]];
     clint_dispatch();
     Ok(true)
   } else if addr == MTIMECMP_BASE & 'n == 8 then {
     if   get_config_print_platform()
-    then print_platform("clint<8>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtimecmp)");
+    then print_platform("clint<8>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtimecmp)");
     mtimecmp = zero_extend(64, data); /* FIXME: Redundant zero_extend currently required by Lem backend */
     clint_dispatch();
     Ok(true)
   } else if addr == MTIMECMP_BASE & 'n == 4 then {
     if   get_config_print_platform()
-    then print_platform("clint<4>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtimecmp)");
+    then print_platform("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtimecmp)");
     mtimecmp = vector_update_subrange(mtimecmp, 31, 0, zero_extend(32, data));  /* FIXME: Redundant zero_extend currently required by Lem backend */
     clint_dispatch();
     Ok(true)
   } else if addr == MTIMECMP_BASE_HI & 'n == 4 then {
     if   get_config_print_platform()
-    then print_platform("clint<4>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtimecmp)");
+    then print_platform("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtimecmp)");
     mtimecmp = vector_update_subrange(mtimecmp, 63, 32, zero_extend(32, data)); /* FIXME: Redundant zero_extend currently required by Lem backend */
     clint_dispatch();
     Ok(true)
   } else if addr == MTIME_BASE & 'n == 8 then {
     if   get_config_print_platform()
-    then print_platform("clint<8>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtime)");
+    then print_platform("clint<8>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtime)");
     mtime = data;
     clint_dispatch();
     Ok(true)
   } else if addr == MTIME_BASE & 'n == 4 then {
     if   get_config_print_platform()
-    then print_platform("clint<4>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtime)");
+    then print_platform("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtime)");
     mtime[31 .. 0] = data;
     clint_dispatch();
     Ok(true)
   } else if addr == MTIME_BASE_HI & 'n == 4 then {
     if   get_config_print_platform()
-    then print_platform("clint<4>[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (mtime)");
+    then print_platform("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtime)");
     mtime[63 .. 32] = data;
     clint_dispatch();
     Ok(true)
   } else {
     if   get_config_print_platform()
-    then print_platform("clint[" ^ BitStr(addr) ^ "] <- " ^ BitStr(data) ^ " (<unmapped>)");
+    then print_platform("clint[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (<unmapped>)");
     Err(E_SAMO_Access_Fault())
   }
 }
@@ -331,7 +331,7 @@ function reset_htif () -> unit = {
 val htif_load : forall 'n, 'n > 0. (AccessType(ext_access_type), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
 function htif_load(t, Physaddr(paddr), width) = {
   if   get_config_print_platform()
-  then print_platform("htif[" ^ hex_bits_str(paddr) ^ "] -> " ^ BitStr(htif_tohost));
+  then print_platform("htif[" ^ hex_bits_str(paddr) ^ "] -> " ^ bits_str(htif_tohost));
   /* FIXME: For now, only allow the expected access widths. */
   if      width == 8 & (paddr == htif_tohost_base())
   then    Ok(zero_extend(64, htif_tohost))         /* FIXME: Redundant zero_extend currently required by Lem backend */
@@ -349,7 +349,7 @@ function htif_load(t, Physaddr(paddr), width) = {
 val htif_store: forall 'n, 0 < 'n <= 8. (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
 function htif_store(Physaddr(paddr), width, data) = {
   if   get_config_print_platform()
-  then print_platform("htif[" ^ hex_bits_str(paddr) ^ "] <- " ^ BitStr(data));
+  then print_platform("htif[" ^ hex_bits_str(paddr) ^ "] <- " ^ bits_str(data));
   /* Store the written value so that we can ack it later. */
   if      width == 8
   then    { htif_cmd_write = bitone;
@@ -379,7 +379,7 @@ function htif_store(Physaddr(paddr), width, data) = {
     match cmd[device] {
       0x00 => { /* syscall-proxy */
         if   get_config_print_platform()
-        then print_platform("htif-syscall-proxy cmd: " ^ BitStr(cmd[payload]));
+        then print_platform("htif-syscall-proxy cmd: " ^ bits_str(cmd[payload]));
         if   cmd[payload][0] == bitone
         then {
              htif_done = true;
@@ -389,16 +389,16 @@ function htif_store(Physaddr(paddr), width, data) = {
       },
       0x01 => { /* terminal */
         if   get_config_print_platform()
-        then print_platform("htif-term cmd: " ^ BitStr(cmd[payload]));
+        then print_platform("htif-term cmd: " ^ bits_str(cmd[payload]));
         match cmd[cmd] {
           0x00 => /* TODO: terminal input handling */ (),
           0x01 => plat_term_write(cmd[payload][7..0]),
-          c    => print("Unknown term cmd: " ^ BitStr(c))
+          c    => print("Unknown term cmd: " ^ bits_str(c))
         };
         /* reset to ack */
         reset_htif()
       },
-      d => print("htif-???? cmd: " ^ BitStr(data))
+      d => print("htif-???? cmd: " ^ bits_str(data))
     }
   };
   Ok(true)

--- a/model/riscv_reg_type.sail
+++ b/model/riscv_reg_type.sail
@@ -14,7 +14,7 @@ let zero_reg : regtype = zeros()
 
 /* default register printer */
 val RegStr : regtype -> string
-function RegStr(r) = BitStr(r)
+function RegStr(r) = bits_str(r)
 
 /* conversions */
 

--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -22,7 +22,7 @@ function run_hart_waiting(step_no : int, wr: WaitReason, instbits : instbits, ex
   // successfully interrupted waits
   if shouldWakeForInterrupt() then {
     if   get_config_print_instr()
-    then print_instr("interrupt exit from " ^ wait_name(wr) ^ " state at PC " ^ BitStr(PC));
+    then print_instr("interrupt exit from " ^ wait_name(wr) ^ " state at PC " ^ bits_str(PC));
 
     // The waiting instruction retires successfully.  The
     // pending interrupts will be handled in the next step.
@@ -33,14 +33,14 @@ function run_hart_waiting(step_no : int, wr: WaitReason, instbits : instbits, ex
   match (wr, valid_reservation(), exit_wait) {
     (WAIT_WRS_STO, false, _) => {
       if   get_config_print_instr()
-      then print_instr("reservation invalid exit from " ^ wait_name(WAIT_WRS_STO) ^ " state at PC " ^ BitStr(PC));
+      then print_instr("reservation invalid exit from " ^ wait_name(WAIT_WRS_STO) ^ " state at PC " ^ bits_str(PC));
 
       hart_state = HART_ACTIVE();
       Step_Execute(Retire_Success(), instbits)
     },
     (WAIT_WRS_NTO, false, _) => {
       if   get_config_print_instr()
-      then print_instr("reservation invalid exit from " ^ wait_name(WAIT_WRS_NTO) ^ " state at PC " ^ BitStr(PC));
+      then print_instr("reservation invalid exit from " ^ wait_name(WAIT_WRS_NTO) ^ " state at PC " ^ bits_str(PC));
 
       hart_state = HART_ACTIVE();
       Step_Execute(Retire_Success(), instbits)
@@ -48,7 +48,7 @@ function run_hart_waiting(step_no : int, wr: WaitReason, instbits : instbits, ex
     // Transition out of waiting states as instructed.
     (WAIT_WFI, _, true) => {
       if   get_config_print_instr()
-      then print_instr("forced exit from " ^ wait_name(WAIT_WFI) ^ " state at PC " ^ BitStr(PC));
+      then print_instr("forced exit from " ^ wait_name(WAIT_WFI) ^ " state at PC " ^ bits_str(PC));
 
       hart_state = HART_ACTIVE();
       // "When TW=1, then if WFI is executed in any
@@ -61,14 +61,14 @@ function run_hart_waiting(step_no : int, wr: WaitReason, instbits : instbits, ex
     },
     (WAIT_WRS_STO, _, true) => {
       if   get_config_print_instr()
-      then print_instr("timed-out exit from " ^ wait_name(WAIT_WRS_STO) ^ " state at PC " ^ BitStr(PC));
+      then print_instr("timed-out exit from " ^ wait_name(WAIT_WRS_STO) ^ " state at PC " ^ bits_str(PC));
 
       hart_state = HART_ACTIVE();
       Step_Execute(Retire_Success(), instbits)
     },
     (WAIT_WRS_NTO, _, true) => {
       if   get_config_print_instr()
-      then print_instr("timed-out exit from " ^ wait_name(WAIT_WRS_NTO) ^ " state at PC " ^ BitStr(PC));
+      then print_instr("timed-out exit from " ^ wait_name(WAIT_WRS_NTO) ^ " state at PC " ^ bits_str(PC));
 
       hart_state = HART_ACTIVE();
       // TODO: This is similar to WFI above for now, but will change to handle
@@ -80,7 +80,7 @@ function run_hart_waiting(step_no : int, wr: WaitReason, instbits : instbits, ex
     // remain waiting
     (_, _, false) => {
       if   get_config_print_instr()
-      then print_instr("remaining in " ^ wait_name(wr) ^ " state at PC " ^ BitStr(PC));
+      then print_instr("remaining in " ^ wait_name(wr) ^ " state at PC " ^ bits_str(PC));
       Step_Waiting(wr)
     }
   }
@@ -101,7 +101,7 @@ function run_hart_active(step_no: nat) -> Step = {
         let instruction = ext_decode_compressed(h);
         if   get_config_print_instr()
         then {
-          print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ BitStr(PC) ^ " (" ^ BitStr(h) ^ ") " ^ to_str(instruction));
+          print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(PC) ^ " (" ^ bits_str(h) ^ ") " ^ to_str(instruction));
         };
         /* check for RVC once here instead of every RVC execute clause. */
         if currentlyEnabled(Ext_Zca) then {
@@ -118,7 +118,7 @@ function run_hart_active(step_no: nat) -> Step = {
         let instruction = ext_decode(w);
         if   get_config_print_instr()
         then {
-          print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ BitStr(PC) ^ " (" ^ BitStr(w) ^ ") " ^ to_str(instruction));
+          print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(PC) ^ " (" ^ bits_str(w) ^ ") " ^ to_str(instruction));
         };
         nextPC = PC + 4;
         let r = execute(instruction);
@@ -199,7 +199,7 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
       } else {
         // Transition into the wait state.
         if   get_config_print_instr()
-        then print_instr("entering " ^ wait_name(wr) ^ " state at PC " ^ BitStr(PC));
+        then print_instr("entering " ^ wait_name(wr) ^ " state at PC " ^ bits_str(PC));
 
         hart_state = HART_WAITING(wr, instbits);
       }

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -157,8 +157,8 @@ function trap_handler(del_priv : Privilege, intr : bool, c : exc_code, pc : xlen
   trap_callback();
   if   get_config_print_platform()
   then print_platform("handling " ^ (if intr then "int#" else "exc#")
-                      ^ BitStr(c) ^ " at priv " ^ to_str(del_priv)
-                      ^ " with tval " ^ BitStr(tval(info)));
+                      ^ bits_str(c) ^ " at priv " ^ to_str(del_priv)
+                      ^ " with tval " ^ bits_str(tval(info)));
 
   match (del_priv) {
     Machine => {

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -61,7 +61,7 @@ mapping privLevel_bits : Privilege <-> priv_level = {
   User       <-> 0b00,
   Supervisor <-> 0b01,
   Machine    <-> 0b11,
-  backwards 0b10 => internal_error(__FILE__, __LINE__, "Invalid privilege level: " ^ BitStr(0b10))
+  backwards 0b10 => internal_error(__FILE__, __LINE__, "Invalid privilege level: " ^ bits_str(0b10))
 }
 
 function privLevel_to_bits(p : Privilege) -> priv_level = privLevel_bits(p)


### PR DESCRIPTION
There was only one place where we used `bit_str()` so this overload is not very useful.