### PR TITLE
Simplify vector_support_level

### DIFF
--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -58,7 +58,7 @@ function clause hartSupports(Ext_B) = config extensions.B.supported
 // Vector Operations
 enum clause extension = Ext_V
 mapping clause extensionName = Ext_V <-> "v"
-function clause hartSupports(Ext_V) = sizeof(vlen_exp) >= 7 & vector_support_config_level >= vector_support_level(Full)
+function clause hartSupports(Ext_V) = sizeof(vlen_exp) >= 7 & vector_support_level >= Full
 // Supervisor
 enum clause extension = Ext_S
 mapping clause extensionName = Ext_S <-> "s"
@@ -293,19 +293,19 @@ function clause hartSupports(Ext_Zvl1024b) = sizeof(vlen_exp) >= 10
 // Vector Extensions for Embedded Processors
 enum clause extension = Ext_Zve32f
 mapping clause extensionName = Ext_Zve32f <-> "zve32f"
-function clause hartSupports(Ext_Zve32f) = sizeof(elen_exp) >= 5 & vector_support_config_level >= vector_support_level(Float_single)
+function clause hartSupports(Ext_Zve32f) = sizeof(elen_exp) >= 5 & vector_support_level >= Float_single
 enum clause extension = Ext_Zve32x
 mapping clause extensionName = Ext_Zve32x <-> "zve32x"
-function clause hartSupports(Ext_Zve32x) = sizeof(elen_exp) >= 5 & vector_support_config_level >= vector_support_level(Integer)
+function clause hartSupports(Ext_Zve32x) = sizeof(elen_exp) >= 5 & vector_support_level >= Integer
 enum clause extension = Ext_Zve64d
 mapping clause extensionName = Ext_Zve64d <-> "zve64d"
-function clause hartSupports(Ext_Zve64d) = sizeof(elen_exp) >= 6 & vector_support_config_level >= vector_support_level(Float_double)
+function clause hartSupports(Ext_Zve64d) = sizeof(elen_exp) >= 6 & vector_support_level >= Float_double
 enum clause extension = Ext_Zve64f
 mapping clause extensionName = Ext_Zve64f <-> "zve64f"
-function clause hartSupports(Ext_Zve64f) = sizeof(elen_exp) >= 6 & vector_support_config_level >= vector_support_level(Float_single)
+function clause hartSupports(Ext_Zve64f) = sizeof(elen_exp) >= 6 & vector_support_level >= Float_single
 enum clause extension = Ext_Zve64x
 mapping clause extensionName = Ext_Zve64x <-> "zve64x"
-function clause hartSupports(Ext_Zve64x) = sizeof(elen_exp) >= 6 & vector_support_config_level >= vector_support_level(Integer)
+function clause hartSupports(Ext_Zve64x) = sizeof(elen_exp) >= 6 & vector_support_level >= Integer
 // Vector BF16 Converts
 enum clause extension = Ext_Zvfbfmin
 mapping clause extensionName = Ext_Zvfbfmin <-> "zvfbfmin"

--- a/model/core/vlen.sail
+++ b/model/core/vlen.sail
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // =======================================================================================
 
+// The order of vector_support is significant - each level implies all of the previous levels.
 enum vector_support = {
   Disabled,
   Integer,
@@ -14,16 +15,17 @@ enum vector_support = {
   Full,
 }
 
-mapping vector_support_level : vector_support <-> nat = {
-  Disabled     <-> 0,
-  Integer      <-> 1,
-  Float_single <-> 2,
-  Float_double <-> 3,
-  Full         <-> 4,
-}
+let vector_support_level : vector_support = config extensions.V.support_level
 
-let vector_support_config = config extensions.V.support_level : vector_support
-let vector_support_config_level = vector_support_level(vector_support_config)
+function vector_support_lt(x : vector_support, y : vector_support) -> bool = num_of_vector_support(x) < num_of_vector_support(y)
+function vector_support_gt(x : vector_support, y : vector_support) -> bool = num_of_vector_support(x) > num_of_vector_support(y)
+function vector_support_le(x : vector_support, y : vector_support) -> bool = num_of_vector_support(x) <= num_of_vector_support(y)
+function vector_support_ge(x : vector_support, y : vector_support) -> bool = num_of_vector_support(x) >= num_of_vector_support(y)
+
+overload operator < = {vector_support_lt}
+overload operator > = {vector_support_gt}
+overload operator <= = {vector_support_le}
+overload operator >= = {vector_support_ge}
 
 type vlen_exp : Int = config extensions.V.vlen_exp
 constraint 3 <= vlen_exp <= 16

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -91,15 +91,15 @@ function check_vlen_elen() -> bool = {
 function check_vext_config() -> bool = {
   var valid : bool = true;
   // Standard Vector Extensions
-  if vector_support_config_level >= vector_support_level(Integer) & (elen_exp : nat) < 5 then {
+  if vector_support_level >= Integer & (elen_exp : nat) < 5 then {
     valid = false;
     print_endline("Zve*x is enabled but ELEN is 2^" ^ dec_str(elen_exp) ^ ": ELEN must be >= 2^5");
   };
-  if vector_support_config_level >= vector_support_level(Float_single) & not(hartSupports(Ext_F)) then {
+  if vector_support_level >= Float_single & not(hartSupports(Ext_F)) then {
     valid = false;
     print_endline("Zve*f is enabled but F is disabled: supporting Zve*f requires F.");
   };
-  if vector_support_config_level >= vector_support_level(Float_double) then {
+  if vector_support_level >= Float_double then {
     if (elen_exp : nat) < 6 then {
       valid = false;
       print_endline("Zve*d is enabled but ELEN is 2^" ^ dec_str(elen_exp) ^ ": ELEN must be >= 2^6");
@@ -121,7 +121,7 @@ function check_vext_config() -> bool = {
     valid = false;
     print_endline("VLEN (set to 2^" ^ dec_str(vlen_exp) ^ ") is below the minimum required for Zve64x (need Zvl64b).");
   };
-  if vector_support_config_level >= vector_support_level(Full) & not(hartSupports(Ext_Zvl128b)) then {
+  if vector_support_level >= Full & not(hartSupports(Ext_Zvl128b)) then {
     valid = false;
     print_endline("VLEN (set to 2^" ^ dec_str(vlen_exp) ^ ") is below the minimum required for V (need Zvl128b).");
   };


### PR DESCRIPTION
Instead of mapping to integers, use `num_of_` and define comparison operators for the enum directly.

Fixes #1344