### PR TITLE
Handle empty CLI input by showing help and exiting unsuccessfully

### DIFF
--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -564,7 +564,7 @@ int main(int argc, char **argv)
 
   if (argc == 1) {
     fprintf(stdout, "%s\n", app.help().c_str());
-    exit(EXIT_SUCCESS);
+    exit(EXIT_FAILURE);
   }
 
   // long_options_offset() is a local addition, so when updating CLI11,


### PR DESCRIPTION
MRunning the program without any arguments previously caused it to exit with a failure due to missing ELF files. Now, if no arguments are provided, the program prints the help text and exits unsuccessfully, without requiring an ELF file.