### PR TITLE
Rename some page table walk error results for clarity.

### DIFF
--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -244,7 +244,7 @@ function translate_TLB_hit forall 'v, is_sv_mode('v) . (
           // Step 9 of VATP. See platform.sail.
           if not(plat_enable_dirty_update) then
             // pte needs dirty/accessed update but that is not enabled
-            Err(PTW_PTE_Update(), ext_ptw)
+            Err(PTW_PTE_Needs_Update(), ext_ptw)
           else {
             // Writeback the PTE (which has new A/D bits)
             write_TLB(tlb_index, tlb_set_pte(ent, pte'));
@@ -292,7 +292,7 @@ function translate_TLB_miss forall 'v, is_sv_mode('v) . (
           // Step 9 of VATP. See platform.sail.
           if not(plat_enable_dirty_update) then
             // pte needs dirty/accessed update but that is not enabled
-            Err(PTW_PTE_Update(), ext_ptw)
+            Err(PTW_PTE_Needs_Update(), ext_ptw)
           else {
             // Writeback the PTE (which has new A/D bits)
             match write_pte(pteAddr, pte_size, pte) {

--- a/model/sys/vmem_ptw.sail
+++ b/model/sys/vmem_ptw.sail
@@ -15,25 +15,25 @@
 // Failure modes for address-translation/page-table-walks
 // PRIVATE
 union PTW_Error = {
-  PTW_Invalid_Addr  : unit,          // invalid source address
-  PTW_No_Access     : unit,          // physical memory access error for a PTE
-  PTW_Invalid_PTE   : unit,
-  PTW_No_Permission : unit,
-  PTW_Misaligned    : unit,          // misaligned superpage
-  PTW_PTE_Update    : unit,          // PTE update needed but not enabled
-  PTW_Ext_Error     : ext_ptw_error  // parameterized for errors from extensions
+  PTW_Invalid_Addr     : unit,          // invalid source address
+  PTW_No_Access        : unit,          // physical memory access error for a PTE
+  PTW_Invalid_PTE      : unit,
+  PTW_No_Permission    : unit,
+  PTW_Misaligned       : unit,          // misaligned superpage
+  PTW_PTE_Needs_Update : unit,          // PTE update needed but not enabled
+  PTW_Ext_Error        : ext_ptw_error  // parameterized for errors from extensions
 }
 
 // PRIVATE: only 'to_str' overload is public
 function ptw_error_to_str(e : PTW_Error) -> string = {
   match e {
-    PTW_Invalid_Addr()   => "invalid-source-addr",
-    PTW_No_Access()      => "mem-access-error",
-    PTW_Invalid_PTE()    => "invalid-pte",
-    PTW_No_Permission()  => "no-permission",
-    PTW_Misaligned()     => "misaligned-superpage",
-    PTW_PTE_Update()     => "pte-update-needed",
-    PTW_Ext_Error(e)     => "extension-error"
+    PTW_Invalid_Addr()     => "invalid-source-addr",
+    PTW_No_Access()        => "mem-access-error",
+    PTW_Invalid_PTE()      => "invalid-pte",
+    PTW_No_Permission()    => "no-permission",
+    PTW_Misaligned()       => "misaligned-superpage",
+    PTW_PTE_Needs_Update() => "pte-update-needed",
+    PTW_Ext_Error(e)       => "extension-error"
   }
 }
 


### PR DESCRIPTION
- `PTW_Access` -> `PTW_No_Access`
- `PTW_PTE_Update` -> `PTW_PTE_Needs_Update`