### PR TITLE
Update clang-format pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: "v19.1.7"
+    rev: "v21.1.5"
     hooks:
       - id: clang-format
         types_or: [c, c++] # Don't try running clang-format on .json files


### PR DESCRIPTION
In preparation for updating the clang-format style, update it. Probably won't affect anything but worth doing just in case.