### PR TITLE
Simplify cur_architecture slightly

### DIFF
--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -78,7 +78,7 @@ bitfield Misa : xlenbits = {
 register misa : Misa =
   [ Mk_Misa(zeros()) with
     // MXL is a read-only field that specifies the native XLEN.
-    MXL = architecture(if xlen == 32 then RV32 else RV64),
+    MXL = architecture_bits(if xlen == 32 then RV32 else RV64),
   ]
 
 // whether misa is R/W
@@ -251,7 +251,7 @@ function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
 
 register mstatus : Mstatus = {
   // Initialise SXL and UXL.
-  let mxl = architecture(if xlen == 32 then RV32 else RV64);
+  let mxl = architecture_bits(if xlen == 32 then RV32 else RV64);
   [ Mk_Mstatus(zeros()) with
     // These fields do not exist on RV32 and are read-only zero
     // if the corresponding mode is not supported.
@@ -275,11 +275,11 @@ function clause write_CSR((0x310, value) if xlen == 32) = { mstatus = legalize_m
 
 // architecture and extension checks
 
-function cur_architecture() -> Architecture = {
+function architecture(priv : Privilege) -> Architecture = {
   if   xlen == 32
   then return RV32;
 
-  architecture(match cur_privilege {
+  architecture_bits(match priv {
     Machine           => misa[MXL],
     Supervisor        => mstatus[SXL],
     User              => mstatus[UXL],
@@ -289,7 +289,7 @@ function cur_architecture() -> Architecture = {
 }
 
 function in32BitMode() -> bool = {
-  cur_architecture() == RV32
+  architecture(cur_privilege) == RV32
 }
 
 bitfield Seccfg : bits(64) = {

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -54,7 +54,7 @@ let sp   : regidx = Regidx(zero_extend(0b10)) // x2, stack pointer
 enum Architecture = {RV32, RV64, RV128}
 type arch_xlen = bits(2)
 
-mapping architecture : Architecture <-> arch_xlen = {
+mapping architecture_bits : Architecture <-> arch_xlen = {
   RV32  <-> 0b01,
   RV64  <-> 0b10,
   RV128 <-> 0b11,

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -164,7 +164,7 @@ register satp : xlenbits
 mapping clause csr_name_map = 0x180  <-> "satp"
 function clause is_CSR_accessible(0x180, priv, _) = currentlyEnabled(Ext_S) & not(priv == Supervisor & mstatus[TVM] == 0b1)
 function clause read_CSR(0x180) = satp
-function clause write_CSR(0x180, value) = { satp = legalize_satp(cur_architecture(), satp, value); Ok(satp) }
+function clause write_CSR(0x180, value) = { satp = legalize_satp(architecture(cur_privilege), satp, value); Ok(satp) }
 
 // ----------------
 // Fields of SATP
@@ -185,7 +185,7 @@ function satp_to_ppn(satp_val) =
 function translationMode(priv : Privilege) -> SATPMode = {
   if priv == Machine then Bare
   else {
-    let arch = if xlen == 32 then RV32 else architecture(mstatus[SXL]);
+    let arch = architecture(Supervisor);
     let mbits : satp_mode = match arch {
       RV64 => {
         // Can't have an effective architecture of RV64 on RV32.


### PR DESCRIPTION
Change `cur_architecture()` which implicitly gets the `cur_privilege` to have `cur_privilege` passed as a parameter. This helps when we explicitly want the `Supervisor` architecture in `vmem.sail`. I renamed the `architecture` encoding mapping to `architecture_bits` to make space for `cur_architecture()` to be renamed to `architecture()`.