### PR TITLE
Simplify compressed changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,10 @@ jobs:
 
     env:
       SAIL_VERSION: "0.19.1"
+      # This helps with reproducible builds by not embedding variable timestamps in files.
+      # This is needed in particular for the Debian package's compressed changelog.
+      # See the comments in `cmake/packaging.cmake`.
+      SOURCE_DATE_EPOCH: "0"
 
     steps:
       # This must be before checkout otherwise Github will use a zip of the
@@ -73,7 +77,7 @@ jobs:
           git config --global --add safe.directory '*'
           cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DSTATIC=TRUE -DENABLE_RISCV_TESTS=TRUE -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE
           cd build
-          ninja all generated_sail_riscv_docs compressed_changelog
+          ninja all generated_sail_riscv_docs
           ctest
           cpack
 


### PR DESCRIPTION
Create the compressed archive at configure time, which means you don't have to remember to run `make compressed_changelog` before running `cpack`. This also removes a dependency on the `gzip` executable which probably won't be available on Windows.

`gzip` was previously used to get a 0 timestamp embedded in the gzip file, which Debian requires. However we can also do that with `export SOURCE_DATE_EPOCH=0`.

I added `SOURCE_DATE_EPOCH` to the Github release workflow. We don't actually generate a Debian package there yet but it's probably a good idea anyway (some other tools respect it).