### PR TITLE
riscv_sim: improve readability of CLI11 help output

### DIFF
--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -568,6 +568,13 @@ int main(int argc, char **argv)
   CLI::App app("Sail RISC-V Model");
   argv = app.ensure_utf8(argv);
   setup_options(app);
+
+  // long_options_offset() is a local addition, so when updating CLI11,
+  // see how https://github.com/CLIUtils/CLI11/pull/1185 ended up,
+  // and possibly implement the upstream solution.
+  app.get_formatter()->long_options_offset(6);
+  app.get_formatter()->column_width(45);
+
   try {
     app.parse(argc, argv);
   } catch (const CLI::ParseError &e) {

--- a/dependencies/CLIUtils/CLI11.hpp
+++ b/dependencies/CLIUtils/CLI11.hpp
@@ -5016,6 +5016,9 @@ class FormatterBase {
     /// The width of the left column (options/flags/subcommands)
     std::size_t column_width_{30};
 
+    /// The offset at which long options begin in the left column
+    std::size_t long_options_offset_{6};
+
     /// The width of the right column (description of options/flags/subcommands)
     std::size_t right_column_width_{65};
 
@@ -5055,6 +5058,10 @@ class FormatterBase {
 
     /// Set the left column width (options/flags/subcommands)
     void column_width(std::size_t val) { column_width_ = val; }
+
+    /// Set the offset at which long options begin in the left column
+    /// XXX: local changes in the spirit of https://github.com/CLIUtils/CLI11/pull/1185
+    void long_options_offset(std::size_t offset) { long_options_offset_ = offset; }
 
     /// Set the right column width (description of options/flags/subcommands)
     void right_column_width(std::size_t val) { right_column_width_ = val; }
@@ -11414,9 +11421,8 @@ CLI11_INLINE std::string Formatter::make_option(const Option *opt, bool is_posit
         std::string longNames = detail::join(vlongNames, ", ");
 
         // Calculate setw sizes
-        const auto shortNamesColumnWidth = static_cast<int>(column_width_ / 3);  // 33% left for short names
-        const auto longNamesColumnWidth = static_cast<int>(std::ceil(
-            static_cast<float>(column_width_) / 3.0f * 2.0f));  // 66% right for long names and options, ceil result
+        const auto shortNamesColumnWidth = static_cast<int>(long_options_offset_);
+        const auto longNamesColumnWidth = static_cast<int>(column_width_) - shortNamesColumnWidth;
         int shortNamesOverSize = 0;
 
         // Print short names


### PR DESCRIPTION
The current help output is a bit hard to read for me:
```
  -h,     --help              Print this help message and exit
          --show-times        Show execution times
          --version           Print model version
          --build-info        Print build information
          --print-default-config
                              Print default configuration
          --validate-config   Validate configuration
          --print-device-tree Print device tree
          --print-isa-string  Print ISA string
          --enable-experimental-extensions
                              Enable experimental extensions
          --use-abi-names     Use ABI register names in trace log
          --device-tree-blob <file>
                              Device tree blob file
          --terminal-log <file>
                              Terminal log output file
          --test-signature <file>
                              Test signature file
          --config <file>     Configuration file
          --trace-output <file>
                              Trace output file
          --signature-granularity <uint>
                              Signature granularity
          --rvfi-dii <int> (within [1 - 65535])
                              RVFI DII port
          --inst-limit <uint> Instruction limit
          --trace-instr       Enable trace output for instruction execution
          --trace-reg         Enable trace output for register access
          --trace-mem         Enable trace output for memory accesses
          --trace-rvfi        Enable trace output for RVFI
          --trace-platform    Enable trace output for privilege changes, MMIO, interrupts
          --trace-step        Add a blank line between steps in the trace output
          --trace-all         Enable all trace output
```
The options in help output will look like this afterwards:
```
  -h, --help                                 Print this help message and exit
      --show-times                           Show execution times
      --version                              Print model version
      --build-info                           Print build information
      --print-default-config                 Print default configuration
      --validate-config                      Validate configuration
      --print-device-tree                    Print device tree
      --print-isa-string                     Print ISA string
      --enable-experimental-extensions       Enable experimental extensions
      --use-abi-names                        Use ABI register names in trace log
      --device-tree-blob <file>              Device tree blob file
      --terminal-log <file>                  Terminal log output file
      --test-signature <file>                Test signature file
      --config <file>                        Configuration file
      --trace-output <file>                  Trace output file
      --signature-granularity <uint>         Signature granularity
      --rvfi-dii <int> (within [1 - 65535])  RVFI DII port
      --inst-limit <uint>                    Instruction limit
      --trace-instr                          Enable trace output for instruction execution
      --trace-reg                            Enable trace output for register access
      --trace-mem                            Enable trace output for memory accesses
      --trace-rvfi                           Enable trace output for RVFI
      --trace-platform                       Enable trace output for privilege changes, MMIO, interrupts
      --trace-step                           Add a blank line between steps in the trace output
      --trace-all                            Enable all trace output
```
The code is explicitly calling a setter to break the build if CLI11 isn't modified after updating.