### PR TITLE
Enable 128-bit memory access

### DIFF
--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -109,7 +109,7 @@ function is_load_store forall ('a : Type) . (ac : AccessType('a)) -> bool =
     InstructionFetch(_) => false,
   }
 
-type is_mem_width('w) = 'w in {1, 2, 4, 8}
+type is_mem_width('w) = 'w in {1, 2, 4, 8, 16}
 
 // architectural interrupt definitions
 

--- a/model/sys/mem.sail
+++ b/model/sys/mem.sail
@@ -44,15 +44,7 @@ function is_aligned_paddr(Physaddr(addr) : physaddr, width : nat1) -> bool =
 function is_aligned_vaddr(Virtaddr(addr) : virtaddr, width : nat1) -> bool =
   unsigned(addr) % width == 0
 
-function is_aligned_bits(vaddr : xlenbits, width : word_width) -> bool =
-  match width {
-    1 => true,
-    2 => vaddr[0..0] == zeros(),
-    4 => vaddr[1..0] == zeros(),
-    8 => vaddr[2..0] == zeros(),
-  }
-
-overload is_aligned_addr = {is_aligned_paddr, is_aligned_vaddr, is_aligned_bits}
+overload is_aligned_addr = {is_aligned_paddr, is_aligned_vaddr}
 
 function read_kind_of_flags (aq : bool, rl : bool, res : bool) -> option(read_kind) =
   match (aq, rl, res) {

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -160,7 +160,7 @@ function vmem_write_addr(vaddr, width, data, acc, aq, rl, res) = {
 
 // External API
 
-function check_misaligned(vaddr : virtaddr, width : word_width) -> bool = {
+function check_misaligned(vaddr : virtaddr, width : word_width_wide) -> bool = {
   if plat_enable_misaligned_access then {
     false
   } else {


### PR DESCRIPTION
Enable 128-bit memory access for potential use by the debug module via abstract commands (Access Memory). Remove unused function is_aligned_bits().