### PR TITLE
Add basic syscall support

### DIFF
--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -42,6 +42,10 @@ add_library(riscv_model
     config_utils.h
     symbol_table.cpp
     symbol_table.h
+    mem.cpp
+    mem.h
+    syscall.cpp
+    syscall.h
     sail_riscv_version.h
     "${CMAKE_CURRENT_BINARY_DIR}/sail_riscv_version.cpp"
     "${CMAKE_BINARY_DIR}/sail_riscv_model.c"

--- a/c_emulator/mem.cpp
+++ b/c_emulator/mem.cpp
@@ -1,0 +1,30 @@
+#include "inttypes.h"
+#include "cstddef"
+#include "mem.h"
+#include "rts.h"
+
+typedef uint64_t reg_t;
+typedef uint64_t addr_t;
+
+void mem::read(addr_t addr, size_t nbytes, void *dst)
+{
+  uint8_t *dest_bytes = static_cast<uint8_t *>(dst);
+  for (size_t i = 0; i < nbytes; ++i) {
+    dest_bytes[i] = read_mem(addr + i);
+  }
+}
+
+void mem::write(addr_t addr, size_t nbytes, const void *src)
+{
+  const uint8_t *src_bytes = static_cast<const uint8_t *>(src);
+  for (size_t i = 0; i < nbytes; ++i) {
+    write_mem(addr + i, src_bytes[i]);
+  }
+}
+
+void mem::clear(addr_t addr, size_t nbytes)
+{
+  for (size_t i = 0; i < nbytes; ++i) {
+    write_mem(addr + i, 0);
+  }
+}

--- a/c_emulator/mem.h
+++ b/c_emulator/mem.h
@@ -1,0 +1,14 @@
+#include <cstddef>
+#include "inttypes.h"
+#include "sail.h"
+
+typedef uint64_t reg_t;
+typedef int64_t sreg_t;
+typedef reg_t addr_t;
+
+class mem {
+public:
+  static void read(addr_t addr, size_t nbytes, void *bytes);
+  static void write(addr_t addr, size_t nbytes, const void *bytes);
+  static void clear(addr_t taddr, size_t nbytes);
+};

--- a/c_emulator/riscv_syscall.h
+++ b/c_emulator/riscv_syscall.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <sail.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+unit dispatch_syscall(uint64_t payload);
+
+#ifdef __cplusplus
+}
+#endif

--- a/c_emulator/syscall.cpp
+++ b/c_emulator/syscall.cpp
@@ -1,0 +1,39 @@
+// See LICENSE for license details.
+
+#include "mem.h"
+#include "syscall.h"
+#include "riscv_syscall.h"
+
+syscall_t syscall;
+
+unit dispatch_syscall(uint64_t payload)
+{
+  syscall.dispatch(payload);
+  return UNIT;
+}
+
+syscall_t::syscall_t()
+    : table(2048)
+{
+}
+
+syscall_t::~syscall_t() { }
+
+void syscall_t::dispatch(addr_t addr)
+{
+  reg_t magicmem[8];
+  mem::read(addr, sizeof(magicmem) / 8, &magicmem);
+
+  reg_t n = magicmem[0];
+
+  if (n >= table.size() || !table[n]) {
+    fprintf(stderr, "bad syscall #%ld\n", n);
+    exit(EXIT_FAILURE);
+  }
+
+  magicmem[0]
+      = (this->table[n])(magicmem[1], magicmem[2], magicmem[3], magicmem[4],
+                         magicmem[5], magicmem[6], magicmem[7]);
+
+  mem::write(addr, sizeof(magicmem) / 8, &magicmem);
+}

--- a/c_emulator/syscall.h
+++ b/c_emulator/syscall.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <sail.h>
+
+typedef uint64_t reg_t;
+
+typedef reg_t (*syscall_func_t)(reg_t, reg_t, reg_t, reg_t, reg_t, reg_t,
+                                reg_t);
+
+class syscall_t {
+public:
+  syscall_t();
+  ~syscall_t();
+
+  void dispatch(addr_t addr);
+
+private:
+  std::vector<syscall_func_t> table;
+};

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -89,6 +89,7 @@ add_custom_command(
         --c-include riscv_prelude.h
         --c-include riscv_platform.h
         --c-include riscv_callbacks.h
+        --c-include riscv_syscall.h
         # Don't dead-code eliminate these functions.
         --c-preserve init_model
         --c-preserve init_boot_requirements

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -24,6 +24,7 @@ val elf_entry = pure {
   c: "elf_entry"
 } : unit -> int
 
+val dispatch_syscall = impure "dispatch_syscall" : bits(64) -> unit
 
 // Cache block size is 2^cache_block_size_exp. Max is `max_mem_access` (4096)
 // because this model performs `cbo.zero` with a single write, and the behaviour
@@ -387,7 +388,9 @@ function htif_store(Physaddr(paddr), width, data) = {
              htif_done = true;
              htif_exit_code = (zero_extend(64, cmd[payload]) >> 1)
         }
-        else ()
+        else {
+             dispatch_syscall(zero_extend(cmd[payload]))
+        }
       },
       0x01 => { /* terminal */
         if   get_config_print_platform()


### PR DESCRIPTION
Allow the emulator to handle system calls from guest applications Changes include:
- mem.cpp, mem.h: add read/write/clear functions for memory access, enabling the emulator to read from and write to guste memory space
- syscall.cpp, syscall.h: implemente the syscall_t class, which manages a table of syscall handler functions, and dispatchs syscall to host.
- riscv_syscall.h: interface for sail code