### PR TITLE
Add new sail_smt_cache to git ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ z3_problems
 /build
 # CMake build directories used by CLion.
 /cmake-build-*
+# z3 cache
+sail_smt_cache


### PR DESCRIPTION
`z3_problems` was renamed to the slightly more descriptive `sail_smt_cache` in the latest versions of the Sail compiler.