### PR TITLE
Reduce duplication in vsetvl-type instructions

### DIFF
--- a/model/extensions/V/vext_vset_insts.sail
+++ b/model/extensions/V/vext_vset_insts.sail
@@ -103,7 +103,7 @@ function execute_vsetvl_type(
   //
   // Also some cases require that VLMAX doesn't change (i.e. LMUL/SEW is constant).
   if SEW_pow_new > (LMUL_pow_new + elen_exp) |
-     (requires_fixed_vlmax & (lmul_sew_ratio != lmul_sew_ratio_new | not(valid_vtype())) then {
+     (requires_fixed_vlmax & (lmul_sew_ratio != lmul_sew_ratio_new | not(valid_vtype()))) then {
     handle_illegal_vtype();
     return RETIRE_SUCCESS;
   };


### PR DESCRIPTION
Reduce duplication by adding a function that can execute all three `vsetvl`-type instructions and delegating to those.

This also makes it a bit easier to see how the instructions differ and how they are the same.