### PR TITLE
Move extension-specific enums from `riscv_types` into their own files. 

### DIFF
--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -85,12 +85,16 @@ extensions {
   }
 
   A {
-    requires riscv_exceptions, riscv, I
+    Zaamo_types {
+      before riscv
+      files riscv_zaamo_types.sail
+    }
     Zaamo {
+      requires riscv, Zaamo_types
       files riscv_insts_zaamo.sail
     }
     Zalrsc {
-      requires Zaamo
+      requires riscv, Zaamo_types
       files riscv_insts_zalrsc.sail
     }
   }

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -106,19 +106,26 @@ extensions {
 
   // RISC-V Bit manipulation extensions
   B {
-    requires riscv
+    B_types {
+      before riscv
+      files riscv_bext_types.sail
+    }
 
-    Zba {
-      files riscv_insts_zba.sail
-    }
-    Zbb {
-      files riscv_insts_zbb.sail
-    }
-    Zbc {
-      files riscv_insts_zbc.sail
-    }
-    Zbs {
-      files riscv_insts_zbs.sail
+    B_insts {
+      requires riscv, B_types
+
+      Zba {
+        files riscv_insts_zba.sail
+      }
+      Zbb {
+        files riscv_insts_zbb.sail
+      }
+      Zbc {
+        files riscv_insts_zbc.sail
+      }
+      Zbs {
+        files riscv_insts_zbs.sail
+      }
     }
   }
 
@@ -207,7 +214,7 @@ extensions {
       files riscv_zkr_control.sail
     }
     Zbkb {
-      requires riscv
+      requires riscv, B_types
       files riscv_insts_zbkb.sail
     }
     Zbkx {

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -70,12 +70,18 @@ extensions {
   requires riscv_core
 
   I {
-    requires riscv_exceptions, riscv
+    I_types {
+      before riscv
+      files riscv_ibase_types.sail
+    }
+    I_insts {
+      requires riscv_exceptions, riscv, I_types
 
-    files
-      riscv_insts_base.sail,
-      riscv_insts_reserved_fence.sail,
-      riscv_jalr_seq.sail
+      files
+        riscv_insts_base.sail,
+        riscv_insts_reserved_fence.sail,
+        riscv_jalr_seq.sail
+    }
   }
 
   A {
@@ -245,8 +251,14 @@ extensions {
 
   // Control and Status Register (CSR) Instructions
   Zicsr {
-    requires riscv, riscv_exceptions, pmp, V_core
-    files riscv_insts_zicsr.sail
+    Zicsr_types {
+      before riscv
+      files riscv_zicsr_types.sail
+    }
+    Zicsr_insts {
+      requires riscv, riscv_exceptions, pmp, V_core, Zicsr_types
+      files riscv_insts_zicsr.sail
+    }
   }
 
   Svinval {
@@ -273,13 +285,25 @@ extensions {
   }
 
   Zawrs {
-    requires riscv
-    files riscv_insts_zawrs.sail
+    Zawrs_types {
+      before riscv
+      files riscv_zawrs_types.sail
+    }
+    Zawrs_insts {
+      requires riscv, Zawrs_types
+      files riscv_insts_zawrs.sail
+    }
   }
 
   Zicond {
-    requires riscv
-    files riscv_insts_zicond.sail
+    Zicond_types {
+      before riscv
+      files riscv_zicond_types.sail
+    }
+    Zicond_insts {
+      requires riscv, Zicond_types
+      files riscv_insts_zicond.sail
+    }
   }
 
   Zicntr {
@@ -287,8 +311,14 @@ extensions {
   }
 
   Zicbom {
-    requires riscv
-    files riscv_insts_zicbom.sail
+    Zicbom_types {
+      before riscv
+      files riscv_zicbom_types.sail
+    }
+    Zicbom_insts {
+      requires riscv, Zicbom_types
+      files riscv_insts_zicbom.sail
+    }
   }
 
   Zicboz {

--- a/model/riscv_bext_types.sail
+++ b/model/riscv_bext_types.sail
@@ -1,0 +1,21 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+type shamt_zba = bits(2)
+
+enum brop_zbb = {ANDN, ORN, XNOR, MAX, MAXU, MIN, MINU, ROL, ROR}
+
+enum brop_zbkb = {PACK, PACKH}
+
+enum brop_zbs = {BCLR, BEXT, BINV, BSET}
+
+enum bropw_zbb = {ROLW, RORW}
+
+enum biop_zbs = {BCLRI, BEXTI, BINVI, BSETI}
+
+enum extop_zbb = {SEXTB, SEXTH, ZEXTH}

--- a/model/riscv_ibase_types.sail
+++ b/model/riscv_ibase_types.sail
@@ -1,0 +1,17 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+enum uop = {LUI, AUIPC}                          /* upper immediate ops */
+enum bop = {BEQ, BNE, BLT, BGE, BLTU, BGEU}      /* branch ops */
+enum iop = {ADDI, SLTI, SLTIU, XORI, ORI, ANDI}  /* immediate ops */
+enum sop = {SLLI, SRLI, SRAI}                    /* shift ops */
+enum rop = {ADD, SUB, SLL, SLT, SLTU, XOR,
+            SRL, SRA, OR, AND}                   /* reg-reg ops */
+
+enum ropw  = {ADDW, SUBW, SLLW, SRLW, SRAW}      /* reg-reg 32-bit ops */
+enum sopw  = {SLLIW, SRLIW, SRAIW}               /* RV64-only shift ops */

--- a/model/riscv_insts_zaamo.sail
+++ b/model/riscv_insts_zaamo.sail
@@ -138,12 +138,5 @@ mapping amo_mnemonic : amoop <-> string = {
   AMOCAS  <-> "amocas",
 }
 
-mapping maybe_aqrl : (bool, bool) <-> string = {
-  (true, true)   <-> ".aqrl",
-  (true, false)  <-> ".aq",
-  (false, true)  <-> ".rl",
-  (false, false) <-> "",
-}
-
 mapping clause assembly = AMO(op, aq, rl, rs2, rs1, width, rd)
   <-> amo_mnemonic(op) ^ "." ^ width_mnemonic_wide(width) ^ maybe_aqrl(aq, rl) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs2) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -270,20 +270,7 @@ function satpMode_of_bits(a : Architecture, m : satp_mode) -> option(SATPMode) =
 
 type csrRW = bits(2)  /* read/write */
 
-/* instruction opcode grouping */
-type shamt_zba = bits(2)
-
-enum brop_zbb = {ANDN, ORN, XNOR, MAX, MAXU, MIN, MINU, ROL, ROR}
-
-enum brop_zbkb = {PACK, PACKH}
-
-enum brop_zbs = {BCLR, BEXT, BINV, BSET}
-
-enum bropw_zbb = {ROLW, RORW}
-
-enum biop_zbs = {BCLRI, BEXTI, BINVI, BSETI}
-
-enum extop_zbb = {SEXTB, SEXTH, ZEXTH}
+/* Wait state reasons */
 
 enum WaitReason = {WAIT_WFI, WAIT_WRS_STO, WAIT_WRS_NTO}
 mapping wait_name : WaitReason <-> string = {

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -271,10 +271,6 @@ function satpMode_of_bits(a : Architecture, m : satp_mode) -> option(SATPMode) =
 type csrRW = bits(2)  /* read/write */
 
 /* instruction opcode grouping */
-enum amoop = {AMOSWAP, AMOADD, AMOXOR, AMOAND, AMOOR, /* AMO ops */
-              AMOMIN, AMOMAX, AMOMINU, AMOMAXU,
-              AMOCAS}
-
 type shamt_zba = bits(2)
 
 enum brop_zbb = {ANDN, ORN, XNOR, MAX, MAXU, MIN, MINU, ROL, ROR}

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -271,21 +271,9 @@ function satpMode_of_bits(a : Architecture, m : satp_mode) -> option(SATPMode) =
 type csrRW = bits(2)  /* read/write */
 
 /* instruction opcode grouping */
-enum uop = {LUI, AUIPC}                          /* upper immediate ops */
-enum bop = {BEQ, BNE, BLT, BGE, BLTU, BGEU}      /* branch ops */
-enum iop = {ADDI, SLTI, SLTIU, XORI, ORI, ANDI}  /* immediate ops */
-enum sop = {SLLI, SRLI, SRAI}                    /* shift ops */
-enum rop = {ADD, SUB, SLL, SLT, SLTU, XOR,
-            SRL, SRA, OR, AND}                   /* reg-reg ops */
-
-enum ropw  = {ADDW, SUBW, SLLW, SRLW, SRAW}           /* reg-reg 32-bit ops */
-enum sopw  = {SLLIW, SRLIW, SRAIW}                    /* RV64-only shift ops */
 enum amoop = {AMOSWAP, AMOADD, AMOXOR, AMOAND, AMOOR, /* AMO ops */
               AMOMIN, AMOMAX, AMOMINU, AMOMAXU,
               AMOCAS}
-enum csrop = {CSRRW, CSRRS, CSRRC}                    /* CSR ops */
-
-enum cbop_zicbom = {CBO_CLEAN, CBO_FLUSH, CBO_INVAL}  /* Zicbom ops */
 
 type shamt_zba = bits(2)
 
@@ -300,10 +288,6 @@ enum bropw_zbb = {ROLW, RORW}
 enum biop_zbs = {BCLRI, BEXTI, BINVI, BSETI}
 
 enum extop_zbb = {SEXTB, SEXTH, ZEXTH}
-
-enum zicondop = {CZERO_EQZ, CZERO_NEZ}
-
-enum wrsop = {WRS_STO, WRS_NTO}
 
 enum WaitReason = {WAIT_WFI, WAIT_WRS_STO, WAIT_WRS_NTO}
 mapping wait_name : WaitReason <-> string = {

--- a/model/riscv_zaamo_types.sail
+++ b/model/riscv_zaamo_types.sail
@@ -1,0 +1,17 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+enum amoop = {AMOSWAP, AMOADD, AMOXOR, AMOAND, AMOOR,
+              AMOMIN, AMOMAX, AMOMINU, AMOMAXU, AMOCAS}
+
+mapping maybe_aqrl : (bool, bool) <-> string = {
+  (true, true)   <-> ".aqrl",
+  (true, false)  <-> ".aq",
+  (false, true)  <-> ".rl",
+  (false, false) <-> "",
+}

--- a/model/riscv_zawrs_types.sail
+++ b/model/riscv_zawrs_types.sail
@@ -1,0 +1,9 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+enum wrsop = {WRS_STO, WRS_NTO}

--- a/model/riscv_zicbom_types.sail
+++ b/model/riscv_zicbom_types.sail
@@ -1,0 +1,9 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+enum cbop_zicbom = {CBO_CLEAN, CBO_FLUSH, CBO_INVAL}

--- a/model/riscv_zicond_types.sail
+++ b/model/riscv_zicond_types.sail
@@ -1,0 +1,9 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+enum zicondop = {CZERO_EQZ, CZERO_NEZ}

--- a/model/riscv_zicsr_types.sail
+++ b/model/riscv_zicsr_types.sail
@@ -1,0 +1,9 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+enum csrop = {CSRRW, CSRRS, CSRRC}


### PR DESCRIPTION
Enums used for the instruction type needed to appear before its definition, causing enums used for instructions from extensions to collect in `riscv_types`.  This moves them into extension-specific `_types` files, making each extension more self-contained.
