### PR TITLE
Enforce braces in C++

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,3 +10,4 @@ PointerAlignment: Right
 SortIncludes: Never
 AlignTrailingComments: true
 AccessModifierOffset: -2
+InsertBraces: true

--- a/c_emulator/riscv_prelude.cpp
+++ b/c_emulator/riscv_prelude.cpp
@@ -29,8 +29,9 @@ unit print_log_instr(const_sail_string s, uint64_t pc)
 
 unit print_step(unit)
 {
-  if (config_print_step)
+  if (config_print_step) {
     fprintf(trace_log, "\n");
+  }
   return UNIT;
 }
 

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -359,8 +359,9 @@ void close_logs(void)
 
 void finish(int ec)
 {
-  if (!sig_file.empty())
+  if (!sig_file.empty()) {
     write_signature(sig_file.c_str());
+  }
 
   model_fini();
   if (gettimeofday(&run_end, NULL) < 0) {
@@ -428,8 +429,9 @@ void run_sail(void)
       CREATE(sail_int)(&sail_step);
       CONVERT_OF(sail_int, mach_int)(&sail_step, step_no);
       is_waiting = ztry_step(sail_step, exit_wait);
-      if (have_exception)
+      if (have_exception) {
         goto step_exception;
+      }
       flush_logs();
       KILL(sail_int)(&sail_step);
       if (rvfi) {
@@ -614,8 +616,9 @@ int inner_main(int argc, char **argv)
   }
 
   if (rvfi) {
-    if (!rvfi->setup_socket(config_print_rvfi))
+    if (!rvfi->setup_socket(config_print_rvfi)) {
       return 1;
+    }
     register_callback(&rvfi_cbs);
   }
 

--- a/c_emulator/rvfi_dii.cpp
+++ b/c_emulator/rvfi_dii.cpp
@@ -133,10 +133,12 @@ void rvfi_handler::send_trace(bool config_print)
     get_and_send_packet(zrvfi_get_exec_packet_v1, config_print);
   } else if (trace_version == 2) {
     get_and_send_packet(zrvfi_get_exec_packet_v2, config_print);
-    if (zrvfi_int_data_present)
+    if (zrvfi_int_data_present) {
       get_and_send_packet(zrvfi_get_int_data, config_print);
-    if (zrvfi_mem_data_present)
+    }
+    if (zrvfi_mem_data_present) {
       get_and_send_packet(zrvfi_get_mem_data, config_print);
+    }
   } else {
     fprintf(stderr, "Sending v%d packets not implemented yet!\n",
             trace_version);


### PR DESCRIPTION
Unbraced blocks are a notorious footgun in C/C++. Fortunately clang-format has an option to automatically insert them.