### PR TITLE
Remove monomorphic `val` declarations by moving types into the function signature.

### DIFF
--- a/model/core/csr_begin.sail
+++ b/model/core/csr_begin.sail
@@ -12,8 +12,7 @@ val csr_name_map : csreg <-> string
 
 scattered mapping csr_name_map
 
-val csr_name : csreg -> string
-function csr_name(csr) = csr_name_map(csr)
+function csr_name(csr : csreg) -> string = csr_name_map(csr)
 overload to_str = {csr_name}
 
 // returns whether a CSR exists

--- a/model/core/ext_regs.sail
+++ b/model/core/ext_regs.sail
@@ -14,12 +14,10 @@
 THIS(csrno, priv, isWrite) allows an extension to block access to csrno,
 at Privilege level priv. It should return true if the access is allowed.
 */
-val ext_check_CSR : (csreg, Privilege, bool) -> bool
-function ext_check_CSR (csrno, p, isWrite) = true
+function ext_check_CSR(csrno : csreg, p : Privilege, isWrite : bool) -> bool = true
 
 /*!
 THIS is called if ext_check_CSR returns false. It should
 cause an appropriate RISCV exception.
  */
-val ext_check_CSR_fail : unit->unit
-function ext_check_CSR_fail () = ()
+function ext_check_CSR_fail() -> unit = ()

--- a/model/core/pc_access.sail
+++ b/model/core/pc_access.sail
@@ -15,20 +15,16 @@
   The value in the PC register is the absolute virtual address of the instruction
   to fetch.
  */
-val get_arch_pc : unit -> xlenbits
-function get_arch_pc() = PC
+function get_arch_pc() -> xlenbits = PC
 
-val get_next_pc : unit -> xlenbits
-function get_next_pc() = nextPC
+function get_next_pc() -> xlenbits = nextPC
 
-val set_next_pc : xlenbits -> unit
-function set_next_pc(pc) = {
+function set_next_pc(pc : xlenbits) -> unit = {
   sail_branch_announce(xlen, pc);
   nextPC = pc
 }
 
-val tick_pc : unit -> unit
-function tick_pc() = {
+function tick_pc() -> unit = {
   PC = nextPC;
   pc_write_callback(PC);
 }

--- a/model/core/prelude.sail
+++ b/model/core/prelude.sail
@@ -19,8 +19,7 @@ $include <hex_bits.sail>
 $include <hex_bits_signed.sail>
 $include <dec_bits.sail>
 
-val not_bit : bit -> bit
-function not_bit(b) = if b == bitone then bitzero else bitone
+function not_bit(b : bit) -> bit = if b == bitone then bitzero else bitone
 
 overload ~ = {not_bool, not_vec, not_bit}
 

--- a/model/core/prelude_mem.sail
+++ b/model/core/prelude_mem.sail
@@ -62,9 +62,7 @@ struct RISCV_strong_access = {
 // sail_mem_write/read interface. This conversion is necessary because
 // the memory interface only supports 32-bit or 64-bit physical
 // addresses regardless of the actual physical address width.
-val physaddrbits_zero_extend : physaddrbits -> bits(64)
-
-function physaddrbits_zero_extend xs = zero_extend(xs)
+function physaddrbits_zero_extend(xs : physaddrbits) -> bits(64) = zero_extend(xs)
 
 instantiation sail_mem_write with
   'pa = physaddrbits,

--- a/model/core/reg_type.sail
+++ b/model/core/reg_type.sail
@@ -13,13 +13,10 @@ type regtype = xlenbits
 let zero_reg : regtype = zeros()
 
 // default register printer
-val RegStr : regtype -> string
-function RegStr(r) = bits_str(r)
+function RegStr(r : regtype) -> string = bits_str(r)
 
 // conversions
 
-val regval_from_reg : regtype -> xlenbits
-function regval_from_reg(r) = r
+function regval_from_reg(r : regtype) -> xlenbits = r
 
-val regval_into_reg : xlenbits -> regtype
-function regval_into_reg(v) = v
+function regval_into_reg(v : xlenbits) -> regtype = v

--- a/model/core/rvfi_dii.sail
+++ b/model/core/rvfi_dii.sail
@@ -22,27 +22,18 @@ bitfield RVFI_DII_Instruction_Packet : bits(64) = {
 
 register rvfi_instruction : RVFI_DII_Instruction_Packet
 
-val rvfi_set_instr_packet : bits(64) -> unit
-
-function rvfi_set_instr_packet(p) =
+function rvfi_set_instr_packet(p : bits(64)) -> unit =
   rvfi_instruction = Mk_RVFI_DII_Instruction_Packet(p)
 
-val rvfi_get_cmd : unit -> bits(8)
+function rvfi_get_cmd() -> bits(8) = rvfi_instruction[rvfi_cmd]
 
-function rvfi_get_cmd () = rvfi_instruction[rvfi_cmd]
+function rvfi_get_insn() -> bits(32) = rvfi_instruction[rvfi_insn]
 
-val rvfi_get_insn : unit -> bits(32)
-
-function rvfi_get_insn () = rvfi_instruction[rvfi_insn]
-
-val print_instr_packet : bits(64) -> unit
-
-function print_instr_packet(bs) = {
+function print_instr_packet(bs : bits(64)) -> unit = {
   let p = Mk_RVFI_DII_Instruction_Packet(bs);
   print_bits("command ", p[rvfi_cmd]);
   print_bits("instruction ", p[rvfi_insn])
 }
-
 
 bitfield RVFI_DII_Execution_Packet_InstMetaData : bits(192) = {
   // The rvfi_order field must be set to the instruction index. No indices
@@ -157,9 +148,7 @@ register rvfi_mem_data : RVFI_DII_Execution_Packet_Ext_MemAccess
 register rvfi_mem_data_present : bool
 
 // Reset the trace
-val rvfi_zero_exec_packet : unit -> unit
-
-function rvfi_zero_exec_packet () = {
+function rvfi_zero_exec_packet() -> unit = {
   rvfi_inst_data = Mk_RVFI_DII_Execution_Packet_InstMetaData(zeros());
   rvfi_pc_data = Mk_RVFI_DII_Execution_Packet_PC(zeros());
   rvfi_int_data = Mk_RVFI_DII_Execution_Packet_Ext_Integer(zeros());
@@ -174,31 +163,24 @@ function rvfi_zero_exec_packet () = {
 
 // FIXME: most of these will no longer be necessary once we use the c2 sail backend.
 
-val rvfi_halt_exec_packet : unit -> unit
-
-function rvfi_halt_exec_packet () =
+function rvfi_halt_exec_packet() -> unit =
   rvfi_inst_data[rvfi_halt] = 0x01
 
-val rvfi_get_int_data : unit -> bits(320)
-function rvfi_get_int_data () = {
+function rvfi_get_int_data() -> bits(320) = {
   assert(rvfi_int_data_present, "reading uninitialized data");
   return rvfi_int_data.bits;
 }
 
-val rvfi_get_mem_data : unit -> bits(704)
-function rvfi_get_mem_data () = {
+function rvfi_get_mem_data() -> bits(704) = {
   assert(rvfi_mem_data_present, "reading uninitialized data");
   return rvfi_mem_data.bits;
 }
 
 val rvfi_encode_width_mask : forall 'n, 0 < 'n <= 32. int('n) -> bits(32)
-
 function rvfi_encode_width_mask(width) =
   (0xFFFFFFFF >> (32 - width))
 
-val print_rvfi_exec : unit -> unit
-
-function print_rvfi_exec () = {
+function print_rvfi_exec() -> unit = {
   print_bits("rvfi_intr     : ", rvfi_inst_data[rvfi_intr]);
   print_bits("rvfi_halt     : ", rvfi_inst_data[rvfi_halt]);
   print_bits("rvfi_trap     : ", rvfi_inst_data[rvfi_trap]);
@@ -246,8 +228,7 @@ function rvfi_read (paddr, width, value) = {
   };
 }
 
-val rvfi_mem_exception : xlenbits -> unit
-function rvfi_mem_exception (paddr) = {
+function rvfi_mem_exception(paddr : xlenbits) -> unit = {
   // Log only the memory address (without the value) if the write fails.
   rvfi_mem_data[rvfi_mem_addr] = zero_extend(paddr);
   rvfi_mem_data_present = true;
@@ -260,6 +241,5 @@ function rvfi_wX (r,v) = {
   rvfi_int_data_present = true;
 }
 
-val rvfi_trap : unit -> unit
-function rvfi_trap () =
+function rvfi_trap() -> unit =
   rvfi_inst_data[rvfi_trap] = 0x01

--- a/model/core/rvfi_dii_v1.sail
+++ b/model/core/rvfi_dii_v1.sail
@@ -31,8 +31,7 @@ bitfield RVFI_DII_Execution_Packet_V1 : bits(704) = {
    rvfi_order     :  63 ..   0, // [00 - 07] Instruction number:      INSTRET value after completion.
 }
 
-val rvfi_get_exec_packet_v1 : unit -> bits(704)
-function rvfi_get_exec_packet_v1 () = {
+function rvfi_get_exec_packet_v1() -> bits(704) = {
   let v1_packet = Mk_RVFI_DII_Execution_Packet_V1(zeros());
   // Convert the v2 packet to a v1 packet
   let v1_packet = update_rvfi_intr(v1_packet, rvfi_inst_data[rvfi_intr]);

--- a/model/core/rvfi_dii_v2.sail
+++ b/model/core/rvfi_dii_v2.sail
@@ -22,8 +22,7 @@ bitfield RVFI_DII_Execution_PacketV2 : bits(512) = {
   unused_data_available_fields : 511 .. 455, // To be used for additional RVFI_DII_Execution_Packet_Ext_* structs
 }
 
-val rvfi_get_v2_support_packet : unit -> bits(704)
-function rvfi_get_v2_support_packet () = {
+function rvfi_get_v2_support_packet() -> bits(704) = {
   let rvfi_exec = Mk_RVFI_DII_Execution_Packet_V1(zeros());
   // Returning 0x3 (using the unused high bits) in halt instead of 0x1 means
   // that we support the version 2 wire format. This is required to keep
@@ -33,16 +32,14 @@ function rvfi_get_v2_support_packet () = {
   return rvfi_exec.bits;
 }
 
-val rvfi_get_v2_trace_size : unit -> bits(64)
-function rvfi_get_v2_trace_size () = {
+function rvfi_get_v2_trace_size() -> bits(64) = {
   let trace_size : bits(64) = to_bits(512);
   let trace_size = if (rvfi_int_data_present) then trace_size + 320 else trace_size;
   let trace_size = if (rvfi_mem_data_present) then trace_size + 704 else trace_size;
   return trace_size >> 3; // we have to return bytes not bits
 }
 
-val rvfi_get_exec_packet_v2 : unit -> bits(512)
-function rvfi_get_exec_packet_v2 () = {
+function rvfi_get_exec_packet_v2() -> bits(512) = {
   // TODO: add the other data
   // TODO: find a way to return a variable-length bitvector
   let packet = Mk_RVFI_DII_Execution_PacketV2(zeros());

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -189,8 +189,7 @@ mapping exceptionType_bits : ExceptionType <-> exc_code = {
   E_Extension(e)         <-> ext_exc_type_bits(e)
 }
 
-val exceptionType_to_str : ExceptionType -> string
-function exceptionType_to_str(e) =
+function exceptionType_to_str(e : ExceptionType) -> string =
   match (e) {
     E_Fetch_Addr_Align()   => "misaligned-fetch",
     E_Fetch_Access_Fault() => "fetch-access-fault",
@@ -231,8 +230,7 @@ function sw_check_code_to_bits (c : SWCheckCodes) -> xlenbits =
 type tv_mode = bits(2)
 enum TrapVectorMode = {TV_Direct, TV_Vector, TV_Reserved}
 
-val trapVectorMode_of_bits : tv_mode -> TrapVectorMode
-function trapVectorMode_of_bits (m) =
+function trapVectorMode_of_bits(m : tv_mode) -> TrapVectorMode =
   match (m) {
     0b00 => TV_Direct,
     0b01 => TV_Vector,

--- a/model/core/types_ext.sail
+++ b/model/core/types_ext.sail
@@ -61,5 +61,4 @@ mapping ext_exc_type_bits : ext_exc_type <-> exc_code = {
 }
 
 // Default conversion of extension exceptions to strings
-val ext_exc_type_to_str : ext_exc_type -> string
-function ext_exc_type_to_str(e) = "extension-exception"
+function ext_exc_type_to_str(e : ext_exc_type) -> string = "extension-exception"

--- a/model/core/vmem_types.sail
+++ b/model/core/vmem_types.sail
@@ -37,8 +37,7 @@ let Data  : ext_access_type = ()
 
 let default_write_acc : ext_access_type = Data
 
-val accessType_to_str : AccessType(ext_access_type) -> string
-function accessType_to_str (a) =
+function accessType_to_str(a : AccessType(ext_access_type)) -> string =
   match (a) {
     Read(_)            => "R",
     Write(_)           => "W",

--- a/model/exceptions/sys_exceptions.sail
+++ b/model/exceptions/sys_exceptions.sail
@@ -38,8 +38,7 @@ function prepare_trap_vector(p : Privilege, cause : Mcause) -> xlenbits = {
 // set_xepc:            used to write a value of the xret target   (no control flow transfer)
 // prepare_xret_target: used to get the value for control transfer to the xret target
 
-val get_xepc : Privilege -> xlenbits
-function get_xepc(p) =
+function get_xepc(p : Privilege) -> xlenbits =
   match p {
     Machine           => align_pc(mepc),
     Supervisor        => align_pc(sepc),
@@ -48,8 +47,7 @@ function get_xepc(p) =
     VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   }
 
-val set_xepc : (Privilege, xlenbits) -> xlenbits
-function set_xepc(p, value) = {
+function set_xepc(p : Privilege, value : xlenbits) -> xlenbits = {
   let target = legalize_xepc(value);
   match p {
     Machine           => mepc = target,
@@ -61,8 +59,7 @@ function set_xepc(p, value) = {
   target
 }
 
-val prepare_xret_target : (Privilege) -> xlenbits
-function prepare_xret_target(p) =
+function prepare_xret_target(p : Privilege) -> xlenbits =
   get_xepc(p)
 
 // other trap-related CSRs

--- a/model/extensions/FD/dext_insts.sail
+++ b/model/extensions/FD/dext_insts.sail
@@ -33,96 +33,85 @@
 // S and D value structure (sign, exponent, mantissa)
 
 // TODO: this should be a 'mapping'
-val      fsplit_D : bits(64) -> (bits(1), bits(11), bits(52))
-function fsplit_D   x64 = (x64[63..63], x64[62..52], x64[51..0])
+function fsplit_D(x64 : bits(64)) -> (bits(1), bits(11), bits(52)) =
+  (x64[63..63], x64[62..52], x64[51..0])
 
-val      fmake_D  : (bits(1), bits(11), bits(52)) -> bits(64)
-function fmake_D (sign, exp, mant) = sign @ exp @ mant
+function fmake_D(sign : bits(1), exp : bits(11), mant : bits(52)) -> bits(64) =
+  sign @ exp @ mant
 
 // ---- Structure tests
 
-val      f_is_neg_inf_D : bits(64) -> bool
-function f_is_neg_inf_D   x64 = {
+function f_is_neg_inf_D(x64 : bits(64)) -> bool = {
   let (sign, exp, mant) = fsplit_D (x64);
   (  (sign == 0b1)
    & (exp  == ones())
    & (mant == zeros()))
 }
 
-val      f_is_neg_norm_D : bits(64) -> bool
-function f_is_neg_norm_D   x64 = {
+function f_is_neg_norm_D(x64 : bits(64)) -> bool = {
   let (sign, exp, mant) = fsplit_D (x64);
   (  (sign == 0b1)
    & (exp  != zeros())
    & (exp  != ones()))
 }
 
-val      f_is_neg_subnorm_D : bits(64) -> bool
-function f_is_neg_subnorm_D   x64 = {
+function f_is_neg_subnorm_D(x64 : bits(64)) -> bool = {
   let (sign, exp, mant) = fsplit_D (x64);
   (  (sign == 0b1)
    & (exp  == zeros())
    & (mant != zeros()))
 }
 
-val      f_is_neg_zero_D : bits(64) -> bool
-function f_is_neg_zero_D   x64 = {
+function f_is_neg_zero_D(x64 : bits(64)) -> bool = {
   let (sign, exp, mant) = fsplit_D (x64);
   (  (sign == ones())
    & (exp  == zeros())
    & (mant == zeros()))
 }
 
-val      f_is_pos_zero_D : bits(64) -> bool
-function f_is_pos_zero_D   x64 = {
+function f_is_pos_zero_D(x64 : bits(64)) -> bool = {
   let (sign, exp, mant) = fsplit_D (x64);
   (  (sign == zeros())
    & (exp  == zeros())
    & (mant == zeros()))
 }
 
-val      f_is_pos_subnorm_D : bits(64) -> bool
-function f_is_pos_subnorm_D   x64 = {
+function f_is_pos_subnorm_D(x64 : bits(64)) -> bool = {
   let (sign, exp, mant) = fsplit_D (x64);
   (  (sign == zeros())
    & (exp  == zeros())
    & (mant != zeros()))
 }
 
-val      f_is_pos_norm_D : bits(64) -> bool
-function f_is_pos_norm_D   x64 = {
+function f_is_pos_norm_D(x64 : bits(64)) -> bool = {
   let (sign, exp, mant) = fsplit_D (x64);
   (  (sign == zeros())
    & (exp  != zeros())
    & (exp  != ones()))
 }
 
-val      f_is_pos_inf_D : bits(64) -> bool
-function f_is_pos_inf_D   x64 = {
+function f_is_pos_inf_D(x64 : bits(64)) -> bool = {
   let (sign, exp, mant) = fsplit_D (x64);
   (  (sign == zeros())
    & (exp  == ones())
    & (mant == zeros()))
 }
 
-val      f_is_SNaN_D : bits(64) -> bool
-function f_is_SNaN_D   x64 = {
+function f_is_SNaN_D(x64 : bits(64)) -> bool = {
   let (sign, exp, mant) = fsplit_D (x64);
   (  (exp == ones())
    & (mant [51] == bitzero)
    & (mant != zeros()))
 }
 
-val      f_is_QNaN_D : bits(64) -> bool
-function f_is_QNaN_D   x64 = {
+function f_is_QNaN_D(x64 : bits(64)) -> bool = {
   let (sign, exp, mant) = fsplit_D (x64);
   (  (exp == ones())
    & (mant [51] == bitone))
 }
 
 // Either QNaN or SNan
-val      f_is_NaN_D : bits(64) -> bool
-function f_is_NaN_D   x64 = {
+function f_is_NaN_D(x64 : bits(64)) -> bool = {
   let (sign, exp, mant) = fsplit_D (x64);
   (  (exp == ones())
    & (mant != zeros()))
@@ -132,15 +121,13 @@ function f_is_NaN_D   x64 = {
 // ***************************************************************
 // Help functions used in the semantic functions
 
-val      negate_D : bits(64) -> bits(64)
-function negate_D (x64) = {
+function negate_D(x64 : bits(64)) -> bits(64) = {
   let (sign, exp, mant) = fsplit_D (x64);
   let new_sign = if (sign == 0b0) then 0b1 else 0b0;
   fmake_D (new_sign, exp, mant)
 }
 
-val      feq_quiet_D : (bits(64), bits (64)) -> (bool, bits(5))
-function feq_quiet_D   (v1,       v2) = {
+function feq_quiet_D(v1 : bits(64), v2 : bits(64)) -> (bool, bits(5)) = {
   let (s1, e1, m1) = fsplit_D (v1);
   let (s2, e2, m2) = fsplit_D (v2);
 
@@ -156,8 +143,7 @@ function feq_quiet_D   (v1,       v2) = {
   (result, fflags)
 }
 
-val      flt_D : (bits(64), bits (64), bool) -> (bool, bits(5))
-function flt_D   (v1,       v2,        is_quiet) = {
+function flt_D(v1 : bits(64), v2 : bits(64), is_quiet : bool) -> (bool, bits(5)) = {
   let (s1, e1, m1) = fsplit_D (v1);
   let (s2, e2, m2) = fsplit_D (v2);
 
@@ -187,8 +173,7 @@ function flt_D   (v1,       v2,        is_quiet) = {
   (result, fflags)
 }
 
-val      fle_D : (bits(64), bits (64), bool) -> (bool, bits(5))
-function fle_D   (v1,       v2,        is_quiet) = {
+function fle_D(v1 : bits(64), v2 : bits(64), is_quiet : bool) -> (bool, bits(5)) = {
   let (s1, e1, m1) = fsplit_D (v1);
   let (s2, e2, m2) = fsplit_D (v2);
 

--- a/model/extensions/FD/fdext_regs.sail
+++ b/model/extensions/FD/fdext_regs.sail
@@ -209,53 +209,45 @@ function wF_bits(Fregidx(i) : fregidx, data: flenbits) -> unit = {
 
 overload F = {rF_bits, wF_bits, rF, wF}
 
-val rF_BF16 : fregidx -> bits(16)
-function rF_BF16(i) = {
+function rF_BF16(i : fregidx) -> bits(16) = {
   nan_unbox(F(i))
 }
 
-val wF_BF16 : (fregidx, bits(16)) -> unit
-function wF_BF16(i, data) = {
+function wF_BF16(i : fregidx, data : bits(16)) -> unit = {
   F(i) = nan_box(data)
 }
 
-val rF_H : fregidx -> bits(16)
-function rF_H(i) = {
+function rF_H(i : fregidx) -> bits(16) = {
   assert(flen >= 16);
   assert(hartSupports(Ext_F) & not(hartSupports(Ext_Zfinx)));
   nan_unbox(F(i))
 }
 
-val wF_H : (fregidx, bits(16)) -> unit
-function wF_H(i, data) = {
+function wF_H(i : fregidx, data : bits(16)) -> unit = {
   assert(flen >= 16);
   assert(hartSupports(Ext_F) & not(hartSupports(Ext_Zfinx)));
   F(i) = nan_box(data)
 }
 
-val rF_S : fregidx -> bits(32)
-function rF_S(i) = {
+function rF_S(i : fregidx) -> bits(32) = {
   assert(flen >= 32);
   assert(hartSupports(Ext_F) & not(hartSupports(Ext_Zfinx)));
   nan_unbox(F(i))
 }
 
-val wF_S : (fregidx, bits(32)) -> unit
-function wF_S(i, data) = {
+function wF_S(i : fregidx, data : bits(32)) -> unit = {
   assert(flen >= 32);
   assert(hartSupports(Ext_F) & not(hartSupports(Ext_Zfinx)));
   F(i) = nan_box(data)
 }
 
-val rF_D : fregidx -> bits(64)
-function rF_D(i) = {
+function rF_D(i : fregidx) -> bits(64) = {
   assert(flen >= 64);
   assert(hartSupports(Ext_F) & not(hartSupports(Ext_Zfinx)));
   F(i)
 }
 
-val wF_D : (fregidx, bits(64)) -> unit
-function wF_D(i, data) = {
+function wF_D(i : fregidx, data : bits(64)) -> unit = {
   assert(flen >= 64);
   assert(hartSupports(Ext_F) & not(hartSupports(Ext_Zfinx)));
   F(i) = data
@@ -266,8 +258,7 @@ overload F_H = { rF_H, wF_H }
 overload F_S = { rF_S, wF_S }
 overload F_D = { rF_D, wF_D }
 
-val rF_or_X_H : fregidx -> bits(16)
-function rF_or_X_H(i) = {
+function rF_or_X_H(i : fregidx) -> bits(16) = {
   assert(flen >= 16);
   assert(hartSupports(Ext_F) != hartSupports(Ext_Zfinx));
   if   hartSupports(Ext_F)
@@ -275,8 +266,7 @@ function rF_or_X_H(i) = {
   else X(fregidx_to_regidx(i))[15..0]
 }
 
-val rF_or_X_S : fregidx -> bits(32)
-function rF_or_X_S(i) = {
+function rF_or_X_S(i : fregidx) -> bits(32) = {
   assert(flen >= 32);
   assert(hartSupports(Ext_F) != hartSupports(Ext_Zfinx));
   if   hartSupports(Ext_F)
@@ -284,8 +274,7 @@ function rF_or_X_S(i) = {
   else X(fregidx_to_regidx(i))[31..0]
 }
 
-val rF_or_X_D : fregidx -> bits(64)
-function rF_or_X_D(i) = {
+function rF_or_X_D(i : fregidx) -> bits(64) = {
   assert(flen >= 64);
   assert(hartSupports(Ext_F) != hartSupports(Ext_Zfinx));
   if   hartSupports(Ext_F)
@@ -299,8 +288,7 @@ function rF_or_X_D(i) = {
   }
 }
 
-val wF_or_X_H : (fregidx, bits(16)) -> unit
-function wF_or_X_H(i, data) = {
+function wF_or_X_H(i : fregidx, data : bits(16)) -> unit = {
   assert(flen >= 16);
   assert(hartSupports(Ext_F) != hartSupports(Ext_Zfinx));
   if   hartSupports(Ext_F)
@@ -308,8 +296,7 @@ function wF_or_X_H(i, data) = {
   else X(fregidx_to_regidx(i)) = sign_extend(data)
 }
 
-val wF_or_X_S : (fregidx, bits(32)) -> unit
-function wF_or_X_S(i, data) = {
+function wF_or_X_S(i : fregidx, data : bits(32)) -> unit = {
   assert(flen >= 32);
   assert(hartSupports(Ext_F) != hartSupports(Ext_Zfinx));
   if   hartSupports(Ext_F)
@@ -317,8 +304,7 @@ function wF_or_X_S(i, data) = {
   else X(fregidx_to_regidx(i)) = sign_extend(data)
 }
 
-val wF_or_X_D : (fregidx, bits(64)) -> unit
-function wF_or_X_D(i, data) = {
+function wF_or_X_D(i : fregidx, data : bits(64)) -> unit = {
   assert (flen >= 64);
   assert(hartSupports(Ext_F) != hartSupports(Ext_Zfinx));
   if   hartSupports(Ext_F)
@@ -438,16 +424,14 @@ bitfield Fcsr : bits(32) = {
 
 register fcsr : Fcsr
 
-val write_fcsr : (bits(3), bits(5)) -> unit
-function write_fcsr (frm, fflags) = {
+function write_fcsr(frm : bits(3), fflags : bits(5)) -> unit = {
   fcsr[FRM]    = frm;      // Note: frm can be an illegal value, 101, 110, 111
   fcsr[FFLAGS] = fflags;
   dirty_fd_context_if_present();
 }
 
 // OR flags into the fflags register.
-val accrue_fflags : (bits(5)) -> unit
-function accrue_fflags(flags) = {
+function accrue_fflags(flags : bits(5)) -> unit = {
   let f = fcsr[FFLAGS] | flags;
   if  fcsr[FFLAGS] != f
   then {

--- a/model/extensions/FD/fext_insts.sail
+++ b/model/extensions/FD/fext_insts.sail
@@ -46,11 +46,9 @@ mapping frm_mnemonic : rounding_mode <-> string = {
   RM_DYN <-> "dyn"
 }
 
-val      valid_rounding_mode : bits(3) -> bool
-function valid_rounding_mode rm = (rm != 0b101 & rm != 0b110)
+function valid_rounding_mode(rm : bits(3)) -> bool = (rm != 0b101 & rm != 0b110)
 
-val      select_instr_or_fcsr_rm : rounding_mode -> option(rounding_mode)
-function select_instr_or_fcsr_rm instr_rm =
+function select_instr_or_fcsr_rm(instr_rm : rounding_mode) -> option(rounding_mode) =
   if (instr_rm == RM_DYN)
   then {
     let fcsr_rm = fcsr[FRM];
@@ -72,96 +70,85 @@ function nvFlag() -> bits(5) = 0b_10000
 // S and D value structure (sign, exponent, mantissa)
 
 // TODO: this should be a 'mapping'
-val      fsplit_S : bits(32) -> (bits(1), bits(8), bits(23))
-function fsplit_S   x32 = (x32[31..31], x32[30..23], x32[22..0])
+function fsplit_S(x32 : bits(32)) -> (bits(1), bits(8), bits(23)) =
+  (x32[31..31], x32[30..23], x32[22..0])
 
-val      fmake_S  : (bits(1), bits(8), bits(23)) -> bits(32)
-function fmake_S (sign, exp, mant) = sign @ exp @ mant
+function fmake_S(sign: bits(1), exp : bits(8), mant : bits(23)) -> bits(32) =
+  sign @ exp @ mant
 
 // ---- Structure tests
 
-val      f_is_neg_inf_S : bits(32) -> bool
-function f_is_neg_inf_S   x32 = {
+function f_is_neg_inf_S(x32 : bits(32)) -> bool = {
   let (sign, exp, mant) = fsplit_S (x32);
   (  (sign == 0b1)
    & (exp  == ones())
    & (mant == zeros()))
 }
 
-val      f_is_neg_norm_S : bits(32) -> bool
-function f_is_neg_norm_S   x32 = {
+function f_is_neg_norm_S(x32 : bits(32)) -> bool = {
   let (sign, exp, mant) = fsplit_S (x32);
   (  (sign == 0b1)
    & (exp  != zeros())
    & (exp  != ones()))
 }
 
-val      f_is_neg_subnorm_S : bits(32) -> bool
-function f_is_neg_subnorm_S   x32 = {
+function f_is_neg_subnorm_S(x32 : bits(32)) -> bool = {
   let (sign, exp, mant) = fsplit_S (x32);
   (  (sign == 0b1)
    & (exp  == zeros())
    & (mant != zeros()))
 }
 
-val      f_is_neg_zero_S : bits(32) -> bool
-function f_is_neg_zero_S   x32 = {
+function f_is_neg_zero_S(x32 : bits(32)) -> bool = {
   let (sign, exp, mant) = fsplit_S (x32);
   (  (sign == ones())
    & (exp  == zeros())
    & (mant == zeros()))
 }
 
-val      f_is_pos_zero_S : bits(32) -> bool
-function f_is_pos_zero_S   x32 = {
+function f_is_pos_zero_S(x32 : bits(32)) -> bool = {
   let (sign, exp, mant) = fsplit_S (x32);
   (  (sign == zeros())
    & (exp  == zeros())
    & (mant == zeros()))
 }
 
-val      f_is_pos_subnorm_S : bits(32) -> bool
-function f_is_pos_subnorm_S   x32 = {
+function f_is_pos_subnorm_S(x32 : bits(32)) -> bool = {
   let (sign, exp, mant) = fsplit_S (x32);
   (  (sign == zeros())
    & (exp  == zeros())
    & (mant != zeros()))
 }
 
-val      f_is_pos_norm_S : bits(32) -> bool
-function f_is_pos_norm_S   x32 = {
+function f_is_pos_norm_S(x32 : bits(32)) -> bool = {
   let (sign, exp, mant) = fsplit_S (x32);
   (  (sign == zeros())
    & (exp  != zeros())
    & (exp  != ones()))
 }
 
-val      f_is_pos_inf_S : bits(32) -> bool
-function f_is_pos_inf_S   x32 = {
+function f_is_pos_inf_S(x32 : bits(32)) -> bool = {
   let (sign, exp, mant) = fsplit_S (x32);
   (  (sign == zeros())
    & (exp  == ones())
    & (mant == zeros()))
 }
 
-val      f_is_SNaN_S : bits(32) -> bool
-function f_is_SNaN_S   x32 = {
+function f_is_SNaN_S(x32 : bits(32)) -> bool = {
   let (sign, exp, mant) = fsplit_S (x32);
   (  (exp == ones())
    & (mant [22] == bitzero)
    & (mant != zeros()))
 }
 
-val      f_is_QNaN_S : bits(32) -> bool
-function f_is_QNaN_S   x32 = {
+function f_is_QNaN_S(x32 : bits(32)) -> bool = {
   let (sign, exp, mant) = fsplit_S (x32);
   (  (exp == ones())
    & (mant [22] == bitone))
 }
 
 // Either QNaN or SNan
-val      f_is_NaN_S : bits(32) -> bool
-function f_is_NaN_S   x32 = {
+function f_is_NaN_S(x32 : bits(32)) -> bool = {
   let (sign, exp, mant) = fsplit_S (x32);
   (  (exp == ones())
    & (mant != zeros()))
@@ -170,15 +157,13 @@ function f_is_NaN_S   x32 = {
 // ***************************************************************
 // Help functions used in the semantic functions
 
-val      negate_S : bits(32) -> bits(32)
-function negate_S (x32) = {
+function negate_S(x32: bits(32)) -> bits(32) = {
   let (sign, exp, mant) = fsplit_S (x32);
   let new_sign = if (sign == 0b0) then 0b1 else 0b0;
   fmake_S (new_sign, exp, mant)
 }
 
-val      feq_quiet_S : (bits(32), bits (32)) -> (bool, bits(5))
-function feq_quiet_S   (v1,       v2) = {
+function feq_quiet_S(v1 : bits(32), v2 : bits(32)) -> (bool, bits(5)) = {
   let (s1, e1, m1) = fsplit_S (v1);
   let (s2, e2, m2) = fsplit_S (v2);
 
@@ -194,8 +179,7 @@ function feq_quiet_S   (v1,       v2) = {
   (result, fflags)
 }
 
-val      flt_S : (bits(32), bits (32), bool) -> (bool, bits(5))
-function flt_S   (v1,       v2,        is_quiet) = {
+function flt_S(v1 : bits(32), v2 : bits(32), is_quiet : bool) -> (bool, bits(5)) = {
   let (s1, e1, m1) = fsplit_S (v1);
   let (s2, e2, m2) = fsplit_S (v2);
 
@@ -225,8 +209,7 @@ function flt_S   (v1,       v2,        is_quiet) = {
   (result, fflags)
 }
 
-val      fle_S : (bits(32), bits (32), bool) -> (bool, bits(5))
-function fle_S   (v1,       v2,        is_quiet) = {
+function fle_S(v1 : bits(32), v2 : bits(32), is_quiet : bool) -> (bool, bits(5)) = {
   let (s1, e1, m1) = fsplit_S (v1);
   let (s2, e2, m2) = fsplit_S (v2);
 

--- a/model/extensions/FD/freg_type.sail
+++ b/model/extensions/FD/freg_type.sail
@@ -15,16 +15,13 @@ type fregtype = flenbits
 let zero_freg : fregtype = zeros()
 
 // default register printer
-val FRegStr : fregtype -> string
-function FRegStr(r) = bits_str(r)
+function FRegStr(r : fregtype) -> string = bits_str(r)
 
 // conversions
 
-val fregval_from_freg : fregtype -> flenbits
-function fregval_from_freg(r) = r
+function fregval_from_freg(r : fregtype) -> flenbits = r
 
-val fregval_into_freg : flenbits -> fregtype
-function fregval_into_freg(v) = v
+function fregval_into_freg(v : flenbits) -> fregtype = v
 
 enum f_madd_op_H = {FMADD_H, FMSUB_H, FNMSUB_H, FNMADD_H}
 

--- a/model/extensions/FD/zfa_insts.sail
+++ b/model/extensions/FD/zfa_insts.sail
@@ -721,8 +721,7 @@ function clause execute(FLTQ_D(rs2, rs1, rd)) = {
 //
 // Implement float64 to int32 conversion without saturation, the
 // result is supplied modulo 2^32.
-val      fcvtmod_helper : bits(64) -> (bits(5), bits(32))
-function fcvtmod_helper(x64) = {
+function fcvtmod_helper(x64 : bits(64)) -> (bits(5), bits(32)) = {
   let (sign, exp, mant) = fsplit_D(x64);
 
   // Detect the non-normal cases

--- a/model/extensions/FD/zfh_insts.sail
+++ b/model/extensions/FD/zfh_insts.sail
@@ -28,108 +28,95 @@ function clause currentlyEnabled(Ext_Zhinxmin) = (hartSupports(Ext_Zhinxmin) & c
 
 // ***************************************************************
 
-val      fsplit_H : bits(16) -> (bits(1), bits(5), bits(10))
-function fsplit_H   (xf16) = (xf16[15..15], xf16[14..10], xf16[9..0])
+function fsplit_H(xf16 : bits(16)) -> (bits(1), bits(5), bits(10)) =
+  (xf16[15..15], xf16[14..10], xf16[9..0])
 
-val      fmake_H  : (bits(1), bits(5), bits(10)) -> bits(16)
-function fmake_H (sign, exp, mant) = sign @ exp @ mant
+function fmake_H(sign : bits(1), exp : bits(5), mant : bits(10)) -> bits(16) =
+  sign @ exp @ mant
 
-val      negate_H : bits(16) -> bits(16)
-function negate_H (xf16) = {
+function negate_H(xf16 : bits(16)) -> bits(16) = {
   let (sign, exp, mant) = fsplit_H (xf16);
   let new_sign = if (sign == 0b0) then 0b1 else 0b0;
   fmake_H (new_sign, exp, mant)
 }
 
-val      f_is_neg_inf_H : bits(16) -> bool
-function f_is_neg_inf_H   xf16 = {
+function f_is_neg_inf_H(xf16 : bits(16)) -> bool = {
   let (sign, exp, mant) = fsplit_H (xf16);
   (  (sign == 0b1)
    & (exp  == ones())
    & (mant == zeros()))
 }
 
-val      f_is_neg_norm_H : bits(16) -> bool
-function f_is_neg_norm_H   xf16 = {
+function f_is_neg_norm_H(xf16 : bits(16)) -> bool = {
   let (sign, exp, mant) = fsplit_H (xf16);
   (  (sign == 0b1)
    & (exp  != zeros())
    & (exp  != ones()))
 }
 
-val      f_is_neg_subnorm_H : bits(16) -> bool
-function f_is_neg_subnorm_H   xf16 = {
+function f_is_neg_subnorm_H(xf16 : bits(16)) -> bool = {
   let (sign, exp, mant) = fsplit_H (xf16);
   (  (sign == 0b1)
    & (exp  == zeros())
    & (mant != zeros()))
 }
 
-val      f_is_pos_subnorm_H : bits(16) -> bool
-function f_is_pos_subnorm_H   xf16 = {
+function f_is_pos_subnorm_H(xf16 : bits(16)) -> bool = {
   let (sign, exp, mant) = fsplit_H (xf16);
   (  (sign == zeros())
    & (exp  == zeros())
    & (mant != zeros()))
 }
 
-val      f_is_pos_norm_H : bits(16) -> bool
-function f_is_pos_norm_H   xf16 = {
+function f_is_pos_norm_H(xf16 : bits(16)) -> bool = {
   let (sign, exp, mant) = fsplit_H (xf16);
   (  (sign == zeros())
    & (exp  != zeros())
    & (exp  != ones()))
 }
 
-val      f_is_pos_inf_H : bits(16) -> bool
-function f_is_pos_inf_H   xf16 = {
+function f_is_pos_inf_H(xf16 : bits(16)) -> bool = {
   let (sign, exp, mant) = fsplit_H (xf16);
   (  (sign == zeros())
    & (exp  == ones())
    & (mant == zeros()))
 }
 
-val      f_is_neg_zero_H : bits(16) -> bool
-function f_is_neg_zero_H   xf16 = {
+function f_is_neg_zero_H(xf16 : bits(16)) -> bool = {
   let (sign, exp, mant) = fsplit_H (xf16);
   (  (sign == ones())
    & (exp  == zeros())
    & (mant == zeros()))
 }
 
-val      f_is_pos_zero_H : bits(16) -> bool
-function f_is_pos_zero_H   xf16 = {
+function f_is_pos_zero_H(xf16 : bits(16)) -> bool = {
   let (sign, exp, mant) = fsplit_H (xf16);
   (  (sign == zeros())
    & (exp  == zeros())
    & (mant == zeros()))
 }
 
-val      f_is_SNaN_H : bits(16) -> bool
-function f_is_SNaN_H   xf16 = {
+function f_is_SNaN_H(xf16 : bits(16)) -> bool = {
   let (sign, exp, mant) = fsplit_H (xf16);
   (  (exp == ones())
    & (mant [9] == bitzero)
    & (mant != zeros()))
 }
 
-val      f_is_QNaN_H : bits(16) -> bool
-function f_is_QNaN_H   xf16 = {
+function f_is_QNaN_H(xf16 : bits(16)) -> bool = {
   let (sign, exp, mant) = fsplit_H (xf16);
   (  (exp == ones())
    & (mant [9] == bitone))
 }
 
 // Either QNaN or SNan
-val      f_is_NaN_H : bits(16) -> bool
-function f_is_NaN_H   xf16 = {
+function f_is_NaN_H(xf16 : bits(16)) -> bool = {
   let (sign, exp, mant) = fsplit_H (xf16);
   (  (exp == ones())
    & (mant != zeros()))
 }
 
-val      fle_H : (bits(16), bits (16), bool) -> (bool, bits(5))
-function fle_H   (v1,       v2,        is_quiet) = {
+function fle_H(v1 : bits(16), v2 : bits(16), is_quiet : bool) -> (bool, bits(5)) = {
   let (s1, e1, m1) = fsplit_H (v1);
   let (s2, e2, m2) = fsplit_H (v2);
 

--- a/model/extensions/V/vext_control.sail
+++ b/model/extensions/V/vext_control.sail
@@ -26,8 +26,7 @@ function clause currentlyEnabled(Ext_Zvfh)    = hartSupports(Ext_Zvfh)     & cur
 function clause currentlyEnabled(Ext_Zvfhmin) = (hartSupports(Ext_Zvfhmin) & currentlyEnabled(Ext_Zve32f)) | currentlyEnabled(Ext_Zvfh)
 
 // num_elem means max(VLMAX,VLEN/SEW)) according to Section 5.4 of RVV spec
-val get_num_elem : (int, sew_bitsize) -> nat1
-function get_num_elem(LMUL_pow, SEW) = {
+function get_num_elem(LMUL_pow : int, SEW : sew_bitsize) -> nat1 = {
   let LMUL_pow_reg = if LMUL_pow < 0 then 0 else LMUL_pow;
   // Ignore lmul < 1 so that the entire vreg is read, allowing all masking to
   // be handled in init_masked_result

--- a/model/extensions/V/vext_fp_red_insts.sail
+++ b/model/extensions/V/vext_fp_red_insts.sail
@@ -27,8 +27,7 @@ mapping clause encdec = RFVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_rfvvfunct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-val process_rfvv_single : (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, nat1, sew_bitsize, range(-3, 3)) -> ExecutionResult
-function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {
+function process_rfvv_single(funct6 : rfvvfunct6, vm : bits(1), vs2 : vregidx, vs1 : vregidx, vd : vregidx, num_elem_vs : nat1, SEW : sew_bitsize, LMUL_pow : range(-3, 3)) -> ExecutionResult = {
   let rm_3b = fcsr[FRM];
   let num_elem_vd = get_num_elem(0, SEW); // vd regardless of LMUL setting
 
@@ -70,8 +69,7 @@ function process_rfvv_single(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_po
   RETIRE_SUCCESS
 }
 
-val process_rfvv_widening_reduction : (rfvvfunct6, bits(1), vregidx, vregidx, vregidx, nat1, sew_bitsize, range(-3, 3)) -> ExecutionResult
-function process_rfvv_widening_reduction(funct6, vm, vs2, vs1, vd, num_elem_vs, SEW, LMUL_pow) = {
+function process_rfvv_widening_reduction(funct6 : rfvvfunct6, vm : bits(1), vs2 : vregidx, vs1 : vregidx, vd : vregidx, num_elem_vs : nat1, SEW : sew_bitsize, LMUL_pow : range(-3, 3)) -> ExecutionResult = {
   let rm_3b          = fcsr[FRM];
   let SEW_widen      = SEW * 2;
 

--- a/model/extensions/V/vext_fp_utils_insts.sail
+++ b/model/extensions/V/vext_fp_utils_insts.sail
@@ -13,8 +13,7 @@
 // Check for valid floating-point operation types
 // 1. Valid element width of floating-point numbers
 // 2. Valid floating-point rounding mode
-val valid_fp_op : (sew_bitsize, bits(3)) -> bool
-function valid_fp_op(SEW, rm_3b) = {
+function valid_fp_op(SEW : sew_bitsize, rm_3b : bits(3)) -> bool = {
   // 128-bit floating-point values will be supported in future extensions
   let valid_sew = (SEW >= 16 & SEW <= 128);
   let valid_rm = not(rm_3b == 0b101 | rm_3b == 0b110 | rm_3b == 0b111);
@@ -22,39 +21,33 @@ function valid_fp_op(SEW, rm_3b) = {
 }
 
 // a. Normal check for floating-point instructions
-val illegal_fp_normal : (vregidx, bits(1), sew_bitsize, bits(3)) -> bool
-function illegal_fp_normal(vd, vm, SEW, rm_3b) = {
+function illegal_fp_normal(vd : vregidx, vm : bits(1), SEW : sew_bitsize, rm_3b : bits(3)) -> bool = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b))
 }
 
 // b. Masked check for floating-point instructions encoded with vm = 0
-val illegal_fp_vd_masked : (vregidx, sew_bitsize, bits(3)) -> bool
-function illegal_fp_vd_masked(vd, SEW, rm_3b) = {
+function illegal_fp_vd_masked(vd : vregidx, SEW : sew_bitsize, rm_3b : bits(3)) -> bool = {
   not(valid_vtype()) | vd == zvreg | not(valid_fp_op(SEW, rm_3b))
 }
 
 // c. Unmasked check for floating-point instructions encoded with vm = 1
-val illegal_fp_vd_unmasked : (sew_bitsize, bits(3)) -> bool
-function illegal_fp_vd_unmasked(SEW, rm_3b) = {
+function illegal_fp_vd_unmasked(SEW : sew_bitsize, rm_3b : bits(3)) -> bool = {
   not(valid_vtype()) | not(valid_fp_op(SEW, rm_3b))
 }
 
 // d. Variable width check for floating-point widening/narrowing instructions
-val illegal_fp_variable_width : (vregidx, bits(1), sew_bitsize, bits(3), int, int) -> bool
-function illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_new, LMUL_pow_new) = {
+function illegal_fp_variable_width(vd : vregidx, vm : bits(1), SEW : sew_bitsize, rm_3b : bits(3), SEW_new : int, LMUL_pow_new : int) -> bool = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm)) | not(valid_fp_op(SEW, rm_3b)) |
   not(valid_eew_emul(SEW_new, LMUL_pow_new))
 }
 
 // e. Normal check for floating-point reduction instructions
-val illegal_fp_reduction : (sew_bitsize, bits(3)) -> bool
-function illegal_fp_reduction(SEW, rm_3b) = {
+function illegal_fp_reduction(SEW : sew_bitsize, rm_3b : bits(3)) -> bool = {
   not(valid_vtype()) | not(assert_vstart(0)) | not(valid_fp_op(SEW, rm_3b))
 }
 
 // f. Variable width check for floating-point widening reduction instructions
-val illegal_fp_widening_reduction : (sew_bitsize, bits(3), int) -> bool
-function illegal_fp_widening_reduction(SEW, rm_3b, EEW) = {
+function illegal_fp_widening_reduction(SEW : sew_bitsize, rm_3b : bits(3), EEW : int) -> bool = {
   not(valid_vtype()) | not(assert_vstart(0)) | not(valid_fp_op(SEW, rm_3b)) |
   not(EEW >= 8 & EEW <= elen)
 }
@@ -171,8 +164,7 @@ function get_scalar_fp(rs1, SEW) = {
 }
 
 // Get the floating point rounding mode from csr fcsr
-val get_fp_rounding_mode : unit -> rounding_mode
-function get_fp_rounding_mode() = encdec_rounding_mode(fcsr[FRM])
+function get_fp_rounding_mode() -> rounding_mode = encdec_rounding_mode(fcsr[FRM])
 
 // Negate a floating point number
 val negate_fp : forall 'm, 'm in {16, 32, 64}. bits('m) -> bits('m)
@@ -402,46 +394,40 @@ function fp_widen(nval) = {
 }
 
 // Floating point functions without softfloat support
-val riscv_f16ToI16 : (bits_rm, bits_H) -> (bits_fflags, bits(16))
-function riscv_f16ToI16 (rm, v) = {
+function riscv_f16ToI16(rm : bits_rm, v : bits_H) -> (bits_fflags, bits(16)) = {
   let (flag, sig32) = riscv_f16ToI32(rm, v);
   if signed(sig32) > signed(0b0 @ ones(15)) then (nvFlag(), 0b0 @ ones(15))
   else if signed(sig32) < signed(0b1 @ zeros(15)) then (nvFlag(), 0b1 @ zeros(15))
   else (flag, sig32[15 .. 0]);
 }
 
-val riscv_f16ToI8 : (bits_rm, bits_H) -> (bits_fflags, bits(8))
-function riscv_f16ToI8 (rm, v) = {
+function riscv_f16ToI8(rm : bits_rm, v : bits_H) -> (bits_fflags, bits(8)) = {
   let (flag, sig32) = riscv_f16ToI32(rm, v);
   if signed(sig32) > signed(0b0 @ ones(7)) then (nvFlag(), 0b0 @ ones(7))
   else if signed(sig32) < signed(0b1 @ zeros(7)) then (nvFlag(), 0b1 @ zeros(7))
   else (flag, sig32[7 .. 0]);
 }
 
-val riscv_f32ToI16 : (bits_rm, bits_S) -> (bits_fflags, bits(16))
-function riscv_f32ToI16 (rm, v) = {
+function riscv_f32ToI16(rm : bits_rm, v : bits_S) -> (bits_fflags, bits(16)) = {
   let (flag, sig32) = riscv_f32ToI32(rm, v);
   if signed(sig32) > signed(0b0 @ ones(15)) then (nvFlag(), 0b0 @ ones(15))
   else if signed(sig32) < signed(0b1 @ zeros(15)) then (nvFlag(), 0b1 @ zeros(15))
   else (flag, sig32[15 .. 0]);
 }
 
-val riscv_f16ToUi16 : (bits_rm, bits_H) -> (bits_fflags, bits(16))
-function riscv_f16ToUi16 (rm, v) = {
+function riscv_f16ToUi16(rm : bits_rm, v : bits_H) -> (bits_fflags, bits(16)) = {
   let (flag, sig32) = riscv_f16ToUi32(rm, v);
   if unsigned(sig32) > unsigned(ones(16)) then (nvFlag(), ones(16))
   else (flag, sig32[15 .. 0]);
 }
 
-val riscv_f16ToUi8 : (bits_rm, bits_H) -> (bits_fflags, bits(8))
-function riscv_f16ToUi8 (rm, v) = {
+function riscv_f16ToUi8(rm : bits_rm, v : bits_H) -> (bits_fflags, bits(8)) = {
   let (flag, sig32) = riscv_f16ToUi32(rm, v);
   if unsigned(sig32) > unsigned(ones(8)) then (nvFlag(), ones(8))
   else (flag, sig32[7 .. 0]);
 }
 
-val riscv_f32ToUi16 : (bits_rm, bits_S) -> (bits_fflags, bits(16))
-function riscv_f32ToUi16 (rm, v) = {
+function riscv_f32ToUi16(rm : bits_rm, v : bits_S) -> (bits_fflags, bits(16)) = {
   let (flag, sig32) = riscv_f32ToUi32(rm, v);
   if unsigned(sig32) > unsigned(ones(16)) then (nvFlag(), ones(16))
   else (flag, sig32[15 .. 0]);
@@ -492,8 +478,7 @@ function rsqrt7 (v, sub) = {
   zero_extend(64, sign @ out_exp @ out_sig)
 }
 
-val riscv_f16Rsqrte7 : (bits_rm, bits_H) -> (bits_fflags, bits_H)
-function riscv_f16Rsqrte7 (rm, v) = {
+function riscv_f16Rsqrte7(rm : bits_rm, v : bits_H) -> (bits_fflags, bits_H) = {
   match fp_class(v) {
     0x0001 => (nvFlag(), 0x7e00),
     0x0002 => (nvFlag(), 0x7e00),
@@ -508,8 +493,7 @@ function riscv_f16Rsqrte7 (rm, v) = {
   }
 }
 
-val riscv_f32Rsqrte7 : (bits_rm, bits_S) -> (bits_fflags, bits_S)
-function riscv_f32Rsqrte7 (rm, v) = {
+function riscv_f32Rsqrte7(rm : bits_rm, v : bits_S) -> (bits_fflags, bits_S) = {
   match fp_class(v)[15 .. 0] {
     0x0001 => (nvFlag(), 0x7fc00000),
     0x0002 => (nvFlag(), 0x7fc00000),
@@ -524,8 +508,7 @@ function riscv_f32Rsqrte7 (rm, v) = {
   }
 }
 
-val riscv_f64Rsqrte7 : (bits_rm, bits_D) -> (bits_fflags, bits_D)
-function riscv_f64Rsqrte7 (rm, v) = {
+function riscv_f64Rsqrte7(rm : bits_rm, v : bits_D) -> (bits_fflags, bits_D) = {
   match fp_class(v)[15 .. 0] {
     0x0001 => (nvFlag(), 0x7ff8000000000000),
     0x0002 => (nvFlag(), 0x7ff8000000000000),
@@ -598,8 +581,7 @@ function recip7 (v, rm_3b, sub) = {
     } else (false, zero_extend(64, sign @ out_exp @ out_sig))
 }
 
-val riscv_f16Recip7 : (bits_rm, bits_H) -> (bits_fflags, bits_H)
-function riscv_f16Recip7 (rm, v) = {
+function riscv_f16Recip7(rm : bits_rm, v : bits_H) -> (bits_fflags, bits_H) = {
   let (round_abnormal_true, res_true) = recip7(v, rm, true);
   let (round_abnormal_false, res_false) = recip7(v, rm, false);
   match fp_class(v) {
@@ -615,8 +597,7 @@ function riscv_f16Recip7 (rm, v) = {
   }
 }
 
-val riscv_f32Recip7 : (bits_rm, bits_S) -> (bits_fflags, bits_S)
-function riscv_f32Recip7 (rm, v) = {
+function riscv_f32Recip7(rm : bits_rm, v : bits_S) -> (bits_fflags, bits_S) = {
   let (round_abnormal_true, res_true) = recip7(v, rm, true);
   let (round_abnormal_false, res_false) = recip7(v, rm, false);
   match fp_class(v)[15 .. 0] {
@@ -632,8 +613,7 @@ function riscv_f32Recip7 (rm, v) = {
   }
 }
 
-val riscv_f64Recip7 : (bits_rm, bits_D) -> (bits_fflags, bits_D)
-function riscv_f64Recip7 (rm, v) = {
+function riscv_f64Recip7(rm : bits_rm, v : bits_D) ->  (bits_fflags, bits_D) = {
   let (round_abnormal_true, res_true) = recip7(v, rm, true);
   let (round_abnormal_false, res_false) = recip7(v, rm, false);
   match fp_class(v)[15 .. 0] {

--- a/model/extensions/V/vext_mem_insts.sail
+++ b/model/extensions/V/vext_mem_insts.sail
@@ -39,8 +39,7 @@ mapping clause encdec = VLSEGTYPE(nf, vm, rs1, width, vd)
   <-> encdec_nfields(nf) @ 0b0 @ 0b00 @ vm @ 0b00000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
   when currentlyEnabled(Ext_Zve32x)
 
-val process_vlseg : (nfields, bits(1), vregidx, word_width, regidx, int, nat1) -> ExecutionResult
-function process_vlseg (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
+function process_vlseg(nf : nfields, vm : bits(1), vd : vregidx, load_width_bytes : word_width, rs1 : regidx, EMUL_pow : int, num_elem : nat1) -> ExecutionResult = {
   let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vd_seg = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
@@ -100,8 +99,7 @@ mapping clause encdec = VLSEGFFTYPE(nf, vm, rs1, width, vd)
   <-> encdec_nfields(nf) @ 0b0 @ 0b00 @ vm @ 0b10000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
   when currentlyEnabled(Ext_Zve32x)
 
-val process_vlsegff : (nfields, bits(1), vregidx, word_width, regidx, int, nat1) -> ExecutionResult
-function process_vlsegff (nf, vm, vd, load_width_bytes, rs1, EMUL_pow, num_elem) = {
+function process_vlsegff(nf : nfields, vm : bits(1), vd : vregidx, load_width_bytes : word_width, rs1 : regidx, EMUL_pow : int, num_elem : nat1) -> ExecutionResult = {
   let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vd_seg = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
@@ -178,8 +176,7 @@ mapping clause encdec = VSSEGTYPE(nf, vm, rs1, width, vs3)
   <-> encdec_nfields(nf) @ 0b0 @ 0b00 @ vm @ 0b00000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
   when currentlyEnabled(Ext_Zve32x)
 
-val process_vsseg : (nfields, bits(1), vregidx, word_width, regidx, int, nat1) -> ExecutionResult
-function process_vsseg (nf, vm, vs3, load_width_bytes, rs1, EMUL_pow, num_elem) = {
+function process_vsseg(nf : nfields, vm : bits(1), vs3 : vregidx, load_width_bytes : word_width, rs1 : regidx, EMUL_pow : int, num_elem : nat1) -> ExecutionResult = {
   let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vs3_seg = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
@@ -236,8 +233,7 @@ mapping clause encdec = VLSSEGTYPE(nf, vm, rs2, rs1, width, vd)
   <-> encdec_nfields(nf) @ 0b0 @ 0b10 @ vm @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
   when currentlyEnabled(Ext_Zve32x)
 
-val process_vlsseg : (nfields, bits(1), vregidx, word_width, regidx, regidx, int, nat1) -> ExecutionResult
-function process_vlsseg (nf, vm, vd, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
+function process_vlsseg(nf : nfields, vm : bits(1), vd : vregidx, load_width_bytes : word_width, rs1 : regidx, rs2 : regidx, EMUL_pow : int, num_elem : nat1) -> ExecutionResult = {
   let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let vm_val  = read_vmask(num_elem, vm, zvreg);
   let vd_seg  = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
@@ -298,8 +294,7 @@ mapping clause encdec = VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3)
   <-> encdec_nfields(nf) @ 0b0 @ 0b10 @ vm @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
   when currentlyEnabled(Ext_Zve32x)
 
-val process_vssseg : (nfields, bits(1), vregidx, word_width, regidx, regidx, int, nat1) -> ExecutionResult
-function process_vssseg (nf, vm, vs3, load_width_bytes, rs1, rs2, EMUL_pow, num_elem) = {
+function process_vssseg(nf : nfields, vm : bits(1), vs3 : vregidx, load_width_bytes : word_width, rs1 : regidx, rs2 : regidx, EMUL_pow : int, num_elem : nat1) -> ExecutionResult = {
   let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vs3_seg = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
@@ -357,8 +352,7 @@ mapping clause encdec = VLUXSEGTYPE(nf, vm, vs2, rs1, width, vd)
   <-> encdec_nfields(nf) @ 0b0 @ 0b01 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
   when currentlyEnabled(Ext_Zve32x)
 
-val process_vlxseg : (nfields, bits(1), vregidx, word_width, word_width, int, int, regidx, vregidx, nat1, int) -> ExecutionResult
-function process_vlxseg (nf, vm, vd, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
+function process_vlxseg(nf : nfields, vm : bits(1), vd : vregidx, EEW_index_bytes : word_width, EEW_data_bytes : word_width, EMUL_index_pow : int, EMUL_data_pow : int, rs1 : regidx, vs2 : vregidx, num_elem : nat1, mop : int) -> ExecutionResult = {
   let EMUL_data_reg = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vd_seg = read_vreg_seg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, nf, vd);
@@ -448,8 +442,7 @@ mapping clause encdec = VSUXSEGTYPE(nf, vm, vs2, rs1, width, vs3)
   <-> encdec_nfields(nf) @ 0b0 @ 0b01 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
   when currentlyEnabled(Ext_Zve32x)
 
-val process_vsxseg : (nfields, bits(1), vregidx, word_width, word_width, int, int, regidx, vregidx, nat1, int) -> ExecutionResult
-function process_vsxseg (nf, vm, vs3, EEW_index_bytes, EEW_data_bytes, EMUL_index_pow, EMUL_data_pow, rs1, vs2, num_elem, mop) = {
+function process_vsxseg(nf : nfields, vm : bits(1), vs3 : vregidx, EEW_index_bytes : word_width, EEW_data_bytes : word_width, EMUL_index_pow : int, EMUL_data_pow : int, rs1 : regidx, vs2 : vregidx, num_elem : nat1, mop : int) -> ExecutionResult = {
   let EMUL_data_reg = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vs3_seg = read_vreg_seg(num_elem, EEW_data_bytes * 8, EMUL_data_pow, nf, vs3);
@@ -536,8 +529,7 @@ mapping clause encdec = VLRETYPE(nf, rs1, width, vd)
   <-> encdec_nfields_pow2(nf) @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
   when currentlyEnabled(Ext_Zve32x)
 
-val process_vlre : (nfields_pow2, vregidx, word_width, regidx, nat) -> ExecutionResult
-function process_vlre (nf, vd, load_width_bytes, rs1, elem_per_reg) = {
+function process_vlre(nf : nfields, vd : vregidx, load_width_bytes : word_width, rs1 : regidx, elem_per_reg : nat) -> ExecutionResult = {
   let start_element : nat = match get_start_element() {
     Ok(v)   => v,
     Err(()) => return Illegal_Instruction()
@@ -597,8 +589,7 @@ mapping clause encdec = VSRETYPE(nf, rs1, vs3)
   <-> encdec_nfields_pow2(nf) @ 0b0 @ 0b00 @ 0b1 @ 0b01000 @ encdec_reg(rs1) @ 0b000 @ encdec_vreg(vs3) @ 0b0100111
   when currentlyEnabled(Ext_Zve32x)
 
-val process_vsre : (nfields_pow2, word_width, regidx, vregidx, nat) -> ExecutionResult
-function process_vsre (nf, load_width_bytes, rs1, vs3, elem_per_reg) = {
+function process_vsre(nf : nfields, load_width_bytes : word_width, rs1 : regidx, vs3 : vregidx, elem_per_reg : nat) -> ExecutionResult = {
   let start_element : nat = match get_start_element() {
     Ok(v)   => v,
     Err(()) => return Illegal_Instruction()
@@ -667,8 +658,7 @@ mapping clause encdec = VMTYPE(rs1, vd_or_vs3, op)
   <-> 0b000 @ 0b0 @ 0b00 @ 0b1 @ 0b01011 @ encdec_reg(rs1) @ 0b000 @ encdec_vreg(vd_or_vs3) @ encdec_lsop(op)
   when currentlyEnabled(Ext_Zve32x)
 
-val process_vm : (vregidx, regidx, nat, nat, vmlsop) -> ExecutionResult
-function process_vm(vd_or_vs3, rs1, num_elem, evl, op) = {
+function process_vm(vd_or_vs3 : vregidx, rs1 : regidx, num_elem : nat, evl : nat, op : vmlsop) -> ExecutionResult = {
   let start_element : nat = match get_start_element() {
     Ok(v)   => v,
     Err(()) => return Illegal_Instruction()

--- a/model/extensions/V/vext_regs.sail
+++ b/model/extensions/V/vext_regs.sail
@@ -190,8 +190,7 @@ function wV_bits(i: vregidx, data: vlenbits) -> unit = {
 
 overload V = {rV_bits, wV_bits, rV, wV}
 
-val init_vregs : unit -> unit
-function init_vregs () = {
+function init_vregs() -> unit = {
   let zero_vreg : vlenbits = zeros();
   vr0  = zero_vreg;
   vr1  = zero_vreg;
@@ -292,27 +291,23 @@ function get_sew_bytes() -> {1, 2, 4, 8} =
 
 // the vector register group multiplier (LMUL)
 // this returns the power of 2 for LMUL
-val get_lmul_pow : unit -> LMUL_pow
-function get_lmul_pow() = {
+function get_lmul_pow() -> LMUL_pow = {
   let lmul_pow = vtype[vlmul];
   lmul_pow_val(lmul_pow)
 }
 
 enum agtype = { UNDISTURBED, AGNOSTIC }
 
-val decode_agtype : bits(1) -> agtype
-function decode_agtype(ag) = {
+function decode_agtype(ag : bits(1)) -> agtype = {
   match ag {
     0b0 => UNDISTURBED,
     0b1 => AGNOSTIC
   }
 }
 
-val get_vtype_vma : unit -> agtype
-function get_vtype_vma() = decode_agtype(vtype[vma])
+function get_vtype_vma() -> agtype = decode_agtype(vtype[vma])
 
-val get_vtype_vta : unit -> agtype
-function get_vtype_vta() = decode_agtype(vtype[vta])
+function get_vtype_vta() -> agtype = decode_agtype(vtype[vta])
 
 bitfield Vcsr : bits(3) = {
   vxrm  : 2 .. 1,
@@ -353,8 +348,7 @@ function set_vstart(value : bits(16)) -> unit = {
   csr_write_callback("vstart", vstart);
 }
 
-val ext_write_vcsr : (bits(2), bits(1)) -> unit
-function ext_write_vcsr (vxrm_val, vxsat_val) = {
+function ext_write_vcsr(vxrm_val : bits(2), vxsat_val : bits(1)) -> unit = {
   vcsr[vxrm]  = vxrm_val; // Note: frm can be an illegal value, 101, 110, 111
   vcsr[vxsat] = vxsat_val;
   dirty_v_context()

--- a/model/extensions/V/vext_utils_insts.sail
+++ b/model/extensions/V/vext_utils_insts.sail
@@ -20,8 +20,7 @@ mapping maybe_vmask : string <-> bits(1) = {
 //
 // 1. vector widening/narrowing instructions
 // 2. vector load/store instructions
-val valid_eew_emul : (int, int) -> bool
-function valid_eew_emul(EEW, EMUL_pow) = {
+function valid_eew_emul(EEW : int, EMUL_pow : int) -> bool = {
   EEW >= 8 & EEW <= elen & EMUL_pow >= -3 & EMUL_pow <= 3
 }
 
@@ -29,14 +28,12 @@ function valid_eew_emul(EEW, EMUL_pow) = {
 //
 // 1. If the vill bit is set, then any attempt to execute a vector instruction that depends upon vtype will raise an illegal instruction exception.
 // 2. vset{i}vl{i} and whole-register loads, stores, and moves do not depend upon vtype.
-val valid_vtype : unit -> bool
-function valid_vtype() = {
+function valid_vtype() -> bool = {
   vtype[vill] == 0b0
 }
 
 // Check for vstart value
-val assert_vstart : int -> bool
-function assert_vstart(i) = {
+function assert_vstart(i : int) -> bool = {
   unsigned(vstart) == i
 }
 
@@ -45,8 +42,7 @@ function assert_vstart(i) = {
 // cannot overlap the source mask register (v0),
 // unless the destination vector register is being written with a mask value (e.g., compares)
 // or the scalar result of a reduction.
-val valid_rd_mask : (vregidx, bits(1)) -> bool
-function valid_rd_mask(rd, vm) = {
+function valid_rd_mask(rd : vregidx, vm : bits(1)) -> bool = {
   vm != 0b0 | rd != zvreg
 }
 
@@ -55,8 +51,7 @@ function valid_rd_mask(rd, vm) = {
 // of the destination register group, and the source EMUL is at least 1.
 // In a narrowing instruction, the overlap is valid only in the lowest-numbered part
 // of the source register group.
-val valid_reg_overlap : (vregidx, vregidx, int, int) -> bool
-function valid_reg_overlap(rs, rd, EMUL_pow_rs, EMUL_pow_rd) = {
+function valid_reg_overlap(rs : vregidx, rd : vregidx, EMUL_pow_rs : int, EMUL_pow_rd : int) -> bool = {
   let rs_group = if EMUL_pow_rs > 0 then 2 ^ EMUL_pow_rs else 1;
   let rd_group = if EMUL_pow_rd > 0 then 2 ^ EMUL_pow_rd else 1;
   let rs_int = unsigned(vregidx_bits(rs));
@@ -72,8 +67,7 @@ function valid_reg_overlap(rs, rd, EMUL_pow_rs, EMUL_pow_rd) = {
 // Check for valid register grouping in vector segment load/store instructions:
 // The EMUL of load vd or store vs3 times the number of fields per segment
 // must not be larger than 8. (EMUL * NFIELDS <= 8)
-val valid_segment : (nfields, int) -> bool
-function valid_segment(nf, EMUL_pow) = {
+function valid_segment(nf : nfields, EMUL_pow : int) -> bool = {
   if EMUL_pow < 0 then nf / (2 ^ (0 - EMUL_pow)) <= 8
   else nf * 2 ^ EMUL_pow <= 8
 }
@@ -83,14 +77,12 @@ function valid_segment(nf, EMUL_pow) = {
 // ******************************************************************************
 
 // a. Normal check including vtype.vill field and vd/v0 overlap if vm = 0
-val illegal_normal : (vregidx, bits(1)) -> bool
-function illegal_normal(vd, vm) = {
+function illegal_normal(vd : vregidx, vm : bits(1)) -> bool = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm))
 }
 
 // b. Masked check for instructions encoded with vm = 0
-val illegal_vd_masked : vregidx -> bool
-function illegal_vd_masked(vd) = {
+function illegal_vd_masked(vd : vregidx) -> bool = {
   not(valid_vtype()) | vd == zvreg
 }
 
@@ -99,8 +91,7 @@ function illegal_vd_masked(vd) = {
 //   2. instructions with scalar rd: vcpop.m, vfirst.m
 //   3. vd as mask register (eew = 1):
 //      vmadc.vvm/vxm/vim, vmsbc.vvm/vxm, mask logical, integer compare, vlm.v, vsm.v
-val illegal_vd_unmasked : unit -> bool
-function illegal_vd_unmasked() = {
+function illegal_vd_unmasked() -> bool = {
   not(valid_vtype())
 }
 
@@ -108,48 +99,41 @@ function illegal_vd_unmasked() = {
 //   1. integer/fixed-point widening/narrowing instructions
 //   2. vector integer extension: vzext, vsext
 //   3. vector crypto extension: zvbb
-val illegal_variable_width : (vregidx, bits(1), int, int) -> bool
-function illegal_variable_width(vd, vm, SEW_new, LMUL_pow_new) = {
+function illegal_variable_width(vd : vregidx, vm : bits(1), SEW_new : int, LMUL_pow_new : int) -> bool = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm)) | not(valid_eew_emul(SEW_new, LMUL_pow_new))
 }
 
 // e. Normal check for reduction instructions:
 //  The destination vector register can overlap the source operands, including the mask register.
 //  Vector reduction operations raise an illegal instruction exception if vstart is non-zero.
-val illegal_reduction : unit -> bool
-function illegal_reduction() = {
+function illegal_reduction() -> bool = {
   not(valid_vtype()) | not(assert_vstart(0))
 }
 
 // f. Variable width check for widening reduction instructions
-val illegal_widening_reduction : (int) -> bool
-function illegal_widening_reduction(EEW) = {
+function illegal_widening_reduction(EEW : int) -> bool = {
   not(valid_vtype()) | not(assert_vstart(0)) | not(EEW >= 8 & EEW <= elen)
 }
 
 // g. Non-indexed load instruction check
-val illegal_load : (vregidx, bits(1), nfields, int, int) -> bool
-function illegal_load(vd, vm, nf, EEW, EMUL_pow) = {
+function illegal_load(vd : vregidx, vm : bits(1), nf : nfields, EEW : int, EMUL_pow : int) -> bool = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm)) |
   not(valid_eew_emul(EEW, EMUL_pow)) | not(valid_segment(nf, EMUL_pow))
 }
 
 // h. Non-indexed store instruction check (with vs3 rather than vd)
-val illegal_store : (nfields, int, int) -> bool
-function illegal_store(nf, EEW, EMUL_pow) = {
+function illegal_store(nf : nfields, EEW : int, EMUL_pow : int) -> bool = {
   not(valid_vtype()) | not(valid_eew_emul(EEW, EMUL_pow)) | not(valid_segment(nf, EMUL_pow))
 }
 
 // i. Indexed load instruction check
-val illegal_indexed_load : (vregidx, bits(1), nfields, int, int, int) -> bool
-function illegal_indexed_load(vd, vm, nf, EEW_index, EMUL_pow_index, EMUL_pow_data) = {
+function illegal_indexed_load(vd : vregidx, vm : bits(1), nf : nfields, EEW_index : int, EMUL_pow_index : int, EMUL_pow_data : int) -> bool = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm)) |
   not(valid_eew_emul(EEW_index, EMUL_pow_index)) | not(valid_segment(nf, EMUL_pow_data))
 }
 
 // j. Indexed store instruction check (with vs3 rather than vd)
-val illegal_indexed_store : (nfields, int, int, int) -> bool
-function illegal_indexed_store(nf, EEW_index, EMUL_pow_index, EMUL_pow_data) = {
+function illegal_indexed_store(nf : nfields, EEW_index : int, EMUL_pow_index : int, EMUL_pow_data : int) -> bool = {
   not(valid_vtype()) | not(valid_eew_emul(EEW_index, EMUL_pow_index)) |
   not(valid_segment(nf, EMUL_pow_data))
 }
@@ -205,8 +189,7 @@ function write_velem_quad_vec(vd, SEW, input, i) = {
 }
 
 // Get the starting element index from csr vtype
-val get_start_element : unit -> result(nat, unit)
-function get_start_element() = {
+function get_start_element() -> result(nat, unit) = {
   let start_element = unsigned(vstart);
   let SEW_pow = get_sew_pow();
   // The use of vstart values greater than the largest element
@@ -220,8 +203,7 @@ function get_start_element() = {
 }
 
 // Get the ending element index from csr vl
-val get_end_element : unit -> int
-function get_end_element() = unsigned(vl) - 1
+function get_end_element() -> int = unsigned(vl) - 1
 
 // Mask handling; creates a pre-masked result vector for vstart, vl, vta/vma, and vm
 // vm should be baked into vm_val from doing read_vmask

--- a/model/extensions/V/vext_vset_insts.sail
+++ b/model/extensions/V/vext_vset_insts.sail
@@ -49,8 +49,7 @@ mapping vtype_assembly : string <-> (bits(1), bits(1), bits(3), bits(3)) = {
   hex_bits_8(ma @ ta @ sew @ lmul)  <-> (ma, ta, sew, lmul),
 }
 
-val handle_illegal_vtype : unit -> unit
-function handle_illegal_vtype() = {
+function handle_illegal_vtype() -> unit = {
   // Note: Implementations can set vill or trap with an illegal
   // instruction if the vtype setting is not supported.
   // TODO: configuration support for both solutions.

--- a/model/extensions/Zicbom/zicbom_insts.sail
+++ b/model/extensions/Zicbom/zicbom_insts.sail
@@ -66,8 +66,7 @@ function cbop_priv_check(p: Privilege) -> checked_cbop = {
   }
 }
 
-val process_clean_inval : (regidx, cbop_zicbom) -> ExecutionResult
-function process_clean_inval(rs1, cbop) = {
+function process_clean_inval(rs1 : regidx, cbop : cbop_zicbom) -> ExecutionResult = {
   let rs1_val = X(rs1);
   let cache_block_size = 2 ^ plat_cache_block_size_exp;
 

--- a/model/extensions/vector_crypto/zvk_utils.sail
+++ b/model/extensions/vector_crypto/zvk_utils.sail
@@ -13,7 +13,7 @@ function zvk_valid_reg_overlap(rs : vregidx, rd : vregidx, emul_pow : int) -> bo
   (rs_int + reg_group_size <= rd_int) | (rd_int + reg_group_size <= rs_int)
 }
 
-function zvk_check_encdec(EGW: nat, EGS: nat1) -> bool = {
+function zvk_check_encdec(EGW : nat, EGS : nat1) -> bool = {
   let LMUL_pow = get_lmul_pow();
   let LMUL_times_VLEN = if LMUL_pow < 0 then vlen / (2 ^ abs_int(LMUL_pow)) else (2 ^ LMUL_pow) * vlen in
   (unsigned(vl) % EGS == 0) & (unsigned(vstart) % EGS == 0) & LMUL_times_VLEN >= EGW
@@ -24,7 +24,7 @@ function zvk_check_encdec(EGW: nat, EGS: nat1) -> bool = {
 
 enum zvk_vsha2_funct6 = {ZVK_VSHA2CH_VV, ZVK_VSHA2CL_VV}
 
-function zvknhab_check_encdec(vs2: vregidx, vs1: vregidx, vd: vregidx) -> bool = {
+function zvknhab_check_encdec(vs2 : vregidx, vs1 : vregidx, vd: vregidx) -> bool = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   zvk_check_encdec(SEW, 4) & zvk_valid_reg_overlap(vs1, vd, LMUL_pow) & zvk_valid_reg_overlap(vs2, vd, LMUL_pow);
@@ -75,7 +75,6 @@ enum zvk_vsm4r_funct6 = {ZVK_VSM4R_VV, ZVK_VSM4R_VS}
 
 function zvk_round_key(X : bits(32), S : bits(32)) -> bits(32) = X ^ (S ^ (S <<< 13) ^ (S <<< 23))
 
-val zvk_sm4_round : (bits(32), bits(32)) -> bits(32)
 function zvk_sm4_round(X : bits(32), S : bits(32)) -> bits(32) =
   X ^ (S ^ (S <<< 2) ^ (S <<< 10) ^ (S <<< 18) ^ (S <<< 24))
 

--- a/model/pmp/pmp_control.sail
+++ b/model/pmp/pmp_control.sail
@@ -9,8 +9,7 @@
 
 // permission checks
 
-val pmpCheckRWX: (Pmpcfg_ent, AccessType(ext_access_type)) -> bool
-function pmpCheckRWX(ent, acc) =
+function pmpCheckRWX(ent : Pmpcfg_ent, acc : AccessType(ext_access_type)) -> bool =
   match acc {
     Read(_)      => ent[R] == 0b1,
     Write(_)     => ent[W] == 0b1,

--- a/model/postlude/decode_ext.sail
+++ b/model/postlude/decode_ext.sail
@@ -10,8 +10,6 @@
 // based on other machine state. This is supported via decode instruction
 // hooks, the default implementation of which is provided below.
 
-val ext_decode_compressed : bits(16) -> instruction
-function ext_decode_compressed(bv) = encdec_compressed(bv)
+function ext_decode_compressed(bv : bits(16)) -> instruction = encdec_compressed(bv)
 
-val ext_decode : bits(32) -> instruction
-function ext_decode(bv) = encdec(bv)
+function ext_decode(bv : bits(32)) -> instruction = encdec(bv)

--- a/model/postlude/insts_end.sail
+++ b/model/postlude/insts_end.sail
@@ -37,7 +37,6 @@ end assembly
 end encdec
 end encdec_compressed
 
-val print_insn : instruction -> string
-function print_insn insn = assembly(insn)
+function print_insn(insn : instruction) -> string = assembly(insn)
 
 overload to_str = {print_insn}

--- a/model/sys/platform.sail
+++ b/model/sys/platform.sail
@@ -219,8 +219,7 @@ function should_inc_mcycle(priv : Privilege) -> bool =
 function should_inc_minstret(priv : Privilege) -> bool =
   mcountinhibit[IR] == 0b0 & counter_priv_filter_bit(minstretcfg, priv) == 0b0
 
-val tick_clock : unit -> unit
-function tick_clock() = {
+function tick_clock() -> unit = {
   if   should_inc_mcycle(cur_privilege)
   then mcycle = mcycle + 1;
 

--- a/model/termination/termination.sail
+++ b/model/termination/termination.sail
@@ -6,8 +6,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // =======================================================================================
 
-val compressed_measure : instruction -> int
-function compressed_measure(instr) =
+function compressed_measure(instr : instruction) -> int =
   match instr {
     C_ADDI4SPN (rdc,nzimm) => 1,
     C_LW (uimm,rsc,rdc) => 1,


### PR DESCRIPTION
This simplifies including these functions into documentation since the `val` does not have to be included as well for completeness.

The code is often more readable as well.