### PR TITLE
Add html doc bundle to build and release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Build simulators and JSON
+      - name: Build simulators, JSON and HTML
         run: |
           git config --global --add safe.directory '*'
           cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DSTATIC=TRUE -DENABLE_RISCV_TESTS=TRUE -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE
@@ -84,6 +84,7 @@ jobs:
           path: |
             build/sail-riscv-*
             build/model/sail_riscv_model.json
+            build/model/sail_riscv_html.tgz
           if-no-files-found: error
 
   release:
@@ -101,6 +102,7 @@ jobs:
           files: |
             release-linux-amd64/sail-riscv-Linux-x86_64.tar.gz
             release-linux-amd64/model/sail_riscv_model.json
+            release-linux-amd64/model/sail_riscv_html.tgz
           fail_on_unmatched_files: true
           tag_name: ${{ inputs.version }}
           body: ${{ inputs.notes }}

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -21,6 +21,9 @@
   [document](./AddingExtensions.md) providing basic suggestions on
   adding an extension to the model has been added.
 
+- A tarfile of the HTML-rendered Sail sources was added to the
+  build and release artifacts.
+
 # Release notes for the 0.8 release
 
 This is a major release with some backwards-incompatible changes.

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -168,7 +168,7 @@ add_custom_target(generated_sail_riscv_docs DEPENDS "${CMAKE_CURRENT_BINARY_DIR}
 
 ############# HTML #############
 
-# Generate HTML zip
+# Generate HTML tgz
 set(model_html_tgz "sail_riscv_html.tgz")
 set(model_html_out "html_docs")
 
@@ -193,7 +193,7 @@ add_custom_command(
         --all-modules
         ${project_file}
 )
-# Create zip with the build directory as working directory.
+# Create tgz with the build directory as working directory.
 add_custom_command(
     DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${model_html_out}"
     OUTPUT ${model_html_tgz}

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -166,6 +166,34 @@ add_custom_command(
 
 add_custom_target(generated_sail_riscv_docs DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${model_doc}")
 
+############# HTML #############
+
+# Generate HTML zip
+set(model_html_tgz "sail_riscv_html.tgz")
+set(model_html_out "html_docs")
+
+add_custom_command(
+    DEPENDS ${sail_srcs} ${project_file}
+    OUTPUT ${model_html_tgz}
+    VERBATIM
+    COMMENT "Building HTML from Sail model"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND
+        ${SAIL_BIN}
+        ${sail_common}
+        # Generate HTML
+        --html
+        -o ${model_html_out}
+        # Input files
+        --all-modules
+        ${project_file}
+    COMMAND
+        cmake -E tar cvfz "${CMAKE_CURRENT_BINARY_DIR}/${model_html_tgz}" ${model_html_out}
+)
+
+add_custom_target(generated_html_tgz DEPENDS ${model_html_tgz})
+add_dependencies(generated_sail_riscv_docs generated_html_tgz)
+
 ############# Formal #############
 
 # Theorem prover backends require compile time configuration.

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -183,12 +183,12 @@ add_custom_command(
         ${sail_common}
         # Generate HTML
         --html
-        -o ${model_html_out}
+        -o "${CMAKE_CURRENT_BINARY_DIR}/${model_html_out}"
         # Input files
         --all-modules
         ${project_file}
     COMMAND
-        cmake -E tar cvfz "${CMAKE_CURRENT_BINARY_DIR}/${model_html_tgz}" ${model_html_out}
+        cmake -E tar cvfz "${CMAKE_CURRENT_BINARY_DIR}/${model_html_tgz}" "${CMAKE_CURRENT_BINARY_DIR}/${model_html_out}"
 )
 
 add_custom_target(generated_html_tgz DEPENDS ${model_html_tgz})

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -174,10 +174,15 @@ set(model_html_out "html_docs")
 
 add_custom_command(
     DEPENDS ${sail_srcs} ${project_file}
-    OUTPUT ${model_html_tgz}
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${model_html_out}"
     VERBATIM
     COMMENT "Building HTML from Sail model"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    # Ensure the output directory exists to work around
+    # a bug in Sail 0.19.1 that got fixed in
+    # https://github.com/rems-project/sail/commit/cbd2c49b8953378685cb135306ed4a3bcde07824
+    COMMAND
+        cmake -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/${model_html_out}"
     COMMAND
         ${SAIL_BIN}
         ${sail_common}
@@ -187,8 +192,15 @@ add_custom_command(
         # Input files
         --all-modules
         ${project_file}
+)
+# Create zip with the build directory as working directory.
+add_custom_command(
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${model_html_out}"
+    OUTPUT ${model_html_tgz}
+    VERBATIM
+    COMMENT "Creating HTML tgz bundle"
     COMMAND
-        cmake -E tar cvfz "${CMAKE_CURRENT_BINARY_DIR}/${model_html_tgz}" "${CMAKE_CURRENT_BINARY_DIR}/${model_html_out}"
+        cmake -E tar cvfz ${model_html_tgz} ${model_html_out}
 )
 
 add_custom_target(generated_html_tgz DEPENDS ${model_html_tgz})


### PR DESCRIPTION
This bundles the Sail unit tests as well, not sure it's worth excluding those.

The generated html and json are separate for now; it might be more convenient that way.

Fixes #1265.