### PR TITLE
Fix location of generated configs for install.

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -11,7 +11,7 @@ foreach (CONFIG__BASE__XLEN IN ITEMS 32 64)
             set(CONFIG_XLEN_IS_64 "false")
             set(CONFIG_XLEN_IS_${CONFIG__BASE__XLEN} "true")
 
-            configure_file(config.json.in ${config_filename})
+            configure_file(config.json.in ${CMAKE_CURRENT_BINARY_DIR}/${config_filename})
 
             install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${config_filename}
                 DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}/config

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -13,7 +13,7 @@ foreach (CONFIG__BASE__XLEN IN ITEMS 32 64)
 
             configure_file(config.json.in ${config_filename})
 
-            install(FILES ${config_filename}
+            install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${config_filename}
                 DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}/config
             )
         endforeach()


### PR DESCRIPTION
The package build broke since it was looking in the source directory for the generated config files.