### PR TITLE
Implement JSON schema validation for the configuration.

### DIFF
--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -20,6 +20,16 @@ message(STATUS "CXX compiler version: ${cxx_compiler_version}")
 # make version available to emulator
 configure_file(sail_riscv_version.cpp.in sail_riscv_version.cpp @ONLY)
 
+# generate the schema populator script
+set(gen_default_schema_input "${CMAKE_CURRENT_SOURCE_DIR}/default_config_schema.h.in")
+configure_file(generate_schema_include.cmake.in generate_schema_include.cmake @ONLY)
+add_custom_command(
+    OUTPUT default_config_schema.h
+    COMMAND cmake -P generate_schema_include.cmake
+    DEPENDS ${schema_file}
+)
+add_custom_target(generated_default_config_schema DEPENDS default_config_schema.h)
+
 ## A library that contains the C model and support code.
 
 add_library(riscv_model
@@ -38,12 +48,13 @@ add_library(riscv_model
     riscv_sail.h
     riscv_softfloat.c
     riscv_softfloat.h
+    "${CMAKE_CURRENT_BINARY_DIR}/default_config_schema.h"
     config_utils.cpp
     config_utils.h
     symbol_table.cpp
     symbol_table.h
-    sail_riscv_version.h
     "${CMAKE_CURRENT_BINARY_DIR}/sail_riscv_version.cpp"
+    sail_riscv_version.h
     "${CMAKE_BINARY_DIR}/sail_riscv_model.c"
     "${CMAKE_BINARY_DIR}/sail_riscv_model.h"
 )
@@ -54,13 +65,15 @@ target_include_directories(riscv_model
         "${CMAKE_CURRENT_SOURCE_DIR}"
         # So `riscv_sail.h` can find `sail_riscv_model.h`.
         "${CMAKE_BINARY_DIR}"
+        # So `config_utils.cpp` can find `default_config_schema.h`
+        "${CMAKE_CURRENT_BINARY_DIR}"
 )
 
 target_link_libraries(riscv_model
-    PUBLIC elfio softfloat CLI11 sail_runtime
+    PUBLIC elfio softfloat CLI11 sail_runtime default_config
 )
 
-add_dependencies(riscv_model generated_sail_riscv_model)
+add_dependencies(riscv_model generated_sail_riscv_model generated_default_config_schema)
 
 ## A binary that can load an ELF file into the model and run it.
 
@@ -89,7 +102,7 @@ set_source_files_properties(
 add_dependencies(sail_riscv_sim generated_sail_riscv_model)
 
 target_link_libraries(sail_riscv_sim
-    PRIVATE riscv_model default_config
+    PRIVATE riscv_model
 )
 
 # TODO: Enable warnings when we use the #include trick

--- a/c_emulator/config_utils.cpp
+++ b/c_emulator/config_utils.cpp
@@ -1,8 +1,20 @@
 #include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <spawn.h>
+#include <unistd.h>
+#include <string.h>
+
 #include <string>
 #include <iostream>
+#include <optional>
+#include <filesystem>
+#include <cstdio>
 
 #include "sail_config.h"
+#include "default_config.h"
+#include "default_config_schema.h"
 #include "config_utils.h"
 
 uint64_t get_config_uint64(const std::vector<const char *> &keypath)
@@ -35,4 +47,113 @@ uint64_t get_config_uint64(const std::vector<const char *> &keypath)
   n = sail_int_get_ui(big_n);
   KILL(sail_int)(&big_n);
   return n;
+}
+
+const char *get_default_config()
+{
+  return DEFAULT_JSON;
+}
+
+const char *get_default_config_schema()
+{
+  return DEFAULT_CONFIG_SCHEMA;
+}
+
+static std::string mk_temp_file(const std::string &filename_template,
+                                const std::string &content)
+{
+  std::string tmpname_src = "/tmp/" + filename_template + "XXXXXX";
+
+  char tmpname[tmpname_src.length() + 1];
+  std::copy(tmpname_src.begin(), tmpname_src.end(), tmpname);
+  tmpname[tmpname_src.length()] = '\0';
+
+  int fd = mkstemp(tmpname);
+  if (fd < 0) {
+    fprintf(stderr, "Unable to create tmp file for %s.\n", tmpname);
+    return std::string();
+  }
+
+  FILE *tmpf = fdopen(fd, "w");
+  if (tmpf == nullptr) {
+    fprintf(stderr, "Unable to write to tmp file for %s.\n", tmpname);
+    return std::string();
+  }
+
+  fputs(content.c_str(), tmpf);
+  fflush(tmpf);
+  fclose(tmpf);
+  close(fd);
+
+  return std::string(tmpname);
+}
+
+static std::string temp_saved_default_config_schema()
+{
+  return mk_temp_file("default_config_schema", get_default_config_schema());
+}
+
+static std::string temp_saved_default_config()
+{
+  return mk_temp_file("default_config", get_default_config());
+}
+
+void validate_config_schema(const std::string &config_file_name)
+{
+  std::string schema_file_name = temp_saved_default_config_schema();
+  if (schema_file_name.empty()) {
+    std::cerr << "Could not save schema to temp file: " << strerror(errno)
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  std::string cf_name;
+  bool have_temp_config_file = false;
+  if (config_file_name.empty()) {
+    // Check the default config by saving it to a temp file.
+    cf_name = temp_saved_default_config();
+    if (cf_name.empty()) {
+      std::cerr << "Could not save default config to temp file: "
+                << strerror(errno) << std::endl;
+      unlink(schema_file_name.c_str());
+      exit(EXIT_FAILURE);
+    }
+    have_temp_config_file = true;
+  } else {
+    cf_name = config_file_name;
+  }
+
+  const char *args[]
+      = {"boon", schema_file_name.c_str(), cf_name.c_str(), nullptr};
+  pid_t pid;
+  int ret = posix_spawnp(&pid, "boon",
+                         nullptr, // file actions
+                         nullptr, // attrs
+                         const_cast<char **>(args),
+                         nullptr); // envp
+  if (ret != 0) {
+    fprintf(stderr,
+            "Error validating schema file with 'boon'. "
+            "Please install boon with 'cargo install boon-cli' and ensure it "
+            "is in PATH.\n");
+    unlink(schema_file_name.c_str());
+    if (have_temp_config_file) {
+      unlink(cf_name.c_str());
+    }
+    exit(EXIT_FAILURE);
+  }
+
+  int status;
+  do {
+    ret = waitpid(pid, &status, WUNTRACED | WCONTINUED);
+  } while (!WIFEXITED(status) && !WIFSIGNALED(status));
+
+  unlink(schema_file_name.c_str());
+  if (have_temp_config_file) {
+    unlink(cf_name.c_str());
+  }
+  if (WIFEXITED(status)) {
+    exit(WEXITSTATUS(status));
+  }
+  exit(EXIT_FAILURE);
 }

--- a/c_emulator/config_utils.h
+++ b/c_emulator/config_utils.h
@@ -1,6 +1,12 @@
 #pragma once
 
 #include <vector>
+#include <string>
 #include "sail.h"
 
 uint64_t get_config_uint64(const std::vector<const char *> &keypath);
+
+const char *get_default_config();
+const char *get_default_config_schema();
+
+void validate_config_schema(const std::string &conf_file);

--- a/c_emulator/default_config_schema.h.in
+++ b/c_emulator/default_config_schema.h.in
@@ -1,0 +1,3 @@
+#pragma once
+
+const char *DEFAULT_CONFIG_SCHEMA = R"##(@CONFIG_SCHEMA@)##";

--- a/c_emulator/generate_schema_include.cmake.in
+++ b/c_emulator/generate_schema_include.cmake.in
@@ -1,0 +1,2 @@
+file(READ @schema_file@ CONFIG_SCHEMA)
+configure_file(@gen_default_schema_input@ default_config_schema.h @ONLY)

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -48,7 +48,8 @@ set(c_model_no_ext "${CMAKE_BINARY_DIR}/sail_riscv_model")
 set(c_model "${c_model_no_ext}.c")
 set(c_model_header "${c_model_no_ext}.h")
 # JSON schema for configuration file.
-set(schema_file "${CMAKE_BINARY_DIR}/sail_riscv_config_schema.json")
+set(schema_base_file "sail_riscv_config_schema.json")
+set(schema_file "${CMAKE_BINARY_DIR}/${schema_base_file}")
 
 if (COVERAGE)
     set(branch_info_file "${c_model_no_ext}.branch_info")
@@ -125,6 +126,9 @@ add_custom_target(generated_sail_riscv_model DEPENDS ${c_model} ${c_model_header
 install(FILES ${schema_file}
     DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}
 )
+# Make schema locations visible to c_emulator build.
+set(schema_file "${schema_file}" PARENT_SCOPE)
+set(installed_schema_location "${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}/${schema_base_file}" PARENT_SCOPE)
 
 ############# JSON #############
 


### PR DESCRIPTION
This uses an externally installed [boon](https://github.com/santhosh-tekuri/boon).

For now, it needs to be explicitly enabled with `--validate-config-schema`. With this flag, _only_ schema conformance is checked; that is, `--validate-config` is still needed to validate other aspects of the configuration.

The schema is embedded into the executable, removing the need
to locate the schema file at run time.