### PR TITLE
Add option not to download jsoncons

### DIFF
--- a/coq-sail-riscv.opam
+++ b/coq-sail-riscv.opam
@@ -8,7 +8,8 @@ bug-reports: "https://github.com/riscv/sail-riscv/issues"
 license: "BSD-2-Clause"
 dev-repo: "git+https://github.com/riscv/sail-riscv.git"
 build: [
-  ["cmake" "-S" "." "-B" "build" "-DCMAKE_BUILD_TYPE=RelWithDebInfo" "-DDOWNLOAD_GMP=FALSE" "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"]
+  # Turn off all downloads for sandboxing; they're not required for the Rocq build anyway
+  ["cmake" "-S" "." "-B" "build" "-DCMAKE_BUILD_TYPE=RelWithDebInfo" "-DDOWNLOAD_GMP=FALSE" "-DDOWNLOAD_JSONCONS=FALSE"]
   ["cmake" "--build" "build" "--target" "build_rocq_rv64d" "build_rocq_rv32d"]
 ]
 install: [

--- a/dependencies/jsoncons/CMakeLists.txt
+++ b/dependencies/jsoncons/CMakeLists.txt
@@ -1,5 +1,8 @@
 include(FetchContent)
 
+# Allow downloads to be turned off (in particular, for targets that don't need it).
+option(DOWNLOAD_JSONCONS "Download jsoncons" ON)
+
 # The jsoncons `unit_tests` target conflicts with our own.
 set(JSONCONS_BUILD_TESTS OFF)
 
@@ -9,4 +12,6 @@ FetchContent_Declare(
   URL_HASH SHA3_256=7AE49B206A2D271C4B1A122824FA76EFAAD91703F3124AC7A66A26D1EEA1D07E
 )
 
-FetchContent_MakeAvailable(jsoncons)
+if (DOWNLOAD_JSONCONS)
+    FetchContent_MakeAvailable(jsoncons)
+endif()


### PR DESCRIPTION
Replaces a previous hack to avoid a download in the Rocq opam package for compatibility with recent versions of cmake.

An alternative to this would be to use `ExternalProject` in the same way that the GMP support works, but that would be a little more involved and change the timing of the download from configure-time to build-time.