### PR TITLE
Greatly simplify the code for reading & writing vector registers/masks

### DIFF
--- a/model/core/prelude.sail
+++ b/model/core/prelude.sail
@@ -229,23 +229,6 @@ overload operator * = {mult_atom, mult_int}
 overload operator / = {quot_positive_round_zero}
 overload operator % = {rem_positive_round_zero}
 
-// helper for vector extension
-// 1. EEW between 8 and 64
-// 2. EMUL in vmv<nr>r.v instructions between 1 and 8
-val log2 : forall 'n, 'n in {1, 2, 4, 8, 16, 32, 64}. int('n) -> int
-function log2(n) = {
-  let result : int = match n {
-    1    => 0,
-    2    => 1,
-    4    => 2,
-    8    => 3,
-    16   => 4,
-    32   => 5,
-    64   => 6
-  };
-  result
-}
-
 // This is a slightly arbitrary limit on the maximum number of bytes
 // in a memory access.  It helps to generate slightly better C code
 // because it means width argument can be fast native integer. It
@@ -271,3 +254,15 @@ val sys_enable_experimental_extensions = pure "sys_enable_experimental_extension
 // bit vectors that aren't a multiple of 4 bits in binary).
 function hex_bits_str forall 'n, 'n >= 0 . (x : bits('n)) -> string =
   bits_str(zero_extend((3 - (('n + 3) % 4)) + 'n, x))
+
+// This can be called to type check that a boolean will always be true.
+// This can be used to verify a fact that the type checker already knows
+// to be true, so in a sense it is redundant. However it is useful for
+// documentation purposes, checking assumptions, and providing nicer errors
+// when editing.
+//
+// It can also be used to narrow down "could not resolve quantifiers" error
+// messages - if you get a list of properties, Sail is saying that *one*
+// of them can't be proven but it doesn't say which. If that happens you can
+// add static_assert() calls for each property to find out which one it is.
+function static_assert forall ('b : Bool), 'b . (_ : bool('b)) -> unit = ()

--- a/model/extensions/V/vext_arith_insts.sail
+++ b/model/extensions/V/vext_arith_insts.sail
@@ -196,6 +196,7 @@ function clause execute NVSTYPE(funct6, vm, vs2, vs1, vd) = {
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -268,6 +269,7 @@ function clause execute NVTYPE(funct6, vm, vs2, vs1, vd) = {
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -570,6 +572,7 @@ function clause execute NXSTYPE(funct6, vm, vs2, rs1, vd) = {
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -642,6 +645,7 @@ function clause execute NXTYPE(funct6, vm, vs2, rs1, vd) = {
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -987,6 +991,7 @@ function clause execute NISTYPE(funct6, vm, vs2, uimm, vd) = {
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1059,6 +1064,7 @@ function clause execute NITYPE(funct6, vm, vs2, uimm, vd) = {
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1302,7 +1308,12 @@ function clause execute VMVRTYPE(vs2, nreg, vd) = {
   let SEW     = get_sew();
   let EMUL    = nreg;
 
-  let EMUL_pow = log2(EMUL);
+  let EMUL_pow : range(0, 3) = match EMUL {
+    1 => 0,
+    2 => 1,
+    4 => 2,
+    8 => 3,
+  };
   let num_elem = get_num_elem(EMUL_pow, SEW);
   let 'n = num_elem;
   let 'm = SEW;
@@ -1552,6 +1563,7 @@ function clause execute WVVTYPE(funct6, vm, vs2, vs1, vd) = {
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1627,6 +1639,7 @@ function clause execute WVTYPE(funct6, vm, vs2, vs1, vd) = {
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1697,6 +1710,7 @@ function clause execute WMVVTYPE(funct6, vm, vs2, vs1, vd) = {
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -2147,6 +2161,7 @@ function clause execute WVXTYPE(funct6, vm, vs2, rs1, vd) = {
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -2221,6 +2236,7 @@ function clause execute WXTYPE(funct6, vm, vs2, rs1, vd) = {
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -2291,6 +2307,7 @@ function clause execute WMVXTYPE(funct6, vm, vs2, rs1, vd) = {
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;

--- a/model/extensions/V/vext_control.sail
+++ b/model/extensions/V/vext_control.sail
@@ -25,91 +25,25 @@ function clause currentlyEnabled(Ext_V) = hartSupports(Ext_V) & (misa[V] == 0b1)
 function clause currentlyEnabled(Ext_Zvfh)    = hartSupports(Ext_Zvfh)     & currentlyEnabled(Ext_Zve32f) & currentlyEnabled(Ext_Zfhmin)
 function clause currentlyEnabled(Ext_Zvfhmin) = (hartSupports(Ext_Zvfhmin) & currentlyEnabled(Ext_Zve32f)) | currentlyEnabled(Ext_Zvfh)
 
-// num_elem means max(VLMAX,VLEN/SEW)) according to Section 5.4 of RVV spec
-function get_num_elem(LMUL_pow : int, SEW : sew_bitsize) -> nat1 = {
-  let LMUL_pow_reg = if LMUL_pow < 0 then 0 else LMUL_pow;
-  // Ignore lmul < 1 so that the entire vreg is read, allowing all masking to
-  // be handled in init_masked_result
-  let num_elem = (2 ^ LMUL_pow_reg) * vlen / SEW;
-  assert(num_elem > 0);
-  num_elem
-}
-
-// Reads a single vreg into multiple elements
-val read_single_vreg : forall 'n 'm, 'n >= 0 & is_sew_bitsize('m) . (int('n), int('m), vregidx) -> vector('n, bits('m))
-function read_single_vreg(num_elem, SEW, vrid) = {
-  // TODO: This should be part of the type signature for this function.
-  assert(num_elem * SEW <= vlen);
-
-  let bv = V(vrid);
-  var result : vector('n, bits('m)) = vector_init(zeros());
-
-  foreach (i from 0 to (num_elem - 1)) {
-    let start_index = i * SEW;
-    result[i] = bv[start_index + SEW - 1 .. start_index];
-  };
-
-  result
-}
-
-// Writes multiple elements into a single vreg
-val write_single_vreg : forall 'n 'm, 'n >= 0 & is_sew_bitsize('m) . (int('n), int('m), vregidx, vector('n, bits('m))) -> unit
-function write_single_vreg(num_elem, SEW, vrid, v) = {
-  var r : vlenbits = zeros();
-
-  assert(SEW <= vlen);
-
-  foreach (i from (num_elem - 1) downto 0) {
-    r = r << SEW;
-    r = r | zero_extend(v[i]);
-  };
-
-  V(vrid) = r
-}
-
-// The general vreg reading operation with num_elem as max(VLMAX,VLEN/SEW))
-val read_vreg : forall 'n 'm 'p, 'n >= 0 & is_sew_bitsize('m) . (int('n), int('m), int('p), vregidx) -> vector('n, bits('m))
-function read_vreg(num_elem, SEW, LMUL_pow, vrid) = {
-  let vrid_val = unsigned(vregidx_bits(vrid));
-  var result : vector('n, bits('m)) = vector_init(zeros());
-  let LMUL_pow_reg = if LMUL_pow < 0 then 0 else LMUL_pow;
-
-  // Check for valid vrid
-  if vrid_val + 2 ^ LMUL_pow_reg > 32 then {
-    // vrid would read past largest vreg (v31)
-    assert(false, "invalid register group: vrid overflow the largest number")
-  } else if vrid_val % (2 ^ LMUL_pow_reg) != 0 then {
-    // vrid must be a multiple of emul
-    assert(false, "invalid register group: vrid is not a multiple of EMUL")
-  } else {
-    // Check if a single register read suffices.
-    if num_elem * SEW < vlen then {
-      result = read_single_vreg('n, SEW, vrid);
-    } else {
-      let 'num_elem_single = vlen / SEW;
-      assert('num_elem_single >= 0);
-      foreach (i_lmul from 0 to (2 ^ LMUL_pow_reg - 1)) {
-        let r_start_i : int = i_lmul * 'num_elem_single;
-        let r_end_i   : int = r_start_i + 'num_elem_single - 1;
-        let vrid_lmul     : vregidx = vregidx_offset(vrid, to_bits_unsafe(5, i_lmul));
-        let single_result : vector('num_elem_single, bits('m)) = read_single_vreg('num_elem_single, SEW, vrid_lmul);
-        foreach (r_i from r_start_i to r_end_i) {
-          let s_i : int = r_i - r_start_i;
-          assert(0 <= r_i & r_i < num_elem);
-          assert(0 <= s_i & s_i < 'num_elem_single);
-          result[r_i] = single_result[s_i];
-        }
-      }
-    }
-  };
-
-  result
+// Get the total number of elements in a register group (not considering `vl`).
+// For fractional groups (negative LMUL_pow) we return the number of elements
+// in a single register. The fractional aspect is handled by `init_masked_result()`.
+//
+// The minimum number of elements is 1.
+// The maximum is VLMAX = LMUL*VLEN/SEW. VLMAX can never be more than vlen
+// because the minimum SEW is 8 and the maximum LMUL is 8. This is also
+// true because all elements must be able to fit into a single register
+// at 1-bit per element for masks.
+function get_num_elem(LMUL_pow : LMUL_pow, SEW : sew_bitsize) -> range(1, vlen) = {
+  assert(vlen >= SEW);
+  (2 ^ max(0, LMUL_pow)) * vlen / SEW
 }
 
 // Read a single element of a vector register group (starting at vrid).
-val read_single_element : forall 'm, is_sew_bitsize('m) . (int('m), nat, vregidx) -> bits('m)
+val read_single_element : forall 'sew, is_sew_bitsize('sew) . (int('sew), nat, vregidx) -> bits('sew)
 function read_single_element(EEW, index, vrid) = {
   assert(EEW <= vlen);
+  static_assert(vlen % EEW == 0);
 
   // Number of EEW-bit elements per vector register.
   let elem_per_reg = vlen / EEW;
@@ -127,33 +61,29 @@ function read_single_element(EEW, index, vrid) = {
   V(vrid)[(offset + EEW - 1) .. offset]
 }
 
-// The general vreg writing operation with num_elem as max(VLMAX,VLEN/SEW))
-val write_vreg : forall 'n 'm 'p, 'n >= 0 & is_sew_bitsize('m) . (int('n), int('m), int('p), vregidx, vector('n, bits('m))) -> unit
-function write_vreg(num_elem, SEW, LMUL_pow, vrid, vec) = {
+// The general vreg reading operation with num_elem as max(VLMAX,VLEN/SEW)).
+val read_vreg : forall 'n 'sew 'p, 'n >= 0 & is_sew_bitsize('sew) . (int('n), int('sew), int('p), vregidx) -> vector('n, bits('sew))
+function read_vreg(num_elem, SEW, LMUL_pow, vrid) = {
+  let vrid_val = unsigned(vregidx_bits(vrid));
   let LMUL_pow_reg = if LMUL_pow < 0 then 0 else LMUL_pow;
+  assert(vrid_val + 2 ^ LMUL_pow_reg <= 32, "invalid register group: vrid overflow the largest number");
+  assert(vrid_val % (2 ^ LMUL_pow_reg) == 0, "invalid register group: vrid is not a multiple of EMUL");
 
-  let 'num_elem_single = vlen / SEW;
-  assert('num_elem_single >= 0);
-  foreach (i_lmul from 0 to (2 ^ LMUL_pow_reg - 1)) {
-    var single_vec : vector('num_elem_single, bits('m)) = vector_init(zeros());
-    let vrid_lmul  : vregidx = vregidx_offset(vrid, to_bits_unsafe(5, i_lmul));
-    let r_start_i  : int = i_lmul * 'num_elem_single;
-    let r_end_i    : int = r_start_i + 'num_elem_single - 1;
-    foreach (r_i from r_start_i to r_end_i) {
-      let s_i : int = r_i - r_start_i;
-      assert(0 <= r_i & r_i < num_elem);
-      assert(0 <= s_i & s_i < 'num_elem_single);
-      single_vec[s_i] = vec[r_i]
-    };
-    write_single_vreg('num_elem_single, SEW, vrid_lmul, single_vec)
-  }
+  var result : vector('n, bits('sew)) = vector_init(zeros());
+
+  foreach (i from 0 to (num_elem - 1)) {
+    result[i] = read_single_element(SEW, i, vrid);
+  };
+
+  result
 }
 
 // Write a single element of a vector register group (starting at vrid),
 // leaving all other elements unchanged.
-val write_single_element : forall 'm, is_sew_bitsize('m) . (int('m), nat, vregidx, bits('m)) -> unit
+val write_single_element : forall 'sew, is_sew_bitsize('sew) . (int('sew), nat, vregidx, bits('sew)) -> unit
 function write_single_element(EEW, index, vrid, value) = {
   assert(EEW <= vlen);
+  static_assert(vlen % EEW == 0);
 
   // Number of EEW-bit elements per vector register.
   let elem_per_reg = vlen / EEW;
@@ -171,58 +101,66 @@ function write_single_element(EEW, index, vrid, value) = {
   V(vrid) = [V(vrid) with (offset + EEW - 1) .. offset = value];
 }
 
-// Mask register reading operation with num_elem as max(VLMAX,vlen/SEW))
-val read_vmask : forall 'n, 'n > 0. (int('n), bits(1), vregidx) -> bits('n)
-function read_vmask(num_elem, vm, vrid) = {
-  assert(num_elem <= vlen);
+// Write a complete vector register group.
+//
+// num_elem: Number of elements in the entire group (ignoring
+//           fractional lmul and vl).
+// SEW:      Element size in bits.
+// LMUL_pow: LMUL exponent; size of the register group.
+//           Negative values indicate fractions of a single register, but
+//           we still require the full register's worth of elements.
+// vrid:     Index of the first register in the group.
+// data:     Data of each element.
+//
+val write_vreg : forall 'n 'sew, 'n >= 0 & is_sew_bitsize('sew) . (int('n), int('sew), LMUL_pow, vregidx, vector('n, bits('sew))) -> unit
+function write_vreg(num_elem, SEW, LMUL_pow, vrid, vec) = {
+  // Number of registers in the group (treating fractional lmul as 0).
+  let group_size = 2 ^ max(LMUL_pow, 0);
 
-  let vreg_val = V(vrid);
-  var result   : bits('n) = ones();
+  assert(SEW <= vlen);
+  static_assert(vlen % SEW == 0);
 
-  if vm == 0b1 then {
-    return result
-  };
+  // Number of SEW-bit elements per vector register.
+  let elem_per_reg = vlen / SEW;
 
-  foreach (i from 0 to (num_elem - 1)) {
-    result[i] = vreg_val[i]
-  };
+  // Normally num_elem == group_size * elem_per_reg, however
+  // in the specific case of fractional lmul with widening instructions
+  // get_num_elem() returns vlen / SEW, but SEW is doubled before
+  // feeding into this instruction, so elem_per_reg is half the
+  // pre-widening value. Since `group_size` will be unchanged
+  // (because max(LMUL_pow, 0) is still 0), we will end up
+  // with num_elem == group_size * (elem_per_reg * 2).
+  //
+  // In that case the second half of the `vec` array will be ignored.
+  assert(num_elem == group_size * elem_per_reg | num_elem == 2 * group_size * elem_per_reg);
 
-  result
+  foreach (reg_in_group from 0 to (group_size - 1)) {
+    var reg_value : vlenbits = zeros();
+    foreach (i_elem from 0 to (elem_per_reg - 1)) {
+      reg_value[(i_elem * SEW) + SEW - 1 .. (i_elem * SEW)] = vec[reg_in_group * elem_per_reg + i_elem];
+    };
+    V(vrid + reg_in_group) = reg_value;
+  }
 }
 
-// This is a special version of read_vmask for carry/borrow instructions, where vm=1 means no carry
-val read_vmask_carry : forall 'n, 'n > 0. (int('n), bits(1), vregidx) -> bits('n)
-function read_vmask_carry(num_elem, vm, vrid) = {
-  assert(num_elem <= vlen);
+// Mask register reading operation with num_elem as max(VLMAX,vlen/SEW)).
+val read_vmask : forall 'n, 0 < 'n <= vlen . (int('n), bits(1), vregidx) -> bits('n)
+function read_vmask(num_elem, vm, vrid) =
+  if vm == 0b1 then ones() else ones('n - num_elem) @ V(vrid)[num_elem - 1 .. 0]
 
-  let vreg_val = V(vrid);
-  var result   : bits('n) = zeros();
-
-  if vm == 0b1 then {
-    return result
-  };
-
-  foreach (i from 0 to (num_elem - 1)) {
-    result[i] = vreg_val[i]
-  };
-
-  result
-}
+// This is a special version of read_vmask for carry/borrow instructions, where vm=1 means no carry.
+val read_vmask_carry : forall 'n, 0 < 'n <= vlen . (int('n), bits(1), vregidx) -> bits('n)
+function read_vmask_carry(num_elem, vm, vrid) =
+  if vm == 0b1 then zeros() else zeros('n - num_elem) @ V(vrid)[num_elem - 1 .. 0]
 
 // Mask register writing operation with num_elem as max(VLMAX,vlen/SEW))
 val write_vmask : forall 'n, 'n > 0. (int('n), vregidx, bits('n)) -> unit
 function write_vmask(num_elem, vrid, v) = {
+  // TODO: This should be part of the type signature.
   assert(0 < num_elem & num_elem <= vlen);
-  let vreg_val = V(vrid);
-  var result : vlenbits = undefined;
 
-  foreach (i from 0 to (num_elem - 1)) {
-    result[i] = v[i]
-  };
-  foreach (i from num_elem to (vlen - 1)) {
-    // Mask tail is always agnostic
-    result[i] = vreg_val[i] // TODO: configuration support
-  };
-
-  V(vrid) = result
+  // Mask tail is always agnostic. Currently we always
+  // leave it undisturbed.
+  // TODO: Configuration support for ones/undisturbed.
+  V(vrid) = [V(vrid) with (num_elem - 1) .. 0 = v]
 }

--- a/model/extensions/V/vext_fp_insts.sail
+++ b/model/extensions/V/vext_fp_insts.sail
@@ -196,7 +196,9 @@ function clause execute FWVVTYPE(funct6, vm, vs2, vs1, vd) = {
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
+
   assert(SEW >= 16 & SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -265,7 +267,9 @@ function clause execute FWVVMATYPE(funct6, vm, vs1, vs2, vd) = {
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
+
   assert(SEW >= 16 & SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -332,7 +336,9 @@ function clause execute FWVTYPE(funct6, vm, vs2, vs1, vd) = {
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
+
   assert(SEW >= 16 & SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -517,7 +523,9 @@ function clause execute VFWUNARY0(vm, vs2, vfwunary0, vd) = {
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
+
   assert(SEW >= 8 & SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1089,7 +1097,9 @@ function clause execute FWVFTYPE(funct6, vm, vs2, rs1, vd) = {
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
+
   assert(SEW >= 16 & SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1157,7 +1167,9 @@ function clause execute FWVFMATYPE(funct6, vm, rs1, vs2, vd) = {
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
+
   assert(SEW >= 16 & SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -1223,7 +1235,9 @@ function clause execute FWFTYPE(funct6, vm, vs2, rs1, vd) = {
 
   if illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen)
   then return Illegal_Instruction();
+
   assert(SEW >= 16 & SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;

--- a/model/extensions/V/vext_mem_insts.sail
+++ b/model/extensions/V/vext_mem_insts.sail
@@ -40,7 +40,7 @@ mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd)
   when (currentlyEnabled(Ext_Zve32x) & vlewidth_pow(width) <= 5)
      | (currentlyEnabled(Ext_Zve64x) & vlewidth_pow(width) <= 6)
 
-function process_vlseg(nf : nfields, vm : bits(1), vd : vregidx, load_width_bytes : word_width, rs1 : regidx, EMUL_pow : int, num_elem : nat1) -> ExecutionResult = {
+function process_vlseg(nf : nfields, vm : bits(1), vd : vregidx, load_width_bytes : word_width, rs1 : regidx, EMUL_pow : int, num_elem : range(1, vlen)) -> ExecutionResult = {
   let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vd_seg = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
@@ -81,6 +81,8 @@ function clause execute VLSEGTYPE(nf, vm, rs1, width, vd) = {
   let SEW_pow = get_sew_pow();
   let LMUL_pow = get_lmul_pow();
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
+  // TODO: The EMUL_pow calculation here is incorrect. See https://github.com/riscv/sail-riscv/issues/1196
+  assert(-3 <= EMUL_pow & EMUL_pow <= 3);
   let num_elem = get_num_elem(EMUL_pow, EEW); // # of element of each register group
 
   assert(num_elem > 0);
@@ -101,7 +103,7 @@ mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd)
   when (currentlyEnabled(Ext_Zve32x) & vlewidth_pow(width) <= 5)
      | (currentlyEnabled(Ext_Zve64x) & vlewidth_pow(width) <= 6)
 
-function process_vlsegff(nf : nfields, vm : bits(1), vd : vregidx, load_width_bytes : word_width, rs1 : regidx, EMUL_pow : int, num_elem : nat1) -> ExecutionResult = {
+function process_vlsegff(nf : nfields, vm : bits(1), vd : vregidx, load_width_bytes : word_width, rs1 : regidx, EMUL_pow : int, num_elem : range(1, vlen)) -> ExecutionResult = {
   let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vd_seg = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
@@ -159,6 +161,8 @@ function clause execute VLSEGFFTYPE(nf, vm, rs1, width, vd) = {
   let SEW_pow = get_sew_pow();
   let LMUL_pow = get_lmul_pow();
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
+  // TODO: The EMUL_pow calculation here is incorrect. See https://github.com/riscv/sail-riscv/issues/1196
+  assert(-3 <= EMUL_pow & EMUL_pow <= 3);
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
   assert(num_elem > 0);
@@ -179,7 +183,7 @@ mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3)
   when (currentlyEnabled(Ext_Zve32x) & vlewidth_pow(width) <= 5)
      | (currentlyEnabled(Ext_Zve64x) & vlewidth_pow(width) <= 6)
 
-function process_vsseg(nf : nfields, vm : bits(1), vs3 : vregidx, load_width_bytes : word_width, rs1 : regidx, EMUL_pow : int, num_elem : nat1) -> ExecutionResult = {
+function process_vsseg(nf : nfields, vm : bits(1), vs3 : vregidx, load_width_bytes : word_width, rs1 : regidx, EMUL_pow : int, num_elem : range(1, vlen)) -> ExecutionResult = {
   let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vs3_seg = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
@@ -217,6 +221,8 @@ function clause execute VSSEGTYPE(nf, vm, rs1, width, vs3) = {
   let SEW_pow = get_sew_pow();
   let LMUL_pow = get_lmul_pow();
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
+  // TODO: The EMUL_pow calculation here is incorrect. See https://github.com/riscv/sail-riscv/issues/1196
+  assert(-3 <= EMUL_pow & EMUL_pow <= 3);
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
   assert(num_elem > 0);
@@ -237,7 +243,7 @@ mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
   when (currentlyEnabled(Ext_Zve32x) & vlewidth_pow(width) <= 5)
      | (currentlyEnabled(Ext_Zve64x) & vlewidth_pow(width) <= 6)
 
-function process_vlsseg(nf : nfields, vm : bits(1), vd : vregidx, load_width_bytes : word_width, rs1 : regidx, rs2 : regidx, EMUL_pow : int, num_elem : nat1) -> ExecutionResult = {
+function process_vlsseg(nf : nfields, vm : bits(1), vd : vregidx, load_width_bytes : word_width, rs1 : regidx, rs2 : regidx, EMUL_pow : int, num_elem : range(1, vlen)) -> ExecutionResult = {
   let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let vm_val  = read_vmask(num_elem, vm, zvreg);
   let vd_seg  = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
@@ -279,6 +285,8 @@ function clause execute VLSSEGTYPE(nf, vm, rs2, rs1, width, vd) = {
   let SEW_pow = get_sew_pow();
   let LMUL_pow = get_lmul_pow();
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
+  // TODO: The EMUL_pow calculation here is incorrect. See https://github.com/riscv/sail-riscv/issues/1196
+  assert(-3 <= EMUL_pow & EMUL_pow <= 3);
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
   assert(num_elem > 0);
@@ -299,7 +307,7 @@ mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
   when (currentlyEnabled(Ext_Zve32x) & vlewidth_pow(width) <= 5)
      | (currentlyEnabled(Ext_Zve64x) & vlewidth_pow(width) <= 6)
 
-function process_vssseg(nf : nfields, vm : bits(1), vs3 : vregidx, load_width_bytes : word_width, rs1 : regidx, rs2 : regidx, EMUL_pow : int, num_elem : nat1) -> ExecutionResult = {
+function process_vssseg(nf : nfields, vm : bits(1), vs3 : vregidx, load_width_bytes : word_width, rs1 : regidx, rs2 : regidx, EMUL_pow : int, num_elem : range(1, vlen)) -> ExecutionResult = {
   let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vs3_seg = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
@@ -338,6 +346,8 @@ function clause execute VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3) = {
   let SEW_pow = get_sew_pow();
   let LMUL_pow = get_lmul_pow();
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
+  // TODO: The EMUL_pow calculation here is incorrect. See https://github.com/riscv/sail-riscv/issues/1196
+  assert(-3 <= EMUL_pow & EMUL_pow <= 3);
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
   assert(num_elem > 0);
@@ -359,7 +369,7 @@ mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   when (currentlyEnabled(Ext_Zve32x) & vlewidth_pow(width) <= 5)
      | (currentlyEnabled(Ext_Zve64x) & vlewidth_pow(width) <= 6 & xlen == 64)
 
-function process_vlxseg(nf : nfields, vm : bits(1), vd : vregidx, EEW_index_bytes : word_width, EEW_data_bytes : word_width, EMUL_index_pow : int, EMUL_data_pow : int, rs1 : regidx, vs2 : vregidx, num_elem : nat1, mop : int) -> ExecutionResult = {
+function process_vlxseg(nf : nfields, vm : bits(1), vd : vregidx, EEW_index_bytes : word_width, EEW_data_bytes : word_width, EMUL_index_pow : int, EMUL_data_pow : int, rs1 : regidx, vs2 : vregidx, num_elem : range(1, vlen), mop : int) -> ExecutionResult = {
   let EMUL_data_reg = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vd_seg = read_vreg_seg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, nf, vd);
@@ -453,7 +463,7 @@ mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   when (currentlyEnabled(Ext_Zve32x) & vlewidth_pow(width) <= 5)
      | (currentlyEnabled(Ext_Zve64x) & vlewidth_pow(width) <= 6 & xlen == 64)
 
-function process_vsxseg(nf : nfields, vm : bits(1), vs3 : vregidx, EEW_index_bytes : word_width, EEW_data_bytes : word_width, EMUL_index_pow : int, EMUL_data_pow : int, rs1 : regidx, vs2 : vregidx, num_elem : nat1, mop : int) -> ExecutionResult = {
+function process_vsxseg(nf : nfields, vm : bits(1), vs3 : vregidx, EEW_index_bytes : word_width, EEW_data_bytes : word_width, EMUL_index_pow : int, EMUL_data_pow : int, rs1 : regidx, vs2 : vregidx, num_elem : range(1, vlen), mop : int) -> ExecutionResult = {
   let EMUL_data_reg = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vs3_seg = read_vreg_seg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, nf, vs3);

--- a/model/extensions/V/vext_utils_insts.sail
+++ b/model/extensions/V/vext_utils_insts.sail
@@ -472,7 +472,12 @@ function read_vreg_seg(num_elem, SEW, LMUL_pow, nf, vrid) = {
 // Shift amounts
 val get_shift_amount : forall 'n, 0 <= 'n . (bits('n), sew_bitsize) -> nat
 function get_shift_amount(bit_val, SEW) = {
-  let lowlog2bits = log2(SEW);
+  let lowlog2bits : range(3, 6) = match SEW {
+    8  => 3,
+    16 => 4,
+    32 => 5,
+    64 => 6,
+  };
   assert(0 < lowlog2bits & lowlog2bits < 'n);
   unsigned(bit_val[lowlog2bits - 1 .. 0]);
 }

--- a/model/extensions/bfloat16/zvfbfmin_insts.sail
+++ b/model/extensions/bfloat16/zvfbfmin_insts.sail
@@ -28,6 +28,7 @@ function clause execute (VFNCVTBF16_F_F_W(vm, vs2, vd)) = {
   then return Illegal_Instruction();
 
   assert(SEW == 16);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -79,6 +80,7 @@ function clause execute (VFWCVTBF16_F_F_V(vm, vs2, vd)) = {
   then return Illegal_Instruction();
 
   assert(SEW == 16);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;

--- a/model/extensions/bfloat16/zvfbfwma_insts.sail
+++ b/model/extensions/bfloat16/zvfbfwma_insts.sail
@@ -29,6 +29,7 @@ function clause execute VFWMACCBF16_VV(vm, vs2, vs1, vd) = {
   then return Illegal_Instruction();
 
   assert(SEW == 16);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -73,6 +74,7 @@ function clause execute VFWMACCBF16_VF(vm, vs2, rs1, vd) = {
   let num_elem = get_num_elem(LMUL_pow, SEW);
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
+  assert(LMUL_pow_widen <= 3);
 
   if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))

--- a/model/extensions/vector_crypto/zvbb_insts.sail
+++ b/model/extensions/vector_crypto/zvbb_insts.sail
@@ -540,6 +540,7 @@ function clause execute VWSLL_VV(vm, vs2, vs1, vd) = {
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -591,6 +592,7 @@ function clause execute VWSLL_VX(vm, vs2, rs1, vd) = {
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -641,6 +643,7 @@ function clause execute VWSLL_VI(vm, vs2, uimm, vd) = {
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
   let 'm = SEW;


### PR DESCRIPTION
The original code was very over-complicated.

Where `assert(-3 <= EMUL_pow & EMUL_pow <= 3);` is added, the calculation of EMUL_pow is clearly wrong - see #1196. Since this was an existing issue I have just added a TODO rather than fixing it.

This also introduces `static_assert()` which can be used for documenting properties that are already known by the type checker to be true (and it will give nice error messages if you edit the code so that it is no longer true).