### PR TITLE
Fix build failure due to circular dependency introduced by merging #1210 and #1208.

### DIFF
--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -355,14 +355,14 @@ extensions {
     }
     Zihintntl_insts {
       requires riscv, Zihintntl_types
-      before I, Zca // NTL instructions override ADD, C.NTL overrides C.ADD
+      before I_insts, Zca // NTL instructions override ADD, C.NTL overrides C.ADD
       files riscv_insts_zihintntl.sail
     }
   }
 
   Zihintpause {
     requires riscv
-    before I // PAUSE overrides a FENCE
+    before I_insts // PAUSE overrides a FENCE
     files riscv_insts_zihintpause.sail
   }
 }


### PR DESCRIPTION
The dependency on `I` in #1208 needed to be refined to `I_types` after `I` was split into `I_types` and `I_insts` in #1210. 