### PR TITLE
Don't save caches when running in the merge queue

### DIFF
--- a/.github/actions/sail-setup/action.yml
+++ b/.github/actions/sail-setup/action.yml
@@ -83,7 +83,8 @@ runs:
         (cd sail; make install)
 
     - name: Save cached opam (macOS or latest Sail)
-      if: runner.os == 'macOS' || inputs.sail-version == 'latest'
+      # Save cache when using Opam only when not run as part of the merge queue
+      if: (runner.os == 'macOS' || inputs.sail-version == 'latest') && github.event_name != 'merge_group' && !startsWith(github.ref, 'refs/heads/gh-readonly-queue')
       id: cache-opam-save
       uses: actions/cache/save@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,8 @@ jobs:
         run: make -C os-boot/linux --jobs=$(nproc)
 
       - name: Cache Linux image
-        if: steps.linux-cache-restore.outputs.cache-hit != 'true'
+        # Update cache only when not run as part of the merge queue
+        if: steps.linux-cache-restore.outputs.cache-hit != 'true' && github.event_name != 'merge_group' && !startsWith(github.ref, 'refs/heads/gh-readonly-queue')
         uses: actions/cache/save@v4
         with:
           path: os-boot/linux/build/fw_payload.elf


### PR DESCRIPTION
We have a lot of cache thrashing happening right now (https://github.com/riscv/sail-riscv/actions/caches) because each branch saves its own cache. There is no resaon to save caches from merge queue branches that will only ever run CI once.