### PR TITLE
Fix a missing `set_abstract` for `config base.E`.

### DIFF
--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -648,6 +648,8 @@ int main(int argc, char **argv)
   sail_set_abstract_vlen_exp();
   sail_set_abstract_ext_d_supported();
   sail_set_abstract_elen_exp();
+  sail_set_abstract_base_E_enabled();
+
   model_init();
 
   if (do_validate_config) {


### PR DESCRIPTION
The symptom was `base.E` could be deleted from the config without a failure.

The uninitialized `abstract_zbase_E_enabled` in the generated C was `false` and hence this was not noticed earlier.
