### PR TITLE
Only save caches on the master branch

### DIFF
--- a/.github/actions/sail-setup/action.yml
+++ b/.github/actions/sail-setup/action.yml
@@ -83,8 +83,8 @@ runs:
         (cd sail; make install)
 
     - name: Save cached opam (macOS or latest Sail)
-      # Save cache when using Opam only when not run as part of the merge queue
-      if: (runner.os == 'macOS' || inputs.sail-version == 'latest') && github.event_name != 'merge_group' && !startsWith(github.ref, 'refs/heads/gh-readonly-queue')
+      # Update cache only on the master branch
+      if: (runner.os == 'macOS' || inputs.sail-version == 'latest') && github.ref == 'refs/heads/master'
       id: cache-opam-save
       uses: actions/cache/save@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,8 @@ jobs:
         run: make -C os-boot/linux --jobs=$(nproc)
 
       - name: Cache Linux image
-        # Update cache only when not run as part of the merge queue
-        if: steps.linux-cache-restore.outputs.cache-hit != 'true' && github.event_name != 'merge_group' && !startsWith(github.ref, 'refs/heads/gh-readonly-queue')
+        # Update cache only on the master branch
+        if: steps.linux-cache-restore.outputs.cache-hit != 'true' && github.ref == 'refs/heads/master'
         uses: actions/cache/save@v4
         with:
           path: os-boot/linux/build/fw_payload.elf


### PR DESCRIPTION
Even after #1325, we are still overflowing the GitHub cache limit. Try only saving caches on the master branch, which PR and merge queue runs can still restore.