### PR TITLE
Improve exception code types

### DIFF
--- a/model/core/callbacks.sail
+++ b/model/core/callbacks.sail
@@ -13,7 +13,7 @@ function mem_write_callback(_) = ()
 val mem_read_callback = pure {c: "mem_read_callback"} : forall 'n, 0 < 'n <= max_mem_access . (/* access type */ string, /* addr */ physaddrbits, /* width */ int('n), /* value */ bits(8 * 'n)) -> unit
 function mem_read_callback(_) = ()
 
-val mem_exception_callback = pure {c: "mem_exception_callback"} : forall 'n, 0 <= 'n < xlen . (/* addr */ physaddrbits, /* num_of_ExceptionType */ int('n)) -> unit
+val mem_exception_callback = pure {c: "mem_exception_callback"} : (/* addr */ physaddrbits, /* exception code */ exc_code) -> unit
 function mem_exception_callback(_) = ()
 
 val pc_write_callback = pure {c: "pc_write_callback"} : xlenbits -> unit

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -125,19 +125,17 @@ enum InterruptType = {
   I_M_External
 }
 
-val interruptType_to_bits : InterruptType -> exc_code
-function interruptType_to_bits (i) =
-  match (i) {
-    I_U_Software => 0x00,
-    I_S_Software => 0x01,
-    I_M_Software => 0x03,
-    I_U_Timer    => 0x04,
-    I_S_Timer    => 0x05,
-    I_M_Timer    => 0x07,
-    I_U_External => 0x08,
-    I_S_External => 0x09,
-    I_M_External => 0x0b
-  }
+mapping interruptType_bits : InterruptType <-> exc_code = {
+  I_U_Software <-> 0b000000, // 0
+  I_S_Software <-> 0b000001, // 1
+  I_M_Software <-> 0b000011, // 3
+  I_U_Timer    <-> 0b000100, // 4
+  I_S_Timer    <-> 0b000101, // 5
+  I_M_Timer    <-> 0b000111, // 7
+  I_U_External <-> 0b001000, // 8
+  I_S_External <-> 0b001001, // 9
+  I_M_External <-> 0b001011, // 11
+}
 
 // architectural exception definitions
 
@@ -163,54 +161,27 @@ union ExceptionType = {
   E_Extension          : ext_exc_type
 }
 
-val exceptionType_to_bits : ExceptionType -> exc_code
-function exceptionType_to_bits(e) =
-  match (e) {
-    E_Fetch_Addr_Align()   => 0x00,
-    E_Fetch_Access_Fault() => 0x01,
-    E_Illegal_Instr()      => 0x02,
-    E_Breakpoint()         => 0x03,
-    E_Load_Addr_Align()    => 0x04,
-    E_Load_Access_Fault()  => 0x05,
-    E_SAMO_Addr_Align()    => 0x06,
-    E_SAMO_Access_Fault()  => 0x07,
-    E_U_EnvCall()          => 0x08,
-    E_S_EnvCall()          => 0x09,
-    E_Reserved_10()        => 0x0a,
-    E_M_EnvCall()          => 0x0b,
-    E_Fetch_Page_Fault()   => 0x0c,
-    E_Load_Page_Fault()    => 0x0d,
-    E_Reserved_14()        => 0x0e,
-    E_SAMO_Page_Fault()    => 0x0f,
+mapping exceptionType_bits : ExceptionType <-> exc_code = {
+  E_Fetch_Addr_Align()   <-> 0b000000, // 0
+  E_Fetch_Access_Fault() <-> 0b000001, // 1
+  E_Illegal_Instr()      <-> 0b000010, // 2
+  E_Breakpoint()         <-> 0b000011, // 3
+  E_Load_Addr_Align()    <-> 0b000100, // 4
+  E_Load_Access_Fault()  <-> 0b000101, // 5
+  E_SAMO_Addr_Align()    <-> 0b000110, // 6
+  E_SAMO_Access_Fault()  <-> 0b000111, // 7
+  E_U_EnvCall()          <-> 0b001000, // 8
+  E_S_EnvCall()          <-> 0b001001, // 9
+  E_Reserved_10()        <-> 0b001010, // 10
+  E_M_EnvCall()          <-> 0b001011, // 11
+  E_Fetch_Page_Fault()   <-> 0b001100, // 12
+  E_Load_Page_Fault()    <-> 0b001101, // 13
+  E_Reserved_14()        <-> 0b001110, // 14
+  E_SAMO_Page_Fault()    <-> 0b001111, // 15
 
-    // extensions
-    E_Extension(e)         => ext_exc_type_to_bits(e)
-  }
-
-val num_of_ExceptionType : ExceptionType -> {'n, (0 <= 'n < xlen). int('n)}
-function num_of_ExceptionType(e) =
-  match (e) {
-    E_Fetch_Addr_Align()   => 0,
-    E_Fetch_Access_Fault() => 1,
-    E_Illegal_Instr()      => 2,
-    E_Breakpoint()         => 3,
-    E_Load_Addr_Align()    => 4,
-    E_Load_Access_Fault()  => 5,
-    E_SAMO_Addr_Align()    => 6,
-    E_SAMO_Access_Fault()  => 7,
-    E_U_EnvCall()          => 8,
-    E_S_EnvCall()          => 9,
-    E_Reserved_10()        => 10,
-    E_M_EnvCall()          => 11,
-    E_Fetch_Page_Fault()   => 12,
-    E_Load_Page_Fault()    => 13,
-    E_Reserved_14()        => 14,
-    E_SAMO_Page_Fault()    => 15,
-
-    // extensions
-    E_Extension(e)         => num_of_ext_exc_type(e)
-
-  }
+  // extensions
+  E_Extension(e)         <-> ext_exc_type_bits(e)
+}
 
 val exceptionType_to_str : ExceptionType -> string
 function exceptionType_to_str(e) =

--- a/model/core/types_common.sail
+++ b/model/core/types_common.sail
@@ -6,4 +6,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // =======================================================================================
 
-type exc_code = bits(8)
+// Exception codes above 64 are reserved, and there
+// isn't space for them medeleg[h] so it is unclear
+// how they would work anyway.
+//
+// Note this type is currently used for exceptions
+// and interrupts, which is unfortunate because
+// exceptions are always <64, but interrupts are <xlen
+// (except with AIA when they are also <64).
+type exc_code = bits(6)

--- a/model/core/types_ext.sail
+++ b/model/core/types_ext.sail
@@ -55,12 +55,10 @@ function ext_translate_exception(e : ext_ptw_error) -> ext_exc_type =
   e // type pun because both are unit; extensions may need to override this
 
 // Default conversion of extension exceptions to bits
-val ext_exc_type_to_bits : ext_exc_type -> exc_code
-function ext_exc_type_to_bits(e) = 0x18 // First code for a custom extension
-
-// Default conversion of extension exceptions to integers
-val num_of_ext_exc_type : ext_exc_type -> {'n, (0 <= 'n < xlen). int('n)}
-function num_of_ext_exc_type(e) = 24 // First code for a custom extension
+mapping ext_exc_type_bits : ext_exc_type <-> exc_code = {
+  // First code for a custom extension
+  () <-> 0b011000, // 24
+}
 
 // Default conversion of extension exceptions to strings
 val ext_exc_type_to_str : ext_exc_type -> string

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -179,7 +179,7 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
   match step_val {
     Step_Pending_Interrupt(intr, priv) => {
       if   get_config_print_instr()
-      then print_bits("Handling interrupt: ", interruptType_to_bits(intr));
+      then print_bits("Handling interrupt: ", interruptType_bits(intr));
       handle_interrupt(intr, priv)
     },
     Step_Ext_Fetch_Failure(e) => ext_handle_fetch_check_error(e),

--- a/model/sys/mem.sail
+++ b/model/sys/mem.sail
@@ -146,7 +146,7 @@ function mem_read_priv_meta (typ, priv, paddr, width, aq, rl, res, meta) = {
     };
   match result {
     Ok(value, _) => mem_read_callback(to_str(typ), bits_of(paddr), width, value),
-    Err(e) => mem_exception_callback(bits_of(paddr), num_of_ExceptionType(e)),
+    Err(e) => mem_exception_callback(bits_of(paddr), exceptionType_bits(e)),
   };
   result
 }
@@ -210,7 +210,7 @@ function mem_write_value_priv_meta (paddr, width, value, typ, priv, meta, aq, rl
     let result = checked_mem_write(paddr, width, value, typ, priv, meta, aq, rl, con);
     match result {
       Ok(_) => mem_write_callback(to_str(typ), bits_of(paddr), width, value),
-      Err(e) => mem_exception_callback(bits_of(paddr), num_of_ExceptionType(e)),
+      Err(e) => mem_exception_callback(bits_of(paddr), exceptionType_bits(e)),
     };
     result
   }

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -34,7 +34,7 @@ function check_CSR(csr : csreg, p : Privilege, isWrite : bool) -> bool =
 // Exception delegation: given an exception and the privilege at which
 // it occurred, returns the privilege at which it should be handled.
 function exception_delegatee(e : ExceptionType, p : Privilege) -> Privilege = {
-  let idx   = num_of_ExceptionType(e);
+  let idx = unsigned(exceptionType_bits(e));
   let super = bit_to_bool(medeleg.bits[idx]);
   // TODO: check VS/VU-mode if hypervisor extension enabled
   let deleg = if currentlyEnabled(Ext_S) & super then Supervisor else Machine;
@@ -219,7 +219,7 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
       if   get_config_print_platform()
       then print_log("trapping from " ^ to_str(cur_priv) ^ " to " ^ to_str(del_priv)
                           ^ " to handle " ^ to_str(e.trap));
-      trap_handler(del_priv, false, exceptionType_to_bits(e.trap), pc, e.excinfo, e.ext)
+      trap_handler(del_priv, false, exceptionType_bits(e.trap), pc, e.excinfo, e.ext)
     },
     CTL_MRET()  => {
       let prev_priv = cur_privilege;
@@ -280,7 +280,7 @@ function handle_exception(xtval : xlenbits, e : ExceptionType) -> unit = {
 }
 
 function handle_interrupt(i : InterruptType, del_priv : Privilege) -> unit =
-  set_next_pc(trap_handler(del_priv, true, interruptType_to_bits(i), PC, None(), None()))
+  set_next_pc(trap_handler(del_priv, true, interruptType_bits(i), PC, None(), None()))
 
 // Reset misa to enable the maximal set of supported extensions.
 function reset_misa() -> unit = {


### PR DESCRIPTION
Switch `exc_code` to 6 bits, [0, 64). For exceptions, higher values are reserved and can't be implemented without significant changes because there would be no space in `medeleg[h]`.

For interrupts, they are actually even further limited to [0, xlen), unless you have AIA which adds `mieh` and so on.

I also changed the functions to mappings which is a bit nicer and removes the need for `num_of_ExceptionType()`.

It's unfortunate that we have to use binary literals but it's not too bad.