### PR TITLE
Remove unused definitions from handwritten_support files

### DIFF
--- a/handwritten_support/RiscvExtras.lean
+++ b/handwritten_support/RiscvExtras.lean
@@ -10,50 +10,15 @@ def prerr_string (_: String) : Unit := ()
 def putchar {T} (_: T ) : Unit := ()
 def string_of_int (z : Int) := s!"{z}"
 
-axiom sys_enable_writable_misa : Unit → Bool
-axiom sys_enable_rvc : Unit → Bool
-axiom sys_enable_fdext : Unit → Bool
-axiom sys_enable_svinval : Unit → Bool
-axiom sys_enable_zcb : Unit → Bool
-axiom sys_enable_zfinx : Unit → Bool
-axiom sys_enable_writable_fiom : Unit → Bool
-axiom sys_enable_vext : Unit → Bool
-axiom sys_enable_bext : Unit → Bool
-axiom sys_enable_zicbom : Unit → Bool
-axiom sys_enable_zicboz : Unit → Bool
-axiom sys_enable_sstc : Unit → Bool
-axiom sys_writable_hpm_counters : Unit → BitVec 32
-axiom sys_enable_zvkb : Unit → Bool
-
-axiom sys_vext_vl_use_ceil : Unit → Bool
-axiom sys_vector_elen_exp : Unit → Nat
-axiom sys_vector_vlen_exp : Unit → Nat
-
-axiom sys_pmp_count : Unit → Nat
-axiom sys_pmp_count_ok : 0 ≤ sys_pmp_count () ∧ sys_pmp_count () ≤ 64
-axiom sys_pmp_grain : Unit → Nat
-axiom sys_pmp_grain_ok : 0 ≤ sys_pmp_grain () ∧ sys_pmp_grain () ≤ 63
-
 section defs
 
 variable [Arch]
 
 -- Platform definitions
-axiom plat_ram_base : Unit → Arch.pa
-axiom plat_ram_size : Unit → Arch.pa
 axiom elf_tohost : Unit → Int
 axiom elf_entry : Unit → Int
-axiom plat_enable_dirty_update : Unit → Bool
-axiom plat_enable_misaligned_access : Unit → Bool
-axiom plat_mtval_has_illegal_inst_bits  : Unit → Bool
-axiom plat_rom_base : Unit → Arch.pa
-axiom plat_rom_size : Unit → Arch.pa
 axiom plat_enable_htif : Unit → Bool
 axiom plat_htif_tohost : Unit → Arch.pa
-axiom plat_clint_base : Unit → Arch.pa
-axiom plat_clint_size : Unit → Arch.pa
-axiom plat_insns_per_tick : Unit → Int
-axiom plat_cache_block_size_exp : Unit → Int
 
 section Effectful
 

--- a/handwritten_support/RiscvExtrasExecutable.lean
+++ b/handwritten_support/RiscvExtrasExecutable.lean
@@ -10,51 +10,15 @@ def prerr_string (_: String) : Unit := ()
 def putchar {T} (_: T ) : Unit := ()
 def string_of_int (z : Int) := s!"{z}"
 
--- From: https://github.com/riscv/sail-riscv/blob/46a813bd847272a8e0901c7310bd362f7ffc303e/c_emulator/riscv_platform_impl.cpp
-def sys_enable_writable_misa (_:Unit) : Bool := true
-def sys_enable_rvc (_:Unit) : Bool := true
-def sys_enable_fdext (_:Unit) : Bool := true
-def sys_enable_svinval (_:Unit) : Bool := false
-def sys_enable_zcb (_:Unit) : Bool := false
-def sys_enable_zfinx (_:Unit) : Bool := false
-def sys_enable_writable_fiom (_:Unit) : Bool := true
-def sys_enable_vext (_:Unit) : Bool := true
-def sys_enable_bext (_:Unit) : Bool := false
-def sys_enable_zicbom (_:Unit) : Bool := false
-def sys_enable_zicboz (_:Unit) : Bool := false
-def sys_enable_sstc (_:Unit) : Bool := false
-def sys_writable_hpm_counters (_:Unit) : BitVec 32 := (0xFFFFFFFF:UInt32).toBitVec
-def sys_enable_zvkb (_: Unit) := false
-
-def sys_vext_vl_use_ceil (_:Unit) : Bool := false
-def sys_vector_elen_exp (_:Unit) : Nat := 0x6
-def sys_vector_vlen_exp (_:Unit) : Nat := 0x9
-
-def sys_pmp_count (_:Unit) : Nat := 0
-theorem sys_pmp_count_ok : 0 ≤ sys_pmp_count () ∧ sys_pmp_count () ≤ 64 := by simp; rw [sys_pmp_count]; simp
-def sys_pmp_grain (_:Unit) : Nat := 0
-theorem sys_pmp_grain_ok : 0 ≤ sys_pmp_grain () ∧ sys_pmp_grain () ≤ 63 := by simp; rw [sys_pmp_grain]; simp
-
 section defs
 
 variable [Arch]
 
 -- Platform definitions
-def plat_ram_base (_:Unit) : BitVec n := 0x80000000
-def plat_ram_size (_:Unit) : BitVec n := 0x80000000
 def elf_tohost (_:Unit) : Int := panic "TODO"
 def elf_entry (_:Unit) : Int := panic "TODO"
-def plat_enable_dirty_update (_:Unit) : Bool := false
-def plat_enable_misaligned_access (_:Unit) : Bool := panic "TODO"
-def plat_mtval_has_illegal_inst_bits  (_:Unit) : Bool := false
-def plat_rom_base (_:Unit) : BitVec n := 0x1000
-def plat_rom_size (_:Unit) : BitVec n := 0x100
 def plat_enable_htif (_ : Unit) := false
 def plat_htif_tohost (_:Unit) : BitVec n := 0x80001000
-def plat_clint_base (_:Unit) : BitVec n := 0x2000000
-def plat_clint_size (_:Unit) : BitVec n := 0xc0000
-def plat_insns_per_tick (_:Unit) : Int := 100
-def plat_cache_block_size_exp (_:Unit) : Int := 6
 
 section Effectful
 

--- a/handwritten_support/riscv_extras_sequential.lem
+++ b/handwritten_support/riscv_extras_sequential.lem
@@ -136,66 +136,6 @@ let match_reservation _ = true
 let cancel_reservation () = ()
 let valid_reservation () = false
 
-val sys_enable_writable_misa : unit -> bool
-let sys_enable_writable_misa () = true
-declare ocaml target_rep function sys_enable_writable_misa = `Platform.enable_writable_misa`
-
-val sys_enable_rvc : unit -> bool
-let sys_enable_rvc () = true
-declare ocaml target_rep function sys_enable_rvc = `Platform.enable_rvc`
-
-val sys_enable_zfinx : unit -> bool
-let sys_enable_zfinx () = false
-declare ocaml target_rep function sys_enable_zfinx = `Platform.enable_zfinx`
-
-val sys_enable_writable_fiom : unit -> bool
-let sys_enable_writable_fiom () = true
-declare ocaml target_rep function sys_enable_writable_fiom = `Platform.enable_writable_fiom`
-
-val plat_ram_base : forall 'a. Size 'a => unit -> bitvector 'a
-let plat_ram_base () = wordFromInteger 0
-declare ocaml target_rep function plat_ram_base = `Platform.dram_base`
-
-val plat_ram_size : forall 'a. Size 'a => unit -> bitvector 'a
-let plat_ram_size () = wordFromInteger 0
-declare ocaml target_rep function plat_ram_size = `Platform.dram_size`
-
-val plat_rom_base : forall 'a. Size 'a => unit -> bitvector 'a
-let plat_rom_base () = wordFromInteger 0
-declare ocaml target_rep function plat_rom_base = `Platform.rom_base`
-
-val plat_rom_size : forall 'a. Size 'a => unit -> bitvector 'a
-let plat_rom_size () = wordFromInteger 0
-declare ocaml target_rep function plat_rom_size = `Platform.rom_size`
-
-val plat_cache_block_size_exp : unit -> integer
-let plat_cache_block_size_exp () = wordFromInteger 0
-declare ocaml target_rep function plat_cache_block_size_exp = `Platform.cache_block_size_exp`
-
-val plat_clint_base : forall 'a. Size 'a => unit -> bitvector 'a
-let plat_clint_base () = wordFromInteger 0
-declare ocaml target_rep function plat_clint_base = `Platform.clint_base`
-
-val plat_clint_size : forall 'a. Size 'a => unit -> bitvector 'a
-let plat_clint_size () = wordFromInteger 0
-declare ocaml target_rep function plat_clint_size = `Platform.clint_size`
-
-val plat_enable_dirty_update : unit -> bool
-let plat_enable_dirty_update () = false
-declare ocaml target_rep function plat_enable_dirty_update = `Platform.enable_dirty_update`
-
-val plat_enable_misaligned_access : unit -> bool
-let plat_enable_misaligned_access () = false
-declare ocaml target_rep function plat_enable_misaligned_access = `Platform.enable_misaligned_access`
-
-val plat_mtval_has_illegal_inst_bits : unit -> bool
-let plat_mtval_has_illegal_inst_bits () = false
-declare ocaml target_rep function plat_mtval_has_illegal_inst_bits = `Platform.mtval_has_illegal_inst_bits`
-
-val plat_insns_per_tick : unit -> integer
-let plat_insns_per_tick () = 1
-declare ocaml target_rep function plat_insns_per_tick = `Platform.insns_per_tick`
-
 val plat_htif_tohost : forall 'a. Size 'a => unit -> bitvector 'a
 let plat_htif_tohost () = wordFromInteger 0
 declare ocaml target_rep function plat_htif_tohost = `Platform.htif_tohost`


### PR DESCRIPTION
Many of the old handwritten_support function definitions are no longer used now that the config system is in place.