### PR TITLE
Make get_config_uint64 more flexible

### DIFF
--- a/c_emulator/config_utils.cpp
+++ b/c_emulator/config_utils.cpp
@@ -1,10 +1,10 @@
-#include <stdlib.h>
-#include <string>
-#include <iostream>
+#include "config_utils.h"
 
+#include <stdexcept>
+
+#include "sail.h"
 #include "sail_config.h"
 #include "sail_riscv_model.h"
-#include "config_utils.h"
 
 // These should eventually be part of compiler-generated `model_init()`,
 // but are consolidated here pending compiler support.
@@ -17,34 +17,56 @@ void init_sail_configured_types()
   sail_set_abstract_base_E_enabled();
 }
 
+std::string keypath_to_str(const std::vector<const char *> &keypath)
+{
+  std::string s;
+  if (keypath.empty()) {
+    return s;
+  }
+  for (auto part : keypath) {
+    s += part;
+    s += ".";
+  }
+  s.pop_back();
+  return s;
+}
+
 uint64_t get_config_uint64(const std::vector<const char *> &keypath)
 {
   sail_config_json json = sail_config_get(keypath.size(), keypath.data());
 
-  if (!json) {
-    std::cerr << "Failed to find configuration option '";
-    for (auto part : keypath) {
-      std::cerr << "." << part;
-    }
-    std::cerr << "'.\n";
-    exit(EXIT_FAILURE);
+  if (json == nullptr) {
+    throw std::runtime_error("Failed to find configuration option '"
+                             + keypath_to_str(keypath) + "'.");
   }
 
-  sail_int big_n;
-  uint64_t n;
-
-  if (!sail_config_is_int(json)) {
-    std::cerr << "Configuration option '";
-    for (auto part : keypath) {
-      std::cerr << "." << part;
-    }
-    std::cerr << "' could not be parsed as an integer.\n";
-    exit(EXIT_FAILURE);
+  if (sail_config_is_int(json)) {
+    sail_int big_n;
+    CREATE(sail_int)(&big_n);
+    sail_config_unwrap_int(&big_n, json);
+    // TODO: This truncates and ignores the sign.
+    uint64_t n = sail_int_get_ui(big_n);
+    KILL(sail_int)(&big_n);
+    return n;
   }
 
-  CREATE(sail_int)(&big_n);
-  sail_config_unwrap_int(&big_n, json);
-  n = sail_int_get_ui(big_n);
-  KILL(sail_int)(&big_n);
-  return n;
+  if (sail_config_is_bits(json)) {
+    lbits big_bits;
+    CREATE(lbits)(&big_bits);
+    sail_config_unwrap_bits(&big_bits, json);
+    if (big_bits.len > 64) {
+      KILL(lbits)(&big_bits);
+      throw std::runtime_error("Couldn't read " + std::to_string(big_bits.len)
+                               + "-bit value '" + keypath_to_str(keypath)
+                               + "' into uint64_t.");
+    }
+    // Second parameter is unused; see
+    // https://github.com/rems-project/sail/issues/1429
+    fbits bits = CONVERT_OF(fbits, lbits)(big_bits, false);
+    KILL(lbits)(&big_bits);
+    return bits;
+  }
+
+  throw std::runtime_error("Configuration option '" + keypath_to_str(keypath)
+                           + "' could not be parsed as an integer.\n");
 }

--- a/c_emulator/config_utils.h
+++ b/c_emulator/config_utils.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include <cstdint>
 #include <vector>
-#include "sail.h"
 
 void init_sail_configured_types();
 
+// Get a uint64_t from the JSON config file. This works with integers and
+// non-abstract bit vectors. Bit vectors over 64 bits throw an exception.
+// Integers over 64 bits are currently silently truncated, and the sign
+// is ignored (-3 will be read as 3).
 uint64_t get_config_uint64(const std::vector<const char *> &keypath);


### PR DESCRIPTION
Add support for reading bit vectors as well as integers. This will be needed in future to read the address that we should write the DTB (Device Tree Binary/Blob) to.