### PR TITLE
Improved clang-format style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,13 +1,37 @@
 Language: Cpp
-BasedOnStyle: WebKit
-AlignArrayOfStructures: Left
-AlignAfterOpenBracket: Align
-AllowShortFunctionsOnASingleLine: Empty
-ColumnLimit: 80
+
+# LLVM is the best tested style because it is used by the Clang-format developers.
+# Other styles tend to be a bit buggy.
+BasedOnStyle: LLVM
+
+# Binpacking arguments/parameters (i.e. wrapping them as if they were prose)
+# is really bad for diffing, conflicts, etc.
+BinPackArguments: false
+BinPackParameters: false
+AlignAfterOpenBracket: BlockIndent
+PackConstructorInitializers: CurrentLine
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+
+# For consistency don't put functions or enums on one line.
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+
+# Slightly less claustrophobic line lengths.
+ColumnLimit: 120
+
+# This just removes some spaces in braced initialiser lists.
 Cpp11BracedListStyle: true
+
+# Indentation is 2 spaces. This matches the style in the Sail code.
 IndentWidth: 2
-PointerAlignment: Right
-SortIncludes: Never
-AlignTrailingComments: true
-AccessModifierOffset: -2
+ContinuationIndentWidth: 2
+
+# Don't allow single-statement unbraced blocks; a notorious footgun.
 InsertBraces: true
+
+# Don't split between the return type and function name, for consistency.
+PenaltyReturnTypeOnItsOwnLine: 10000
+
+# Nicer constructor lists.
+BreakConstructorInitializers: AfterColon

--- a/c_emulator/config_utils.h
+++ b/c_emulator/config_utils.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <cstdint>
-#include <vector>
 #include <string>
+#include <vector>
 
 // Get a uint64_t from the JSON config file. This works with integers and
 // non-abstract bit vectors. Bit vectors over 64 bits throw an exception.

--- a/c_emulator/elf_loader.cpp
+++ b/c_emulator/elf_loader.cpp
@@ -3,79 +3,63 @@
 
 #include <elfio/elfio.hpp>
 
-ELF::ELF(std::unique_ptr<ELFIO::elfio> reader)
-    : m_reader(std::move(reader))
-{
+ELF::ELF(std::unique_ptr<ELFIO::elfio> reader) : m_reader(std::move(reader)) {
 }
 
-ELF ELF::open(const std::string &filename)
-{
+ELF ELF::open(const std::string &filename) {
   auto reader = std::make_unique<ELFIO::elfio>();
 
   if (!reader->load(filename)) {
-    throw std::runtime_error("File '" + filename
-                             + "' is not found or it is not an ELF file");
+    throw std::runtime_error("File '" + filename + "' is not found or it is not an ELF file");
   }
 
   if (reader->get_machine() != ELFIO::EM_RISCV) {
-    throw std::runtime_error("File '" + filename
-                             + "' is not a RISC-V ELF file");
+    throw std::runtime_error("File '" + filename + "' is not a RISC-V ELF file");
   }
 
   return ELF(std::move(reader));
 }
 
-Architecture ELF::architecture() const
-{
+Architecture ELF::architecture() const {
   switch (m_reader->get_class()) {
   case ELFIO::ELFCLASS32:
     return Architecture::RV32;
   case ELFIO::ELFCLASS64:
     return Architecture::RV64;
   default:
-    throw std::runtime_error("Unknown ELF class "
-                             + std::to_string(m_reader->get_class()));
+    throw std::runtime_error("Unknown ELF class " + std::to_string(m_reader->get_class()));
   }
 }
 
 // Entry point.
-uint64_t ELF::entry() const
-{
+uint64_t ELF::entry() const {
   return m_reader->get_entry();
 }
 
-void ELF::load(
-    std::function<void(uint64_t, const uint8_t *, uint64_t)> writer) const
-{
+void ELF::load(std::function<void(uint64_t, const uint8_t *, uint64_t)> writer) const {
   for (const auto &seg : m_reader->segments) {
     if (seg->get_type() == ELFIO::PT_LOAD) {
       // It's a segment that we should load into memory.
       if (seg->get_file_size() > seg->get_memory_size()) {
         // File size must be <= memory size.
-        throw std::runtime_error("Invalid ELF segment: file size ("
-                                 + std::to_string(seg->get_file_size())
-                                 + ") is greater than memory size ("
-                                 + std::to_string(seg->get_memory_size())
-                                 + ")");
+        throw std::runtime_error(
+          "Invalid ELF segment: file size (" + std::to_string(seg->get_file_size()) +
+          ") is greater than memory size (" + std::to_string(seg->get_memory_size()) + ")"
+        );
       }
       // Write the data to memory.
-      writer(seg->get_physical_address(),
-             reinterpret_cast<const uint8_t *>(seg->get_data()),
-             seg->get_file_size());
+      writer(seg->get_physical_address(), reinterpret_cast<const uint8_t *>(seg->get_data()), seg->get_file_size());
       // If the memory size is greater than the file size the remaining
       // bytes should be zeroed.
       if (seg->get_memory_size() > seg->get_file_size()) {
-        std::vector<uint8_t> zeros(
-            seg->get_memory_size() - seg->get_file_size(), 0);
-        writer(seg->get_physical_address() + seg->get_file_size(), zeros.data(),
-               zeros.size());
+        std::vector<uint8_t> zeros(seg->get_memory_size() - seg->get_file_size(), 0);
+        writer(seg->get_physical_address() + seg->get_file_size(), zeros.data(), zeros.size());
       }
     }
   }
 }
 
-std::map<std::string, uint64_t> ELF::symbols() const
-{
+std::map<std::string, uint64_t> ELF::symbols() const {
   using namespace ELFIO;
 
   std::map<std::string, uint64_t> symbolMap;
@@ -92,11 +76,9 @@ std::map<std::string, uint64_t> ELF::symbols() const
     Elf_Half section_index = 0;
     unsigned char other = '\x00';
 
-    while (accessor.get_symbol(index, name, value, size, bind, type,
-                               section_index, other)) {
-      if ((type == STT_NOTYPE || type == STT_FUNC || type == STT_OBJECT
-           || type == STT_COMMON)
-          && section_index != SHN_UNDEF) {
+    while (accessor.get_symbol(index, name, value, size, bind, type, section_index, other)) {
+      if ((type == STT_NOTYPE || type == STT_FUNC || type == STT_OBJECT || type == STT_COMMON) &&
+          section_index != SHN_UNDEF) {
         symbolMap[name] = value;
       }
       ++index;

--- a/c_emulator/elf_loader.h
+++ b/c_emulator/elf_loader.h
@@ -25,10 +25,11 @@ public:
   // Return the entry point (where execution should begin).
   uint64_t entry() const;
 
-  using ElfWriteFn = std::function<void(uint64_t,        // address
-                                        const uint8_t *, // data
-                                        uint64_t         // length
-                                        )>;
+  using ElfWriteFn = std::function<void(
+    uint64_t,        // address
+    const uint8_t *, // data
+    uint64_t         // length
+  )>;
 
   // Call `writer()` to load all of the loadable sections into memory (or you
   // can do anything else with them).

--- a/c_emulator/riscv_callbacks_if.cpp
+++ b/c_emulator/riscv_callbacks_if.cpp
@@ -5,117 +5,120 @@
 // Default implementations that do nothing.
 
 // Callback invoked before each step
-void callbacks_if::pre_step_callback([[maybe_unused]] hart::Model &model,
-                                     [[maybe_unused]] bool is_waiting)
-{
+void callbacks_if::pre_step_callback([[maybe_unused]] hart::Model &model, [[maybe_unused]] bool is_waiting) {
 }
 
 // Callback invoked after each step
-void callbacks_if::post_step_callback([[maybe_unused]] hart::Model &model,
-                                      [[maybe_unused]] bool is_waiting)
-{
+void callbacks_if::post_step_callback([[maybe_unused]] hart::Model &model, [[maybe_unused]] bool is_waiting) {
 }
 
-void callbacks_if::fetch_callback([[maybe_unused]] hart::Model &model,
-                                  [[maybe_unused]] sbits opcode)
-{
+void callbacks_if::fetch_callback([[maybe_unused]] hart::Model &model, [[maybe_unused]] sbits opcode) {
 }
 
-void callbacks_if::mem_write_callback([[maybe_unused]] hart::Model &model,
-                                      [[maybe_unused]] const char *type,
-                                      [[maybe_unused]] sbits paddr,
-                                      [[maybe_unused]] uint64_t width,
-                                      [[maybe_unused]] lbits value)
-{
+void callbacks_if::mem_write_callback(
+  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] const char *type,
+  [[maybe_unused]] sbits paddr,
+  [[maybe_unused]] uint64_t width,
+  [[maybe_unused]] lbits value
+) {
 }
 
-void callbacks_if::mem_read_callback([[maybe_unused]] hart::Model &model,
-                                     [[maybe_unused]] const char *type,
-                                     [[maybe_unused]] sbits paddr,
-                                     [[maybe_unused]] uint64_t width,
-                                     [[maybe_unused]] lbits value)
-{
+void callbacks_if::mem_read_callback(
+  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] const char *type,
+  [[maybe_unused]] sbits paddr,
+  [[maybe_unused]] uint64_t width,
+  [[maybe_unused]] lbits value
+) {
 }
 
 void callbacks_if::mem_exception_callback(
-    [[maybe_unused]] hart::Model &model, [[maybe_unused]] sbits paddr,
-    [[maybe_unused]] uint64_t num_of_exception)
-{
+  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] sbits paddr,
+  [[maybe_unused]] uint64_t num_of_exception
+) {
 }
 
 void callbacks_if::xreg_full_write_callback(
-    [[maybe_unused]] hart::Model &model,
-    [[maybe_unused]] const_sail_string abi_name, [[maybe_unused]] sbits reg,
-    [[maybe_unused]] sbits value)
-{
+  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] const_sail_string abi_name,
+  [[maybe_unused]] sbits reg,
+  [[maybe_unused]] sbits value
+) {
 }
 
-void callbacks_if::freg_write_callback([[maybe_unused]] hart::Model &model,
-                                       [[maybe_unused]] unsigned reg,
-                                       [[maybe_unused]] sbits value)
-{
+void callbacks_if::freg_write_callback(
+  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] unsigned reg,
+  [[maybe_unused]] sbits value
+) {
 }
 
 void callbacks_if::csr_full_write_callback(
-    [[maybe_unused]] hart::Model &model,
-    [[maybe_unused]] const_sail_string csr_name, [[maybe_unused]] unsigned reg,
-    [[maybe_unused]] sbits value)
-{
+  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] const_sail_string csr_name,
+  [[maybe_unused]] unsigned reg,
+  [[maybe_unused]] sbits value
+) {
 }
 
 void callbacks_if::csr_full_read_callback(
-    [[maybe_unused]] hart::Model &model,
-    [[maybe_unused]] const_sail_string csr_name, [[maybe_unused]] unsigned reg,
-    [[maybe_unused]] sbits value)
-{
+  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] const_sail_string csr_name,
+  [[maybe_unused]] unsigned reg,
+  [[maybe_unused]] sbits value
+) {
 }
 
-void callbacks_if::vreg_write_callback([[maybe_unused]] hart::Model &model,
-                                       [[maybe_unused]] unsigned reg,
-                                       [[maybe_unused]] lbits value)
-{
+void callbacks_if::vreg_write_callback(
+  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] unsigned reg,
+  [[maybe_unused]] lbits value
+) {
 }
 
-void callbacks_if::pc_write_callback([[maybe_unused]] hart::Model &model,
-                                     [[maybe_unused]] sbits new_pc)
-{
+void callbacks_if::pc_write_callback([[maybe_unused]] hart::Model &model, [[maybe_unused]] sbits new_pc) {
 }
 
-void callbacks_if::redirect_callback([[maybe_unused]] hart::Model &model,
-                                     [[maybe_unused]] sbits new_pc)
-{
+void callbacks_if::redirect_callback([[maybe_unused]] hart::Model &model, [[maybe_unused]] sbits new_pc) {
 }
 
-void callbacks_if::trap_callback([[maybe_unused]] hart::Model &model,
-                                 [[maybe_unused]] bool is_interrupt,
-                                 [[maybe_unused]] fbits cause)
-{
+void callbacks_if::trap_callback(
+  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] bool is_interrupt,
+  [[maybe_unused]] fbits cause
+) {
 }
 
 // Page table walk callbacks
 void callbacks_if::ptw_start_callback(
-    [[maybe_unused]] hart::Model &model, [[maybe_unused]] uint64_t vpn,
-    [[maybe_unused]] hart::zMemoryAccessTypezIuzK access_type,
-    [[maybe_unused]] hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege)
-{
+  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] uint64_t vpn,
+  [[maybe_unused]] hart::zMemoryAccessTypezIuzK access_type,
+  [[maybe_unused]] hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+) {
 }
 
-void callbacks_if::ptw_step_callback([[maybe_unused]] hart::Model &model,
-                                     [[maybe_unused]] int64_t level,
-                                     [[maybe_unused]] sbits pte_addr,
-                                     [[maybe_unused]] uint64_t pte)
-{
+void callbacks_if::ptw_step_callback(
+  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] int64_t level,
+  [[maybe_unused]] sbits pte_addr,
+  [[maybe_unused]] uint64_t pte
+) {
 }
 
-void callbacks_if::ptw_success_callback([[maybe_unused]] hart::Model &model,
-                                        [[maybe_unused]] uint64_t final_ppn,
-                                        [[maybe_unused]] int64_t level)
-{
+void callbacks_if::ptw_success_callback(
+  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] uint64_t final_ppn,
+  [[maybe_unused]] int64_t level
+) {
 }
 
 void callbacks_if::ptw_fail_callback(
-    [[maybe_unused]] hart::Model &model,
-    [[maybe_unused]] hart::zPTW_Error error_type,
-    [[maybe_unused]] int64_t level, [[maybe_unused]] sbits pte_addr)
-{
+  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] hart::zPTW_Error error_type,
+  [[maybe_unused]] int64_t level,
+  [[maybe_unused]] sbits pte_addr
+) {
 }

--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -10,7 +10,7 @@ struct zMemoryAccessTypezIuzK;
 struct ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9;
 struct zPTW_Error;
 
-}
+} // namespace hart
 
 class callbacks_if {
 public:
@@ -24,53 +24,39 @@ public:
 
   virtual void fetch_callback(hart::Model &model, sbits opcode);
 
-  virtual void mem_write_callback(hart::Model &model, const char *type,
-                                  sbits paddr, uint64_t width, lbits value);
+  virtual void mem_write_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value);
 
-  virtual void mem_read_callback(hart::Model &model, const char *type,
-                                 sbits paddr, uint64_t width, lbits value);
+  virtual void mem_read_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value);
 
-  virtual void mem_exception_callback(hart::Model &model, sbits paddr,
-                                      uint64_t num_of_exception);
+  virtual void mem_exception_callback(hart::Model &model, sbits paddr, uint64_t num_of_exception);
 
-  virtual void xreg_full_write_callback(hart::Model &model,
-                                        const_sail_string abi_name, sbits reg,
-                                        sbits value);
+  virtual void xreg_full_write_callback(hart::Model &model, const_sail_string abi_name, sbits reg, sbits value);
 
-  virtual void freg_write_callback(hart::Model &model, unsigned reg,
-                                   sbits value);
+  virtual void freg_write_callback(hart::Model &model, unsigned reg, sbits value);
 
-  virtual void csr_full_write_callback(hart::Model &model,
-                                       const_sail_string csr_name, unsigned reg,
-                                       sbits value);
+  virtual void csr_full_write_callback(hart::Model &model, const_sail_string csr_name, unsigned reg, sbits value);
 
-  virtual void csr_full_read_callback(hart::Model &model,
-                                      const_sail_string csr_name, unsigned reg,
-                                      sbits value);
+  virtual void csr_full_read_callback(hart::Model &model, const_sail_string csr_name, unsigned reg, sbits value);
 
-  virtual void vreg_write_callback(hart::Model &model, unsigned reg,
-                                   lbits value);
+  virtual void vreg_write_callback(hart::Model &model, unsigned reg, lbits value);
 
   virtual void pc_write_callback(hart::Model &model, sbits new_pc);
 
   virtual void redirect_callback(hart::Model &model, sbits new_pc);
 
-  virtual void trap_callback(hart::Model &model, bool is_interrupt,
-                             fbits cause);
+  virtual void trap_callback(hart::Model &model, bool is_interrupt, fbits cause);
 
   // Page table walk callbacks
-  virtual void
-  ptw_start_callback(hart::Model &model, uint64_t vpn,
-                     hart::zMemoryAccessTypezIuzK access_type,
-                     hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege);
+  virtual void ptw_start_callback(
+    hart::Model &model,
+    uint64_t vpn,
+    hart::zMemoryAccessTypezIuzK access_type,
+    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+  );
 
-  virtual void ptw_step_callback(hart::Model &model, int64_t level,
-                                 sbits pte_addr, uint64_t pte);
+  virtual void ptw_step_callback(hart::Model &model, int64_t level, sbits pte_addr, uint64_t pte);
 
-  virtual void ptw_success_callback(hart::Model &model, uint64_t final_ppn,
-                                    int64_t level);
+  virtual void ptw_success_callback(hart::Model &model, uint64_t final_ppn, int64_t level);
 
-  virtual void ptw_fail_callback(hart::Model &model,
-                                 hart::zPTW_Error error_type, int64_t level,
-                                 sbits pte_addr);
+  virtual void ptw_fail_callback(hart::Model &model, hart::zPTW_Error error_type, int64_t level, sbits pte_addr);
 };

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -1,12 +1,11 @@
-#include "riscv_config.h"
 #include "riscv_callbacks_log.h"
+#include "riscv_config.h"
 #include "sail_riscv_model.h"
+#include <inttypes.h>
 #include <stdlib.h>
 #include <vector>
-#include <inttypes.h>
 
-void print_lbits_hex(FILE *trace_log, lbits val, int length = 0)
-{
+void print_lbits_hex(FILE *trace_log, lbits val, int length = 0) {
   if (length == 0) {
     length = val.len;
   }
@@ -18,91 +17,95 @@ void print_lbits_hex(FILE *trace_log, lbits val, int length = 0)
   fprintf(trace_log, "\n");
 }
 
-log_callbacks::log_callbacks(bool config_print_reg,
-                             bool config_print_mem_access,
-                             bool config_print_ptw, bool config_use_abi_names,
-                             FILE *trace_log)
-    : config_print_reg(config_print_reg)
-    , config_print_mem_access(config_print_mem_access)
-    , config_use_abi_names(config_use_abi_names)
-    , config_print_ptw(config_print_ptw)
-    , trace_log(trace_log)
-{
+log_callbacks::log_callbacks(
+  bool config_print_reg,
+  bool config_print_mem_access,
+  bool config_print_ptw,
+  bool config_use_abi_names,
+  FILE *trace_log
+) :
+    config_print_reg(config_print_reg),
+    config_print_mem_access(config_print_mem_access),
+    config_use_abi_names(config_use_abi_names),
+    config_print_ptw(config_print_ptw),
+    trace_log(trace_log) {
 }
 
 // Implementations of default callbacks for trace printing.
 // The model assumes that these functions do not change the state of the model.
 
-void log_callbacks::mem_write_callback(hart::Model &model, const char *type,
-                                       sbits paddr, uint64_t width, lbits value)
-{
+void log_callbacks::mem_write_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value) {
   if (trace_log != nullptr && config_print_mem_access) {
-    fprintf(trace_log, "mem[%s,0x%0*" PRIX64 "] <- 0x", type,
-            static_cast<int>((model.zphysaddrbits_len + 3) / 4), paddr.bits);
+    fprintf(
+      trace_log,
+      "mem[%s,0x%0*" PRIX64 "] <- 0x",
+      type,
+      static_cast<int>((model.zphysaddrbits_len + 3) / 4),
+      paddr.bits
+    );
     print_lbits_hex(trace_log, value, width);
   }
 }
 
-void log_callbacks::mem_read_callback(hart::Model &model, const char *type,
-                                      sbits paddr, uint64_t width, lbits value)
-{
+void log_callbacks::mem_read_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value) {
   if (trace_log != nullptr && config_print_mem_access) {
-    fprintf(trace_log, "mem[%s,0x%0*" PRIX64 "] -> 0x", type,
-            static_cast<int>((model.zphysaddrbits_len + 3) / 4), paddr.bits);
+    fprintf(
+      trace_log,
+      "mem[%s,0x%0*" PRIX64 "] -> 0x",
+      type,
+      static_cast<int>((model.zphysaddrbits_len + 3) / 4),
+      paddr.bits
+    );
     print_lbits_hex(trace_log, value, width);
   }
 }
 
-void log_callbacks::xreg_full_write_callback(hart::Model &,
-                                             const_sail_string abi_name,
-                                             sbits reg, sbits value)
-{
+void log_callbacks::xreg_full_write_callback(hart::Model &, const_sail_string abi_name, sbits reg, sbits value) {
   if (trace_log != nullptr && config_print_reg) {
     if (config_use_abi_names) {
-      fprintf(trace_log, "%s <- 0x%0*" PRIX64 "\n", abi_name,
-              static_cast<int>(value.len / 4), value.bits);
+      fprintf(trace_log, "%s <- 0x%0*" PRIX64 "\n", abi_name, static_cast<int>(value.len / 4), value.bits);
     } else {
-      fprintf(trace_log, "x%" PRIu64 " <- 0x%0*" PRIX64 "\n", reg.bits,
-              static_cast<int>(value.len / 4), value.bits);
+      fprintf(trace_log, "x%" PRIu64 " <- 0x%0*" PRIX64 "\n", reg.bits, static_cast<int>(value.len / 4), value.bits);
     }
   }
 }
 
-void log_callbacks::freg_write_callback(hart::Model &, unsigned reg,
-                                        sbits value)
-{
+void log_callbacks::freg_write_callback(hart::Model &, unsigned reg, sbits value) {
   // TODO: will only print bits; should we print in floating point format?
   if (trace_log != nullptr && config_print_reg) {
     // TODO: Might need to change from PRIX64 to PRIX128 once the "Q"
     // extension is supported
-    fprintf(trace_log, "f%d <- 0x%0*" PRIX64 "\n", reg,
-            static_cast<int>(value.len / 4), value.bits);
+    fprintf(trace_log, "f%d <- 0x%0*" PRIX64 "\n", reg, static_cast<int>(value.len / 4), value.bits);
   }
 }
 
-void log_callbacks::csr_full_write_callback(hart::Model &,
-                                            const_sail_string csr_name,
-                                            unsigned reg, sbits value)
-{
+void log_callbacks::csr_full_write_callback(hart::Model &, const_sail_string csr_name, unsigned reg, sbits value) {
   if (trace_log != nullptr && config_print_reg) {
-    fprintf(trace_log, "CSR %s (0x%03X) <- 0x%0*" PRIX64 "\n", csr_name, reg,
-            static_cast<int>(value.len / 4), value.bits);
+    fprintf(
+      trace_log,
+      "CSR %s (0x%03X) <- 0x%0*" PRIX64 "\n",
+      csr_name,
+      reg,
+      static_cast<int>(value.len / 4),
+      value.bits
+    );
   }
 }
 
-void log_callbacks::csr_full_read_callback(hart::Model &,
-                                           const_sail_string csr_name,
-                                           unsigned reg, sbits value)
-{
+void log_callbacks::csr_full_read_callback(hart::Model &, const_sail_string csr_name, unsigned reg, sbits value) {
   if (trace_log != nullptr && config_print_reg) {
-    fprintf(trace_log, "CSR %s (0x%03X) -> 0x%0*" PRIX64 "\n", csr_name, reg,
-            static_cast<int>(value.len / 4), value.bits);
+    fprintf(
+      trace_log,
+      "CSR %s (0x%03X) -> 0x%0*" PRIX64 "\n",
+      csr_name,
+      reg,
+      static_cast<int>(value.len / 4),
+      value.bits
+    );
   }
 }
 
-void log_callbacks::vreg_write_callback(hart::Model &, unsigned reg,
-                                        lbits value)
-{
+void log_callbacks::vreg_write_callback(hart::Model &, unsigned reg, lbits value) {
   if (trace_log != nullptr && config_print_reg) {
     fprintf(trace_log, "v%d <- 0x", reg);
     print_lbits_hex(trace_log, value);
@@ -111,54 +114,47 @@ void log_callbacks::vreg_write_callback(hart::Model &, unsigned reg,
 
 // Page table walk callback
 void log_callbacks::ptw_start_callback(
-    hart::Model &model, uint64_t vpn, hart::zMemoryAccessTypezIuzK access_type,
-    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege)
-{
+  hart::Model &model,
+  uint64_t vpn,
+  hart::zMemoryAccessTypezIuzK access_type,
+  hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+) {
   if (trace_log != nullptr && config_print_ptw) {
     sail_string str_ac, str_pr;
     CREATE(sail_string)(&str_ac);
     CREATE(sail_string)(&str_pr);
     model.zaccessType_to_str(&str_ac, access_type);
     model.zprivLevel_to_str(&str_pr, privilege.ztup0);
-    fprintf(trace_log,
-            "PTW: Start, vpn=0x%" PRIx64 ", access_type=%s, privilege=%s", vpn,
-            str_ac, str_pr);
+    fprintf(trace_log, "PTW: Start, vpn=0x%" PRIx64 ", access_type=%s, privilege=%s", vpn, str_ac, str_pr);
     KILL(sail_string)(&str_ac);
     KILL(sail_string)(&str_pr);
   }
 }
 
-void log_callbacks::ptw_step_callback(hart::Model & /*model*/, int64_t level,
-                                      sbits pte_addr, uint64_t pte)
-{
+void log_callbacks::ptw_step_callback(hart::Model & /*model*/, int64_t level, sbits pte_addr, uint64_t pte) {
   if (trace_log != nullptr && config_print_ptw) {
-    fprintf(trace_log,
-            "PTW: Step, level=%ld, pte=0x%" PRIX64 ", pte_addr=0x%" PRIX64 "\n",
-            level, pte, pte_addr.bits);
+    fprintf(trace_log, "PTW: Step, level=%ld, pte=0x%" PRIX64 ", pte_addr=0x%" PRIX64 "\n", level, pte, pte_addr.bits);
   }
 }
 
-void log_callbacks::ptw_success_callback(hart::Model & /*model*/,
-                                         uint64_t final_ppn, int64_t level)
-{
+void log_callbacks::ptw_success_callback(hart::Model & /*model*/, uint64_t final_ppn, int64_t level) {
   if (trace_log != nullptr && config_print_ptw) {
-    fprintf(trace_log, "PTW: Success, final_ppn=0x%" PRIx64 ", level=%ld",
-            final_ppn, level);
+    fprintf(trace_log, "PTW: Success, final_ppn=0x%" PRIx64 ", level=%ld", final_ppn, level);
   }
 }
 
-void log_callbacks::ptw_fail_callback(hart::Model &model,
-                                      struct hart::zPTW_Error error_type,
-                                      int64_t level, sbits pte_addr)
-{
+void log_callbacks::ptw_fail_callback(
+  hart::Model &model,
+  struct hart::zPTW_Error error_type,
+  int64_t level,
+  sbits pte_addr
+) {
   // failed trace is always available
   if (trace_log != nullptr) {
     sail_string str_et;
     CREATE(sail_string)(&str_et);
     model.zptw_error_to_str(&str_et, error_type);
-    fprintf(trace_log,
-            "PTW: failed, error=%s, level=%ld, pte_addr=0x%" PRIX64 "\n",
-            str_et, level, pte_addr.bits);
+    fprintf(trace_log, "PTW: failed, error=%s, level=%ld, pte_addr=0x%" PRIX64 "\n", str_et, level, pte_addr.bits);
     KILL(sail_string)(&str_et);
   }
 }

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -1,43 +1,42 @@
 #pragma once
-#include "sail.h"
 #include "riscv_callbacks_if.h"
+#include "sail.h"
 
 class log_callbacks : public callbacks_if {
 
 public:
-  explicit log_callbacks(bool config_print_reg = true,
-                         bool config_print_mem_access = true,
-                         bool config_print_ptw = true,
-                         bool config_use_abi_names = false,
+  explicit log_callbacks(
+    bool config_print_reg = true,
+    bool config_print_mem_access = true,
+    bool config_print_ptw = true,
+    bool config_use_abi_names = false,
 
-                         FILE *trace_log = nullptr);
+    FILE *trace_log = nullptr
+  );
 
   // callbacks_if
-  void mem_write_callback(hart::Model &model, const char *type, sbits paddr,
-                          uint64_t width, lbits value) override;
-  void mem_read_callback(hart::Model &model, const char *type, sbits paddr,
-                         uint64_t width, lbits value) override;
-  void xreg_full_write_callback(hart::Model &model, const_sail_string abi_name,
-                                sbits reg, sbits value) override;
-  void freg_write_callback(hart::Model &model, unsigned reg,
-                           sbits value) override;
-  void csr_full_write_callback(hart::Model &model, const_sail_string csr_name,
-                               unsigned reg, sbits value) override;
-  void csr_full_read_callback(hart::Model &model, const_sail_string csr_name,
-                              unsigned reg, sbits value) override;
-  void vreg_write_callback(hart::Model &model, unsigned reg,
-                           lbits value) override;
+  void mem_write_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
+  void mem_read_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
+  void xreg_full_write_callback(hart::Model &model, const_sail_string abi_name, sbits reg, sbits value) override;
+  void freg_write_callback(hart::Model &model, unsigned reg, sbits value) override;
+  void csr_full_write_callback(hart::Model &model, const_sail_string csr_name, unsigned reg, sbits value) override;
+  void csr_full_read_callback(hart::Model &model, const_sail_string csr_name, unsigned reg, sbits value) override;
+  void vreg_write_callback(hart::Model &model, unsigned reg, lbits value) override;
   // Page table walk callback
   void ptw_start_callback(
-      hart::Model &model, uint64_t vpn,
-      hart::zMemoryAccessTypezIuzK access_type,
-      hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege) override;
-  void ptw_step_callback(hart::Model &model, int64_t level, sbits pte_addr,
-                         uint64_t pte) override;
-  void ptw_success_callback(hart::Model &model, uint64_t final_ppn,
-                            int64_t level) override;
-  void ptw_fail_callback(hart::Model &model, struct hart::zPTW_Error error_type,
-                         int64_t level, sbits pte_addr) override;
+    hart::Model &model,
+    uint64_t vpn,
+    hart::zMemoryAccessTypezIuzK access_type,
+    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+  ) override;
+  void ptw_step_callback(hart::Model &model, int64_t level, sbits pte_addr, uint64_t pte) override;
+  void ptw_success_callback(hart::Model &model, uint64_t final_ppn, int64_t level) override;
+  void ptw_fail_callback(
+    hart::Model &model,
+    struct hart::zPTW_Error error_type,
+    int64_t level,
+    sbits pte_addr
+  ) override;
 
 private:
   bool config_print_reg;

--- a/c_emulator/riscv_callbacks_rvfi.cpp
+++ b/c_emulator/riscv_callbacks_rvfi.cpp
@@ -1,25 +1,20 @@
-#include "riscv_config.h"
 #include "riscv_callbacks_rvfi.h"
-#include <stdlib.h>
+#include "riscv_config.h"
 #include <inttypes.h>
+#include <stdlib.h>
 
 #include "sail_riscv_model.h"
 
 // Implementations of default callbacks for RVFI.
 // The model assumes that these functions do not change the state of the model.
 
-void rvfi_callbacks::mem_write_callback(hart::Model &model, const char *,
-                                        sbits paddr, uint64_t width,
-                                        lbits value)
-{
+void rvfi_callbacks::mem_write_callback(hart::Model &model, const char *, sbits paddr, uint64_t width, lbits value) {
   if (config_enable_rvfi) {
     model.zrvfi_write(paddr, width, value);
   }
 }
 
-void rvfi_callbacks::mem_read_callback(hart::Model &model, const char *,
-                                       sbits paddr, uint64_t width, lbits value)
-{
+void rvfi_callbacks::mem_read_callback(hart::Model &model, const char *, sbits paddr, uint64_t width, lbits value) {
   if (config_enable_rvfi) {
     sail_int len;
     CREATE(sail_int)(&len);
@@ -29,26 +24,19 @@ void rvfi_callbacks::mem_read_callback(hart::Model &model, const char *,
   }
 }
 
-void rvfi_callbacks::mem_exception_callback(hart::Model &model, sbits paddr,
-                                            uint64_t)
-{
+void rvfi_callbacks::mem_exception_callback(hart::Model &model, sbits paddr, uint64_t) {
   if (config_enable_rvfi) {
     model.zrvfi_mem_exception(paddr);
   }
 }
 
-void rvfi_callbacks::xreg_full_write_callback(hart::Model &model,
-                                              const_sail_string, sbits reg,
-                                              sbits value)
-{
+void rvfi_callbacks::xreg_full_write_callback(hart::Model &model, const_sail_string, sbits reg, sbits value) {
   if (config_enable_rvfi) {
     model.zrvfi_wX(reg.bits, value);
   }
 }
 
-void rvfi_callbacks::trap_callback(hart::Model &model, bool is_interrupt,
-                                   fbits cause)
-{
+void rvfi_callbacks::trap_callback(hart::Model &model, bool is_interrupt, fbits cause) {
   (void)is_interrupt;
   (void)cause;
   if (config_enable_rvfi) {

--- a/c_emulator/riscv_callbacks_rvfi.h
+++ b/c_emulator/riscv_callbacks_rvfi.h
@@ -1,19 +1,14 @@
 #pragma once
-#include "sail.h"
 #include "riscv_callbacks_if.h"
+#include "sail.h"
 
 class rvfi_callbacks : public callbacks_if {
 
 public:
   // callbacks_if
-  void mem_write_callback(hart::Model &model, const char *type, sbits paddr,
-                          uint64_t width, lbits value) override;
-  void mem_read_callback(hart::Model &model, const char *type, sbits paddr,
-                         uint64_t width, lbits value) override;
-  void mem_exception_callback(hart::Model &model, sbits paddr,
-                              uint64_t num_of_exception) override;
-  void xreg_full_write_callback(hart::Model &model, const_sail_string abi_name,
-                                sbits reg, sbits value) override;
-  void trap_callback(hart::Model &model, bool is_interrupt,
-                     fbits cause) override;
+  void mem_write_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
+  void mem_read_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
+  void mem_exception_callback(hart::Model &model, sbits paddr, uint64_t num_of_exception) override;
+  void xreg_full_write_callback(hart::Model &model, const_sail_string abi_name, sbits reg, sbits value) override;
+  void trap_callback(hart::Model &model, bool is_interrupt, fbits cause) override;
 };

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -5,149 +5,123 @@
 #include <unistd.h>
 
 #include "riscv_callbacks_if.h"
-#include "symbol_table.h"
 #include "riscv_config.h"
+#include "symbol_table.h"
 
 int term_fd = 1; // set during startup
-void plat_term_write_impl(char c)
-{
+void plat_term_write_impl(char c) {
   if (write(term_fd, &c, sizeof(c)) < 0) {
     fprintf(stderr, "Unable to write to terminal!\n");
   }
 }
 
-void ModelImpl::register_callback(callbacks_if *cb)
-{
-  if (std::find(m_callbacks.begin(), m_callbacks.end(), cb)
-      == m_callbacks.end()) {
+void ModelImpl::register_callback(callbacks_if *cb) {
+  if (std::find(m_callbacks.begin(), m_callbacks.end(), cb) == m_callbacks.end()) {
     m_callbacks.push_back(cb);
   }
 }
 
-void ModelImpl::remove_callback(callbacks_if *cb)
-{
-  m_callbacks.erase(std::remove(m_callbacks.begin(), m_callbacks.end(), cb),
-                    m_callbacks.end());
+void ModelImpl::remove_callback(callbacks_if *cb) {
+  m_callbacks.erase(std::remove(m_callbacks.begin(), m_callbacks.end(), cb), m_callbacks.end());
 }
 
-void ModelImpl::call_pre_step_callbacks(bool is_waiting)
-{
+void ModelImpl::call_pre_step_callbacks(bool is_waiting) {
   for (auto c : m_callbacks) {
     c->pre_step_callback(*this, is_waiting);
   }
 }
 
-void ModelImpl::call_post_step_callbacks(bool is_waiting)
-{
+void ModelImpl::call_post_step_callbacks(bool is_waiting) {
   for (auto c : m_callbacks) {
     c->post_step_callback(*this, is_waiting);
   }
 }
 
-void ModelImpl::set_enable_experimental_extensions(bool en)
-{
+void ModelImpl::set_enable_experimental_extensions(bool en) {
   m_enable_experimental_extensions = en;
 }
 
-void ModelImpl::set_reservation_set_size_exp(uint64_t exponent)
-{
+void ModelImpl::set_reservation_set_size_exp(uint64_t exponent) {
   m_reservation_set_addr_mask = ~((1 << exponent) - 1);
 }
 
-unit ModelImpl::fetch_callback(sbits opcode)
-{
+unit ModelImpl::fetch_callback(sbits opcode) {
   for (auto c : m_callbacks) {
     c->fetch_callback(*this, opcode);
   }
   return UNIT;
 }
 
-unit ModelImpl::mem_write_callback(const char *type, sbits paddr,
-                                   uint64_t width, lbits value)
-{
+unit ModelImpl::mem_write_callback(const char *type, sbits paddr, uint64_t width, lbits value) {
   for (auto c : m_callbacks) {
     c->mem_write_callback(*this, type, paddr, width, value);
   }
   return UNIT;
 }
-unit ModelImpl::mem_read_callback(const char *type, sbits paddr, uint64_t width,
-                                  lbits value)
-{
+unit ModelImpl::mem_read_callback(const char *type, sbits paddr, uint64_t width, lbits value) {
   for (auto c : m_callbacks) {
     c->mem_read_callback(*this, type, paddr, width, value);
   }
   return UNIT;
 }
 
-unit ModelImpl::mem_exception_callback(sbits paddr, uint64_t num_of_exception)
-{
+unit ModelImpl::mem_exception_callback(sbits paddr, uint64_t num_of_exception) {
   for (auto c : m_callbacks) {
     c->mem_exception_callback(*this, paddr, num_of_exception);
   }
   return UNIT;
 }
 
-unit ModelImpl::xreg_full_write_callback(const_sail_string abi_name, sbits reg,
-                                         sbits value)
-{
+unit ModelImpl::xreg_full_write_callback(const_sail_string abi_name, sbits reg, sbits value) {
   for (auto c : m_callbacks) {
     c->xreg_full_write_callback(*this, abi_name, reg, value);
   }
   return UNIT;
 }
 
-unit ModelImpl::freg_write_callback(unsigned reg, sbits value)
-{
+unit ModelImpl::freg_write_callback(unsigned reg, sbits value) {
   for (auto c : m_callbacks) {
     c->freg_write_callback(*this, reg, value);
   }
   return UNIT;
 }
 
-unit ModelImpl::csr_full_write_callback(const_sail_string csr_name,
-                                        unsigned reg, sbits value)
-{
+unit ModelImpl::csr_full_write_callback(const_sail_string csr_name, unsigned reg, sbits value) {
   for (auto c : m_callbacks) {
     c->csr_full_write_callback(*this, csr_name, reg, value);
   }
   return UNIT;
 }
 
-unit ModelImpl::csr_full_read_callback(const_sail_string csr_name, unsigned reg,
-                                       sbits value)
-{
+unit ModelImpl::csr_full_read_callback(const_sail_string csr_name, unsigned reg, sbits value) {
   for (auto c : m_callbacks) {
     c->csr_full_read_callback(*this, csr_name, reg, value);
   }
   return UNIT;
 }
 
-unit ModelImpl::vreg_write_callback(unsigned reg, lbits value)
-{
+unit ModelImpl::vreg_write_callback(unsigned reg, lbits value) {
   for (auto c : m_callbacks) {
     c->vreg_write_callback(*this, reg, value);
   }
   return UNIT;
 }
 
-unit ModelImpl::pc_write_callback(sbits new_pc)
-{
+unit ModelImpl::pc_write_callback(sbits new_pc) {
   for (auto c : m_callbacks) {
     c->pc_write_callback(*this, new_pc);
   }
   return UNIT;
 }
 
-unit ModelImpl::redirect_callback(sbits new_pc)
-{
+unit ModelImpl::redirect_callback(sbits new_pc) {
   for (auto c : m_callbacks) {
     c->redirect_callback(*this, new_pc);
   }
   return UNIT;
 }
 
-unit ModelImpl::trap_callback(bool is_interrupt, fbits cause)
-{
+unit ModelImpl::trap_callback(bool is_interrupt, fbits cause) {
   for (auto c : m_callbacks) {
     c->trap_callback(*this, is_interrupt, cause);
   }
@@ -155,34 +129,31 @@ unit ModelImpl::trap_callback(bool is_interrupt, fbits cause)
 }
 
 unit ModelImpl::ptw_start_callback(
-    uint64_t vpn, hart::zMemoryAccessTypezIuzK access_type,
-    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege)
-{
+  uint64_t vpn,
+  hart::zMemoryAccessTypezIuzK access_type,
+  hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+) {
   for (auto c : m_callbacks) {
     c->ptw_start_callback(*this, vpn, access_type, privilege);
   }
   return UNIT;
 }
 
-unit ModelImpl::ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte)
-{
+unit ModelImpl::ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte) {
   for (auto c : m_callbacks) {
     c->ptw_step_callback(*this, level, pte_addr, pte);
   }
   return UNIT;
 }
 
-unit ModelImpl::ptw_success_callback(uint64_t final_ppn, int64_t level)
-{
+unit ModelImpl::ptw_success_callback(uint64_t final_ppn, int64_t level) {
   for (auto c : m_callbacks) {
     c->ptw_success_callback(*this, final_ppn, level);
   }
   return UNIT;
 }
 
-unit ModelImpl::ptw_fail_callback(hart::zPTW_Error error_type, int64_t level,
-                                  sbits pte_addr)
-{
+unit ModelImpl::ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sbits pte_addr) {
   for (auto c : m_callbacks) {
     c->ptw_fail_callback(*this, error_type, level, pte_addr);
   }
@@ -190,8 +161,7 @@ unit ModelImpl::ptw_fail_callback(hart::zPTW_Error error_type, int64_t level,
 }
 
 // Provides entropy for the scalar cryptography extension.
-mach_bits ModelImpl::plat_get_16_random_bits(unit)
-{
+mach_bits ModelImpl::plat_get_16_random_bits(unit) {
   // This function can be changed to support deterministic sequences of
   // pseudo-random bytes. This is useful for testing.
   return m_gen64();
@@ -202,112 +172,90 @@ mach_bits ModelImpl::plat_get_16_random_bits(unit)
 // either directly in `load_reservation()` or by calling
 // `cancel_reservation()`.
 
-unit ModelImpl::load_reservation(sbits addr, uint64_t width)
-{
+unit ModelImpl::load_reservation(sbits addr, uint64_t width) {
   m_reservation = addr.bits & m_reservation_set_addr_mask;
   m_reservation_valid = true;
 
   // Ensure the reservation set subsumes the reserved bytes.
-  assert((width > 0)
-         && (((addr.bits + width - 1) & m_reservation_set_addr_mask)
-             == m_reservation));
+  assert((width > 0) && (((addr.bits + width - 1) & m_reservation_set_addr_mask) == m_reservation));
 
   return UNIT;
 }
 
-bool ModelImpl::match_reservation(sbits addr)
-{
-  return m_reservation_valid
-      && (m_reservation & m_reservation_set_addr_mask)
-      == (addr.bits & m_reservation_set_addr_mask);
+bool ModelImpl::match_reservation(sbits addr) {
+  return m_reservation_valid &&
+         (m_reservation & m_reservation_set_addr_mask) == (addr.bits & m_reservation_set_addr_mask);
 }
 
-unit ModelImpl::cancel_reservation(unit)
-{
+unit ModelImpl::cancel_reservation(unit) {
   m_reservation_valid = false;
   return UNIT;
 }
 
-bool ModelImpl::valid_reservation(unit)
-{
+bool ModelImpl::valid_reservation(unit) {
   return m_reservation_valid;
 }
 
-unit ModelImpl::plat_term_write(mach_bits s)
-{
+unit ModelImpl::plat_term_write(mach_bits s) {
   plat_term_write_impl(static_cast<char>(s));
   return UNIT;
 }
 
-bool ModelImpl::sys_enable_experimental_extensions(unit)
-{
+bool ModelImpl::sys_enable_experimental_extensions(unit) {
   return m_enable_experimental_extensions;
 }
 
-unit ModelImpl::print_string(const_sail_string prefix, const_sail_string msg)
-{
+unit ModelImpl::print_string(const_sail_string prefix, const_sail_string msg) {
   printf("%s%s\n", prefix, msg);
   return UNIT;
 }
 
-unit ModelImpl::print_log(const_sail_string s)
-{
+unit ModelImpl::print_log(const_sail_string s) {
   fprintf(trace_log, "%s\n", s);
   return UNIT;
 }
 
-unit ModelImpl::print_log_instr(const_sail_string s, uint64_t pc)
-{
+unit ModelImpl::print_log_instr(const_sail_string s, uint64_t pc) {
   auto maybe_symbol = symbolize_address(g_symbols, pc);
   if (maybe_symbol.has_value()) {
-    fprintf(trace_log, "%-80s    %s+%" PRIu64 "\n", s,
-            maybe_symbol->second.c_str(), pc - maybe_symbol->first);
+    fprintf(trace_log, "%-80s    %s+%" PRIu64 "\n", s, maybe_symbol->second.c_str(), pc - maybe_symbol->first);
   } else {
     fprintf(trace_log, "%s\n", s);
   }
   return UNIT;
 }
 
-unit ModelImpl::print_step(unit)
-{
+unit ModelImpl::print_step(unit) {
   if (config_print_step) {
     fprintf(trace_log, "\n");
   }
   return UNIT;
 }
 
-bool ModelImpl::get_config_print_instr(unit)
-{
+bool ModelImpl::get_config_print_instr(unit) {
   return config_print_instr;
 }
 
-bool ModelImpl::get_config_print_clint(unit)
-{
+bool ModelImpl::get_config_print_clint(unit) {
   return config_print_clint;
 }
-bool ModelImpl::get_config_print_exception(unit)
-{
+bool ModelImpl::get_config_print_exception(unit) {
   return config_print_exception;
 }
-bool ModelImpl::get_config_print_interrupt(unit)
-{
+bool ModelImpl::get_config_print_interrupt(unit) {
   return config_print_interrupt;
 }
-bool ModelImpl::get_config_print_htif(unit)
-{
+bool ModelImpl::get_config_print_htif(unit) {
   return config_print_htif;
 }
-bool ModelImpl::get_config_print_pma(unit)
-{
+bool ModelImpl::get_config_print_pma(unit) {
   return config_print_pma;
 }
 
-bool ModelImpl::get_config_rvfi(unit)
-{
+bool ModelImpl::get_config_rvfi(unit) {
   return config_enable_rvfi;
 }
 
-bool ModelImpl::get_config_use_abi_names(unit)
-{
+bool ModelImpl::get_config_use_abi_names(unit) {
   return config_use_abi_names;
 }

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -28,21 +28,16 @@ private:
   // These functions are called by the Sail code.
 
   unit fetch_callback(sbits opcode) override;
-  unit mem_write_callback(const char *type, sbits paddr, uint64_t width,
-                          lbits value) override;
-  unit mem_read_callback(const char *type, sbits paddr, uint64_t width,
-                         lbits value) override;
+  unit mem_write_callback(const char *type, sbits paddr, uint64_t width, lbits value) override;
+  unit mem_read_callback(const char *type, sbits paddr, uint64_t width, lbits value) override;
   unit mem_exception_callback(sbits paddr, uint64_t num_of_exception) override;
-  unit xreg_full_write_callback(const_sail_string abi_name, sbits reg,
-                                sbits value) override;
+  unit xreg_full_write_callback(const_sail_string abi_name, sbits reg, sbits value) override;
   unit freg_write_callback(unsigned reg, sbits value) override;
   // `full` indicates that the name and index of the CSR are provided.
   // 64 bit CSRs use a long_csr_write_callback Sail function that automatically
   // makes two csr_full_write_callback calls on RV32.
-  unit csr_full_write_callback(const_sail_string csr_name, unsigned reg,
-                               sbits value) override;
-  unit csr_full_read_callback(const_sail_string csr_name, unsigned reg,
-                              sbits value) override;
+  unit csr_full_write_callback(const_sail_string csr_name, unsigned reg, sbits value) override;
+  unit csr_full_read_callback(const_sail_string csr_name, unsigned reg, sbits value) override;
   unit vreg_write_callback(unsigned reg, lbits value) override;
   unit pc_write_callback(sbits new_pc) override;
   unit redirect_callback(sbits new_pc) override;
@@ -50,12 +45,13 @@ private:
 
   // Page table walk callbacks
   unit ptw_start_callback(
-      uint64_t vpn, hart::zMemoryAccessTypezIuzK access_type,
-      hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege) override;
+    uint64_t vpn,
+    hart::zMemoryAccessTypezIuzK access_type,
+    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+  ) override;
   unit ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte) override;
   unit ptw_success_callback(uint64_t final_ppn, int64_t level) override;
-  unit ptw_fail_callback(hart::zPTW_Error error_type, int64_t level,
-                         sbits pte_addr) override;
+  unit ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sbits pte_addr) override;
   // Provides entropy for the scalar cryptography extension.
   mach_bits plat_get_16_random_bits(unit) override;
 
@@ -93,12 +89,11 @@ private:
 
   bool m_enable_experimental_extensions = false;
 
-  static unsigned seed()
-  {
+  static unsigned seed() {
     std::random_device rd;
     return rd();
   }
 
   // Randomly seeded PRNG.
-  std::mt19937_64 m_gen64 {seed()};
+  std::mt19937_64 m_gen64{seed()};
 };

--- a/c_emulator/riscv_platform_if.cpp
+++ b/c_emulator/riscv_platform_if.cpp
@@ -8,205 +8,182 @@
 // A better solution is to allow passing in `hart::Model&` to `model_test()`.
 // See https://github.com/rems-project/sail/issues/1556
 
-unit PlatformInterface::fetch_callback([[maybe_unused]] sbits opcode)
-{
+unit PlatformInterface::fetch_callback([[maybe_unused]] sbits opcode) {
   return UNIT;
 }
 
-unit PlatformInterface::mem_write_callback([[maybe_unused]] const char *type,
-                                           [[maybe_unused]] sbits paddr,
-                                           [[maybe_unused]] uint64_t width,
-                                           [[maybe_unused]] lbits value)
-{
+unit PlatformInterface::mem_write_callback(
+  [[maybe_unused]] const char *type,
+  [[maybe_unused]] sbits paddr,
+  [[maybe_unused]] uint64_t width,
+  [[maybe_unused]] lbits value
+) {
   return UNIT;
 }
 
-unit PlatformInterface::mem_read_callback([[maybe_unused]] const char *type,
-                                          [[maybe_unused]] sbits paddr,
-                                          [[maybe_unused]] uint64_t width,
-                                          [[maybe_unused]] lbits value)
-{
+unit PlatformInterface::mem_read_callback(
+  [[maybe_unused]] const char *type,
+  [[maybe_unused]] sbits paddr,
+  [[maybe_unused]] uint64_t width,
+  [[maybe_unused]] lbits value
+) {
   return UNIT;
 }
 
 unit PlatformInterface::mem_exception_callback(
-    [[maybe_unused]] sbits paddr, [[maybe_unused]] uint64_t num_of_exception)
-{
+  [[maybe_unused]] sbits paddr,
+  [[maybe_unused]] uint64_t num_of_exception
+) {
   return UNIT;
 }
 
 unit PlatformInterface::xreg_full_write_callback(
-    [[maybe_unused]] const_sail_string abi_name, [[maybe_unused]] sbits reg,
-    [[maybe_unused]] sbits value)
-{
+  [[maybe_unused]] const_sail_string abi_name,
+  [[maybe_unused]] sbits reg,
+  [[maybe_unused]] sbits value
+) {
   return UNIT;
 }
 
-unit PlatformInterface::freg_write_callback([[maybe_unused]] unsigned reg,
-                                            [[maybe_unused]] sbits value)
-{
+unit PlatformInterface::freg_write_callback([[maybe_unused]] unsigned reg, [[maybe_unused]] sbits value) {
   return UNIT;
 }
 
 unit PlatformInterface::csr_full_write_callback(
-    [[maybe_unused]] const_sail_string csr_name, [[maybe_unused]] unsigned reg,
-    [[maybe_unused]] sbits value)
-{
+  [[maybe_unused]] const_sail_string csr_name,
+  [[maybe_unused]] unsigned reg,
+  [[maybe_unused]] sbits value
+) {
   return UNIT;
 }
 
 unit PlatformInterface::csr_full_read_callback(
-    [[maybe_unused]] const_sail_string csr_name, [[maybe_unused]] unsigned reg,
-    [[maybe_unused]] sbits value)
-{
+  [[maybe_unused]] const_sail_string csr_name,
+  [[maybe_unused]] unsigned reg,
+  [[maybe_unused]] sbits value
+) {
   return UNIT;
 }
 
-unit PlatformInterface::vreg_write_callback([[maybe_unused]] unsigned reg,
-                                            [[maybe_unused]] lbits value)
-{
+unit PlatformInterface::vreg_write_callback([[maybe_unused]] unsigned reg, [[maybe_unused]] lbits value) {
   return UNIT;
 }
 
-unit PlatformInterface::pc_write_callback([[maybe_unused]] sbits new_pc)
-{
+unit PlatformInterface::pc_write_callback([[maybe_unused]] sbits new_pc) {
   return UNIT;
 }
 
-unit PlatformInterface::redirect_callback([[maybe_unused]] sbits new_pc)
-{
+unit PlatformInterface::redirect_callback([[maybe_unused]] sbits new_pc) {
   return UNIT;
 }
 
-unit PlatformInterface::trap_callback([[maybe_unused]] bool is_interrupt,
-                                      [[maybe_unused]] fbits cause)
-{
+unit PlatformInterface::trap_callback([[maybe_unused]] bool is_interrupt, [[maybe_unused]] fbits cause) {
   return UNIT;
 }
 
 unit PlatformInterface::ptw_start_callback(
-    [[maybe_unused]] uint64_t vpn,
-    [[maybe_unused]] hart::zMemoryAccessTypezIuzK access_type,
-    [[maybe_unused]] hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege)
-{
+  [[maybe_unused]] uint64_t vpn,
+  [[maybe_unused]] hart::zMemoryAccessTypezIuzK access_type,
+  [[maybe_unused]] hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+) {
   return UNIT;
 }
 
-unit PlatformInterface::ptw_step_callback([[maybe_unused]] int64_t level,
-                                          [[maybe_unused]] sbits pte_addr,
-                                          [[maybe_unused]] uint64_t pte)
-{
+unit PlatformInterface::ptw_step_callback(
+  [[maybe_unused]] int64_t level,
+  [[maybe_unused]] sbits pte_addr,
+  [[maybe_unused]] uint64_t pte
+) {
   return UNIT;
 }
-unit PlatformInterface::ptw_success_callback(
-    [[maybe_unused]] uint64_t final_ppn, [[maybe_unused]] int64_t level)
-{
+unit PlatformInterface::ptw_success_callback([[maybe_unused]] uint64_t final_ppn, [[maybe_unused]] int64_t level) {
   return UNIT;
 }
 unit PlatformInterface::ptw_fail_callback(
-    [[maybe_unused]] hart::zPTW_Error error_type,
-    [[maybe_unused]] int64_t level, [[maybe_unused]] sbits pte_addr)
-{
+  [[maybe_unused]] hart::zPTW_Error error_type,
+  [[maybe_unused]] int64_t level,
+  [[maybe_unused]] sbits pte_addr
+) {
   return UNIT;
 }
 
-mach_bits PlatformInterface::plat_get_16_random_bits(unit)
-{
+mach_bits PlatformInterface::plat_get_16_random_bits(unit) {
   return 0;
 }
 
-unit PlatformInterface::load_reservation(sbits, uint64_t)
-{
+unit PlatformInterface::load_reservation(sbits, uint64_t) {
   return UNIT;
 }
 
-bool PlatformInterface::match_reservation(sbits)
-{
+bool PlatformInterface::match_reservation(sbits) {
   return false;
 }
 
-unit PlatformInterface::cancel_reservation(unit)
-{
+unit PlatformInterface::cancel_reservation(unit) {
   return UNIT;
 }
 
-bool PlatformInterface::valid_reservation(unit)
-{
+bool PlatformInterface::valid_reservation(unit) {
   return false;
 }
 
-unit PlatformInterface::plat_term_write(mach_bits)
-{
+unit PlatformInterface::plat_term_write(mach_bits) {
   return UNIT;
 }
 
-bool PlatformInterface::sys_enable_experimental_extensions(unit)
-{
+bool PlatformInterface::sys_enable_experimental_extensions(unit) {
   return true;
 }
 
-unit PlatformInterface::print_string(const_sail_string prefix,
-                                     const_sail_string msg)
-{
+unit PlatformInterface::print_string(const_sail_string prefix, const_sail_string msg) {
   (void)prefix;
   (void)msg;
   return UNIT;
 }
 
-unit PlatformInterface::print_log(const_sail_string s)
-{
+unit PlatformInterface::print_log(const_sail_string s) {
   (void)s;
   return UNIT;
 }
 
-unit PlatformInterface::print_log_instr(const_sail_string s, uint64_t pc)
-{
+unit PlatformInterface::print_log_instr(const_sail_string s, uint64_t pc) {
   (void)s;
   (void)pc;
   return UNIT;
 }
 
-unit PlatformInterface::print_step(unit)
-{
+unit PlatformInterface::print_step(unit) {
   return UNIT;
 }
 
-bool PlatformInterface::get_config_print_instr(unit)
-{
+bool PlatformInterface::get_config_print_instr(unit) {
   return false;
 }
 
-bool PlatformInterface::get_config_print_clint(unit)
-{
+bool PlatformInterface::get_config_print_clint(unit) {
   return false;
 }
 
-bool PlatformInterface::get_config_print_exception(unit)
-{
+bool PlatformInterface::get_config_print_exception(unit) {
   return false;
 }
 
-bool PlatformInterface::get_config_print_interrupt(unit)
-{
+bool PlatformInterface::get_config_print_interrupt(unit) {
   return false;
 }
 
-bool PlatformInterface::get_config_print_htif(unit)
-{
+bool PlatformInterface::get_config_print_htif(unit) {
   return false;
 }
 
-bool PlatformInterface::get_config_print_pma(unit)
-{
+bool PlatformInterface::get_config_print_pma(unit) {
   return false;
 }
 
-bool PlatformInterface::get_config_rvfi(unit)
-{
+bool PlatformInterface::get_config_rvfi(unit) {
   return false;
 }
 
-bool PlatformInterface::get_config_use_abi_names(unit)
-{
+bool PlatformInterface::get_config_use_abi_names(unit) {
   return false;
 }

--- a/c_emulator/riscv_platform_if.h
+++ b/c_emulator/riscv_platform_if.h
@@ -12,7 +12,7 @@ struct zMemoryAccessTypezIuzK;
 struct ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9;
 struct zPTW_Error;
 
-}
+} // namespace hart
 
 // The Model class derives from this one so when Sail calls C callback
 // functions it actually calls methods of this class. However they are
@@ -27,24 +27,19 @@ class PlatformInterface {
 public:
   virtual unit fetch_callback(sbits opcode);
 
-  virtual unit mem_write_callback(const char *type, sbits paddr, uint64_t width,
-                                  lbits value);
+  virtual unit mem_write_callback(const char *type, sbits paddr, uint64_t width, lbits value);
 
-  virtual unit mem_read_callback(const char *type, sbits paddr, uint64_t width,
-                                 lbits value);
+  virtual unit mem_read_callback(const char *type, sbits paddr, uint64_t width, lbits value);
 
   virtual unit mem_exception_callback(sbits paddr, uint64_t num_of_exception);
 
-  virtual unit xreg_full_write_callback(const_sail_string abi_name, sbits reg,
-                                        sbits value);
+  virtual unit xreg_full_write_callback(const_sail_string abi_name, sbits reg, sbits value);
 
   virtual unit freg_write_callback(unsigned reg, sbits value);
 
-  virtual unit csr_full_write_callback(const_sail_string csr_name, unsigned reg,
-                                       sbits value);
+  virtual unit csr_full_write_callback(const_sail_string csr_name, unsigned reg, sbits value);
 
-  virtual unit csr_full_read_callback(const_sail_string csr_name, unsigned reg,
-                                      sbits value);
+  virtual unit csr_full_read_callback(const_sail_string csr_name, unsigned reg, sbits value);
 
   virtual unit vreg_write_callback(unsigned reg, lbits value);
 
@@ -55,13 +50,14 @@ public:
   virtual unit trap_callback(bool is_interrupt, fbits cause);
 
   // Page table walk callbacks
-  virtual unit
-  ptw_start_callback(uint64_t vpn, hart::zMemoryAccessTypezIuzK access_type,
-                     hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege);
+  virtual unit ptw_start_callback(
+    uint64_t vpn,
+    hart::zMemoryAccessTypezIuzK access_type,
+    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+  );
   virtual unit ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte);
   virtual unit ptw_success_callback(uint64_t final_ppn, int64_t level);
-  virtual unit ptw_fail_callback(hart::zPTW_Error error_type, int64_t level,
-                                 sbits pte_addr);
+  virtual unit ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sbits pte_addr);
 
   // Provides entropy for the scalar cryptography extension.
   virtual mach_bits plat_get_16_random_bits(unit);

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -1,38 +1,38 @@
 #include <cassert>
-#include <ctype.h>
 #include <climits>
+#include <cstring>
+#include <ctype.h>
+#include <errno.h>
 #include <exception>
+#include <fcntl.h>
+#include <iostream>
+#include <optional>
 #include <stdexcept>
 #include <stdio.h>
 #include <stdlib.h>
-#include <errno.h>
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <sys/time.h>
-#include <fcntl.h>
-#include <optional>
-#include <iostream>
+#include <sys/types.h>
+#include <unistd.h>
 #include <vector>
-#include <cstring>
 
-#include "jsoncons/config/version.hpp"
 #include "CLI11.hpp"
 #include "elf_loader.h"
+#include "jsoncons/config/version.hpp"
+#include "rts.h"
 #include "sail.h"
 #include "sail_config.h"
-#include "rts.h"
 #include "symbol_table.h"
 #ifdef SAILCOV
 #include "sail_coverage.h"
 #endif
-#include "rvfi_dii.h"
 #include "config_utils.h"
-#include "sail_riscv_version.h"
 #include "riscv_callbacks_log.h"
 #include "riscv_callbacks_rvfi.h"
 #include "riscv_model_impl.h"
+#include "rvfi_dii.h"
+#include "sail_riscv_version.h"
 
 bool do_show_times = false;
 bool do_print_version = false;
@@ -92,165 +92,136 @@ char *sailcov_file = nullptr;
 // from the C Sail output which was necessarily global.
 ModelImpl g_model;
 
-static void print_dts(void)
-{
+static void print_dts(void) {
   char *dts = nullptr;
   g_model.zgenerate_dts(&dts, UNIT);
   fprintf(stdout, "%s", dts);
   KILL(sail_string)(&dts);
 }
 
-static void print_isa(void)
-{
+static void print_isa(void) {
   char *isa = nullptr;
   g_model.zgenerate_canonical_isa_string(&isa, UNIT);
   fprintf(stdout, "%s\n", isa);
   KILL(sail_string)(&isa);
 }
 
-static void print_build_info(void)
-{
-  std::cout << "Sail RISC-V release: " << version_info::release_version
-            << std::endl;
+static void print_build_info(void) {
+  std::cout << "Sail RISC-V release: " << version_info::release_version << std::endl;
   std::cout << "Sail RISC-V git: " << version_info::git_version << std::endl;
   std::cout << "Sail: " << version_info::sail_version << std::endl;
-  std::cout << "C++ compiler: " << version_info::cxx_compiler_version
-            << std::endl;
+  std::cout << "C++ compiler: " << version_info::cxx_compiler_version << std::endl;
   std::cout << "CLI11: " << CLI11_VERSION << std::endl;
   std::cout << "ELFIO: " << ELFIO_VERSION << std::endl;
   std::cout << "JSONCONS: " << jsoncons::version() << std::endl;
 }
 
-std::vector<uint8_t> read_file(const std::string &file_path)
-{
+std::vector<uint8_t> read_file(const std::string &file_path) {
   std::ifstream instream(file_path, std::ios::in | std::ios::binary);
-  return {std::istreambuf_iterator<char>(instream),
-          std::istreambuf_iterator<char>()};
+  return {std::istreambuf_iterator<char>(instream), std::istreambuf_iterator<char>()};
 }
 
 // Set up command line option processing.
-static void setup_options(CLI::App &app)
-{
+static void setup_options(CLI::App &app) {
   app.add_flag("--show-times", do_show_times, "Show execution times");
   app.add_flag("--version", do_print_version, "Print model version");
   app.add_flag("--build-info", do_print_build_info, "Print build information");
-  app.add_flag("--print-default-config", do_print_default_config,
-               "Print default configuration");
-  app.add_flag("--print-config-schema", do_print_config_schema,
-               "Print configuration schema");
-  app.add_flag("--validate-config", do_validate_config,
-               "Exit after config validation (it is always validated)");
+  app.add_flag("--print-default-config", do_print_default_config, "Print default configuration");
+  app.add_flag("--print-config-schema", do_print_config_schema, "Print configuration schema");
+  app.add_flag("--validate-config", do_validate_config, "Exit after config validation (it is always validated)");
   app.add_flag("--print-device-tree", do_print_dts, "Print device tree");
   app.add_flag("--print-isa-string", do_print_isa, "Print ISA string");
-  app.add_flag("--enable-experimental-extensions",
-               config_enable_experimental_extensions,
-               "Enable experimental extensions");
-  app.add_flag("--use-abi-names", config_use_abi_names,
-               "Use ABI register names in trace log");
+  app.add_flag(
+    "--enable-experimental-extensions",
+    config_enable_experimental_extensions,
+    "Enable experimental extensions"
+  );
+  app.add_flag("--use-abi-names", config_use_abi_names, "Use ABI register names in trace log");
 
   app.add_option("--device-tree-blob", dtb_file, "Device tree blob file")
-      ->check(CLI::ExistingFile)
-      ->option_text("<file>");
-  app.add_option("--terminal-log", term_log, "Terminal log output file")
-      ->option_text("<file>");
-  app.add_option("--test-signature", sig_file, "Test signature file")
-      ->option_text("<file>");
-  app.add_option("--config", config_file, "Configuration file")
-      ->check(CLI::ExistingFile)
-      ->option_text("<file>");
-  app.add_option("--trace-output", trace_log_path, "Trace output file")
-      ->option_text("<file>");
+    ->check(CLI::ExistingFile)
+    ->option_text("<file>");
+  app.add_option("--terminal-log", term_log, "Terminal log output file")->option_text("<file>");
+  app.add_option("--test-signature", sig_file, "Test signature file")->option_text("<file>");
+  app.add_option("--config", config_file, "Configuration file")->check(CLI::ExistingFile)->option_text("<file>");
+  app.add_option("--trace-output", trace_log_path, "Trace output file")->option_text("<file>");
 
-  app.add_option("--signature-granularity", signature_granularity,
-                 "Signature granularity")
-      ->option_text("<uint>");
+  app.add_option("--signature-granularity", signature_granularity, "Signature granularity")->option_text("<uint>");
   app.add_option("--rvfi-dii", rvfi_dii_port, "RVFI DII port")
-      ->check(CLI::Range(1, 65535))
-      ->option_text("<int> (within [1 - 65535])");
-  app.add_option("--inst-limit", insn_limit, "Instruction limit")
-      ->option_text("<uint>");
+    ->check(CLI::Range(1, 65535))
+    ->option_text("<int> (within [1 - 65535])");
+  app.add_option("--inst-limit", insn_limit, "Instruction limit")->option_text("<uint>");
 #ifdef SAILCOV
-  app.add_option("--sailcov-file", sailcov_file, "Sail coverage output file")
-      ->option_text("<file>");
+  app.add_option("--sailcov-file", sailcov_file, "Sail coverage output file")->option_text("<file>");
 #endif
 
-  app.add_flag("--trace-instr", config_print_instr,
-               "Enable trace output for instruction execution");
-  app.add_flag("--trace-ptw", config_print_ptw,
-               "Enable trace output for Page Table walk");
-  app.add_flag("--trace-reg", config_print_reg,
-               "Enable trace output for register access");
-  app.add_flag("--trace-mem", config_print_mem_access,
-               "Enable trace output for memory accesses");
-  app.add_flag("--trace-rvfi", config_print_rvfi,
-               "Enable trace output for RVFI");
-  app.add_flag("--trace-clint", config_print_clint,
-               "Enable trace output for CLINT memory accesses and status");
-  app.add_flag("--trace-exception", config_print_exception,
-               "Enable trace output for exceptions");
-  app.add_flag("--trace-interrupt", config_print_interrupt,
-               "Enable trace output for interrupts");
-  app.add_flag("--trace-htif", config_print_htif,
-               "Enable trace output for HTIF operations");
-  app.add_flag("--trace-pma", config_print_pma,
-               "Enable trace output for PMA checks");
+  app.add_flag("--trace-instr", config_print_instr, "Enable trace output for instruction execution");
+  app.add_flag("--trace-ptw", config_print_ptw, "Enable trace output for Page Table walk");
+  app.add_flag("--trace-reg", config_print_reg, "Enable trace output for register access");
+  app.add_flag("--trace-mem", config_print_mem_access, "Enable trace output for memory accesses");
+  app.add_flag("--trace-rvfi", config_print_rvfi, "Enable trace output for RVFI");
+  app.add_flag("--trace-clint", config_print_clint, "Enable trace output for CLINT memory accesses and status");
+  app.add_flag("--trace-exception", config_print_exception, "Enable trace output for exceptions");
+  app.add_flag("--trace-interrupt", config_print_interrupt, "Enable trace output for interrupts");
+  app.add_flag("--trace-htif", config_print_htif, "Enable trace output for HTIF operations");
+  app.add_flag("--trace-pma", config_print_pma, "Enable trace output for PMA checks");
   app.add_flag_callback(
-      "--trace-platform",
-      [] {
-        config_print_clint = true;
-        config_print_exception = true;
-        config_print_interrupt = true;
-        config_print_htif = true;
-        config_print_pma = true;
-      },
-      "Enable trace output for platform-level events (MMIO, interrupts, "
-      "exceptions, CLINT, HTIF, PMA)");
-  app.add_flag("--trace-step", config_print_step,
-               "Add a blank line between steps in the trace output");
+    "--trace-platform",
+    [] {
+      config_print_clint = true;
+      config_print_exception = true;
+      config_print_interrupt = true;
+      config_print_htif = true;
+      config_print_pma = true;
+    },
+    "Enable trace output for platform-level events (MMIO, interrupts, "
+    "exceptions, CLINT, HTIF, PMA)"
+  );
+  app.add_flag("--trace-step", config_print_step, "Add a blank line between steps in the trace output");
 
   app.add_flag_callback(
-      "--trace-all",
-      [] {
-        config_print_instr = true;
-        config_print_reg = true;
-        config_print_mem_access = true;
-        config_print_rvfi = true;
-        config_print_clint = true;
-        config_print_exception = true;
-        config_print_interrupt = true;
-        config_print_htif = true;
-        config_print_pma = true;
-        config_print_step = true;
-        config_print_ptw = true;
-      },
-      "Enable all trace output");
+    "--trace-all",
+    [] {
+      config_print_instr = true;
+      config_print_reg = true;
+      config_print_mem_access = true;
+      config_print_rvfi = true;
+      config_print_clint = true;
+      config_print_exception = true;
+      config_print_interrupt = true;
+      config_print_htif = true;
+      config_print_pma = true;
+      config_print_step = true;
+      config_print_ptw = true;
+    },
+    "Enable all trace output"
+  );
 
   // All positional arguments are treated as ELF files.  All ELF files
   // are loaded into memory, but only the first is scanned for the
   // magic `tohost/{begin,end}_signature` symbols.
   app.add_option(
-      "elfs", elfs,
-      "List of ELF files to load. They will be loaded in order, possibly "
-      "overwriting each other. PC will be set to the entry point of the first "
-      "file. This is optional with some arguments, e.g. --print-isa-string.");
+    "elfs",
+    elfs,
+    "List of ELF files to load. They will be loaded in order, possibly "
+    "overwriting each other. PC will be set to the entry point of the first "
+    "file. This is optional with some arguments, e.g. --print-isa-string."
+  );
 }
 
-uint64_t load_sail(const std::string &filename, bool main_file)
-{
+uint64_t load_sail(const std::string &filename, bool main_file) {
   ELF elf = ELF::open(filename);
 
   switch (elf.architecture()) {
   case Architecture::RV32:
     if (g_model.zxlen != 32) {
-      fprintf(stderr, "32-bit ELF not supported by RV%" PRIu64 " model.\n",
-              g_model.zxlen);
+      fprintf(stderr, "32-bit ELF not supported by RV%" PRIu64 " model.\n", g_model.zxlen);
       exit(EXIT_FAILURE);
     }
     break;
   case Architecture::RV64:
     if (g_model.zxlen != 64) {
-      fprintf(stderr, "64-bit ELF not supported by RV%" PRIu64 " model.\n",
-              g_model.zxlen);
+      fprintf(stderr, "64-bit ELF not supported by RV%" PRIu64 " model.\n", g_model.zxlen);
       exit(EXIT_FAILURE);
     }
     break;
@@ -301,8 +272,7 @@ uint64_t load_sail(const std::string &filename, bool main_file)
   return elf.entry();
 }
 
-void write_dtb_to_rom(const std::vector<uint8_t> &dtb)
-{
+void write_dtb_to_rom(const std::vector<uint8_t> &dtb) {
   uint64_t addr = get_config_uint64({"memory", "dtb_address"});
 
   for (uint8_t d : dtb) {
@@ -310,14 +280,11 @@ void write_dtb_to_rom(const std::vector<uint8_t> &dtb)
   }
 }
 
-void init_platform_constants()
-{
-  g_model.set_reservation_set_size_exp(
-      get_config_uint64({"platform", "reservation_set_size_exp"}));
+void init_platform_constants() {
+  g_model.set_reservation_set_size_exp(get_config_uint64({"platform", "reservation_set_size_exp"}));
 }
 
-void init_sail(uint64_t elf_entry, const char *config_file)
-{
+void init_sail(uint64_t elf_entry, const char *config_file) {
   // zset_pc_reset_address must be called before zinit_model
   // because reset happens inside init_model().
   g_model.zset_pc_reset_address(elf_entry);
@@ -329,19 +296,21 @@ void init_sail(uint64_t elf_entry, const char *config_file)
 }
 
 /* reinitialize to clear state and memory, typically across tests runs */
-void reinit_sail(uint64_t elf_entry, const char *config_file)
-{
+void reinit_sail(uint64_t elf_entry, const char *config_file) {
   g_model.model_fini();
   g_model.model_init();
   init_sail(elf_entry, config_file);
 }
 
-void write_signature(const char *file)
-{
+void write_signature(const char *file) {
   if (mem_sig_start >= mem_sig_end) {
-    fprintf(stderr,
-            "Invalid signature region [0x%0" PRIx64 ",0x%0" PRIx64 "] to %s.\n",
-            mem_sig_start, mem_sig_end, file);
+    fprintf(
+      stderr,
+      "Invalid signature region [0x%0" PRIx64 ",0x%0" PRIx64 "] to %s.\n",
+      mem_sig_start,
+      mem_sig_end,
+      file
+    );
     return;
   }
   FILE *f = fopen(file, "w");
@@ -350,8 +319,7 @@ void write_signature(const char *file)
     return;
   }
   /* write out words depending on signature granularity in signature area */
-  for (uint64_t addr = mem_sig_start; addr < mem_sig_end;
-       addr += signature_granularity) {
+  for (uint64_t addr = mem_sig_start; addr < mem_sig_end; addr += signature_granularity) {
     /* most-significant byte first */
     for (int i = signature_granularity - 1; i >= 0; i--) {
       uint8_t byte = (uint8_t)read_mem(addr + i);
@@ -362,8 +330,7 @@ void write_signature(const char *file)
   fclose(f);
 }
 
-void close_logs(void)
-{
+void close_logs(void) {
 #ifdef SAILCOV
   if (sail_coverage_exit() != 0) {
     fprintf(stderr, "Could not write coverage information!\n");
@@ -375,8 +342,7 @@ void close_logs(void)
   }
 }
 
-void finish()
-{
+void finish() {
   // Don't write a signature if there was an internal Sail exception.
   if (!g_model.have_exception && !sig_file.empty()) {
     write_signature(sig_file.c_str());
@@ -390,10 +356,8 @@ void finish()
       fprintf(stderr, "Cannot gettimeofday: %s\n", strerror(errno));
       exit(EXIT_FAILURE);
     }
-    int init_msecs = (init_end.tv_sec - init_start.tv_sec) * 1000
-        + (init_end.tv_usec - init_start.tv_usec) / 1000;
-    int exec_msecs = (run_end.tv_sec - init_end.tv_sec) * 1000
-        + (run_end.tv_usec - init_end.tv_usec) / 1000;
+    int init_msecs = (init_end.tv_sec - init_start.tv_sec) * 1000 + (init_end.tv_usec - init_start.tv_usec) / 1000;
+    int exec_msecs = (run_end.tv_sec - init_end.tv_sec) * 1000 + (run_end.tv_usec - init_end.tv_usec) / 1000;
     double Kips = ((double)total_insns) / ((double)exec_msecs);
     fprintf(stderr, "Initialization:   %d msecs\n", init_msecs);
     fprintf(stderr, "Execution:        %d msecs\n", exec_msecs);
@@ -404,16 +368,14 @@ void finish()
   exit(EXIT_SUCCESS);
 }
 
-void flush_logs(void)
-{
+void flush_logs(void) {
   if (config_print_instr) {
     fflush(stderr);
     fflush(trace_log);
   }
 }
 
-void run_sail(void)
-{
+void run_sail(void) {
   bool is_waiting = false;
   bool exit_wait = true;
 
@@ -421,8 +383,7 @@ void run_sail(void)
   mach_int step_no = 0;
   uint64_t insn_cnt = 0;
 
-  uint64_t insns_per_tick
-      = get_config_uint64({"platform", "instructions_per_tick"});
+  uint64_t insns_per_tick = get_config_uint64({"platform", "instructions_per_tick"});
 
   struct timeval interval_start;
   if (gettimeofday(&interval_start, nullptr) < 0) {
@@ -474,16 +435,13 @@ void run_sail(void)
     }
 
     if (do_show_times && (total_insns & 0xfffff) == 0) {
-      uint64_t start_us = 1000000 * ((uint64_t)interval_start.tv_sec)
-          + ((uint64_t)interval_start.tv_usec);
+      uint64_t start_us = 1000000 * ((uint64_t)interval_start.tv_sec) + ((uint64_t)interval_start.tv_usec);
       if (gettimeofday(&interval_start, nullptr) < 0) {
         fprintf(stderr, "Cannot gettimeofday: %s\n", strerror(errno));
         exit(EXIT_FAILURE);
       }
-      uint64_t end_us = 1000000 * ((uint64_t)interval_start.tv_sec)
-          + ((uint64_t)interval_start.tv_usec);
-      fprintf(stdout, "kips: %" PRIu64 "\n",
-              ((uint64_t)1000) * 0x100000 / (end_us - start_us));
+      uint64_t end_us = 1000000 * ((uint64_t)interval_start.tv_sec) + ((uint64_t)interval_start.tv_usec);
+      fprintf(stdout, "kips: %" PRIu64 "\n", ((uint64_t)1000) * 0x100000 / (end_us - start_us));
     }
 
     if (g_model.zhtif_done) {
@@ -507,22 +465,17 @@ void run_sail(void)
   finish();
 }
 
-void init_logs()
-{
-  if (!term_log.empty()
-      && (term_fd = open(term_log.c_str(), O_WRONLY | O_CREAT | O_TRUNC,
-                         S_IRUSR | S_IRGRP | S_IROTH | S_IWUSR))
-          < 0) {
-    fprintf(stderr, "Cannot create terminal log '%s': %s\n", term_log.c_str(),
-            strerror(errno));
+void init_logs() {
+  if (!term_log.empty() &&
+      (term_fd = open(term_log.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IRGRP | S_IROTH | S_IWUSR)) < 0) {
+    fprintf(stderr, "Cannot create terminal log '%s': %s\n", term_log.c_str(), strerror(errno));
     exit(EXIT_FAILURE);
   }
 
   if (!trace_log_path.empty()) {
     trace_log = fopen(trace_log_path.c_str(), "w+");
     if (trace_log == nullptr) {
-      fprintf(stderr, "Cannot create trace log '%s': %s\n",
-              trace_log_path.c_str(), strerror(errno));
+      fprintf(stderr, "Cannot create trace log '%s': %s\n", trace_log_path.c_str(), strerror(errno));
       exit(EXIT_FAILURE);
     }
   }
@@ -534,8 +487,7 @@ void init_logs()
 #endif
 }
 
-int inner_main(int argc, char **argv)
-{
+int inner_main(int argc, char **argv) {
   CLI::App app("Sail RISC-V Model");
   argv = app.ensure_utf8(argv);
   setup_options(app);
@@ -587,8 +539,7 @@ int inner_main(int argc, char **argv)
     fprintf(stderr, "using %s for test-signature output.\n", sig_file.c_str());
   }
   if (signature_granularity != DEFAULT_SIGNATURE_GRANULARITY) {
-    fprintf(stderr, "setting signature-granularity to %d bytes\n",
-            signature_granularity);
+    fprintf(stderr, "setting signature-granularity to %d bytes\n", signature_granularity);
   }
   if (config_enable_experimental_extensions) {
     fprintf(stderr, "enabling unratified extensions.\n");
@@ -646,8 +597,7 @@ int inner_main(int argc, char **argv)
   }
 
   init_logs();
-  log_callbacks log_cbs(config_print_reg, config_print_mem_access,
-                        config_print_ptw, config_use_abi_names, trace_log);
+  log_callbacks log_cbs(config_print_reg, config_print_mem_access, config_print_ptw, config_use_abi_names, trace_log);
   g_model.register_callback(&log_cbs);
 
   if (gettimeofday(&init_start, nullptr) < 0) {
@@ -668,8 +618,7 @@ int inner_main(int argc, char **argv)
   }
 
   const std::string &initial_elf_file = elfs[0];
-  uint64_t entry = rvfi ? rvfi->get_entry()
-                        : load_sail(initial_elf_file, /*main_file=*/true);
+  uint64_t entry = rvfi ? rvfi->get_entry() : load_sail(initial_elf_file, /*main_file=*/true);
 
   fprintf(stdout, "Entry point: 0x%" PRIx64 "\n", entry);
 
@@ -702,8 +651,7 @@ int inner_main(int argc, char **argv)
   return 0;
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
   // Catch all exceptions and print them a bit more nicely than the default.
   try {
     return inner_main(argc, argv);

--- a/c_emulator/riscv_softfloat.cpp
+++ b/c_emulator/riscv_softfloat.cpp
@@ -5,17 +5,15 @@ extern "C" {
 #include "softfloat.h"
 }
 
-static uint_fast8_t uint8_of_rm(uint64_t rm)
-{
+static uint_fast8_t uint8_of_rm(uint64_t rm) {
   return static_cast<uint_fast8_t>(rm);
 }
 
-#define SOFTFLOAT_PRELUDE(rm)                                                  \
-  softfloat_exceptionFlags = 0;                                                \
+#define SOFTFLOAT_PRELUDE(rm)                                                                                          \
+  softfloat_exceptionFlags = 0;                                                                                        \
   softfloat_roundingMode = uint8_of_rm(rm)
 
-bv5_bv16 softfloat_f16add(uint64_t rm, uint64_t v1, uint64_t v2)
-{
+bv5_bv16 softfloat_f16add(uint64_t rm, uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a, b, res;
@@ -26,8 +24,7 @@ bv5_bv16 softfloat_f16add(uint64_t rm, uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv16 softfloat_f16sub(uint64_t rm, uint64_t v1, uint64_t v2)
-{
+bv5_bv16 softfloat_f16sub(uint64_t rm, uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a, b, res;
@@ -38,8 +35,7 @@ bv5_bv16 softfloat_f16sub(uint64_t rm, uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv16 softfloat_f16mul(uint64_t rm, uint64_t v1, uint64_t v2)
-{
+bv5_bv16 softfloat_f16mul(uint64_t rm, uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a, b, res;
@@ -50,8 +46,7 @@ bv5_bv16 softfloat_f16mul(uint64_t rm, uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv16 softfloat_f16div(uint64_t rm, uint64_t v1, uint64_t v2)
-{
+bv5_bv16 softfloat_f16div(uint64_t rm, uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a, b, res;
@@ -62,8 +57,7 @@ bv5_bv16 softfloat_f16div(uint64_t rm, uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_f32add(uint64_t rm, uint64_t v1, uint64_t v2)
-{
+bv5_bv32 softfloat_f32add(uint64_t rm, uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, b, res;
@@ -74,8 +68,7 @@ bv5_bv32 softfloat_f32add(uint64_t rm, uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_f32sub(uint64_t rm, uint64_t v1, uint64_t v2)
-{
+bv5_bv32 softfloat_f32sub(uint64_t rm, uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, b, res;
@@ -86,8 +79,7 @@ bv5_bv32 softfloat_f32sub(uint64_t rm, uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_f32mul(uint64_t rm, uint64_t v1, uint64_t v2)
-{
+bv5_bv32 softfloat_f32mul(uint64_t rm, uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, b, res;
@@ -98,8 +90,7 @@ bv5_bv32 softfloat_f32mul(uint64_t rm, uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_f32div(uint64_t rm, uint64_t v1, uint64_t v2)
-{
+bv5_bv32 softfloat_f32div(uint64_t rm, uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, b, res;
@@ -110,8 +101,7 @@ bv5_bv32 softfloat_f32div(uint64_t rm, uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_f64add(uint64_t rm, uint64_t v1, uint64_t v2)
-{
+bv5_bv64 softfloat_f64add(uint64_t rm, uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, b, res;
@@ -122,8 +112,7 @@ bv5_bv64 softfloat_f64add(uint64_t rm, uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_f64sub(uint64_t rm, uint64_t v1, uint64_t v2)
-{
+bv5_bv64 softfloat_f64sub(uint64_t rm, uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, b, res;
@@ -134,8 +123,7 @@ bv5_bv64 softfloat_f64sub(uint64_t rm, uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_f64mul(uint64_t rm, uint64_t v1, uint64_t v2)
-{
+bv5_bv64 softfloat_f64mul(uint64_t rm, uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, b, res;
@@ -146,8 +134,7 @@ bv5_bv64 softfloat_f64mul(uint64_t rm, uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_f64div(uint64_t rm, uint64_t v1, uint64_t v2)
-{
+bv5_bv64 softfloat_f64div(uint64_t rm, uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, b, res;
@@ -158,8 +145,7 @@ bv5_bv64 softfloat_f64div(uint64_t rm, uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv16 softfloat_f16muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3)
-{
+bv5_bv16 softfloat_f16muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a, b, c, res;
@@ -171,8 +157,7 @@ bv5_bv16 softfloat_f16muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_f32muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3)
-{
+bv5_bv32 softfloat_f32muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, b, c, res;
@@ -184,8 +169,7 @@ bv5_bv32 softfloat_f32muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_f64muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3)
-{
+bv5_bv64 softfloat_f64muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, b, c, res;
@@ -197,8 +181,7 @@ bv5_bv64 softfloat_f64muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv16 softfloat_f16sqrt(uint64_t rm, uint64_t v)
-{
+bv5_bv16 softfloat_f16sqrt(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a, res;
@@ -208,8 +191,7 @@ bv5_bv16 softfloat_f16sqrt(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_f32sqrt(uint64_t rm, uint64_t v)
-{
+bv5_bv32 softfloat_f32sqrt(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, res;
@@ -219,8 +201,7 @@ bv5_bv32 softfloat_f32sqrt(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_f64sqrt(uint64_t rm, uint64_t v)
-{
+bv5_bv64 softfloat_f64sqrt(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, res;
@@ -233,8 +214,7 @@ bv5_bv64 softfloat_f64sqrt(uint64_t rm, uint64_t v)
 // The boolean 'true' argument in the conversion calls below selects
 // 'exact' conversion, which sets the Inexact exception flag if
 // needed.
-bv5_bv32 softfloat_f16toi32(uint64_t rm, uint64_t v)
-{
+bv5_bv32 softfloat_f16toi32(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a;
@@ -246,8 +226,7 @@ bv5_bv32 softfloat_f16toi32(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_f16toui32(uint64_t rm, uint64_t v)
-{
+bv5_bv32 softfloat_f16toui32(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a;
@@ -259,8 +238,7 @@ bv5_bv32 softfloat_f16toui32(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_f16toi64(uint64_t rm, uint64_t v)
-{
+bv5_bv64 softfloat_f16toi64(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a;
@@ -272,8 +250,7 @@ bv5_bv64 softfloat_f16toi64(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_f16toui64(uint64_t rm, uint64_t v)
-{
+bv5_bv64 softfloat_f16toui64(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a;
@@ -285,8 +262,7 @@ bv5_bv64 softfloat_f16toui64(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_f32toi32(uint64_t rm, uint64_t v)
-{
+bv5_bv32 softfloat_f32toi32(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, res;
@@ -297,8 +273,7 @@ bv5_bv32 softfloat_f32toi32(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_f32toui32(uint64_t rm, uint64_t v)
-{
+bv5_bv32 softfloat_f32toui32(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, res;
@@ -309,8 +284,7 @@ bv5_bv32 softfloat_f32toui32(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_f32toi64(uint64_t rm, uint64_t v)
-{
+bv5_bv64 softfloat_f32toi64(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a;
@@ -322,8 +296,7 @@ bv5_bv64 softfloat_f32toi64(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_f32toui64(uint64_t rm, uint64_t v)
-{
+bv5_bv64 softfloat_f32toui64(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a;
@@ -335,8 +308,7 @@ bv5_bv64 softfloat_f32toui64(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_f64toi32(uint64_t rm, uint64_t v)
-{
+bv5_bv32 softfloat_f64toi32(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a;
@@ -348,8 +320,7 @@ bv5_bv32 softfloat_f64toi32(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_f64toui32(uint64_t rm, uint64_t v)
-{
+bv5_bv32 softfloat_f64toui32(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a;
@@ -361,8 +332,7 @@ bv5_bv32 softfloat_f64toui32(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_f64toi64(uint64_t rm, uint64_t v)
-{
+bv5_bv64 softfloat_f64toi64(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, res;
@@ -373,8 +343,7 @@ bv5_bv64 softfloat_f64toi64(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_f64toui64(uint64_t rm, uint64_t v)
-{
+bv5_bv64 softfloat_f64toui64(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, res;
@@ -385,8 +354,7 @@ bv5_bv64 softfloat_f64toui64(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv16 softfloat_i32tof16(uint64_t rm, uint64_t v)
-{
+bv5_bv16 softfloat_i32tof16(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t res;
@@ -395,8 +363,7 @@ bv5_bv16 softfloat_i32tof16(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv16 softfloat_ui32tof16(uint64_t rm, uint64_t v)
-{
+bv5_bv16 softfloat_ui32tof16(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t res;
@@ -405,8 +372,7 @@ bv5_bv16 softfloat_ui32tof16(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv16 softfloat_i64tof16(uint64_t rm, uint64_t v)
-{
+bv5_bv16 softfloat_i64tof16(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t res;
@@ -415,8 +381,7 @@ bv5_bv16 softfloat_i64tof16(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv16 softfloat_ui64tof16(uint64_t rm, uint64_t v)
-{
+bv5_bv16 softfloat_ui64tof16(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t res;
@@ -425,8 +390,7 @@ bv5_bv16 softfloat_ui64tof16(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_i32tof32(uint64_t rm, uint64_t v)
-{
+bv5_bv32 softfloat_i32tof32(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t res;
@@ -435,8 +399,7 @@ bv5_bv32 softfloat_i32tof32(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_ui32tof32(uint64_t rm, uint64_t v)
-{
+bv5_bv32 softfloat_ui32tof32(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t res;
@@ -445,8 +408,7 @@ bv5_bv32 softfloat_ui32tof32(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_i64tof32(uint64_t rm, uint64_t v)
-{
+bv5_bv32 softfloat_i64tof32(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t res;
@@ -455,8 +417,7 @@ bv5_bv32 softfloat_i64tof32(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_ui64tof32(uint64_t rm, uint64_t v)
-{
+bv5_bv32 softfloat_ui64tof32(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t res;
@@ -465,8 +426,7 @@ bv5_bv32 softfloat_ui64tof32(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_i32tof64(uint64_t rm, uint64_t v)
-{
+bv5_bv64 softfloat_i32tof64(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t res;
@@ -475,8 +435,7 @@ bv5_bv64 softfloat_i32tof64(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_ui32tof64(uint64_t rm, uint64_t v)
-{
+bv5_bv64 softfloat_ui32tof64(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t res;
@@ -485,8 +444,7 @@ bv5_bv64 softfloat_ui32tof64(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_i64tof64(uint64_t rm, uint64_t v)
-{
+bv5_bv64 softfloat_i64tof64(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t res;
@@ -495,8 +453,7 @@ bv5_bv64 softfloat_i64tof64(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_ui64tof64(uint64_t rm, uint64_t v)
-{
+bv5_bv64 softfloat_ui64tof64(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t res;
@@ -505,8 +462,7 @@ bv5_bv64 softfloat_ui64tof64(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_f16tof32(uint64_t rm, uint64_t v)
-{
+bv5_bv32 softfloat_f16tof32(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a;
@@ -517,8 +473,7 @@ bv5_bv32 softfloat_f16tof32(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_f16tof64(uint64_t rm, uint64_t v)
-{
+bv5_bv64 softfloat_f16tof64(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a;
@@ -529,8 +484,7 @@ bv5_bv64 softfloat_f16tof64(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_f32tof64(uint64_t rm, uint64_t v)
-{
+bv5_bv64 softfloat_f32tof64(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a;
@@ -541,8 +495,7 @@ bv5_bv64 softfloat_f32tof64(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv16 softfloat_f32tof16(uint64_t rm, uint64_t v)
-{
+bv5_bv16 softfloat_f32tof16(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a;
@@ -553,8 +506,7 @@ bv5_bv16 softfloat_f32tof16(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv16 softfloat_f64tof16(uint64_t rm, uint64_t v)
-{
+bv5_bv16 softfloat_f64tof16(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a;
@@ -565,8 +517,7 @@ bv5_bv16 softfloat_f64tof16(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_f64tof32(uint64_t rm, uint64_t v)
-{
+bv5_bv32 softfloat_f64tof32(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a;
@@ -577,8 +528,7 @@ bv5_bv32 softfloat_f64tof32(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv16 softfloat_f32tobf16(uint64_t rm, uint64_t v)
-{
+bv5_bv16 softfloat_f32tobf16(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a;
@@ -589,8 +539,7 @@ bv5_bv16 softfloat_f32tobf16(uint64_t rm, uint64_t v)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bool softfloat_f16lt(uint64_t v1, uint64_t v2)
-{
+bv5_bool softfloat_f16lt(uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(0);
 
   float16_t a, b;
@@ -601,8 +550,7 @@ bv5_bool softfloat_f16lt(uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res};
 }
 
-bv5_bool softfloat_f16lt_quiet(uint64_t v1, uint64_t v2)
-{
+bv5_bool softfloat_f16lt_quiet(uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(0);
 
   float16_t a, b;
@@ -613,8 +561,7 @@ bv5_bool softfloat_f16lt_quiet(uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res};
 }
 
-bv5_bool softfloat_f16le(uint64_t v1, uint64_t v2)
-{
+bv5_bool softfloat_f16le(uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(0);
 
   float16_t a, b;
@@ -625,8 +572,7 @@ bv5_bool softfloat_f16le(uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res};
 }
 
-bv5_bool softfloat_f16le_quiet(uint64_t v1, uint64_t v2)
-{
+bv5_bool softfloat_f16le_quiet(uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(0);
 
   float16_t a, b;
@@ -637,8 +583,7 @@ bv5_bool softfloat_f16le_quiet(uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res};
 }
 
-bv5_bool softfloat_f16eq(uint64_t v1, uint64_t v2)
-{
+bv5_bool softfloat_f16eq(uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(0);
 
   float16_t a, b;
@@ -649,8 +594,7 @@ bv5_bool softfloat_f16eq(uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res};
 }
 
-bv5_bool softfloat_f32lt(uint64_t v1, uint64_t v2)
-{
+bv5_bool softfloat_f32lt(uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(0);
 
   float32_t a, b;
@@ -661,8 +605,7 @@ bv5_bool softfloat_f32lt(uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res};
 }
 
-bv5_bool softfloat_f32lt_quiet(uint64_t v1, uint64_t v2)
-{
+bv5_bool softfloat_f32lt_quiet(uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(0);
 
   float32_t a, b;
@@ -673,8 +616,7 @@ bv5_bool softfloat_f32lt_quiet(uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res};
 }
 
-bv5_bool softfloat_f32le(uint64_t v1, uint64_t v2)
-{
+bv5_bool softfloat_f32le(uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(0);
 
   float32_t a, b;
@@ -685,8 +627,7 @@ bv5_bool softfloat_f32le(uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res};
 }
 
-bv5_bool softfloat_f32le_quiet(uint64_t v1, uint64_t v2)
-{
+bv5_bool softfloat_f32le_quiet(uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(0);
 
   float32_t a, b;
@@ -697,8 +638,7 @@ bv5_bool softfloat_f32le_quiet(uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res};
 }
 
-bv5_bool softfloat_f32eq(uint64_t v1, uint64_t v2)
-{
+bv5_bool softfloat_f32eq(uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(0);
 
   float32_t a, b;
@@ -709,8 +649,7 @@ bv5_bool softfloat_f32eq(uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res};
 }
 
-bv5_bool softfloat_f64lt(uint64_t v1, uint64_t v2)
-{
+bv5_bool softfloat_f64lt(uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(0);
 
   float64_t a, b;
@@ -721,8 +660,7 @@ bv5_bool softfloat_f64lt(uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res};
 }
 
-bv5_bool softfloat_f64lt_quiet(uint64_t v1, uint64_t v2)
-{
+bv5_bool softfloat_f64lt_quiet(uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(0);
 
   float64_t a, b;
@@ -733,8 +671,7 @@ bv5_bool softfloat_f64lt_quiet(uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res};
 }
 
-bv5_bool softfloat_f64le(uint64_t v1, uint64_t v2)
-{
+bv5_bool softfloat_f64le(uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(0);
 
   float64_t a, b;
@@ -745,8 +682,7 @@ bv5_bool softfloat_f64le(uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res};
 }
 
-bv5_bool softfloat_f64le_quiet(uint64_t v1, uint64_t v2)
-{
+bv5_bool softfloat_f64le_quiet(uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(0);
 
   float64_t a, b;
@@ -757,8 +693,7 @@ bv5_bool softfloat_f64le_quiet(uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res};
 }
 
-bv5_bool softfloat_f64eq(uint64_t v1, uint64_t v2)
-{
+bv5_bool softfloat_f64eq(uint64_t v1, uint64_t v2) {
   SOFTFLOAT_PRELUDE(0);
 
   float64_t a, b;
@@ -769,8 +704,7 @@ bv5_bool softfloat_f64eq(uint64_t v1, uint64_t v2)
   return {softfloat_exceptionFlags, res};
 }
 
-bv5_bv16 softfloat_f16roundToInt(uint64_t rm, uint64_t v, bool exact)
-{
+bv5_bv16 softfloat_f16roundToInt(uint64_t rm, uint64_t v, bool exact) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t a, res;
@@ -781,8 +715,7 @@ bv5_bv16 softfloat_f16roundToInt(uint64_t rm, uint64_t v, bool exact)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv32 softfloat_f32roundToInt(uint64_t rm, uint64_t v, bool exact)
-{
+bv5_bv32 softfloat_f32roundToInt(uint64_t rm, uint64_t v, bool exact) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t a, res;
@@ -793,8 +726,7 @@ bv5_bv32 softfloat_f32roundToInt(uint64_t rm, uint64_t v, bool exact)
   return {softfloat_exceptionFlags, res.v};
 }
 
-bv5_bv64 softfloat_f64roundToInt(uint64_t rm, uint64_t v, bool exact)
-{
+bv5_bv64 softfloat_f64roundToInt(uint64_t rm, uint64_t v, bool exact) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t a, res;

--- a/c_emulator/riscv_softfloat.h
+++ b/c_emulator/riscv_softfloat.h
@@ -25,12 +25,9 @@ bv5_bv64 softfloat_f64sub(uint64_t rm, uint64_t v1, uint64_t v2);
 bv5_bv64 softfloat_f64mul(uint64_t rm, uint64_t v1, uint64_t v2);
 bv5_bv64 softfloat_f64div(uint64_t rm, uint64_t v1, uint64_t v2);
 
-bv5_bv16 softfloat_f16muladd(uint64_t rm, uint64_t v1, uint64_t v2,
-                             uint64_t v3);
-bv5_bv32 softfloat_f32muladd(uint64_t rm, uint64_t v1, uint64_t v2,
-                             uint64_t v3);
-bv5_bv64 softfloat_f64muladd(uint64_t rm, uint64_t v1, uint64_t v2,
-                             uint64_t v3);
+bv5_bv16 softfloat_f16muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3);
+bv5_bv32 softfloat_f32muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3);
+bv5_bv64 softfloat_f64muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3);
 
 bv5_bv16 softfloat_f16sqrt(uint64_t rm, uint64_t v);
 bv5_bv32 softfloat_f32sqrt(uint64_t rm, uint64_t v);

--- a/c_emulator/sail_riscv_version.h
+++ b/c_emulator/sail_riscv_version.h
@@ -9,4 +9,4 @@ extern const std::string_view git_version;
 extern const std::string_view sail_version;
 extern const std::string_view cxx_compiler_version;
 
-};
+}; // namespace version_info

--- a/c_emulator/symbol_table.cpp
+++ b/c_emulator/symbol_table.cpp
@@ -1,9 +1,7 @@
 #include "symbol_table.h"
 #include <optional>
 
-std::map<uint64_t, std::string>
-reverse_symbol_table(const std::map<std::string, uint64_t> &symbols)
-{
+std::map<uint64_t, std::string> reverse_symbol_table(const std::map<std::string, uint64_t> &symbols) {
   std::map<uint64_t, std::string> reversed;
   for (const auto &it : symbols) {
     // If multiple symbols have the same value the last one alphabetically wins.
@@ -12,10 +10,10 @@ reverse_symbol_table(const std::map<std::string, uint64_t> &symbols)
   return reversed;
 }
 
-std::optional<std::pair<uint64_t, const std::string &>>
-symbolize_address(const std::map<uint64_t, std::string> &symbols,
-                  uint64_t address)
-{
+std::optional<std::pair<uint64_t, const std::string &>> symbolize_address(
+  const std::map<uint64_t, std::string> &symbols,
+  uint64_t address
+) {
   // Find the first symbol > the address.
   auto it = symbols.upper_bound(address);
   if (it == symbols.begin()) {

--- a/c_emulator/symbol_table.h
+++ b/c_emulator/symbol_table.h
@@ -1,20 +1,20 @@
 #pragma once
 
 #include <cstdint>
-#include <optional>
 #include <map>
+#include <optional>
 #include <string>
 
 // Reverse a symbol table so instead of name->value it's value->name.
-std::map<uint64_t, std::string>
-reverse_symbol_table(const std::map<std::string, uint64_t> &symbols);
+std::map<uint64_t, std::string> reverse_symbol_table(const std::map<std::string, uint64_t> &symbols);
 
 // Find the symbol that is closest to `address` in value (but not greater than
 // it). Return the symbol name and the symbol value (not the offset to
 // `address`).
-std::optional<std::pair<uint64_t, const std::string &>>
-symbolize_address(const std::map<uint64_t, std::string> &symbols,
-                  uint64_t address);
+std::optional<std::pair<uint64_t, const std::string &>> symbolize_address(
+  const std::map<uint64_t, std::string> &symbols,
+  uint64_t address
+);
 
 // Global symbol table.
 // TODO: Don't use globals.

--- a/test/first_party/src/common/encoding.h
+++ b/test/first_party/src/common/encoding.h
@@ -348,34 +348,34 @@
 
 #ifdef __GNUC__
 
-#define read_csr(reg)                                                          \
-  ({                                                                           \
-    unsigned long __tmp;                                                       \
-    asm volatile("csrr %0, " #reg : "=r"(__tmp));                              \
-    __tmp;                                                                     \
+#define read_csr(reg)                                                                                                  \
+  ({                                                                                                                   \
+    unsigned long __tmp;                                                                                               \
+    asm volatile("csrr %0, " #reg : "=r"(__tmp));                                                                      \
+    __tmp;                                                                                                             \
   })
 
 #define write_csr(reg, val) ({ asm volatile("csrw " #reg ", %0" ::"rK"(val)); })
 
-#define swap_csr(reg, val)                                                     \
-  ({                                                                           \
-    unsigned long __tmp;                                                       \
-    asm volatile("csrrw %0, " #reg ", %1" : "=r"(__tmp) : "rK"(val));          \
-    __tmp;                                                                     \
+#define swap_csr(reg, val)                                                                                             \
+  ({                                                                                                                   \
+    unsigned long __tmp;                                                                                               \
+    asm volatile("csrrw %0, " #reg ", %1" : "=r"(__tmp) : "rK"(val));                                                  \
+    __tmp;                                                                                                             \
   })
 
-#define set_csr(reg, bit)                                                      \
-  ({                                                                           \
-    unsigned long __tmp;                                                       \
-    asm volatile("csrrs %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit));          \
-    __tmp;                                                                     \
+#define set_csr(reg, bit)                                                                                              \
+  ({                                                                                                                   \
+    unsigned long __tmp;                                                                                               \
+    asm volatile("csrrs %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit));                                                  \
+    __tmp;                                                                                                             \
   })
 
-#define clear_csr(reg, bit)                                                    \
-  ({                                                                           \
-    unsigned long __tmp;                                                       \
-    asm volatile("csrrc %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit));          \
-    __tmp;                                                                     \
+#define clear_csr(reg, bit)                                                                                            \
+  ({                                                                                                                   \
+    unsigned long __tmp;                                                                                               \
+    asm volatile("csrrc %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit));                                                  \
+    __tmp;                                                                                                             \
   })
 
 #define rdtime() read_csr(time)

--- a/test/first_party/src/common/nanoprintf.h
+++ b/test/first_party/src/common/nanoprintf.h
@@ -18,8 +18,7 @@
 #endif
 
 #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
-#define NPF_PRINTF_ATTR(FORMAT_INDEX, VARGS_INDEX)                             \
-  __attribute__((format(printf, FORMAT_INDEX, VARGS_INDEX)))
+#define NPF_PRINTF_ATTR(FORMAT_INDEX, VARGS_INDEX) __attribute__((format(printf, FORMAT_INDEX, VARGS_INDEX)))
 #else
 #define NPF_PRINTF_ATTR(FORMAT_INDEX, VARGS_INDEX)
 #endif
@@ -35,18 +34,14 @@ extern "C" {
 // The npf_ functions do not return negative values, since the lack of 'l'
 // length modifier support makes encoding errors impossible.
 
-NPF_VISIBILITY int npf_snprintf(char *buffer, size_t bufsz, const char *format,
-                                ...) NPF_PRINTF_ATTR(3, 4);
+NPF_VISIBILITY int npf_snprintf(char *buffer, size_t bufsz, const char *format, ...) NPF_PRINTF_ATTR(3, 4);
 
-NPF_VISIBILITY int npf_vsnprintf(char *buffer, size_t bufsz, char const *format,
-                                 va_list vlist) NPF_PRINTF_ATTR(3, 0);
+NPF_VISIBILITY int npf_vsnprintf(char *buffer, size_t bufsz, char const *format, va_list vlist) NPF_PRINTF_ATTR(3, 0);
 
 typedef void (*npf_putc)(int c, void *ctx);
-NPF_VISIBILITY int npf_pprintf(npf_putc pc, void *pc_ctx, char const *format,
-                               ...) NPF_PRINTF_ATTR(3, 4);
+NPF_VISIBILITY int npf_pprintf(npf_putc pc, void *pc_ctx, char const *format, ...) NPF_PRINTF_ATTR(3, 4);
 
-NPF_VISIBILITY int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format,
-                                va_list vlist) NPF_PRINTF_ATTR(3, 0);
+NPF_VISIBILITY int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list vlist) NPF_PRINTF_ATTR(3, 0);
 
 #ifdef __cplusplus
 }
@@ -76,12 +71,9 @@ NPF_VISIBILITY int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format,
 #endif
 
 // Pick reasonable defaults if nothing's been configured.
-#if !defined(NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS)                     \
-    && !defined(NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS)                    \
-    && !defined(NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS)                        \
-    && !defined(NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS)                        \
-    && !defined(NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS)                       \
-    && !defined(NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS)
+#if !defined(NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS) && !defined(NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS) &&  \
+  !defined(NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS) && !defined(NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS) &&              \
+  !defined(NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS) && !defined(NANOPRINTF_USE_WRITEBACK_FORMAT_SPECIFIERS)
 #define NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS 1
 #define NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS 1
 #define NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS 1
@@ -111,8 +103,7 @@ NPF_VISIBILITY int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format,
 #endif
 
 // Ensure flags are compatible.
-#if (NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1)                              \
-    && (NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 0)
+#if (NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1) && (NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 0)
 #error Precision format specifiers must be enabled if float support is enabled.
 #endif
 
@@ -137,8 +128,7 @@ NPF_VISIBILITY int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format,
 #define NANOPRINTF_GCC_PAST_4_6 0
 #else
 #define NANOPRINTF_CLANG 0
-#if defined(__GNUC__)                                                          \
-    && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 6)))
+#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 6)))
 #define NANOPRINTF_GCC_PAST_4_6 1
 #else
 #define NANOPRINTF_GCC_PAST_4_6 0
@@ -179,18 +169,17 @@ NPF_VISIBILITY int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format,
 #pragma warning(push)
 #pragma warning(disable : 4619) // there is no warning number 'number'
 // C4619 has to be disabled first!
-#pragma warning(disable : 4127) // conditional expression is constant
-#pragma warning(disable : 4505) // unreferenced local function has been removed
-#pragma warning(disable : 4514) // unreferenced inline function has been removed
-#pragma warning(disable : 4701) // potentially uninitialized local variable used
-#pragma warning(disable : 4706) // assignment within conditional expression
-#pragma warning(disable : 4710) // function not inlined
-#pragma warning(disable : 4711) // function selected for inline expansion
-#pragma warning(disable : 4820) // padding added after struct member
-#pragma warning(disable : 5039) // potentially throwing function passed to
-                                // extern C function
-#pragma warning(                                                               \
-    disable : 5045) // compiler will insert Spectre mitigation for memory load
+#pragma warning(disable : 4127)  // conditional expression is constant
+#pragma warning(disable : 4505)  // unreferenced local function has been removed
+#pragma warning(disable : 4514)  // unreferenced inline function has been removed
+#pragma warning(disable : 4701)  // potentially uninitialized local variable used
+#pragma warning(disable : 4706)  // assignment within conditional expression
+#pragma warning(disable : 4710)  // function not inlined
+#pragma warning(disable : 4711)  // function selected for inline expansion
+#pragma warning(disable : 4820)  // padding added after struct member
+#pragma warning(disable : 5039)  // potentially throwing function passed to
+                                 // extern C function
+#pragma warning(disable : 5045)  // compiler will insert Spectre mitigation for memory load
 #pragma warning(disable : 5262)  // implicit switch fall-through
 #pragma warning(disable : 26812) // enum type is unscoped
 #endif
@@ -203,8 +192,7 @@ NPF_VISIBILITY int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format,
 #define NPF_NOINLINE
 #endif
 
-#if (NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1)                        \
-    || (NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1)
+#if (NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1) || (NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1)
 enum {
   NPF_FMT_SPEC_OPT_NONE,
   NPF_FMT_SPEC_OPT_LITERAL,
@@ -283,8 +271,7 @@ typedef struct npf_bufputc_ctx {
 } npf_bufputc_ctx_t;
 
 #if NANOPRINTF_USE_LARGE_FORMAT_SPECIFIERS == 1
-typedef char
-    npf_size_is_ptrdiff[(sizeof(size_t) == sizeof(ptrdiff_t)) ? 1 : -1];
+typedef char npf_size_is_ptrdiff[(sizeof(size_t) == sizeof(ptrdiff_t)) ? 1 : -1];
 typedef ptrdiff_t npf_ssize_t;
 #endif
 
@@ -292,14 +279,11 @@ typedef ptrdiff_t npf_ssize_t;
 #include <intrin.h>
 #endif
 
-static int npf_max(int x, int y)
-{
+static int npf_max(int x, int y) {
   return (x > y) ? x : y;
 }
 
-static int npf_parse_format_spec(char const *format,
-                                 npf_format_spec_t *out_spec)
-{
+static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec) {
   char const *cur = format;
 
 #if NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1
@@ -455,8 +439,7 @@ static int npf_parse_format_spec(char const *format,
       tmp_conv = NPF_FMT_SPEC_CONV_HEX_INT;
     }
     out_spec->conv_spec = (uint8_t)tmp_conv;
-#if (NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1)                        \
-    && (NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1)
+#if (NANOPRINTF_USE_FIELD_WIDTH_FORMAT_SPECIFIERS == 1) && (NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1)
     if (out_spec->prec_opt != NPF_FMT_SPEC_OPT_NONE) {
       out_spec->leading_zero_pad = 0;
     }
@@ -533,9 +516,7 @@ static int npf_parse_format_spec(char const *format,
   return (int)(cur - format);
 }
 
-static NPF_NOINLINE int npf_utoa_rev(npf_uint_t val, char *buf,
-                                     uint_fast8_t base, char case_adj)
-{
+static NPF_NOINLINE int npf_utoa_rev(npf_uint_t val, char *buf, uint_fast8_t base, char case_adj) {
   uint_fast8_t n = 0;
   do {
     int_fast8_t const d = (int_fast8_t)(val % base);
@@ -570,8 +551,7 @@ typedef int_fast16_t npf_ftoa_exp_t;
 #endif
 typedef NANOPRINTF_CONVERSION_FLOAT_TYPE npf_ftoa_man_t;
 
-#if (NANOPRINTF_CONVERSION_BUFFER_SIZE <= UINT_FAST8_MAX)                      \
-    && (UINT_FAST8_MAX <= INT_MAX)
+#if (NANOPRINTF_CONVERSION_BUFFER_SIZE <= UINT_FAST8_MAX) && (UINT_FAST8_MAX <= INT_MAX)
 typedef uint_fast8_t npf_ftoa_dec_t;
 #else
 typedef int npf_ftoa_dec_t;
@@ -583,8 +563,7 @@ enum {
   NPF_DOUBLE_MAN_BITS = DBL_MANT_DIG - 1,
   NPF_DOUBLE_BIN_BITS = sizeof(npf_double_bin_t) * CHAR_BIT,
   NPF_FTOA_MAN_BITS = sizeof(npf_ftoa_man_t) * CHAR_BIT,
-  NPF_FTOA_SHIFT_BITS
-  = ((NPF_FTOA_MAN_BITS < DBL_MANT_DIG) ? NPF_FTOA_MAN_BITS : DBL_MANT_DIG) - 1
+  NPF_FTOA_SHIFT_BITS = ((NPF_FTOA_MAN_BITS < DBL_MANT_DIG) ? NPF_FTOA_MAN_BITS : DBL_MANT_DIG) - 1
 };
 
 /* Generally, floating-point conversion implementations use
@@ -596,8 +575,7 @@ enum {
    extended further by adding dynamic scaling and configurable integer width by
    Oskars Rubenis (https://github.com/Okarss). */
 
-static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, double f)
-{
+static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, double f) {
   char const *ret = NULL;
   npf_double_bin_t bin;
   { // Union-cast is UB pre-C11, compiler optimizes byte-copy loop.
@@ -610,9 +588,7 @@ static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, double f)
 
   // Unsigned -> signed int casting is IB and can raise a signal but generally
   // doesn't.
-  npf_ftoa_exp_t exp
-      = (npf_ftoa_exp_t)((npf_ftoa_exp_t)(bin >> NPF_DOUBLE_MAN_BITS)
-                         & NPF_DOUBLE_EXP_MASK);
+  npf_ftoa_exp_t exp = (npf_ftoa_exp_t)((npf_ftoa_exp_t)(bin >> NPF_DOUBLE_MAN_BITS) & NPF_DOUBLE_EXP_MASK);
 
   bin &= ((npf_double_bin_t)0x1 << NPF_DOUBLE_MAN_BITS) - 1;
   if (exp == (npf_ftoa_exp_t)NPF_DOUBLE_EXP_MASK) { // special value
@@ -641,9 +617,7 @@ static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, double f)
     npf_ftoa_man_t man_i;
 
     if (exp >= 0) {
-      int_fast8_t shift_i
-          = (int_fast8_t)((exp > NPF_FTOA_SHIFT_BITS) ? (int)NPF_FTOA_SHIFT_BITS
-                                                      : exp);
+      int_fast8_t shift_i = (int_fast8_t)((exp > NPF_FTOA_SHIFT_BITS) ? (int)NPF_FTOA_SHIFT_BITS : exp);
       npf_ftoa_exp_t exp_i = (npf_ftoa_exp_t)(exp - shift_i);
       shift_i = (int_fast8_t)(NPF_DOUBLE_MAN_BITS - shift_i);
       man_i = (npf_ftoa_man_t)(bin >> shift_i);
@@ -691,23 +665,17 @@ static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, double f)
     if (exp < NPF_DOUBLE_MAN_BITS) {
       int_fast8_t shift_f = (int_fast8_t)((exp < 0) ? -1 : exp);
       npf_ftoa_exp_t exp_f = (npf_ftoa_exp_t)(exp - shift_f);
-      npf_double_bin_t bin_f = bin
-          << ((NPF_DOUBLE_BIN_BITS - NPF_DOUBLE_MAN_BITS) + shift_f);
+      npf_double_bin_t bin_f = bin << ((NPF_DOUBLE_BIN_BITS - NPF_DOUBLE_MAN_BITS) + shift_f);
 
       // This if-else statement can be completely optimized at compile time.
       if (NPF_DOUBLE_BIN_BITS > NPF_FTOA_MAN_BITS) {
-        man_f = (npf_ftoa_man_t)(bin_f >> ((unsigned)(NPF_DOUBLE_BIN_BITS
-                                                      - NPF_FTOA_MAN_BITS)
-                                           % NPF_DOUBLE_BIN_BITS));
-        carry = (uint_fast8_t)((bin_f >> ((unsigned)(NPF_DOUBLE_BIN_BITS
-                                                     - NPF_FTOA_MAN_BITS - 1)
-                                          % NPF_DOUBLE_BIN_BITS))
-                               & 0x1);
+        man_f = (npf_ftoa_man_t)(bin_f >> ((unsigned)(NPF_DOUBLE_BIN_BITS - NPF_FTOA_MAN_BITS) % NPF_DOUBLE_BIN_BITS));
+        carry =
+          (uint_fast8_t)((bin_f >> ((unsigned)(NPF_DOUBLE_BIN_BITS - NPF_FTOA_MAN_BITS - 1) % NPF_DOUBLE_BIN_BITS)) &
+                         0x1);
       } else {
         man_f = (npf_ftoa_man_t)((npf_ftoa_man_t)bin_f
-                                 << ((unsigned)(NPF_FTOA_MAN_BITS
-                                                - NPF_DOUBLE_BIN_BITS)
-                                     % NPF_FTOA_MAN_BITS));
+                                 << ((unsigned)(NPF_FTOA_MAN_BITS - NPF_DOUBLE_BIN_BITS) % NPF_FTOA_MAN_BITS));
         carry = 0;
       }
 
@@ -740,9 +708,7 @@ static int npf_ftoa_rev(char *buf, npf_format_spec_t const *spec, double f)
       // Print the fraction
       for (;;) {
         buf[--dec_f] = (char)('0' + (char)(man_f >> (NPF_FTOA_MAN_BITS - 4)));
-        man_f = (npf_ftoa_man_t)(man_f
-                                 & ~((npf_ftoa_man_t)0xF
-                                     << (NPF_FTOA_MAN_BITS - 4)));
+        man_f = (npf_ftoa_man_t)(man_f & ~((npf_ftoa_man_t)0xF << (NPF_FTOA_MAN_BITS - 4)));
         if (!dec_f) {
           break;
         }
@@ -785,8 +751,7 @@ exit:
 #endif // NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS
 
 #if NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS == 1
-static int npf_bin_len(npf_uint_t u)
-{
+static int npf_bin_len(npf_uint_t u) {
   // Return the length of the binary string format of 'u', preferring
   // intrinsics.
   if (!u) {
@@ -829,16 +794,14 @@ static int npf_bin_len(npf_uint_t u)
 }
 #endif
 
-static void npf_bufputc(int c, void *ctx)
-{
+static void npf_bufputc(int c, void *ctx) {
   npf_bufputc_ctx_t *bpc = (npf_bufputc_ctx_t *)ctx;
   if (bpc->cur < bpc->len) {
     bpc->dst[bpc->cur++] = (char)c;
   }
 }
 
-static void npf_bufputc_nop(int c, void *ctx)
-{
+static void npf_bufputc_nop(int c, void *ctx) {
   (void)c;
   (void)ctx;
 }
@@ -849,30 +812,28 @@ typedef struct npf_cnt_putc_ctx {
   int n;
 } npf_cnt_putc_ctx_t;
 
-static void npf_putc_cnt(int c, void *ctx)
-{
+static void npf_putc_cnt(int c, void *ctx) {
   npf_cnt_putc_ctx_t *pc_cnt = (npf_cnt_putc_ctx_t *)ctx;
   ++pc_cnt->n;
   pc_cnt->pc(c, pc_cnt->ctx); // sibling-call optimization
 }
 
-#define NPF_PUTC(VAL)                                                          \
-  do {                                                                         \
-    npf_putc_cnt((int)(VAL), &pc_cnt);                                         \
+#define NPF_PUTC(VAL)                                                                                                  \
+  do {                                                                                                                 \
+    npf_putc_cnt((int)(VAL), &pc_cnt);                                                                                 \
   } while (0)
 
-#define NPF_EXTRACT(MOD, CAST_TO, EXTRACT_AS)                                  \
-  case NPF_FMT_SPEC_LEN_MOD_##MOD:                                             \
-    val = (CAST_TO)va_arg(args, EXTRACT_AS);                                   \
+#define NPF_EXTRACT(MOD, CAST_TO, EXTRACT_AS)                                                                          \
+  case NPF_FMT_SPEC_LEN_MOD_##MOD:                                                                                     \
+    val = (CAST_TO)va_arg(args, EXTRACT_AS);                                                                           \
     break
 
-#define NPF_WRITEBACK(MOD, TYPE)                                               \
-  case NPF_FMT_SPEC_LEN_MOD_##MOD:                                             \
-    *(va_arg(args, TYPE *)) = (TYPE)pc_cnt.n;                                  \
+#define NPF_WRITEBACK(MOD, TYPE)                                                                                       \
+  case NPF_FMT_SPEC_LEN_MOD_##MOD:                                                                                     \
+    *(va_arg(args, TYPE *)) = (TYPE)pc_cnt.n;                                                                          \
     break
 
-int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args)
-{
+int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args) {
   npf_format_spec_t fs;
   char const *cur = format;
   npf_cnt_putc_ctx_t pc_cnt;
@@ -939,9 +900,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args)
     case NPF_FMT_SPEC_CONV_STRING: {
       cbuf = va_arg(args, char *);
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
-      for (char const *s = cbuf;
-           ((fs.prec_opt == NPF_FMT_SPEC_OPT_NONE) || (cbuf_len < fs.prec))
-           && *s;
+      for (char const *s = cbuf; ((fs.prec_opt == NPF_FMT_SPEC_OPT_NONE) || (cbuf_len < fs.prec)) && *s;
            ++s, ++cbuf_len)
         ;
 #else
@@ -1025,15 +984,14 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args)
       } else
 #endif
 #if NANOPRINTF_USE_BINARY_FORMAT_SPECIFIERS == 1
-          if (fs.conv_spec == NPF_FMT_SPEC_CONV_BINARY) {
+        if (fs.conv_spec == NPF_FMT_SPEC_CONV_BINARY) {
         cbuf_len = npf_bin_len(val);
         u.binval = val;
       } else
 #endif
       {
-        uint_fast8_t const base = (fs.conv_spec == NPF_FMT_SPEC_CONV_OCTAL)
-            ? 8u
-            : ((fs.conv_spec == NPF_FMT_SPEC_CONV_HEX_INT) ? 16u : 10u);
+        uint_fast8_t const base =
+          (fs.conv_spec == NPF_FMT_SPEC_CONV_OCTAL) ? 8u : ((fs.conv_spec == NPF_FMT_SPEC_CONV_HEX_INT) ? 16u : 10u);
         cbuf_len = npf_utoa_rev(val, cbuf, base, fs.case_adjust);
       }
 
@@ -1057,8 +1015,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args)
     } break;
 
     case NPF_FMT_SPEC_CONV_POINTER: {
-      cbuf_len = npf_utoa_rev((npf_uint_t)(uintptr_t)va_arg(args, void *), cbuf,
-                              16, 'a' - 'A');
+      cbuf_len = npf_utoa_rev((npf_uint_t)(uintptr_t)va_arg(args, void *), cbuf, 16, 'a' - 'A');
       need_0x = 'x';
     } break;
 
@@ -1109,9 +1066,8 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args)
     // Compute the field width pad character
     if (fs.field_width_opt != NPF_FMT_SPEC_OPT_NONE) {
       if (fs.leading_zero_pad) { // '0' flag is only legal with numeric types
-        if ((fs.conv_spec != NPF_FMT_SPEC_CONV_STRING)
-            && (fs.conv_spec != NPF_FMT_SPEC_CONV_CHAR)
-            && (fs.conv_spec != NPF_FMT_SPEC_CONV_PERCENT)) {
+        if ((fs.conv_spec != NPF_FMT_SPEC_CONV_STRING) && (fs.conv_spec != NPF_FMT_SPEC_CONV_CHAR) &&
+            (fs.conv_spec != NPF_FMT_SPEC_CONV_PERCENT)) {
 #if NANOPRINTF_USE_PRECISION_FORMAT_SPECIFIERS == 1
           if ((fs.prec_opt != NPF_FMT_SPEC_OPT_NONE) && !fs.prec && zero) {
             pad_c = ' ';
@@ -1132,10 +1088,8 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args)
     if (fs.conv_spec != NPF_FMT_SPEC_CONV_STRING) {
 #if NANOPRINTF_USE_FLOAT_FORMAT_SPECIFIERS == 1
       // float precision is after the decimal point
-      if ((fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_DEC)
-          && (fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_SCI)
-          && (fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_SHORTEST)
-          && (fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_HEX))
+      if ((fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_DEC) && (fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_SCI) &&
+          (fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_SHORTEST) && (fs.conv_spec != NPF_FMT_SPEC_CONV_FLOAT_HEX))
 #endif
       {
         prec_pad = npf_max(0, fs.prec - cbuf_len);
@@ -1228,8 +1182,7 @@ int npf_vpprintf(npf_putc pc, void *pc_ctx, char const *format, va_list args)
 #undef NPF_EXTRACT
 #undef NPF_WRITEBACK
 
-int npf_pprintf(npf_putc pc, void *pc_ctx, char const *format, ...)
-{
+int npf_pprintf(npf_putc pc, void *pc_ctx, char const *format, ...) {
   va_list val;
   va_start(val, format);
   int const rv = npf_vpprintf(pc, pc_ctx, format, val);
@@ -1237,8 +1190,7 @@ int npf_pprintf(npf_putc pc, void *pc_ctx, char const *format, ...)
   return rv;
 }
 
-int npf_snprintf(char *buffer, size_t bufsz, const char *format, ...)
-{
+int npf_snprintf(char *buffer, size_t bufsz, const char *format, ...) {
   va_list val;
   va_start(val, format);
   int const rv = npf_vsnprintf(buffer, bufsz, format, val);
@@ -1246,8 +1198,7 @@ int npf_snprintf(char *buffer, size_t bufsz, const char *format, ...)
   return rv;
 }
 
-int npf_vsnprintf(char *buffer, size_t bufsz, char const *format, va_list vlist)
-{
+int npf_vsnprintf(char *buffer, size_t bufsz, char const *format, va_list vlist) {
   npf_bufputc_ctx_t bufputc_ctx;
   bufputc_ctx.dst = buffer;
   bufputc_ctx.len = bufsz;

--- a/test/first_party/src/common/runtime.c
+++ b/test/first_party/src/common/runtime.c
@@ -2,8 +2,7 @@
 
 extern void htif_putc(int c, void *ctx);
 
-int printf(const char *fmt, ...)
-{
+int printf(const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
   int rc = npf_vpprintf(&htif_putc, NULL, fmt, ap);

--- a/test/first_party/src/test_hello_world.c
+++ b/test/first_party/src/test_hello_world.c
@@ -2,8 +2,7 @@
 
 #include "common/runtime.h"
 
-int main()
-{
+int main() {
   printf("Hello %s%c %d %u %f\n", "world", '!', 1, 2, 3.f);
   return 0;
 }

--- a/test/first_party/src/test_max_pmp.c
+++ b/test/first_party/src/test_max_pmp.c
@@ -1,7 +1,7 @@
 #include "common/runtime.h"
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #define PMPCFG_L (0b1 << 7)
 #define PMPCFG_NA4 (0b10 << 3)
@@ -15,8 +15,7 @@
 
 volatile unsigned GLOBAL = 1;
 
-int main()
-{
+int main() {
   printf("Testing 0xFF..FF PMP addresses\n");
 
   uint_xlen_t ones = UINT_XLEN_MAX;

--- a/test/first_party/src/test_pmp_access.c
+++ b/test/first_party/src/test_pmp_access.c
@@ -6,8 +6,8 @@
 #include "common/runtime.h"
 
 #include <stdbool.h>
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #define PMPCFG_L (0b1 << 7)
 #define PMPCFG_NA4 (0b10 << 3)
@@ -34,39 +34,38 @@ enum AccessType {
 
 // Try to read REGION and return true if it succeeds, false if it traps.
 // This clobbers the trap handler if there is one.
-__attribute__((naked)) bool read_succeeds()
-{
+__attribute__((naked)) bool read_succeeds() {
   // This is a hack, but set mtvec so it will jump to `trap` on a trap. This
   // doesn't check mcause and assumes there's no existing trap handler. It also
   // assumes we are already in machine mode.
   asm volatile(
-      // Store mstatus in mscratch. We need to restore it
-      // on a trap because it changes MPRV.
-      "csrr a0, mstatus;"
-      "csrw mscratch, a0;"
-      // Set trap handler to 1:
-      "la a0, 1f;"
-      "csrw mtvec, a0;"
-      // Do a load.
-      "la a0, REGION;"
-      "lbu a0, 0(a0);"
-      // Return 1 (true).
-      "li a0, 1;"
-      "ret;"
-      // Trap handler must be 4-byte aligned.
-      ".balign 4;"
-      "1:"
-      // Restore mstatus.
-      "csrr a0, mscratch;"
-      "csrw mstatus, a0;"
-      // Return 0 (false).
-      "li a0, 0;"
-      "ret;");
+    // Store mstatus in mscratch. We need to restore it
+    // on a trap because it changes MPRV.
+    "csrr a0, mstatus;"
+    "csrw mscratch, a0;"
+    // Set trap handler to 1:
+    "la a0, 1f;"
+    "csrw mtvec, a0;"
+    // Do a load.
+    "la a0, REGION;"
+    "lbu a0, 0(a0);"
+    // Return 1 (true).
+    "li a0, 1;"
+    "ret;"
+    // Trap handler must be 4-byte aligned.
+    ".balign 4;"
+    "1:"
+    // Restore mstatus.
+    "csrr a0, mscratch;"
+    "csrw mstatus, a0;"
+    // Return 0 (false).
+    "li a0, 0;"
+    "ret;"
+  );
 }
 
 // Same as read_succeeds but with a store instead.
-__attribute__((naked)) bool write_succeeds()
-{
+__attribute__((naked)) bool write_succeeds() {
   asm volatile("csrr a0, mstatus;"
                "csrw mscratch, a0;"
                "la a0, 1f;"
@@ -83,14 +82,13 @@ __attribute__((naked)) bool write_succeeds()
                "ret;");
 }
 
-void set_pmp0_access(uint8_t access)
-{
+void set_pmp0_access(uint8_t access) {
   // We enable pmpaddr1 with all access, otherwise we will get traps when trying
   // to do loads/stores e.g. to the stack with effective privilege Supervisor or
   // User.
 
-  uint_xlen_t pmpcfg0 = (PMPCFG_NAPOT | access) |             // pmpaddr0
-      ((PMPCFG_NAPOT | PMPCFG_R | PMPCFG_W | PMPCFG_X) << 8); // pmpaddr1
+  uint_xlen_t pmpcfg0 = (PMPCFG_NAPOT | access) |                               // pmpaddr0
+                        ((PMPCFG_NAPOT | PMPCFG_R | PMPCFG_W | PMPCFG_X) << 8); // pmpaddr1
 
   asm volatile("csrw pmpcfg0, %[cfg]" : : [cfg] "r"(pmpcfg0));
   // PMP changes require an SFENCE.VMA on any hart that implements
@@ -105,8 +103,7 @@ enum Privilege {
   User,
 };
 
-void set_effective_privilege(enum Privilege priv)
-{
+void set_effective_privilege(enum Privilege priv) {
   // Set mstatus.MPP and mstatus.MPRV so that loads/stores are
   // done in the specified mode.
 
@@ -134,12 +131,10 @@ void set_effective_privilege(enum Privilege priv)
   asm volatile("csrs mstatus, %[mpp]" : : [mpp] "r"(mpp));
 }
 
-int main()
-{
+int main() {
   // Configure pmpaddr0 to match REGION and pmpaddr1 to match everything.
   uint_xlen_t ones = UINT_XLEN_MAX;
-  uint_xlen_t region_pmpaddr
-      = ((uint_xlen_t)(&REGION) >> 2) | ~(ones << (REGION_SIZE_EXP - 3));
+  uint_xlen_t region_pmpaddr = ((uint_xlen_t)(&REGION) >> 2) | ~(ones << (REGION_SIZE_EXP - 3));
   asm volatile("csrw pmpaddr0, %[pmpaddr]" : : [pmpaddr] "r"(region_pmpaddr));
   asm volatile("csrw pmpaddr1, %[pmpaddr]" : : [pmpaddr] "r"(ones));
   // Turn both PMPs off. Recall pmpaddr0 and pmpaddr1 are both configured in

--- a/test/unit_tests/main_unit_tests.cpp
+++ b/test/unit_tests/main_unit_tests.cpp
@@ -22,8 +22,7 @@ bool config_use_abi_names = false;
 
 FILE *trace_log = stdout;
 
-int main()
-{
+int main() {
   sail_config_set_string(get_default_config());
   model_test();
 }


### PR DESCRIPTION
This fixes various annoyances in our clang-format style that have been bothering me for a while:

* Binpacking arguments/parameters and aligning them to the opening `(` is *really* bad for diffs/conflict resolution. This changes it to try to match the "prettier" algorithm (also used by Sail's autoformatter), which has much simpler and better behaviour - if the arguments fit on one line do that, otherwise put each argument on its own line.
* Don't put functions on one line. This is also a little diff-unfriendly and feels unnecessarily inconsistent to me.
* The line length limit of 80 characters is very constrictive so I increased it to 120 characters.
* For some reason it didn't put `{` on a new line... except for function bodies, which is weirdly inconsistent. Now `{` never starts on a new line.
* Sort `#include`s. This might have been needed in the past but I verified it builds with sorted includes now.