### PR TITLE
Remove unused `ext_check_phys_mem_{read,write}` hooks.

### DIFF
--- a/model/riscv_addr_checks.sail
+++ b/model/riscv_addr_checks.sail
@@ -61,10 +61,3 @@ function ext_data_get_addr(base : regidx, offset : xlenbits, acc : AccessType(ex
 
 function ext_handle_data_check_error(err : ext_data_addr_error) -> unit =
   ()
-
-/* Default implementations of these hooks permit all accesses.  */
-function ext_check_phys_mem_read (access_type, paddr, width, acquire, release, reserved, read_meta) =
-  Ext_PhysAddr_OK ()
-
-function ext_check_phys_mem_write(write_kind, paddr, width, data, metadata) =
-  Ext_PhysAddr_OK ()

--- a/model/riscv_addr_checks_common.sail
+++ b/model/riscv_addr_checks_common.sail
@@ -28,24 +28,3 @@ union Ext_DataAddr_Check ('a : Type) = {
   Ext_DataAddr_OK : virtaddr,    /* Address to use for the data access */
   Ext_DataAddr_Error : 'a
 }
-
-union Ext_PhysAddr_Check = {
-  Ext_PhysAddr_OK : unit,
-  Ext_PhysAddr_Error : ExceptionType
-}
-
-/*!
- * Validate a read from physical memory.
- * THIS(access_type, paddr, size, acquire, release, reserved, read_meta) should
- * return Some(exception) to abort the read or None to allow it to proceed. The
- * check is performed after PMP checks and does not apply to MMIO memory.
- */
-val ext_check_phys_mem_read : forall 'n, 0 < 'n <= max_mem_access . (AccessType (ext_access_type), physaddr, int('n), bool, bool, bool, bool) -> Ext_PhysAddr_Check
-
-/*!
- * Validate a write to physical memory.
- * THIS(write_kind, paddr, size, data, metadata) should return Some(exception)
- * to abort the write or None to allow it to proceed. The check is performed
- * after PMP checks and does not apply to MMIO memory.
- */
-val ext_check_phys_mem_write : forall 'n, 0 < 'n <= max_mem_access . (write_kind, physaddr, int('n), bits(8 * 'n), mem_meta) -> Ext_PhysAddr_Check

--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -119,10 +119,8 @@ function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (
       if   within_mmio_readable(paddr, width)
       then MemoryOpResult_add_meta(mmio_read(t, paddr, width), default_meta)
       else if within_phys_mem(paddr, width)
-      then match ext_check_phys_mem_read(t, paddr, width, aq, rl, res, meta) {
-        Ext_PhysAddr_OK()     => phys_mem_read(t, paddr, width, aq, rl, res, meta),
-        Ext_PhysAddr_Error(e) => Err(e)
-      } else match t {
+      then phys_mem_read(t, paddr, width, aq, rl, res, meta)
+      else match t {
         InstructionFetch() => Err(E_Fetch_Access_Fault()),
         Read(Data) => Err(E_Load_Access_Fault()),
         _          => Err(E_SAMO_Access_Fault())
@@ -195,10 +193,7 @@ function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
       else if within_phys_mem(paddr, width)
       then {
         let wk = write_kind_of_flags(aq, rl, con);
-        match ext_check_phys_mem_write (wk, paddr, width, data, meta) {
-          Ext_PhysAddr_OK() => phys_mem_write(wk, paddr, width, data, meta),
-          Ext_PhysAddr_Error(e)  => Err(e),
-        }
+        phys_mem_write(wk, paddr, width, data, meta)
       } else Err(E_SAMO_Access_Fault())
     }
   }


### PR DESCRIPTION
These seem to be unused in both the CTSRD and Alliance CHERI models.