### PR TITLE
Use boon for build-time schema validation of generated configs.

### DIFF
--- a/.github/workflows/compile-lean.yml
+++ b/.github/workflows/compile-lean.yml
@@ -20,7 +20,7 @@ jobs:
       - name: System dependencies (ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
         run: |
-          sudo apt install build-essential libgmp-dev z3 cvc4 opam
+          sudo apt install build-essential libgmp-dev z3 cvc4 opam cargo
 
       - name: Restore cached opam
         id: cache-opam-restore

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           # Ninja is used because the CMake Makefile generator doesn't
           # build top-level targets in parallel unfortunately.
-          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DFIRST_PARTY_TESTS=TRUE -DENABLE_RISCV_TESTS=TRUE -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE
+          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_BUILD_TIME_SCHEMA_VALIDATION=TRUE -DFIRST_PARTY_TESTS=TRUE -DENABLE_RISCV_TESTS=TRUE -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE
           ninja -C build all generated_sail_riscv_docs generated_smt_rv64d generated_smt_rv32d
           ctest --test-dir build --output-junit tests.xml --output-on-failure
 

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -27,12 +27,12 @@ jobs:
       - name: Install packages (Linux)
         if: startsWith(matrix.os, 'ubuntu-')
         run: |
-          sudo apt install -y --no-install-recommends pkg-config libgmp-dev curl ninja-build
+          sudo apt install -y --no-install-recommends pkg-config libgmp-dev curl ninja-build cargo
 
       - name: Install packages (macOS)
         if: startsWith(matrix.os, 'macos-')
         run: |
-          brew install opam llvm lld
+          brew install opam llvm lld rust
           echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
 
       - name: Install CMake

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,8 @@ jobs:
               gcc \
               gcc-c++ \
               cmake \
-              ninja-build
+              ninja-build \
+              cargo
           curl --location --output sail.tar.gz https://github.com/rems-project/sail/releases/download/$SAIL_VERSION-linux-binary/sail.tar.gz
           tar --directory=/usr/local --strip-components=1 --extract --file sail.tar.gz
 

--- a/.github/workflows/rocq.yml
+++ b/.github/workflows/rocq.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install packages
         run: |
           apt update
-          apt install -y --no-install-recommends cmake
+          apt install -y --no-install-recommends cmake cargo
           eval `opam env --safe`
           # We're still using Rocq's old name for compatibility with versions < 9
           opam install -y coq=9.0.0 coq-sail-stdpp=$SAIL_VERSION

--- a/.github/workflows/run-full-tests.yml
+++ b/.github/workflows/run-full-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install packages (Linux)
         run: |
           sudo apt update
-          sudo apt install -y --no-install-recommends pkg-config libgmp-dev curl ninja-build
+          sudo apt install -y --no-install-recommends pkg-config libgmp-dev curl ninja-build cargo
       - name: Install CMake
         uses: jwlawson/actions-setup-cmake@v2
         with:

--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -60,7 +60,7 @@ target_link_libraries(riscv_model
     PUBLIC elfio softfloat sail_runtime
 )
 
-add_dependencies(riscv_model generated_sail_riscv_model)
+add_dependencies(riscv_model generated_sail_riscv_model validate_configs)
 
 ## A binary that can load an ELF file into the model and run it.
 

--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -60,7 +60,10 @@ target_link_libraries(riscv_model
     PUBLIC elfio softfloat sail_runtime
 )
 
-add_dependencies(riscv_model generated_sail_riscv_model validate_configs)
+add_dependencies(riscv_model generated_sail_riscv_model)
+if (ENABLE_BUILD_TIME_SCHEMA_VALIDATION)
+  add_dependencies(riscv_model validate_configs)
+endif()
 
 ## A binary that can load an ELF file into the model and run it.
 

--- a/cmake/modules/FindCargo.cmake
+++ b/cmake/modules/FindCargo.cmake
@@ -1,0 +1,61 @@
+# From https://github.com/alilleybrinker/FindCargo.cmake/blob/main/FindCargo.cmake
+
+# MIT License
+#
+# Copyright (c) 2022 Andrew Lilley Brinker
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Find Cargo, possibly in ~/.cargo. Make sure to check in any `bin` subdirectories
+# on the program search path
+# TODO: Remove the Unix-ism ($ENV{HOME}) and replace it with something platform-agnostic.
+find_program(CARGO_EXECUTABLE cargo PATHS "$ENV{HOME}/.cargo" PATH_SUFFIXES bin)
+
+set(CARGO_VERSION "")
+set(CARGO_CHANNEL "stable")
+
+# If we found it, see if we can get its version.
+if(CARGO_EXECUTABLE)
+    execute_process(COMMAND ${CARGO_EXECUTABLE} -V OUTPUT_VARIABLE CARGO_VERSION_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if(CARGO_VERSION_OUTPUT MATCHES "cargo ([0-9]+\\.[0-9]+\\.[0-9]+).*")
+        set(CARGO_VERSION ${CMAKE_MATCH_1})
+    endif()
+
+    execute_process(COMMAND ${CARGO_EXECUTABLE} -V OUTPUT_VARIABLE CARGO_CHANNEL_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if(CARGO_CHANNEL_OUTPUT MATCHES "cargo [0-9]+\\.[0-9]+\\.[0-9]+-([a-zA-Z]*).*")
+        set(CARGO_CHANNEL ${CMAKE_MATCH_1})
+    endif()
+endif()
+
+# Hides the CARGO_EXECUTABLE variable unless advanced variables are requested
+mark_as_advanced(CARGO_EXECUTABLE)
+
+# Require that we find both the executable and the version. Otherwise error out.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    Cargo
+    REQUIRED_VARS
+        CARGO_VERSION
+        CARGO_CHANNEL
+        CARGO_EXECUTABLE
+    VERSION_VAR
+        CARGO_VERSION
+)

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,4 +1,8 @@
 # Create a variety of configuration files for different XLEN/ELEN/VLENs.
+# This list needs to be kept consistent with `validate_generated_configs.cmake.in`
+# in this directory.
+
+set(generated_configs "")
 foreach (CONFIG__BASE__XLEN IN ITEMS 32 64)
     foreach(CONFIG__V__ELEN_EXP RANGE 5 6)
         foreach(CONFIG__V__VLEN_EXP RANGE 7 9)
@@ -11,7 +15,9 @@ foreach (CONFIG__BASE__XLEN IN ITEMS 32 64)
             set(CONFIG_XLEN_IS_64 "false")
             set(CONFIG_XLEN_IS_${CONFIG__BASE__XLEN} "true")
 
-            configure_file(config.json.in ${CMAKE_CURRENT_BINARY_DIR}/${config_filename})
+            set(generated_config ${CMAKE_CURRENT_BINARY_DIR}/${config_filename})
+            configure_file(config.json.in ${generated_config})
+            list(APPEND generated_configs ${generated_config})
 
             install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${config_filename}
                 DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}/config
@@ -28,3 +34,5 @@ add_library(default_config INTERFACE
 )
 
 target_include_directories(default_config INTERFACE "${CMAKE_CURRENT_BINARY_DIR}")
+
+set(generated_configs ${generated_configs} PARENT_SCOPE)

--- a/config/validate_generated_configs.cmake.in
+++ b/config/validate_generated_configs.cmake.in
@@ -1,0 +1,22 @@
+# This list needs to be kept consistent with `CMakeLists.txt` in this directory.
+
+set(boon_path @boon_path@)
+set(schema_file @schema_file@)
+
+foreach (CONFIG__BASE__XLEN IN ITEMS 32 64)
+    foreach(CONFIG__V__ELEN_EXP RANGE 5 6)
+        foreach(CONFIG__V__VLEN_EXP RANGE 7 9)
+
+            math(EXPR vlen "1 << ${CONFIG__V__VLEN_EXP}")
+            math(EXPR elen "1 << ${CONFIG__V__ELEN_EXP}")
+
+            set(config_filename "rv${CONFIG__BASE__XLEN}d_v${vlen}_e${elen}.json")
+
+            message(STATUS "Validating ${config_filename} against ${schema_file}")
+            execute_process(
+                COMMAND ${boon_path} ${schema_file} ${config_filename}
+                COMMAND_ERROR_IS_FATAL ANY
+            )
+        endforeach()
+    endforeach()
+endforeach()

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory("CLI11")
 add_subdirectory("elfio")
 add_subdirectory("softfloat")
+add_subdirectory("boon")

--- a/dependencies/boon/CMakeLists.txt
+++ b/dependencies/boon/CMakeLists.txt
@@ -1,28 +1,32 @@
-find_package(Cargo)
-if(NOT Cargo_FOUND)
-    set(try_rustup "installing rustup from https://rustup.rs")
-    if (APPLE)
-        message(FATAL_ERROR "Cargo not found. Try 'brew install rust' or ${try_rustup}.")
-    elseif (UNIX)
-        message(FATAL_ERROR "Cargo not found. Try 'sudo apt install cargo' or 'sudo dnf install cargo' or ${try_rustup}.")
-    else()
-        message(FATAL_ERROR "Cargo not found. Try ${try_rustup}.")
-    endif()
+option(ENABLE_BUILD_TIME_SCHEMA_VALIDATION "Enable schema validation of generated configurations using Boon." OFF)
+
+if (ENABLE_BUILD_TIME_SCHEMA_VALIDATION)
+  find_package(Cargo)
+  if(NOT Cargo_FOUND)
+      set(try_rustup "installing rustup from https://rustup.rs")
+      if (APPLE)
+          message(FATAL_ERROR "Cargo not found. Try 'brew install rust' or ${try_rustup}.")
+      elseif (UNIX)
+          message(FATAL_ERROR "Cargo not found. Try 'sudo apt install cargo' or 'sudo dnf install cargo' or ${try_rustup}.")
+      else()
+          message(FATAL_ERROR "Cargo not found. Try ${try_rustup}.")
+      endif()
+  endif()
+
+  include(ExternalProject)
+  ExternalProject_Add(
+      boon
+      DOWNLOAD_COMMAND ""
+      CONFIGURE_COMMAND ""
+      BUILD_COMMAND ""
+      # TODO: Once we depend on CMake 3.26, use INSTALL_BYPRODUCTS
+      BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/bin/boon"
+      INSTALL_COMMAND cargo install boon-cli --locked --root ${CMAKE_CURRENT_BINARY_DIR}
+  )
+
+  add_executable(boon_cli IMPORTED GLOBAL)
+  add_dependencies(boon_cli boon)
+  set_target_properties(boon_cli PROPERTIES
+      IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/bin/boon"
+  )
 endif()
-
-include(ExternalProject)
-ExternalProject_Add(
-    boon
-    DOWNLOAD_COMMAND ""
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    # TODO: Once we depend on CMake 3.26, use INSTALL_BYPRODUCTS
-    BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/bin/boon"
-    INSTALL_COMMAND cargo install boon-cli --locked --root ${CMAKE_CURRENT_BINARY_DIR}
-)
-
-add_executable(boon_cli IMPORTED GLOBAL)
-add_dependencies(boon_cli boon)
-set_target_properties(boon_cli PROPERTIES
-    IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/bin/boon"
-)

--- a/dependencies/boon/CMakeLists.txt
+++ b/dependencies/boon/CMakeLists.txt
@@ -1,0 +1,28 @@
+find_package(Cargo)
+if(NOT Cargo_FOUND)
+    set(try_rustup "installing rustup from https://rustup.rs")
+    if (APPLE)
+        message(FATAL_ERROR "Cargo not found. Try 'brew install rust' or ${try_rustup}.")
+    elseif (UNIX)
+        message(FATAL_ERROR "Cargo not found. Try 'sudo apt install cargo' or 'sudo dnf install cargo' or ${try_rustup}.")
+    else()
+        message(FATAL_ERROR "Cargo not found. Try ${try_rustup}.")
+    endif()
+endif()
+
+include(ExternalProject)
+ExternalProject_Add(
+    boon
+    DOWNLOAD_COMMAND ""
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    # TODO: Once we depend on CMake 3.26, use INSTALL_BYPRODUCTS
+    BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/bin/boon"
+    INSTALL_COMMAND cargo install boon-cli --locked --root ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+add_executable(boon_cli IMPORTED GLOBAL)
+add_dependencies(boon_cli boon)
+set_target_properties(boon_cli PROPERTIES
+    IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/bin/boon"
+)

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -128,6 +128,28 @@ install(FILES ${schema_file}
     DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}
 )
 
+# generate script to validate generated configurations
+get_property(boon_path
+    TARGET boon_cli
+    PROPERTY IMPORTED_LOCATION
+)
+configure_file(${CMAKE_SOURCE_DIR}/config/validate_generated_configs.cmake.in
+    ${CMAKE_BINARY_DIR}/config/validate_generated_configs.cmake
+    @ONLY)
+
+# run the script after the schema is generated and if the generated configs
+# have changed.
+set(config_validation_stamp_file "${CMAKE_CURRENT_BINARY_DIR}/validated_configs.stamp")
+add_custom_command(
+    DEPENDS boon_cli generated_sail_riscv_model ${generated_configs}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/config
+    COMMAND cmake -P validate_generated_configs.cmake
+    COMMAND ${CMAKE_COMMAND} -E touch ${config_validation_stamp_file}
+    VERBATIM
+    OUTPUT ${config_validation_stamp_file}
+)
+add_custom_target(validate_configs DEPENDS ${config_validation_stamp_file})
+
 ############# JSON #############
 
 # Generate JSON snippets file.

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -128,27 +128,29 @@ install(FILES ${schema_file}
     DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}
 )
 
-# generate script to validate generated configurations
-get_property(boon_path
-    TARGET boon_cli
-    PROPERTY IMPORTED_LOCATION
-)
-configure_file(${CMAKE_SOURCE_DIR}/config/validate_generated_configs.cmake.in
-    ${CMAKE_BINARY_DIR}/config/validate_generated_configs.cmake
-    @ONLY)
+if (ENABLE_BUILD_TIME_SCHEMA_VALIDATION)
+  # generate script to validate generated configurations
+  get_property(boon_path
+      TARGET boon_cli
+      PROPERTY IMPORTED_LOCATION
+  )
+  configure_file(${CMAKE_SOURCE_DIR}/config/validate_generated_configs.cmake.in
+      ${CMAKE_BINARY_DIR}/config/validate_generated_configs.cmake
+      @ONLY)
 
-# run the script after the schema is generated and if the generated configs
-# have changed.
-set(config_validation_stamp_file "${CMAKE_CURRENT_BINARY_DIR}/validated_configs.stamp")
-add_custom_command(
-    DEPENDS boon_cli generated_sail_riscv_model ${generated_configs}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/config
-    COMMAND cmake -P validate_generated_configs.cmake
-    COMMAND ${CMAKE_COMMAND} -E touch ${config_validation_stamp_file}
-    VERBATIM
-    OUTPUT ${config_validation_stamp_file}
-)
-add_custom_target(validate_configs DEPENDS ${config_validation_stamp_file})
+  # run the script after the schema is generated and if the generated configs
+  # have changed.
+  set(config_validation_stamp_file "${CMAKE_CURRENT_BINARY_DIR}/validated_configs.stamp")
+  add_custom_command(
+      DEPENDS boon_cli generated_sail_riscv_model ${generated_configs}
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/config
+      COMMAND cmake -P validate_generated_configs.cmake
+      COMMAND ${CMAKE_COMMAND} -E touch ${config_validation_stamp_file}
+      VERBATIM
+      OUTPUT ${config_validation_stamp_file}
+  )
+  add_custom_target(validate_configs DEPENDS ${config_validation_stamp_file})
+endif()
 
 ############# JSON #############
 


### PR DESCRIPTION
boon is built from source since boon binary releases are only available for Linux and MacOS, and the Linux binaries do not work on older Ubuntu.  Building from source however does introduce a build dependency on cargo and a Rust toolchain.