### PR TITLE
add option to control tval update by ebreak

### DIFF
--- a/config/rv32d.json
+++ b/config/rv32d.json
@@ -7,7 +7,8 @@
       "len": 32,
       "value": "0xFFFF_FFFF"
     },
-    "mtval_has_illegal_instruction_bits": false
+    "mtval_has_illegal_instruction_bits": false,
+    "excp_breakpoint_updates_tval": true
   },
   "memory": {
     "pmp": {

--- a/config/rv64d.json
+++ b/config/rv64d.json
@@ -7,7 +7,8 @@
       "len": 32,
       "value": "0xFFFF_FFFF"
     },
-    "mtval_has_illegal_instruction_bits": false
+    "mtval_has_illegal_instruction_bits": false,
+    "excp_breakpoint_updates_tval": true
   },
   "memory": {
     "pmp": {

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -8,6 +8,9 @@
 
 /* Machine-mode and supervisor-mode functionality. */
 
+/* whether breakpoint exception stores pc or zero into tval */
+let plat_excp_breakpoint_updates_tval : bool = config base.excp_breakpoint_updates_tval
+
 function effectivePrivilege(t : AccessType(ext_access_type), m : Mstatus, priv : Privilege) -> Privilege =
   if   t != InstructionFetch() & m[MPRV] == 0b1
   then privLevel_of_bits(m[MPP])
@@ -168,7 +171,7 @@ function trap_handler(del_priv : Privilege, intr : bool, c : exc_code, pc : xlen
        mstatus[MPIE] = mstatus[MIE];
        mstatus[MIE]  = 0b0;
        mstatus[MPP]  = privLevel_to_bits(cur_privilege);
-       mtval         = tval(info);
+       mtval         = if not(plat_excp_breakpoint_updates_tval) & c == 0x03 then zeros() else tval(info);
        mepc          = pc;
 
        cur_privilege = del_priv;
@@ -192,7 +195,7 @@ function trap_handler(del_priv : Privilege, intr : bool, c : exc_code, pc : xlen
                            Supervisor => 0b1,
                            Machine => internal_error(__FILE__, __LINE__, "invalid privilege for s-mode trap")
                          };
-       stval           = tval(info);
+       stval           = if not(plat_excp_breakpoint_updates_tval) & c == 0x03 then zeros() else tval(info);
        sepc            = pc;
 
        cur_privilege   = del_priv;


### PR DESCRIPTION
1. add 'excp_breakpoint_updates_tval' option
2. apply the option to exception handling

reference
  based on privileged spec 3.1.16
  " The  hardware  platform  will  specify  which  exceptions  must  set mtval
  informatively, which may unconditionally set it to zero"

  "If  mtval  is written with a nonzero value when a breakpoint,
  address-misaligned, access-fault, or page-fault
  exception occurs on an instruction fetch, load, or store, then  mtval
  will contain the faulting virtual address."

  It is implementation-defined that ebreak could update tval with zero
  of faulting virtual address.