### PR TITLE
Fix Clang warnings: format strings and a variable-length array.

### DIFF
--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -61,7 +61,7 @@ void log_callbacks::xreg_full_write_callback(const_sail_string abi_name,
       fprintf(trace_log, "%s <- 0x%0*" PRIX64 "\n", abi_name,
               static_cast<int>(zxlen / 4), value.bits);
     } else {
-      fprintf(trace_log, "x%lu <- 0x%0*" PRIX64 "\n", reg.bits,
+      fprintf(trace_log, "x%" PRIu64 " <- 0x%0*" PRIX64 "\n", reg.bits,
               static_cast<int>(zxlen / 4), value.bits);
     }
   }

--- a/c_emulator/riscv_prelude.cpp
+++ b/c_emulator/riscv_prelude.cpp
@@ -19,8 +19,8 @@ unit print_log_instr(const_sail_string s, uint64_t pc)
 {
   auto maybe_symbol = symbolize_address(g_symbols, pc);
   if (maybe_symbol.has_value()) {
-    fprintf(trace_log, "%-80s    %s+%lu\n", s, maybe_symbol->second.c_str(),
-            pc - maybe_symbol->first);
+    fprintf(trace_log, "%-80s    %s+%" PRIu64 "\n", s,
+            maybe_symbol->second.c_str(), pc - maybe_symbol->first);
   } else {
     fprintf(trace_log, "%s\n", s);
   }

--- a/c_emulator/rvfi_dii.cpp
+++ b/c_emulator/rvfi_dii.cpp
@@ -12,6 +12,7 @@
 #include <netinet/ip.h>
 #include <fcntl.h>
 #include <string.h>
+#include <vector>
 
 #include "sail.h"
 #include "riscv_sail.h"
@@ -109,12 +110,11 @@ void rvfi_handler::get_and_send_packet(packet_reader_fn reader,
     fprintf(stderr, "Unexpected large packet size (> 4KB): %zd\n", send_size);
     exit(EXIT_FAILURE);
   }
-  unsigned char bytes[send_size];
   /* mpz_export might not write all of the null bytes */
-  memset(bytes, 0, sizeof(bytes));
-  mpz_export(bytes, NULL, -1, 1, 0, 0, *(packet.bits));
+  std::vector<unsigned char> bytes(send_size, 0);
+  mpz_export(bytes.data(), NULL, -1, 1, 0, 0, *(packet.bits));
   /* Ensure that we can send a full packet */
-  if (write(dii_sock, bytes, send_size) != send_size) {
+  if (write(dii_sock, bytes.data(), send_size) != send_size) {
     fprintf(stderr, "Writing RVFI DII trace failed: %s\n", strerror(errno));
     exit(EXIT_FAILURE);
   }


### PR DESCRIPTION
Variable length arrays are a language extension. Clang warns about this. MacOS builds use Clang so we see these in CI.

Also fix `uint64_t` printf specifier.