### PR TITLE
Fix `read_vreg` for negative LMUL in widening vector instructions.

### DIFF
--- a/model/riscv_vext_control.sail
+++ b/model/riscv_vext_control.sail
@@ -22,12 +22,15 @@ function get_num_elem(LMUL_pow, SEW) = {
 /* Reads a single vreg into multiple elements */
 val read_single_vreg : forall 'n 'm, 'n >= 0 & is_sew_bitsize('m) . (int('n), int('m), vregidx) -> vector('n, bits('m))
 function read_single_vreg(num_elem, SEW, vrid) = {
+  // TODO: This should be part of the type signature for this function.
+  assert(num_elem * SEW <= vlen);
+
   let bv = V(vrid);
   var result : vector('n, bits('m)) = vector_init(zeros());
 
   foreach (i from 0 to (num_elem - 1)) {
     let start_index = i * SEW;
-    result[i] = slice(bv, start_index, SEW);
+    result[i] = bv[start_index + SEW - 1 .. start_index];
   };
 
   result


### PR DESCRIPTION
Call the single register read only when all the (potentially wider) elements fit into `vlen` bits.

This fixes a bug with widening instructions with negative LMUL, where a negative LMUL was assumed to imply that a single register read sufficed.  In this situation, using `num_elems` in conjunction with the widened SEW could cause out-of-bounds read-accesses into the register's bits.