### PR TITLE
Add configurations for page-fault traps that could set mtval.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -21,7 +21,7 @@
       "fetch_access_fault": true,
       "fetch_page_fault": true,
       "software_check": true,
-      "reserved_faults": false
+      "reserved_exceptions": false
     }
   },
   "memory": {

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -289,7 +289,10 @@ function xtval_exception_value(e : ExceptionType, excinfo : xlenbits) -> option(
     E_M_EnvCall() => false,
     E_Extension(_) => true,
     // the rest are all reserved exceptions
-    _ => config base.xtval_nonzero.reserved_faults,
+    E_Reserved_10() => config base.xtval_nonzero.reserved_exceptions,
+    E_Reserved_14() => config base.xtval_nonzero.reserved_exceptions,
+    E_Reserved_16() => config base.xtval_nonzero.reserved_exceptions,
+    E_Reserved_17() => config base.xtval_nonzero.reserved_exceptions,
   } then Some(excinfo) else None()
 }
 


### PR DESCRIPTION
These were missed in #1225, and are needed for Sstvala.