### PR TITLE
Improve trap_handler with TrapCause union

### DIFF
--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -117,25 +117,52 @@ enum InterruptType = {
   I_U_Software,
   I_S_Software,
   I_M_Software,
+  // I_VS_Software,
   I_U_Timer,
   I_S_Timer,
+  // I_VS_Timer,
   I_M_Timer,
   I_U_External,
   I_S_External,
-  I_M_External
+  // I_VS_External,
+  I_M_External,
+  // I_G_External,
 }
 
 mapping interruptType_bits : InterruptType <-> exc_code = {
   I_U_Software <-> 0b000000, // 0
   I_S_Software <-> 0b000001, // 1
+  // I_VS_Software <-> 0b00010, // 2
   I_M_Software <-> 0b000011, // 3
   I_U_Timer    <-> 0b000100, // 4
   I_S_Timer    <-> 0b000101, // 5
+  // I_VS_Timer    <-> 0b00110, // 6
   I_M_Timer    <-> 0b000111, // 7
   I_U_External <-> 0b001000, // 8
   I_S_External <-> 0b001001, // 9
+  // I_VS_External <-> 0b001010, // 10
   I_M_External <-> 0b001011, // 11
+  // I_G_External  <-> 0b001100, // 12
 }
+
+function interruptType_to_str(i : InterruptType) -> string =
+  match (i) {
+    I_U_Software  => "user-software-interrupt",
+    I_S_Software  => "supervisor-software-interrupt",
+    // I_VS_Software => "virtual-supervisor-software-interrupt",
+    I_M_Software  => "machine-software-interrupt",
+    I_U_Timer     => "user-timer-interrupt",
+    I_S_Timer     => "supervisor-timer-interrupt",
+    // I_VS_Timer    => "virtual-supervisor-timer-interrupt",
+    I_M_Timer     => "machine-timer-interrupt",
+    I_U_External  => "user-external-interrupt",
+    I_S_External  => "supervisor-external-interrupt",
+    // I_VS_External => "virtual-supervisor-external-interrupt",
+    I_M_External  => "machine-external-interrupt",
+    // I_G_External  => "guest-external-interrupt"
+  }
+
+overload to_str = {interruptType_to_str}
 
 // architectural exception definitions
 
@@ -224,6 +251,30 @@ function sw_check_code_to_bits (c : SWCheckCodes) -> xlenbits =
   match (c) {
     LANDING_PAD_FAULT  => zero_extend(0b010),
   }
+
+// An architectural trap can be caused by either an interrupt or an exception
+
+union TrapCause = {
+  Interrupt : InterruptType,
+  Exception : ExceptionType,
+}
+
+mapping trapCause_bits : TrapCause <-> exc_code = {
+  Interrupt(i) <-> interruptType_bits(i),
+  Exception(e) <-> exceptionType_bits(e),
+}
+
+function trapCause_is_interrupt(t : TrapCause) -> bool = match t {
+  Interrupt(_) => true,
+  Exception(_) => false,
+}
+
+function trapCause_to_str(t : TrapCause) -> string = match t {
+  Interrupt(i) => "int#" ^ interruptType_to_str(i),
+  Exception(e) => "exc#" ^ exceptionType_to_str(e),
+}
+
+overload to_str = {trapCause_to_str}
 
 // trap modes
 

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -152,20 +152,24 @@ function track_trap(p : Privilege) -> unit = {
 }
 
 // handle exceptional ctl flow by updating nextPC and operating privilege
-function trap_handler(del_priv : Privilege, intr : bool, c : exc_code, pc : xlenbits, info : option(xlenbits), ext : option(ext_exception))
+function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info : option(xlenbits), ext : option(ext_exception))
                      -> xlenbits = {
   trap_callback();
+
   if   get_config_print_platform()
-  then print_log("handling " ^ (if intr then "int#" else "exc#")
-                      ^ bits_str(c) ^ " at priv " ^ to_str(del_priv)
+  then print_log("handling " ^ to_str(c)
+                      ^ " at priv " ^ to_str(del_priv)
                       ^ " with tval " ^ bits_str(tval(info)));
 
   if hartSupports(Ext_Zicfilp) then zicfilp_preserve_elp_on_trap(del_priv);
 
+  let is_interrupt = bool_to_bits(trapCause_is_interrupt(c));
+  let cause        = zero_extend(xlen - 1, trapCause_bits(c));
+
   match (del_priv) {
     Machine => {
-      mcause[IsInterrupt] = bool_to_bits(intr);
-      mcause[Cause]       = zero_extend(c);
+      mcause[IsInterrupt] = is_interrupt;
+      mcause[Cause]       = cause;
 
       mstatus[MPIE] = mstatus[MIE];
       mstatus[MIE]  = 0b0;
@@ -184,8 +188,8 @@ function trap_handler(del_priv : Privilege, intr : bool, c : exc_code, pc : xlen
     Supervisor => {
       assert (currentlyEnabled(Ext_S), "no supervisor mode present for delegation");
 
-      scause[IsInterrupt] = bool_to_bits(intr);
-      scause[Cause]       = zero_extend(c);
+      scause[IsInterrupt] = is_interrupt;
+      scause[Cause]       = cause;
 
       mstatus[SPIE] = mstatus[SIE];
       mstatus[SIE]  = 0b0;
@@ -221,7 +225,7 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
       if   get_config_print_platform()
       then print_log("trapping from " ^ to_str(cur_priv) ^ " to " ^ to_str(del_priv)
                           ^ " to handle " ^ to_str(e.trap));
-      trap_handler(del_priv, false, exceptionType_bits(e.trap), pc, e.excinfo, e.ext)
+      trap_handler(del_priv, Exception(e.trap), pc, e.excinfo, e.ext)
     },
     CTL_MRET()  => {
       let prev_priv = cur_privilege;
@@ -288,7 +292,7 @@ function handle_exception(xtval : xlenbits, e : ExceptionType) -> unit = {
 }
 
 function handle_interrupt(i : InterruptType, del_priv : Privilege) -> unit =
-  set_next_pc(trap_handler(del_priv, true, interruptType_bits(i), PC, None(), None()))
+  set_next_pc(trap_handler(del_priv, Interrupt(i), PC, None(), None()))
 
 // Reset misa to enable the maximal set of supported extensions.
 function reset_misa() -> unit = {


### PR DESCRIPTION
An architectural trap can be caused by either an interrupt or an exception.