### PR TITLE
Validate generated configs at build time

### DIFF
--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -105,6 +105,18 @@ target_link_libraries(sail_riscv_sim
     PRIVATE CLI11 riscv_model
 )
 
+# After the emulator is built, use it to validate the generated config files.
+foreach (config_filename IN LISTS generated_config_filenames)
+    add_custom_command(
+        TARGET sail_riscv_sim
+        POST_BUILD
+        COMMAND $<TARGET_FILE:sail_riscv_sim>
+                    --validate-config
+                    --config ${config_filename}
+        VERBATIM
+    )
+endforeach()
+
 # TODO: Enable warnings when we use the #include trick
 # to include the generated Sail code. Currently it
 # generates too many warnings to turn these on globally.

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(config_validation_files)
+set(generated_config_filenames)
 
 # Create a variety of configuration files for different XLEN/ELEN/VLENs.
 foreach (CONFIG__BASE__XLEN IN ITEMS 32 64)
@@ -19,27 +19,13 @@ foreach (CONFIG__BASE__XLEN IN ITEMS 32 64)
                 DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}/config
             )
 
-            # After the emulator is built, run it to verify this config is valid.
-            add_custom_command(
-                DEPENDS sail_riscv_sim
-                OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${config_filename}.valid"
-                COMMAND $<TARGET_FILE:sail_riscv_sim>
-                            --validate-config
-                            --config ${CMAKE_CURRENT_BINARY_DIR}/${config_filename}
-                            > "${config_filename}.out"
-                # Only if successful, move the .out to .valid (otherwise
-                # things will go wrong when it fails but still generates the .out file).
-                COMMAND cmake -E rename "${config_filename}.out" "${config_filename}.valid"
-                COMMENT "Validating config file ${config_filename}"
-                VERBATIM
-            )
-            list(APPEND config_validation_files "${CMAKE_CURRENT_BINARY_DIR}/${config_filename}.valid")
+            list(APPEND generated_config_filenames "${CMAKE_CURRENT_BINARY_DIR}/${config_filename}")
         endforeach()
     endforeach()
 endforeach()
 
-# This target runs the C emulator to validate all of the configs generated here.
-add_custom_target(config_validation ALL DEPENDS ${config_validation_files})
+# Make list of config files visible to c_emulator build.
+set(generated_config_filenames "${generated_config_filenames}" PARENT_SCOPE)
 
 # Embed the default config in a C header.
 file(READ "${CMAKE_CURRENT_BINARY_DIR}/rv64d_v256_e64.json" DEFAULT_JSON)


### PR DESCRIPTION
Once the emulator is built this will run it with `--validate-config` on all of the generated configs (this includes the default one).

This is done by default with `make` (including `./build_simulators.sh`).

I verified that it works by breaking the config and then fixing it again.