### PR TITLE
Add split attributes to `execute` clauses for the documentation backend.

### DIFF
--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -23,7 +23,8 @@ mapping encdec_uop : uop <-> bits(7) = {
 mapping clause encdec = UTYPE(imm, rd, op)
   <-> imm @ encdec_reg(rd) @ encdec_uop(op)
 
-function clause execute (UTYPE(imm, rd, op)) = {
+$[split op]
+function clause execute UTYPE(imm, rd, op) = {
   let off : xlenbits = sign_extend(imm @ 0x000);
   X(rd) = match op {
     LUI   => off,
@@ -110,7 +111,8 @@ mapping encdec_bop : bop <-> bits(3) = {
 mapping clause encdec = BTYPE(imm7_6 @ imm5_0 @ imm7_5_0 @ imm5_4_1 @ 0b0, rs2, rs1, op)
   <-> imm7_6 : bits(1) @ imm7_5_0 : bits(6) @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_bop(op) @ imm5_4_1 : bits(4) @ imm5_0 : bits(1) @ 0b1100011
 
-function clause execute (BTYPE(imm, rs2, rs1, op)) = {
+$[split op]
+function clause execute BTYPE(imm, rs2, rs1, op) = {
   let taken : bool = match op {
     BEQ  => X(rs1) == X(rs2),
     BNE  => X(rs1) != X(rs2),
@@ -151,7 +153,8 @@ mapping encdec_iop : iop <-> bits(3) = {
 mapping clause encdec = ITYPE(imm, rs1, rd, op)
   <-> imm @ encdec_reg(rs1) @ encdec_iop(op) @ encdec_reg(rd) @ 0b0010011
 
-function clause execute (ITYPE (imm, rs1, rd, op)) = {
+$[split op]
+function clause execute ITYPE(imm, rs1, rd, op) = {
   let immext : xlenbits = sign_extend(imm);
   X(rd) = match op {
     ADDI  => X(rs1) + immext,
@@ -195,7 +198,8 @@ mapping clause encdec = SHIFTIOP(shamt, rs1, rd, SRAI)
   <-> 0b010000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
   when xlen == 64 | shamt[5] == bitzero
 
-function clause execute (SHIFTIOP(shamt, rs1, rd, op)) = {
+$[split op]
+function clause execute SHIFTIOP(shamt, rs1, rd, op) = {
   let shamt = shamt[log2_xlen - 1 .. 0];
   X(rd) = match op {
     SLLI => X(rs1) << shamt,
@@ -228,7 +232,8 @@ mapping clause encdec = RTYPE(rs2, rs1, rd, SRL)  <-> 0b0000000 @ encdec_reg(rs2
 mapping clause encdec = RTYPE(rs2, rs1, rd, SUB)  <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
 mapping clause encdec = RTYPE(rs2, rs1, rd, SRA)  <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
 
-function clause execute (RTYPE(rs2, rs1, rd, op)) = {
+$[split op]
+function clause execute RTYPE(rs2, rs1, rd, op) = {
   X(rd) = match op {
     ADD  => X(rs1) + X(rs2),
     SLT  => zero_extend(bool_to_bits(X(rs1) <_s X(rs2))),
@@ -357,7 +362,8 @@ mapping clause encdec = RTYPEW(rs2, rs1, rd, SRAW)
   <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0111011
   when xlen == 64
 
-function clause execute (RTYPEW(rs2, rs1, rd, op)) = {
+$[split op]
+function clause execute RTYPEW(rs2, rs1, rd, op) = {
   let rs1_val = X(rs1)[31..0];
   let rs2_val = X(rs2)[31..0];
   let result : bits(32) = match op {
@@ -396,7 +402,8 @@ mapping clause encdec = SHIFTIWOP(shamt, rs1, rd, SRAIW)
   <-> 0b0100000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0011011
   when xlen == 64
 
-function clause execute (SHIFTIWOP(shamt, rs1, rd, op)) = {
+$[split op]
+function clause execute SHIFTIWOP(shamt, rs1, rd, op) = {
   let rs1_val = X(rs1)[31..0];
   let result : bits(32) = match op {
     SLLIW => rs1_val << shamt,

--- a/model/riscv_insts_dext.sail
+++ b/model/riscv_insts_dext.sail
@@ -275,7 +275,8 @@ mapping clause encdec = F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, FNMADD_D)
 
 // Execution semantics ================================
 
-function clause execute (F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, op)) = {
+$[split op]
+function clause execute F_MADD_TYPE_D(rs3, rs2, rs1, rm, rd, op) = {
   let rs1_val_64b = F_or_X_D(rs1);
   let rs2_val_64b = F_or_X_D(rs2);
   let rs3_val_64b = F_or_X_D(rs3);
@@ -342,7 +343,8 @@ mapping clause encdec = F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, FDIV_D)
 
 // Execution semantics ================================
 
-function clause execute (F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, op)) = {
+$[split op]
+function clause execute F_BIN_RM_TYPE_D(rs2, rs1, rm, rd, op) = {
   let rs1_val_64b = F_or_X_D(rs1);
   let rs2_val_64b = F_or_X_D(rs2);
   match (select_instr_or_fcsr_rm (rm)) {

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -371,7 +371,8 @@ mapping clause encdec = F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, FNMADD_S)
 
 // Execution semantics ================================
 
-function clause execute (F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, op)) = {
+$[split op]
+function clause execute F_MADD_TYPE_S(rs3, rs2, rs1, rm, rd, op) = {
   let rs1_val_32b = F_or_X_S(rs1);
   let rs2_val_32b = F_or_X_S(rs2);
   let rs3_val_32b = F_or_X_S(rs3);
@@ -437,7 +438,8 @@ mapping clause encdec = F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, FDIV_S)
 
 // Execution semantics ================================
 
-function clause execute (F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, op)) = {
+$[split op]
+function clause execute F_BIN_RM_TYPE_S(rs2, rs1, rm, rd, op) = {
   let rs1_val_32b = F_or_X_S(rs1);
   let rs2_val_32b = F_or_X_S(rs2);
   match (select_instr_or_fcsr_rm (rm)) {

--- a/model/riscv_insts_zaamo.sail
+++ b/model/riscv_insts_zaamo.sail
@@ -54,7 +54,8 @@ mapping clause encdec = AMO(op, aq, rl, rs2, rs1, size, rd)
 
 // NOTE: Currently, we only EA if address translation is successful.
 // This may need revisiting.
-function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
+$[split op]
+function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
   let 'width = width;
 
   // This is checked during decoding.

--- a/model/riscv_insts_zbb.sail
+++ b/model/riscv_insts_zbb.sail
@@ -59,7 +59,8 @@ mapping zbb_rtypew_mnemonic : bropw_zbb <-> string = {
 mapping clause assembly = ZBB_RTYPEW(rs2, rs1, rd, op)
   <-> zbb_rtypew_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (ZBB_RTYPEW(rs2, rs1, rd, op)) = {
+$[split op]
+function clause execute ZBB_RTYPEW(rs2, rs1, rd, op) = {
   let rs1_val = X(rs1)[31..0];
   let shamt = X(rs2)[4..0];
   let result : bits(32) = match op {
@@ -124,7 +125,8 @@ mapping zbb_rtype_mnemonic : brop_zbb <-> string = {
 mapping clause assembly = ZBB_RTYPE(rs2, rs1, rd, op)
   <-> zbb_rtype_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (ZBB_RTYPE(rs2, rs1, rd, op)) = {
+$[split op]
+function clause execute ZBB_RTYPE(rs2, rs1, rd, op) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
   let result : xlenbits = match op {
@@ -170,7 +172,8 @@ mapping zbb_extop_mnemonic : extop_zbb <-> string = {
 mapping clause assembly = ZBB_EXTOP(rs1, rd, op)
   <-> zbb_extop_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (ZBB_EXTOP(rs1, rd, op)) = {
+$[split op]
+function clause execute ZBB_EXTOP(rs1, rd, op) = {
   let rs1_val = X(rs1);
   let result : xlenbits = match op {
     SEXTB => sign_extend(rs1_val[7..0]),

--- a/model/riscv_insts_zbkb.sail
+++ b/model/riscv_insts_zbkb.sail
@@ -25,7 +25,8 @@ mapping zbkb_rtype_mnemonic : brop_zbkb <-> string = {
 mapping clause assembly = ZBKB_RTYPE(rs2, rs1, rd, op)
   <-> zbkb_rtype_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (ZBKB_RTYPE(rs2, rs1, rd, op)) = {
+$[split op]
+function clause execute ZBKB_RTYPE(rs2, rs1, rd, op) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
   let result : xlenbits = match op {

--- a/model/riscv_insts_zbs.sail
+++ b/model/riscv_insts_zbs.sail
@@ -37,7 +37,8 @@ mapping zbs_iop_mnemonic : biop_zbs <-> string = {
 mapping clause assembly = ZBS_IOP(shamt, rs1, rd, op)
   <-> zbs_iop_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_6(shamt)
 
-function clause execute (ZBS_IOP(shamt, rs1, rd, op)) = {
+$[split op]
+function clause execute ZBS_IOP(shamt, rs1, rd, op) = {
   let rs1_val = X(rs1);
   let mask : xlenbits = if xlen == 32
                         then zero_extend(0b1) << shamt[4..0]
@@ -81,7 +82,8 @@ mapping zbs_rtype_mnemonic : brop_zbs <-> string = {
 mapping clause assembly = ZBS_RTYPE(rs2, rs1, rd, op)
   <-> zbs_rtype_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (ZBS_RTYPE(rs2, rs1, rd, op)) = {
+$[split op]
+function clause execute ZBS_RTYPE(rs2, rs1, rd, op) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
   let mask : xlenbits = if xlen == 32

--- a/model/riscv_insts_zfh.sail
+++ b/model/riscv_insts_zfh.sail
@@ -204,7 +204,8 @@ mapping clause encdec = F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, FDIV_H)
 
 // Execution semantics ================================
 
-function clause execute (F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, op)) = {
+$[split op]
+function clause execute F_BIN_RM_TYPE_H(rs2, rs1, rm, rd, op) = {
   let rs1_val_16b = F_or_X_H(rs1);
   let rs2_val_16b = F_or_X_H(rs2);
   match (select_instr_or_fcsr_rm (rm)) {
@@ -267,7 +268,8 @@ mapping clause encdec = F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, FNMADD_H)
 
 // Execution semantics ================================
 
-function clause execute (F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, op)) = {
+$[split op]
+function clause execute F_MADD_TYPE_H(rs3, rs2, rs1, rm, rd, op) = {
   let rs1_val_16b = F_or_X_H(rs1);
   let rs2_val_16b = F_or_X_H(rs2);
   let rs3_val_16b = F_or_X_H(rs3);

--- a/model/riscv_insts_zicond.sail
+++ b/model/riscv_insts_zicond.sail
@@ -27,6 +27,7 @@ mapping zicond_mnemonic : zicondop <-> string = {
 mapping clause assembly = ZICOND_RTYPE(rs2, rs1, rd, op)
   <-> zicond_mnemonic(op) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
+$[split op]
 function clause execute ZICOND_RTYPE(rs2, rs1, rd, op) = {
   let condition : bool = match op {
     CZERO_EQZ => X(rs2) == zeros(),


### PR DESCRIPTION
This should help generate bodies for individual instructions from a combined `execute` clause.