### PR TITLE
A couple of fixes for config schema validation.

### DIFF
--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -26,7 +26,7 @@ configure_file(generate_schema_include.cmake.in generate_schema_include.cmake @O
 add_custom_command(
     OUTPUT config_schema.h
     COMMAND cmake -P generate_schema_include.cmake
-    DEPENDS generated_sail_riscv_model
+    DEPENDS generated_sail_riscv_model ${schema_file}
 )
 add_custom_target(generated_config_schema DEPENDS config_schema.h)
 

--- a/c_emulator/config_utils.cpp
+++ b/c_emulator/config_utils.cpp
@@ -99,17 +99,20 @@ void validate_config_schema(const std::string &conf_file)
   jsonschema::json_schema<json> compiled
       = jsonschema::make_json_schema(std::move(schema), options);
 
+  std::string source = conf_file.empty() ? "default configuration"
+                                         : "configuration in " + conf_file;
+
   // Parse the config.
   json config;
-  std::string source;
-
-  if (conf_file.empty()) {
-    config = json::parse(get_default_config());
-    source = "default configuration";
-  } else {
-    std::ifstream is(conf_file);
-    config = json::parse(is);
-    source = "configuration in " + conf_file;
+  try {
+    if (conf_file.empty()) {
+      config = json::parse(get_default_config());
+    } else {
+      std::ifstream is(conf_file);
+      config = json::parse(is);
+    }
+  } catch (const std::exception &ex) {
+    throw std::runtime_error("Cannot parse " + source + ": " + ex.what() + ".");
   }
 
   // Validate.


### PR DESCRIPTION
- Ensure that `config_schema.h` gets regenerated when the schema file changes.
  This bug is triggered when switching between git branches that have different schemas.

- Give a more informative error message on config parsing errors.
   This now gives (for e.g.):
       `Error: Cannot parse configuration in <path>/rv32d_v128_e32.json: Invalid value at line 85 and column 20.`
   versus the rather abrupt:
       `Error: Invalid value at line 85 and column 20`
