### PR TITLE
Fix experimental extension failure in theorem prover targets

### DIFF
--- a/handwritten_support/RiscvExtras.lean
+++ b/handwritten_support/RiscvExtras.lean
@@ -36,6 +36,7 @@ axiom cancel_reservation : Unit → SailM Unit
 axiom valid_reservation : Unit → Bool
 
 axiom get_16_random_bits : Unit → SailM (BitVec 16)
+axiom sys_enable_experimental_extensions : Unit → Bool
 
 end Effectful
 

--- a/handwritten_support/RiscvExtrasExecutable.lean
+++ b/handwritten_support/RiscvExtrasExecutable.lean
@@ -36,6 +36,7 @@ def cancel_reservation : Unit → SailM Unit := λ _ => panic "TODO"
 def valid_reservation : Unit → Bool := λ _ => false
 
 def get_16_random_bits : Unit → SailM (BitVec 16) := λ _ => panic "TODO"
+def sys_enable_experimental_extensions : Unit → Bool := λ _ => false
 
 end Effectful
 

--- a/handwritten_support/riscv_extras.lem
+++ b/handwritten_support/riscv_extras.lem
@@ -36,6 +36,8 @@ val plat_get_16_random_bits : forall 'abort 'barrier 'cache_op 'fault 'pa 'tlb_o
 let plat_get_16_random_bits () = choose_bitvector "plat_get_16_random_bits" 16
 declare ocaml target_rep function plat_get_16_random_bits = `Platform.get_16_random_bits`
 
+def sys_enable_experimental_extensions () = false
+
 val shift_bits_right : bitvector -> bitvector -> bitvector
 let shift_bits_right v m = shiftr v (uint m)
 val shift_bits_left : bitvector -> bitvector -> bitvector


### PR DESCRIPTION
The `sys_enable_experimental_extensions` function was not added to the handwritten files for the theorem provers.

This fixes the Lean build failure in #1245.