### PR TITLE
Reset PC on reset, and improve tohost address handling

### DIFF
--- a/c_emulator/riscv_platform.cpp
+++ b/c_emulator/riscv_platform.cpp
@@ -69,16 +69,6 @@ unit plat_term_write(mach_bits s)
   return UNIT;
 }
 
-bool plat_enable_htif(unit)
-{
-  return rv_enable_htif;
-}
-
-mach_bits plat_htif_tohost(unit)
-{
-  return rv_htif_tohost;
-}
-
 bool sys_enable_experimental_extensions(unit)
 {
   return rv_enable_experimental_extensions;

--- a/c_emulator/riscv_platform.h
+++ b/c_emulator/riscv_platform.h
@@ -15,9 +15,6 @@ bool valid_reservation(unit);
 
 unit plat_term_write(mach_bits);
 
-mach_bits plat_htif_tohost(unit);
-bool plat_enable_htif(unit);
-
 bool sys_enable_experimental_extensions(unit);
 
 unit memea(mach_bits, sail_int);

--- a/c_emulator/riscv_platform_impl.cpp
+++ b/c_emulator/riscv_platform_impl.cpp
@@ -17,9 +17,6 @@ uint64_t rv_16_random_bits(void)
   return (uint64_t)val;
 }
 
-uint64_t rv_htif_tohost = UINT64_C(0x80001000);
-bool rv_enable_htif = true;
-
 bool rv_enable_experimental_extensions = false;
 
 int term_fd = 1; // set during startup

--- a/c_emulator/riscv_platform_impl.h
+++ b/c_emulator/riscv_platform_impl.h
@@ -7,9 +7,6 @@
 // Provides entropy for the scalar cryptography extension.
 extern uint64_t rv_16_random_bits(void);
 
-extern uint64_t rv_htif_tohost;
-extern bool rv_enable_htif;
-
 extern bool rv_enable_experimental_extensions;
 
 extern FILE *trace_log;

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -53,6 +53,9 @@ int rvfi_dii_port = 0;
 std::optional<rvfi_handler> rvfi;
 std::vector<std::string> elfs;
 
+// The address of the HTIF tohost port, if it is enabled.
+std::optional<uint64_t> htif_tohost_address;
+
 rvfi_callbacks rvfi_cbs;
 
 std::string sig_file;
@@ -250,10 +253,10 @@ uint64_t load_sail(const std::string &filename, bool main_file)
     const auto &tohost = symbols.find("tohost");
     if (tohost == symbols.end()) {
       fprintf(stderr, "Unable to locate tohost symbol; disabling HTIF.\n");
-      rv_enable_htif = false;
+      htif_tohost_address = std::nullopt;
     } else {
-      rv_htif_tohost = tohost->second;
-      fprintf(stdout, "HTIF located at 0x%0" PRIx64 "\n", rv_htif_tohost);
+      htif_tohost_address = tohost->second;
+      fprintf(stdout, "HTIF located at 0x%0" PRIx64 "\n", *htif_tohost_address);
     }
     // Locate test-signature locations if any.
     const auto &begin_sig = symbols.find("begin_signature");
@@ -291,8 +294,13 @@ void write_dtb_to_rom(const std::vector<uint8_t> &dtb)
 
 void init_sail(uint64_t elf_entry, const char *config_file)
 {
+  // zset_pc_reset_address must be called before zinit_model
+  // because reset happens inside init_model().
+  zset_pc_reset_address(elf_entry);
+  if (htif_tohost_address.has_value()) {
+    zenable_htif(*htif_tohost_address);
+  }
   zinit_model(config_file != nullptr ? config_file : "");
-  zforce_pc(elf_entry);
   zinit_boot_requirements(UNIT);
 }
 

--- a/handwritten_support/RiscvExtras.lean
+++ b/handwritten_support/RiscvExtras.lean
@@ -22,11 +22,6 @@ section defs
 variable [Arch]
 
 -- Platform definitions
-axiom elf_tohost : Unit → Int
-axiom elf_entry : Unit → Int
-axiom plat_enable_htif : Unit → Bool
-axiom plat_htif_tohost : Unit → Arch.pa
-
 section Effectful
 
 variable {Register : Type} {RegisterType : Register → Type} [DecidableEq Register] [Hashable Register]

--- a/handwritten_support/RiscvExtrasExecutable.lean
+++ b/handwritten_support/RiscvExtrasExecutable.lean
@@ -22,11 +22,6 @@ section defs
 variable [Arch]
 
 -- Platform definitions
-def elf_tohost (_:Unit) : Int := panic "TODO"
-def elf_entry (_:Unit) : Int := panic "TODO"
-def plat_enable_htif (_ : Unit) := false
-def plat_htif_tohost (_:Unit) : BitVec n := 0x80001000
-
 section Effectful
 
 variable {Register : Type} {RegisterType : Register → Type} [DecidableEq Register] [Hashable Register]

--- a/handwritten_support/riscv_extras.lem
+++ b/handwritten_support/riscv_extras.lem
@@ -23,13 +23,6 @@ let match_reservation _ = true
 let cancel_reservation () = return ()
 let valid_reservation () = false
 
-val plat_enable_htif : unit -> bool
-let plat_enable_htif () = false
-
-val plat_htif_tohost : unit -> bitvector
-let plat_htif_tohost () = []
-declare ocaml target_rep function plat_htif_tohost = `Platform.htif_tohost`
-
 val plat_term_write : forall 'abort 'barrier 'cache_op 'fault 'pa 'tlb_op 'translation_summary 'trans_start 'trans_end 'arch_ak 'rv 'e. bitvector -> monad 'abort 'barrier 'cache_op 'fault 'pa 'tlb_op 'translation_summary 'trans_start 'trans_end 'arch_ak 'rv unit 'e
 let plat_term_write _ = return ()
 declare ocaml target_rep function plat_term_write = `Platform.term_write`

--- a/handwritten_support/riscv_extras.v
+++ b/handwritten_support/riscv_extras.v
@@ -28,10 +28,6 @@ match vs with
 | _ => Fail "empty list in internal_pick"
 end.
 
-(*val elf_entry : unit -> integer*)
-Definition elf_entry (_:unit) : Z := 0.
-(*declare ocaml target_rep function elf_entry := `Elf_loader.elf_entry`*)
-
 (*val get_time_ns : unit -> integer*)
 Definition get_time_ns (_:unit) : Z := 0.
 (*declare ocaml target_rep function get_time_ns := `(fun () -> Big_int.of_int (int_of_float (1e9 *. Unix.gettimeofday ())))`*)
@@ -41,4 +37,3 @@ Definition get_time_ns (_:unit) : Z := 0.
 Definition mults_vec {n} (l : mword n) (r : mword n) : mword (2 * n) := mults_vec l r.
 Definition mult_vec {n} (l : mword n) (r : mword n) : mword (2 * n) := mult_vec l r.
 Definition print_string (_ _:string) : unit := tt.
-Definition plat_enable_htif (_:unit) : bool := false.

--- a/handwritten_support/riscv_extras_sequential.lem
+++ b/handwritten_support/riscv_extras_sequential.lem
@@ -74,10 +74,6 @@ let match_reservation _ = true
 let cancel_reservation () = ()
 let valid_reservation () = false
 
-val plat_htif_tohost : forall 'a. Size 'a => unit -> bitvector 'a
-let plat_htif_tohost () = wordFromInteger 0
-declare ocaml target_rep function plat_htif_tohost = `Platform.htif_tohost`
-
 val plat_term_write : forall 'a. Size 'a => bitvector 'a -> unit
 let plat_term_write _ = ()
 declare ocaml target_rep function plat_term_write = `Platform.term_write`

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -94,7 +94,8 @@ add_custom_command(
         --c-preserve init_boot_requirements
         --c-preserve try_step
         --c-preserve tick_clock
-        --c-preserve force_pc
+        --c-preserve enable_htif
+        --c-preserve set_pc_reset_address
         --c-preserve generate_dts
         --c-preserve config_is_valid
         --c-preserve generate_canonical_isa_string

--- a/model/main.sail
+++ b/model/main.sail
@@ -9,26 +9,10 @@
 // When the symbolic execution is running a litmus test, it sets a
 // different entry point for each thread in the compiled litmus test.
 
-val get_entry_point : unit -> xlenbits
-
-$ifdef SYMBOLIC
-
-$include <elf.sail>
-
-function get_entry_point() = to_bits_checked(elf_entry())
-
-$else
-
-function get_entry_point() = zero_extend(0x1000)
-
-$endif
-
 function main() : unit -> unit = {
-  PC = get_entry_point();
-  print_bits("PC = ", PC);
-
   try {
     init_model("");
+    print_bits("PC = ", PC);
     sail_end_cycle();
     loop()
   } catch {

--- a/model/riscv_model.sail
+++ b/model/riscv_model.sail
@@ -8,6 +8,9 @@
 
 // Chip reset. This only does the minimum resets required by the RISC-V spec.
 function reset() -> unit = {
+  // Come out of WFI/WRS.
+  hart_state = HART_ACTIVE();
+
   reset_sys();
   reset_vmem();
 
@@ -21,7 +24,6 @@ function init_model(config_filename : string) -> unit = {
                              then "Default config"
                              else "Config in " ^ config_filename)
                              ^ " is invalid.");
-  hart_state = HART_ACTIVE();
   init_platform();
   reset();
 }

--- a/model/riscv_pc_access.sail
+++ b/model/riscv_pc_access.sail
@@ -31,8 +31,3 @@ function tick_pc() = {
   PC = nextPC;
   pc_write_callback(PC);
 }
-
-// For forcing PC from C. This is ugly.
-function force_pc(pc : bits(64)) -> unit = {
-  PC = truncate(pc, xlen);
-}

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -14,17 +14,6 @@
    - it relies on externs to get platform address information and doesn't hardcode them
 */
 
-val elf_tohost = pure {
-  interpreter: "Elf_loader.elf_tohost",
-  c: "elf_tohost"
-} :  unit -> int
-
-val elf_entry = pure {
-  interpreter: "Elf_loader.elf_entry",
-  c: "elf_entry"
-} : unit -> int
-
-
 // Cache block size is 2^cache_block_size_exp. Max is `max_mem_access` (4096)
 // because this model performs `cbo.zero` with a single write, and the behaviour
 // with cache blocks larger than a page is not clearly defined.
@@ -59,15 +48,12 @@ register plat_rom_size : physaddrbits = to_bits_checked(config platform.rom.size
 register plat_clint_base : physaddrbits = to_bits_checked(config platform.clint.base : int)
 register plat_clint_size : physaddrbits = to_bits_checked(config platform.clint.size : int)
 
-// Whether HTIF (Host Target InterFace) is enabled. This is used for
-// console output and signalling the end of tests.
-val plat_enable_htif = pure "plat_enable_htif" : unit -> bool
-
-/* Location of HTIF ports */
-val plat_htif_tohost = pure {c: "plat_htif_tohost", lem: "plat_htif_tohost"} : unit -> bits(64)
-function htif_tohost_base() -> physaddrbits = trunc(plat_htif_tohost())
-
-// todo: fromhost
+// Location of HTIF (Host Target InterFace) tohost port. None if not enabled.
+// This is used for console output and signalling the end of tests.
+register htif_tohost_base : option(physaddrbits) = None()
+let htif_tohost_size = 8
+// This is called externally. bits(64) is used because it's easier to deal with from C.
+function enable_htif(tohost_addr : bits(64)) -> unit = htif_tohost_base = Some(trunc(tohost_addr))
 
 /* Physical memory map predicates */
 
@@ -114,10 +100,13 @@ function within_clint forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : ph
 }
 
 function within_htif_writable forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : physaddr, width : int('n)) -> bool =
-    plat_enable_htif() & (htif_tohost_base() == addr | (htif_tohost_base() + 4 == addr & width == 4))
+  match htif_tohost_base {
+    None() => false,
+    Some(base) => (addr <_u base + htif_tohost_size) & (addr + width >=_u base)
+  }
 
-function within_htif_readable forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : physaddr, width : int('n)) -> bool =
-    plat_enable_htif() & (htif_tohost_base() == addr | (htif_tohost_base() + 4 == addr & width == 4))
+function within_htif_readable forall 'n, 0 < 'n <= max_mem_access . (addr : physaddr, width : int('n)) -> bool =
+  within_htif_writable(addr, width)
 
 /* CLINT (Core Local Interruptor), based on Spike. */
 
@@ -303,6 +292,7 @@ bitfield htif_cmd : bits(64) = {
   payload : 47 .. 0
 }
 
+// Current value of the HTIF tohost register.
 register htif_tohost : bits(64)
 register htif_done   : bool
 register htif_exit_code : bits(64)
@@ -330,46 +320,58 @@ function reset_htif () -> unit = {
  * dispatched the address.
  */
 
-val htif_load : forall 'n, 'n > 0. (AccessType(ext_access_type), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
-function htif_load(t, Physaddr(paddr), width) = {
+val htif_load : forall 'n, 0 < 'n <= max_mem_access . (AccessType(ext_access_type), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
+function htif_load(acc, Physaddr(paddr), width) = {
   if   get_config_print_platform()
   then print_log("htif[" ^ hex_bits_str(paddr) ^ "] -> " ^ bits_str(htif_tohost));
-  /* FIXME: For now, only allow the expected access widths. */
-  if      width == 8 & (paddr == htif_tohost_base())
+
+  let base : physaddrbits = match htif_tohost_base {
+    Some(base) => base,
+    None() => internal_error(__FILE__, __LINE__, "HTIF load while HTIF isn't enabled"),
+  };
+
+  // Only aligned 4-byte and 8-byte accesses are supported.
+  if      width == 8 & paddr == base
   then    Ok(zero_extend(64, htif_tohost))         /* FIXME: Redundant zero_extend currently required by Lem backend */
-  else if width == 4 & paddr == htif_tohost_base()
+  else if width == 4 & paddr == base
   then    Ok(zero_extend(32, htif_tohost[31..0]))  /* FIXME: Redundant zero_extend currently required by Lem backend */
-  else if width == 4 & paddr == htif_tohost_base() + 4
+  else if width == 4 & paddr == base + 4
   then    Ok(zero_extend(32, htif_tohost[63..32])) /* FIXME: Redundant zero_extend currently required by Lem backend */
-  else match t {
+  else match acc {
     InstructionFetch() => Err(E_Fetch_Access_Fault()),
     Read(Data) => Err(E_Load_Access_Fault()),
     _          => Err(E_SAMO_Access_Fault())
   }
 }
 
-val htif_store: forall 'n, 0 < 'n <= 8. (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
+val htif_store : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
 function htif_store(Physaddr(paddr), width, data) = {
   if   get_config_print_platform()
   then print_log("htif[" ^ hex_bits_str(paddr) ^ "] <- " ^ bits_str(data));
-  /* Store the written value so that we can ack it later. */
-  if      width == 8
+
+  let base : physaddrbits = match htif_tohost_base {
+    Some(base) => base,
+    None() => internal_error(__FILE__, __LINE__, "HTIF store while HTIF isn't enabled"),
+  };
+
+  // Store the written value so that we can ack it later.
+  // Only aligned 4-byte and 8-byte accesses are supported.
+  if      width == 8 & paddr == base
   then    { htif_cmd_write = bitone;
             htif_payload_writes = htif_payload_writes + 1;
             htif_tohost = zero_extend(data) }
-  else if width == 4 & paddr == htif_tohost_base()
+  else if width == 4 & paddr == base
   then    { if   data == htif_tohost[31 .. 0]
             then htif_payload_writes = htif_payload_writes + 1
             else htif_payload_writes = 0x1;
             htif_tohost = vector_update_subrange(htif_tohost, 31, 0, data) }
-  else if width == 4 & paddr == htif_tohost_base() + 4
+  else if width == 4 & paddr == base + 4
   then    { if   data[15 .. 0] == htif_tohost[47 .. 32]
             then htif_payload_writes = htif_payload_writes + 1
             else htif_payload_writes = 0x1;
             htif_cmd_write = bitone;
             htif_tohost = vector_update_subrange(htif_tohost, 63, 32, data) }
-  /* unaligned command writes are not supported and will not be detected */
-  else    { htif_tohost = zero_extend(data) };
+  else return Err(E_SAMO_Access_Fault());
 
   /* Execute if there were repeated writes of the same payload without
    * a cmd (e.g. in riscv-tests), or we have a complete htif command.
@@ -420,7 +422,7 @@ function within_mmio_writable forall 'n, 0 < 'n <= max_mem_access . (addr : phys
 function mmio_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext_access_type), paddr : physaddr, width : int('n)) -> MemoryOpResult(bits(8 * 'n)) =
   if   within_clint(paddr, width)
   then clint_load(t, paddr, width)
-  else if within_htif_readable(paddr, width) & (1 <= 'n)
+  else if within_htif_readable(paddr, width)
   then htif_load(t, paddr, width)
   else match t {
     InstructionFetch() => Err(E_Fetch_Access_Fault()),
@@ -428,10 +430,10 @@ function mmio_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext_acc
     _          => Err(E_SAMO_Access_Fault())
   }
 
-function mmio_write forall 'n, 0 <'n <= max_mem_access . (paddr : physaddr, width : int('n), data: bits(8 * 'n)) -> MemoryOpResult(bool) =
+function mmio_write forall 'n, 0 < 'n <= max_mem_access . (paddr : physaddr, width : int('n), data: bits(8 * 'n)) -> MemoryOpResult(bool) =
   if   within_clint(paddr, width)
   then clint_store(paddr, width, data)
-  else if within_htif_writable(paddr, width) & 'n <= 8
+  else if within_htif_writable(paddr, width)
   then htif_store(paddr, width, data)
   else Err(E_SAMO_Access_Fault())
 

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -295,6 +295,12 @@ function reset_misa() -> unit = {
   csr_write_callback("misa", misa.bits);
 }
 
+// Address to reset PC to on reset.
+register pc_reset_address : xlenbits = zeros()
+// This is called externally to set the PC reset address to the ELF entry point.
+// bits(64) is used because it's easier to deal with in C.
+function set_pc_reset_address(addr : bits(64)) -> unit = pc_reset_address = trunc(addr)
+
 // This function is called on reset, so it should only perform the reset actions
 // described in the "Reset" section of the privileged architecture specification.
 function reset_sys() -> unit = {
@@ -322,7 +328,8 @@ function reset_sys() -> unit = {
   cancel_reservation();
 
   // "The pc is set to an implementation-defined reset vector."
-  // This is outside the scope of this function.
+  PC = pc_reset_address;
+  nextPC = pc_reset_address;
 
   // "The mcause register is set to a value indicating the cause of the reset."
   // "The mcause values after reset have implementation-specific interpretation,


### PR DESCRIPTION
1. Add a PC reset address that PC is reset to every time the chip is reset. Configure this to be the ELF entry point.
2. Switch the ELF entry point and HTIF tohost setting to be setters rather than callbacks. These are static values and setters are much easier to deal with.
3. Remove the unused `elf_tohost` and `elf_entry` functions.