### PR TITLE
Add Bfloat16 tests for Zvfbfmin and Zvfbfwma extensions

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake options for test downloads
 set(TEST_DOWNLOAD_URL "https://github.com/riscv-software-src/sail-riscv-tests/releases/download" CACHE STRING "Base URL to download precompiled riscv-tests and riscv-vector-tests from")
-set(TEST_DOWNLOAD_VERSION "2025-07-16" CACHE STRING "Version of precompiled tests to download")
+set(TEST_DOWNLOAD_VERSION "2025-10-14" CACHE STRING "Version of precompiled tests to download")
 
 # Function to download and extract test files
 function(download_riscv_tests DOWNLOAD_PATH TARBALL_NAME DOWNLOAD_URL)


### PR DESCRIPTION
Update to latest RISC-V Vector Test suite 2025-10-14 with added Bfloat16 tests for the Zvfbfmin and Zvfbfwma extensions.

Added tests for the following instructions:
```
fncvtbf16.f.f.w
vfwcvtbf16.f.f.v
vfwmaccbf16.vv
vfwmaccbf16.vf
```