### PR TITLE
Add more state change callbacks

### DIFF
--- a/c_emulator/riscv_callbacks.cpp
+++ b/c_emulator/riscv_callbacks.cpp
@@ -18,6 +18,14 @@ void remove_callback(callbacks_if *cb)
                   callbacks.end());
 }
 
+unit fetch_callback(sbits opcode)
+{
+  for (auto c : callbacks) {
+    c->fetch_callback(opcode);
+  }
+  return UNIT;
+}
+
 unit mem_write_callback(const char *type, sbits paddr, uint64_t width,
                         lbits value)
 {
@@ -86,18 +94,26 @@ unit vreg_write_callback(unsigned reg, lbits value)
   return UNIT;
 }
 
-unit pc_write_callback(sbits value)
+unit pc_write_callback(sbits new_pc)
 {
   for (auto c : callbacks) {
-    c->pc_write_callback(value);
+    c->pc_write_callback(new_pc);
   }
   return UNIT;
 }
 
-unit trap_callback(unit)
+unit redirect_callback(sbits new_pc)
 {
   for (auto c : callbacks) {
-    c->trap_callback();
+    c->redirect_callback(new_pc);
+  }
+  return UNIT;
+}
+
+unit trap_callback(bool is_interrupt, fbits cause)
+{
+  for (auto c : callbacks) {
+    c->trap_callback(is_interrupt, cause);
   }
   return UNIT;
 }

--- a/c_emulator/riscv_callbacks.h
+++ b/c_emulator/riscv_callbacks.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif
 
+unit fetch_callback(sbits opcode);
 unit mem_write_callback(const char *type, sbits paddr, uint64_t width,
                         lbits value);
 unit mem_read_callback(const char *type, sbits paddr, uint64_t width,
@@ -21,8 +22,9 @@ unit csr_full_write_callback(const_sail_string csr_name, unsigned reg,
 unit csr_full_read_callback(const_sail_string csr_name, unsigned reg,
                             sbits value);
 unit vreg_write_callback(unsigned reg, lbits value);
-unit pc_write_callback(sbits value);
-unit trap_callback(unit);
+unit pc_write_callback(sbits new_pc);
+unit redirect_callback(sbits new_pc);
+unit trap_callback(bool is_interrupt, fbits cause);
 
 #ifdef __cplusplus
 }

--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -10,6 +10,7 @@ public:
   virtual ~callbacks_if() = default;
 
   // TODO: finding ways to improve the format
+  virtual void fetch_callback(sbits opcode) = 0;
   virtual void mem_write_callback(const char *type, sbits paddr, uint64_t width,
                                   lbits value)
       = 0;
@@ -29,8 +30,9 @@ public:
                                       sbits value)
       = 0;
   virtual void vreg_write_callback(unsigned reg, lbits value) = 0;
-  virtual void pc_write_callback(sbits value) = 0;
-  virtual void trap_callback() = 0;
+  virtual void pc_write_callback(sbits new_pc) = 0;
+  virtual void redirect_callback(sbits new_pc) = 0;
+  virtual void trap_callback(bool is_interrupt, fbits cause) = 0;
 };
 
 void register_callback(callbacks_if *cb);

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -31,6 +31,11 @@ log_callbacks::log_callbacks(bool config_print_reg,
 // Implementations of default callbacks for trace printing.
 // The model assumes that these functions do not change the state of the model.
 
+void log_callbacks::fetch_callback(sbits opcode)
+{
+  (void)opcode;
+}
+
 void log_callbacks::mem_write_callback(const char *type, sbits paddr,
                                        uint64_t width, lbits value)
 {
@@ -104,6 +109,18 @@ void log_callbacks::vreg_write_callback(unsigned reg, lbits value)
   }
 }
 
-void log_callbacks::pc_write_callback(sbits) { }
+void log_callbacks::pc_write_callback(sbits new_pc)
+{
+  (void)new_pc;
+}
 
-void log_callbacks::trap_callback() { }
+void log_callbacks::redirect_callback(sbits new_pc)
+{
+  (void)new_pc;
+}
+
+void log_callbacks::trap_callback(bool is_interrupt, fbits cause)
+{
+  (void)is_interrupt;
+  (void)cause;
+}

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -10,6 +10,7 @@ public:
                 bool config_use_abi_names = false, FILE *trace_log = nullptr);
 
   // callbacks_if
+  void fetch_callback(sbits opcode) override;
   void mem_write_callback(const char *type, sbits paddr, uint64_t width,
                           lbits value) override;
   void mem_read_callback(const char *type, sbits paddr, uint64_t width,
@@ -23,8 +24,9 @@ public:
   void csr_full_read_callback(const_sail_string csr_name, unsigned reg,
                               sbits value) override;
   void vreg_write_callback(unsigned reg, lbits value) override;
-  void pc_write_callback(sbits value) override;
-  void trap_callback() override;
+  void pc_write_callback(sbits new_pc) override;
+  void redirect_callback(sbits new_pc) override;
+  void trap_callback(bool is_interrupt, fbits cause) override;
 
 private:
   bool config_print_reg;

--- a/c_emulator/riscv_callbacks_rvfi.cpp
+++ b/c_emulator/riscv_callbacks_rvfi.cpp
@@ -6,6 +6,11 @@
 
 // Implementations of default callbacks for RVFI.
 // The model assumes that these functions do not change the state of the model.
+void rvfi_callbacks::fetch_callback(sbits opcode)
+{
+  (void)opcode;
+}
+
 void rvfi_callbacks::mem_write_callback(const char *, sbits paddr,
                                         uint64_t width, lbits value)
 {
@@ -53,10 +58,20 @@ void rvfi_callbacks::csr_full_read_callback(const_sail_string, unsigned, sbits)
 
 void rvfi_callbacks::vreg_write_callback(unsigned, lbits) { }
 
-void rvfi_callbacks::pc_write_callback(sbits) { }
-
-void rvfi_callbacks::trap_callback()
+void rvfi_callbacks::pc_write_callback(sbits new_pc)
 {
+  (void)new_pc;
+}
+
+void rvfi_callbacks::redirect_callback(sbits new_pc)
+{
+  (void)new_pc;
+}
+
+void rvfi_callbacks::trap_callback(bool is_interrupt, fbits cause)
+{
+  (void)is_interrupt;
+  (void)cause;
   if (config_enable_rvfi) {
     zrvfi_trap(UNIT);
   }

--- a/c_emulator/riscv_callbacks_rvfi.h
+++ b/c_emulator/riscv_callbacks_rvfi.h
@@ -6,6 +6,7 @@ class rvfi_callbacks : public callbacks_if {
 
 public:
   // callbacks_if
+  void fetch_callback(sbits opcode) override;
   void mem_write_callback(const char *type, sbits paddr, uint64_t width,
                           lbits value) override;
   void mem_read_callback(const char *type, sbits paddr, uint64_t width,
@@ -19,8 +20,9 @@ public:
   void csr_full_read_callback(const_sail_string csr_name, unsigned reg,
                               sbits value) override;
   void vreg_write_callback(unsigned reg, lbits value) override;
-  void pc_write_callback(sbits value) override;
-  void trap_callback() override;
+  void pc_write_callback(sbits new_pc) override;
+  void redirect_callback(sbits new_pc) override;
+  void trap_callback(bool is_interrupt, fbits cause) override;
 };
 
 extern "C" {

--- a/model/core/callbacks.sail
+++ b/model/core/callbacks.sail
@@ -7,6 +7,12 @@
 // =======================================================================================
 
 // Callbacks for state-changing events
+
+/// Called upon successful instruction fetch with the opcode.
+/// If there is a fetch error then this is not called (but trap_callback() will be).
+val fetch_callback = pure {c: "fetch_callback"} : forall 'n, 'n in {16, 32}. (bits('n)) -> unit
+function fetch_callback(_) = ()
+
 val mem_write_callback = pure {c: "mem_write_callback"} : forall 'n, 0 < 'n <= max_mem_access . (/* access type */ string, /* addr */ physaddrbits, /* width */ int('n), /* value */ bits(8 * 'n)) -> unit
 function mem_write_callback(_) = ()
 
@@ -16,7 +22,10 @@ function mem_read_callback(_) = ()
 val mem_exception_callback = pure {c: "mem_exception_callback"} : (/* addr */ physaddrbits, /* exception code */ exc_code) -> unit
 function mem_exception_callback(_) = ()
 
-val pc_write_callback = pure {c: "pc_write_callback"} : xlenbits -> unit
+/// Called at the end of every step when PC is advanced to the next
+/// instruction. This includes taken branches. It is not called when
+/// the hart is waiting in WFI/WRS. The parameter is the new PC.
+val pc_write_callback = pure {c: "pc_write_callback"} : (/* new_pc */ xlenbits) -> unit
 function pc_write_callback(_) = ()
 
 val xreg_full_write_callback = pure {c: "xreg_full_write_callback"} : (string, regidx, xlenbits) -> unit
@@ -28,7 +37,23 @@ function csr_full_write_callback(_) = ()
 val csr_full_read_callback = pure {c: "csr_full_read_callback"} : (string, csreg, xlenbits) -> unit
 function csr_full_read_callback(_) = ()
 
-val trap_callback = pure {c: "trap_callback"} : unit -> unit
+/// Called when control flow is redirected from just executing the next instruction.
+/// This includes:
+///
+///  * Unconditional jumps (jal, jalr)
+///  * Traps
+///  * Returning from trap handlers (mret, sret)
+///  * Conditional branches that are taken (even if the target is the same instruction that
+///    would have been executed if they were not taken).
+///
+/// The parameter is the new PC. pc_write_callback() will also be called after
+/// this with the same parameter.
+val redirect_callback = pure {c: "redirect_callback"} : (/* new_pc */ xlenbits) -> unit
+function redirect_callback(_) = ()
+
+/// Called on interrupts and exceptions. The exc_code does not include the 'interrupt' bit which is
+/// in a separate bool.
+val trap_callback = pure {c: "trap_callback"} : (/* is_interrupt */ bool, /* interrupt/exception cause */ exc_code) -> unit
 function trap_callback(_) = ()
 
 // Overloads for easier use of callbacks

--- a/model/core/pc_access.sail
+++ b/model/core/pc_access.sail
@@ -21,7 +21,8 @@ function get_next_pc() -> xlenbits = nextPC
 
 function set_next_pc(pc : xlenbits) -> unit = {
   sail_branch_announce(xlen, pc);
-  nextPC = pc
+  nextPC = pc;
+  redirect_callback(pc);
 }
 
 function tick_pc() -> unit = {

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -97,6 +97,7 @@ function run_hart_active(step_no: nat) -> Step = {
       // non-error cases:
       F_RVC(h) => {
         sail_instr_announce(h);
+        fetch_callback(h);
         let instbits : instbits = zero_extend(h);
         let instruction = ext_decode_compressed(h);
         if   get_config_print_instr()
@@ -120,6 +121,7 @@ function run_hart_active(step_no: nat) -> Step = {
       },
       F_Base(w) => {
         sail_instr_announce(w);
+        fetch_callback(w);
         let instbits : instbits = zero_extend(w);
         let instruction = ext_decode(w);
         if   get_config_print_instr()

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -154,7 +154,10 @@ function track_trap(p : Privilege) -> unit = {
 // handle exceptional ctl flow by updating nextPC and operating privilege
 function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info : option(xlenbits), ext : option(ext_exception))
                      -> xlenbits = {
-  trap_callback();
+  let is_interrupt = trapCause_is_interrupt(c);
+  let cause        = trapCause_bits(c);
+
+  trap_callback(is_interrupt, cause);
 
   if   get_config_print_platform()
   then print_log("handling " ^ to_str(c)
@@ -163,13 +166,10 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
 
   if hartSupports(Ext_Zicfilp) then zicfilp_preserve_elp_on_trap(del_priv);
 
-  let is_interrupt = bool_to_bits(trapCause_is_interrupt(c));
-  let cause        = zero_extend(xlen - 1, trapCause_bits(c));
-
   match (del_priv) {
     Machine => {
-      mcause[IsInterrupt] = is_interrupt;
-      mcause[Cause]       = cause;
+      mcause[IsInterrupt] = bool_to_bits(is_interrupt);
+      mcause[Cause]       = zero_extend(cause);
 
       mstatus[MPIE] = mstatus[MIE];
       mstatus[MIE]  = 0b0;
@@ -188,8 +188,8 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
     Supervisor => {
       assert (currentlyEnabled(Ext_S), "no supervisor mode present for delegation");
 
-      scause[IsInterrupt] = is_interrupt;
-      scause[Cause]       = cause;
+      scause[IsInterrupt] = bool_to_bits(is_interrupt);
+      scause[Cause]       = zero_extend(cause);
 
       mstatus[SPIE] = mstatus[SIE];
       mstatus[SIE]  = 0b0;


### PR DESCRIPTION
This adds a few state change callbacks that we needed for an internal binary logging format. They aren't used by the RVFI or log callback handlers but they should also be useful for the open source binary logging format that we eventually add (#545).

* Add a `fetch_callback` that says which instruction was executed (if any).
* Add `redirect_callback` that is called for taken and unconditional branches.
* Add `is_interrupt` and `cause` to `trap_callback`.

I also renamed `value` to `new_pc` to be a bit more explicit.

Fixes #1352