### PR TITLE
Move print_log_instr to new fetch_callback

### DIFF
--- a/c_emulator/riscv_callbacks.cpp
+++ b/c_emulator/riscv_callbacks.cpp
@@ -18,6 +18,14 @@ void remove_callback(callbacks_if *cb)
                   callbacks.end());
 }
 
+unit fetch_callback(sail_int step_no, uint64_t code, bool rvc)
+{
+  for (auto cb : callbacks) {
+    cb->fetch_callback(step_no, code, rvc);
+  }
+  return UNIT;
+}
+
 unit mem_write_callback(const char *type, sbits paddr, uint64_t width,
                         lbits value)
 {

--- a/c_emulator/riscv_callbacks.h
+++ b/c_emulator/riscv_callbacks.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif
 
+unit fetch_callback(sail_int step_no, uint64_t code, bool rvc);
 unit mem_write_callback(const char *type, sbits paddr, uint64_t width,
                         lbits value);
 unit mem_read_callback(const char *type, sbits paddr, uint64_t width,

--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -10,6 +10,9 @@ public:
   virtual ~callbacks_if() = default;
 
   // TODO: finding ways to improve the format
+  virtual void fetch_callback(sail_int /*step_no*/, uint64_t /*code*/,
+                              bool /*rvc*/) { };
+
   virtual void mem_write_callback(const char *type, sbits paddr, uint64_t width,
                                   lbits value)
       = 0;

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -107,3 +107,24 @@ void log_callbacks::vreg_write_callback(unsigned reg, lbits value)
 void log_callbacks::pc_write_callback(sbits) { }
 
 void log_callbacks::trap_callback() { }
+
+#define CREATEX(T, val)                                                        \
+  T val;                                                                       \
+  CREATE(T)(&val);
+
+void log_callbacks::fetch_callback(sail_int step_no, uint64_t code, bool rvc)
+{
+  CREATEX(sail_string, cur_privilege_str);
+  zprivLevel_to_str(&cur_privilege_str, zcur_privilege);
+  CREATEX(sail_string, insn_str);
+  char code_str[11] = {};
+  if (rvc) {
+    zassembly_half(&insn_str, (uint16_t)code);
+    sprintf(code_str, "0x%" PRIX16, (uint16_t)code);
+  } else {
+    zassembly_word(&insn_str, (uint32_t)code);
+    sprintf(code_str, "0x%" PRIX32, (uint32_t)code);
+  }
+  gmp_printf("[%Zd] [%s]: 0x%" PRIX64 " (%s) %s", step_no, cur_privilege_str,
+             zPC.bits, code_str, insn_str);
+}

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -10,6 +10,9 @@ public:
                 bool config_use_abi_names = false, FILE *trace_log = NULL);
 
   // callbacks_if
+  virtual void fetch_callback(sail_int step_no, uint64_t code,
+                              bool rvc) override;
+
   void mem_write_callback(const char *type, sbits paddr, uint64_t width,
                           lbits value) override;
   void mem_read_callback(const char *type, sbits paddr, uint64_t width,

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -98,6 +98,8 @@ add_custom_command(
         --c-preserve generate_dts
         --c-preserve config_is_valid
         --c-preserve generate_canonical_isa_string
+        --c-preserve assembly_half
+        --c-preserve assembly_word
         # Preserve RVFI functions.
         --c-preserve rvfi_set_instr_packet
         --c-preserve rvfi_get_cmd

--- a/model/riscv_callbacks.sail
+++ b/model/riscv_callbacks.sail
@@ -7,6 +7,9 @@
 /*=======================================================================================*/
 
 // Callbacks for state-changing events
+val fetch_callback = pure {c: "fetch_callback"} : (nat, bits(32), bool) -> unit
+function fetch_callback(_, _, _) = ()
+
 val mem_write_callback = pure {c: "mem_write_callback"} : forall 'n, 0 < 'n <= max_mem_access . (/* access type */ string, /* addr */ physaddrbits, /* width */ int('n), /* value */ bits(8 * 'n)) -> unit
 function mem_write_callback(_) = ()
 

--- a/model/riscv_insts_end.sail
+++ b/model/riscv_insts_end.sail
@@ -40,4 +40,16 @@ end encdec_compressed
 val print_insn : instruction -> string
 function print_insn insn = assembly(insn)
 
+val assembly_half : half -> string
+function assembly_half(code) = {
+    let insn : instruction = encdec_compressed(code);
+    assembly(insn)
+}
+
+val assembly_word : word -> string
+function assembly_word(code) = {
+    let insn : instruction = encdec(code);
+    assembly(insn)
+}
+
 overload to_str = {print_insn}

--- a/model/riscv_step.sail
+++ b/model/riscv_step.sail
@@ -99,10 +99,7 @@ function run_hart_active(step_no: nat) -> Step = {
         sail_instr_announce(h);
         let instbits : instbits = zero_extend(h);
         let instruction = ext_decode_compressed(h);
-        if   get_config_print_instr()
-        then {
-          print_log_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(PC) ^ " (" ^ bits_str(h) ^ ") " ^ to_str(instruction), zero_extend(PC));
-        };
+        fetch_callback(step_no, zero_extend(h), true);
         /* check for RVC once here instead of every RVC execute clause. */
         if currentlyEnabled(Ext_Zca) then {
           nextPC = PC + 2;
@@ -116,10 +113,7 @@ function run_hart_active(step_no: nat) -> Step = {
         sail_instr_announce(w);
         let instbits : instbits = zero_extend(w);
         let instruction = ext_decode(w);
-        if   get_config_print_instr()
-        then {
-          print_log_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(PC) ^ " (" ^ bits_str(w) ^ ") " ^ to_str(instruction), zero_extend(PC));
-        };
+        fetch_callback(step_no, zero_extend(w), false);
         nextPC = PC + 4;
         let r = execute(instruction);
         Step_Execute(r, instbits)


### PR DESCRIPTION
This add a new callback type fetch_callback, which will be called after fetch done. I set a default empty implementation for fetch_callback, so we don't have to add an empty implementation for rvfi_callback as well.
This also move the function print_log_instr to fetch_callback.

But this is just a propose now, because there are still many ugly places in the code.

1. The c implemation of fetch_callback is much complex then sail version. The interaction between sail and C is not very convenient.
2. It decoded twice, both in sail(before execute) and c(fetch_callback). 
	One solution maybe is passing the decoded `zinstruction` value to c, but this will cause issue about file dependency
    `fetch_callback(riscv_core) -> zinstruction(riscv_postlude) -> (riscv_core)`