### PR TITLE
Consolidate the setting of abstract types in a single function.

### DIFF
--- a/c_emulator/config_utils.cpp
+++ b/c_emulator/config_utils.cpp
@@ -3,7 +3,19 @@
 #include <iostream>
 
 #include "sail_config.h"
+#include "sail_riscv_model.h"
 #include "config_utils.h"
+
+// These should eventually be part of compiler-generated `model_init()`,
+// but are consolidated here pending compiler support.
+void init_sail_configured_types()
+{
+  sail_set_abstract_xlen();
+  sail_set_abstract_vlen_exp();
+  sail_set_abstract_ext_d_supported();
+  sail_set_abstract_elen_exp();
+  sail_set_abstract_base_E_enabled();
+}
 
 uint64_t get_config_uint64(const std::vector<const char *> &keypath)
 {

--- a/c_emulator/config_utils.h
+++ b/c_emulator/config_utils.h
@@ -3,4 +3,6 @@
 #include <vector>
 #include "sail.h"
 
+void init_sail_configured_types();
+
 uint64_t get_config_uint64(const std::vector<const char *> &keypath);

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -300,11 +300,8 @@ void init_sail(uint64_t elf_entry, const char *config_file)
 void reinit_sail(uint64_t elf_entry, const char *config_file)
 {
   model_fini();
-  sail_set_abstract_xlen();
-  sail_set_abstract_vlen_exp();
-  sail_set_abstract_ext_d_supported();
-  sail_set_abstract_elen_exp();
-  sail_set_abstract_base_E_enabled();
+
+  init_sail_configured_types();
   model_init();
   init_sail(elf_entry, config_file);
 }
@@ -567,12 +564,8 @@ int inner_main(int argc, char **argv)
   } else {
     sail_config_set_string(DEFAULT_JSON);
   }
-  sail_set_abstract_xlen();
-  sail_set_abstract_vlen_exp();
-  sail_set_abstract_ext_d_supported();
-  sail_set_abstract_elen_exp();
-  sail_set_abstract_base_E_enabled();
 
+  init_sail_configured_types();
   model_init();
 
   if (do_validate_config) {

--- a/test/unit_tests/main_unit_tests.cpp
+++ b/test/unit_tests/main_unit_tests.cpp
@@ -2,8 +2,7 @@
 #include <sail_config.h>
 
 #include "default_config.h"
-
-#include "sail_riscv_model.h"
+#include "config_utils.h"
 
 // Generated in the model C code. This is a simple test runner that just
 // runs the tests in series and aborts on the first failure. In future
@@ -25,9 +24,6 @@ int main()
   trace_log = stdout;
 
   sail_config_set_string(DEFAULT_JSON);
-  sail_set_abstract_xlen();
-  sail_set_abstract_vlen_exp();
-  sail_set_abstract_ext_d_supported();
-  sail_set_abstract_elen_exp();
+  init_sail_configured_types();
   model_test();
 }


### PR DESCRIPTION
It is too easy to miss adding each one in multiple places. This should go away once the compiler can generate them as part of `model_init()`.