### PR TITLE
Remove unused  `ext_control_check_addr` hook function.

### DIFF
--- a/model/riscv_addr_checks.sail
+++ b/model/riscv_addr_checks.sail
@@ -36,10 +36,6 @@ type ext_control_addr_error = unit
  * value, which will have bit[0] cleared by the caller if needed.
  */
 
-/* the control address is derived from a non-PC register, e.g. in JALR */
-function ext_control_check_addr(pc : xlenbits) -> Ext_ControlAddr_Check(ext_control_addr_error) =
-  Ext_ControlAddr_OK(Virtaddr(pc))
-
 /* the control address is derived from the PC register, e.g. in JAL */
 function ext_control_check_pc(pc : xlenbits) -> Ext_ControlAddr_Check(ext_control_addr_error) =
   Ext_ControlAddr_OK(Virtaddr(pc))


### PR DESCRIPTION
This accidentally became unused when `jump_to` was added, however there is currently no difference between `ext_control_check_addr` and `ext_control_check_pc` in the latest implemented CHERI spec (0.9.3), and in the latest draft spec this check has been removed entirely.