### PR TITLE
Simplify read/write kinds

### DIFF
--- a/model/prelude_mem.sail
+++ b/model/prelude_mem.sail
@@ -18,8 +18,6 @@ $include <concurrency_interface.sail>
 
 enum write_kind = {
   Write_plain,
-  Write_RISCV_release,
-  Write_RISCV_strong_release,
   Write_RISCV_conditional,
   Write_RISCV_conditional_release,
   Write_RISCV_conditional_strong_release,
@@ -28,8 +26,6 @@ enum write_kind = {
 enum read_kind = {
   Read_plain,
   Read_ifetch,
-  Read_RISCV_acquire,
-  Read_RISCV_strong_acquire,
   Read_RISCV_reserved,
   Read_RISCV_reserved_acquire,
   Read_RISCV_reserved_strong_acquire,
@@ -84,8 +80,6 @@ function write_ram(wk, Physaddr(addr), width, data, meta) = {
   let request : Mem_write_request('n, 64, physaddrbits, unit, RISCV_strong_access) = struct {
     access_kind = match wk {
       Write_plain => AK_explicit(struct { variety = AV_plain, strength = AS_normal }),
-      Write_RISCV_release => AK_explicit(struct { variety = AV_plain, strength = AS_rel_or_acq }),
-      Write_RISCV_strong_release => AK_arch(struct { variety = AV_plain }),
       Write_RISCV_conditional => AK_explicit(struct { variety = AV_exclusive, strength = AS_normal }),
       Write_RISCV_conditional_release => AK_explicit(struct { variety = AV_exclusive, strength = AS_rel_or_acq }),
       Write_RISCV_conditional_strong_release => AK_arch(struct { variety = AV_exclusive }),
@@ -126,8 +120,6 @@ function read_ram(rk, Physaddr(addr), width, read_meta) = {
     access_kind = match rk {
       Read_plain => AK_explicit(struct { variety = AV_plain, strength = AS_normal }),
       Read_ifetch => AK_ifetch(),
-      Read_RISCV_acquire => AK_explicit(struct { variety = AV_plain, strength = AS_rel_or_acq }),
-      Read_RISCV_strong_acquire => AK_arch(struct { variety = AV_plain }),
       Read_RISCV_reserved => AK_explicit(struct { variety = AV_exclusive, strength = AS_normal }),
       Read_RISCV_reserved_acquire => AK_explicit(struct { variety = AV_exclusive, strength = AS_rel_or_acq }),
       Read_RISCV_reserved_strong_acquire => AK_arch(struct { variety = AV_exclusive }),

--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -55,44 +55,31 @@ function is_aligned_bits(vaddr : xlenbits, width : word_width) -> bool =
 
 overload is_aligned_addr = {is_aligned_paddr, is_aligned_vaddr, is_aligned_bits}
 
-function read_kind_of_flags (aq : bool, rl : bool, res : bool) -> option(read_kind) =
+function read_kind_of_flags (aq : bool, rl : bool, res : bool) -> read_kind =
   match (aq, rl, res) {
-    (false, false, false) => Some(Read_plain),
-    (true, false, false)  => Some(Read_RISCV_acquire),
-    (true, true, false)   => Some(Read_RISCV_strong_acquire),
-    (false, false, true)  => Some(Read_RISCV_reserved),
-    (true, false, true)   => Some(Read_RISCV_reserved_acquire),
-    (true, true, true)    => Some(Read_RISCV_reserved_strong_acquire),
-    (false, true, false)  => None(), /* should these be instead throwing error_not_implemented as below? */
-    (false, true, true)   => None()
+    (false, false, false) => Read_plain,
+    (true, false, false)  => internal_error(__FILE__, __LINE__, "Load with acquire semantics should be unreachable"),
+    (true, true, false)   => internal_error(__FILE__, __LINE__, "Load with acquire-release semantics should be unreachable"),
+    (false, false, true)  => Read_RISCV_reserved,
+    (true, false, true)   => Read_RISCV_reserved_acquire,
+    (true, true, true)    => Read_RISCV_reserved_strong_acquire,
+    // This is never called with rl=true and aq=false.
+    (false, true, false)  => internal_error(__FILE__, __LINE__, "Load with release semantics should be unreachable"),
+    (false, true, true)   => internal_error(__FILE__, __LINE__, "Load-reserved with release semantics should be unreachable"),
   }
 
 function write_kind_of_flags (aq : bool, rl : bool, con : bool) -> write_kind =
   match (aq, rl, con) {
     (false, false, false) => Write_plain,
-    (false, true,  false) => Write_RISCV_release,
+    (false, true,  false) => internal_error(__FILE__, __LINE__, "Store with release semantics should be unreachable"),
     (false, false, true)  => Write_RISCV_conditional,
     (false, true , true)  => Write_RISCV_conditional_release,
-    (true,  true,  false) => Write_RISCV_strong_release,
+    (true,  true,  false) => internal_error(__FILE__, __LINE__, "Store with aquire-release semantics should be unreachable"),
     (true,  true , true)  => Write_RISCV_conditional_strong_release,
-    // throw an illegal instruction here?
-    (true,  false, false) => throw(Error_not_implemented("store.aq")),
-    (true,  false, true)  => throw(Error_not_implemented("sc.aq"))
+    // This is never called with aq=true and rl=false.
+    (true,  false, false) => internal_error(__FILE__, __LINE__, "Store with acquire semantics should be unreachable"),
+    (true,  false, true)  => internal_error(__FILE__, __LINE__, "Store-conditional with acquire semantics should be unreachable"),
   }
-
-// only used for actual memory regions, to avoid MMIO effects
-function phys_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext_access_type), paddr : physaddr, width : int('n), aq : bool, rl: bool, res : bool, meta : bool) -> MemoryOpResult((bits(8 * 'n), mem_meta)) = {
-  let result = (match read_kind_of_flags(aq, rl, res) {
-    Some(rk) => Some(read_ram(rk, paddr, width, meta)),
-    None()   => None()
-  }) : option((bits(8 * 'n), mem_meta));
-  match (t, result) {
-    (InstructionFetch(), None()) => Err(E_Fetch_Access_Fault()),
-    (Read(Data), None()) => Err(E_Load_Access_Fault()),
-    (_,          None()) => Err(E_SAMO_Access_Fault()),
-    (_,      Some(v, m)) => Ok(v, m),
-  }
-}
 
 // Check if access is permitted according to PMPs and PMAs.
 val phys_access_check : forall 'n, 0 < 'n <= max_mem_access . (AccessType(ext_access_type), Privilege, physaddr, int('n)) -> option(ExceptionType)
@@ -119,8 +106,10 @@ function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (
       if   within_mmio_readable(paddr, width)
       then MemoryOpResult_add_meta(mmio_read(t, paddr, width), default_meta)
       else if within_phys_mem(paddr, width)
-      then phys_mem_read(t, paddr, width, aq, rl, res, meta)
-      else match t {
+      then {
+        let rk = read_kind_of_flags(aq, rl, res);
+        Ok(read_ram(rk, paddr, width, meta))
+      } else match t {
         InstructionFetch() => Err(E_Fetch_Access_Fault()),
         Read(Data) => Err(E_Load_Access_Fault()),
         _          => Err(E_SAMO_Access_Fault())
@@ -169,10 +158,6 @@ function mem_write_ea (addr, width, aq, rl, con) =
   then Err(E_SAMO_Addr_Align())
   else Ok(write_ram_ea(write_kind_of_flags(aq, rl, con), addr, width))
 
-// only used for actual memory regions, to avoid MMIO effects
-function phys_mem_write forall 'n, 0 < 'n <= max_mem_access . (wk : write_kind, paddr : physaddr, width : int('n), data : bits(8 * 'n), meta : mem_meta) -> MemoryOpResult(bool) =
-  Ok(write_ram(wk, paddr, width, data, meta))
-
 /* dispatches to MMIO regions or physical memory regions depending on physical memory map */
 function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
   paddr : physaddr,
@@ -193,7 +178,7 @@ function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
       else if within_phys_mem(paddr, width)
       then {
         let wk = write_kind_of_flags(aq, rl, con);
-        phys_mem_write(wk, paddr, width, data, meta)
+        Ok(write_ram(wk, paddr, width, data, meta))
       } else Err(E_SAMO_Access_Fault())
     }
   }


### PR DESCRIPTION
Remove the `option()` return type on `read_kind_of_flags` and remove some `read_kind`/`write_kind` values because they are all unreachable.

`res`/`con` are only true for AMOs and lr/sc. In those cases we always condition `rl` on `aq` or vice versa. This means half the entries are unreachable.