### PR TITLE
Remove redundant parentheses around instruction arguments in execute clauses.

### DIFF
--- a/model/extensions/A/zalrsc_insts.sail
+++ b/model/extensions/A/zalrsc_insts.sail
@@ -34,7 +34,7 @@ mapping clause encdec = LOADRES(aq, rl, rs1, width, rd)
 // requires cancelling the reservation in some additional places, e.g. xRET, and
 // that will break comparison with a DUT that doesn't require cancellation there.
 
-function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
+function clause execute LOADRES(aq, rl, rs1, width, rd) = {
   // This is checked during decoding.
   assert(width <= xlen_bytes);
 
@@ -59,7 +59,7 @@ mapping clause encdec = STORECON(aq, rl, rs2, rs1, width, rd)
   when currentlyEnabled(Ext_Zalrsc) & lrsc_width_valid(width)
 
 // NOTE: Currently, we only EA if address translation is successful. This may need revisiting.
-function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
+function clause execute STORECON(aq, rl, rs2, rs1, width, rd) = {
   // This is checked during decoding.
   assert(width <= xlen_bytes);
 

--- a/model/extensions/B/zba_insts.sail
+++ b/model/extensions/B/zba_insts.sail
@@ -19,7 +19,7 @@ mapping clause encdec = SLLIUW(shamt, rs1, rd)
 mapping clause assembly = SLLIUW(shamt, rs1, rd)
   <-> "slli.uw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_6(shamt)
 
-function clause execute (SLLIUW(shamt, rs1, rd)) = {
+function clause execute SLLIUW(shamt, rs1, rd) = {
   X(rd) = zero_extend(X(rs1)[31..0]) << shamt;
   RETIRE_SUCCESS
 }
@@ -47,7 +47,7 @@ mapping zba_rtypeuw_mnemonic : shamt_zba <-> string = {
 mapping clause assembly = ZBA_RTYPEUW(rs2, rs1, rd, shamt)
   <-> zba_rtypeuw_mnemonic(shamt) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (ZBA_RTYPEUW(rs2, rs1, rd, shamt)) = {
+function clause execute ZBA_RTYPEUW(rs2, rs1, rd, shamt) = {
   X(rd) = (zero_extend(X(rs1)[31..0]) << shamt) + X(rs2);
   RETIRE_SUCCESS
 }
@@ -68,7 +68,7 @@ mapping zba_rtype_mnemonic : shamt_zba <-> string = {
 mapping clause assembly = ZBA_RTYPE(rs2, rs1, rd, shamt)
   <-> zba_rtype_mnemonic(shamt) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (ZBA_RTYPE(rs2, rs1, rd, shamt)) = {
+function clause execute ZBA_RTYPE(rs2, rs1, rd, shamt) = {
   X(rd) = (X(rs1) << shamt) + X(rs2);
   RETIRE_SUCCESS
 }

--- a/model/extensions/B/zbb_insts.sail
+++ b/model/extensions/B/zbb_insts.sail
@@ -19,7 +19,7 @@ mapping clause encdec = RORIW(shamt, rs1, rd)
 mapping clause assembly = RORIW(shamt, rs1, rd)
   <-> "roriw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_5(shamt)
 
-function clause execute (RORIW(shamt, rs1, rd)) = {
+function clause execute RORIW(shamt, rs1, rd) = {
   X(rd) = sign_extend(X(rs1)[31..0] >>> shamt);
   RETIRE_SUCCESS
 }
@@ -34,7 +34,7 @@ mapping clause encdec = RORI(shamt, rs1, rd)
 mapping clause assembly = RORI(shamt, rs1, rd)
   <-> "rori" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_6(shamt)
 
-function clause execute (RORI(shamt, rs1, rd)) = {
+function clause execute RORI(shamt, rs1, rd) = {
   let shamt = shamt[log2_xlen - 1 .. 0];
   X(rd) = X(rs1) >>> shamt;
   RETIRE_SUCCESS
@@ -198,7 +198,7 @@ mapping clause encdec = REV8(rs1, rd)
 mapping clause assembly = REV8(rs1, rd)
   <-> "rev8" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (REV8(rs1, rd)) = {
+function clause execute REV8(rs1, rd) = {
   X(rd) = rev8(X(rs1));
   RETIRE_SUCCESS
 }
@@ -213,7 +213,7 @@ mapping clause encdec = ORCB(rs1, rd)
 mapping clause assembly = ORCB(rs1, rd)
   <-> "orc.b" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (ORCB(rs1, rd)) = {
+function clause execute ORCB(rs1, rd) = {
   let rs1_val = X(rs1);
   var result : xlenbits = zeros();
   foreach (i from 0 to (xlen - 8) by 8)
@@ -234,7 +234,7 @@ mapping clause encdec = CPOP(rs1, rd)
 mapping clause assembly = CPOP(rs1, rd)
   <-> "cpop" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (CPOP(rs1, rd)) = {
+function clause execute CPOP(rs1, rd) = {
   X(rd) = to_bits(count_ones(X(rs1)));
   RETIRE_SUCCESS
 }
@@ -249,7 +249,7 @@ mapping clause encdec = CPOPW(rs1, rd)
 mapping clause assembly = CPOPW(rs1, rd)
   <-> "cpopw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (CPOPW(rs1, rd)) = {
+function clause execute CPOPW(rs1, rd) = {
   X(rd) = to_bits(count_ones(X(rs1)[31 .. 0]));
   RETIRE_SUCCESS
 }
@@ -264,7 +264,7 @@ mapping clause encdec = CLZ(rs1, rd)
 mapping clause assembly = CLZ(rs1, rd)
   <-> "clz" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (CLZ(rs1, rd)) = {
+function clause execute CLZ(rs1, rd) = {
   X(rd) = to_bits(count_leading_zeros(X(rs1)));
   RETIRE_SUCCESS
 }
@@ -279,7 +279,7 @@ mapping clause encdec = CLZW(rs1, rd)
 mapping clause assembly = CLZW(rs1, rd)
   <-> "clzw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (CLZW(rs1, rd)) = {
+function clause execute CLZW(rs1, rd) = {
   X(rd) = to_bits(count_leading_zeros(X(rs1)[31 .. 0]));
   RETIRE_SUCCESS
 }
@@ -294,7 +294,7 @@ mapping clause encdec = CTZ(rs1, rd)
 mapping clause assembly = CTZ(rs1, rd)
   <-> "ctz" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (CTZ(rs1, rd)) = {
+function clause execute CTZ(rs1, rd) = {
   X(rd) = to_bits(count_trailing_zeros(X(rs1)));
   RETIRE_SUCCESS
 }
@@ -309,7 +309,7 @@ mapping clause encdec = CTZW(rs1, rd)
 mapping clause assembly = CTZW(rs1, rd)
   <-> "ctzw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (CTZW(rs1, rd)) = {
+function clause execute CTZW(rs1, rd) = {
   X(rd) = to_bits(count_trailing_zeros(X(rs1)[31 .. 0]));
   RETIRE_SUCCESS
 }

--- a/model/extensions/B/zbc_insts.sail
+++ b/model/extensions/B/zbc_insts.sail
@@ -19,7 +19,7 @@ mapping clause encdec = CLMUL(rs2, rs1, rd)
 mapping clause assembly = CLMUL(rs2, rs1, rd)
   <-> "clmul" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (CLMUL(rs2, rs1, rd)) = {
+function clause execute CLMUL(rs2, rs1, rd) = {
   let prod = carryless_mul(X(rs1), X(rs2));
   X(rd) = prod[xlen - 1 .. 0];
   RETIRE_SUCCESS
@@ -35,7 +35,7 @@ mapping clause encdec = CLMULH(rs2, rs1, rd)
 mapping clause assembly = CLMULH(rs2, rs1, rd)
   <-> "clmulh" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (CLMULH(rs2, rs1, rd)) = {
+function clause execute CLMULH(rs2, rs1, rd) = {
   let prod = carryless_mul(X(rs1), X(rs2));
   X(rd) = prod[2 * xlen - 1 .. xlen];
   RETIRE_SUCCESS
@@ -51,7 +51,7 @@ mapping clause encdec = CLMULR(rs2, rs1, rd)
 mapping clause assembly = CLMULR(rs2, rs1, rd)
   <-> "clmulr" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (CLMULR(rs2, rs1, rd)) = {
+function clause execute CLMULR(rs2, rs1, rd) = {
   X(rd) = carryless_mulr(X(rs1), X(rs2));
   RETIRE_SUCCESS
 }

--- a/model/extensions/C/zca_insts.sail
+++ b/model/extensions/C/zca_insts.sail
@@ -36,7 +36,7 @@ mapping clause encdec_compressed = C_ADDI4SPN(rd, nz96 @ nz54 @ nz3 @ nz2)
   <-> 0b000 @ nz54 : bits(2) @ nz96 : bits(4) @ nz2 : bits(1) @ nz3 : bits(1) @ encdec_creg(rd) @ 0b00
   when nz96 @ nz54 @ nz3 @ nz2 != 0b00000000 & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_ADDI4SPN(rdc, nzimm)) = {
+function clause execute C_ADDI4SPN(rdc, nzimm) = {
   let imm : bits(12) = (0b00 @ nzimm @ 0b00);
   let rd = creg2reg_idx(rdc);
   execute(ITYPE(imm, sp, rd, ADDI))
@@ -54,7 +54,7 @@ mapping clause encdec_compressed = C_LW(ui6 @ ui53 @ ui2, rs1, rd)
   <-> 0b010 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_creg(rd) @ 0b00
   when currentlyEnabled(Ext_Zca)
 
-function clause execute (C_LW(uimm, rsc, rdc)) = {
+function clause execute C_LW(uimm, rsc, rdc) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   let rd = creg2reg_idx(rdc);
   let rs = creg2reg_idx(rsc);
@@ -71,7 +71,7 @@ mapping clause encdec_compressed = C_LD(ui76 @ ui53, rs1, rd)
   <-> 0b011 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_creg(rd) @ 0b00
   when xlen == 64 & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_LD(uimm, rsc, rdc)) = {
+function clause execute C_LD(uimm, rsc, rdc) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
   let rd = creg2reg_idx(rdc);
   let rs = creg2reg_idx(rsc);
@@ -89,7 +89,7 @@ mapping clause encdec_compressed = C_SW(ui6 @ ui53 @ ui2, rs1, rs2)
   <-> 0b110 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_creg(rs2) @ 0b00
   when currentlyEnabled(Ext_Zca)
 
-function clause execute (C_SW(uimm, rsc1, rsc2)) = {
+function clause execute C_SW(uimm, rsc1, rsc2) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   let rs1 = creg2reg_idx(rsc1);
   let rs2 = creg2reg_idx(rsc2);
@@ -107,7 +107,7 @@ mapping clause encdec_compressed = C_SD(ui76 @ ui53, rs1, rs2)
   <-> 0b111 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_creg(rs2) @ 0b00
       if xlen == 64 & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_SD(uimm, rsc1, rsc2)) = {
+function clause execute C_SD(uimm, rsc1, rsc2) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
   let rs1 = creg2reg_idx(rsc1);
   let rs2 = creg2reg_idx(rsc2);
@@ -128,7 +128,7 @@ mapping clause encdec_compressed = C_ADDI(imm5 @ imm40, rsd)
   <-> 0b000 @ imm5 : bits(1) @ encdec_reg(rsd) @ imm40 : bits(5) @ 0b01
   when rsd != zreg & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_ADDI(imm, rsd)) = {
+function clause execute C_ADDI(imm, rsd) = {
   let imm : bits(12) = sign_extend(imm);
   execute(ITYPE(imm, rsd, rsd, ADDI))
 }
@@ -144,7 +144,7 @@ mapping clause encdec_compressed = C_JAL(i11 @ i10 @ i98 @ i7 @ i6 @ i5 @ i4 @ i
   <-> 0b001 @ i11 : bits(1) @ i4 : bits(1) @ i98 : bits(2) @ i10 : bits(1) @ i6 : bits(1) @ i7 : bits(1) @ i31 : bits(3) @ i5 : bits(1) @ 0b01
   when xlen == 32 & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_JAL(imm)) =
+function clause execute C_JAL(imm) =
   execute(JAL(sign_extend(imm @ 0b0), ra))
 
 mapping clause assembly = C_JAL(imm)
@@ -158,7 +158,7 @@ mapping clause encdec_compressed = C_ADDIW(imm5 @ imm40, rsd)
   <-> 0b001 @ imm5 : bits(1) @ encdec_reg(rsd) @ imm40 : bits(5) @ 0b01
   when rsd != zreg & xlen == 64 & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_ADDIW(imm, rsd)) =
+function clause execute C_ADDIW(imm, rsd) =
   execute(ADDIW(sign_extend(imm), rsd, rsd))
 
 mapping clause assembly = C_ADDIW(imm, rsd)
@@ -173,7 +173,7 @@ mapping clause encdec_compressed = C_LI(imm5 @ imm40, rd)
   <-> 0b010 @ imm5 : bits(1) @ encdec_reg(rd) @ imm40 : bits(5) @ 0b01
   when currentlyEnabled(Ext_Zca)
 
-function clause execute (C_LI(imm, rd)) = {
+function clause execute C_LI(imm, rd) = {
   let imm : bits(12) = sign_extend(imm);
   execute(ITYPE(imm, zreg, rd, ADDI))
 }
@@ -188,7 +188,7 @@ mapping clause encdec_compressed = C_ADDI16SP(nzi9 @ nzi87 @ nzi6 @ nzi5 @ nzi4)
   <-> 0b011 @ nzi9 : bits(1) @ /* x2 */ 0b00010 @ nzi4 : bits(1) @ nzi6 : bits(1) @ nzi87 : bits(2) @ nzi5 : bits(1) @ 0b01
   when nzi9 @ nzi87 @ nzi6 @ nzi5 @ nzi4 != 0b000000 & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_ADDI16SP(imm)) = {
+function clause execute C_ADDI16SP(imm) = {
   let imm : bits(12) = sign_extend(imm @ 0x0);
   execute(ITYPE(imm, sp, sp, ADDI))
 }
@@ -207,7 +207,7 @@ mapping clause encdec_compressed = C_LUI(imm17 @ imm1612, rd)
   <-> 0b011 @ imm17 : bits(1) @ encdec_reg(rd) @ imm1612 : bits(5) @ 0b01
   when rd != sp & imm17 @ imm1612 != 0b000000 & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_LUI(imm, rd)) = {
+function clause execute C_LUI(imm, rd) = {
   let res : bits(20) = sign_extend(imm);
   execute(UTYPE(res, rd, LUI))
 }
@@ -224,7 +224,7 @@ mapping clause encdec_compressed = C_SRLI(shamt5 @ shamt40, rsd)
   <-> 0b100 @ shamt5 : bits(1) @ 0b00 @ encdec_creg(rsd) @ shamt40 : bits(5) @ 0b01
   when (xlen == 64 | shamt5 == 0b0) & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_SRLI(shamt, rsd)) = {
+function clause execute C_SRLI(shamt, rsd) = {
   let rsd = creg2reg_idx(rsd);
   execute(SHIFTIOP(shamt, rsd, rsd, SRLI))
 }
@@ -240,7 +240,7 @@ mapping clause encdec_compressed = C_SRAI(shamt5 @ shamt40, rsd)
   <-> 0b100 @ shamt5 : bits(1) @ 0b01 @ encdec_creg(rsd) @ shamt40 : bits(5) @ 0b01
   when (xlen == 64 | shamt5 == 0b0) & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_SRAI(shamt, rsd)) = {
+function clause execute C_SRAI(shamt, rsd) = {
   let rsd = creg2reg_idx(rsd);
   execute(SHIFTIOP(shamt, rsd, rsd, SRAI))
 }
@@ -255,7 +255,7 @@ mapping clause encdec_compressed = C_ANDI(i5 @ i40, rsd)
   <-> 0b100 @ i5 : bits(1) @ 0b10 @ encdec_creg(rsd) @ i40 : bits(5) @ 0b01
   when currentlyEnabled(Ext_Zca)
 
-function clause execute (C_ANDI(imm, rsd)) = {
+function clause execute C_ANDI(imm, rsd) = {
   let rsd = creg2reg_idx(rsd);
   execute(ITYPE(sign_extend(imm), rsd, rsd, ANDI))
 }
@@ -270,7 +270,7 @@ mapping clause encdec_compressed = C_SUB(rsd, rs2)
   <-> 0b100 @ 0b0 @ 0b11 @ encdec_creg(rsd) @ 0b00 @ encdec_creg(rs2) @ 0b01
   when currentlyEnabled(Ext_Zca)
 
-function clause execute (C_SUB(rsd, rs2)) = {
+function clause execute C_SUB(rsd, rs2) = {
   let rsd = creg2reg_idx(rsd);
   let rs2 = creg2reg_idx(rs2);
   execute(RTYPE(rs2, rsd, rsd, SUB))
@@ -286,7 +286,7 @@ mapping clause encdec_compressed = C_XOR(rsd, rs2)
   <-> 0b100 @ 0b0 @ 0b11 @ encdec_creg(rsd) @ 0b01 @ encdec_creg(rs2) @ 0b01
   when currentlyEnabled(Ext_Zca)
 
-function clause execute (C_XOR(rsd, rs2)) = {
+function clause execute C_XOR(rsd, rs2) = {
   let rsd = creg2reg_idx(rsd);
   let rs2 = creg2reg_idx(rs2);
   execute(RTYPE(rs2, rsd, rsd, XOR))
@@ -302,7 +302,7 @@ mapping clause encdec_compressed = C_OR(rsd, rs2)
   <-> 0b100 @ 0b0 @ 0b11 @ encdec_creg(rsd) @ 0b10 @ encdec_creg(rs2) @ 0b01
   when currentlyEnabled(Ext_Zca)
 
-function clause execute (C_OR(rsd, rs2)) = {
+function clause execute C_OR(rsd, rs2) = {
   let rsd = creg2reg_idx(rsd);
   let rs2 = creg2reg_idx(rs2);
   execute(RTYPE(rs2, rsd, rsd, OR))
@@ -318,7 +318,7 @@ mapping clause encdec_compressed = C_AND(rsd, rs2)
   <-> 0b100 @ 0b0 @ 0b11 @ encdec_creg(rsd) @ 0b11 @ encdec_creg(rs2) @ 0b01
   when currentlyEnabled(Ext_Zca)
 
-function clause execute (C_AND(rsd, rs2)) = {
+function clause execute C_AND(rsd, rs2) = {
   let rsd = creg2reg_idx(rsd);
   let rs2 = creg2reg_idx(rs2);
   execute(RTYPE(rs2, rsd, rsd, AND))
@@ -334,7 +334,7 @@ mapping clause encdec_compressed = C_SUBW(rsd, rs2)
   <-> 0b100 @ 0b1 @ 0b11 @ encdec_creg(rsd) @ 0b00 @ encdec_creg(rs2) @ 0b01
   when xlen == 64 & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_SUBW(rsd, rs2)) = {
+function clause execute C_SUBW(rsd, rs2) = {
   let rsd = creg2reg_idx(rsd);
   let rs2 = creg2reg_idx(rs2);
   execute(RTYPEW(rs2, rsd, rsd, SUBW))
@@ -351,7 +351,7 @@ mapping clause encdec_compressed = C_ADDW(rsd, rs2)
   <-> 0b100 @ 0b1 @ 0b11 @ encdec_creg(rsd) @ 0b01 @ encdec_creg(rs2) @ 0b01
   when xlen == 64 & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_ADDW(rsd, rs2)) = {
+function clause execute C_ADDW(rsd, rs2) = {
   let rsd = creg2reg_idx(rsd);
   let rs2 = creg2reg_idx(rs2);
   execute(RTYPEW(rs2, rsd, rsd, ADDW))
@@ -368,7 +368,7 @@ mapping clause encdec_compressed = C_J(i11 @ i10 @ i98 @ i7 @ i6 @ i5 @ i4 @ i31
   <-> 0b101 @ i11 : bits(1) @ i4 : bits(1) @ i98 : bits(2) @ i10 : bits(1) @ i6 : bits(1) @ i7 : bits(1) @ i31 : bits(3) @ i5 : bits(1) @ 0b01
   when currentlyEnabled(Ext_Zca)
 
-function clause execute (C_J(imm)) =
+function clause execute C_J(imm) =
   execute(JAL(sign_extend(imm @ 0b0), zreg))
 
 mapping clause assembly = C_J(imm)
@@ -381,7 +381,7 @@ mapping clause encdec_compressed = C_BEQZ(i8 @ i76 @ i5 @ i43 @ i21, rs)
   <-> 0b110 @ i8 : bits(1) @ i43 : bits(2) @ encdec_creg(rs) @ i76 : bits(2) @ i21 : bits(2) @ i5 : bits(1) @ 0b01
   when currentlyEnabled(Ext_Zca)
 
-function clause execute (C_BEQZ(imm, rs)) =
+function clause execute C_BEQZ(imm, rs) =
   execute(BTYPE(sign_extend(imm @ 0b0), zreg, creg2reg_idx(rs), BEQ))
 
 mapping clause assembly = C_BEQZ(imm, rs)
@@ -394,7 +394,7 @@ mapping clause encdec_compressed = C_BNEZ(i8 @ i76 @ i5 @ i43 @ i21, rs)
   <-> 0b111 @ i8 : bits(1) @ i43 : bits(2) @ encdec_creg(rs) @ i76 : bits(2) @ i21 : bits(2) @ i5 : bits(1) @ 0b01
   when currentlyEnabled(Ext_Zca)
 
-function clause execute (C_BNEZ(imm, rs)) =
+function clause execute C_BNEZ(imm, rs) =
   execute(BTYPE(sign_extend(imm @ 0b0), zreg, creg2reg_idx(rs), BNE))
 
 mapping clause assembly = C_BNEZ(imm, rs)
@@ -408,7 +408,7 @@ mapping clause encdec_compressed = C_SLLI(shamt5 @ shamt40, rsd)
   <-> 0b000 @ shamt5 : bits(1) @ encdec_reg(rsd) @ shamt40 : bits(5) @ 0b10
   when (xlen == 64 | shamt5 == 0b0) & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_SLLI(shamt, rsd)) =
+function clause execute C_SLLI(shamt, rsd) =
   execute(SHIFTIOP(shamt, rsd, rsd, SLLI))
 
 mapping clause assembly = C_SLLI(shamt, rsd)
@@ -421,7 +421,7 @@ mapping clause encdec_compressed = C_LWSP(ui76 @ ui5 @ ui42, rd)
   <-> 0b010 @ ui5 : bits(1) @ encdec_reg(rd) @ ui42 : bits(3) @ ui76 : bits(2) @ 0b10
   when rd != zreg & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_LWSP(uimm, rd)) = {
+function clause execute C_LWSP(uimm, rd) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   execute(LOAD(imm, sp, rd, false, 4))
 }
@@ -437,7 +437,7 @@ mapping clause encdec_compressed = C_LDSP(ui86 @ ui5 @ ui43, rd)
   <-> 0b011 @ ui5 : bits(1) @ encdec_reg(rd) @ ui43 : bits(2) @ ui86 : bits(3) @ 0b10
   when rd != zreg & xlen == 64 & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_LDSP(uimm, rd)) = {
+function clause execute C_LDSP(uimm, rd) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
   execute(LOAD(imm, sp, rd, false, 8))
 }
@@ -453,7 +453,7 @@ mapping clause encdec_compressed = C_SWSP(ui76 @ ui52, rs2)
   <-> 0b110 @ ui52 : bits(4) @ ui76 : bits(2) @ encdec_reg(rs2) @ 0b10
   when currentlyEnabled(Ext_Zca)
 
-function clause execute (C_SWSP(uimm, rs2)) = {
+function clause execute C_SWSP(uimm, rs2) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   execute(STORE(imm, rs2, sp, 4))
 }
@@ -468,7 +468,7 @@ mapping clause encdec_compressed = C_SDSP(ui86 @ ui53, rs2)
   <-> 0b111 @ ui53 : bits(3) @ ui86 : bits(3) @ encdec_reg(rs2) @ 0b10
   when xlen == 64 & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_SDSP(uimm, rs2)) = {
+function clause execute C_SDSP(uimm, rs2) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
   execute(STORE(imm, rs2, sp, 8))
 }
@@ -484,7 +484,7 @@ mapping clause encdec_compressed = C_JR(rs1)
   <-> 0b100 @ 0b0 @ encdec_reg(rs1) @ 0b00000 @ 0b10
   when rs1 != zreg & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_JR(rs1)) =
+function clause execute C_JR(rs1) =
   execute(JALR(zeros(), rs1, zreg))
 
 mapping clause assembly = C_JR(rs1)
@@ -498,7 +498,7 @@ mapping clause encdec_compressed = C_JALR(rs1)
   <-> 0b100 @ 0b1 @ encdec_reg(rs1) @ 0b00000 @ 0b10
   when rs1 != zreg & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_JALR(rs1)) =
+function clause execute C_JALR(rs1) =
   execute(JALR(zeros(), rs1, ra))
 
 mapping clause assembly = C_JALR(rs1)
@@ -514,7 +514,7 @@ mapping clause encdec_compressed = C_MV(rd, rs2)
   <-> 0b100 @ 0b0 @ encdec_reg(rd) @ encdec_reg(rs2) @ 0b10
   when rs2 != zreg & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_MV(rd, rs2)) =
+function clause execute C_MV(rd, rs2) =
   execute(RTYPE(rs2, zreg, rd, ADD))
 
 mapping clause assembly = C_MV(rd, rs2)
@@ -542,7 +542,7 @@ mapping clause encdec_compressed = C_ADD(rsd, rs2)
   <-> 0b100 @ 0b1 @ encdec_reg(rsd) @ encdec_reg(rs2) @ 0b10
   when rs2 != zreg & currentlyEnabled(Ext_Zca)
 
-function clause execute (C_ADD(rsd, rs2)) =
+function clause execute C_ADD(rsd, rs2) =
   execute(RTYPE(rs2, rsd, rsd, ADD))
 
 mapping clause assembly = C_ADD(rsd, rs2)

--- a/model/extensions/FD/dext_insts.sail
+++ b/model/extensions/FD/dext_insts.sail
@@ -439,7 +439,7 @@ mapping clause encdec = F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_LU)
 
 // Execution semantics ================================
 
-function clause execute (F_UN_RM_FF_TYPE_D(rs1, rm, rd, FSQRT_D)) = {
+function clause execute F_UN_RM_FF_TYPE_D(rs1, rm, rd, FSQRT_D) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -454,7 +454,7 @@ function clause execute (F_UN_RM_FF_TYPE_D(rs1, rm, rd, FSQRT_D)) = {
   }
 }
 
-function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_W_D)) = {
+function clause execute F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_W_D) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -469,7 +469,7 @@ function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_W_D)) = {
   }
 }
 
-function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_WU_D)) = {
+function clause execute F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_WU_D) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -484,7 +484,7 @@ function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_WU_D)) = {
   }
 }
 
-function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_W)) = {
+function clause execute F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_W) = {
   let rs1_val_W = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -499,7 +499,7 @@ function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_W)) = {
   }
 }
 
-function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_WU)) = {
+function clause execute F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_WU) = {
   let rs1_val_WU = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -514,7 +514,7 @@ function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_WU)) = {
   }
 }
 
-function clause execute (F_UN_RM_FF_TYPE_D(rs1, rm, rd, FCVT_S_D)) = {
+function clause execute F_UN_RM_FF_TYPE_D(rs1, rm, rd, FCVT_S_D) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -529,7 +529,7 @@ function clause execute (F_UN_RM_FF_TYPE_D(rs1, rm, rd, FCVT_S_D)) = {
   }
 }
 
-function clause execute (F_UN_RM_FF_TYPE_D(rs1, rm, rd, FCVT_D_S)) = {
+function clause execute F_UN_RM_FF_TYPE_D(rs1, rm, rd, FCVT_D_S) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -544,7 +544,7 @@ function clause execute (F_UN_RM_FF_TYPE_D(rs1, rm, rd, FCVT_D_S)) = {
   }
 }
 
-function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_L_D)) = {
+function clause execute F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_L_D) = {
   assert(xlen >= 64);
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
@@ -560,7 +560,7 @@ function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_L_D)) = {
   }
 }
 
-function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_LU_D)) = {
+function clause execute F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_LU_D) = {
   assert(xlen >= 64);
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
@@ -576,7 +576,7 @@ function clause execute (F_UN_RM_FX_TYPE_D(rs1, rm, rd, FCVT_LU_D)) = {
   }
 }
 
-function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_L)) = {
+function clause execute F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_L) = {
   assert(xlen >= 64);
   let rs1_val_L = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
@@ -592,7 +592,7 @@ function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_L)) = {
   }
 }
 
-function clause execute (F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_LU)) = {
+function clause execute F_UN_RM_XF_TYPE_D(rs1, rm, rd, FCVT_D_LU) = {
   assert(xlen >= 64);
   let rs1_val_LU = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
@@ -692,7 +692,7 @@ mapping clause encdec = F_BIN_X_TYPE_D(rs2, rs1, rd, FLE_D)
 
 // Execution semantics ================================
 
-function clause execute (F_BIN_F_TYPE_D(rs2, rs1, rd, FSGNJ_D)) = {
+function clause execute F_BIN_F_TYPE_D(rs2, rs1, rd, FSGNJ_D) = {
   let rs1_val_D    = F_or_X_D(rs1);
   let rs2_val_D    = F_or_X_D(rs2);
 
@@ -704,7 +704,7 @@ function clause execute (F_BIN_F_TYPE_D(rs2, rs1, rd, FSGNJ_D)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_F_TYPE_D(rs2, rs1, rd, FSGNJN_D)) = {
+function clause execute F_BIN_F_TYPE_D(rs2, rs1, rd, FSGNJN_D) = {
   let rs1_val_D    = F_or_X_D(rs1);
   let rs2_val_D    = F_or_X_D(rs2);
   let (s1, e1, m1) = fsplit_D (rs1_val_D);
@@ -715,7 +715,7 @@ function clause execute (F_BIN_F_TYPE_D(rs2, rs1, rd, FSGNJN_D)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_F_TYPE_D(rs2, rs1, rd, FSGNJX_D)) = {
+function clause execute F_BIN_F_TYPE_D(rs2, rs1, rd, FSGNJX_D) = {
   let rs1_val_D    = F_or_X_D(rs1);
   let rs2_val_D    = F_or_X_D(rs2);
   let (s1, e1, m1) = fsplit_D (rs1_val_D);
@@ -726,7 +726,7 @@ function clause execute (F_BIN_F_TYPE_D(rs2, rs1, rd, FSGNJX_D)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_F_TYPE_D(rs2, rs1, rd, FMIN_D)) = {
+function clause execute F_BIN_F_TYPE_D(rs2, rs1, rd, FMIN_D) = {
   let rs1_val_D = F_or_X_D(rs1);
   let rs2_val_D = F_or_X_D(rs2);
 
@@ -746,7 +746,7 @@ function clause execute (F_BIN_F_TYPE_D(rs2, rs1, rd, FMIN_D)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_F_TYPE_D(rs2, rs1, rd, FMAX_D)) = {
+function clause execute F_BIN_F_TYPE_D(rs2, rs1, rd, FMAX_D) = {
   let rs1_val_D = F_or_X_D(rs1);
   let rs2_val_D = F_or_X_D(rs2);
 
@@ -766,7 +766,7 @@ function clause execute (F_BIN_F_TYPE_D(rs2, rs1, rd, FMAX_D)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_X_TYPE_D(rs2, rs1, rd, FEQ_D)) = {
+function clause execute F_BIN_X_TYPE_D(rs2, rs1, rd, FEQ_D) = {
   let rs1_val_D = F_or_X_D(rs1);
   let rs2_val_D = F_or_X_D(rs2);
 
@@ -778,7 +778,7 @@ function clause execute (F_BIN_X_TYPE_D(rs2, rs1, rd, FEQ_D)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_X_TYPE_D(rs2, rs1, rd, FLT_D)) = {
+function clause execute F_BIN_X_TYPE_D(rs2, rs1, rd, FLT_D) = {
   let rs1_val_D = F_or_X_D(rs1);
   let rs2_val_D = F_or_X_D(rs2);
 
@@ -790,7 +790,7 @@ function clause execute (F_BIN_X_TYPE_D(rs2, rs1, rd, FLT_D)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_X_TYPE_D(rs2, rs1, rd, FLE_D)) = {
+function clause execute F_BIN_X_TYPE_D(rs2, rs1, rd, FLE_D) = {
   let rs1_val_D = F_or_X_D(rs1);
   let rs2_val_D = F_or_X_D(rs2);
 
@@ -854,7 +854,7 @@ mapping clause encdec = F_UN_F_TYPE_D(rs1, rd, FMV_D_X)
 
 // Execution semantics ================================
 
-function clause execute (F_UN_X_TYPE_D(rs1, rd, FCLASS_D)) = {
+function clause execute F_UN_X_TYPE_D(rs1, rd, FCLASS_D) = {
   let rs1_val_D = F_or_X_D(rs1);
 
   let rd_val_10b : bits (10) =
@@ -874,13 +874,13 @@ function clause execute (F_UN_X_TYPE_D(rs1, rd, FCLASS_D)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_UN_X_TYPE_D(rs1, rd, FMV_X_D)) = {
+function clause execute F_UN_X_TYPE_D(rs1, rd, FMV_X_D) = {
   assert(xlen >= 64 & flen >= 64);
   X(rd) = sign_extend(F(rs1)[63..0]);
   RETIRE_SUCCESS
 }
 
-function clause execute (F_UN_F_TYPE_D(rs1, rd, FMV_D_X)) = {
+function clause execute F_UN_F_TYPE_D(rs1, rd, FMV_D_X) = {
   assert(xlen >= 64 & flen >= 64);
   F(rd) = nan_box(X(rs1)[63..0]);
   RETIRE_SUCCESS

--- a/model/extensions/FD/fext_insts.sail
+++ b/model/extensions/FD/fext_insts.sail
@@ -288,7 +288,7 @@ mapping clause encdec = LOAD_FP(imm, rs1, rd, width)
 
 // Execution semantics ================================
 
-function clause execute(LOAD_FP(imm, rs1, rd, width)) = {
+function clause execute LOAD_FP(imm, rs1, rd, width) = {
   // This is checked during decoding.
   assert(width <= flen_bytes);
 
@@ -323,7 +323,7 @@ mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, width)
 
 // Execution semantics ================================
 
-function clause execute (STORE_FP(imm, rs2, rs1, width)) = {
+function clause execute STORE_FP(imm, rs2, rs1, width) = {
   // This is checked during decoding.
   assert(width <= flen_bytes);
 
@@ -526,7 +526,7 @@ mapping clause encdec = F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_LU)
 
 // Execution semantics ================================
 
-function clause execute (F_UN_RM_FF_TYPE_S(rs1, rm, rd, FSQRT_S)) = {
+function clause execute F_UN_RM_FF_TYPE_S(rs1, rm, rd, FSQRT_S) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -541,7 +541,7 @@ function clause execute (F_UN_RM_FF_TYPE_S(rs1, rm, rd, FSQRT_S)) = {
   }
 }
 
-function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_W_S)) = {
+function clause execute F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_W_S) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -556,7 +556,7 @@ function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_W_S)) = {
   }
 }
 
-function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_WU_S)) = {
+function clause execute F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_WU_S) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -571,7 +571,7 @@ function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_WU_S)) = {
   }
 }
 
-function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_W)) = {
+function clause execute F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_W) = {
   let rs1_val_W = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -586,7 +586,7 @@ function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_W)) = {
   }
 }
 
-function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_WU)) = {
+function clause execute F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_WU) = {
   let rs1_val_WU = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -601,7 +601,7 @@ function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_WU)) = {
   }
 }
 
-function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_L_S)) = {
+function clause execute F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_L_S) = {
   assert(xlen >= 64);
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
@@ -617,7 +617,7 @@ function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_L_S)) = {
   }
 }
 
-function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_LU_S)) = {
+function clause execute F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_LU_S) = {
   assert(xlen >= 64);
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
@@ -633,7 +633,7 @@ function clause execute (F_UN_RM_FX_TYPE_S(rs1, rm, rd, FCVT_LU_S)) = {
   }
 }
 
-function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_L)) = {
+function clause execute F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_L) = {
   assert(xlen >= 64);
   let rs1_val_L = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
@@ -649,7 +649,7 @@ function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_L)) = {
   }
 }
 
-function clause execute (F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_LU)) = {
+function clause execute F_UN_RM_XF_TYPE_S(rs1, rm, rd, FCVT_S_LU) = {
   assert(xlen >= 64);
   let rs1_val_LU = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
@@ -744,7 +744,7 @@ mapping clause encdec = F_BIN_TYPE_X_S(rs2, rs1, rd, FLE_S)
 
 // Execution semantics ================================
 
-function clause execute (F_BIN_TYPE_F_S(rs2, rs1, rd, FSGNJ_S)) = {
+function clause execute F_BIN_TYPE_F_S(rs2, rs1, rd, FSGNJ_S) = {
   let rs1_val_S    = F_or_X_S(rs1);
   let rs2_val_S    = F_or_X_S(rs2);
   let (s1, e1, m1) = fsplit_S (rs1_val_S);
@@ -755,7 +755,7 @@ function clause execute (F_BIN_TYPE_F_S(rs2, rs1, rd, FSGNJ_S)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_F_S(rs2, rs1, rd, FSGNJN_S)) = {
+function clause execute F_BIN_TYPE_F_S(rs2, rs1, rd, FSGNJN_S) = {
   let rs1_val_S    = F_or_X_S(rs1);
   let rs2_val_S    = F_or_X_S(rs2);
   let (s1, e1, m1) = fsplit_S (rs1_val_S);
@@ -766,7 +766,7 @@ function clause execute (F_BIN_TYPE_F_S(rs2, rs1, rd, FSGNJN_S)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_F_S(rs2, rs1, rd, FSGNJX_S)) = {
+function clause execute F_BIN_TYPE_F_S(rs2, rs1, rd, FSGNJX_S) = {
   let rs1_val_S    = F_or_X_S(rs1);
   let rs2_val_S    = F_or_X_S(rs2);
   let (s1, e1, m1) = fsplit_S (rs1_val_S);
@@ -777,7 +777,7 @@ function clause execute (F_BIN_TYPE_F_S(rs2, rs1, rd, FSGNJX_S)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_F_S(rs2, rs1, rd, FMIN_S)) = {
+function clause execute F_BIN_TYPE_F_S(rs2, rs1, rd, FMIN_S) = {
   let rs1_val_S = F_or_X_S(rs1);
   let rs2_val_S = F_or_X_S(rs2);
 
@@ -797,7 +797,7 @@ function clause execute (F_BIN_TYPE_F_S(rs2, rs1, rd, FMIN_S)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_F_S(rs2, rs1, rd, FMAX_S)) = {
+function clause execute F_BIN_TYPE_F_S(rs2, rs1, rd, FMAX_S) = {
   let rs1_val_S = F_or_X_S(rs1);
   let rs2_val_S = F_or_X_S(rs2);
 
@@ -817,7 +817,7 @@ function clause execute (F_BIN_TYPE_F_S(rs2, rs1, rd, FMAX_S)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_X_S(rs2, rs1, rd, FEQ_S)) = {
+function clause execute F_BIN_TYPE_X_S(rs2, rs1, rd, FEQ_S) = {
   let rs1_val_S = F_or_X_S(rs1);
   let rs2_val_S = F_or_X_S(rs2);
 
@@ -829,7 +829,7 @@ function clause execute (F_BIN_TYPE_X_S(rs2, rs1, rd, FEQ_S)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_X_S(rs2, rs1, rd, FLT_S)) = {
+function clause execute F_BIN_TYPE_X_S(rs2, rs1, rd, FLT_S) = {
   let rs1_val_S = F_or_X_S(rs1);
   let rs2_val_S = F_or_X_S(rs2);
 
@@ -841,7 +841,7 @@ function clause execute (F_BIN_TYPE_X_S(rs2, rs1, rd, FLT_S)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_TYPE_X_S(rs2, rs1, rd, FLE_S)) = {
+function clause execute F_BIN_TYPE_X_S(rs2, rs1, rd, FLE_S) = {
   let rs1_val_S = F_or_X_S(rs1);
   let rs2_val_S = F_or_X_S(rs2);
 
@@ -903,7 +903,7 @@ mapping clause encdec = F_UN_TYPE_F_S(rs1, rd, FMV_W_X)
 
 // Execution semantics ================================
 
-function clause execute (F_UN_TYPE_X_S(rs1, rd, FCLASS_S)) = {
+function clause execute F_UN_TYPE_X_S(rs1, rd, FCLASS_S) = {
   let rs1_val_S = F_or_X_S(rs1);
 
   let rd_val_10b : bits (10) =
@@ -923,12 +923,12 @@ function clause execute (F_UN_TYPE_X_S(rs1, rd, FCLASS_S)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_UN_TYPE_X_S(rs1, rd, FMV_X_W)) = {
+function clause execute F_UN_TYPE_X_S(rs1, rd, FMV_X_W) = {
   X(rd) = sign_extend(F(rs1)[31..0]);
   RETIRE_SUCCESS
 }
 
-function clause execute (F_UN_TYPE_F_S(rs1, rd, FMV_W_X)) = {
+function clause execute F_UN_TYPE_F_S(rs1, rd, FMV_W_X) = {
   F(rd) = nan_box(X(rs1)[31..0]);
   RETIRE_SUCCESS
 }

--- a/model/extensions/FD/zcd_insts.sail
+++ b/model/extensions/FD/zcd_insts.sail
@@ -14,7 +14,7 @@ mapping clause encdec_compressed = C_FLDSP(ui86 @ ui5 @ ui43, rd)
   <-> 0b001 @ ui5 : bits(1) @ encdec_freg(rd) @ ui43 : bits(2) @ ui86 : bits(3) @ 0b10
   when currentlyEnabled(Ext_Zcd)
 
-function clause execute (C_FLDSP(uimm, rd)) = {
+function clause execute C_FLDSP(uimm, rd) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
   execute(LOAD_FP(imm, sp, rd, 8))
 }
@@ -29,7 +29,7 @@ mapping clause encdec_compressed = C_FSDSP(ui86 @ ui53, rs2)
   <-> 0b101 @ ui53 : bits(3) @ ui86 : bits(3) @ encdec_freg(rs2) @ 0b10
   when currentlyEnabled(Ext_Zcd)
 
-function clause execute (C_FSDSP(uimm, rs2)) = {
+function clause execute C_FSDSP(uimm, rs2) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
   execute(STORE_FP(imm, rs2, sp, 8))
 }
@@ -44,7 +44,7 @@ mapping clause encdec_compressed = C_FLD(ui76 @ ui53, rs1, rd)
   <-> 0b001 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_cfreg(rd) @ 0b00
   when currentlyEnabled(Ext_Zcd)
 
-function clause execute (C_FLD(uimm, rsc, rdc)) = {
+function clause execute C_FLD(uimm, rsc, rdc) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
   let rd = cfregidx_to_fregidx(rdc);
   let rs = creg2reg_idx(rsc);
@@ -61,7 +61,7 @@ mapping clause encdec_compressed = C_FSD(ui76 @ ui53, rs1, rs2)
   <-> 0b101 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui76 : bits(2) @ encdec_cfreg(rs2) @ 0b00
   when currentlyEnabled(Ext_Zcd)
 
-function clause execute (C_FSD(uimm, rsc1, rsc2)) = {
+function clause execute C_FSD(uimm, rsc1, rsc2) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
   let rs1 = creg2reg_idx(rsc1);
   let rs2 = cfregidx_to_fregidx(rsc2);

--- a/model/extensions/FD/zcf_insts.sail
+++ b/model/extensions/FD/zcf_insts.sail
@@ -14,7 +14,7 @@ mapping clause encdec_compressed = C_FLWSP(ui76 @ ui5 @ ui42, rd)
   <-> 0b011 @ ui5 : bits(1) @ encdec_freg(rd) @ ui42 : bits(3) @ ui76 : bits(2) @ 0b10
   when currentlyEnabled(Ext_Zcf)
 
-function clause execute (C_FLWSP(imm, rd)) = {
+function clause execute C_FLWSP(imm, rd) = {
   let imm : bits(12) = zero_extend(imm @ 0b00);
   execute(LOAD_FP(imm, sp, rd, 4))
 }
@@ -30,7 +30,7 @@ mapping clause encdec_compressed = C_FSWSP(ui76 @ ui52, rs2)
   <-> 0b111 @ ui52 : bits(4) @ ui76 : bits(2) @ encdec_freg(rs2) @ 0b10
   when currentlyEnabled(Ext_Zcf)
 
-function clause execute (C_FSWSP(uimm, rs2)) = {
+function clause execute C_FSWSP(uimm, rs2) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   execute(STORE_FP(imm, rs2, sp, 4))
 }
@@ -46,7 +46,7 @@ mapping clause encdec_compressed = C_FLW(ui6 @ ui53 @ ui2, rs1, rd)
   <-> 0b011 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_cfreg(rd) @ 0b00
   when currentlyEnabled(Ext_Zcf)
 
-function clause execute (C_FLW(uimm, rsc, rdc)) = {
+function clause execute C_FLW(uimm, rsc, rdc) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   let rd = cfregidx_to_fregidx(rdc);
   let rs = creg2reg_idx(rsc);
@@ -64,7 +64,7 @@ mapping clause encdec_compressed = C_FSW(ui6 @ ui53 @ ui2, rs1, rs2)
   <-> 0b111 @ ui53 : bits(3) @ encdec_creg(rs1) @ ui2 : bits(1) @ ui6 : bits(1) @ encdec_cfreg(rs2) @ 0b00
   when currentlyEnabled(Ext_Zcf)
 
-function clause execute (C_FSW(uimm, rsc1, rsc2)) = {
+function clause execute C_FSW(uimm, rsc1, rsc2) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   let rs1 = creg2reg_idx(rsc1);
   let rs2 = cfregidx_to_fregidx(rsc2);

--- a/model/extensions/FD/zfa_insts.sail
+++ b/model/extensions/FD/zfa_insts.sail
@@ -19,7 +19,7 @@ mapping clause encdec = FLI_H(constantidx, rd)
 mapping clause assembly = FLI_H(constantidx, rd)
   <-> "fli.h" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_5(constantidx)
 
-function clause execute (FLI_H(constantidx, rd)) = {
+function clause execute FLI_H(constantidx, rd) = {
   let bits : bits(16) = match constantidx {
     0b00000 => { 0xbc00 },  // -1.0
     0b00001 => { 0x0400 },  // minimum positive normal
@@ -69,7 +69,7 @@ mapping clause encdec = FLI_S(constantidx, rd)
 mapping clause assembly = FLI_S(constantidx, rd)
   <-> "fli.s" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_5(constantidx)
 
-function clause execute (FLI_S(constantidx, rd)) = {
+function clause execute FLI_S(constantidx, rd) = {
   let bits : bits(32) = match constantidx {
     0b00000 => { 0xbf800000 },  // -1.0
     0b00001 => { 0x00800000 },  // minimum positive normal
@@ -119,7 +119,7 @@ mapping clause encdec = FLI_D(constantidx, rd)
 mapping clause assembly = FLI_D(constantidx, rd)
   <-> "fli.d" ^ spc() ^ freg_name(rd) ^ sep() ^ hex_bits_5(constantidx)
 
-function clause execute (FLI_D(constantidx, rd)) = {
+function clause execute FLI_D(constantidx, rd) = {
   let bits : bits(64) = match constantidx {
     0b00000 => { 0xbff0000000000000 },  // -1.0
     0b00001 => { 0x0010000000000000 },  // minimum positive normal
@@ -171,7 +171,7 @@ mapping clause assembly = FMINM_H(rs2, rs1, rd)
                 ^ sep() ^ freg_name(rs1)
                 ^ sep() ^ freg_name(rs2)
 
-function clause execute (FMINM_H(rs2, rs1, rd)) = {
+function clause execute FMINM_H(rs2, rs1, rd) = {
   let rs1_val_H = F_H(rs1);
   let rs2_val_H = F_H(rs2);
 
@@ -202,7 +202,7 @@ mapping clause assembly = FMAXM_H(rs2, rs1, rd)
                 ^ sep() ^ freg_name(rs1)
                 ^ sep() ^ freg_name(rs2)
 
-function clause execute (FMAXM_H(rs2, rs1, rd)) = {
+function clause execute FMAXM_H(rs2, rs1, rd) = {
   let rs1_val_H = F_H(rs1);
   let rs2_val_H = F_H(rs2);
 
@@ -233,7 +233,7 @@ mapping clause assembly = FMINM_S(rs2, rs1, rd)
                 ^ sep() ^ freg_name(rs1)
                 ^ sep() ^ freg_name(rs2)
 
-function clause execute (FMINM_S(rs2, rs1, rd)) = {
+function clause execute FMINM_S(rs2, rs1, rd) = {
   let rs1_val_S = F_S(rs1);
   let rs2_val_S = F_S(rs2);
 
@@ -264,7 +264,7 @@ mapping clause assembly = FMAXM_S(rs2, rs1, rd)
                 ^ sep() ^ freg_name(rs1)
                 ^ sep() ^ freg_name(rs2)
 
-function clause execute (FMAXM_S(rs2, rs1, rd)) = {
+function clause execute FMAXM_S(rs2, rs1, rd) = {
   let rs1_val_S = F_S(rs1);
   let rs2_val_S = F_S(rs2);
 
@@ -295,7 +295,7 @@ mapping clause assembly = FMINM_D(rs2, rs1, rd)
                 ^ sep() ^ freg_name(rs1)
                 ^ sep() ^ freg_name(rs2)
 
-function clause execute (FMINM_D(rs2, rs1, rd)) = {
+function clause execute FMINM_D(rs2, rs1, rd) = {
   let rs1_val_D = F_D(rs1);
   let rs2_val_D = F_D(rs2);
 
@@ -326,7 +326,7 @@ mapping clause assembly = FMAXM_D(rs2, rs1, rd)
                 ^ sep() ^ freg_name(rs1)
                 ^ sep() ^ freg_name(rs2)
 
-function clause execute (FMAXM_D(rs2, rs1, rd)) = {
+function clause execute FMAXM_D(rs2, rs1, rd) = {
   let rs1_val_D = F_D(rs1);
   let rs2_val_D = F_D(rs2);
 
@@ -357,7 +357,7 @@ mapping clause assembly = FROUND_H(rs1, rm, rd)
                  ^ sep() ^ freg_name(rs1)
                  ^ sep() ^ frm_mnemonic(rm)
 
-function clause execute (FROUND_H(rs1, rm, rd)) = {
+function clause execute FROUND_H(rs1, rm, rd) = {
   let rs1_val_H = F_H(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
@@ -386,7 +386,7 @@ mapping clause assembly = FROUNDNX_H(rs1, rm, rd)
                    ^ sep() ^ freg_name(rs1)
                    ^ sep() ^ frm_mnemonic(rm)
 
-function clause execute (FROUNDNX_H(rs1, rm, rd)) = {
+function clause execute FROUNDNX_H(rs1, rm, rd) = {
   let rs1_val_H = F_H(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
@@ -415,7 +415,7 @@ mapping clause assembly = FROUND_S(rs1, rm, rd)
                  ^ sep() ^ freg_name(rs1)
                  ^ sep() ^ frm_mnemonic(rm)
 
-function clause execute (FROUND_S(rs1, rm, rd)) = {
+function clause execute FROUND_S(rs1, rm, rd) = {
   let rs1_val_S = F_S(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
@@ -444,7 +444,7 @@ mapping clause assembly = FROUNDNX_S(rs1, rm, rd)
                    ^ sep() ^ freg_name(rs1)
                    ^ sep() ^ frm_mnemonic(rm)
 
-function clause execute (FROUNDNX_S(rs1, rm, rd)) = {
+function clause execute FROUNDNX_S(rs1, rm, rd) = {
   let rs1_val_S = F_S(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
@@ -473,7 +473,7 @@ mapping clause assembly = FROUND_D(rs1, rm, rd)
                  ^ sep() ^ freg_name(rs1)
                  ^ sep() ^ frm_mnemonic(rm)
 
-function clause execute (FROUND_D(rs1, rm, rd)) = {
+function clause execute FROUND_D(rs1, rm, rd) = {
   let rs1_val_D = F_D(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
@@ -502,7 +502,7 @@ mapping clause assembly = FROUNDNX_D(rs1, rm, rd)
                    ^ sep() ^ freg_name(rs1)
                    ^ sep() ^ frm_mnemonic(rm)
 
-function clause execute (FROUNDNX_D(rs1, rm, rd)) = {
+function clause execute FROUNDNX_D(rs1, rm, rd) = {
   let rs1_val_D = F_D(rs1);
 
   match (select_instr_or_fcsr_rm(rm)) {
@@ -530,7 +530,7 @@ mapping clause assembly = FMVH_X_D(rs1, rd)
   <-> "fmvh.x.d" ^ spc() ^ reg_name(rd)
                  ^ sep() ^ freg_name(rs1)
 
-function clause execute (FMVH_X_D(rs1, rd)) = {
+function clause execute FMVH_X_D(rs1, rd) = {
   let rs1_val_D           = F_D(rs1)[63..32];
   let rd_val_X : xlenbits = sign_extend(rs1_val_D);
   X(rd)                   = rd_val_X;
@@ -550,7 +550,7 @@ mapping clause assembly = FMVP_D_X(rs2, rs1, rd)
                  ^ sep() ^ reg_name(rs1)
                  ^ sep() ^ reg_name(rs2)
 
-function clause execute (FMVP_D_X(rs2, rs1, rd)) = {
+function clause execute FMVP_D_X(rs2, rs1, rd) = {
   let rs1_val_X     = X(rs1)[31..0];
   let rs2_val_X     = X(rs2)[31..0];
 
@@ -578,7 +578,7 @@ mapping clause assembly = FLEQ_H(rs2, rs1, rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
-function clause execute(FLEQ_H(rs2, rs1, rd)) = {
+function clause execute FLEQ_H(rs2, rs1, rd) = {
   let rs1_val_H = F_H(rs1);
   let rs2_val_H = F_H(rs2);
 
@@ -603,7 +603,7 @@ mapping clause assembly = FLTQ_H(rs2, rs1, rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
-function clause execute(FLTQ_H(rs2, rs1, rd)) = {
+function clause execute FLTQ_H(rs2, rs1, rd) = {
   let rs1_val_H = F_H(rs1);
   let rs2_val_H = F_H(rs2);
 
@@ -628,7 +628,7 @@ mapping clause assembly = FLEQ_S(rs2, rs1, rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
-function clause execute(FLEQ_S(rs2, rs1, rd)) = {
+function clause execute FLEQ_S(rs2, rs1, rd) = {
   let rs1_val_S = F_S(rs1);
   let rs2_val_S = F_S(rs2);
 
@@ -653,7 +653,7 @@ mapping clause assembly = FLTQ_S(rs2, rs1, rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
-function clause execute(FLTQ_S(rs2, rs1, rd)) = {
+function clause execute FLTQ_S(rs2, rs1, rd) = {
   let rs1_val_S = F_S(rs1);
   let rs2_val_S = F_S(rs2);
 
@@ -679,7 +679,7 @@ mapping clause assembly = FLEQ_D(rs2, rs1, rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
-function clause execute(FLEQ_D(rs2, rs1, rd)) = {
+function clause execute FLEQ_D(rs2, rs1, rd) = {
   let rs1_val_D = F_D(rs1);
   let rs2_val_D = F_D(rs2);
 
@@ -704,7 +704,7 @@ mapping clause assembly = FLTQ_D(rs2, rs1, rd)
                ^ sep() ^ freg_name(rs1)
                ^ sep() ^ freg_name(rs2)
 
-function clause execute(FLTQ_D(rs2, rs1, rd)) = {
+function clause execute FLTQ_D(rs2, rs1, rd) = {
   let rs1_val_D = F_D(rs1);
   let rs2_val_D = F_D(rs2);
 
@@ -786,7 +786,7 @@ mapping clause encdec = FCVTMOD_W_D(rs1, rd)
 mapping clause assembly = FCVTMOD_W_D(rs1, rd)
   <-> "fcvtmod.w.d" ^ spc() ^ reg_name(rd) ^ sep() ^ freg_name(rs1) ^ sep() ^ "rtz"
 
-function clause execute(FCVTMOD_W_D(rs1, rd)) = {
+function clause execute FCVTMOD_W_D(rs1, rd) = {
   let rs1_val_D = F_D(rs1);
   let (fflags, rd_val) = fcvtmod_helper(rs1_val_D);
   accrue_fflags(fflags);

--- a/model/extensions/FD/zfh_insts.sail
+++ b/model/extensions/FD/zfh_insts.sail
@@ -352,7 +352,7 @@ mapping clause encdec = F_BIN_X_TYPE_H(rs2, rs1, rd, FLE_H)
 
 // Execution semantics ================================
 
-function clause execute (F_BIN_F_TYPE_H(rs2, rs1, rd, FSGNJ_H)) = {
+function clause execute F_BIN_F_TYPE_H(rs2, rs1, rd, FSGNJ_H) = {
   let rs1_val_H    = F_or_X_H(rs1);
   let rs2_val_H    = F_or_X_H(rs2);
   let (s1, e1, m1) = fsplit_H (rs1_val_H);
@@ -363,7 +363,7 @@ function clause execute (F_BIN_F_TYPE_H(rs2, rs1, rd, FSGNJ_H)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_F_TYPE_H(rs2, rs1, rd, FSGNJN_H)) = {
+function clause execute F_BIN_F_TYPE_H(rs2, rs1, rd, FSGNJN_H) = {
   let rs1_val_H    = F_or_X_H(rs1);
   let rs2_val_H    = F_or_X_H(rs2);
   let (s1, e1, m1) = fsplit_H (rs1_val_H);
@@ -374,7 +374,7 @@ function clause execute (F_BIN_F_TYPE_H(rs2, rs1, rd, FSGNJN_H)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_F_TYPE_H(rs2, rs1, rd, FSGNJX_H)) = {
+function clause execute F_BIN_F_TYPE_H(rs2, rs1, rd, FSGNJX_H) = {
   let rs1_val_H    = F_or_X_H(rs1);
   let rs2_val_H    = F_or_X_H(rs2);
   let (s1, e1, m1) = fsplit_H (rs1_val_H);
@@ -385,7 +385,7 @@ function clause execute (F_BIN_F_TYPE_H(rs2, rs1, rd, FSGNJX_H)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_F_TYPE_H(rs2, rs1, rd, FMIN_H)) = {
+function clause execute F_BIN_F_TYPE_H(rs2, rs1, rd, FMIN_H) = {
   let rs1_val_H = F_or_X_H(rs1);
   let rs2_val_H = F_or_X_H(rs2);
 
@@ -405,7 +405,7 @@ function clause execute (F_BIN_F_TYPE_H(rs2, rs1, rd, FMIN_H)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_F_TYPE_H(rs2, rs1, rd, FMAX_H)) = {
+function clause execute F_BIN_F_TYPE_H(rs2, rs1, rd, FMAX_H) = {
   let rs1_val_H = F_or_X_H(rs1);
   let rs2_val_H = F_or_X_H(rs2);
 
@@ -425,7 +425,7 @@ function clause execute (F_BIN_F_TYPE_H(rs2, rs1, rd, FMAX_H)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_X_TYPE_H(rs2, rs1, rd, FEQ_H)) = {
+function clause execute F_BIN_X_TYPE_H(rs2, rs1, rd, FEQ_H) = {
   let rs1_val_H = F_or_X_H(rs1);
   let rs2_val_H = F_or_X_H(rs2);
 
@@ -437,7 +437,7 @@ function clause execute (F_BIN_X_TYPE_H(rs2, rs1, rd, FEQ_H)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_X_TYPE_H(rs2, rs1, rd, FLT_H)) = {
+function clause execute F_BIN_X_TYPE_H(rs2, rs1, rd, FLT_H) = {
   let rs1_val_H = F_or_X_H(rs1);
   let rs2_val_H = F_or_X_H(rs2);
 
@@ -449,7 +449,7 @@ function clause execute (F_BIN_X_TYPE_H(rs2, rs1, rd, FLT_H)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_BIN_X_TYPE_H(rs2, rs1, rd, FLE_H)) = {
+function clause execute F_BIN_X_TYPE_H(rs2, rs1, rd, FLE_H) = {
   let rs1_val_H = F_or_X_H(rs1);
   let rs2_val_H = F_or_X_H(rs2);
 
@@ -559,7 +559,7 @@ mapping clause encdec = F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_LU)
 
 // Execution semantics ================================
 
-function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FSQRT_H)) = {
+function clause execute F_UN_RM_FF_TYPE_H(rs1, rm, rd, FSQRT_H) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -574,7 +574,7 @@ function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FSQRT_H)) = {
   }
 }
 
-function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_W_H)) = {
+function clause execute F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_W_H) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -589,7 +589,7 @@ function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_W_H)) = {
   }
 }
 
-function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_WU_H)) = {
+function clause execute F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_WU_H) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -604,7 +604,7 @@ function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_WU_H)) = {
   }
 }
 
-function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_W)) = {
+function clause execute F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_W) = {
   let rs1_val_W = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -619,7 +619,7 @@ function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_W)) = {
   }
 }
 
-function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_WU)) = {
+function clause execute F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_WU) = {
   let rs1_val_WU = X(rs1) [31..0];
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -634,7 +634,7 @@ function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_WU)) = {
   }
 }
 
-function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_H_S)) = {
+function clause execute F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_H_S) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -649,7 +649,7 @@ function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_H_S)) = {
   }
 }
 
-function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_H_D)) = {
+function clause execute F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_H_D) = {
   let rs1_val_D = F_or_X_D(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -664,7 +664,7 @@ function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_H_D)) = {
   }
 }
 
-function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_S_H)) = {
+function clause execute F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_S_H) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -679,7 +679,7 @@ function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_S_H)) = {
   }
 }
 
-function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_D_H)) = {
+function clause execute F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_D_H) = {
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -694,7 +694,7 @@ function clause execute (F_UN_RM_FF_TYPE_H(rs1, rm, rd, FCVT_D_H)) = {
   }
 }
 
-function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_L_H)) = {
+function clause execute F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_L_H) = {
   assert(xlen >= 64);
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
@@ -710,7 +710,7 @@ function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_L_H)) = {
   }
 }
 
-function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_LU_H)) = {
+function clause execute F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_LU_H) = {
   assert(xlen >= 64);
   let rs1_val_H = F_or_X_H(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
@@ -726,7 +726,7 @@ function clause execute (F_UN_RM_FX_TYPE_H(rs1, rm, rd, FCVT_LU_H)) = {
   }
 }
 
-function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_L)) = {
+function clause execute F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_L) = {
   assert(xlen >= 64);
   let rs1_val_L = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
@@ -742,7 +742,7 @@ function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_L)) = {
   }
 }
 
-function clause execute (F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_LU)) = {
+function clause execute F_UN_RM_XF_TYPE_H(rs1, rm, rd, FCVT_H_LU) = {
   assert(xlen >= 64);
   let rs1_val_LU = X(rs1)[63..0];
   match (select_instr_or_fcsr_rm (rm)) {
@@ -822,7 +822,7 @@ mapping clause encdec = F_UN_F_TYPE_H(rs1, rd, FMV_H_X)
 
 // Execution semantics ================================
 
-function clause execute (F_UN_X_TYPE_H(rs1, rd, FCLASS_H)) = {
+function clause execute F_UN_X_TYPE_H(rs1, rd, FCLASS_H) = {
   let rs1_val_H = F_or_X_H(rs1);
 
   let rd_val_10b : bits (10) =
@@ -842,14 +842,14 @@ function clause execute (F_UN_X_TYPE_H(rs1, rd, FCLASS_H)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (F_UN_X_TYPE_H(rs1, rd, FMV_X_H)) = {
+function clause execute F_UN_X_TYPE_H(rs1, rd, FMV_X_H) = {
   let rs1_val_H            = F(rs1)[15..0];
   let rd_val_X  : xlenbits = sign_extend(rs1_val_H);
   X(rd) = rd_val_X;
   RETIRE_SUCCESS
 }
 
-function clause execute (F_UN_F_TYPE_H(rs1, rd, FMV_H_X)) = {
+function clause execute F_UN_F_TYPE_H(rs1, rd, FMV_H_X) = {
   let rs1_val_X            = X(rs1);
   let rd_val_H             = rs1_val_X [15..0];
   F(rd) = nan_box (rd_val_H);

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -72,7 +72,7 @@ union clause instruction = JAL : (bits(21), regidx)
 mapping clause encdec = JAL(imm_19 @ imm_7_0 @ imm_8 @ imm_18_13 @ imm_12_9 @ 0b0, rd)
   <-> imm_19 : bits(1) @ imm_18_13 : bits(6) @ imm_12_9 : bits(4) @ imm_8 : bits(1) @ imm_7_0 : bits(8) @ encdec_reg(rd) @ 0b1101111
 
-function clause execute (JAL(imm, rd)) = {
+function clause execute JAL(imm, rd) = {
   let link_address = get_next_pc();
   match jump_to(PC + sign_extend(imm)) {
     Retire_Success() => { X(rd) = link_address; Retire_Success() },
@@ -280,7 +280,7 @@ mapping clause encdec = LOAD(imm, rs1, rd, is_unsigned, width)
   <-> imm @ encdec_reg(rs1) @ bool_bits(is_unsigned) @ width_enc(width) @ encdec_reg(rd) @ 0b0000011
   when valid_load_encdec(width, is_unsigned)
 
-function clause execute (LOAD(imm, rs1, rd, is_unsigned, width)) = {
+function clause execute LOAD(imm, rs1, rd, is_unsigned, width) = {
   let offset : xlenbits = sign_extend(imm);
 
   // This is checked during decoding.
@@ -310,7 +310,7 @@ mapping clause encdec = STORE(imm7 @ imm5, rs2, rs1, width)
   <-> imm7 : bits(7) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ width_enc(width) @ imm5 : bits(5) @ 0b0100011
   when width <= xlen_bytes
 
-function clause execute (STORE(imm, rs2, rs1, width)) = {
+function clause execute STORE(imm, rs2, rs1, width) = {
   let offset : xlenbits = sign_extend(imm);
 
   // This is checked during decoding.
@@ -333,7 +333,7 @@ mapping clause encdec = ADDIW(imm, rs1, rd)
   <-> imm @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0011011
   when xlen == 64
 
-function clause execute (ADDIW(imm, rs1, rd)) = {
+function clause execute ADDIW(imm, rs1, rd) = {
   let result = X(rs1) + sign_extend(imm);
   X(rd) = sign_extend(result[31..0]);
   RETIRE_SUCCESS
@@ -437,7 +437,7 @@ function effective_fence_set(set : bits(4), fiom : bool) -> bits(4) = {
   } else set
 }
 
-function clause execute (FENCE(pred, succ)) = {
+function clause execute FENCE(pred, succ) = {
   // If the FIOM bit in menvcfg/senvcfg is set then the I/O bits can imply R/W.
   let fiom = is_fiom_active();
   let pred = effective_fence_set(pred, fiom);
@@ -500,7 +500,7 @@ union clause instruction = FENCE_TSO : unit
 mapping clause encdec = FENCE_TSO()
   <-> 0b1000 @ 0b0011 @ 0b0011 @ 0b00000 @ 0b000 @ 0b00000 @ 0b0001111
 
-function clause execute (FENCE_TSO()) = {
+function clause execute FENCE_TSO() = {
   sail_barrier(Barrier_RISCV_tso);
   RETIRE_SUCCESS
 }

--- a/model/extensions/I/jalr_rmem.sail
+++ b/model/extensions/I/jalr_rmem.sail
@@ -8,7 +8,7 @@
 
 // The definition for the memory model.
 
-function clause execute (JALR(imm, rs1, rd)) = {
+function clause execute JALR(imm, rs1, rd) = {
   // FIXME: this does not check for a misaligned target address. See jalr_seq.sail.
   // write rd before anything else to prevent unintended strength
   X(rd) = nextPC; // compatible with JALR, C.JR and C.JALR

--- a/model/extensions/I/jalr_seq.sail
+++ b/model/extensions/I/jalr_seq.sail
@@ -8,7 +8,7 @@
 
 // The definition for the sequential model.
 
-function clause execute (JALR(imm, rs1, rd)) = {
+function clause execute JALR(imm, rs1, rd) = {
   // For the sequential model, the memory-model definition doesn't work directly
   // if rs1 = rd. We would effectively have to keep a regfile for reads and another for
   // writes, and swap on instruction completion. This could perhaps be optimized in

--- a/model/extensions/I/reserved_fence_insts.sail
+++ b/model/extensions/I/reserved_fence_insts.sail
@@ -12,7 +12,7 @@ mapping clause encdec = FENCE_RESERVED(fm, pred, succ, rs, rd)
   <-> fm : bits(4) @ pred : bits(4) @ succ : bits(4) @ encdec_reg(rs) @ 0b000 @ encdec_reg(rd) @ 0b0001111
       when (fm != 0b0000 & fm != 0b1000) | rs != zreg | rd != zreg
 
-function clause execute (FENCE_RESERVED(fm, pred, succ, rs, rd)) = RETIRE_SUCCESS
+function clause execute FENCE_RESERVED(fm, pred, succ, rs, rd) = RETIRE_SUCCESS
 
 mapping clause assembly = FENCE_RESERVED(fm, pred, succ, rs, rd)
   <-> "fence.reserved." ^ fence_bits(pred) ^ "." ^ fence_bits(succ) ^ "."

--- a/model/extensions/K/zbkb_insts.sail
+++ b/model/extensions/K/zbkb_insts.sail
@@ -47,7 +47,7 @@ mapping clause encdec = ZBKB_PACKW(rs2, rs1, rd)
 mapping clause assembly = ZBKB_PACKW(rs2, rs1, rd)
   <-> "packw" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (ZBKB_PACKW(rs2, rs1, rd)) = {
+function clause execute ZBKB_PACKW(rs2, rs1, rd) = {
   assert(xlen == 64);
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
@@ -66,7 +66,7 @@ mapping clause encdec = ZIP(rs1, rd)
 mapping clause assembly = ZIP(rs1, rd)
   <-> "zip" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (ZIP(rs1, rd)) = {
+function clause execute ZIP(rs1, rd) = {
   assert(xlen == 32);
   let rs1_val = X(rs1);
   var result : xlenbits = zeros();
@@ -88,7 +88,7 @@ mapping clause encdec = UNZIP(rs1, rd)
 mapping clause assembly = UNZIP(rs1, rd)
   <-> "unzip" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (UNZIP(rs1, rd)) = {
+function clause execute UNZIP(rs1, rd) = {
   assert(xlen == 32);
   let rs1_val = X(rs1);
   var result : xlenbits = zeros();
@@ -110,7 +110,7 @@ mapping clause encdec = BREV8(rs1, rd)
 mapping clause assembly = BREV8(rs1, rd)
   <-> "brev8" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (BREV8(rs1, rd)) = {
+function clause execute BREV8(rs1, rd) = {
   X(rd) = brev8(X(rs1));
   RETIRE_SUCCESS
 }

--- a/model/extensions/K/zbkx_insts.sail
+++ b/model/extensions/K/zbkx_insts.sail
@@ -18,7 +18,7 @@ mapping clause encdec = XPERM8(rs2, rs1, rd)
 mapping clause assembly = XPERM8(rs2, rs1, rd)
   <-> "xperm8" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (XPERM8(rs2, rs1, rd)) = {
+function clause execute XPERM8(rs2, rs1, rd) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
   var result : xlenbits = zeros();
@@ -42,7 +42,7 @@ mapping clause encdec = XPERM4(rs2, rs1, rd)
 mapping clause assembly = XPERM4(rs2, rs1, rd)
   <-> "xperm4" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (XPERM4(rs2, rs1, rd)) = {
+function clause execute XPERM4(rs2, rs1, rd) = {
   let rs1_val = X(rs1);
   let rs2_val = X(rs2);
   var result : xlenbits = zeros();

--- a/model/extensions/K/zkn_insts.sail
+++ b/model/extensions/K/zkn_insts.sail
@@ -45,28 +45,28 @@ mapping clause assembly = SHA256SUM0 (rs1, rd)
 mapping clause assembly = SHA256SUM1 (rs1, rd)
   <-> "sha256sum1" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (SHA256SIG0(rs1, rd)) = {
+function clause execute SHA256SIG0(rs1, rd) = {
   let inb    : bits(32) = X(rs1)[31..0];
   let result : bits(32) = (inb >>> 7) ^ (inb >>> 18) ^ (inb >>  3);
   X(rd)      = sign_extend(result);
   RETIRE_SUCCESS
 }
 
-function clause execute (SHA256SIG1(rs1, rd)) = {
+function clause execute SHA256SIG1(rs1, rd) = {
   let inb    : bits(32) = X(rs1)[31..0];
   let result : bits(32) = (inb >>> 17) ^ (inb >>> 19) ^ (inb >> 10);
   X(rd)      = sign_extend(result);
   RETIRE_SUCCESS
 }
 
-function clause execute (SHA256SUM0(rs1, rd)) = {
+function clause execute SHA256SUM0(rs1, rd) = {
   let inb    : bits(32) = X(rs1)[31..0];
   let result : bits(32) = (inb >>> 2) ^ (inb >>> 13) ^ (inb >>> 22);
   X(rd)      = sign_extend(result);
   RETIRE_SUCCESS
 }
 
-function clause execute (SHA256SUM1(rs1, rd)) = {
+function clause execute SHA256SUM1(rs1, rd) = {
   let inb    : bits(32) = X(rs1)[31..0];
   let result : bits(32) = (inb >>> 6) ^ (inb >>> 11) ^ (inb >>> 25);
   X(rd)      = sign_extend(result);
@@ -87,7 +87,7 @@ mapping clause encdec = AES32ESMI (bs, rs2, rs1, rd)
 mapping clause assembly = AES32ESMI (bs, rs2, rs1, rd) <->
     "aes32esmi" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_2(bs)
 
-function clause execute (AES32ESMI (bs, rs2, rs1, rd)) = {
+function clause execute AES32ESMI (bs, rs2, rs1, rd) = {
   let shamt   : bits( 5) = bs @ 0b000; // shamt = bs*8
   let si      : bits( 8) = (X(rs2) >> shamt)[7..0]; // SBox Input
   let so      : bits( 8) = aes_sbox_fwd(si);
@@ -106,7 +106,7 @@ mapping clause encdec = AES32ESI (bs, rs2, rs1, rd)
 mapping clause assembly = AES32ESI (bs, rs2, rs1, rd) <->
     "aes32esi" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_2(bs)
 
-function clause execute (AES32ESI (bs, rs2, rs1, rd)) = {
+function clause execute AES32ESI (bs, rs2, rs1, rd) = {
   let shamt   : bits( 5) = bs @ 0b000; // shamt = bs*8
   let si      : bits( 8) = (X(rs2) >> shamt)[7..0]; // SBox Input
   let so      : bits(32) = 0x000000 @ aes_sbox_fwd(si);
@@ -129,7 +129,7 @@ mapping clause encdec = AES32DSMI (bs, rs2, rs1, rd)
 mapping clause assembly = AES32DSMI (bs, rs2, rs1, rd) <->
     "aes32dsmi" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_2(bs)
 
-function clause execute (AES32DSMI (bs, rs2, rs1, rd)) = {
+function clause execute AES32DSMI (bs, rs2, rs1, rd) = {
   let shamt   : bits( 5) = bs @ 0b000; // shamt = bs*8
   let si      : bits( 8) = (X(rs2) >> shamt)[7..0]; // SBox Input
   let so      : bits( 8) = aes_sbox_inv(si);
@@ -148,7 +148,7 @@ mapping clause encdec = AES32DSI (bs, rs2, rs1, rd)
 mapping clause assembly = AES32DSI (bs, rs2, rs1, rd) <->
     "aes32dsi" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_2(bs)
 
-function clause execute (AES32DSI (bs, rs2, rs1, rd)) = {
+function clause execute AES32DSI (bs, rs2, rs1, rd) = {
   let shamt   : bits( 5) = bs @ 0b000; // shamt = bs*8
   let si      : bits( 8) = (X(rs2) >> shamt)[7..0]; // SBox Input
   let so      : bits(32) = 0x000000 @ aes_sbox_inv(si);
@@ -209,37 +209,37 @@ mapping clause assembly = SHA512SUM0R (rs2, rs1, rd)
 mapping clause assembly = SHA512SUM1R (rs2, rs1, rd)
   <-> "sha512sum1r" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
-function clause execute (SHA512SIG0H(rs2, rs1, rd)) = {
+function clause execute SHA512SIG0H(rs2, rs1, rd) = {
   X(rd) = sign_extend((X(rs1) >>  1) ^ (X(rs1) >>  7) ^ (X(rs1) >>  8) ^
                (X(rs2) << 31)                  ^ (X(rs2) << 24));
   RETIRE_SUCCESS
 }
 
-function clause execute (SHA512SIG0L(rs2, rs1, rd)) = {
+function clause execute SHA512SIG0L(rs2, rs1, rd) = {
   X(rd) = sign_extend((X(rs1) >>  1) ^ (X(rs1) >>  7) ^ (X(rs1) >>  8) ^
                (X(rs2) << 31) ^ (X(rs2) << 25) ^ (X(rs2) << 24));
   RETIRE_SUCCESS
 }
 
-function clause execute (SHA512SIG1H(rs2, rs1, rd)) = {
+function clause execute SHA512SIG1H(rs2, rs1, rd) = {
   X(rd) = sign_extend((X(rs1) <<  3) ^ (X(rs1) >>  6) ^ (X(rs1) >> 19) ^
                (X(rs2) >> 29)                  ^ (X(rs2) << 13));
   RETIRE_SUCCESS
 }
 
-function clause execute (SHA512SIG1L(rs2, rs1, rd)) = {
+function clause execute SHA512SIG1L(rs2, rs1, rd) = {
   X(rd) = sign_extend((X(rs1) <<  3) ^ (X(rs1) >>  6) ^ (X(rs1) >> 19) ^
                (X(rs2) >> 29) ^ (X(rs2) << 26) ^ (X(rs2) << 13));
   RETIRE_SUCCESS
 }
 
-function clause execute (SHA512SUM0R(rs2, rs1, rd)) = {
+function clause execute SHA512SUM0R(rs2, rs1, rd) = {
   X(rd) = sign_extend((X(rs1) << 25) ^ (X(rs1) << 30) ^ (X(rs1) >> 28) ^
                (X(rs2) >>  7) ^ (X(rs2) >>  2) ^ (X(rs2) <<  4));
   RETIRE_SUCCESS
 }
 
-function clause execute (SHA512SUM1R(rs2, rs1, rd)) = {
+function clause execute SHA512SUM1R(rs2, rs1, rd) = {
   X(rd) = sign_extend((X(rs1) << 23) ^ (X(rs1) >> 14) ^ (X(rs1) >> 18) ^
                (X(rs2) >>  9) ^ (X(rs2) << 18) ^ (X(rs2) << 14));
   RETIRE_SUCCESS
@@ -308,7 +308,7 @@ mapping clause assembly = AES64DS (rs2, rs1, rd)
 // Note: The decoding for this instruction ensures that `rnum` is always in
 // the range 0x0..0xA. See the encdec clause for AES64KS1I.
 // The rum == 0xA case is used specifically for the AES-256 KeySchedule
-function clause execute (AES64KS1I(rnum, rs1, rd)) = {
+function clause execute AES64KS1I(rnum, rs1, rd) = {
   assert(xlen == 64);
   let prev     : bits(32) = X(rs1)[63..32];
   let subwords : bits(32) = aes_subword_fwd(prev);
@@ -318,7 +318,7 @@ function clause execute (AES64KS1I(rnum, rs1, rd)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (AES64KS2(rs2, rs1, rd)) = {
+function clause execute AES64KS2(rs2, rs1, rd) = {
   assert(xlen == 64);
   let w0 : bits(32) = X(rs1)[63..32] ^ X(rs2)[31..0];
   let w1 : bits(32) = X(rs1)[63..32] ^ X(rs2)[31..0] ^ X(rs2)[63..32];
@@ -326,7 +326,7 @@ function clause execute (AES64KS2(rs2, rs1, rd)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (AES64IM(rs1, rd)) = {
+function clause execute AES64IM(rs1, rd) = {
   assert(xlen == 64);
   let w0 : bits(32) = aes_mixcolumn_inv(X(rs1)[31.. 0]);
   let w1 : bits(32) = aes_mixcolumn_inv(X(rs1)[63..32]);
@@ -334,7 +334,7 @@ function clause execute (AES64IM(rs1, rd)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (AES64ESM(rs2, rs1, rd)) = {
+function clause execute AES64ESM(rs2, rs1, rd) = {
   assert(xlen == 64);
   let sr : bits(64) = aes_rv64_shiftrows_fwd(X(rs2), X(rs1));
   let wd : bits(64) = sr[63..0];
@@ -343,7 +343,7 @@ function clause execute (AES64ESM(rs2, rs1, rd)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (AES64ES(rs2, rs1, rd)) = {
+function clause execute AES64ES(rs2, rs1, rd) = {
   assert(xlen == 64);
   let sr : bits(64) = aes_rv64_shiftrows_fwd(X(rs2), X(rs1));
   let wd : bits(64) = sr[63..0];
@@ -351,7 +351,7 @@ function clause execute (AES64ES(rs2, rs1, rd)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (AES64DSM(rs2, rs1, rd)) = {
+function clause execute AES64DSM(rs2, rs1, rd) = {
   assert(xlen == 64);
   let sr : bits(64) = aes_rv64_shiftrows_inv(X(rs2), X(rs1));
   let wd : bits(64) = sr[63..0];
@@ -360,7 +360,7 @@ function clause execute (AES64DSM(rs2, rs1, rd)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (AES64DS(rs2, rs1, rd)) = {
+function clause execute AES64DS(rs2, rs1, rd) = {
   assert(xlen == 64);
   let sr : bits(64) = aes_rv64_shiftrows_inv(X(rs2), X(rs1));
   let wd : bits(64) = sr[63..0];
@@ -406,7 +406,7 @@ mapping clause assembly = SHA512SUM1 (rs1, rd)
 
 // Execute clauses for the 64-bit SHA512 instructions.
 
-function clause execute (SHA512SIG0(rs1, rd)) = {
+function clause execute SHA512SIG0(rs1, rd) = {
   assert(xlen == 64);
   let input  : bits(64) = X(rs1);
   let result : bits(64) = (input >>>  1) ^ (input >>>  8) ^ (input >> 7);
@@ -414,7 +414,7 @@ function clause execute (SHA512SIG0(rs1, rd)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (SHA512SIG1(rs1, rd)) = {
+function clause execute SHA512SIG1(rs1, rd) = {
   assert(xlen == 64);
   let input  : bits(64) = X(rs1);
   let result : bits(64) = (input >>> 19) ^ (input >>> 61) ^ (input >> 6);
@@ -422,7 +422,7 @@ function clause execute (SHA512SIG1(rs1, rd)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (SHA512SUM0(rs1, rd)) = {
+function clause execute SHA512SUM0(rs1, rd) = {
   assert(xlen == 64);
   let input  : bits(64) = X(rs1);
   let result : bits(64) = (input >>> 28) ^ (input >>> 34) ^ (input >>> 39);
@@ -430,7 +430,7 @@ function clause execute (SHA512SUM0(rs1, rd)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (SHA512SUM1(rs1, rd)) = {
+function clause execute SHA512SUM1(rs1, rd) = {
   assert(xlen == 64);
   let input  : bits(64) = X(rs1);
   let result : bits(64) = (input >>> 14) ^ (input >>> 18) ^ (input >>> 41);

--- a/model/extensions/K/zks_insts.sail
+++ b/model/extensions/K/zks_insts.sail
@@ -28,14 +28,14 @@ mapping clause assembly = SM3P0 (rs1, rd) <->
 mapping clause assembly = SM3P1 (rs1, rd) <->
   "sm3p1" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
-function clause execute (SM3P0(rs1, rd)) = {
+function clause execute SM3P0(rs1, rd) = {
   let r1     : bits(32) = X(rs1)[31..0];
   let result : bits(32) =  r1 ^ (r1 <<< 9) ^ (r1 <<< 17);
   X(rd) = sign_extend(result);
   RETIRE_SUCCESS
 }
 
-function clause execute (SM3P1(rs1, rd)) = {
+function clause execute SM3P1(rs1, rd) = {
   let r1     : bits(32) = X(rs1)[31..0];
   let result : bits(32) =  r1 ^ (r1 <<< 15) ^ (r1 <<< 23);
   X(rd) = sign_extend(result);
@@ -64,7 +64,7 @@ mapping clause assembly = SM4ED (bs, rs2, rs1, rd) <->
 mapping clause assembly = SM4KS (bs, rs2, rs1, rd) <->
     "sm4ks" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2) ^ sep() ^ hex_bits_2(bs)
 
-function clause execute (SM4ED (bs, rs2, rs1, rd)) = {
+function clause execute SM4ED (bs, rs2, rs1, rd) = {
   let shamt : bits(5)  = bs @ 0b000; // shamt = bs*8
   let sb_in : bits(8)  = (X(rs2)[31..0] >> shamt)[7..0];
   let x     : bits(32) = 0x000000 @ sm4_sbox(sb_in);
@@ -77,7 +77,7 @@ function clause execute (SM4ED (bs, rs2, rs1, rd)) = {
   RETIRE_SUCCESS
 }
 
-function clause execute (SM4KS (bs, rs2, rs1, rd)) = {
+function clause execute SM4KS (bs, rs2, rs1, rd) = {
   let shamt : bits(5)  = (bs @ 0b000); // shamt = bs*8
   let sb_in : bits(8)  = (X(rs2)[31..0] >> shamt)[7..0];
   let x     : bits(32) = 0x000000 @ sm4_sbox(sb_in);

--- a/model/extensions/M/mext_insts.sail
+++ b/model/extensions/M/mext_insts.sail
@@ -26,7 +26,7 @@ mapping clause encdec = MUL(rs2, rs1, rd, mul_op)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_mul_op(mul_op) @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_M) | currentlyEnabled(Ext_Zmmul)
 
-function clause execute (MUL(rs2, rs1, rd, mul_op)) = {
+function clause execute MUL(rs2, rs1, rd, mul_op) = {
   let rs1_bits = X(rs1);
   let rs2_bits = X(rs2);
   let rs1_int = if mul_op.signed_rs1 then signed(rs1_bits) else unsigned(rs1_bits);
@@ -56,7 +56,7 @@ mapping clause encdec = DIV(rs2, rs1, rd, is_unsigned)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b10 @ bool_bits(is_unsigned) @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_M)
 
-function clause execute (DIV(rs2, rs1, rd, is_unsigned)) = {
+function clause execute DIV(rs2, rs1, rd, is_unsigned) = {
   let rs1_bits = X(rs1);
   let rs2_bits = X(rs2);
   let rs1_int = if is_unsigned then unsigned(rs1_bits) else signed(rs1_bits);
@@ -79,7 +79,7 @@ mapping clause encdec = REM(rs2, rs1, rd, is_unsigned)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b11 @ bool_bits(is_unsigned) @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_M)
 
-function clause execute (REM(rs2, rs1, rd, is_unsigned)) = {
+function clause execute REM(rs2, rs1, rd, is_unsigned) = {
   let rs1_bits = X(rs1);
   let rs2_bits = X(rs2);
   let rs1_int = if is_unsigned then unsigned(rs1_bits) else signed(rs1_bits);
@@ -101,7 +101,7 @@ mapping clause encdec = MULW(rs2, rs1, rd)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0111011
   when xlen == 64 & (currentlyEnabled(Ext_M) | currentlyEnabled(Ext_Zmmul))
 
-function clause execute (MULW(rs2, rs1, rd)) = {
+function clause execute MULW(rs2, rs1, rd) = {
   let rs1_bits = X(rs1)[31..0];
   let rs2_bits = X(rs2)[31..0];
   let rs1_int = signed(rs1_bits);
@@ -123,7 +123,7 @@ mapping clause encdec = DIVW(rs2, rs1, rd, is_unsigned)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b10 @ bool_bits(is_unsigned) @ encdec_reg(rd) @ 0b0111011
   when xlen == 64 & currentlyEnabled(Ext_M)
 
-function clause execute (DIVW(rs2, rs1, rd, is_unsigned)) = {
+function clause execute DIVW(rs2, rs1, rd, is_unsigned) = {
   let rs1_bits = X(rs1)[31..0];
   let rs2_bits = X(rs2)[31..0];
   let rs1_int = if is_unsigned then unsigned(rs1_bits) else signed(rs1_bits);
@@ -147,7 +147,7 @@ mapping clause encdec = REMW(rs2, rs1, rd, is_unsigned)
   <-> 0b0000001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b11 @ bool_bits(is_unsigned) @ encdec_reg(rd) @ 0b0111011
   when xlen == 64 & currentlyEnabled(Ext_M)
 
-function clause execute (REMW(rs2, rs1, rd, is_unsigned)) = {
+function clause execute REMW(rs2, rs1, rd, is_unsigned) = {
   let rs1_bits = X(rs1)[31..0];
   let rs2_bits = X(rs2)[31..0];
   let rs1_int = if is_unsigned then unsigned(rs1_bits) else signed(rs1_bits);

--- a/model/extensions/V/vext_arith_insts.sail
+++ b/model/extensions/V/vext_arith_insts.sail
@@ -44,7 +44,7 @@ mapping clause encdec = VVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_vvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VVTYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute VVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_pow  = get_sew_pow();
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -182,7 +182,7 @@ mapping clause encdec = NVSTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_nvsfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(NVSTYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute NVSTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -253,7 +253,7 @@ mapping clause encdec = NVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_nvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(NVTYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute NVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -319,7 +319,7 @@ mapping clause encdec = MASKTYPEV (vs2, vs1,  vd)
   <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(MASKTYPEV(vs2, vs1, vd)) = {
+function clause execute MASKTYPEV(vs2, vs1, vd) = {
   let start_element : nat = match get_start_element() {
     Ok(v)   => v,
     Err(()) => return Illegal_Instruction()
@@ -371,7 +371,7 @@ mapping clause encdec = MOVETYPEV (vs1, vd)
   <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(MOVETYPEV(vs1, vd)) = {
+function clause execute MOVETYPEV(vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -432,7 +432,7 @@ mapping clause encdec = VXTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_vxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VXTYPE(funct6, vm, vs2, rs1, vd)) = {
+function clause execute VXTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -551,7 +551,7 @@ mapping clause encdec = NXSTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_nxsfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(NXSTYPE(funct6, vm, vs2, rs1, vd)) = {
+function clause execute NXSTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -622,7 +622,7 @@ mapping clause encdec = NXTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_nxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(NXTYPE(funct6, vm, vs2, rs1, vd)) = {
+function clause execute NXTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -695,7 +695,7 @@ mapping clause encdec = VXSG(funct6, vm, vs2, rs1, vd)
   <-> encdec_vxsgfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VXSG(funct6, vm, vs2, rs1, vd)) = {
+function clause execute VXSG(funct6, vm, vs2, rs1, vd) = {
   let SEW_pow  = get_sew_pow();
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -762,7 +762,7 @@ mapping clause encdec = MASKTYPEX(vs2, rs1, vd)
   <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(MASKTYPEX(vs2, rs1, vd)) = {
+function clause execute MASKTYPEX(vs2, rs1, vd) = {
   let start_element : nat = match get_start_element() {
     Ok(v)   => v,
     Err(()) => return Illegal_Instruction()
@@ -814,7 +814,7 @@ mapping clause encdec = MOVETYPEX (rs1, vd)
   <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(MOVETYPEX(rs1, vd)) = {
+function clause execute MOVETYPEX(rs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -867,7 +867,7 @@ mapping clause encdec = VITYPE(funct6, vm, vs2, simm, vd)
   <-> encdec_vifunct6(funct6) @ vm @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VITYPE(funct6, vm, vs2, simm, vd)) = {
+function clause execute VITYPE(funct6, vm, vs2, simm, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -962,7 +962,7 @@ mapping clause encdec = NISTYPE(funct6, vm, vs2, uimm, vd)
   <-> encdec_nisfunct6(funct6) @ vm @ encdec_vreg(vs2) @ uimm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(NISTYPE(funct6, vm, vs2, uimm, vd)) = {
+function clause execute NISTYPE(funct6, vm, vs2, uimm, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -1033,7 +1033,7 @@ mapping clause encdec = NITYPE(funct6, vm, vs2, uimm, vd)
   <-> encdec_nifunct6(funct6) @ vm @ encdec_vreg(vs2) @ uimm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(NITYPE(funct6, vm, vs2, uimm, vd)) = {
+function clause execute NITYPE(funct6, vm, vs2, uimm, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -1106,7 +1106,7 @@ mapping clause encdec = VISG(funct6, vm, vs2, simm, vd)
   <-> encdec_visgfunct6(funct6) @ vm @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VISG(funct6, vm, vs2, simm, vd)) = {
+function clause execute VISG(funct6, vm, vs2, simm, vd) = {
   let SEW_pow  = get_sew_pow();
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -1173,7 +1173,7 @@ mapping clause encdec = MASKTYPEI(vs2, simm, vd)
   <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(MASKTYPEI(vs2, simm, vd)) = {
+function clause execute MASKTYPEI(vs2, simm, vd) = {
   let start_element : nat = match get_start_element() {
     Ok(v)   => v,
     Err(()) => return Illegal_Instruction()
@@ -1225,7 +1225,7 @@ mapping clause encdec = MOVETYPEI (vd, simm)
   <-> 0b010111 @ 0b1 @ 0b00000 @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(MOVETYPEI(vd, simm)) = {
+function clause execute MOVETYPEI(vd, simm) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -1276,7 +1276,7 @@ mapping clause encdec = VMVRTYPE(vs2, nreg, vd)
   <-> 0b100111 @ 0b1 @ encdec_vreg(vs2) @ encdec_nreg(nreg) @ 0b011 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VMVRTYPE(vs2, nreg, vd)) = {
+function clause execute VMVRTYPE(vs2, nreg, vd) = {
   let start_element : nat = match get_start_element() {
     Ok(v)   => v,
     Err(()) => return Illegal_Instruction()
@@ -1335,7 +1335,7 @@ mapping clause encdec = MVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_mvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(MVVTYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute MVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -1455,7 +1455,7 @@ mapping clause encdec = MVVMATYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_mvvmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(MVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute MVVMATYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -1518,7 +1518,7 @@ mapping clause encdec = WVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_wvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(WVVTYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute WVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -1593,7 +1593,7 @@ mapping clause encdec = WVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_wvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(WVTYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute WVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -1661,7 +1661,7 @@ mapping clause encdec =  WMVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_wmvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(WMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute WMVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -1731,7 +1731,7 @@ mapping clause encdec = VEXTTYPE(funct6, vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ vext_vs1(funct6) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VEXTTYPE(funct6, vm, vs2, vd)) = {
+function clause execute VEXTTYPE(funct6, vm, vs2, vd) = {
   let SEW = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -1803,7 +1803,7 @@ mapping clause encdec = VMVXS(vs2, rd)
   <-> 0b010000 @ 0b1 @ encdec_vreg(vs2) @ 0b00000 @ 0b010 @ encdec_reg(rd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VMVXS(vs2, rd)) = {
+function clause execute VMVXS(vs2, rd) = {
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
@@ -1832,7 +1832,7 @@ mapping clause encdec = MVVCOMPRESS(vs2, vs1, vd)
   <-> 0b010111 @ 0b1 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(MVVCOMPRESS(vs2, vs1, vd)) = {
+function clause execute MVVCOMPRESS(vs2, vs1, vd) = {
   let start_element : nat = match get_start_element() {
     Ok(v)   => v,
     Err(()) => return Illegal_Instruction()
@@ -1910,7 +1910,7 @@ mapping clause encdec = MVXTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_mvxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(MVXTYPE(funct6, vm, vs2, rs1, vd)) = {
+function clause execute MVXTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -2041,7 +2041,7 @@ mapping clause encdec = MVXMATYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_mvxmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(MVXMATYPE(funct6, vm, vs2, rs1, vd)) = {
+function clause execute MVXMATYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -2105,7 +2105,7 @@ mapping clause encdec = WVXTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_wvxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(WVXTYPE(funct6, vm, vs2, rs1, vd)) = {
+function clause execute WVXTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -2179,7 +2179,7 @@ mapping clause encdec = WXTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_wxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(WXTYPE(funct6, vm, vs2, rs1, vd)) = {
+function clause execute WXTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -2247,7 +2247,7 @@ mapping clause encdec = WMVXTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_wmvxfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(WMVXTYPE(funct6, vm, vs2, rs1, vd)) = {
+function clause execute WMVXTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -2308,7 +2308,7 @@ mapping clause encdec = VMVSX(rs1, vd)
   <-> 0b010000 @ 0b1 @ 0b00000 @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VMVSX(rs1, vd)) = {
+function clause execute VMVSX(rs1, vd) = {
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
 

--- a/model/extensions/V/vext_fp_insts.sail
+++ b/model/extensions/V/vext_fp_insts.sail
@@ -35,7 +35,7 @@ mapping clause encdec = FVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_fvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(FVVTYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute FVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -113,7 +113,7 @@ mapping clause encdec = FVVMATYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_fvvmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(FVVMATYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute FVVMATYPE(funct6, vm, vs2, vs1, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -183,7 +183,7 @@ mapping clause encdec = FWVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_fwvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(FWVVTYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute FWVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -251,7 +251,7 @@ mapping clause encdec = FWVVMATYPE(funct6, vm, vs1, vs2, vd)
   <-> encdec_fwvvmafunct6(funct6) @ vm @ encdec_vreg(vs1) @ encdec_vreg(vs2) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(FWVVMATYPE(funct6, vm, vs1, vs2, vd)) = {
+function clause execute FWVVMATYPE(funct6, vm, vs1, vs2, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -318,7 +318,7 @@ mapping clause encdec = FWVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_fwvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(FWVTYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute FWVTYPE(funct6, vm, vs2, vs1, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -384,7 +384,7 @@ mapping clause encdec = VFUNARY0(vm, vs2, vfunary0, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ encdec_vfunary0_vs1(vfunary0) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(VFUNARY0(vm, vs2, vfunary0, vd)) = {
+function clause execute VFUNARY0(vm, vs2, vfunary0, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -501,7 +501,7 @@ mapping clause encdec = VFWUNARY0(vm, vs2, vfwunary0, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ encdec_vfwunary0_vs1(vfwunary0) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(VFWUNARY0(vm, vs2, vfwunary0, vd)) = {
+function clause execute VFWUNARY0(vm, vs2, vfwunary0, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -634,7 +634,7 @@ mapping clause encdec = VFNUNARY0(vm, vs2, vfnunary0, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ encdec_vfnunary0_vs1(vfnunary0) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(VFNUNARY0(vm, vs2, vfnunary0, vd)) = {
+function clause execute VFNUNARY0(vm, vs2, vfnunary0, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -773,7 +773,7 @@ mapping clause encdec = VFUNARY1(vm, vs2, vfunary1, vd)
   <-> 0b010011 @ vm @ encdec_vreg(vs2) @ encdec_vfunary1_vs1(vfunary1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(VFUNARY1(vm, vs2, vfunary1, vd)) = {
+function clause execute VFUNARY1(vm, vs2, vfunary1, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -852,7 +852,7 @@ mapping clause encdec = VFMVFS(vs2, rd)
   <-> 0b010000 @ 0b1 @ encdec_vreg(vs2) @ 0b00000 @ 0b001 @ encdec_freg(rd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(VFMVFS(vs2, rd)) = {
+function clause execute VFMVFS(vs2, rd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
@@ -901,7 +901,7 @@ mapping clause encdec = FVFTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_fvffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(FVFTYPE(funct6, vm, vs2, rs1, vd)) = {
+function clause execute FVFTYPE(funct6, vm, vs2, rs1, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -994,7 +994,7 @@ mapping clause encdec = FVFMATYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_fvfmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(FVFMATYPE(funct6, vm, vs2, rs1, vd)) = {
+function clause execute FVFMATYPE(funct6, vm, vs2, rs1, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -1064,7 +1064,7 @@ mapping clause encdec = FWVFTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_fwvffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(FWVFTYPE(funct6, vm, vs2, rs1, vd)) = {
+function clause execute FWVFTYPE(funct6, vm, vs2, rs1, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -1131,7 +1131,7 @@ mapping clause encdec = FWVFMATYPE(funct6, vm, rs1, vs2, vd)
   <-> encdec_fwvfmafunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(FWVFMATYPE(funct6, vm, rs1, vs2, vd)) = {
+function clause execute FWVFMATYPE(funct6, vm, rs1, vs2, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -1197,7 +1197,7 @@ mapping clause encdec = FWFTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_fwffunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(FWFTYPE(funct6, vm, vs2, rs1, vd)) = {
+function clause execute FWFTYPE(funct6, vm, vs2, rs1, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -1254,7 +1254,7 @@ mapping clause encdec = VFMERGE(vs2, rs1, vd)
   <-> 0b010111 @ 0b0 @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(VFMERGE(vs2, rs1, vd)) = {
+function clause execute VFMERGE(vs2, rs1, vd) = {
   let rm_3b         = fcsr[FRM];
   let start_element : nat = match get_start_element() {
     Ok(v)   => v,
@@ -1309,7 +1309,7 @@ mapping clause encdec = VFMV(rs1, vd)
   <-> 0b010111 @ 0b1 @ 0b00000 @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(VFMV(rs1, vd)) = {
+function clause execute VFMV(rs1, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -1349,7 +1349,7 @@ mapping clause encdec = VFMVSF(rs1, vd)
   <-> 0b010000 @ 0b1 @ 0b00000 @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(VFMVSF(rs1, vd)) = {
+function clause execute VFMVSF(rs1, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);

--- a/model/extensions/V/vext_fp_red_insts.sail
+++ b/model/extensions/V/vext_fp_red_insts.sail
@@ -110,7 +110,7 @@ function process_rfvv_widening_reduction(funct6, vm, vs2, vs1, vd, num_elem_vs, 
   RETIRE_SUCCESS
 }
 
-function clause execute(RFVVTYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute RFVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem_vs = get_num_elem(LMUL_pow, SEW);

--- a/model/extensions/V/vext_fp_vm_insts.sail
+++ b/model/extensions/V/vext_fp_vm_insts.sail
@@ -26,7 +26,7 @@ mapping clause encdec = FVVMTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_fvvmfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(FVVMTYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute FVVMTYPE(funct6, vm, vs2, vs1, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
@@ -93,7 +93,7 @@ mapping clause encdec = FVFMTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_fvfmfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32f)
 
-function clause execute(FVFMTYPE(funct6, vm, vs2, rs1, vd)) = {
+function clause execute FVFMTYPE(funct6, vm, vs2, rs1, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();

--- a/model/extensions/V/vext_mask_insts.sail
+++ b/model/extensions/V/vext_mask_insts.sail
@@ -29,7 +29,7 @@ mapping clause encdec = MMTYPE(funct6, vs2, vs1, vd)
   <-> encdec_mmfunct6(funct6) @ 0b1 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(MMTYPE(funct6, vs2, vs1, vd)) = {
+function clause execute MMTYPE(funct6, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = vlen;
@@ -90,7 +90,7 @@ mapping clause encdec = VCPOP_M(vm, vs2, rd)
   <-> 0b010000 @ vm @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_reg(rd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VCPOP_M(vm, vs2, rd)) = {
+function clause execute VCPOP_M(vm, vs2, rd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = vlen;
@@ -128,7 +128,7 @@ mapping clause encdec = VFIRST_M(vm, vs2, rd)
   <-> 0b010000 @ vm @ encdec_vreg(vs2) @ 0b10001 @ 0b010 @ encdec_reg(rd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VFIRST_M(vm, vs2, rd)) = {
+function clause execute VFIRST_M(vm, vs2, rd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = vlen;
@@ -168,7 +168,7 @@ mapping clause encdec = VMSBF_M(vm, vs2, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ 0b00001 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VMSBF_M(vm, vs2, vd)) = {
+function clause execute VMSBF_M(vm, vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = vlen;
@@ -212,7 +212,7 @@ mapping clause encdec = VMSIF_M(vm, vs2, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ 0b00011 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VMSIF_M(vm, vs2, vd)) = {
+function clause execute VMSIF_M(vm, vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = vlen;
@@ -256,7 +256,7 @@ mapping clause encdec = VMSOF_M(vm, vs2, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ 0b00010 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VMSOF_M(vm, vs2, vd)) = {
+function clause execute VMSOF_M(vm, vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = vlen;
@@ -304,7 +304,7 @@ mapping clause encdec = VIOTA_M(vm, vs2, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VIOTA_M(vm, vs2, vd)) = {
+function clause execute VIOTA_M(vm, vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -348,7 +348,7 @@ mapping clause encdec = VID_V(vm, vd)
   <-> 0b010100 @ vm @ 0b00000 @ 0b10001 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VID_V(vm, vd)) = {
+function clause execute VID_V(vm, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);

--- a/model/extensions/V/vext_mem_insts.sail
+++ b/model/extensions/V/vext_mem_insts.sail
@@ -74,7 +74,7 @@ function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) =
   RETIRE_SUCCESS
 }
 
-function clause execute(VLSEGTYPE(nf, vm, rs1, width, vd)) = {
+function clause execute VLSEGTYPE(nf, vm, rs1, width, vd) = {
   let EEW_pow = vlewidth_pow(width);
   let load_width_bytes = 2 ^ (EEW_pow - 3);
   let EEW = 2 ^ EEW_pow;
@@ -152,7 +152,7 @@ function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem)
   RETIRE_SUCCESS
 }
 
-function clause execute(VLSEGFFTYPE(nf, vm, rs1, width, vd)) = {
+function clause execute VLSEGFFTYPE(nf, vm, rs1, width, vd) = {
   let EEW_pow = vlewidth_pow(width);
   let load_width_bytes = 2 ^ (EEW_pow - 3);
   let EEW = 2 ^ EEW_pow;
@@ -210,7 +210,7 @@ function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) 
   RETIRE_SUCCESS
 }
 
-function clause execute(VSSEGTYPE(nf, vm, rs1, width, vs3)) = {
+function clause execute VSSEGTYPE(nf, vm, rs1, width, vs3) = {
   let EEW_pow = vlewidth_pow(width);
   let load_width_bytes = 2 ^ (EEW_pow - 3);
   let EEW = 2 ^ EEW_pow;
@@ -272,7 +272,7 @@ function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_e
   RETIRE_SUCCESS
 }
 
-function clause execute(VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)) = {
+function clause execute VLSSEGTYPE(nf, vm, rs2, rs1, width, vd) = {
   let EEW_pow = vlewidth_pow(width);
   let load_width_bytes = 2 ^ (EEW_pow - 3);
   let EEW = 2 ^ EEW_pow;
@@ -331,7 +331,7 @@ function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_
   RETIRE_SUCCESS
 }
 
-function clause execute(VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)) = {
+function clause execute VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3) = {
   let EEW_pow = vlewidth_pow(width);
   let EEW = 2 ^ EEW_pow;
   let load_width_bytes = 2 ^ (EEW_pow - 3);
@@ -394,7 +394,7 @@ function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index
   RETIRE_SUCCESS
 }
 
-function clause execute(VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
+function clause execute VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd) = {
   let EEW_index_pow = vlewidth_pow(width);
   let EEW_index_bytes = 2 ^ (EEW_index_pow - 3);
   let EEW_data_pow = get_sew_pow();
@@ -421,7 +421,7 @@ mapping clause encdec = VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   <-> encdec_nfields(nf) @ 0b0 @ 0b11 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd)) = {
+function clause execute VLOXSEGTYPE(nf, vm, vs2, rs1, width, vd) = {
   let EEW_index_pow = vlewidth_pow(width);
   let EEW_index_bytes = 2 ^ (EEW_index_pow - 3);
   let EEW_data_pow = get_sew_pow();
@@ -482,7 +482,7 @@ function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_inde
   RETIRE_SUCCESS
 }
 
-function clause execute(VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
+function clause execute VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3) = {
   let EEW_index_pow = vlewidth_pow(width);
   let EEW_index_bytes = 2 ^ (EEW_index_pow - 3);
   let EEW_data_pow = get_sew_pow();
@@ -509,7 +509,7 @@ mapping clause encdec = VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   <-> encdec_nfields(nf) @ 0b0 @ 0b11 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3)) = {
+function clause execute VSOXSEGTYPE(nf, vm, vs2, rs1, width, vs3) = {
   let EEW_index_pow = vlewidth_pow(width);
   let EEW_index_bytes = 2 ^ (EEW_index_pow - 3);
   let EEW_data_pow = get_sew_pow();
@@ -576,7 +576,7 @@ function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
   RETIRE_SUCCESS
 }
 
-function clause execute(VLRETYPE(nf, rs1, width, vd)) = {
+function clause execute VLRETYPE(nf, rs1, width, vd) = {
   let EEW_pow = vlewidth_pow(width);
   let load_width_bytes = 2 ^ (EEW_pow - 3);
   let EEW = 2 ^ EEW_pow;
@@ -642,7 +642,7 @@ function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
   RETIRE_SUCCESS
 }
 
-function clause execute(VSRETYPE(nf, rs1, vs3)) = {
+function clause execute VSRETYPE(nf, rs1, vs3) = {
   let load_width_bytes = 1;
   let EEW = 8;
   let elem_per_reg = vlen / EEW;
@@ -703,7 +703,7 @@ function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
   RETIRE_SUCCESS
 }
 
-function clause execute(VMTYPE(rs1, vd_or_vs3, op)) = {
+function clause execute VMTYPE(rs1, vd_or_vs3, op) = {
   let EEW = 8;
   let EMUL_pow = 0;
   let vl_val = unsigned(vl);

--- a/model/extensions/V/vext_red_insts.sail
+++ b/model/extensions/V/vext_red_insts.sail
@@ -23,7 +23,7 @@ mapping clause encdec = RIVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_rivvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(RIVVTYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute RIVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let SEW_widen = SEW * 2;
@@ -94,7 +94,7 @@ mapping clause encdec = RMVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_rmvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(RMVVTYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute RMVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem_vs = get_num_elem(LMUL_pow, SEW);

--- a/model/extensions/V/vext_vm_insts.sail
+++ b/model/extensions/V/vext_vm_insts.sail
@@ -26,7 +26,7 @@ mapping clause encdec = VVMTYPE(funct6, vs2, vs1, vd)
   <-> encdec_vvmfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VVMTYPE(funct6, vs2, vs1, vd)) = {
+function clause execute VVMTYPE(funct6, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -85,7 +85,7 @@ mapping clause encdec = VVMCTYPE(funct6, vs2, vs1, vd)
   <-> encdec_vvmcfunct6(funct6) @ 0b1 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VVMCTYPE(funct6, vs2, vs1, vd)) = {
+function clause execute VVMCTYPE(funct6, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -143,7 +143,7 @@ mapping clause encdec = VVMSTYPE(funct6, vs2, vs1, vd)
   <-> encdec_vvmsfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VVMSTYPE(funct6, vs2, vs1, vd)) = {
+function clause execute VVMSTYPE(funct6, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -206,7 +206,7 @@ mapping clause encdec = VVCMPTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_vvcmpfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VVCMPTYPE(funct6, vm, vs2, vs1, vd)) = {
+function clause execute VVCMPTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -273,7 +273,7 @@ mapping clause encdec = VXMTYPE(funct6, vs2, rs1, vd)
   <-> encdec_vxmfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VXMTYPE(funct6, vs2, rs1, vd)) = {
+function clause execute VXMTYPE(funct6, vs2, rs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -332,7 +332,7 @@ mapping clause encdec = VXMCTYPE(funct6, vs2, rs1, vd)
   <-> encdec_vxmcfunct6(funct6) @ 0b1 @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VXMCTYPE(funct6, vs2, rs1, vd)) = {
+function clause execute VXMCTYPE(funct6, vs2, rs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -390,7 +390,7 @@ mapping clause encdec = VXMSTYPE(funct6, vs2, rs1, vd)
   <-> encdec_vxmsfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VXMSTYPE(funct6, vs2, rs1, vd)) = {
+function clause execute VXMSTYPE(funct6, vs2, rs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -455,7 +455,7 @@ mapping clause encdec = VXCMPTYPE(funct6, vm, vs2, rs1, vd)
   <-> encdec_vxcmpfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VXCMPTYPE(funct6, vm, vs2, rs1, vd)) = {
+function clause execute VXCMPTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -525,7 +525,7 @@ mapping clause encdec = VIMTYPE(funct6, vs2, simm, vd)
   <-> encdec_vimfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VIMTYPE(funct6, vs2, simm, vd)) = {
+function clause execute VIMTYPE(funct6, vs2, simm, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -581,7 +581,7 @@ mapping clause encdec = VIMCTYPE(funct6, vs2, simm, vd)
   <-> encdec_vimcfunct6(funct6) @ 0b1 @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VIMCTYPE(funct6, vs2, simm, vd)) = {
+function clause execute VIMCTYPE(funct6, vs2, simm, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -636,7 +636,7 @@ mapping clause encdec = VIMSTYPE(funct6, vs2, simm, vd)
   <-> encdec_vimsfunct6(funct6) @ 0b0 @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VIMSTYPE(funct6, vs2, simm, vd)) = {
+function clause execute VIMSTYPE(funct6, vs2, simm, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -697,7 +697,7 @@ mapping clause encdec = VICMPTYPE(funct6, vm, vs2, simm, vd)
   <-> encdec_vicmpfunct6(funct6) @ vm @ encdec_vreg(vs2) @ simm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute(VICMPTYPE(funct6, vm, vs2, simm, vd)) = {
+function clause execute VICMPTYPE(funct6, vm, vs2, simm, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);

--- a/model/extensions/Zawrs/zawrs_insts.sail
+++ b/model/extensions/Zawrs/zawrs_insts.sail
@@ -22,10 +22,10 @@ mapping clause encdec = WRS(op)
   <-> encdec_wrsop(op) @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
   when currentlyEnabled(Ext_Zawrs)
 
-function clause execute (WRS(WRS_STO)) =
+function clause execute WRS(WRS_STO) =
   Enter_Wait(WAIT_WRS_STO)
 
-function clause execute (WRS(WRS_NTO)) =
+function clause execute WRS(WRS_NTO) =
   Enter_Wait(WAIT_WRS_NTO)
 
 mapping clause assembly = WRS(WRS_STO) <-> "wrs.sto"

--- a/model/extensions/Zicbom/zicbom_insts.sail
+++ b/model/extensions/Zicbom/zicbom_insts.sail
@@ -137,17 +137,17 @@ function process_clean_inval(rs1, cbop) = {
   }
 }
 
-function clause execute(ZICBOM(CBO_CLEAN, rs1)) =
+function clause execute ZICBOM(CBO_CLEAN, rs1) =
   if   cbo_clean_flush_enabled(cur_privilege)
   then process_clean_inval(rs1, CBO_CLEAN)
   else Illegal_Instruction()
 
-function clause execute(ZICBOM(CBO_FLUSH, rs1)) =
+function clause execute ZICBOM(CBO_FLUSH, rs1) =
   if   cbo_clean_flush_enabled(cur_privilege)
   then process_clean_inval(rs1, CBO_FLUSH)
   else Illegal_Instruction()
 
-function clause execute(ZICBOM(CBO_INVAL, rs1)) =
+function clause execute ZICBOM(CBO_INVAL, rs1) =
   match cbop_priv_check(cur_privilege) {
     CBOP_ILLEGAL         => Illegal_Instruction(),
     CBOP_ILLEGAL_VIRTUAL => internal_error(__FILE__, __LINE__, "unimplemented"),

--- a/model/extensions/Zicbop/zicbop_insts.sail
+++ b/model/extensions/Zicbop/zicbop_insts.sail
@@ -32,4 +32,4 @@ mapping prefetch_mnemonic : cbop_zicbop <-> string = {
 mapping clause assembly = ZICBOP(cbop, rs1, offset)
   <-> prefetch_mnemonic(cbop) ^ spc() ^ hex_bits_12(offset) ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
 
-function clause execute(ZICBOP(cbop, rs1, offset)) = RETIRE_SUCCESS
+function clause execute ZICBOP(cbop, rs1, offset) = RETIRE_SUCCESS

--- a/model/extensions/Zicboz/zicboz_insts.sail
+++ b/model/extensions/Zicboz/zicboz_insts.sail
@@ -22,7 +22,7 @@ mapping clause encdec = ZICBOZ(rs1)
 mapping clause assembly = ZICBOZ(rs1)
   <-> "cbo.zero" ^ spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
 
-function clause execute(ZICBOZ(rs1)) = {
+function clause execute ZICBOZ(rs1) = {
   if cbo_zero_enabled(cur_privilege) then {
     let rs1_val = X(rs1);
     let cache_block_size = 2 ^ plat_cache_block_size_exp;

--- a/model/extensions/bfloat16/zfbfmin_insts.sail
+++ b/model/extensions/bfloat16/zfbfmin_insts.sail
@@ -16,7 +16,7 @@ mapping clause encdec = FCVT_BF16_S(rs1, rm, rd)
   <-> 0b01000 @ 0b10 @ 0b01000 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b1010011
   when currentlyEnabled(Ext_Zfbfmin)
 
-function clause execute (FCVT_BF16_S(rs1, rm, rd)) = {
+function clause execute FCVT_BF16_S(rs1, rm, rd) = {
   let rs1_val_S = F_or_X_S(rs1);
   match (select_instr_or_fcsr_rm (rm)) {
     None() => Illegal_Instruction(),
@@ -40,7 +40,7 @@ mapping clause encdec = FCVT_S_BF16(rs1, rm, rd)
   <-> 0b01000 @ 0b00 @ 0b00110 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b1010011
   when currentlyEnabled(Ext_Zfbfmin)
 
-function clause execute (FCVT_S_BF16(rs1, rm, rd)) = {
+function clause execute FCVT_S_BF16(rs1, rm, rd) = {
   if select_instr_or_fcsr_rm(rm) == None()
   then return Illegal_Instruction();
 

--- a/model/extensions/rmem/insts_rmem.sail
+++ b/model/extensions/rmem/insts_rmem.sail
@@ -17,7 +17,7 @@ union clause instruction = STOP_FETCHING : unit
 mapping clause encdec = STOP_FETCHING()
   <-> 0xfade @ 0b00000000 @ 0b0 @ 0b00 @ 0b010 @ 0b11
 
-function clause execute (STOP_FETCHING()) = RETIRE_SUCCESS
+function clause execute STOP_FETCHING() = RETIRE_SUCCESS
 
 mapping clause assembly = STOP_FETCHING() <-> "stop_fetching"
 
@@ -27,6 +27,6 @@ union clause instruction = THREAD_START : unit
 mapping clause encdec = THREAD_START()
   <-> 0xc0de @ 0b00000000 @ 0b0 @ 0b00 @ 0b010 @ 0b11
 
-function clause execute (THREAD_START()) = RETIRE_SUCCESS
+function clause execute THREAD_START() = RETIRE_SUCCESS
 
 mapping clause assembly = THREAD_START() <-> "thread_start"

--- a/model/extensions/vector_crypto/zvbb_insts.sail
+++ b/model/extensions/vector_crypto/zvbb_insts.sail
@@ -18,7 +18,7 @@ mapping clause encdec = VANDN_VV(vm, vs1, vs2, vd)
 mapping clause assembly = VANDN_VV(vm, vs1, vs2, vd)
   <-> "vandn.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
-function clause execute (VANDN_VV(vm, vs1, vs2, vd)) = {
+function clause execute VANDN_VV(vm, vs1, vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -55,7 +55,7 @@ mapping clause encdec = VANDN_VX(vm, vs2, rs1, vd)
 mapping clause assembly = VANDN_VX(vm, vs2, rs1, vd)
   <-> "vandn.vx" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
 
-function clause execute (VANDN_VX(vm, vs2, rs1, vd)) = {
+function clause execute VANDN_VX(vm, vs2, rs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -92,7 +92,7 @@ mapping clause encdec = VBREV_V(vm, vs2, vd)
 mapping clause assembly = VBREV_V(vm, vs2, vd)
   <-> "vbrev.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
-function clause execute (VBREV_V(vm, vs2, vd)) = {
+function clause execute VBREV_V(vm, vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -132,7 +132,7 @@ mapping clause encdec = VBREV8_V(vm, vs2, vd)
 mapping clause assembly = VBREV8_V(vm, vs2, vd)
   <-> "vbrev8.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
-function clause execute (VBREV8_V(vm, vs2, vd)) = {
+function clause execute VBREV8_V(vm, vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -169,7 +169,7 @@ mapping clause encdec = VREV8_V(vm, vs2, vd)
 mapping clause assembly = VREV8_V(vm, vs2, vd)
   <-> "vrev8.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
-function clause execute (VREV8_V(vm, vs2, vd)) = {
+function clause execute VREV8_V(vm, vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -206,7 +206,7 @@ mapping clause encdec = VCLZ_V (vm, vs2, vd)
 mapping clause assembly = VCLZ_V (vm, vs2, vd)
   <-> "vclz.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
-function clause execute (VCLZ_V(vm, vs2, vd)) = {
+function clause execute VCLZ_V(vm, vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -244,7 +244,7 @@ mapping clause encdec = VCTZ_V (vm, vs2, vd)
 mapping clause assembly = VCTZ_V (vm, vs2, vd)
   <-> "vctz.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
-function clause execute (VCTZ_V(vm, vs2, vd)) = {
+function clause execute VCTZ_V(vm, vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -282,7 +282,7 @@ mapping clause encdec = VCPOP_V (vm, vs2, vd)
 mapping clause assembly = VCPOP_V (vm, vs2, vd)
   <-> "vcpop.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
-function clause execute (VCPOP_V(vm, vs2, vd)) = {
+function clause execute VCPOP_V(vm, vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -323,7 +323,7 @@ mapping clause encdec = VROL_VV(vm, vs1, vs2, vd)
 mapping clause assembly = VROL_VV(vm, vs1, vs2, vd)
  <-> "vrol.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
-function clause execute (VROL_VV(vm, vs1, vs2, vd)) = {
+function clause execute VROL_VV(vm, vs1, vs2, vd) = {
   let SEW_pow  = get_sew_pow();
   let SEW      = 2 ^ SEW_pow;
   let LMUL_pow = get_lmul_pow();
@@ -361,7 +361,7 @@ mapping clause encdec = VROL_VX(vm, vs2, rs1, vd)
 mapping clause assembly = VROL_VX(vm, vs2, rs1, vd)
  <-> "vrol.vx" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
 
-function clause execute (VROL_VX(vm, vs2, rs1, vd)) = {
+function clause execute VROL_VX(vm, vs2, rs1, vd) = {
   let SEW_pow  = get_sew_pow();
   let SEW      = 2 ^ SEW_pow;
   let LMUL_pow = get_lmul_pow();
@@ -399,7 +399,7 @@ mapping clause encdec = VROR_VV(vm, vs1, vs2, vd)
 mapping clause assembly = VROR_VV(vm, vs1, vs2, vd)
  <-> "vror.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
-function clause execute (VROR_VV(vm, vs1, vs2, vd)) = {
+function clause execute VROR_VV(vm, vs1, vs2, vd) = {
   let SEW_pow  = get_sew_pow();
   let SEW      = 2 ^ SEW_pow;
   let LMUL_pow = get_lmul_pow();
@@ -437,7 +437,7 @@ mapping clause encdec = VROR_VX(vm, vs2, rs1, vd)
 mapping clause assembly = VROR_VX(vm, vs2, rs1, vd)
  <-> "vror.vx" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1)^ maybe_vmask(vm)
 
-function clause execute (VROR_VX(vm, vs2, rs1, vd)) = {
+function clause execute VROR_VX(vm, vs2, rs1, vd) = {
   let SEW_pow  = get_sew_pow();
   let SEW      = 2 ^ SEW_pow;
   let LMUL_pow = get_lmul_pow();
@@ -475,7 +475,7 @@ mapping clause encdec = VROR_VI(vm, vs2, uimm5 @ uimm40, vd)
 mapping clause assembly = VROR_VI(vm, vs2, uimm, vd)
  <-> "vror.vi" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_6(uimm) ^ maybe_vmask(vm)
 
-function clause execute (VROR_VI(vm, vs2, uimm, vd)) = {
+function clause execute VROR_VI(vm, vs2, uimm, vd) = {
   let SEW_pow  = get_sew_pow();
   let SEW      = 2 ^ SEW_pow;
   let LMUL_pow = get_lmul_pow();
@@ -513,7 +513,7 @@ mapping clause encdec = VWSLL_VV (vm, vs2, vs1, vd)
 mapping clause assembly = VWSLL_VV (vm, vs2, vs1, vd)
   <-> "vwsll.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
-function clause execute (VWSLL_VV(vm, vs2, vs1, vd)) = {
+function clause execute VWSLL_VV(vm, vs2, vs1, vd) = {
   let SEW            = get_sew();
   let LMUL_pow       = get_lmul_pow();
   let num_elem       = get_num_elem(LMUL_pow, SEW);
@@ -564,7 +564,7 @@ mapping clause encdec = VWSLL_VX (vm, vs2, rs1, vd)
 mapping clause assembly = VWSLL_VX (vm, vs2, rs1, vd)
   <-> "vwsll.vx" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
 
-function clause execute (VWSLL_VX(vm, vs2, rs1, vd)) = {
+function clause execute VWSLL_VX(vm, vs2, rs1, vd) = {
   let SEW            = get_sew();
   let LMUL_pow       = get_lmul_pow();
   let num_elem       = get_num_elem(LMUL_pow, SEW);
@@ -613,7 +613,7 @@ mapping clause encdec = VWSLL_VI (vm, vs2, uimm, vd)
 mapping clause assembly = VWSLL_VI (vm, vs2, uimm, vd)
   <-> "vwsll.vi" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ hex_bits_5(uimm) ^ maybe_vmask(vm)
 
-function clause execute (VWSLL_VI(vm, vs2, uimm, vd)) = {
+function clause execute VWSLL_VI(vm, vs2, uimm, vd) = {
   let SEW            = get_sew();
   let LMUL_pow       = get_lmul_pow();
   let num_elem       = get_num_elem(LMUL_pow, SEW);

--- a/model/extensions/vector_crypto/zvbc_insts.sail
+++ b/model/extensions/vector_crypto/zvbc_insts.sail
@@ -17,7 +17,7 @@ mapping clause encdec = VCLMUL_VV (vm, vs2, vs1, vd)
 mapping clause assembly = VCLMUL_VV (vm, vs2, vs1, vd)
   <-> "vclmul.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
-function clause execute (VCLMUL_VV(vm, vs2, vs1, vd)) = {
+function clause execute VCLMUL_VV(vm, vs2, vs1, vd) = {
   let SEW       = get_sew();
   let LMUL_pow  = get_lmul_pow();
 
@@ -55,7 +55,7 @@ mapping clause encdec = VCLMUL_VX (vm, vs2, rs1, vd)
 mapping clause assembly = VCLMUL_VX (vm, vs2, rs1, vd)
   <-> "vclmul.vx" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
 
-function clause execute (VCLMUL_VX(vm, vs2, rs1, vd)) = {
+function clause execute VCLMUL_VX(vm, vs2, rs1, vd) = {
   let SEW       = get_sew();
   let LMUL_pow  = get_lmul_pow();
 
@@ -94,7 +94,7 @@ mapping clause encdec = VCLMULH_VV (vm, vs2, vs1, vd)
 mapping clause assembly = VCLMULH_VV (vm, vs2, vs1, vd)
   <-> "vclmulh.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
-function clause execute (VCLMULH_VV(vm, vs2, vs1, vd)) = {
+function clause execute VCLMULH_VV(vm, vs2, vs1, vd) = {
   let SEW       = get_sew();
   let LMUL_pow  = get_lmul_pow();
 
@@ -132,7 +132,7 @@ mapping clause encdec = VCLMULH_VX (vm, vs2, rs1, vd)
 mapping clause assembly = VCLMULH_VX (vm, vs2, rs1, vd)
   <-> "vclmulh.vx" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
 
-function clause execute (VCLMULH_VX(vm, vs2, rs1, vd)) = {
+function clause execute VCLMULH_VX(vm, vs2, rs1, vd) = {
   let SEW       = get_sew();
   let LMUL_pow  = get_lmul_pow();
 

--- a/model/extensions/vector_crypto/zvkg_insts.sail
+++ b/model/extensions/vector_crypto/zvkg_insts.sail
@@ -14,7 +14,7 @@ mapping clause encdec = VGHSH_VV(vs2, vs1, vd)
   <-> 0b1011001 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvkg) & get_sew() == 32 & zvk_check_encdec(128, 4)
 
-function clause execute (VGHSH_VV(vs2, vs1, vd)) = {
+function clause execute VGHSH_VV(vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -62,7 +62,7 @@ mapping clause encdec = VGMUL_VV(vs2, vd)
   <-> 0b1010001 @ encdec_vreg(vs2) @ 0b10001 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvkg) & get_sew() == 32 & zvk_check_encdec(128, 4)
 
-function clause execute (VGMUL_VV(vs2, vd)) = {
+function clause execute VGMUL_VV(vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);

--- a/model/extensions/vector_crypto/zvkned_insts.sail
+++ b/model/extensions/vector_crypto/zvkned_insts.sail
@@ -20,7 +20,7 @@ mapping clause encdec = VAESDF(funct6, vs2, vd)
   when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4) & (funct6 == ZVK_VAESDF_VV |
   zvk_valid_reg_overlap(vs2, vd, get_lmul_pow()))
 
-function clause execute (VAESDF(funct6, vs2, vd)) = {
+function clause execute VAESDF(funct6, vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -72,7 +72,7 @@ mapping clause encdec = VAESDM(funct6, vs2, vd)
   when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4) & (funct6 == ZVK_VAESDM_VV |
   zvk_valid_reg_overlap(vs2, vd, get_lmul_pow()))
 
-function clause execute (VAESDM(funct6, vs2, vd)) = {
+function clause execute VAESDM(funct6, vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -125,7 +125,7 @@ mapping clause encdec = VAESEF(funct6, vs2, vd)
   when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4) & (funct6 == ZVK_VAESEF_VV |
   zvk_valid_reg_overlap(vs2, vd, get_lmul_pow()))
 
-function clause execute (VAESEF(funct6, vs2, vd)) = {
+function clause execute VAESEF(funct6, vs2, vd) = {
   let SEW = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -177,7 +177,7 @@ mapping clause encdec = VAESEM(funct6, vs2, vd)
   when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4) & (funct6 == ZVK_VAESEM_VV |
   zvk_valid_reg_overlap(vs2, vd, get_lmul_pow()))
 
-function clause execute (VAESEM(funct6, vs2, vd)) = {
+function clause execute VAESEM(funct6, vs2, vd) = {
   let SEW = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -224,7 +224,7 @@ mapping clause encdec = VAESKF1_VI(vs2, rnd, vd)
   <-> 0b1000101 @ encdec_vreg(vs2) @ rnd @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
 
-function clause execute (VAESKF1_VI(vs2, rnd, vd)) = {
+function clause execute VAESKF1_VI(vs2, rnd, vd) = {
   let SEW = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -273,7 +273,7 @@ mapping clause encdec = VAESKF2_VI(vs2, rnd, vd)
   <-> 0b1010101 @ encdec_vreg(vs2) @ rnd @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
 
-function clause execute (VAESKF2_VI(vs2, rnd, vd)) = {
+function clause execute VAESKF2_VI(vs2, rnd, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -323,7 +323,7 @@ mapping clause encdec = VAESZ_VS(vs2, vd)
   <-> 0b1010011 @ encdec_vreg(vs2) @ 0b00111 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4) & zvk_valid_reg_overlap(vs2, vd, get_lmul_pow())
 
-function clause execute (VAESZ_VS(vs2, vd)) = {
+function clause execute VAESZ_VS(vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);

--- a/model/extensions/vector_crypto/zvknhab_insts.sail
+++ b/model/extensions/vector_crypto/zvknhab_insts.sail
@@ -18,7 +18,7 @@ mapping clause encdec = VSHA2MS_VV(vs2, vs1, vd)
 mapping clause assembly = VSHA2MS_VV(vs2, vs1, vd)
   <-> "vsha2ms.vv" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1)
 
-function clause execute (VSHA2MS_VV(vs2, vs1, vd)) = {
+function clause execute VSHA2MS_VV(vs2, vs1, vd) = {
   let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -85,7 +85,7 @@ mapping vsha2_mnemonic : zvk_vsha2_funct6 <-> string = {
 mapping clause assembly = ZVKSHA2TYPE(funct6, vs2, vs1, vd)
   <-> vsha2_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1)
 
-function clause execute (ZVKSHA2TYPE(funct6, vs2, vs1, vd)) = {
+function clause execute ZVKSHA2TYPE(funct6, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);

--- a/model/extensions/vector_crypto/zvksed_insts.sail
+++ b/model/extensions/vector_crypto/zvksed_insts.sail
@@ -14,7 +14,7 @@ mapping clause encdec = VSM4K_VI(vs2, uimm, vd)
   <-> 0b1000011 @ encdec_vreg(vs2) @ uimm @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvksed) & get_sew() == 32 & zvk_check_encdec(128, 4)
 
-function clause execute (VSM4K_VI(vs2, uimm, vd)) = {
+function clause execute VSM4K_VI(vs2, uimm, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -71,7 +71,7 @@ mapping clause encdec = ZVKSM4RTYPE(ZVK_VSM4R_VS, vs2, vd)
   <-> 0b1010011 @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvksed) & get_sew() == 32 & zvk_check_encdec(128, 4) & zvk_valid_reg_overlap(vs2, vd, get_lmul_pow())
 
-function clause execute (ZVKSM4RTYPE(funct6, vs2, vd)) = {
+function clause execute ZVKSM4RTYPE(funct6, vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);

--- a/model/extensions/vector_crypto/zvksh_insts.sail
+++ b/model/extensions/vector_crypto/zvksh_insts.sail
@@ -14,7 +14,7 @@ mapping clause encdec = VSM3ME_VV(vs2, vs1, vd)
   <-> 0b1000001 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1110111
    when currentlyEnabled(Ext_Zvksh) & get_sew() == 32 & zvk_check_encdec(256, 8) & zvk_valid_reg_overlap(vs2, vd, get_lmul_pow())
 
-function clause execute (VSM3ME_VV(vs2, vs1, vd)) = {
+function clause execute VSM3ME_VV(vs2, vs1, vd) = {
   let 'SEW     = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -57,7 +57,7 @@ mapping clause encdec = VSM3C_VI(vs2, uimm, vd)
   <-> 0b1010111 @ encdec_vreg(vs2) @ uimm @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvksh) & get_sew() == 32 & zvk_check_encdec(256, 8) & zvk_valid_reg_overlap(vs2, vd, get_lmul_pow())
 
-function clause execute (VSM3C_VI(vs2, uimm, vd)) = {
+function clause execute VSM3C_VI(vs2, uimm, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);

--- a/model/postlude/insts_end.sail
+++ b/model/postlude/insts_end.sail
@@ -12,7 +12,7 @@
 
 mapping clause encdec = ILLEGAL(s) <-> s
 
-function clause execute (ILLEGAL(s)) = Illegal_Instruction()
+function clause execute ILLEGAL(s) = Illegal_Instruction()
 
 mapping clause assembly = ILLEGAL(s) <-> "illegal" ^ spc() ^ hex_bits_32(s)
 


### PR DESCRIPTION
They were used inconsistently, which may cause confusion when included in documentation.