### PR TITLE
Fix softfloat debug builds

### DIFF
--- a/dependencies/softfloat/berkeley-softfloat-3/build/Linux-x86_64-GCC/platform.h
+++ b/dependencies/softfloat/berkeley-softfloat-3/build/Linux-x86_64-GCC/platform.h
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /*----------------------------------------------------------------------------
 *----------------------------------------------------------------------------*/
 #ifdef __GNUC_STDC_INLINE__
-#define INLINE inline
+#define INLINE static inline
 #else
 #define INLINE extern inline
 #endif
@@ -51,4 +51,3 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define SOFTFLOAT_BUILTIN_CLZ 1
 #define SOFTFLOAT_INTRINSIC_INT128 1
 #include "opts-GCC.h"
-


### PR DESCRIPTION
I'm not sure exactly why softfloat is set up like this, but with `INLINE` only defined as `inline`, then it was possible in debug builds to get undefined references to some of the inlined functions (e.g. `softfloat_countLeadingZeros32`). Apparently in C99 `inline` functions *might* not actually get emitted; you need to use `static inline`. I don't fully understand why but ChatGPT called this "The C99 Inline Mess" when I asked about it so probably not worth digging!

The old version of `platform.h` also used `static inline`.