### PR TITLE
Provide default callback implementations

### DIFF
--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -13,34 +13,52 @@ public:
   virtual void mem_write_callback([[maybe_unused]] const char *type,
                                   [[maybe_unused]] sbits paddr,
                                   [[maybe_unused]] uint64_t width,
-                                  [[maybe_unused]] lbits value) { }
+                                  [[maybe_unused]] lbits value)
+  {
+  }
   virtual void mem_read_callback([[maybe_unused]] const char *type,
                                  [[maybe_unused]] sbits paddr,
                                  [[maybe_unused]] uint64_t width,
-                                 [[maybe_unused]] lbits value) { }
+                                 [[maybe_unused]] lbits value)
+  {
+  }
   virtual void
   mem_exception_callback([[maybe_unused]] sbits paddr,
-                         [[maybe_unused]] uint64_t num_of_exception) { }
+                         [[maybe_unused]] uint64_t num_of_exception)
+  {
+  }
   virtual void
   xreg_full_write_callback([[maybe_unused]] const_sail_string abi_name,
                            [[maybe_unused]] sbits reg,
-                           [[maybe_unused]] sbits value) { }
+                           [[maybe_unused]] sbits value)
+  {
+  }
   virtual void freg_write_callback([[maybe_unused]] unsigned reg,
-                                   [[maybe_unused]] sbits value) { }
+                                   [[maybe_unused]] sbits value)
+  {
+  }
   virtual void
   csr_full_write_callback([[maybe_unused]] const_sail_string csr_name,
                           [[maybe_unused]] unsigned reg,
-                          [[maybe_unused]] sbits value) { }
+                          [[maybe_unused]] sbits value)
+  {
+  }
   virtual void
   csr_full_read_callback([[maybe_unused]] const_sail_string csr_name,
                          [[maybe_unused]] unsigned reg,
-                         [[maybe_unused]] sbits value) { }
+                         [[maybe_unused]] sbits value)
+  {
+  }
   virtual void vreg_write_callback([[maybe_unused]] unsigned reg,
-                                   [[maybe_unused]] lbits value) { }
+                                   [[maybe_unused]] lbits value)
+  {
+  }
   virtual void pc_write_callback([[maybe_unused]] sbits new_pc) { }
   virtual void redirect_callback([[maybe_unused]] sbits new_pc) { }
   virtual void trap_callback([[maybe_unused]] bool is_interrupt,
-                             [[maybe_unused]] fbits cause) { }
+                             [[maybe_unused]] fbits cause)
+  {
+  }
 };
 
 void register_callback(callbacks_if *cb);

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -31,11 +31,6 @@ log_callbacks::log_callbacks(bool config_print_reg,
 // Implementations of default callbacks for trace printing.
 // The model assumes that these functions do not change the state of the model.
 
-// void log_callbacks::fetch_callback(sbits opcode)
-// {
-//   (void)opcode;
-// }
-
 void log_callbacks::mem_write_callback(const char *type, sbits paddr,
                                        uint64_t width, lbits value)
 {
@@ -55,8 +50,6 @@ void log_callbacks::mem_read_callback(const char *type, sbits paddr,
     print_lbits_hex(trace_log, value, width);
   }
 }
-
-// void log_callbacks::mem_exception_callback(sbits, uint64_t) { }
 
 void log_callbacks::xreg_full_write_callback(const_sail_string abi_name,
                                              sbits reg, sbits value)
@@ -108,19 +101,3 @@ void log_callbacks::vreg_write_callback(unsigned reg, lbits value)
     print_lbits_hex(trace_log, value);
   }
 }
-
-// void log_callbacks::pc_write_callback(sbits new_pc)
-// {
-//   (void)new_pc;
-// }
-
-// void log_callbacks::redirect_callback(sbits new_pc)
-// {
-//   (void)new_pc;
-// }
-
-// void log_callbacks::trap_callback(bool is_interrupt, fbits cause)
-// {
-//   (void)is_interrupt;
-//   (void)cause;
-// }

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -10,13 +10,10 @@ public:
                 bool config_use_abi_names = false, FILE *trace_log = nullptr);
 
   // callbacks_if
-  // void fetch_callback(sbits opcode) override;
   void mem_write_callback(const char *type, sbits paddr, uint64_t width,
                           lbits value) override;
   void mem_read_callback(const char *type, sbits paddr, uint64_t width,
                          lbits value) override;
-  // void mem_exception_callback(sbits paddr, uint64_t num_of_exception)
-  // override;
   void xreg_full_write_callback(const_sail_string abi_name, sbits reg,
                                 sbits value) override;
   void freg_write_callback(unsigned reg, sbits value) override;
@@ -25,9 +22,6 @@ public:
   void csr_full_read_callback(const_sail_string csr_name, unsigned reg,
                               sbits value) override;
   void vreg_write_callback(unsigned reg, lbits value) override;
-  // void pc_write_callback(sbits new_pc) override;
-  // void redirect_callback(sbits new_pc) override;
-  // void trap_callback(bool is_interrupt, fbits cause) override;
 
 private:
   bool config_print_reg;

--- a/c_emulator/riscv_callbacks_rvfi.cpp
+++ b/c_emulator/riscv_callbacks_rvfi.cpp
@@ -6,10 +6,6 @@
 
 // Implementations of default callbacks for RVFI.
 // The model assumes that these functions do not change the state of the model.
-// void rvfi_callbacks::fetch_callback(sbits opcode)
-// {
-//   (void)opcode;
-// }
 
 void rvfi_callbacks::mem_write_callback(const char *, sbits paddr,
                                         uint64_t width, lbits value)
@@ -45,30 +41,6 @@ void rvfi_callbacks::xreg_full_write_callback(const_sail_string, sbits reg,
     zrvfi_wX(reg.bits, value);
   }
 }
-
-// void rvfi_callbacks::freg_write_callback(unsigned, sbits) { }
-
-// void rvfi_callbacks::csr_full_write_callback(const_sail_string, unsigned,
-// sbits)
-// {
-// }
-
-// void rvfi_callbacks::csr_full_read_callback(const_sail_string, unsigned,
-// sbits)
-// {
-// }
-
-// void rvfi_callbacks::vreg_write_callback(unsigned, lbits) { }
-
-// void rvfi_callbacks::pc_write_callback(sbits new_pc)
-// {
-//   (void)new_pc;
-// }
-
-// void rvfi_callbacks::redirect_callback(sbits new_pc)
-// {
-//   (void)new_pc;
-// }
 
 void rvfi_callbacks::trap_callback(bool is_interrupt, fbits cause)
 {

--- a/c_emulator/riscv_callbacks_rvfi.h
+++ b/c_emulator/riscv_callbacks_rvfi.h
@@ -6,7 +6,6 @@ class rvfi_callbacks : public callbacks_if {
 
 public:
   // callbacks_if
-  // void fetch_callback(sbits opcode) override;
   void mem_write_callback(const char *type, sbits paddr, uint64_t width,
                           lbits value) override;
   void mem_read_callback(const char *type, sbits paddr, uint64_t width,
@@ -14,16 +13,6 @@ public:
   void mem_exception_callback(sbits paddr, uint64_t num_of_exception) override;
   void xreg_full_write_callback(const_sail_string abi_name, sbits reg,
                                 sbits value) override;
-  // void freg_write_callback(unsigned reg, sbits value) override;
-  // void csr_full_write_callback(const_sail_string csr_name, unsigned reg,sbits
-  // value) override;
-
-  // void csr_full_read_callback(const_sail_string csr_name, unsigned reg,sbits
-  // value) override;
-
-  // void vreg_write_callback(unsigned reg, lbits value) override;
-  // void pc_write_callback(sbits new_pc) override;
-  // void redirect_callback(sbits new_pc) override;
   void trap_callback(bool is_interrupt, fbits cause) override;
 };
 


### PR DESCRIPTION
Remove callbacks which are empty. Add default implementation in base class.