### PR TITLE
add base case to currentlyEnabled

### DIFF
--- a/model/postlude/insts_end.sail
+++ b/model/postlude/insts_end.sail
@@ -26,6 +26,8 @@ mapping clause assembly = C_ILLEGAL(s) <-> "c.illegal" ^ spc() ^ hex_bits_16(s)
 
 // *****************************************************************
 
+function clause currentlyEnabled _ = false
+
 // End definitions
 end extension
 end extensionName


### PR DESCRIPTION
currentlyEnabled should return false for any extensions that are not included in the current build.