### PR TITLE
Refactor immediates in encoding clauses for readability.

### DIFF
--- a/model/extensions/C/zca_insts.sail
+++ b/model/extensions/C/zca_insts.sail
@@ -16,7 +16,7 @@
 union clause instruction = C_NOP : (bits(6))
 
 mapping clause encdec_compressed = C_NOP(imm)
-  <-> 0b000 @ imm[5] : bits(1) @ 0b00000 @ imm[4..0] : bits(5) @ 0b01
+  <-> 0b000 @ imm[5] @ 0b00000 @ imm[4..0] @ 0b01
   when currentlyEnabled(Ext_Zca)
 
 function clause execute C_NOP(_) = RETIRE_SUCCESS
@@ -56,7 +56,7 @@ mapping clause assembly = C_ADDI4SPN(rdc, nzimm)
 union clause instruction = C_LW : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_LW(uimm, rs1, rd)
-  <-> 0b010 @ uimm[3..1] : bits(3) @ encdec_creg(rs1) @ uimm[0] : bits(1) @ uimm[4] : bits(1) @ encdec_creg(rd) @ 0b00
+  <-> 0b010 @ uimm[3..1] @ encdec_creg(rs1) @ uimm[0] @ uimm[4] @ encdec_creg(rd) @ 0b00
   when currentlyEnabled(Ext_Zca)
 
 function clause execute C_LW(uimm, rsc, rdc) = {
@@ -73,7 +73,7 @@ mapping clause assembly = C_LW(uimm, rsc, rdc)
 union clause instruction = C_LD : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_LD(uimm, rs1, rd)
-  <-> 0b011 @ uimm[2..0] : bits(3) @ encdec_creg(rs1) @ uimm[4..3] : bits(2) @ encdec_creg(rd) @ 0b00
+  <-> 0b011 @ uimm[2..0] @ encdec_creg(rs1) @ uimm[4..3] @ encdec_creg(rd) @ 0b00
   when xlen == 64 & currentlyEnabled(Ext_Zca)
 
 function clause execute C_LD(uimm, rsc, rdc) = {
@@ -91,7 +91,7 @@ mapping clause assembly = C_LD(uimm, rsc, rdc)
 union clause instruction = C_SW : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SW(uimm, rs1, rs2)
-  <-> 0b110 @ uimm[3..1] : bits(3) @ encdec_creg(rs1) @ uimm[0] : bits(1) @ uimm[4] : bits(1) @ encdec_creg(rs2) @ 0b00
+  <-> 0b110 @ uimm[3..1] @ encdec_creg(rs1) @ uimm[0] @ uimm[4] @ encdec_creg(rs2) @ 0b00
   when currentlyEnabled(Ext_Zca)
 
 function clause execute C_SW(uimm, rsc1, rsc2) = {
@@ -108,7 +108,7 @@ mapping clause assembly = C_SW(uimm, rsc1, rsc2)
 union clause instruction = C_SD : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SD(uimm, rs1, rs2)
-  <-> 0b111 @ uimm[2..0] : bits(3) @ encdec_creg(rs1) @ uimm[4..3] : bits(2) @ encdec_creg(rs2) @ 0b00
+  <-> 0b111 @ uimm[2..0] @ encdec_creg(rs1) @ uimm[4..3] @ encdec_creg(rs2) @ 0b00
   when xlen == 64 & currentlyEnabled(Ext_Zca)
 
 function clause execute C_SD(uimm, rsc1, rsc2) = {
@@ -128,7 +128,7 @@ union clause instruction = C_ADDI : (bits(6), regidx)
 // Code points with rsd=x0 are c.nop.
 // c.addi with imm=0 are hints.
 mapping clause encdec_compressed = C_ADDI(imm, rsd)
-  <-> 0b000 @ imm[5] : bits(1) @ encdec_reg(rsd) @ imm[4..0] : bits(5) @ 0b01
+  <-> 0b000 @ imm[5] @ encdec_reg(rsd) @ imm[4..0] @ 0b01
   when rsd != zreg & currentlyEnabled(Ext_Zca)
 
 function clause execute C_ADDI(imm, rsd) = {
@@ -144,7 +144,7 @@ mapping clause assembly = C_ADDI(imm, rsd)
 union clause instruction = C_JAL : (bits(11))
 
 mapping clause encdec_compressed = C_JAL(imm)
-  <-> 0b001 @ imm[10] : bits(1) @ imm[3] : bits(1) @ imm[8..7] : bits(2) @ imm[9] : bits(1) @ imm[5] : bits(1) @ imm[6] : bits(1) @ imm[2..0] : bits(3) @ imm[4] : bits(1) @ 0b01
+  <-> 0b001 @ imm[10] @ imm[3] @ imm[8..7] @ imm[9] @ imm[5] @ imm[6] @ imm[2..0] @ imm[4] @ 0b01
   when xlen == 32 & currentlyEnabled(Ext_Zca)
 
 function clause execute C_JAL(imm) =
@@ -158,7 +158,7 @@ mapping clause assembly = C_JAL(imm)
 union clause instruction = C_ADDIW : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_ADDIW(imm, rsd)
-  <-> 0b001 @ imm[5] : bits(1) @ encdec_reg(rsd) @ imm[4..0] : bits(5) @ 0b01
+  <-> 0b001 @ imm[5] @ encdec_reg(rsd) @ imm[4..0] @ 0b01
   when rsd != zreg & xlen == 64 & currentlyEnabled(Ext_Zca)
 
 function clause execute C_ADDIW(imm, rsd) =
@@ -173,7 +173,7 @@ union clause instruction = C_LI : (bits(6), regidx)
 
 // c.li with rd=x0 are hints.
 mapping clause encdec_compressed = C_LI(imm, rd)
-  <-> 0b010 @ imm[5] : bits(1) @ encdec_reg(rd) @ imm[4..0] : bits(5) @ 0b01
+  <-> 0b010 @ imm[5] @ encdec_reg(rd) @ imm[4..0] @ 0b01
   when currentlyEnabled(Ext_Zca)
 
 function clause execute C_LI(imm, rd) = {
@@ -276,7 +276,7 @@ union clause instruction = C_ANDI : (bits(6), cregidx)
 
 $[wavedrom "C.ANDI imm[5] C.ANDI dest imm[4:0] C1"]
 mapping clause encdec_compressed = C_ANDI(imm, rsd)
-  <-> 0b100 @ imm[5] : bits(1) @ 0b10 @ encdec_creg(rsd) @ imm[4..0] : bits(5) @ 0b01
+  <-> 0b100 @ imm[5] @ 0b10 @ encdec_creg(rsd) @ imm[4..0] @ 0b01
   when currentlyEnabled(Ext_Zca)
 
 function clause execute C_ANDI(imm, rsd) = {
@@ -389,7 +389,7 @@ mapping clause assembly = C_ADDW(rsd, rs2)
 union clause instruction = C_J : (bits(11))
 
 mapping clause encdec_compressed = C_J(imm)
-  <-> 0b101 @ imm[10] : bits(1) @ imm[3] : bits(1) @ imm[8..7] : bits(2) @ imm[9] : bits(1) @ imm[5] : bits(1) @ imm[6] : bits(1) @ imm[2..0] : bits(3) @ imm[4] : bits(1) @ 0b01
+  <-> 0b101 @ imm[10] @ imm[3] @ imm[8..7] @ imm[9] @ imm[5] @ imm[6] @ imm[2..0] @ imm[4] @ 0b01
   when currentlyEnabled(Ext_Zca)
 
 function clause execute C_J(imm) =
@@ -402,7 +402,7 @@ mapping clause assembly = C_J(imm)
 union clause instruction = C_BEQZ : (bits(8), cregidx)
 
 mapping clause encdec_compressed = C_BEQZ(imm, rs)
-  <-> 0b110 @ imm[7] : bits(1) @ imm[3..2] : bits(2) @ encdec_creg(rs) @ imm[6..5] : bits(2) @ imm[1..0] : bits(2) @ imm[4] : bits(1) @ 0b01
+  <-> 0b110 @ imm[7] @ imm[3..2] @ encdec_creg(rs) @ imm[6..5] @ imm[1..0] @ imm[4] @ 0b01
   when currentlyEnabled(Ext_Zca)
 
 function clause execute C_BEQZ(imm, rs) =
@@ -415,7 +415,7 @@ mapping clause assembly = C_BEQZ(imm, rs)
 union clause instruction = C_BNEZ : (bits(8), cregidx)
 
 mapping clause encdec_compressed = C_BNEZ(imm, rs)
-  <-> 0b111 @ imm[7] : bits(1) @ imm[3..2] : bits(2) @ encdec_creg(rs) @ imm[6..5] : bits(2) @ imm[1..0] : bits(2) @ imm[4] : bits(1) @ 0b01
+  <-> 0b111 @ imm[7] @ imm[3..2] @ encdec_creg(rs) @ imm[6..5] @ imm[1..0] @ imm[4] @ 0b01
   when currentlyEnabled(Ext_Zca)
 
 function clause execute C_BNEZ(imm, rs) =
@@ -448,7 +448,7 @@ mapping clause assembly = C_SLLI(shamt, rsd)
 union clause instruction = C_LWSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_LWSP(uimm, rd)
-  <-> 0b010 @ uimm[3] : bits(1) @ encdec_reg(rd) @ uimm[2..0] : bits(3) @ uimm[5..4] : bits(2) @ 0b10
+  <-> 0b010 @ uimm[3] @ encdec_reg(rd) @ uimm[2..0] @ uimm[5..4] @ 0b10
   when rd != zreg & currentlyEnabled(Ext_Zca)
 
 function clause execute C_LWSP(uimm, rd) = {
@@ -464,7 +464,7 @@ mapping clause assembly = C_LWSP(uimm, rd)
 union clause instruction = C_LDSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_LDSP(uimm, rd)
-  <-> 0b011 @ uimm[2] : bits(1) @ encdec_reg(rd) @ uimm[1..0] : bits(2) @ uimm[5..3] : bits(3) @ 0b10
+  <-> 0b011 @ uimm[2] @ encdec_reg(rd) @ uimm[1..0] @ uimm[5..3] @ 0b10
   when rd != zreg & xlen == 64 & currentlyEnabled(Ext_Zca)
 
 function clause execute C_LDSP(uimm, rd) = {
@@ -480,7 +480,7 @@ mapping clause assembly = C_LDSP(uimm, rd)
 union clause instruction = C_SWSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_SWSP(uimm, rs2)
-  <-> 0b110 @ uimm[3..0] : bits(4) @ uimm[5..4] : bits(2) @ encdec_reg(rs2) @ 0b10
+  <-> 0b110 @ uimm[3..0] @ uimm[5..4] @ encdec_reg(rs2) @ 0b10
   when currentlyEnabled(Ext_Zca)
 
 function clause execute C_SWSP(uimm, rs2) = {
@@ -495,7 +495,7 @@ mapping clause assembly = C_SWSP(uimm, rs2)
 union clause instruction = C_SDSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_SDSP(uimm, rs2)
-  <-> 0b111 @ uimm[2..0] : bits(3) @ uimm[5..3] : bits(3) @ encdec_reg(rs2) @ 0b10
+  <-> 0b111 @ uimm[2..0] @ uimm[5..3] @ encdec_reg(rs2) @ 0b10
   when xlen == 64 & currentlyEnabled(Ext_Zca)
 
 function clause execute C_SDSP(uimm, rs2) = {

--- a/model/extensions/C/zcb_insts.sail
+++ b/model/extensions/C/zcb_insts.sail
@@ -12,7 +12,7 @@ union clause instruction = C_LBU : (bits(2), cregidx, cregidx)
 
 $[wavedrom "FUNCT3 _ _ _ _ _ C0"]
 mapping clause encdec_compressed = C_LBU(uimm, rdc, rsc1)
-  <-> 0b100 @ 0b000 @ encdec_creg(rsc1) @ uimm[0] : bits(1) @ uimm[1] : bits(1) @ encdec_creg(rdc) @ 0b00
+  <-> 0b100 @ 0b000 @ encdec_creg(rsc1) @ uimm[0] @ uimm[1] @ encdec_creg(rdc) @ 0b00
   when currentlyEnabled(Ext_Zcb)
 
 mapping clause assembly = C_LBU(uimm, rdc, rsc1) <->
@@ -69,7 +69,7 @@ union clause instruction = C_SB : (bits(2), cregidx, cregidx)
 
 $[wavedrom "FUNCT3 _ _ _ _ _ C0"]
 mapping clause encdec_compressed = C_SB(uimm, rsc1, rsc2)
-  <-> 0b100 @ 0b010 @ encdec_creg(rsc1) @ uimm[0] : bits(1) @ uimm[1] : bits(1) @ encdec_creg(rsc2) @ 0b00
+  <-> 0b100 @ 0b010 @ encdec_creg(rsc1) @ uimm[0] @ uimm[1] @ encdec_creg(rsc2) @ 0b00
   when currentlyEnabled(Ext_Zcb)
 
 mapping clause assembly = C_SB(uimm, rsc1, rsc2) <->

--- a/model/extensions/FD/fext_insts.sail
+++ b/model/extensions/FD/fext_insts.sail
@@ -303,7 +303,7 @@ union clause instruction = STORE_FP : (bits(12), fregidx, regidx, word_width)
 
 $[wavedrom "offset[11:5] src base _ _ offset[4:0] STORE-FP"]
 mapping clause encdec = STORE_FP(imm, rs2, rs1, width)
-  <-> imm[11..5] : bits(7) @ encdec_freg(rs2) @ encdec_reg(rs1) @ 0b0 @ width_enc(width) @ imm[4..0] : bits(5) @ 0b010_0111
+  <-> imm[11..5] @ encdec_freg(rs2) @ encdec_reg(rs1) @ 0b0 @ width_enc(width) @ imm[4..0] @ 0b010_0111
   when float_load_store_width_supported(width)
 
 // Execution semantics ================================

--- a/model/extensions/FD/zcd_insts.sail
+++ b/model/extensions/FD/zcd_insts.sail
@@ -11,7 +11,7 @@ function clause currentlyEnabled(Ext_Zcd) = hartSupports(Ext_Zcd) & currentlyEna
 union clause instruction = C_FLDSP : (bits(6), fregidx)
 
 mapping clause encdec_compressed = C_FLDSP(uimm, rd)
-  <-> 0b001 @ uimm[2] : bits(1) @ encdec_freg(rd) @ uimm[1..0] : bits(2) @ uimm[5..3] : bits(3) @ 0b10
+  <-> 0b001 @ uimm[2] @ encdec_freg(rd) @ uimm[1..0] @ uimm[5..3] @ 0b10
   when currentlyEnabled(Ext_Zcd)
 
 function clause execute C_FLDSP(uimm, rd) = {
@@ -26,7 +26,7 @@ mapping clause assembly = C_FLDSP(uimm, rd)
 union clause instruction = C_FSDSP : (bits(6), fregidx)
 
 mapping clause encdec_compressed = C_FSDSP(uimm, rs2)
-  <-> 0b101 @ uimm[2..0] : bits(3) @ uimm[5..3] : bits(3) @ encdec_freg(rs2) @ 0b10
+  <-> 0b101 @ uimm[2..0] @ uimm[5..3] @ encdec_freg(rs2) @ 0b10
   when currentlyEnabled(Ext_Zcd)
 
 function clause execute C_FSDSP(uimm, rs2) = {
@@ -41,7 +41,7 @@ mapping clause assembly = C_FSDSP(uimm, rs2)
 union clause instruction = C_FLD : (bits(5), cregidx, cfregidx)
 
 mapping clause encdec_compressed = C_FLD(uimm, rs1, rd)
-  <-> 0b001 @ uimm[2..0] : bits(3) @ encdec_creg(rs1) @ uimm[4..3] : bits(2) @ encdec_cfreg(rd) @ 0b00
+  <-> 0b001 @ uimm[2..0] @ encdec_creg(rs1) @ uimm[4..3] @ encdec_cfreg(rd) @ 0b00
   when currentlyEnabled(Ext_Zcd)
 
 function clause execute C_FLD(uimm, rsc, rdc) = {
@@ -58,7 +58,7 @@ mapping clause assembly = C_FLD(uimm, rsc, rdc)
 union clause instruction = C_FSD : (bits(5), cregidx, cfregidx)
 
 mapping clause encdec_compressed = C_FSD(uimm, rs1, rs2)
-  <-> 0b101 @ uimm[2..0] : bits(3) @ encdec_creg(rs1) @ uimm[4..3] : bits(2) @ encdec_cfreg(rs2) @ 0b00
+  <-> 0b101 @ uimm[2..0] @ encdec_creg(rs1) @ uimm[4..3] @ encdec_cfreg(rs2) @ 0b00
   when currentlyEnabled(Ext_Zcd)
 
 function clause execute C_FSD(uimm, rsc1, rsc2) = {

--- a/model/extensions/FD/zcf_insts.sail
+++ b/model/extensions/FD/zcf_insts.sail
@@ -11,7 +11,7 @@ function clause currentlyEnabled(Ext_Zcf) = hartSupports(Ext_Zcf) & currentlyEna
 union clause instruction = C_FLWSP : (bits(6), fregidx)
 
 mapping clause encdec_compressed = C_FLWSP(uimm, rd)
-  <-> 0b011 @ uimm[3] : bits(1) @ encdec_freg(rd) @ uimm[2..0] : bits(3) @ uimm[5..4] : bits(2) @ 0b10
+  <-> 0b011 @ uimm[3] @ encdec_freg(rd) @ uimm[2..0] @ uimm[5..4] @ 0b10
   when currentlyEnabled(Ext_Zcf)
 
 function clause execute C_FLWSP(imm, rd) = {
@@ -27,7 +27,7 @@ mapping clause assembly = C_FLWSP(imm, rd)
 union clause instruction = C_FSWSP : (bits(6), fregidx)
 
 mapping clause encdec_compressed = C_FSWSP(uimm, rs2)
-  <-> 0b111 @ uimm[3..0] : bits(4) @ uimm[5..4] : bits(2) @ encdec_freg(rs2) @ 0b10
+  <-> 0b111 @ uimm[3..0] @ uimm[5..4] @ encdec_freg(rs2) @ 0b10
   when currentlyEnabled(Ext_Zcf)
 
 function clause execute C_FSWSP(uimm, rs2) = {
@@ -43,7 +43,7 @@ mapping clause assembly = C_FSWSP(uimm, rs2)
 union clause instruction = C_FLW : (bits(5), cregidx, cfregidx)
 
 mapping clause encdec_compressed = C_FLW(uimm, rs1, rd)
-  <-> 0b011 @ uimm[3..1] : bits(3) @ encdec_creg(rs1) @ uimm[0] : bits(1) @ uimm[4] : bits(1) @ encdec_cfreg(rd) @ 0b00
+  <-> 0b011 @ uimm[3..1] @ encdec_creg(rs1) @ uimm[0] @ uimm[4] @ encdec_cfreg(rd) @ 0b00
   when currentlyEnabled(Ext_Zcf)
 
 function clause execute C_FLW(uimm, rsc, rdc) = {
@@ -61,7 +61,7 @@ mapping clause assembly = C_FLW(uimm, rsc, rdc)
 union clause instruction = C_FSW : (bits(5), cregidx, cfregidx)
 
 mapping clause encdec_compressed = C_FSW(uimm, rs1, rs2)
-  <-> 0b111 @ uimm[3..1] : bits(3) @ encdec_creg(rs1) @ uimm[0] : bits(1) @ uimm[4] : bits(1) @ encdec_cfreg(rs2) @ 0b00
+  <-> 0b111 @ uimm[3..1] @ encdec_creg(rs1) @ uimm[0] @ uimm[4] @ encdec_cfreg(rs2) @ 0b00
   when currentlyEnabled(Ext_Zcf)
 
 function clause execute C_FSW(uimm, rsc1, rsc2) = {

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -70,7 +70,7 @@ function jump_to(target : xlenbits) -> ExecutionResult = {
 union clause instruction = JAL : (bits(21), regidx)
 $[wavedrom "_ offset[20:1] _ _ dest JAL"]
 mapping clause encdec = JAL(imm @ 0b0, rd)
-  <-> imm[19] : bits(1) @ imm[9..0] : bits(10) @ imm[10] : bits(1) @ imm[18..11] : bits(8) @ encdec_reg(rd) @ 0b1101111
+  <-> imm[19] @ imm[9..0] @ imm[10] @ imm[18..11] @ encdec_reg(rd) @ 0b1101111
 
 function clause execute JAL(imm, rd) = {
   let link_address = get_next_pc();
@@ -110,7 +110,7 @@ mapping encdec_bop : bop <-> bits(3) = {
 }
 
 mapping clause encdec = BTYPE(imm @ 0b0, rs2, rs1, op)
-  <-> imm[11] : bits(1) @ imm[9..4] : bits(6) @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_bop(op) @ imm[3..0] : bits(4) @ imm[10] : bits(1) @ 0b1100011
+  <-> imm[11] @ imm[9..4] @ encdec_reg(rs2) @ encdec_reg(rs1) @ encdec_bop(op) @ imm[3..0] @ imm[10] @ 0b1100011
 
 $[split op]
 function clause execute BTYPE(imm, rs2, rs1, op) = {
@@ -310,7 +310,7 @@ union clause instruction = STORE : (bits(12), regidx, regidx, word_width)
 
 $[wavedrom "offset[11:5] src base _ width offset[4:0] STORE"]
 mapping clause encdec = STORE(imm, rs2, rs1, width)
-  <-> imm[11..5] : bits(7) @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ width_enc(width) @ imm[4..0] : bits(5) @ 0b0100011
+  <-> imm[11..5] @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b0 @ width_enc(width) @ imm[4..0] @ 0b0100011
   when width <= xlen_bytes
 
 function clause execute STORE(imm, rs2, rs1, width) = {

--- a/model/extensions/vector_crypto/zvbb_insts.sail
+++ b/model/extensions/vector_crypto/zvbb_insts.sail
@@ -482,7 +482,7 @@ union clause instruction = VROR_VI : (bits(1), vregidx, bits(6), vregidx)
 
 $[wavedrom "_ _ _ _ _ OPIVI _ OP-V"]
 mapping clause encdec = VROR_VI(vm, vs2, uimm, vd)
-  <-> 0b01010 @ uimm[5] @ vm @ encdec_vreg(vs2) @ uimm[4..0] : bits(5) @ 0b011 @ encdec_vreg(vd) @ 0b1010111
+  <-> 0b01010 @ uimm[5] @ vm @ encdec_vreg(vs2) @ uimm[4..0] @ 0b011 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvkb) & (get_sew() <= 32 | (get_sew() == 64 & currentlyEnabled(Ext_Zve64x)))
 
 mapping clause assembly = VROR_VI(vm, vs2, uimm, vd)


### PR DESCRIPTION
Use indices into immediates instead of building the immediate from concatenated parts. 
Not all cases could be handled due to a Sail compiler bug: rems-project/sail#1540.

Addresses #1339.