### PR TITLE
Remove duplicate config_print checks

### DIFF
--- a/c_emulator/riscv_prelude.cpp
+++ b/c_emulator/riscv_prelude.cpp
@@ -8,10 +8,9 @@ unit print_string(sail_string prefix, sail_string msg)
   return UNIT;
 }
 
-unit print_instr(sail_string s)
+unit print_log(sail_string s)
 {
-  if (config_print_instr)
-    fprintf(trace_log, "%s\n", s);
+  fprintf(trace_log, "%s\n", s);
   return UNIT;
 }
 
@@ -19,13 +18,6 @@ unit print_step(unit)
 {
   if (config_print_step)
     fprintf(trace_log, "\n");
-  return UNIT;
-}
-
-unit print_platform(sail_string s)
-{
-  if (config_print_platform)
-    fprintf(trace_log, "%s\n", s);
   return UNIT;
 }
 

--- a/c_emulator/riscv_prelude.h
+++ b/c_emulator/riscv_prelude.h
@@ -9,9 +9,8 @@ extern "C" {
 
 unit print_string(sail_string prefix, sail_string msg);
 
-unit print_instr(sail_string s);
+unit print_log(sail_string s);
 unit print_step(unit);
-unit print_platform(sail_string s);
 
 bool get_config_print_instr(unit);
 bool get_config_print_platform(unit);

--- a/model/prelude.sail
+++ b/model/prelude.sail
@@ -55,8 +55,7 @@ overload max = {max_int}
 
 val print_string = pure "print_string" : (string, string) -> unit
 
-val print_instr    = pure {interpreter: "print_endline", c: "print_instr", lem: "print_dbg", _: "print_endline"} : string -> unit
-val print_platform = pure {interpreter: "print_endline", c: "print_platform", lem: "print_dbg", _: "print_endline"} : string -> unit
+val print_log = pure {interpreter: "print_endline", c: "print_log", lem: "print_dbg", _: "print_endline"} : string -> unit
 
 val print_step = pure {c: "print_step"} : unit -> unit
 function print_step() = ()

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -90,11 +90,13 @@ function within_phys_mem forall 'n, 'n <= max_mem_access. (Physaddr(addr) : phys
            & (addr_int + sizeof('n)) <= (rom_base_int + rom_size_int))
   then    true
   else {
-    print_platform("within_phys_mem: " ^ bits_str(addr) ^ " not within phys-mem:");
-    print_platform("  plat_rom_base: " ^ bits_str(plat_rom_base));
-    print_platform("  plat_rom_size: " ^ bits_str(plat_rom_size));
-    print_platform("  plat_ram_base: " ^ bits_str(plat_ram_base));
-    print_platform("  plat_ram_size: " ^ bits_str(plat_ram_size));
+    if get_config_print_platform() then {
+      print_log("within_phys_mem: " ^ bits_str(addr) ^ " not within phys-mem:");
+      print_log("  plat_rom_base: " ^ bits_str(plat_rom_base));
+      print_log("  plat_rom_size: " ^ bits_str(plat_rom_size));
+      print_log("  plat_ram_base: " ^ bits_str(plat_ram_base));
+      print_log("  plat_ram_size: " ^ bits_str(plat_ram_size));
+    };
     false
   }
 }
@@ -156,51 +158,51 @@ function clint_load(t, Physaddr(addr), width) = {
   if addr == MSIP_BASE & ('n == 8 | 'n == 4)
   then {
     if   get_config_print_platform()
-    then print_platform("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mip[MSI]));
+    then print_log("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mip[MSI]));
     Ok(zero_extend(sizeof(8 * 'n), mip[MSI]))
   }
   else if addr == MTIMECMP_BASE & ('n == 4)
   then {
     if   get_config_print_platform()
-    then print_platform("clint<4>[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtimecmp[31..0]));
+    then print_log("clint<4>[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtimecmp[31..0]));
     /* FIXME: Redundant zero_extend currently required by Lem backend */
     Ok(zero_extend(32, mtimecmp[31..0]))
   }
   else if addr == MTIMECMP_BASE & ('n == 8)
   then {
     if   get_config_print_platform()
-    then print_platform("clint<8>[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtimecmp));
+    then print_log("clint<8>[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtimecmp));
     /* FIXME: Redundant zero_extend currently required by Lem backend */
     Ok(zero_extend(64, mtimecmp))
   }
   else if addr == MTIMECMP_BASE_HI & ('n == 4)
   then {
     if   get_config_print_platform()
-    then print_platform("clint-hi<4>[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtimecmp[63..32]));
+    then print_log("clint-hi<4>[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtimecmp[63..32]));
     /* FIXME: Redundant zero_extend currently required by Lem backend */
     Ok(zero_extend(32, mtimecmp[63..32]))
   }
   else if addr == MTIME_BASE & ('n == 4)
   then {
     if   get_config_print_platform()
-    then print_platform("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtime));
+    then print_log("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtime));
     Ok(zero_extend(32, mtime[31..0]))
   }
   else if addr == MTIME_BASE & ('n == 8)
   then {
     if   get_config_print_platform()
-    then print_platform("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtime));
+    then print_log("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtime));
     Ok(zero_extend(64, mtime))
   }
   else if addr == MTIME_BASE_HI & ('n == 4)
   then {
     if   get_config_print_platform()
-    then print_platform("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtime));
+    then print_log("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtime));
     Ok(zero_extend(32, mtime[63..32]))
   }
   else {
     if   get_config_print_platform()
-    then print_platform("clint[" ^ bits_str(addr) ^ "] -> <not-mapped>");
+    then print_log("clint[" ^ bits_str(addr) ^ "] -> <not-mapped>");
     match t {
       InstructionFetch() => Err(E_Fetch_Access_Fault()),
       Read(Data) => Err(E_Load_Access_Fault()),
@@ -215,7 +217,7 @@ function clint_dispatch() -> unit = {
     mip[STI] = bool_to_bits(stimecmp <=_u mtime);
   };
   if get_config_print_platform()
-  then print_platform("clint mtime " ^ bits_str(mtime) ^ " (mip.MTI <- " ^ bits_str(mip[MTI]) ^
+  then print_log("clint mtime " ^ bits_str(mtime) ^ " (mip.MTI <- " ^ bits_str(mip[MTI]) ^
     (if currentlyEnabled(Ext_Sstc) then ", mip.STI <- " ^ bits_str(mip[STI]) else "") ^ ")");
 }
 
@@ -224,49 +226,49 @@ function clint_store(Physaddr(addr), width, data) = {
   let addr = addr - plat_clint_base;
   if addr == MSIP_BASE & ('n == 8 | 'n == 4) then {
     if   get_config_print_platform()
-    then print_platform("clint[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mip.MSI <- " ^ bits_str(data[0..0]) ^ ")");
+    then print_log("clint[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mip.MSI <- " ^ bits_str(data[0..0]) ^ ")");
     mip[MSI] = [data[0]];
     clint_dispatch();
     Ok(true)
   } else if addr == MTIMECMP_BASE & 'n == 8 then {
     if   get_config_print_platform()
-    then print_platform("clint<8>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtimecmp)");
+    then print_log("clint<8>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtimecmp)");
     mtimecmp = zero_extend(64, data); /* FIXME: Redundant zero_extend currently required by Lem backend */
     clint_dispatch();
     Ok(true)
   } else if addr == MTIMECMP_BASE & 'n == 4 then {
     if   get_config_print_platform()
-    then print_platform("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtimecmp)");
+    then print_log("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtimecmp)");
     mtimecmp = vector_update_subrange(mtimecmp, 31, 0, zero_extend(32, data));  /* FIXME: Redundant zero_extend currently required by Lem backend */
     clint_dispatch();
     Ok(true)
   } else if addr == MTIMECMP_BASE_HI & 'n == 4 then {
     if   get_config_print_platform()
-    then print_platform("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtimecmp)");
+    then print_log("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtimecmp)");
     mtimecmp = vector_update_subrange(mtimecmp, 63, 32, zero_extend(32, data)); /* FIXME: Redundant zero_extend currently required by Lem backend */
     clint_dispatch();
     Ok(true)
   } else if addr == MTIME_BASE & 'n == 8 then {
     if   get_config_print_platform()
-    then print_platform("clint<8>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtime)");
+    then print_log("clint<8>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtime)");
     mtime = data;
     clint_dispatch();
     Ok(true)
   } else if addr == MTIME_BASE & 'n == 4 then {
     if   get_config_print_platform()
-    then print_platform("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtime)");
+    then print_log("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtime)");
     mtime[31 .. 0] = data;
     clint_dispatch();
     Ok(true)
   } else if addr == MTIME_BASE_HI & 'n == 4 then {
     if   get_config_print_platform()
-    then print_platform("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtime)");
+    then print_log("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtime)");
     mtime[63 .. 32] = data;
     clint_dispatch();
     Ok(true)
   } else {
     if   get_config_print_platform()
-    then print_platform("clint[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (<unmapped>)");
+    then print_log("clint[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (<unmapped>)");
     Err(E_SAMO_Access_Fault())
   }
 }
@@ -331,7 +333,7 @@ function reset_htif () -> unit = {
 val htif_load : forall 'n, 'n > 0. (AccessType(ext_access_type), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
 function htif_load(t, Physaddr(paddr), width) = {
   if   get_config_print_platform()
-  then print_platform("htif[" ^ hex_bits_str(paddr) ^ "] -> " ^ bits_str(htif_tohost));
+  then print_log("htif[" ^ hex_bits_str(paddr) ^ "] -> " ^ bits_str(htif_tohost));
   /* FIXME: For now, only allow the expected access widths. */
   if      width == 8 & (paddr == htif_tohost_base())
   then    Ok(zero_extend(64, htif_tohost))         /* FIXME: Redundant zero_extend currently required by Lem backend */
@@ -349,7 +351,7 @@ function htif_load(t, Physaddr(paddr), width) = {
 val htif_store: forall 'n, 0 < 'n <= 8. (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
 function htif_store(Physaddr(paddr), width, data) = {
   if   get_config_print_platform()
-  then print_platform("htif[" ^ hex_bits_str(paddr) ^ "] <- " ^ bits_str(data));
+  then print_log("htif[" ^ hex_bits_str(paddr) ^ "] <- " ^ bits_str(data));
   /* Store the written value so that we can ack it later. */
   if      width == 8
   then    { htif_cmd_write = bitone;
@@ -379,7 +381,7 @@ function htif_store(Physaddr(paddr), width, data) = {
     match cmd[device] {
       0x00 => { /* syscall-proxy */
         if   get_config_print_platform()
-        then print_platform("htif-syscall-proxy cmd: " ^ bits_str(cmd[payload]));
+        then print_log("htif-syscall-proxy cmd: " ^ bits_str(cmd[payload]));
         if   cmd[payload][0] == bitone
         then {
              htif_done = true;
@@ -389,7 +391,7 @@ function htif_store(Physaddr(paddr), width, data) = {
       },
       0x01 => { /* terminal */
         if   get_config_print_platform()
-        then print_platform("htif-term cmd: " ^ bits_str(cmd[payload]));
+        then print_log("htif-term cmd: " ^ bits_str(cmd[payload]));
         match cmd[cmd] {
           0x00 => /* TODO: terminal input handling */ (),
           0x01 => plat_term_write(cmd[payload][7..0]),

--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -22,7 +22,7 @@ function run_hart_waiting(step_no : int, wr: WaitReason, instbits : instbits, ex
   // successfully interrupted waits
   if shouldWakeForInterrupt() then {
     if   get_config_print_instr()
-    then print_instr("interrupt exit from " ^ wait_name(wr) ^ " state at PC " ^ bits_str(PC));
+    then print_log("interrupt exit from " ^ wait_name(wr) ^ " state at PC " ^ bits_str(PC));
 
     // The waiting instruction retires successfully.  The
     // pending interrupts will be handled in the next step.
@@ -33,14 +33,14 @@ function run_hart_waiting(step_no : int, wr: WaitReason, instbits : instbits, ex
   match (wr, valid_reservation(), exit_wait) {
     (WAIT_WRS_STO, false, _) => {
       if   get_config_print_instr()
-      then print_instr("reservation invalid exit from " ^ wait_name(WAIT_WRS_STO) ^ " state at PC " ^ bits_str(PC));
+      then print_log("reservation invalid exit from " ^ wait_name(WAIT_WRS_STO) ^ " state at PC " ^ bits_str(PC));
 
       hart_state = HART_ACTIVE();
       Step_Execute(Retire_Success(), instbits)
     },
     (WAIT_WRS_NTO, false, _) => {
       if   get_config_print_instr()
-      then print_instr("reservation invalid exit from " ^ wait_name(WAIT_WRS_NTO) ^ " state at PC " ^ bits_str(PC));
+      then print_log("reservation invalid exit from " ^ wait_name(WAIT_WRS_NTO) ^ " state at PC " ^ bits_str(PC));
 
       hart_state = HART_ACTIVE();
       Step_Execute(Retire_Success(), instbits)
@@ -48,7 +48,7 @@ function run_hart_waiting(step_no : int, wr: WaitReason, instbits : instbits, ex
     // Transition out of waiting states as instructed.
     (WAIT_WFI, _, true) => {
       if   get_config_print_instr()
-      then print_instr("forced exit from " ^ wait_name(WAIT_WFI) ^ " state at PC " ^ bits_str(PC));
+      then print_log("forced exit from " ^ wait_name(WAIT_WFI) ^ " state at PC " ^ bits_str(PC));
 
       hart_state = HART_ACTIVE();
       // "When TW=1, then if WFI is executed in any
@@ -61,14 +61,14 @@ function run_hart_waiting(step_no : int, wr: WaitReason, instbits : instbits, ex
     },
     (WAIT_WRS_STO, _, true) => {
       if   get_config_print_instr()
-      then print_instr("timed-out exit from " ^ wait_name(WAIT_WRS_STO) ^ " state at PC " ^ bits_str(PC));
+      then print_log("timed-out exit from " ^ wait_name(WAIT_WRS_STO) ^ " state at PC " ^ bits_str(PC));
 
       hart_state = HART_ACTIVE();
       Step_Execute(Retire_Success(), instbits)
     },
     (WAIT_WRS_NTO, _, true) => {
       if   get_config_print_instr()
-      then print_instr("timed-out exit from " ^ wait_name(WAIT_WRS_NTO) ^ " state at PC " ^ bits_str(PC));
+      then print_log("timed-out exit from " ^ wait_name(WAIT_WRS_NTO) ^ " state at PC " ^ bits_str(PC));
 
       hart_state = HART_ACTIVE();
       // TODO: This is similar to WFI above for now, but will change to handle
@@ -80,7 +80,7 @@ function run_hart_waiting(step_no : int, wr: WaitReason, instbits : instbits, ex
     // remain waiting
     (_, _, false) => {
       if   get_config_print_instr()
-      then print_instr("remaining in " ^ wait_name(wr) ^ " state at PC " ^ bits_str(PC));
+      then print_log("remaining in " ^ wait_name(wr) ^ " state at PC " ^ bits_str(PC));
       Step_Waiting(wr)
     }
   }
@@ -101,7 +101,7 @@ function run_hart_active(step_no: nat) -> Step = {
         let instruction = ext_decode_compressed(h);
         if   get_config_print_instr()
         then {
-          print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(PC) ^ " (" ^ bits_str(h) ^ ") " ^ to_str(instruction));
+          print_log("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(PC) ^ " (" ^ bits_str(h) ^ ") " ^ to_str(instruction));
         };
         /* check for RVC once here instead of every RVC execute clause. */
         if currentlyEnabled(Ext_Zca) then {
@@ -118,7 +118,7 @@ function run_hart_active(step_no: nat) -> Step = {
         let instruction = ext_decode(w);
         if   get_config_print_instr()
         then {
-          print_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(PC) ^ " (" ^ bits_str(w) ^ ") " ^ to_str(instruction));
+          print_log("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(PC) ^ " (" ^ bits_str(w) ^ ") " ^ to_str(instruction));
         };
         nextPC = PC + 4;
         let r = execute(instruction);
@@ -199,7 +199,7 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
       } else {
         // Transition into the wait state.
         if   get_config_print_instr()
-        then print_instr("entering " ^ wait_name(wr) ^ " state at PC " ^ bits_str(PC));
+        then print_log("entering " ^ wait_name(wr) ^ " state at PC " ^ bits_str(PC));
 
         hart_state = HART_WAITING(wr, instbits);
       }

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -156,7 +156,7 @@ function trap_handler(del_priv : Privilege, intr : bool, c : exc_code, pc : xlen
                      -> xlenbits = {
   trap_callback();
   if   get_config_print_platform()
-  then print_platform("handling " ^ (if intr then "int#" else "exc#")
+  then print_log("handling " ^ (if intr then "int#" else "exc#")
                       ^ bits_str(c) ^ " at priv " ^ to_str(del_priv)
                       ^ " with tval " ^ bits_str(tval(info)));
 
@@ -213,7 +213,7 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
     (_, CTL_TRAP(e)) => {
       let del_priv = exception_delegatee(e.trap, cur_priv);
       if   get_config_print_platform()
-      then print_platform("trapping from " ^ to_str(cur_priv) ^ " to " ^ to_str(del_priv)
+      then print_log("trapping from " ^ to_str(cur_priv) ^ " to " ^ to_str(del_priv)
                           ^ " to handle " ^ to_str(e.trap));
       trap_handler(del_priv, false, exceptionType_to_bits(e.trap), pc, e.excinfo, e.ext)
     },
@@ -229,7 +229,7 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
       long_csr_write_callback("mstatus", "mstatush", mstatus.bits);
 
       if   get_config_print_platform()
-      then print_platform("ret-ing from " ^ to_str(prev_priv) ^ " to " ^ to_str(cur_privilege));
+      then print_log("ret-ing from " ^ to_str(prev_priv) ^ " to " ^ to_str(cur_privilege));
 
       prepare_xret_target(Machine)
     },
@@ -245,7 +245,7 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
       long_csr_write_callback("mstatus", "mstatush", mstatus.bits);
 
       if   get_config_print_platform()
-      then print_platform("ret-ing from " ^ to_str(prev_priv)
+      then print_log("ret-ing from " ^ to_str(prev_priv)
                           ^ " to " ^ to_str(cur_privilege));
 
       prepare_xret_target(Supervisor)


### PR DESCRIPTION
The config flags `config_print_instr` and `config_print_platform` are checked twice in the Sail and C code. This commit removes the C functions `print_instr()` and `print_platform()`, and replaces them with a single function `print_trace()`, which doesn't do a redundant check.

Fixes #1174