### PR TITLE
Add wavedrom annotations for some instruction encodings.

### DIFF
--- a/model/extensions/B/zba_insts.sail
+++ b/model/extensions/B/zba_insts.sail
@@ -12,6 +12,7 @@ function clause currentlyEnabled(Ext_Zba) = hartSupports(Ext_Zba) | currentlyEna
 // *****************************************************************
 union clause instruction = SLLIUW : (bits(6), regidx, regidx)
 
+$[wavedrom "SLLI.UW _ _ SLLI.UW _ OP-IMM-32"]
 mapping clause encdec = SLLIUW(shamt, rs1, rd)
   <-> 0b000010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
   when currentlyEnabled(Ext_Zba) & xlen == 64
@@ -28,6 +29,8 @@ function clause execute SLLIUW(shamt, rs1, rd) = {
 union clause instruction = ZBA_RTYPEUW : (regidx, regidx, regidx, shamt_zba)
 
 // add.uw
+
+$[wavedrom "ADD.UW _ _ ADD.UW _ _ OP-32"]
 mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, 0b00)
   <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b00 @ 0b0 @ encdec_reg(rd) @ 0b0111011
   when currentlyEnabled(Ext_Zba) & xlen == 64

--- a/model/extensions/B/zbb_insts.sail
+++ b/model/extensions/B/zbb_insts.sail
@@ -12,6 +12,7 @@ function clause currentlyEnabled(Ext_Zbkb) = hartSupports(Ext_Zbkb)
 // *****************************************************************
 union clause instruction = RORIW : (bits(5), regidx, regidx)
 
+$[wavedrom "RORIW _ _ RORIW _ OP-IMM-32"]
 mapping clause encdec = RORIW(shamt, rs1, rd)
   <-> 0b0110000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0011011
   when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 64
@@ -27,6 +28,7 @@ function clause execute RORIW(shamt, rs1, rd) = {
 // *****************************************************************
 union clause instruction = RORI : (bits(6), regidx, regidx)
 
+$[wavedrom "RORI _ _ RORI _ OP-IMM"]
 mapping clause encdec = RORI(shamt, rs1, rd)
   <-> 0b011000 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
   when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & (xlen == 64 | shamt[5] == bitzero)
@@ -43,10 +45,12 @@ function clause execute RORI(shamt, rs1, rd) = {
 // *****************************************************************
 union clause instruction = ZBB_RTYPEW : (regidx, regidx, regidx, bropw_zbb)
 
+$[wavedrom "ROLW _ _ ROLW _ OP-32"]
 mapping clause encdec = ZBB_RTYPEW(rs2, rs1, rd, ROLW)
   <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0111011
   when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 64
 
+$[wavedrom "RORW _ _ RORW _ OP-32"]
 mapping clause encdec = ZBB_RTYPEW(rs2, rs1, rd, RORW)
   <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0111011
   when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 64
@@ -74,38 +78,47 @@ function clause execute ZBB_RTYPEW(rs2, rs1, rd, op) = {
 // *****************************************************************
 union clause instruction = ZBB_RTYPE : (regidx, regidx, regidx, brop_zbb)
 
+$[wavedrom "ANDN _ _ ANDN _ OP"]
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, ANDN)
   <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
 
+$[wavedrom "ORN _ _ ORN _ OP"]
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, ORN)
   <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
 
+$[wavedrom "XNOR _ _ XNOR _ OP"]
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, XNOR)
   <-> 0b0100000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
 
+$[wavedrom "MINMAX/CLMUL _ _ MAX _ OP"]
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, MAX)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b110 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb)
 
+$[wavedrom "MINMAX/CLMUL _ _ MAXU _ OP"]
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, MAXU)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb)
 
+$[wavedrom "MINMAX/CLMUL _ _ MIN _ OP"]
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, MIN)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb)
 
+$[wavedrom "MINMAX/CLMUL _ _ MINU _ OP"]
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, MINU)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb)
 
+$[wavedrom "ROL _ _ ROL _ OP"]
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, ROL)
   <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
 
+$[wavedrom "ROR _ _ ROR _ OP"]
 mapping clause encdec = ZBB_RTYPE(rs2, rs1, rd, ROR)
   <-> 0b0110000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)
@@ -147,18 +160,22 @@ function clause execute ZBB_RTYPE(rs2, rs1, rd, op) = {
 // *****************************************************************
 union clause instruction = ZBB_EXTOP : (regidx, regidx, extop_zbb)
 
+$[wavedrom "_ SEXT.B _ SEXT.B/SEXT.H _ OP-IMM"]
 mapping clause encdec = ZBB_EXTOP(rs1, rd, SEXTB)
   <-> 0b0110000 @ 0b00100 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbb)
 
+$[wavedrom "_ SEXT.H _ SEXT.B/SEXT.H _ OP-IMM"]
 mapping clause encdec = ZBB_EXTOP(rs1, rd, SEXTH)
   <-> 0b0110000 @ 0b00101 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbb)
 
+$[wavedrom "_ _ _ ZEXT.H _ OP"]
 mapping clause encdec = ZBB_EXTOP(rs1, rd, ZEXTH)
   <-> 0b0000100 @ 0b00000 @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbb) & xlen == 32
 
+$[wavedrom "_ _ _ ZEXT.H _ OP-32"]
 mapping clause encdec = ZBB_EXTOP(rs1, rd, ZEXTH)
   <-> 0b0000100 @ 0b00000 @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0111011
   when currentlyEnabled(Ext_Zbb) & xlen == 64
@@ -187,6 +204,7 @@ function clause execute ZBB_EXTOP(rs1, rd, op) = {
 // *****************************************************************
 union clause instruction = REV8 : (regidx, regidx)
 
+$[wavedrom "_ _ _ _ OP-IMM"]
 mapping clause encdec = REV8(rs1, rd)
   <-> 0b011010011000 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
   when (currentlyEnabled(Ext_Zbb) | currentlyEnabled(Ext_Zbkb)) & xlen == 32
@@ -206,6 +224,7 @@ function clause execute REV8(rs1, rd) = {
 // *****************************************************************
 union clause instruction = ORCB : (regidx, regidx)
 
+$[wavedrom "_ _ _ _ OP-IMM"]
 mapping clause encdec = ORCB(rs1, rd)
   <-> 0b001010000111 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbb)
@@ -227,8 +246,9 @@ function clause execute ORCB(rs1, rd) = {
 // *****************************************************************
 union clause instruction = CPOP : (regidx, regidx)
 
+$[wavedrom "CPOP CPOP _ CPOP _ OP-IMM"]
 mapping clause encdec = CPOP(rs1, rd)
-  <-> 0b011000000010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
+  <-> 0b0110000 @ 0b00010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbb)
 
 mapping clause assembly = CPOP(rs1, rd)
@@ -242,8 +262,9 @@ function clause execute CPOP(rs1, rd) = {
 // *****************************************************************
 union clause instruction = CPOPW : (regidx, regidx)
 
+$[wavedrom "CPOPW CPOPW _ CPOPW _ OP-IMM-32"]
 mapping clause encdec = CPOPW(rs1, rd)
-  <-> 0b011000000010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
+  <-> 0b0110000 @ 0b00010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
   when currentlyEnabled(Ext_Zbb) & xlen == 64
 
 mapping clause assembly = CPOPW(rs1, rd)
@@ -257,8 +278,9 @@ function clause execute CPOPW(rs1, rd) = {
 // *****************************************************************
 union clause instruction = CLZ : (regidx, regidx)
 
+$[wavedrom "CLZ CLZ _ CLZ _ OP-IMM"]
 mapping clause encdec = CLZ(rs1, rd)
-  <-> 0b011000000000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
+  <-> 0b0110000 @ 0b00000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbb)
 
 mapping clause assembly = CLZ(rs1, rd)
@@ -272,8 +294,9 @@ function clause execute CLZ(rs1, rd) = {
 // *****************************************************************
 union clause instruction = CLZW : (regidx, regidx)
 
+$[wavedrom "CLZW CLZW _ CLZW _ OP-IMM-32"]
 mapping clause encdec = CLZW(rs1, rd)
-  <-> 0b011000000000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
+  <-> 0b0110000 @ 0b00000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
   when currentlyEnabled(Ext_Zbb) & xlen == 64
 
 mapping clause assembly = CLZW(rs1, rd)
@@ -287,8 +310,9 @@ function clause execute CLZW(rs1, rd) = {
 // *****************************************************************
 union clause instruction = CTZ : (regidx, regidx)
 
+$[wavedrom "CTZ/CTZW CTZ/CTZW _ CTZ/CTZW _ OP-IMM"]
 mapping clause encdec = CTZ(rs1, rd)
-  <-> 0b011000000001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
+  <-> 0b0110000 @ 0b00001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbb)
 
 mapping clause assembly = CTZ(rs1, rd)
@@ -302,8 +326,9 @@ function clause execute CTZ(rs1, rd) = {
 // *****************************************************************
 union clause instruction = CTZW : (regidx, regidx)
 
+$[wavedrom "CTZ/CTZW CTZ/CTZW _ CTZ/CTZW _ OP-IMM-32"]
 mapping clause encdec = CTZW(rs1, rd)
-  <-> 0b011000000001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
+  <-> 0b0110000 @ 0b00001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0011011
   when currentlyEnabled(Ext_Zbb) & xlen == 64
 
 mapping clause assembly = CTZW(rs1, rd)

--- a/model/extensions/B/zbc_insts.sail
+++ b/model/extensions/B/zbc_insts.sail
@@ -12,6 +12,7 @@ function clause currentlyEnabled(Ext_Zbkc) = hartSupports(Ext_Zbkc)
 // *****************************************************************
 union clause instruction = CLMUL : (regidx, regidx, regidx)
 
+$[wavedrom "MINMAX/CLMUL _ _ CLMUL _ OP"]
 mapping clause encdec = CLMUL(rs2, rs1, rd)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbc) | currentlyEnabled(Ext_Zbkc)
@@ -28,6 +29,7 @@ function clause execute CLMUL(rs2, rs1, rd) = {
 // *****************************************************************
 union clause instruction = CLMULH : (regidx, regidx, regidx)
 
+$[wavedrom "MINMAX/CLMUL _ _ CLMULH _ OP"]
 mapping clause encdec = CLMULH(rs2, rs1, rd)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b011 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbc) | currentlyEnabled(Ext_Zbkc)
@@ -44,6 +46,7 @@ function clause execute CLMULH(rs2, rs1, rd) = {
 // *****************************************************************
 union clause instruction = CLMULR : (regidx, regidx, regidx)
 
+$[wavedrom "MINMAX/CLMUL _ _ CLMULR _ OP"]
 mapping clause encdec = CLMULR(rs2, rs1, rd)
   <-> 0b0000101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbc)

--- a/model/extensions/B/zbs_insts.sail
+++ b/model/extensions/B/zbs_insts.sail
@@ -11,18 +11,22 @@ function clause currentlyEnabled(Ext_Zbs) = hartSupports(Ext_Zbs) | currentlyEna
 // *****************************************************************
 union clause instruction = ZBS_IOP : (bits(6), regidx, regidx, biop_zbs)
 
+$[wavedrom "BEXTI/BCLRI _ _ BCLRI _ OP-IMM"]
 mapping clause encdec = ZBS_IOP(shamt, rs1, rd, BCLRI)
   <-> 0b010010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
 
+$[wavedrom "BEXTI/BCLRI _ _ BEXTI _ OP-IMM"]
 mapping clause encdec = ZBS_IOP(shamt, rs1, rd, BEXTI)
   <-> 0b010010 @ shamt @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
 
+$[wavedrom "BINVI _ _ BINVI _ OP-IMM"]
 mapping clause encdec = ZBS_IOP(shamt, rs1, rd, BINVI)
   <-> 0b011010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
 
+$[wavedrom "BSETI _ _ BSETI _ OP-IMM"]
 mapping clause encdec = ZBS_IOP(shamt, rs1, rd, BSETI)
   <-> 0b001010 @ shamt @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbs) & (xlen == 64 | shamt[5] == bitzero)
@@ -56,18 +60,22 @@ function clause execute ZBS_IOP(shamt, rs1, rd, op) = {
 // *****************************************************************
 union clause instruction = ZBS_RTYPE : (regidx, regidx, regidx, brop_zbs)
 
+$[wavedrom "BCLR/BEXT _ _ BCLR _ OP"]
 mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, BCLR)
   <-> 0b0100100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbs)
 
+$[wavedrom "BCLR/BEXT _ _ BEXT _ OP"]
 mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, BEXT)
   <-> 0b0100100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbs)
 
+$[wavedrom "BINV _ _ BINV _ OP"]
 mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, BINV)
   <-> 0b0110100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbs)
 
+$[wavedrom "BSET _ _ BSET _ OP"]
 mapping clause encdec = ZBS_RTYPE(rs2, rs1, rd, BSET)
   <-> 0b0010100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbs)

--- a/model/extensions/C/zca_insts.sail
+++ b/model/extensions/C/zca_insts.sail
@@ -32,6 +32,7 @@ mapping clause assembly = C_NOP(imm)
 // *****************************************************************
 union clause instruction = C_ADDI4SPN : (cregidx, bits(8))
 
+$[wavedrom "C.ADDI4SPN _ _ _ _ dest C0"]
 mapping clause encdec_compressed = C_ADDI4SPN(rd, nz96 @ nz54 @ nz3 @ nz2)
   <-> 0b000 @ nz54 : bits(2) @ nz96 : bits(4) @ nz2 : bits(1) @ nz3 : bits(1) @ encdec_creg(rd) @ 0b00
   when nz96 @ nz54 @ nz3 @ nz2 != 0b00000000 & currentlyEnabled(Ext_Zca)
@@ -251,6 +252,7 @@ mapping clause assembly = C_SRAI(shamt, rsd)
 // *****************************************************************
 union clause instruction = C_ANDI : (bits(6), cregidx)
 
+$[wavedrom "C.ANDI imm[5] C.ANDI dest imm[4:0] C1"]
 mapping clause encdec_compressed = C_ANDI(i5 @ i40, rsd)
   <-> 0b100 @ i5 : bits(1) @ 0b10 @ encdec_creg(rsd) @ i40 : bits(5) @ 0b01
   when currentlyEnabled(Ext_Zca)
@@ -404,6 +406,7 @@ mapping clause assembly = C_BNEZ(imm, rs)
 union clause instruction = C_SLLI : (bits(6), regidx)
 
 // c.slli with shamt=0 or rsd=x0 are hints.
+$[wavedrom "C.SLLI shamt[5] dest!=0 shamt[4:0] C2"]
 mapping clause encdec_compressed = C_SLLI(shamt5 @ shamt40, rsd)
   <-> 0b000 @ shamt5 : bits(1) @ encdec_reg(rsd) @ shamt40 : bits(5) @ 0b10
   when (xlen == 64 | shamt5 == 0b0) & currentlyEnabled(Ext_Zca)
@@ -524,8 +527,9 @@ mapping clause assembly = C_MV(rd, rs2)
 // *****************************************************************
 union clause instruction = C_EBREAK : unit
 
+$[wavedrom "C.EBREAK 0 C2"]
 mapping clause encdec_compressed = C_EBREAK()
-  <-> 0b100 @ 0b1 @ 0b00000 @ 0b00000 @ 0b10
+  <-> 0b1001 @ 0b0000000000 @ 0b10
   when currentlyEnabled(Ext_Zca)
 
 function clause execute C_EBREAK() =

--- a/model/extensions/C/zcb_insts.sail
+++ b/model/extensions/C/zcb_insts.sail
@@ -10,6 +10,7 @@ function clause currentlyEnabled(Ext_Zcb) = hartSupports(Ext_Zcb) & currentlyEna
 
 union clause instruction = C_LBU : (bits(2), cregidx, cregidx)
 
+$[wavedrom "FUNCT3 _ _ _ _ _ C0"]
 mapping clause encdec_compressed = C_LBU(uimm1 @ uimm0, rdc, rsc1)
   <-> 0b100 @ 0b000 @ encdec_creg(rsc1) @ uimm0 : bits(1) @ uimm1 : bits(1) @ encdec_creg(rdc) @ 0b00
   when currentlyEnabled(Ext_Zcb)
@@ -28,6 +29,7 @@ function clause execute C_LBU(uimm, rdc, rsc1) = {
 
 union clause instruction = C_LHU : (bits(2), cregidx, cregidx)
 
+$[wavedrom "FUNCT3 _ _ _ _ _ C0"]
 mapping clause encdec_compressed = C_LHU(uimm1 @ 0b0, rdc, rsc1)
   <-> 0b100 @ 0b001 @ encdec_creg(rsc1) @ 0b0 @ uimm1 : bits(1) @ encdec_creg(rdc) @ 0b00
   when currentlyEnabled(Ext_Zcb)
@@ -46,6 +48,7 @@ function clause execute C_LHU(uimm, rdc, rsc1) = {
 
 union clause instruction = C_LH : (bits(2), cregidx, cregidx)
 
+$[wavedrom "FUNCT3 _ _ _ _ _ C0"]
 mapping clause encdec_compressed = C_LH(uimm1 @ 0b0, rdc, rsc1)
   <-> 0b100 @ 0b001 @ encdec_creg(rsc1) @ 0b1 @ uimm1 : bits(1) @ encdec_creg(rdc) @ 0b00
   when currentlyEnabled(Ext_Zcb)
@@ -64,6 +67,7 @@ function clause execute C_LH(uimm, rdc, rsc1) = {
 
 union clause instruction = C_SB : (bits(2), cregidx, cregidx)
 
+$[wavedrom "FUNCT3 _ _ _ _ _ C0"]
 mapping clause encdec_compressed = C_SB(uimm1 @ uimm0, rsc1, rsc2)
   <-> 0b100 @ 0b010 @ encdec_creg(rsc1) @ uimm0 : bits(1) @ uimm1 : bits(1) @ encdec_creg(rsc2) @ 0b00
   when currentlyEnabled(Ext_Zcb)
@@ -82,6 +86,7 @@ function clause execute C_SB(uimm, rsc1, rsc2) = {
 
 union clause instruction = C_SH : (bits(2), cregidx, cregidx)
 
+$[wavedrom "FUNCT3 _ _ _ _ _ C0"]
 mapping clause encdec_compressed = C_SH(uimm1 @ 0b0, rsc1, rsc2)
   <-> 0b100 @ 0b011 @ encdec_creg(rsc1) @ 0b0 @ uimm1 : bits(1) @ encdec_creg(rsc2) @ 0b00
   when currentlyEnabled(Ext_Zcb)
@@ -100,6 +105,7 @@ function clause execute C_SH(uimm, rsc1, rsc2) = {
 
 union clause instruction = C_ZEXT_B : (cregidx)
 
+$[wavedrom "FUNCT3 _ SRCDST FUNCT2 C.ZEXT.B C1"]
 mapping clause encdec_compressed = C_ZEXT_B(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b000 @ 0b01
   when currentlyEnabled(Ext_Zcb)
@@ -117,6 +123,7 @@ function clause execute C_ZEXT_B(rsdc) = {
 
 union clause instruction = C_SEXT_B : (cregidx)
 
+$[wavedrom "FUNCT3 _ SRCDST FUNCT2 C.SEXT.B C1"]
 mapping clause encdec_compressed = C_SEXT_B(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b001 @ 0b01
   when currentlyEnabled(Ext_Zcb) & currentlyEnabled(Ext_Zbb)
@@ -133,6 +140,7 @@ function clause execute C_SEXT_B(rsdc) = {
 
 union clause instruction = C_ZEXT_H : (cregidx)
 
+$[wavedrom "FUNCT3 _ SRCDST FUNCT2 C.ZEXT.H C1"]
 mapping clause encdec_compressed = C_ZEXT_H(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b010 @ 0b01
   when currentlyEnabled(Ext_Zcb) & currentlyEnabled(Ext_Zbb)
@@ -149,6 +157,7 @@ function clause execute C_ZEXT_H(rsdc) = {
 
 union clause instruction = C_SEXT_H : (cregidx)
 
+$[wavedrom "FUNCT3 _ SRCDST FUNCT2 C.SEXT.H C1"]
 mapping clause encdec_compressed = C_SEXT_H(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b011 @ 0b01
   when currentlyEnabled(Ext_Zcb) & currentlyEnabled(Ext_Zbb)
@@ -165,6 +174,7 @@ function clause execute C_SEXT_H(rsdc) = {
 
 union clause instruction = C_ZEXT_W : (cregidx)
 
+$[wavedrom "FUNCT3 _ SRCDST FUNCT2 C.ZEXT.W C1"]
 mapping clause encdec_compressed = C_ZEXT_W(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b100 @ 0b01
   when currentlyEnabled(Ext_Zcb) & currentlyEnabled(Ext_Zba) & xlen == 64
@@ -181,6 +191,7 @@ function clause execute C_ZEXT_W(rsdc) = {
 
 union clause instruction = C_NOT : (cregidx)
 
+$[wavedrom "FUNCT3 _ SRCDST FUNCT2 C.NOT C1"]
 mapping clause encdec_compressed = C_NOT(rsdc)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b11 @ 0b101 @ 0b01
   when currentlyEnabled(Ext_Zcb)
@@ -198,6 +209,7 @@ function clause execute C_NOT(rsdc) = {
 
 union clause instruction = C_MUL : (cregidx, cregidx)
 
+$[wavedrom "FUNCT3 _ SRCDST FUNCT2 SRC2 C1"]
 mapping clause encdec_compressed = C_MUL(rsdc, rsc2)
   <-> 0b100 @ 0b111 @ encdec_creg(rsdc) @ 0b10 @ encdec_creg(rsc2) @ 0b01
   when currentlyEnabled(Ext_Zcb) & (currentlyEnabled(Ext_M) | currentlyEnabled(Ext_Zmmul))

--- a/model/extensions/FD/fext_insts.sail
+++ b/model/extensions/FD/fext_insts.sail
@@ -265,6 +265,7 @@ union clause instruction = LOAD_FP : (bits(12), regidx, fregidx, word_width)
 
 // instruction <-> Binary encoding ================================
 
+$[wavedrom "offset[11:0] base _ _ dest LOAD-FP"]
 mapping clause encdec = LOAD_FP(imm, rs1, rd, width)
   <-> imm @ encdec_reg(rs1) @ 0b0 @ width_enc(width) @ encdec_freg(rd) @ 0b000_0111
   when float_load_store_width_supported(width)
@@ -300,6 +301,7 @@ union clause instruction = STORE_FP : (bits(12), fregidx, regidx, word_width)
 
 // instruction <-> Binary encoding ================================
 
+$[wavedrom "offset[11:5] src base _ _ offset[4:0] STORE-FP"]
 mapping clause encdec = STORE_FP(imm7 @ imm5, rs2, rs1, width)
   <-> imm7 : bits(7) @ encdec_freg(rs2) @ encdec_reg(rs1) @ 0b0 @ width_enc(width) @ imm5 : bits(5) @ 0b010_0111
   when float_load_store_width_supported(width)

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -69,8 +69,9 @@ function jump_to(target : xlenbits) -> ExecutionResult = {
 // *****************************************************************
 union clause instruction = JAL : (bits(21), regidx)
 
-mapping clause encdec = JAL(imm_19 @ imm_7_0 @ imm_8 @ imm_18_13 @ imm_12_9 @ 0b0, rd)
-  <-> imm_19 : bits(1) @ imm_18_13 : bits(6) @ imm_12_9 : bits(4) @ imm_8 : bits(1) @ imm_7_0 : bits(8) @ encdec_reg(rd) @ 0b1101111
+$[wavedrom "_ offset[20:1] _ _ dest JAL"]
+mapping clause encdec = JAL(imm_19 @ imm_7_0 @ imm_8 @ imm_18_9 @ 0b0, rd)
+  <-> imm_19 : bits(1) @ imm_18_9 : bits(10) @ imm_8 : bits(1) @ imm_7_0 : bits(8) @ encdec_reg(rd) @ 0b1101111
 
 function clause execute JAL(imm, rd) = {
   let link_address = get_next_pc();
@@ -88,6 +89,7 @@ mapping clause assembly = JAL(imm, rd)
 // *****************************************************************
 union clause instruction = JALR : (bits(12), regidx, regidx)
 
+$[wavedrom "offset[11:0] base 0 dest JALR"]
 mapping clause encdec = JALR(imm, rs1, rd)
   <-> imm @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b1100111
 
@@ -276,6 +278,7 @@ function valid_load_encdec(width : word_width, is_unsigned : bool) -> bool =
 val extend_value : forall 'n, 0 < 'n <= xlen. (bool, bits('n)) -> xlenbits
 function extend_value(is_unsigned, value) = if is_unsigned then zero_extend(value) else sign_extend(value)
 
+$[wavedrom "offset[11:0] base _ width dest LOAD"]
 mapping clause encdec = LOAD(imm, rs1, rd, is_unsigned, width)
   <-> imm @ encdec_reg(rs1) @ bool_bits(is_unsigned) @ width_enc(width) @ encdec_reg(rd) @ 0b0000011
   when valid_load_encdec(width, is_unsigned)
@@ -306,6 +309,7 @@ mapping clause assembly = LOAD(imm, rs1, rd, is_unsigned, width)
 // *****************************************************************
 union clause instruction = STORE : (bits(12), regidx, regidx, word_width)
 
+$[wavedrom "offset[11:5] src base _ width offset[4:0] STORE"]
 mapping clause encdec = STORE(imm7 @ imm5, rs2, rs1, width)
   <-> imm7 : bits(7) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ width_enc(width) @ imm5 : bits(5) @ 0b0100011
   when width <= xlen_bytes
@@ -329,6 +333,7 @@ mapping clause assembly = STORE(imm, rs2, rs1, width)
 // *****************************************************************
 union clause instruction = ADDIW : (bits(12), regidx, regidx)
 
+$[wavedrom "I-immediate[11:0] src ADDIW dest OP-IMM-32"]
 mapping clause encdec = ADDIW(imm, rs1, rd)
   <-> imm @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0011011
   when xlen == 64

--- a/model/extensions/K/zbkb_insts.sail
+++ b/model/extensions/K/zbkb_insts.sail
@@ -9,10 +9,12 @@
 // *****************************************************************
 union clause instruction = ZBKB_RTYPE : (regidx, regidx, regidx, brop_zbkb)
 
+$[wavedrom "PACK _ _ PACK _ OP"]
 mapping clause encdec = ZBKB_RTYPE(rs2, rs1, rd, PACK)
   <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbkb)
 
+$[wavedrom "PACKH _ _ PACKH _ OP"]
 mapping clause encdec = ZBKB_RTYPE(rs2, rs1, rd, PACKH)
   <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbkb)
@@ -40,6 +42,7 @@ function clause execute ZBKB_RTYPE(rs2, rs1, rd, op) = {
 // *****************************************************************
 union clause instruction = ZBKB_PACKW : (regidx, regidx, regidx)
 
+$[wavedrom "_ _ _ _ _ OP-32"]
 mapping clause encdec = ZBKB_PACKW(rs2, rs1, rd)
   <-> 0b0000100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0111011
   when currentlyEnabled(Ext_Zbkb) & xlen == 64
@@ -59,6 +62,7 @@ function clause execute ZBKB_PACKW(rs2, rs1, rd) = {
 // *****************************************************************
 union clause instruction = ZIP : (regidx, regidx)
 
+$[wavedrom "_ _ _ _ OP-IMM"]
 mapping clause encdec = ZIP(rs1, rd)
   <-> 0b000010001111 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbkb) & xlen == 32
@@ -81,6 +85,7 @@ function clause execute ZIP(rs1, rd) = {
 // *****************************************************************
 union clause instruction = UNZIP : (regidx, regidx)
 
+$[wavedrom "_ _ _ _ OP-IMM"]
 mapping clause encdec = UNZIP(rs1, rd)
   <-> 0b000010001111 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbkb) & xlen == 32
@@ -103,6 +108,7 @@ function clause execute UNZIP(rs1, rd) = {
 // *****************************************************************
 union clause instruction = BREV8 : (regidx, regidx)
 
+$[wavedrom "_ _ _ _ OP-IMM"]
 mapping clause encdec = BREV8(rs1, rd)
   <-> 0b011010000111 @ encdec_reg(rs1) @ 0b101 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zbkb)

--- a/model/extensions/K/zbkx_insts.sail
+++ b/model/extensions/K/zbkx_insts.sail
@@ -11,6 +11,7 @@ function clause currentlyEnabled(Ext_Zbkx) = hartSupports(Ext_Zbkx)
 // *****************************************************************
 union clause instruction = XPERM8 : (regidx, regidx, regidx)
 
+$[wavedrom "_ _ _ _ _ OP"]
 mapping clause encdec = XPERM8(rs2, rs1, rd)
   <-> 0b0010100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbkx)
@@ -35,6 +36,7 @@ function clause execute XPERM8(rs2, rs1, rd) = {
 // *****************************************************************
 union clause instruction = XPERM4 : (regidx, regidx, regidx)
 
+$[wavedrom "_ _ _ _ _ OP"]
 mapping clause encdec = XPERM4(rs2, rs1, rd)
   <-> 0b0010100 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b010 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zbkx)

--- a/model/extensions/K/zkn_insts.sail
+++ b/model/extensions/K/zkn_insts.sail
@@ -17,18 +17,22 @@ union clause instruction = SHA256SIG1 : (regidx, regidx)
 union clause instruction = SHA256SUM0 : (regidx, regidx)
 union clause instruction = SHA256SUM1 : (regidx, regidx)
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SHA256SUM0 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zknh)
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SHA256SUM1 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zknh)
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SHA256SIG0 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00010 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zknh)
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SHA256SIG1 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00011 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zknh)
@@ -80,6 +84,7 @@ function clause currentlyEnabled(Ext_Zkne) = hartSupports(Ext_Zkne)
 
 union clause instruction = AES32ESMI : (bits(2), regidx, regidx, regidx)
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = AES32ESMI (bs, rs2, rs1, rd)
   <-> bs @ 0b10011 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zkne) & xlen == 32
@@ -99,6 +104,7 @@ function clause execute AES32ESMI (bs, rs2, rs1, rd) = {
 
 union clause instruction = AES32ESI : (bits(2), regidx, regidx, regidx)
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = AES32ESI (bs, rs2, rs1, rd)
   <-> bs @ 0b10001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zkne) & xlen == 32
@@ -122,6 +128,7 @@ function clause currentlyEnabled(Ext_Zknd) = hartSupports(Ext_Zknd)
 
 union clause instruction = AES32DSMI : (bits(2), regidx, regidx, regidx)
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = AES32DSMI (bs, rs2, rs1, rd)
   <-> bs @ 0b10111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zknd) & xlen == 32
@@ -141,6 +148,7 @@ function clause execute AES32DSMI (bs, rs2, rs1, rd) = {
 
 union clause instruction = AES32DSI  : (bits(2), regidx, regidx, regidx)
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = AES32DSI (bs, rs2, rs1, rd)
   <-> bs @ 0b10101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zknd) & xlen == 32
@@ -167,26 +175,32 @@ union clause instruction = SHA512SIG1H : (regidx, regidx, regidx)
 union clause instruction = SHA512SUM0R : (regidx, regidx, regidx)
 union clause instruction = SHA512SUM1R : (regidx, regidx, regidx)
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SHA512SUM0R (rs2, rs1, rd)
   <-> 0b01 @ 0b01000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zknh) & xlen == 32
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SHA512SUM1R (rs2, rs1, rd)
   <-> 0b01 @ 0b01001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zknh) & xlen == 32
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SHA512SIG0L (rs2, rs1, rd)
   <-> 0b01 @ 0b01010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zknh) & xlen == 32
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SHA512SIG0H (rs2, rs1, rd)
   <-> 0b01 @ 0b01110 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zknh) & xlen == 32
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SHA512SIG1L (rs2, rs1, rd)
   <-> 0b01 @ 0b01011 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zknh) & xlen == 32
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SHA512SIG1H (rs2, rs1, rd)
   <-> 0b01 @ 0b01111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zknh) & xlen == 32
@@ -256,30 +270,37 @@ union clause instruction = AES64ES   : (regidx, regidx, regidx)
 union clause instruction = AES64DSM  : (regidx, regidx, regidx)
 union clause instruction = AES64DS   : (regidx, regidx, regidx)
 
+$[wavedrom "_ _ _ _ _ _ _ _"]
 mapping clause encdec = AES64KS1I (rnum, rs1, rd)
   <-> 0b00 @ 0b11000 @ 0b1 @ rnum @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when (currentlyEnabled(Ext_Zkne) | currentlyEnabled(Ext_Zknd)) & (xlen == 64) & (rnum <_u 0xB)
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = AES64IM (rs1, rd)
   <-> 0b00 @ 0b11000 @ 0b00000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zknd) & xlen == 64
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = AES64KS2 (rs2, rs1, rd)
   <-> 0b01 @ 0b11111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when (currentlyEnabled(Ext_Zkne) | currentlyEnabled(Ext_Zknd)) & xlen == 64
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = AES64ESM (rs2, rs1, rd)
   <-> 0b00 @ 0b11011 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zkne) & xlen == 64
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = AES64ES (rs2, rs1, rd)
   <-> 0b00 @ 0b11001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zkne) & xlen == 64
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = AES64DSM (rs2, rs1, rd)
   <-> 0b00 @ 0b11111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zknd) & xlen == 64
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = AES64DS (rs2, rs1, rd)
   <-> 0b00 @ 0b11101 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zknd) & xlen == 64
@@ -376,18 +397,22 @@ union clause instruction = SHA512SIG1 : (regidx, regidx)
 union clause instruction = SHA512SUM0 : (regidx, regidx)
 union clause instruction = SHA512SUM1 : (regidx, regidx)
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SHA512SUM0 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00100 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zknh) & xlen == 64
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SHA512SUM1 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00101 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zknh) & xlen == 64
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SHA512SIG0 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00110 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zknh) & xlen == 64
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SHA512SIG1 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b00111 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zknh) & xlen == 64

--- a/model/extensions/K/zks_insts.sail
+++ b/model/extensions/K/zks_insts.sail
@@ -14,10 +14,12 @@ function clause currentlyEnabled(Ext_Zksh) = hartSupports(Ext_Zksh)
 union clause instruction = SM3P0 : (regidx, regidx)
 union clause instruction = SM3P1 : (regidx, regidx)
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SM3P0 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b01000 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zksh)
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SM3P1 (rs1, rd)
   <-> 0b00 @ 0b01000 @ 0b01001 @ encdec_reg(rs1) @ 0b001 @ encdec_reg(rd) @ 0b0010011
   when currentlyEnabled(Ext_Zksh)
@@ -50,10 +52,12 @@ function clause currentlyEnabled(Ext_Zksed) = hartSupports(Ext_Zksed)
 union clause instruction = SM4ED : (bits(2), regidx, regidx, regidx)
 union clause instruction = SM4KS : (bits(2), regidx, regidx, regidx)
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SM4ED (bs, rs2, rs1, rd)
   <-> bs @ 0b11000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zksed)
 
+$[wavedrom "_ _ _ _ _ _ _"]
 mapping clause encdec = SM4KS (bs, rs2, rs1, rd)
   <-> bs @ 0b11010 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zksed)

--- a/model/extensions/Zicbom/zicbom_insts.sail
+++ b/model/extensions/Zicbom/zicbom_insts.sail
@@ -21,6 +21,7 @@ mapping encdec_cbop : cbop_zicbom <-> bits(12) = {
   CBO_INVAL <-> 0b000000000000,
 }
 
+$[wavedrom "CBO-OP base CBO _ MISC-MEM"]
 mapping clause encdec = ZICBOM(cbop, rs1)
   <-> encdec_cbop(cbop) @ encdec_reg(rs1) @ 0b010 @ 0b00000 @ 0b0001111
   when currentlyEnabled(Ext_Zicbom)

--- a/model/extensions/Zicbop/zicbop_insts.sail
+++ b/model/extensions/Zicbop/zicbop_insts.sail
@@ -19,6 +19,7 @@ mapping encdec_cbop_zicbop : cbop_zicbop <-> bits(5) = {
   PREFETCH_W <-> 0b00011,
 }
 
+$[wavedrom "offset[11:5] PREFETCH-OP base ORI offset[4:0] OP-IMM"]
 mapping clause encdec = ZICBOP(cbop, rs1, offset11_5 @ 0b00000)
   <-> offset11_5 @ encdec_cbop_zicbop(cbop) @ encdec_reg(rs1) @ 0b110 @ 0b00000 @ 0b0010011
   when currentlyEnabled(Ext_Zicbop)

--- a/model/extensions/Zicboz/zicboz_insts.sail
+++ b/model/extensions/Zicboz/zicboz_insts.sail
@@ -15,6 +15,7 @@ function cbo_zero_enabled(p : Privilege) -> bool = feature_enabled_for_priv(p, m
 // *****************************************************************
 union clause instruction = ZICBOZ : (regidx)
 
+$[wavedrom "CBO.ZERO base CBO _ MISC-MEM"]
 mapping clause encdec = ZICBOZ(rs1)
   <-> 0b000000000100 @ encdec_reg(rs1) @ 0b010 @ 0b00000 @ 0b0001111
   when currentlyEnabled(Ext_Zicboz)

--- a/model/extensions/Zicond/zicond_insts.sail
+++ b/model/extensions/Zicond/zicond_insts.sail
@@ -15,6 +15,7 @@ mapping encdec_zicondop : zicondop <-> bits(3) = {
   CZERO_NEZ <-> 0b111,
 }
 
+$[wavedrom "CZERO condition value CZERO.OP _ OP"]
 mapping clause encdec = ZICOND_RTYPE(rs2, rs1, rd, op)
   <-> 0b0000111 @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_zicondop(op) @ encdec_reg(rd) @ 0b0110011
   when currentlyEnabled(Ext_Zicond)

--- a/model/extensions/Zifenci/zifencei_insts.sail
+++ b/model/extensions/Zifenci/zifencei_insts.sail
@@ -15,6 +15,7 @@ function clause currentlyEnabled(Ext_Zifencei) = hartSupports(Ext_Zifencei)
 
 union clause instruction = FENCEI : unit
 
+$[wavedrom "0 0 FENCE.I 0 MISC-MEM"]
 mapping clause encdec = FENCEI()
   <-> 0b000000000000 @ 0b00000 @ 0b001 @ 0b00000 @ 0b0001111
   when currentlyEnabled(Ext_Zifencei)

--- a/model/extensions/bfloat16/zfbfmin_insts.sail
+++ b/model/extensions/bfloat16/zfbfmin_insts.sail
@@ -12,6 +12,7 @@ function clause currentlyEnabled(Ext_Zfbfmin) = hartSupports(Ext_Zfbfmin) & curr
 
 union clause instruction = FCVT_BF16_S : (fregidx, rounding_mode, fregidx)
 
+$[wavedrom "fcvt h bf16.s _ _ _ OP-FP"]
 mapping clause encdec = FCVT_BF16_S(rs1, rm, rd)
   <-> 0b01000 @ 0b10 @ 0b01000 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b1010011
   when currentlyEnabled(Ext_Zfbfmin)
@@ -36,6 +37,7 @@ mapping clause assembly = FCVT_BF16_S(rs1, rm, rd)
 
 union clause instruction = FCVT_S_BF16 : (fregidx, rounding_mode, fregidx)
 
+$[wavedrom "fcvt s bf16.s _ _ _ OP-FP"]
 mapping clause encdec = FCVT_S_BF16(rs1, rm, rd)
   <-> 0b01000 @ 0b00 @ 0b00110 @ encdec_freg(rs1) @ encdec_rounding_mode(rm) @ encdec_freg(rd) @ 0b1010011
   when currentlyEnabled(Ext_Zfbfmin)

--- a/model/extensions/bfloat16/zvfbfmin_insts.sail
+++ b/model/extensions/bfloat16/zvfbfmin_insts.sail
@@ -10,6 +10,7 @@ function clause currentlyEnabled(Ext_Zvfbfmin) = hartSupports(Ext_Zvfbfmin) & cu
 
 union clause instruction = VFNCVTBF16_F_F_W : (bits(1), vregidx, vregidx)
 
+$[wavedrom "VFUNARY0 _ _ vfncvtbf16 OPFVV _ OP-V"]
 mapping clause encdec = VFNCVTBF16_F_F_W(vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b11101 @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvfbfmin) & get_sew() == 16
@@ -60,6 +61,7 @@ mapping clause assembly = VFNCVTBF16_F_F_W(vm, vs2, vd)
 
 union clause instruction = VFWCVTBF16_F_F_V : (bits(1), vregidx, vregidx)
 
+$[wavedrom "VFUNARY0 _ _ vfwcvtbf16 OPFVV _ OP-V"]
 mapping clause encdec = VFWCVTBF16_F_F_V(vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01101 @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvfbfmin) & get_sew() == 16

--- a/model/extensions/bfloat16/zvfbfwma_insts.sail
+++ b/model/extensions/bfloat16/zvfbfwma_insts.sail
@@ -10,6 +10,7 @@ function clause currentlyEnabled(Ext_Zvfbfwma) = hartSupports(Ext_Zvfbfwma) & cu
 
 union clause instruction = VFWMACCBF16_VV : (bits(1), vregidx, vregidx, vregidx)
 
+$[wavedrom "vfwmaccbf16 _ _ _ OPFVV _ OP-V"]
 mapping clause encdec = VFWMACCBF16_VV(vm, vs2, vs1, vd)
   <-> 0b111011 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b001 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvfbfwma) & get_sew() == 16
@@ -60,6 +61,7 @@ mapping clause assembly = VFWMACCBF16_VV(vm, vs2, vs1, vd)
 
 union clause instruction = VFWMACCBF16_VF : (bits(1), vregidx, fregidx, vregidx)
 
+$[wavedrom "vfwmaccbf16 _ _ _ OPFVF _ OP-V"]
 mapping clause encdec = VFWMACCBF16_VF(vm, vs2, rs1, vd)
   <-> 0b111011 @ vm @ encdec_vreg(vs2) @ encdec_freg(rs1) @ 0b101 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvfbfwma) & get_sew() == 16

--- a/model/extensions/vector_crypto/zvbb_insts.sail
+++ b/model/extensions/vector_crypto/zvbb_insts.sail
@@ -11,6 +11,7 @@ function clause currentlyEnabled(Ext_Zvkb) = (hartSupports(Ext_Zvkb) & currently
 
 union clause instruction = VANDN_VV : (bits(1), vregidx, vregidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPIVV _ OP-V"]
 mapping clause encdec = VANDN_VV(vm, vs1, vs2, vd)
   <-> 0b000001 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvkb)
@@ -48,6 +49,7 @@ function clause execute VANDN_VV(vm, vs1, vs2, vd) = {
 
 union clause instruction = VANDN_VX : (bits(1), vregidx, regidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPIVX _ OP-V"]
 mapping clause encdec = VANDN_VX(vm, vs2, rs1, vd)
   <-> 0b000001 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvkb)
@@ -85,6 +87,7 @@ function clause execute VANDN_VX(vm, vs2, rs1, vd) = {
 
 union clause instruction = VBREV_V : (bits(1), vregidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPMVV _ OP-V"]
 mapping clause encdec = VBREV_V(vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01010 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvbb)
@@ -125,6 +128,7 @@ function clause execute VBREV_V(vm, vs2, vd) = {
 
 union clause instruction = VBREV8_V : (bits(1), vregidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPMVV _ OP-V"]
 mapping clause encdec = VBREV8_V(vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01000 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvkb)
@@ -162,6 +166,7 @@ function clause execute VBREV8_V(vm, vs2, vd) = {
 
 union clause instruction = VREV8_V : (bits(1), vregidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPMVV _ OP-V"]
 mapping clause encdec = VREV8_V(vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01001 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvkb)
@@ -199,6 +204,7 @@ function clause execute VREV8_V(vm, vs2, vd) = {
 
 union clause instruction = VCLZ_V : (bits(1), vregidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPMVV _ OP-V"]
 mapping clause encdec = VCLZ_V (vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01100 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvbb)
@@ -237,6 +243,7 @@ function clause execute VCLZ_V(vm, vs2, vd) = {
 
 union clause instruction = VCTZ_V : (bits(1), vregidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPMVV _ OP-V"]
 mapping clause encdec = VCTZ_V (vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01101 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvbb)
@@ -275,6 +282,7 @@ function clause execute VCTZ_V(vm, vs2, vd) = {
 
 union clause instruction = VCPOP_V : (bits(1), vregidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPMVV _ OP-V"]
 mapping clause encdec = VCPOP_V (vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b01110 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvbb)
@@ -316,6 +324,7 @@ function clause execute VCPOP_V(vm, vs2, vd) = {
 
 union clause instruction = VROL_VV : (bits(1), vregidx, vregidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPIVV _ OP-V"]
 mapping clause encdec = VROL_VV(vm, vs1, vs2, vd)
   <-> 0b010101 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvkb)
@@ -354,6 +363,7 @@ function clause execute VROL_VV(vm, vs1, vs2, vd) = {
 
 union clause instruction = VROL_VX : (bits(1), vregidx, regidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPIVX _ OP-V"]
 mapping clause encdec = VROL_VX(vm, vs2, rs1, vd)
   <-> 0b010101 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvkb)
@@ -392,6 +402,7 @@ function clause execute VROL_VX(vm, vs2, rs1, vd) = {
 
 union clause instruction = VROR_VV : (bits(1), vregidx, vregidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPIVV _ OP-V"]
 mapping clause encdec = VROR_VV(vm, vs1, vs2, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvkb)
@@ -430,6 +441,7 @@ function clause execute VROR_VV(vm, vs1, vs2, vd) = {
 
 union clause instruction = VROR_VX : (bits(1), vregidx, regidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPIVX _ OP-V"]
 mapping clause encdec = VROR_VX(vm, vs2, rs1, vd)
   <-> 0b010100 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvkb)
@@ -468,6 +480,7 @@ function clause execute VROR_VX(vm, vs2, rs1, vd) = {
 
 union clause instruction = VROR_VI : (bits(1), vregidx, bits(6), vregidx)
 
+$[wavedrom "_ _ _ _ _ OPIVI _ OP-V"]
 mapping clause encdec = VROR_VI(vm, vs2, uimm5 @ uimm40, vd)
   <-> 0b01010 @ uimm5 @ vm @ encdec_vreg(vs2) @ uimm40 : bits(5) @ 0b011 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvkb)
@@ -506,6 +519,7 @@ function clause execute VROR_VI(vm, vs2, uimm, vd) = {
 
 union clause instruction = VWSLL_VV : (bits(1), vregidx, vregidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPIVV _ OP-V"]
 mapping clause encdec = VWSLL_VV (vm, vs2, vs1, vd)
   <-> 0b110101 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvbb)
@@ -557,6 +571,7 @@ function clause execute VWSLL_VV(vm, vs2, vs1, vd) = {
 
 union clause instruction = VWSLL_VX : (bits(1), vregidx, regidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPIVX _ OP-V"]
 mapping clause encdec = VWSLL_VX (vm, vs2, rs1, vd)
   <-> 0b110101 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvbb)
@@ -606,6 +621,7 @@ function clause execute VWSLL_VX(vm, vs2, rs1, vd) = {
 
 union clause instruction = VWSLL_VI : (bits(1), vregidx, bits(5), vregidx)
 
+$[wavedrom "_ _ _ _ OPIVI _ OP-V"]
 mapping clause encdec = VWSLL_VI (vm, vs2, uimm, vd)
   <-> 0b110101 @ vm @ encdec_vreg(vs2) @ uimm @ 0b011 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvbb)

--- a/model/extensions/vector_crypto/zvbc_insts.sail
+++ b/model/extensions/vector_crypto/zvbc_insts.sail
@@ -10,6 +10,7 @@ function clause currentlyEnabled(Ext_Zvbc) = hartSupports(Ext_Zvbc) & currentlyE
 
 union clause instruction = VCLMUL_VV : (bits(1), vregidx, vregidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPMVV _ OP-V"]
 mapping clause encdec = VCLMUL_VV (vm, vs2, vs1, vd)
   <-> 0b001100 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvbc) & get_sew() == 64
@@ -48,6 +49,7 @@ function clause execute VCLMUL_VV(vm, vs2, vs1, vd) = {
 
 union clause instruction = VCLMUL_VX : (bits(1), vregidx, regidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPMVX _ OP-V"]
 mapping clause encdec = VCLMUL_VX (vm, vs2, rs1, vd)
   <-> 0b001100 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvbc) & get_sew() == 64
@@ -87,6 +89,7 @@ function clause execute VCLMUL_VX(vm, vs2, rs1, vd) = {
 
 union clause instruction = VCLMULH_VV : (bits(1), vregidx, vregidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPMVV _ OP-V"]
 mapping clause encdec = VCLMULH_VV (vm, vs2, vs1, vd)
   <-> 0b001101 @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvbc) & get_sew() == 64
@@ -125,6 +128,7 @@ function clause execute VCLMULH_VV(vm, vs2, vs1, vd) = {
 
 union clause instruction = VCLMULH_VX : (bits(1), vregidx, regidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPMVX _ OP-V"]
 mapping clause encdec = VCLMULH_VX (vm, vs2, rs1, vd)
   <-> 0b001101 @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvbc) & get_sew() == 64

--- a/model/extensions/vector_crypto/zvkg_insts.sail
+++ b/model/extensions/vector_crypto/zvkg_insts.sail
@@ -10,6 +10,7 @@ function clause currentlyEnabled(Ext_Zvkg) = hartSupports(Ext_Zvkg) & currentlyE
 
 union clause instruction = VGHSH_VV : (vregidx, vregidx, vregidx)
 
+$[wavedrom "_ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = VGHSH_VV(vs2, vs1, vd)
   <-> 0b1011001 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvkg) & get_sew() == 32 & zvk_check_encdec(128, 4)
@@ -58,6 +59,7 @@ mapping clause assembly = VGHSH_VV(vs2, vs1, vd)
 
 union clause instruction = VGMUL_VV : (vregidx, vregidx)
 
+$[wavedrom "_ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = VGMUL_VV(vs2, vd)
   <-> 0b1010001 @ encdec_vreg(vs2) @ 0b10001 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvkg) & get_sew() == 32 & zvk_check_encdec(128, 4)

--- a/model/extensions/vector_crypto/zvkned_insts.sail
+++ b/model/extensions/vector_crypto/zvkned_insts.sail
@@ -15,6 +15,7 @@ mapping encdec_vaesdf : zvk_vaesdf_funct6 <-> bits(6) = {
   ZVK_VAESDF_VS <-> 0b101001,
 }
 
+$[wavedrom "VAESDF.OP _ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = VAESDF(funct6, vs2, vd)
   <-> encdec_vaesdf(funct6) @ 0b1 @ encdec_vreg(vs2) @ 0b00001 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4) & (funct6 == ZVK_VAESDF_VV |
@@ -67,6 +68,7 @@ mapping encdec_vaesdm : zvk_vaesdm_funct6 <-> bits(6) = {
   ZVK_VAESDM_VS <-> 0b101001,
 }
 
+$[wavedrom "VAESDM.OP _ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = VAESDM(funct6, vs2, vd)
   <-> encdec_vaesdm(funct6) @ 0b1 @ encdec_vreg(vs2) @ 0b00000 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4) & (funct6 == ZVK_VAESDM_VV |
@@ -120,6 +122,7 @@ mapping encdec_vaesef : zvk_vaesef_funct6 <-> bits(6) = {
   ZVK_VAESEF_VS <-> 0b101001,
 }
 
+$[wavedrom "VAESEF.OP _ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = VAESEF(funct6, vs2, vd)
   <-> encdec_vaesef(funct6) @ 0b1 @ encdec_vreg(vs2) @ 0b00011 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4) & (funct6 == ZVK_VAESEF_VV |
@@ -172,6 +175,7 @@ mapping encdec_vaesem : zvk_vaesem_funct6 <-> bits(6) = {
   ZVK_VAESEM_VS <-> 0b101001,
 }
 
+$[wavedrom "VAESEM.OP _ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = VAESEM(funct6, vs2, vd)
   <-> encdec_vaesem(funct6) @ 0b1 @ encdec_vreg(vs2) @ 0b00010 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4) & (funct6 == ZVK_VAESEM_VV |
@@ -220,6 +224,7 @@ mapping clause assembly = VAESEM(funct6, vs2, vd)
 
 union clause instruction = VAESKF1_VI : (vregidx, bits(5), vregidx)
 
+$[wavedrom "_ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = VAESKF1_VI(vs2, rnd, vd)
   <-> 0b1000101 @ encdec_vreg(vs2) @ rnd @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
@@ -269,8 +274,9 @@ mapping clause assembly = VAESKF1_VI(vs2, rnd, vd)
 
 union clause instruction = VAESKF2_VI : (vregidx, bits(5), vregidx)
 
+$[wavedrom "_ _ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = VAESKF2_VI(vs2, rnd, vd)
-  <-> 0b1010101 @ encdec_vreg(vs2) @ rnd @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  <-> 0b101010 @ 0b1 @ encdec_vreg(vs2) @ rnd @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4)
 
 function clause execute VAESKF2_VI(vs2, rnd, vd) = {
@@ -319,8 +325,9 @@ mapping clause assembly = VAESKF2_VI(vs2, rnd, vd)
 
 union clause instruction = VAESZ_VS : (vregidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = VAESZ_VS(vs2, vd)
-  <-> 0b1010011 @ encdec_vreg(vs2) @ 0b00111 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  <-> 0b101001 @ 0b1 @ encdec_vreg(vs2) @ 0b00111 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvkned) & get_sew() == 32 & zvk_check_encdec(128, 4) & zvk_valid_reg_overlap(vs2, vd, get_lmul_pow())
 
 function clause execute VAESZ_VS(vs2, vd) = {

--- a/model/extensions/vector_crypto/zvknhab_insts.sail
+++ b/model/extensions/vector_crypto/zvknhab_insts.sail
@@ -11,8 +11,9 @@ function clause currentlyEnabled(Ext_Zvknhb) = hartSupports(Ext_Zvknhb) & curren
 
 union clause instruction = VSHA2MS_VV : (vregidx, vregidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = VSHA2MS_VV(vs2, vs1, vd)
-  <-> 0b1011011 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  <-> 0b101101 @ 0b1 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when (currentlyEnabled(Ext_Zvknha) & get_sew() == 32) | (currentlyEnabled(Ext_Zvknhb) & (get_sew() == 32 | get_sew() == 64)) & zvknhab_check_encdec(vs2, vs1, vd)
 
 mapping clause assembly = VSHA2MS_VV(vs2, vs1, vd)
@@ -73,6 +74,7 @@ mapping encdec_vsha2 : zvk_vsha2_funct6 <-> bits(6) = {
   ZVK_VSHA2CL_VV <-> 0b101111,
 }
 
+$[wavedrom "VSHA2C.OP _ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = ZVKSHA2TYPE(funct6, vs2, vs1, vd)
   <-> encdec_vsha2(funct6) @ 0b1 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when (currentlyEnabled(Ext_Zvknha) & get_sew() == 32) | (currentlyEnabled(Ext_Zvknhb) & (get_sew() == 32 | get_sew() == 64)) & zvknhab_check_encdec(vs2, vs1, vd)

--- a/model/extensions/vector_crypto/zvksed_insts.sail
+++ b/model/extensions/vector_crypto/zvksed_insts.sail
@@ -10,8 +10,9 @@ function clause currentlyEnabled(Ext_Zvksed) = hartSupports(Ext_Zvksed) & curren
 
 union clause instruction = VSM4K_VI : (vregidx, bits(5), vregidx)
 
+$[wavedrom "_ _ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = VSM4K_VI(vs2, uimm, vd)
-  <-> 0b1000011 @ encdec_vreg(vs2) @ uimm @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  <-> 0b100001 @ 0b1 @ encdec_vreg(vs2) @ uimm @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvksed) & get_sew() == 32 & zvk_check_encdec(128, 4)
 
 function clause execute VSM4K_VI(vs2, uimm, vd) = {
@@ -63,12 +64,14 @@ mapping clause assembly = VSM4K_VI(vs2, uimm, vd)
 
 union clause instruction = ZVKSM4RTYPE : (zvk_vsm4r_funct6, vregidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = ZVKSM4RTYPE(ZVK_VSM4R_VV, vs2, vd)
-  <-> 0b1010001 @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  <-> 0b101000 @ 0b1 @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvksed) & get_sew() == 32 & zvk_check_encdec(128, 4)
 
+$[wavedrom "_ _ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = ZVKSM4RTYPE(ZVK_VSM4R_VS, vs2, vd)
-  <-> 0b1010011 @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  <-> 0b101001 @ 0b1 @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvksed) & get_sew() == 32 & zvk_check_encdec(128, 4) & zvk_valid_reg_overlap(vs2, vd, get_lmul_pow())
 
 function clause execute ZVKSM4RTYPE(funct6, vs2, vd) = {

--- a/model/extensions/vector_crypto/zvksh_insts.sail
+++ b/model/extensions/vector_crypto/zvksh_insts.sail
@@ -10,8 +10,9 @@ function clause currentlyEnabled(Ext_Zvksh) = hartSupports(Ext_Zvksh) & currentl
 
 union clause instruction = VSM3ME_VV : (vregidx, vregidx, vregidx)
 
+$[wavedrom "_ _ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = VSM3ME_VV(vs2, vs1, vd)
-  <-> 0b1000001 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1110111
+  <-> 0b100000 @ 0b1 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1110111
    when currentlyEnabled(Ext_Zvksh) & get_sew() == 32 & zvk_check_encdec(256, 8) & zvk_valid_reg_overlap(vs2, vd, get_lmul_pow())
 
 function clause execute VSM3ME_VV(vs2, vs1, vd) = {
@@ -53,6 +54,7 @@ mapping clause assembly = VSM3ME_VV(vs2, vs1, vd)
 
 union clause instruction = VSM3C_VI : (vregidx, bits(5), vregidx)
 
+$[wavedrom "_ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = VSM3C_VI(vs2, uimm, vd)
   <-> 0b1010111 @ encdec_vreg(vs2) @ uimm @ 0b010 @ encdec_vreg(vd) @ 0b1110111
   when currentlyEnabled(Ext_Zvksh) & get_sew() == 32 & zvk_check_encdec(256, 8) & zvk_valid_reg_overlap(vs2, vd, get_lmul_pow())

--- a/model/mops/Zimop/zimop_insts.sail
+++ b/model/mops/Zimop/zimop_insts.sail
@@ -11,10 +11,12 @@ function clause currentlyEnabled(Ext_Zimop) = hartSupports(Ext_Zimop)
 union clause instruction = ZIMOP_MOP_R : (bits(5), regidx, regidx)
 union clause instruction = ZIMOP_MOP_RR : (bits(3), regidx, regidx, regidx)
 
+$[wavedrom "_ n[4] _ n[3:2] _ n[1:0] _ _ _ SYSTEM"]
 mapping clause encdec = ZIMOP_MOP_R(mop_30 @ mop_27_26 @ mop_21_20, rs1, rd)
   <-> 0b1 @ mop_30 : bits(1) @ 0b00 @ mop_27_26 : bits(2) @ 0b0111 @ mop_21_20 : bits(2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b1110011
   when currentlyEnabled(Ext_Zimop)
 
+$[wavedrom "_ n[2] _ n[1:0] _ _ _ _ _ SYSTEM"]
 mapping clause encdec = ZIMOP_MOP_RR(mop_30 @ mop_27_26, rs2, rs1, rd)
   <-> 0b1 @ mop_30 : bits(1) @ 0b00 @ mop_27_26 : bits(2) @ 0b1 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b1110011
   when currentlyEnabled(Ext_Zimop)


### PR DESCRIPTION
These have been added only to instructions that have their own dedicated diagram in the manual.  Instructions that are grouped into a single diagram will need more tooling support from the asciidoc backend.

In some cases, bitvector literals in encodings have been split or joined to better match the spec diagram.