### PR TITLE
Add basic NMI support

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -55,6 +55,7 @@
       "base": 33554432,
       "size": 786432
     },
+    "nmi_handler_address": 0,
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
     "wfi_is_nop": true

--- a/model/core/nmi.sail
+++ b/model/core/nmi.sail
@@ -1,0 +1,16 @@
+type nmi_cause = bits(xlen - 1)
+
+// Pending Non Maskable Interrupt. If this is Some() an NMI is taken.
+// This is not a real RISC-V CSR; it is used by the model to
+// decide whether to trap to an NMI or not.
+//
+// The value is written to mcause. A value of 0 means unknown.
+// Other values are implementation defined.
+//
+// This is reset to None() automatically when the NMI is taken.
+register pending_nmi : option(nmi_cause) = None()
+
+// Utility function to set the above value from C etc. This has
+// nicer generated C types than dealing with option(nmi_cause) directly.
+$option --c-preserve set_pending_nmi
+function set_pending_nmi(cause : bits(31)) -> unit = pending_nmi = Some(zero_extend(cause))

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -12,6 +12,7 @@ register hart_state : HartState = HART_ACTIVE()
 
 union Step = {
   Step_Pending_Interrupt  : (InterruptType, Privilege),
+  Step_Pending_NMI        : (nmi_cause),
   Step_Ext_Fetch_Failure  : ext_fetch_addr_error,
   Step_Fetch_Failure      : (virtaddr, ExceptionType),
   Step_Execute            : (ExecutionResult, instbits),
@@ -87,44 +88,47 @@ function run_hart_waiting(step_no : int, wr: WaitReason, instbits : instbits, ex
 }
 
 function run_hart_active(step_no: nat) -> Step = {
-  match dispatchInterrupt(cur_privilege) {
-    Some(intr, priv) => Step_Pending_Interrupt(intr, priv),
-    None() => match ext_fetch_hook(fetch()) {
-      // extension error
-      F_Ext_Error(e)   => Step_Ext_Fetch_Failure(e),
-      // standard error
-      F_Error(e, addr) => Step_Fetch_Failure(Virtaddr(addr), e),
-      // non-error cases:
-      F_RVC(h) => {
-        sail_instr_announce(h);
-        let instbits : instbits = zero_extend(h);
-        let instruction = ext_decode_compressed(h);
-        if   get_config_print_instr()
-        then {
-          print_log_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(PC) ^ " (" ^ bits_str(h) ^ ") " ^ to_str(instruction), zero_extend(PC));
-        };
-        // check for RVC once here instead of every RVC execute clause.
-        if currentlyEnabled(Ext_Zca) then {
-          nextPC = PC + 2;
+  match pending_nmi {
+    Some(cause) => Step_Pending_NMI(cause),
+    None() => match dispatchInterrupt(cur_privilege) {
+      Some(intr, priv) => Step_Pending_Interrupt(intr, priv),
+      None() => match ext_fetch_hook(fetch()) {
+        // extension error
+        F_Ext_Error(e)   => Step_Ext_Fetch_Failure(e),
+        // standard error
+        F_Error(e, addr) => Step_Fetch_Failure(Virtaddr(addr), e),
+        // non-error cases:
+        F_RVC(h) => {
+          sail_instr_announce(h);
+          let instbits : instbits = zero_extend(h);
+          let instruction = ext_decode_compressed(h);
+          if   get_config_print_instr()
+          then {
+            print_log_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(PC) ^ " (" ^ bits_str(h) ^ ") " ^ to_str(instruction), zero_extend(PC));
+          };
+          // check for RVC once here instead of every RVC execute clause.
+          if currentlyEnabled(Ext_Zca) then {
+            nextPC = PC + 2;
+            let r = execute(instruction);
+            Step_Execute(r, instbits)
+          } else {
+            Step_Execute(Illegal_Instruction(), instbits)
+          }
+        },
+        F_Base(w) => {
+          sail_instr_announce(w);
+          let instbits : instbits = zero_extend(w);
+          let instruction = ext_decode(w);
+          if   get_config_print_instr()
+          then {
+            print_log_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(PC) ^ " (" ^ bits_str(w) ^ ") " ^ to_str(instruction), zero_extend(PC));
+          };
+          nextPC = PC + 4;
           let r = execute(instruction);
           Step_Execute(r, instbits)
-        } else {
-          Step_Execute(Illegal_Instruction(), instbits)
         }
-      },
-      F_Base(w) => {
-        sail_instr_announce(w);
-        let instbits : instbits = zero_extend(w);
-        let instruction = ext_decode(w);
-        if   get_config_print_instr()
-        then {
-          print_log_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(PC) ^ " (" ^ bits_str(w) ^ ") " ^ to_str(instruction), zero_extend(PC));
-        };
-        nextPC = PC + 4;
-        let r = execute(instruction);
-        Step_Execute(r, instbits)
       }
-    }
+    },
   }
 }
 
@@ -181,6 +185,12 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
       if   get_config_print_instr()
       then print_bits("Handling interrupt: ", interruptType_to_bits(intr));
       handle_interrupt(intr, priv)
+    },
+    Step_Pending_NMI(cause) => {
+      if   get_config_print_instr()
+      then print_endline("Handling non-maskable interrupt");
+      handle_nmi(cause);
+      pending_nmi = None();
     },
     Step_Ext_Fetch_Failure(e) => ext_handle_fetch_check_error(e),
     Step_Fetch_Failure(vaddr, e) => handle_exception(bits_of(vaddr), e),

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -26,6 +26,7 @@ core {
     core/regs.sail,
     core/pc_access.sail,
     core/sys_regs.sail,
+    core/nmi.sail,
     core/ext_regs.sail,
     core/addr_checks_common.sail,
     core/addr_checks.sail,

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -257,6 +257,24 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
   }
 }
 
+// Non-Maskable Interrupt handler address. This is not required
+// to be static. If a non-static value is needed this can be
+// replaced with a callback function.
+let nmi_handler_address : xlenbits = to_bits_checked(config platform.nmi_handler_address : int)
+
+function nmi_handler(cause : nmi_cause, pc : xlenbits) -> xlenbits = {
+  cur_privilege = Machine;
+
+  mcause[Cause] = cause;
+  mcause[IsInterrupt] = 0b1;
+  mepc = pc;
+
+  csr_write_callback("mcause", mcause.bits);
+  csr_write_callback("mepc", mepc);
+
+  nmi_handler_address
+}
+
 // Compute the value to write to mtval on a trap.
 function xtval_exception_value(e : ExceptionType, excinfo : xlenbits) -> option(xlenbits) = {
   if match e {
@@ -281,6 +299,9 @@ function handle_exception(xtval : xlenbits, e : ExceptionType) -> unit = {
 
 function handle_interrupt(i : InterruptType, del_priv : Privilege) -> unit =
   set_next_pc(trap_handler(del_priv, true, interruptType_to_bits(i), PC, None(), None()))
+
+function handle_nmi(cause : nmi_cause) -> unit =
+  set_next_pc(nmi_handler(cause, PC))
 
 // Reset misa to enable the maximal set of supported extensions.
 function reset_misa() -> unit = {


### PR DESCRIPTION
If you call `zset_pending_nmi(0)` before `ztry_step()` then this will now trigger an NMI and jump to a configurable address.