### PR TITLE
Fix Lean CMake target dependencies, flags, and outputs

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -375,12 +375,16 @@ foreach (xlen IN ITEMS 32 64)
         --lean-import-file ../handwritten_support/RiscvExtras.lean
         -o "Lean_${arch_uppercase}"
     )
+    set(lean_sail_executable
+        --lean-import-file ../handwritten_support/RiscvExtrasExecutable.lean
+        -o "Lean_${arch_uppercase}_executable"
+    )
     add_custom_command(
         DEPENDS
             ${sail_srcs}
             ${project_file}
             ${config_file}
-            ${CMAKE_SOURCE_DIR}/handwritten_support/RiscvExtrasExecutable.lean
+            ${CMAKE_SOURCE_DIR}/handwritten_support/RiscvExtras.lean
         VERBATIM
         OUTPUT "lean_${arch_uppercase}.lean"
         COMMENT "Building Lean definitions from Sail model (${arch})"
@@ -399,7 +403,7 @@ foreach (xlen IN ITEMS 32 64)
             ${sail_srcs}
             ${project_file}
             ${config_file}
-            ${CMAKE_SOURCE_DIR}/handwritten_support/RiscvExtras.lean
+            ${CMAKE_SOURCE_DIR}/handwritten_support/RiscvExtrasExecutable.lean
         VERBATIM
         OUTPUT "lean_executable_${arch_uppercase}.lean"
         COMMENT "Building executable Lean definitions from Sail model (${arch})"

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -386,7 +386,7 @@ foreach (xlen IN ITEMS 32 64)
             ${config_file}
             ${CMAKE_SOURCE_DIR}/handwritten_support/RiscvExtras.lean
         VERBATIM
-        OUTPUT "lean_${arch_uppercase}.lean"
+        OUTPUT "Lean_${arch_uppercase}/Lean${arch_uppercase}.lean"
         COMMENT "Building Lean definitions from Sail model (${arch})"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND
@@ -405,7 +405,7 @@ foreach (xlen IN ITEMS 32 64)
             ${config_file}
             ${CMAKE_SOURCE_DIR}/handwritten_support/RiscvExtrasExecutable.lean
         VERBATIM
-        OUTPUT "lean_executable_${arch_uppercase}.lean"
+        OUTPUT "Lean_${arch_uppercase}_executable/Lean${arch_uppercase}Executable.lean"
         COMMENT "Building executable Lean definitions from Sail model (${arch})"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND
@@ -418,8 +418,8 @@ foreach (xlen IN ITEMS 32 64)
             ${project_file}
     )
 
-    add_custom_target(generated_lean_${arch} DEPENDS "lean_${arch_uppercase}.lean")
-    add_custom_target(generated_lean_executable_${arch} DEPENDS "lean_executable_${arch_uppercase}.lean")
+    add_custom_target(generated_lean_${arch} DEPENDS "Lean_${arch_uppercase}/Lean${arch_uppercase}.lean")
+    add_custom_target(generated_lean_executable_${arch} DEPENDS "Lean_${arch_uppercase}_executable/Lean${arch_uppercase}Executable.lean")
 
     ############# Lem #############
 


### PR DESCRIPTION
Not sure exactly when things went wrong, but the Lean targets got a bit mixed up. This resolves the following issues:
- The executable target depended on the standard handwritten_support file and the standard target depended on the executable handwritten_support file.
- The `lean_sail_executable` variable was no longer defined, so the executable definitions were not included and the output directory was not named correctly.
- The output file was not actually generated, so the target was always rebuilt even if nothing had changed.