### PR TITLE
Fix htif memory range check

### DIFF
--- a/model/sys/platform.sail
+++ b/model/sys/platform.sail
@@ -50,7 +50,7 @@ function within_clint forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : ph
 function within_htif_writable forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : physaddr, width : int('n)) -> bool =
   match htif_tohost_base {
     None() => false,
-    Some(base) => (addr <_u base + htif_tohost_size) & (addr + width >=_u base)
+    Some(base) => (addr <_u base + htif_tohost_size) & (addr + width >_u base)
   }
 
 function within_htif_readable forall 'n, 0 < 'n <= max_mem_access . (addr : physaddr, width : int('n)) -> bool =


### PR DESCRIPTION
Previously an access that *just* touched the bottom of HTIF would have incorrectly been counted as within HTIF. E.g. if HTIF is at 0x8 and you do a 4-byte access to 0x4.