### PR TITLE
Fix file name references after restructuring

### DIFF
--- a/doc/AddingExtensions.md
+++ b/doc/AddingExtensions.md
@@ -37,7 +37,7 @@ specification.
 ## Registering and configuring the extension
 
 An enum clause for the extension needs to be added to
-[riscv_extensions.sail](../model/core/extensions.sail) at an
+[extensions.sail](../model/core/extensions.sail) at an
 appropriate location according to the canonical ordering described
 there. The extension should also be added to the
 `extensions_ordered_for_isa_string` array.
@@ -55,7 +55,7 @@ fields of this entry.
 
 The value of `"supported"` in the JSON config file is used to define
 the `hartSupports` clause for the extension in
-[riscv_extensions.sail](../model/core/extensions.sail) using the
+[extensions.sail](../model/core/extensions.sail) using the
 `config extensions.<ext_name>.supported` construct.
 
 A definition for the `currentlyEnabled` clause for the extension
@@ -66,13 +66,13 @@ should be provided in one of the files implementing the extension.
 Each new set of instructions can be specified in a separate
 self-contained file, with their instruction encodings, assembly
 language specifications and the corresponding encoders and decoders,
-and execution semantics. The various `riscv_insts_*.sail` files can be
+and execution semantics. The various `<ext_name>_insts.sail` files can be
 examined for examples on how this can be done. Care should be taken when
 defining the assembly clauses to ensure they are consistent with the
 format expected by assemblers in standard toolchains.
 
 Instructions that interact with virtual memory can use the functions
-defined in [riscv_vmem_utils.sail](../model/sys/vmem_utils.sail).
+defined in [vmem_utils.sail](../model/sys/vmem_utils.sail).
 
 ## Adding new CSRs
 

--- a/doc/ReadingGuide.md
+++ b/doc/ReadingGuide.md
@@ -21,11 +21,11 @@ modules. The RISC-V specification consists of a few core modules and
 several extension modules. Within a module, the later files in the
 module usually depend on the earlier ones.
 
-The `riscv_core`, `riscv` and `riscv_postlude` modules are the primary
+The `core`, `riscv` and `postlude` modules are the primary
 core modules, with most of the other modules being submodules of the
 `extensions` module.
 
-### The `riscv_core` module
+### The `core` module
 
 This module provide the types and functions that the rest of the
 modules depend on.
@@ -61,7 +61,7 @@ allowing the model to be used with testing tools such as
 [TestRIG](https://github.com/CTSRD-CHERI/TestRIG). These files can be
 ignored on a first reading.
 
-`riscv_types*.sail` and `*types.sail` contain important types
+`types_*.sail` and `*_types.sail` contain important types
 that are used in the rest of the specification.
 [types.sail](../model/core/types.sail) contains some basic
 RISC-V definitions. This file should be read early since these
@@ -104,7 +104,7 @@ The floating point arithmetic in the model is implemented by a wrapper
 around the Berkeley Softfloat library; this wrapper is implemented in
 [softfloat_interface.sail](../model/core/softfloat_interface.sail).
 
-### The `riscv_exceptions` and `pmp` modules
+### The `exceptions` and `pmp` modules
 
 The handling of the addresses involved in exception handling are
 specified by the functions in
@@ -113,7 +113,7 @@ while
 [sync_exception.sail](../model/exceptions/sync_exception.sail)
 defines a structure that is used to capture the architectural
 information for an exception. These files constitute the
-`riscv_exceptions` module.
+`exceptions` module.
 
 The `pmp` module implements physical memory protection
 (PMP). [pmp_regs.sail](../model/pmp/pmp_regs.sail) defines
@@ -166,7 +166,7 @@ account.
 
 [insts_begin.sail](../model/sys/insts_begin.sail) sets up
 the infrastructure for the definition of instructions in the rest of
-the model. Files matching `insts_*.sail` capture the
+the model. Files matching `<ext_name>_insts.sail` capture the
 instruction definitions and their assembly language formats. Each file
 contains the instructions for an extension. Each instruction is
 represented as a variant clause of the `instruction` type, and its
@@ -177,7 +177,7 @@ language formats. Though the assembly mappings are defined
 bidirectionally, only the disassembler direction (i.e., binary
 encoding to assembler) is used.
 
-### The `riscv_postlude` module
+### The `postlude` module
 
 This module essentially completes the specification by providing
 implementations of the instruction fetcher and the driving function
@@ -187,7 +187,7 @@ for the fetch-decode-execute cycle.
 [csr_end.sail](../model/postlude/csr_end.sail) terminate the
 scattered definitions begun in the `insts_begin.sail` file in
 the `riscv` module and the `csr_begin.sail` file in the
-`riscv_core` module respectively.
+`core` module respectively.
 
 Definitions for the instruction stepper are in
 [step_common.sail](../model/postlude/step_common.sail), while
@@ -236,7 +236,7 @@ Vector (`V`) and cryptography (`Zk*`) extensions.
 
 ### Other modules
 
-The `riscv_termination` module specifies
+The `termination` module specifies
 [functions](../model/termination.sail) that are used to prove
 loop termination for theorem prover backends of Sail. The
 `unit_tests` module collects Sail unit tests for the specification.

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -30,7 +30,7 @@ execute_process(
         ${SAIL_BIN}
         ${project_file}
         --require-version ${SAIL_REQUIRED_VER}
-        # include riscv_termination.sail in the list of dependencies
+        # include termination.sail in the list of dependencies
         --variable "TERMINATION_FILE = true"
         --all-modules
         --list-files

--- a/model/core/addr_checks_common.sail
+++ b/model/core/addr_checks_common.sail
@@ -10,7 +10,7 @@
 // addresses used to access memory and perhaps modify them.  This file
 // defines the return values used by functions that perform this interposition.
 //
-// The model defines defaults for these functions in riscv_addr_checks.sail;
+// The model defines defaults for these functions in addr_checks.sail;
 // extensions would need to define their own functions to override them.
 
 union Ext_DataAddr_Check ('a : Type) = {

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -25,7 +25,7 @@ scattered function hartSupports
 // extensions to be supported in hardware, but temporarily disabled via a CSR, in
 // which case this function should return false.
 // Note: when adding a new extension, adjust the associated termination measure
-// in the file riscv_terminiation.sail, as explained in the comment in
+// in the file termination.sail, as explained in the comment in
 // that file.
 val currentlyEnabled : extension -> bool
 scattered function currentlyEnabled

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -940,7 +940,7 @@ function clause write_CSR(0x7a0, value) = { tselect = value; Ok(tselect) }
 
 //
 // Entropy Source - Platform access to random bits.
-// NOTE: This would be better placed in riscv_platform.sail, but that file
+// NOTE: This would be better placed in platform.sail, but that file
 // appears _after_ this one in the compile order meaning the valspec
 // for this function is unavailable when it's first encountered in
 // read_seed_csr. Hence it appears here.

--- a/model/extensions/FD/dext_insts.sail
+++ b/model/extensions/FD/dext_insts.sail
@@ -16,8 +16,8 @@
 
 // ***************************************************************
 // IMPORTANT!
-// The files 'riscv_insts_fext.sail', 'riscv_insts_dext.sail' and
-// 'riscv_insts_zfh.sail' define the F, D and Zfh extensions,
+// The files 'fext_insts.sail', 'dext_insts.sail' and
+// 'zfh_insts.sail' define the F, D and Zfh extensions,
 // respectively.
 // The texts follow each other very closely; please try to maintain
 // this correspondence as the files are maintained for bug-fixes,
@@ -25,7 +25,7 @@
 
 // ***************************************************************
 // Note: Rounding Modes and Floating point accrued exception flags
-// are defined in riscv_insts_fext.sail.
+// are defined in fext_insts.sail.
 // In RISC-V, the D extension requires the F extension, so that
 // should have been processed before this one.
 
@@ -242,11 +242,11 @@ function validDoubleRegs(n, regs) = {
 
 // *****************************************************************
 // Floating-point loads
-// These are defined in: riscv_insts_fext.sail
+// These are defined in: fext_insts.sail
 
 // *****************************************************************
 // Floating-point stores
-// These are defined in: riscv_insts_fext.sail
+// These are defined in: fext_insts.sail
 
 // *****************************************************************
 // Fused multiply-add

--- a/model/extensions/FD/fext_insts.sail
+++ b/model/extensions/FD/fext_insts.sail
@@ -16,8 +16,8 @@
 
 // ***************************************************************
 // IMPORTANT!
-// The files 'riscv_insts_fext.sail', 'riscv_insts_dext.sail' and
-// 'riscv_insts_zfh.sail' define the F, D and Zfh extensions,
+// The files 'fext_insts.sail', 'dext_insts.sail' and
+// 'zfh_insts.sail' define the F, D and Zfh extensions,
 // respectively.
 // The texts follow each other very closely; please try to maintain
 // this correspondence as the files are maintained for bug-fixes,

--- a/model/extensions/FD/zfh_insts.sail
+++ b/model/extensions/FD/zfh_insts.sail
@@ -19,8 +19,8 @@ function clause currentlyEnabled(Ext_Zhinxmin) = (hartSupports(Ext_Zhinxmin) & c
 
 // ***************************************************************
 // IMPORTANT!
-// The files 'riscv_insts_fext.sail', 'riscv_insts_dext.sail' and
-// 'riscv_insts_zfh.sail' define the F, D and Zfh extensions,
+// The files 'fext_insts.sail', 'dext_insts.sail' and
+// 'zfh_insts.sail' define the F, D and Zfh extensions,
 // respectively.
 // The texts follow each other very closely; please try to maintain
 // this correspondence as the files are maintained for bug-fixes,
@@ -172,11 +172,11 @@ function haveHalfMin() -> bool = haveHalfFPU() | currentlyEnabled(Ext_Zfhmin) | 
 
 // *****************************************************************
 // Floating-point loads
-// These are defined in: riscv_insts_fext.sail
+// These are defined in: fext_insts.sail
 
 // *****************************************************************
 // Floating-point stores
-// These are defined in: riscv_insts_fext.sail
+// These are defined in: fext_insts.sail
 
 // Binary ops with rounding mode
 

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -94,7 +94,7 @@ mapping clause encdec = JALR(imm, rs1, rd)
 mapping clause assembly = JALR(imm, rs1, rd)
   <-> "jalr" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_signed_12(imm) ^ "(" ^ reg_name(rs1) ^ ")"
 
-// see riscv_jalr_seq.sail or riscv_jalr_rmem.sail for the execute clause.
+// see jalr_seq.sail or jalr_rmem.sail for the execute clause.
 
 // *****************************************************************
 union clause instruction = BTYPE : (bits(13), regidx, regidx, bop)

--- a/model/jalr_rmem.sail
+++ b/model/jalr_rmem.sail
@@ -9,7 +9,7 @@
 // The definition for the memory model.
 
 function clause execute (JALR(imm, rs1, rd)) = {
-  // FIXME: this does not check for a misaligned target address. See riscv_jalr_seq.sail.
+  // FIXME: this does not check for a misaligned target address. See jalr_seq.sail.
   // write rd before anything else to prevent unintended strength
   X(rd) = nextPC; // compatible with JALR, C.JR and C.JALR
   let newPC : xlenbits = X(rs1) + sign_extend(imm);

--- a/model/sys/insts_begin.sail
+++ b/model/sys/insts_begin.sail
@@ -26,7 +26,7 @@ val encdec_compressed : instruction <-> bits(16)
 scattered mapping encdec_compressed
 
 // We declare the ILLEGAL/C_ILLEGAL instruction clauses here instead of in
-// riscv_insts_end, so that model extensions can make use of them.
+// insts_end, so that model extensions can make use of them.
 // However, the encdec mapping must come last to ensure that all
 // unmatched encodings decode to an illegal instruction.
 union clause instruction = ILLEGAL : word

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -26,7 +26,7 @@
 // (1) we can meaningfully test SFENCE.VMA which is a no-op without TLBs;
 // (2) we can greatly speed up simulation speed
 //     (e.g., from 10s of minutes to few minutes for Linux boot)
-// The TLB implementation is in a separate file: riscv_vmem_tlb.sail
+// The TLB implementation is in a separate file: vmem_tlb.sail
 // The code in this file is structured and commented so you can easily
 // ignore TLB functionality at first reading.
 
@@ -159,7 +159,7 @@ function pt_walk(
 // ****************************************************************
 // Architectural SATP CSR
 
-// PUBLIC: see also riscv_insts_zicsr.sail and other CSR-related files
+// PUBLIC: see also zicsr_insts.sail and other CSR-related files
 register satp : xlenbits
 mapping clause csr_name_map = 0x180  <-> "satp"
 function clause is_CSR_accessible(0x180, priv, _) = currentlyEnabled(Ext_S) & not(priv == Supervisor & mstatus[TVM] == 0b1)
@@ -241,7 +241,7 @@ function translate_TLB_hit forall 'v, is_sv_mode('v) . (
       match update_PTE_Bits(pte, ac) {
         None()     => Ok(tlb_get_ppn(sv_width, ent, vpn), ext_ptw),
         Some(pte') =>
-          // Step 9 of VATP. See riscv_platform.sail.
+          // Step 9 of VATP. See platform.sail.
           if not(plat_enable_dirty_update) then
             // pte needs dirty/accessed update but that is not enabled
             Err(PTW_PTE_Update(), ext_ptw)
@@ -289,7 +289,7 @@ function translate_TLB_miss forall 'v, is_sv_mode('v) . (
           Ok(ppn, ext_ptw)
         },
         Some(pte) =>
-          // Step 9 of VATP. See riscv_platform.sail.
+          // Step 9 of VATP. See platform.sail.
           if not(plat_enable_dirty_update) then
             // pte needs dirty/accessed update but that is not enabled
             Err(PTW_PTE_Update(), ext_ptw)
@@ -359,7 +359,7 @@ function translateAddr(
 ) -> TR_Result(physaddr, ExceptionType) = {
 
   // Effective privilege takes into account mstatus.PRV, mstatus.MPP
-  // See riscv_sys_regs.sail for effectivePrivilege() and cur_privilege
+  // See sys_regs.sail for effectivePrivilege() and cur_privilege
   let effPriv = effectivePrivilege(ac, mstatus, cur_privilege);
 
   let mode = translationMode(effPriv);

--- a/model/sys/vmem_pte.sail
+++ b/model/sys/vmem_pte.sail
@@ -116,7 +116,7 @@ function check_PTE_permission(ac        : AccessType(ext_access_type),
   let pte_W = bits_to_bool(pte_flags[W]);
   let pte_X = bits_to_bool(pte_flags[X]);
 
-  // Steps 6 and 8 of VATP, roughly (see riscv_vmem.sail).
+  // Steps 6 and 8 of VATP, roughly (see vmem.sail).
   // (TODO: Step 7 awaits shadow stack implementation (Zicfiss).)
   let access_ok : bool = match ac {
     Read(_)             => pte_R | (pte_X & mxr),

--- a/model/sys/vmem_ptw.sail
+++ b/model/sys/vmem_ptw.sail
@@ -10,7 +10,7 @@
 // PTW exceptions
 
 // 'ext_ptw' supports (non-standard) extensions to the default addr-translation and PTW.
-// See riscv_types_ext.sail for definitions.
+// See types_ext.sail for definitions.
 
 // Failure modes for address-translation/page-table-walks
 // PRIVATE

--- a/model/sys/vmem_tlb.sail
+++ b/model/sys/vmem_tlb.sail
@@ -79,10 +79,10 @@ function tlb_hash forall 'v, is_sv_mode('v) . (
 ) -> tlb_index_range =
   unsigned(vpn[5 .. 0])
 
-// PUBLIC: invoked in reset_vmem() [riscv_vmem.sail]
+// PUBLIC: invoked in reset_vmem() [vmem.sail]
 function reset_TLB() -> unit = tlb = vector_init(None())
 
-// PUBLIC: invoked in translate_TLB_hit() [riscv_vmem.sail]
+// PUBLIC: invoked in translate_TLB_hit() [vmem.sail]
 function write_TLB(index : tlb_index_range, entry : TLB_Entry) -> unit =
   tlb[index] = Some(entry)
 
@@ -112,7 +112,7 @@ function flush_TLB_Entry(ent   : TLB_Entry,
   asid_matches & addr_matches
 }
 
-// PUBLIC: invoked in translate() [riscv_vmem.sail]
+// PUBLIC: invoked in translate() [vmem.sail]
 function lookup_TLB forall 'v, is_sv_mode('v) . (
   sv_width : int('v),
   asid     : asidbits,
@@ -127,7 +127,7 @@ function lookup_TLB forall 'v, is_sv_mode('v) . (
   }
 }
 
-// PUBLIC: invoked in translate_TLB_miss() [riscv_vmem.sail]
+// PUBLIC: invoked in translate_TLB_miss() [vmem.sail]
 function add_to_TLB forall 'v, is_sv_mode('v) . (
   sv_width : int('v),
   asid     : asidbits,
@@ -161,7 +161,7 @@ function add_to_TLB forall 'v, is_sv_mode('v) . (
 }
 
 // Top-level TLB flush function
-// PUBLIC: invoked from SFENCE_VMA [riscv_insts_base.sail]
+// PUBLIC: invoked from SFENCE_VMA [insts_base.sail]
 function flush_TLB(asid : option(asidbits),
                    addr : option(xlenbits)) -> unit = {
   foreach (i from 0 to (length(tlb) - 1)) {


### PR DESCRIPTION
There were lots of leftover references to files that still had the `riscv_` prefix.