### PR TITLE
Enhance CSR access result granularity and report illegal access reasons

### DIFF
--- a/.github/workflows/rocq.yml
+++ b/.github/workflows/rocq.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Common setup
         uses: ./.github/actions/sail-setup
+        with:
+          sail-version: "latest"
 
       - name: Install Rocq-specific opam packages
         run: |
@@ -37,6 +39,7 @@ jobs:
 
       - name: Generate Rocq model
         run: |
+          eval `opam env --safe`
           cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDOWNLOAD_GMP=FALSE
           cmake --build build --target generated_rocq_rv64d
 

--- a/model/core/csr_begin.sail
+++ b/model/core/csr_begin.sail
@@ -15,9 +15,76 @@ scattered mapping csr_name_map
 function csr_name(csr : csreg) -> string = csr_name_map(csr)
 overload to_str = {csr_name}
 
+union CSRAccessIllegalReason = {
+  // Attempt to perform an unsupported operation (e.g., write to a read-only CSR)
+  CSR_Illegal_AccessType : CSRAccessType,
+
+  // Current privilege level is lower than the CSR's minimum required privilege
+  CSR_Illegal_Privilege : Privilege,
+
+  // Extension is not enabled
+  CSR_Illegal_ExtDisabled : extension,
+
+  // CSR is not accessible in the current XLEN mode (e.g., RV32-only CSR in RV64)
+  CSR_Illegal_XlenMismatch : unit,
+
+  // Counter CSR bit not enabled
+  CSR_Illegal_Counter : (range(0, 31), Privilege),
+
+  // Attempted read without a write raises an illegal-instruction exception
+  // regardless of mode and access control bits
+  CSR_Illegal_SeedReadWithoutWrite : unit,
+  // Attempted access seed csr, but mseccfg[XSEED] is not enabled
+  CSR_Illegal_XSEEDNotEnabled : Privilege,
+
+  // Used for one or more specific CSRS that are inaccessible due to complex conditions
+  // (e.g., OR, or privilege mixed bit checks).
+  CSR_Illegal_FCSR    : unit,
+  CSR_Illegal_Mseccfg : unit,
+  CSR_Illegal_Satp    : unit,
+  CSR_Illegal_Stateen : unit,
+  CSR_Illegal_Sstc    : unit,
+
+  // CSR is not defined in spec or not implemented by sail-model yet
+  CSR_Illegal_NotDefined : unit,
+}
+
+union CSRAccessResult = {
+  CSRAccess_Success : unit,
+
+  // Accessing the CSR is illegal currently and should raise Illegal_Instruction Exception
+  CSRAccess_Illegal : CSRAccessIllegalReason,
+
+  // Like CSRAccess_Illegal, but raise Virtual_Instruction Exception
+  CSRAccess_Virtual : unit,
+}
+
 // returns whether a CSR exists
-val is_CSR_accessible : (csreg, Privilege, CSRAccessType) -> bool
+val is_CSR_accessible : (csreg, Privilege, CSRAccessType) -> CSRAccessResult
 scattered function is_CSR_accessible
+
+function csr_defined_if(exist : bool) -> CSRAccessResult =
+  if   exist
+  then CSRAccess_Success()
+  else CSRAccess_Illegal(CSR_Illegal_NotDefined())
+
+// CSR require ext is enabled.
+function csr_requires_ext(ext : extension) -> CSRAccessResult =
+  if   currentlyEnabled(ext)
+  then CSRAccess_Success()
+  else CSRAccess_Illegal(CSR_Illegal_ExtDisabled(ext))
+
+function csr_requires_xlen_32() -> CSRAccessResult =
+  if   xlen == 32
+  then CSRAccess_Success()
+  else CSRAccess_Illegal(CSR_Illegal_XlenMismatch())
+
+function csr_access_result_and(r1 : CSRAccessResult, r2 : CSRAccessResult) -> CSRAccessResult =
+  if      r1 != CSRAccess_Success() then r1
+  else if r2 != CSRAccess_Success() then r2
+  else    CSRAccess_Success()
+
+overload operator & = { csr_access_result_and }
 
 // returns the value of the CSR if it is defined
 val read_CSR : csreg -> xlenbits

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -124,7 +124,7 @@ private function legalize_misa(m : Misa, v : xlenbits) -> Misa = {
 }
 
 mapping clause csr_name_map = 0x301  <-> "misa"
-function clause is_CSR_accessible(0x301, _, _) = true // misa
+function clause is_CSR_accessible(0x301, _, _) = CSRAccess_Success() // misa
 function clause read_CSR(0x301) = misa.bits
 function clause write_CSR(0x301, value) = { misa = legalize_misa(misa, value); Ok(misa.bits) }
 
@@ -269,8 +269,8 @@ register mstatus : Mstatus = {
 mapping clause csr_name_map = 0x300  <-> "mstatus"
 mapping clause csr_name_map = 0x310  <-> "mstatush"
 
-function clause is_CSR_accessible(0x300, _, _) = true // mstatus
-function clause is_CSR_accessible(0x310, _, _) = xlen == 32 // mstatush
+function clause is_CSR_accessible(0x300, _, _) = CSRAccess_Success() // mstatus
+function clause is_CSR_accessible(0x310, _, _) = csr_requires_xlen_32() // mstatush
 
 function clause read_CSR(0x300) = mstatus.bits[xlen - 1 .. 0]
 function clause read_CSR(0x310 if xlen == 32) = mstatus.bits[63 .. 32]
@@ -331,8 +331,13 @@ mapping clause csr_name_map = 0x747  <-> "mseccfg"
 mapping clause csr_name_map = 0x757  <-> "mseccfgh"
 
 // "mseccfg exists if Zkr is implemented, or if it is required by other processor features."
-function clause is_CSR_accessible(0x747, _, _) = currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp) // mseccfg
-function clause is_CSR_accessible(0x757, _, _) = (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp)) & xlen == 32 // mseccfgh
+function mseccfg_csr_accessible() -> CSRAccessResult =
+  if (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp))
+  then CSRAccess_Success()
+  else CSRAccess_Illegal(CSR_Illegal_Mseccfg())
+
+function clause is_CSR_accessible(0x747, _, _) = mseccfg_csr_accessible() // mseccfg
+function clause is_CSR_accessible(0x757, _, _) = mseccfg_csr_accessible() & csr_requires_xlen_32() // mseccfgh
 
 function clause read_CSR(0x747) = mseccfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x757 if xlen == 32) = mseccfg.bits[63 .. 32]
@@ -424,12 +429,12 @@ mapping clause csr_name_map = 0x30A  <-> "menvcfg"
 mapping clause csr_name_map = 0x31A  <-> "menvcfgh"
 mapping clause csr_name_map = 0x10A  <-> "senvcfg"
 
-function clause is_CSR_accessible(0x30A, _, _) = currentlyEnabled(Ext_U) // menvcfg
-function clause is_CSR_accessible(0x31A, _, _) = currentlyEnabled(Ext_U) & (xlen == 32) // menvcfgh
+function clause is_CSR_accessible(0x30A, _, _) = csr_requires_ext(Ext_U) // menvcfg
+function clause is_CSR_accessible(0x31A, _, _) = csr_requires_ext(Ext_U) & csr_requires_xlen_32() // menvcfgh
 
 // This should ideally also check `xstateen.ENVCFG`, but due to module
 // interdependency issues, that is handled by `stateen_allows_CSR_access`.
-function clause is_CSR_accessible(0x10A, _, _) = currentlyEnabled(Ext_S) // senvcfg
+function clause is_CSR_accessible(0x10A, _, _) = csr_requires_ext(Ext_S) // senvcfg
 
 function clause read_CSR(0x30A) = menvcfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x31A if xlen == 32) = menvcfg.bits[63 .. 32]
@@ -549,11 +554,11 @@ mapping clause csr_name_map = 0x302  <-> "medeleg"
 mapping clause csr_name_map = 0x312  <-> "medelegh"
 mapping clause csr_name_map = 0x303  <-> "mideleg"
 
-function clause is_CSR_accessible(0x304, _, _) = true // mie
-function clause is_CSR_accessible(0x344, _, _) = true // mip
-function clause is_CSR_accessible(0x302, _, _) = currentlyEnabled(Ext_S) // medeleg
-function clause is_CSR_accessible(0x312, _, _) = currentlyEnabled(Ext_S) & xlen == 32 // medelegh
-function clause is_CSR_accessible(0x303, _, _) = currentlyEnabled(Ext_S) // mideleg
+function clause is_CSR_accessible(0x304, _, _) = CSRAccess_Success() // mie
+function clause is_CSR_accessible(0x344, _, _) = CSRAccess_Success() // mip
+function clause is_CSR_accessible(0x302, _, _) = csr_requires_ext(Ext_S) // medeleg
+function clause is_CSR_accessible(0x312, _, _) = csr_requires_ext(Ext_S) & csr_requires_xlen_32() // medelegh
+function clause is_CSR_accessible(0x303, _, _) = csr_requires_ext(Ext_S) // mideleg
 
 function clause read_CSR(0x304) = mie.bits
 function clause read_CSR(0x344) = mip.bits
@@ -592,7 +597,7 @@ bitfield Mcause : xlenbits = {
 }
 register mcause : Mcause
 mapping clause csr_name_map = 0x342  <-> "mcause"
-function clause is_CSR_accessible(0x342, _, _) = true // mcause
+function clause is_CSR_accessible(0x342, _, _) = CSRAccess_Success() // mcause
 function clause read_CSR(0x342) = mcause.bits
 function clause write_CSR(0x342, value) = { mcause.bits = value; Ok(mcause.bits) }
 
@@ -639,8 +644,8 @@ register mscratch : xlenbits
 mapping clause csr_name_map = 0x343  <-> "mtval"
 mapping clause csr_name_map = 0x340  <-> "mscratch"
 
-function clause is_CSR_accessible(0x343, _, _) = true // mtval
-function clause is_CSR_accessible(0x340, _, _) = true // mscratch
+function clause is_CSR_accessible(0x343, _, _) = CSRAccess_Success() // mtval
+function clause is_CSR_accessible(0x340, _, _) = CSRAccess_Success() // mscratch
 
 function clause read_CSR(0x343) = mtval
 function clause read_CSR(0x340) = mscratch
@@ -665,7 +670,7 @@ private function legalize_scounteren(_c : Counteren, v : xlenbits) -> Counteren 
 
 register scounteren : Counteren
 mapping clause csr_name_map = 0x106  <-> "scounteren"
-function clause is_CSR_accessible(0x106, _, _) = currentlyEnabled(Ext_S) // scounteren
+function clause is_CSR_accessible(0x106, _, _) = csr_requires_ext(Ext_S) // scounteren
 function clause read_CSR(0x106) = zero_extend(scounteren.bits)
 function clause write_CSR(0x106, value) = { scounteren = legalize_scounteren(scounteren, value); Ok(zero_extend(scounteren.bits)) }
 
@@ -677,7 +682,7 @@ function legalize_mcounteren(_c : Counteren, v : xlenbits) -> Counteren = {
 
 register mcounteren : Counteren
 mapping clause csr_name_map = 0x306  <-> "mcounteren"
-function clause is_CSR_accessible(0x306, _, _) = currentlyEnabled(Ext_U) // mcounteren
+function clause is_CSR_accessible(0x306, _, _) = csr_requires_ext(Ext_U) // mcounteren
 function clause read_CSR(0x306) = zero_extend(mcounteren.bits)
 function clause write_CSR(0x306, value) = { mcounteren = legalize_mcounteren(mcounteren, value); Ok(zero_extend(mcounteren.bits)) }
 
@@ -697,7 +702,7 @@ private function legalize_mcountinhibit(_c : Counterin, v : xlenbits) -> Counter
 
 register mcountinhibit : Counterin
 mapping clause csr_name_map = 0x320  <-> "mcountinhibit"
-function clause is_CSR_accessible(0x320, _, _) = true // mcountinhibit
+function clause is_CSR_accessible(0x320, _, _) = CSRAccess_Success() // mcountinhibit
 function clause read_CSR(0x320) = zero_extend(mcountinhibit.bits)
 function clause write_CSR(0x320, value) = { mcountinhibit = legalize_mcountinhibit(mcountinhibit, value); Ok(zero_extend(mcountinhibit.bits)) }
 
@@ -733,11 +738,11 @@ mapping clause csr_name_map = 0xF13  <-> "mimpid"
 mapping clause csr_name_map = 0xF14  <-> "mhartid"
 mapping clause csr_name_map = 0xF15  <-> "mconfigptr"
 
-function clause is_CSR_accessible(0xf11, _, _) = true // mvendorid
-function clause is_CSR_accessible(0xf12, _, _) = true // marchdid
-function clause is_CSR_accessible(0xf13, _, _) = true // mimpid
-function clause is_CSR_accessible(0xf14, _, _) = true // mhartid
-function clause is_CSR_accessible(0xf15, _, _) = true // mconfigptr
+function clause is_CSR_accessible(0xf11, _, _) = CSRAccess_Success() // mvendorid
+function clause is_CSR_accessible(0xf12, _, _) = CSRAccess_Success() // marchdid
+function clause is_CSR_accessible(0xf13, _, _) = CSRAccess_Success() // mimpid
+function clause is_CSR_accessible(0xf14, _, _) = CSRAccess_Success() // mhartid
+function clause is_CSR_accessible(0xf15, _, _) = CSRAccess_Success() // mconfigptr
 
 function clause read_CSR(0xF11) = zero_extend(mvendorid)
 function clause read_CSR(0xF12) = marchid
@@ -809,7 +814,7 @@ private function legalize_sstatus(m : Mstatus, v : xlenbits) -> Mstatus = {
 }
 
 mapping clause csr_name_map = 0x100  <-> "sstatus"
-function clause is_CSR_accessible(0x100, _, _) = currentlyEnabled(Ext_S) // sstatus
+function clause is_CSR_accessible(0x100, _, _) = csr_requires_ext(Ext_S) // sstatus
 function clause read_CSR(0x100) = lower_mstatus(mstatus).bits[xlen - 1 .. 0]
 function clause write_CSR(0x100, value) = { mstatus = legalize_sstatus(mstatus, value); Ok(lower_mstatus(mstatus).bits[xlen - 1 .. 0]) }
 
@@ -861,7 +866,7 @@ private function legalize_sip(m : Minterrupts, d : Minterrupts, v : xlenbits) ->
 }
 
 mapping clause csr_name_map = 0x144  <-> "sip"
-function clause is_CSR_accessible(0x144, _, _) = currentlyEnabled(Ext_S) // sip
+function clause is_CSR_accessible(0x144, _, _) = csr_requires_ext(Ext_S) // sip
 function clause read_CSR(0x144) = lower_mip(mip, mideleg).bits
 function clause write_CSR(0x144, value) = { mip = legalize_sip(mip, mideleg, value); Ok(lower_mip(mip, mideleg).bits) }
 
@@ -883,7 +888,7 @@ private function legalize_sie(m : Minterrupts, d : Minterrupts, v : xlenbits) ->
 
 
 mapping clause csr_name_map = 0x104  <-> "sie"
-function clause is_CSR_accessible(0x104, _, _) = currentlyEnabled(Ext_S) // sie
+function clause is_CSR_accessible(0x104, _, _) = csr_requires_ext(Ext_S) // sie
 function clause read_CSR(0x104) = lower_mie(mie, mideleg).bits
 function clause write_CSR(0x104, value) = { mie = legalize_sie(mie, mideleg, value); Ok(lower_mie(mie, mideleg).bits) }
 
@@ -899,9 +904,9 @@ mapping clause csr_name_map = 0x140  <-> "sscratch"
 mapping clause csr_name_map = 0x142  <-> "scause"
 mapping clause csr_name_map = 0x143  <-> "stval"
 
-function clause is_CSR_accessible(0x140, _, _) = currentlyEnabled(Ext_S) // sscratch
-function clause is_CSR_accessible(0x142, _, _) = currentlyEnabled(Ext_S) // scause
-function clause is_CSR_accessible(0x143, _, _) = currentlyEnabled(Ext_S) // stval
+function clause is_CSR_accessible(0x140, _, _) = csr_requires_ext(Ext_S) // sscratch
+function clause is_CSR_accessible(0x142, _, _) = csr_requires_ext(Ext_S) // scause
+function clause is_CSR_accessible(0x143, _, _) = csr_requires_ext(Ext_S) // stval
 
 function clause read_CSR(0x140) = sscratch
 function clause read_CSR(0x142) = scause.bits
@@ -969,7 +974,7 @@ mapping clause csr_name_map = 0x7a1  <-> "tdata1"
 mapping clause csr_name_map = 0x7a2  <-> "tdata2"
 mapping clause csr_name_map = 0x7a3  <-> "tdata3"
 
-function clause is_CSR_accessible(0x7a0, _, _) = true
+function clause is_CSR_accessible(0x7a0, _, _) = CSRAccess_Success()
 function clause read_CSR(0x7a0) = ~(tselect)  // this indicates we don't have any trigger support
 function clause write_CSR(0x7a0, value) = { tselect = value; Ok(tselect) }
 
@@ -999,3 +1004,7 @@ function feature_enabled_for_priv(p : Privilege, machine_enable_bit : bits(1), s
 // Return true if the counter is enabled.
 function counter_enabled(index: range(0, 31), priv : Privilege) -> bool =
   feature_enabled_for_priv(priv, mcounteren.bits[index], scounteren.bits[index])
+
+function csr_requires_counter(index : range(0, 31), priv : Privilege) -> CSRAccessResult =
+  if counter_enabled(index, priv) then CSRAccess_Success()
+  else CSRAccess_Illegal(CSR_Illegal_Counter(index, priv))

--- a/model/exceptions/sys_exceptions.sail
+++ b/model/exceptions/sys_exceptions.sail
@@ -85,10 +85,10 @@ mapping clause csr_name_map = 0x141  <-> "sepc"
 mapping clause csr_name_map = 0x305  <-> "mtvec"
 mapping clause csr_name_map = 0x341  <-> "mepc"
 
-function clause is_CSR_accessible(0x105, _, _) = currentlyEnabled(Ext_S) // stvec
-function clause is_CSR_accessible(0x141, _, _) = currentlyEnabled(Ext_S) // sepc
-function clause is_CSR_accessible(0x305, _, _) = true // mtvec
-function clause is_CSR_accessible(0x341, _, _) = true // mepc
+function clause is_CSR_accessible(0x105, _, _) = csr_requires_ext(Ext_S) // stvec
+function clause is_CSR_accessible(0x141, _, _) = csr_requires_ext(Ext_S) // sepc
+function clause is_CSR_accessible(0x305, _, _) = CSRAccess_Success() // mtvec
+function clause is_CSR_accessible(0x341, _, _) = CSRAccess_Success() // mepc
 
 function clause read_CSR(0x105) = get_stvec()
 function clause read_CSR(0x141) = get_xepc(Supervisor)

--- a/model/extensions/FD/fdext_control.sail
+++ b/model/extensions/FD/fdext_control.sail
@@ -24,11 +24,16 @@ mapping clause csr_name_map = 0x001  <-> "fflags"
 mapping clause csr_name_map = 0x002  <-> "frm"
 mapping clause csr_name_map = 0x003  <-> "fcsr"
 
+function fcsr_accessible() -> CSRAccessResult =
+  if   (currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx))
+  then CSRAccess_Success()
+  else CSRAccess_Illegal(CSR_Illegal_FCSR())
+
 // These should ideally also check `xstateen.FCSR`, but due to module
 // interdependency issues, that is handled by `stateen_allows_CSR_access`.
-function clause is_CSR_accessible (0x001, _, _) = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
-function clause is_CSR_accessible (0x002, _, _) = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
-function clause is_CSR_accessible (0x003, _, _) = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
+function clause is_CSR_accessible (0x001, _, _) = fcsr_accessible()
+function clause is_CSR_accessible (0x002, _, _) = fcsr_accessible()
+function clause is_CSR_accessible (0x003, _, _) = fcsr_accessible()
 
 function clause read_CSR (0x001) = zero_extend(fcsr[FFLAGS])
 function clause read_CSR (0x002) = zero_extend(fcsr[FRM])

--- a/model/extensions/K/zkr_control.sail
+++ b/model/extensions/K/zkr_control.sail
@@ -42,13 +42,13 @@ private function write_seed_csr () -> xlenbits = zeros()
 // CSR mapping
 mapping clause csr_name_map = 0x015  <-> "seed"
 function clause is_CSR_accessible(0x015, priv, access_type) =
-  currentlyEnabled(Ext_Zkr) &
-  // Read-only access is not allowed.
-  (access_type != CSRRead) &
-  (match priv {
-    Machine => true,
-    Supervisor => mseccfg[SSEED] == 0b1,
-    User => mseccfg[USEED] == 0b1,
+  csr_requires_ext(Ext_Zkr)
+  & (if (access_type == CSRRead) then CSRAccess_Illegal(CSR_Illegal_SeedReadWithoutWrite()) else CSRAccess_Success())
+  & (match priv {
+    Machine => CSRAccess_Success(),
+    Supervisor => if mseccfg[SSEED] == 0b1 then CSRAccess_Success() else CSRAccess_Illegal(CSR_Illegal_XSEEDNotEnabled(priv)),
+    User => if mseccfg[USEED] == 0b1 then CSRAccess_Success() else CSRAccess_Illegal(CSR_Illegal_XSEEDNotEnabled(priv)),
+    // TODO: wait for Hypervisor extension
     VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
     VirtualUser => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   })

--- a/model/extensions/Smcntrpmf/smcntrpmf.sail
+++ b/model/extensions/Smcntrpmf/smcntrpmf.sail
@@ -28,10 +28,10 @@ mapping clause csr_name_map = 0x721  <-> "mcyclecfgh"
 mapping clause csr_name_map = 0x322  <-> "minstretcfg"
 mapping clause csr_name_map = 0x722  <-> "minstretcfgh"
 
-function clause is_CSR_accessible(0x321, _, _) = currentlyEnabled(Ext_Smcntrpmf) // mcyclecfg
-function clause is_CSR_accessible(0x721, _, _) = currentlyEnabled(Ext_Smcntrpmf) & xlen == 32 // mcyclecfgh
-function clause is_CSR_accessible(0x322, _, _) = currentlyEnabled(Ext_Smcntrpmf) // minstretcfg
-function clause is_CSR_accessible(0x722, _, _) = currentlyEnabled(Ext_Smcntrpmf) & xlen == 32 // minstretcfgh
+function clause is_CSR_accessible(0x321, _, _) = csr_requires_ext(Ext_Smcntrpmf) // mcyclecfg
+function clause is_CSR_accessible(0x721, _, _) = csr_requires_ext(Ext_Smcntrpmf) & csr_requires_xlen_32() // mcyclecfgh
+function clause is_CSR_accessible(0x322, _, _) = csr_requires_ext(Ext_Smcntrpmf) // minstretcfg
+function clause is_CSR_accessible(0x722, _, _) = csr_requires_ext(Ext_Smcntrpmf) & csr_requires_xlen_32() // minstretcfgh
 
 function clause read_CSR(0x321) = mcyclecfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x721 if xlen == 32) = mcyclecfg.bits[63 .. 32]

--- a/model/extensions/Sscofpmf/sscofpmf.sail
+++ b/model/extensions/Sscofpmf/sscofpmf.sail
@@ -48,7 +48,7 @@ private function write_mhpmeventh(index : hpmidx, value : bits(32)) -> unit =
   mhpmevent[index] = legalize_hpmevent(Mk_HpmEvent(value @ mhpmevent[index].bits[31 .. 0]))
 
 // mhpmevent3..31h
-function clause is_CSR_accessible((0b0111001 /* 0x720 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Sscofpmf) & (xlen == 32)
+function clause is_CSR_accessible((0b0111001 /* 0x720 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = csr_requires_ext(Ext_Sscofpmf) & csr_requires_xlen_32()
 function clause read_CSR(0b0111001 /* 0x720 */ @ index : bits(5) if xlen == 32 & unsigned(index) >= 3) = read_mhpmeventh(hpmidx_from_bits(index))
 function clause write_CSR((0b0111001 /* 0x720 */ @ index : bits(5), value) if xlen == 32 & unsigned(index) >= 3) = {
   let index = hpmidx_from_bits(index);
@@ -78,6 +78,6 @@ private function get_scountovf(priv : Privilege) -> bits(32) = {
 }
 
 // scountovf
-function clause is_CSR_accessible(0xDA0, _, _) = currentlyEnabled(Ext_Sscofpmf) & currentlyEnabled(Ext_S)
+function clause is_CSR_accessible(0xDA0, _, _) = csr_requires_ext(Ext_Sscofpmf) & csr_requires_ext(Ext_S)
 function clause read_CSR(0xDA0) = zero_extend(get_scountovf(cur_privilege))
 // scountovf is read-only.

--- a/model/extensions/Ssqosid/ssqosid.sail
+++ b/model/extensions/Ssqosid/ssqosid.sail
@@ -31,7 +31,7 @@ register srmcfg : Srmcfg
 // Ssqosid - Quality-of-Service (Qos) Identifiers
 mapping clause csr_name_map = 0x181  <-> "srmcfg"
 
-function clause is_CSR_accessible(0x181, _, _) = currentlyEnabled(Ext_Ssqosid)
+function clause is_CSR_accessible(0x181, _, _) = csr_requires_ext(Ext_Ssqosid)
 
 function clause read_CSR(0x181) = srmcfg.bits
 

--- a/model/extensions/Sstc/sstc.sail
+++ b/model/extensions/Sstc/sstc.sail
@@ -10,16 +10,19 @@
 mapping clause csr_name_map = 0x14D  <-> "stimecmp"
 mapping clause csr_name_map = 0x15D  <-> "stimecmph"
 
-function sstc_CSRs_accessible(priv : Privilege) -> bool =
-    priv == Machine | (priv == Supervisor & mcounteren[TM] == 0b1 & menvcfg[STCE] == 0b1)
+function sstc_CSRs_accessible(priv : Privilege) -> CSRAccessResult =
+  if   (priv == Machine) | (priv == Supervisor & mcounteren[TM] == 0b1 & menvcfg[STCE] == 0b1)
+  then CSRAccess_Success()
+  else CSRAccess_Illegal(CSR_Illegal_Sstc())
 
 function clause is_CSR_accessible(0x14D, priv, _) =
-    currentlyEnabled(Ext_S) & currentlyEnabled(Ext_Sstc) &
-    sstc_CSRs_accessible(priv)
+  csr_requires_ext(Ext_S) & csr_requires_ext(Ext_Sstc)
+  & sstc_CSRs_accessible(priv)
 
 function clause is_CSR_accessible(0x15D, priv, _) =
-    currentlyEnabled(Ext_S) & currentlyEnabled(Ext_Sstc) & xlen == 32 &
-    sstc_CSRs_accessible(priv)
+  csr_requires_ext(Ext_S) & csr_requires_ext(Ext_Sstc)
+  & sstc_CSRs_accessible(priv)
+  & csr_requires_xlen_32()
 
 function clause read_CSR(0x14D) = stimecmp[xlen - 1 .. 0]
 function clause read_CSR(0x15D if xlen == 32) = stimecmp[63 .. 32]

--- a/model/extensions/Stateen/stateen_csrs.sail
+++ b/model/extensions/Stateen/stateen_csrs.sail
@@ -15,14 +15,18 @@ mapping clause csr_name_map = 0x31D <-> "mstateen1h"
 mapping clause csr_name_map = 0x31E <-> "mstateen2h"
 mapping clause csr_name_map = 0x31F <-> "mstateen3h"
 
-function clause is_CSR_accessible(0x30C, _, _) = is_mstateen_accessible()
-function clause is_CSR_accessible(0x30D, _, _) = is_mstateen_accessible()
-function clause is_CSR_accessible(0x30E, _, _) = is_mstateen_accessible()
-function clause is_CSR_accessible(0x30F, _, _) = is_mstateen_accessible()
-function clause is_CSR_accessible(0x31C, _, _) = is_mstateen_accessible() & (xlen == 32)
-function clause is_CSR_accessible(0x31D, _, _) = is_mstateen_accessible() & (xlen == 32)
-function clause is_CSR_accessible(0x31E, _, _) = is_mstateen_accessible() & (xlen == 32)
-function clause is_CSR_accessible(0x31F, _, _) = is_mstateen_accessible() & (xlen == 32)
+function mstateen_csr_accessible() -> CSRAccessResult = if is_mstateen_accessible() then CSRAccess_Success() else CSRAccess_Illegal(CSR_Illegal_Stateen())
+function hstateen_csr_accessible() -> CSRAccessResult = if is_hstateen_accessible() then CSRAccess_Success() else CSRAccess_Illegal(CSR_Illegal_Stateen())
+function sstateen_csr_accessible() -> CSRAccessResult = if is_sstateen_accessible() then CSRAccess_Success() else CSRAccess_Illegal(CSR_Illegal_Stateen())
+
+function clause is_CSR_accessible(0x30C, _, _) = mstateen_csr_accessible()
+function clause is_CSR_accessible(0x30D, _, _) = mstateen_csr_accessible()
+function clause is_CSR_accessible(0x30E, _, _) = mstateen_csr_accessible()
+function clause is_CSR_accessible(0x30F, _, _) = mstateen_csr_accessible()
+function clause is_CSR_accessible(0x31C, _, _) = mstateen_csr_accessible() & csr_requires_xlen_32()
+function clause is_CSR_accessible(0x31D, _, _) = mstateen_csr_accessible() & csr_requires_xlen_32()
+function clause is_CSR_accessible(0x31E, _, _) = mstateen_csr_accessible() & csr_requires_xlen_32()
+function clause is_CSR_accessible(0x31F, _, _) = mstateen_csr_accessible() & csr_requires_xlen_32()
 
 function clause read_CSR(0x30C) = mstateen0.bits[xlen - 1 .. 0]
 function clause read_CSR(0x30D) = mstateen1.bits[xlen - 1 .. 0]
@@ -55,14 +59,14 @@ mapping clause csr_name_map = 0x61D <-> "hstateen1h"
 mapping clause csr_name_map = 0x61E <-> "hstateen2h"
 mapping clause csr_name_map = 0x61F <-> "hstateen3h"
 
-function clause is_CSR_accessible(0x60C, _, _) = is_hstateen_accessible()
-function clause is_CSR_accessible(0x60D, _, _) = is_hstateen_accessible()
-function clause is_CSR_accessible(0x60E, _, _) = is_hstateen_accessible()
-function clause is_CSR_accessible(0x60F, _, _) = is_hstateen_accessible()
-function clause is_CSR_accessible(0x61C, _, _) = (xlen == 32) & is_hstateen_accessible()
-function clause is_CSR_accessible(0x61D, _, _) = (xlen == 32) & is_hstateen_accessible()
-function clause is_CSR_accessible(0x61E, _, _) = (xlen == 32) & is_hstateen_accessible()
-function clause is_CSR_accessible(0x61F, _, _) = (xlen == 32) & is_hstateen_accessible()
+function clause is_CSR_accessible(0x60C, _, _) = hstateen_csr_accessible()
+function clause is_CSR_accessible(0x60D, _, _) = hstateen_csr_accessible()
+function clause is_CSR_accessible(0x60E, _, _) = hstateen_csr_accessible()
+function clause is_CSR_accessible(0x60F, _, _) = hstateen_csr_accessible()
+function clause is_CSR_accessible(0x61C, _, _) = csr_requires_xlen_32() & hstateen_csr_accessible()
+function clause is_CSR_accessible(0x61D, _, _) = csr_requires_xlen_32() & hstateen_csr_accessible()
+function clause is_CSR_accessible(0x61E, _, _) = csr_requires_xlen_32() & hstateen_csr_accessible()
+function clause is_CSR_accessible(0x61F, _, _) = csr_requires_xlen_32() & hstateen_csr_accessible()
 
 function clause read_CSR(0x60C) = (hstateen0.bits & get_hstateen_mask(0))[xlen - 1 .. 0]
 function clause read_CSR(0x60D) = (hstateen1.bits & get_hstateen_mask(1))[xlen - 1 .. 0]
@@ -91,10 +95,10 @@ mapping clause csr_name_map = 0x10D <-> "sstateen1"
 mapping clause csr_name_map = 0x10E <-> "sstateen2"
 mapping clause csr_name_map = 0x10F <-> "sstateen3"
 
-function clause is_CSR_accessible(0x10C, _, _) = is_sstateen_accessible()
-function clause is_CSR_accessible(0x10D, _, _) = is_sstateen_accessible()
-function clause is_CSR_accessible(0x10E, _, _) = is_sstateen_accessible()
-function clause is_CSR_accessible(0x10F, _, _) = is_sstateen_accessible()
+function clause is_CSR_accessible(0x10C, _, _) = sstateen_csr_accessible()
+function clause is_CSR_accessible(0x10D, _, _) = sstateen_csr_accessible()
+function clause is_CSR_accessible(0x10E, _, _) = sstateen_csr_accessible()
+function clause is_CSR_accessible(0x10F, _, _) = sstateen_csr_accessible()
 
 function clause read_CSR(0x10C) = { let mask = get_sstateen_mask(0); zero_extend(sstateen0.bits & mask[31..0]) }
 function clause read_CSR(0x10D) = { let mask = get_sstateen_mask(1); zero_extend(sstateen1.bits & mask[31..0]) }

--- a/model/extensions/V/vext_regs.sail
+++ b/model/extensions/V/vext_regs.sail
@@ -307,13 +307,13 @@ mapping clause csr_name_map = 0xC20  <-> "vl"
 mapping clause csr_name_map = 0xC21  <-> "vtype"
 mapping clause csr_name_map = 0xC22  <-> "vlenb"
 
-function clause is_CSR_accessible(0x008, _, _) = currentlyEnabled(Ext_Zve32x) // vstart
-function clause is_CSR_accessible(0x009, _, _) = currentlyEnabled(Ext_Zve32x) // vxsat
-function clause is_CSR_accessible(0x00A, _, _) = currentlyEnabled(Ext_Zve32x) // vxrm
-function clause is_CSR_accessible(0x00F, _, _) = currentlyEnabled(Ext_Zve32x) // vcsr
-function clause is_CSR_accessible(0xC20, _, _) = currentlyEnabled(Ext_Zve32x) // vl
-function clause is_CSR_accessible(0xC21, _, _) = currentlyEnabled(Ext_Zve32x) // vtype
-function clause is_CSR_accessible(0xC22, _, _) = currentlyEnabled(Ext_Zve32x) // vlenb
+function clause is_CSR_accessible(0x008, _, _) = csr_requires_ext(Ext_Zve32x) // vstart
+function clause is_CSR_accessible(0x009, _, _) = csr_requires_ext(Ext_Zve32x) // vxsat
+function clause is_CSR_accessible(0x00A, _, _) = csr_requires_ext(Ext_Zve32x) // vxrm
+function clause is_CSR_accessible(0x00F, _, _) = csr_requires_ext(Ext_Zve32x) // vcsr
+function clause is_CSR_accessible(0xC20, _, _) = csr_requires_ext(Ext_Zve32x) // vl
+function clause is_CSR_accessible(0xC21, _, _) = csr_requires_ext(Ext_Zve32x) // vtype
+function clause is_CSR_accessible(0xC22, _, _) = csr_requires_ext(Ext_Zve32x) // vlenb
 
 function clause read_CSR(0x008) = vstart
 function clause read_CSR(0x009) = zero_extend(vcsr[vxsat])

--- a/model/extensions/Zicntr/zicntr_control.sail
+++ b/model/extensions/Zicntr/zicntr_control.sail
@@ -15,12 +15,12 @@ mapping clause csr_name_map = 0xC80  <-> "cycleh"
 mapping clause csr_name_map = 0xC81  <-> "timeh"
 mapping clause csr_name_map = 0xC82  <-> "instreth"
 
-function clause is_CSR_accessible(0xC00, priv, _) = currentlyEnabled(Ext_Zicntr) & counter_enabled(0, priv) // cycle
-function clause is_CSR_accessible(0xC01, priv, _) = currentlyEnabled(Ext_Zicntr) & counter_enabled(1, priv) // time
-function clause is_CSR_accessible(0xC02, priv, _) = currentlyEnabled(Ext_Zicntr) & counter_enabled(2, priv) // instret
-function clause is_CSR_accessible(0xC80, priv, _) = currentlyEnabled(Ext_Zicntr) & xlen == 32 & counter_enabled(0, priv) // cycleh
-function clause is_CSR_accessible(0xC81, priv, _) = currentlyEnabled(Ext_Zicntr) & xlen == 32 & counter_enabled(1, priv) // timeh
-function clause is_CSR_accessible(0xC82, priv, _) = currentlyEnabled(Ext_Zicntr) & xlen == 32 & counter_enabled(2, priv) // instreth
+function clause is_CSR_accessible(0xC00, priv, _) = csr_requires_ext(Ext_Zicntr) & csr_requires_counter(0, priv) // cycle
+function clause is_CSR_accessible(0xC01, priv, _) = csr_requires_ext(Ext_Zicntr) & csr_requires_counter(1, priv) // time
+function clause is_CSR_accessible(0xC02, priv, _) = csr_requires_ext(Ext_Zicntr) & csr_requires_counter(2, priv) // instret
+function clause is_CSR_accessible(0xC80, priv, _) = csr_requires_ext(Ext_Zicntr) & csr_requires_xlen_32() & csr_requires_counter(0, priv) // cycleh
+function clause is_CSR_accessible(0xC81, priv, _) = csr_requires_ext(Ext_Zicntr) & csr_requires_xlen_32() & csr_requires_counter(1, priv) // timeh
+function clause is_CSR_accessible(0xC82, priv, _) = csr_requires_ext(Ext_Zicntr) & csr_requires_xlen_32() & csr_requires_counter(2, priv) // instreth
 
 function clause read_CSR(0xC00) = mcycle[(xlen - 1) .. 0]
 function clause read_CSR(0xC01) = mtime[(xlen - 1) .. 0]
@@ -36,10 +36,10 @@ mapping clause csr_name_map = 0xB02  <-> "minstret"
 mapping clause csr_name_map = 0xB80  <-> "mcycleh"
 mapping clause csr_name_map = 0xB82  <-> "minstreth"
 
-function clause is_CSR_accessible(0xB00, _, _) = currentlyEnabled(Ext_Zicntr) // mcycle
-function clause is_CSR_accessible(0xB02, _, _) = currentlyEnabled(Ext_Zicntr) // minstret
-function clause is_CSR_accessible(0xB80, _, _) = currentlyEnabled(Ext_Zicntr) & xlen == 32 // mcycleh
-function clause is_CSR_accessible(0xB82, _, _) = currentlyEnabled(Ext_Zicntr) & xlen == 32 // minstreth
+function clause is_CSR_accessible(0xB00, _, _) = csr_requires_ext(Ext_Zicntr) // mcycle
+function clause is_CSR_accessible(0xB02, _, _) = csr_requires_ext(Ext_Zicntr) // minstret
+function clause is_CSR_accessible(0xB80, _, _) = csr_requires_ext(Ext_Zicntr) & csr_requires_xlen_32() // mcycleh
+function clause is_CSR_accessible(0xB82, _, _) = csr_requires_ext(Ext_Zicntr) & csr_requires_xlen_32() // minstreth
 
 function clause read_CSR(0xB00) = mcycle[(xlen - 1) .. 0]
 function clause read_CSR(0xB02) = minstret[(xlen - 1) .. 0]

--- a/model/extensions/Zicsr/zicsr_insts.sail
+++ b/model/extensions/Zicsr/zicsr_insts.sail
@@ -40,33 +40,35 @@ function csr_access_type(op : csrop, rd_is_x0 : bool, rs1_imm_is_zero : bool) ->
     (CSRRC, _, false) => CSRReadWrite,
   }
 
-function doCSR(csr : csreg, rs1_val : xlenbits, rd : regidx, op : csrop, access_type : CSRAccessType) -> ExecutionResult = {
-  if   not(check_CSR(csr, cur_privilege, access_type))
-  then Illegal_Instruction()
-  else if not(ext_check_CSR(csr, cur_privilege, access_type))
-  then Ext_CSR_Check_Failure()
-  else {
-    // A pure write (i.e. CSRRW with rd == 0) should not generate read side-effects.
-    let csr_val : xlenbits = if access_type != CSRWrite then read_CSR(csr) else zeros();
-    if access_type != CSRRead then {
-      let new_val : xlenbits = match op {
-        CSRRW => rs1_val,
-        CSRRS => csr_val | rs1_val,
-        CSRRC => csr_val & ~(rs1_val)
-      };
-      match write_CSR(csr, new_val) {
-        Ok(final_val) => {
-          csr_write_callback(csr, final_val);
-          X(rd) = csr_val;
-          RETIRE_SUCCESS
-        },
-        Err(()) => Illegal_Instruction()
-      }
-    } else {
-      csr_read_callback(csr, csr_val);
-      X(rd) = csr_val;
-      RETIRE_SUCCESS
+function doCSR(csr : csreg, rs1_val : xlenbits, rd : regidx, op : csrop, access_type: CSRAccessType) -> ExecutionResult = {
+  match check_CSR(csr, cur_privilege, access_type) {
+    CSRAccess_Success() => (),
+    CSRAccess_Illegal(_) => return Illegal_Instruction(),
+    CSRAccess_Virtual(_) => return Virtual_Instruction(),
+  };
+
+  if not(ext_check_CSR(csr, cur_privilege, access_type)) then return Ext_CSR_Check_Failure();
+
+  // A pure write (i.e. CSRRW with rd == 0) should not generate read side-effects.
+  let csr_val : xlenbits = if access_type != CSRWrite then read_CSR(csr) else zeros();
+  if access_type != CSRRead then {
+    let new_val : xlenbits = match op {
+      CSRRW => rs1_val,
+      CSRRS => csr_val | rs1_val,
+      CSRRC => csr_val & ~(rs1_val)
+    };
+    match write_CSR(csr, new_val) {
+      Ok(final_val) => {
+        csr_write_callback(csr, final_val);
+        X(rd) = csr_val;
+        RETIRE_SUCCESS
+      },
+      Err(()) => Illegal_Instruction()
     }
+  } else {
+    csr_read_callback(csr, csr_val);
+    X(rd) = csr_val;
+    RETIRE_SUCCESS
   }
 }
 

--- a/model/extensions/Zihpm/zihpm.sail
+++ b/model/extensions/Zihpm/zihpm.sail
@@ -224,7 +224,7 @@ function write_mhpmevent(index : hpmidx, value : xlenbits) -> unit =
   }))
 
 // Hardware Performance Monitoring event selection
-function clause is_CSR_accessible((0b0011001 /* 0x320 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) // mhpmevent3..31
+function clause is_CSR_accessible((0b0011001 /* 0x320 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = csr_requires_ext(Ext_Zihpm) // mhpmevent3..31
 function clause read_CSR(0b0011001 /* 0x320 */ @ index : bits(5) if unsigned(index) >= 3) = read_mhpmevent(hpmidx_from_bits(index))
 function clause write_CSR((0b0011001 /* 0x320 */ @ index : bits(5), value) if unsigned(index) >= 3) = {
   let index = hpmidx_from_bits(index);
@@ -233,8 +233,8 @@ function clause write_CSR((0b0011001 /* 0x320 */ @ index : bits(5), value) if un
 }
 
 // Hardware Performance Monitoring machine mode counters
-function clause is_CSR_accessible((0b1011000 /* 0xB00 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) // mhpmcounter3..31
-function clause is_CSR_accessible((0b1011100 /* 0xB80 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & xlen == 32 // mhpmcounterh3..31
+function clause is_CSR_accessible((0b1011000 /* 0xB00 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = csr_requires_ext(Ext_Zihpm) // mhpmcounter3..31
+function clause is_CSR_accessible((0b1011100 /* 0xB80 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = csr_requires_ext(Ext_Zihpm) & csr_requires_xlen_32() // mhpmcounterh3..31
 
 function clause read_CSR(0b1011000 /* 0xB00 */ @ index : bits(5) if unsigned(index) >= 3) = read_mhpmcounter(hpmidx_from_bits(index))
 function clause read_CSR(0b1011100 /* 0xB80 */ @ index : bits(5) if xlen == 32 & unsigned(index) >= 3) = read_mhpmcounterh(hpmidx_from_bits(index))
@@ -251,8 +251,13 @@ function clause write_CSR((0b1011100 /* 0xB80 */ @ index : bits(5), value) if xl
 }
 
 // Hardware Performance Monitoring user mode counters
-function clause is_CSR_accessible((0b1100000 /* 0xC00 */ @ index : bits(5), priv, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & currentlyEnabled(Ext_U) & counter_enabled(unsigned(index), priv) // hpmcounter3..31
-function clause is_CSR_accessible((0b1100100 /* 0xC80 */ @ index : bits(5), priv, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & currentlyEnabled(Ext_U) & xlen == 32 & counter_enabled(unsigned(index), priv) // hpmcounterh3..31
+function clause is_CSR_accessible((0b1100000 /* 0xC00 */ @ index : bits(5), priv, _) if unsigned(index) >= 3) =
+  csr_requires_ext(Ext_Zihpm) & csr_requires_ext(Ext_U)
+  & csr_requires_counter(unsigned(index), priv) // hpmcounter3..31
+function clause is_CSR_accessible((0b1100100 /* 0xC80 */ @ index : bits(5), priv, _) if unsigned(index) >= 3) =
+  csr_requires_ext(Ext_Zihpm) & csr_requires_ext(Ext_U)
+  & csr_requires_xlen_32()
+  & csr_requires_counter(unsigned(index), priv) // hpmcounterh3..31
 
 function clause read_CSR(0b1100000 /* 0xC00 */ @ index : bits(5) if unsigned(index) >= 3) = read_mhpmcounter(hpmidx_from_bits(index))
 function clause read_CSR(0b1100100 /* 0xC80 */ @ index : bits(5) if xlen == 32 & unsigned(index) >= 3) = read_mhpmcounterh(hpmidx_from_bits(index))

--- a/model/pmp/pmp_regs.sail
+++ b/model/pmp/pmp_regs.sail
@@ -250,19 +250,19 @@ mapping clause csr_name_map = 0x3EE  <-> "pmpaddr62"
 mapping clause csr_name_map = 0x3EF  <-> "pmpaddr63"
 
 // pmpcfgN
-function clause is_CSR_accessible(0x3A @ idx : bits(4), _, _) = sys_pmp_count > 4 * unsigned(idx) & (idx[0] == 0b0 | xlen == 32)
-function clause read_CSR(0x3A @ idx : bits(4) if idx[0] == 0b0 | xlen == 32) = pmpReadCfgReg(unsigned(idx))
-function clause write_CSR((0x3A @ idx : bits(4), value) if idx[0] == 0b0 | xlen == 32) = {
+function clause is_CSR_accessible(0x3A @ idx : bits(4), _, _) = csr_defined_if(sys_pmp_count > 4 * unsigned(idx) & (idx[0] == 0b0 | xlen == 32))
+function clause read_CSR(0x3A @ idx : bits(4) if idx[0] == bitzero | xlen == 32) = pmpReadCfgReg(unsigned(idx))
+function clause write_CSR((0x3A @ idx : bits(4), value) if idx[0] == bitzero | xlen == 32) = {
   let idx = unsigned(idx);
   pmpWriteCfgReg(idx, value);
   Ok(pmpReadCfgReg(idx))
 }
 
 // pmpaddrN. Unfortunately the PMP index does not nicely align with the CSR index bits.
-function clause is_CSR_accessible(0x3B @ idx : bits(4), _, _) = sys_pmp_count > unsigned(0b00 @ idx)
-function clause is_CSR_accessible(0x3C @ idx : bits(4), _, _) = sys_pmp_count > unsigned(0b01 @ idx)
-function clause is_CSR_accessible(0x3D @ idx : bits(4), _, _) = sys_pmp_count > unsigned(0b10 @ idx)
-function clause is_CSR_accessible(0x3E @ idx : bits(4), _, _) = sys_pmp_count > unsigned(0b11 @ idx)
+function clause is_CSR_accessible(0x3B @ idx : bits(4), _, _) = csr_defined_if(sys_pmp_count > unsigned(0b00 @ idx))
+function clause is_CSR_accessible(0x3C @ idx : bits(4), _, _) = csr_defined_if(sys_pmp_count > unsigned(0b01 @ idx))
+function clause is_CSR_accessible(0x3D @ idx : bits(4), _, _) = csr_defined_if(sys_pmp_count > unsigned(0b10 @ idx))
+function clause is_CSR_accessible(0x3E @ idx : bits(4), _, _) = csr_defined_if(sys_pmp_count > unsigned(0b11 @ idx))
 
 function clause read_CSR(0x3B @ idx : bits(4)) = pmpReadAddrReg(unsigned(0b00 @ idx))
 function clause read_CSR(0x3C @ idx : bits(4)) = pmpReadAddrReg(unsigned(0b01 @ idx))

--- a/model/postlude/csr_end.sail
+++ b/model/postlude/csr_end.sail
@@ -9,17 +9,17 @@
 mapping clause csr_name_map = reg <-> hex_bits_12(reg)
 end csr_name_map
 
-function clause is_CSR_accessible(_) = false
+function clause is_CSR_accessible(_) = CSRAccess_Illegal(CSR_Illegal_NotDefined())
 end is_CSR_accessible
 
 function clause read_CSR(csr) = {
-   // This should be impossible because is_CSR_accessible() should have returned false.
+   // This should be impossible because is_CSR_accessible() should have returned CSRAccess_Illegal.
    internal_error(__FILE__, __LINE__, "Read from CSR that does not exist: " ^ bits_str(csr));
 }
 end read_CSR
 
 function clause write_CSR(csr, _) = {
-   // This should be impossible because is_CSR_accessible() should have returned false.
+   // This should be impossible because is_CSR_accessible() should have returned CSRAccess_Illegal.
    internal_error(__FILE__, __LINE__, "Write to CSR that does not exist: " ^ bits_str(csr));
 }
 end write_CSR

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -37,18 +37,24 @@ private function privLevel_to_CSR_privbits(p : Privilege) -> nom_priv_bits =
   }
 
 // Check that the CSR access is made with sufficient privilege.
-function check_CSR_priv(csr : csreg, p : Privilege) -> bool =
-  privLevel_to_CSR_privbits(p) >=_u csrPriv(csr)
+function check_CSR_priv(csr : csreg, p : Privilege) -> CSRAccessResult =
+  if privLevel_to_CSR_privbits(p) >=_u csrPriv(csr)
+  then CSRAccess_Success()
+  else CSRAccess_Illegal(CSR_Illegal_Privilege(p))
 
 // Check that the CSR access isn't a write to a read-only CSR.
-function check_CSR_access(csr : csreg, access_type : CSRAccessType) -> bool =
-  not((access_type == CSRWrite | access_type == CSRReadWrite) & (csrAccess(csr) == 0b11))
+function check_CSR_access_type(csr : csreg, access_type : CSRAccessType) -> CSRAccessResult =
+  if (access_type == CSRWrite | access_type == CSRReadWrite) & (csrAccess(csr) == 0b11)
+  then CSRAccess_Illegal(CSR_Illegal_AccessType(access_type))
+  else CSRAccess_Success()
 
-function check_CSR(csr : csreg, p : Privilege, access_type : CSRAccessType) -> bool =
-    check_CSR_priv(csr, p)
-  & check_CSR_access(csr, access_type)
+function check_CSR(csr : csreg, p : Privilege, access_type : CSRAccessType) -> CSRAccessResult =
+  check_CSR_priv(csr, p)
+  & check_CSR_access_type(csr, access_type)
   & is_CSR_accessible(csr, p, access_type)
-  & stateen_allows_CSR_access(csr, p, access_type)
+  & (if   stateen_allows_CSR_access(csr, p, access_type)
+     then CSRAccess_Success()
+     else CSRAccess_Illegal(CSR_Illegal_Stateen()))
 
 // Exception delegation: given an exception and the privilege at which
 // it occurred, returns the privilege at which it should be handled.

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -175,7 +175,10 @@ termination_measure pt_walk(_,_,_,_,_,_,_,level,_, _) = level
 
 register satp : xlenbits
 mapping clause csr_name_map = 0x180  <-> "satp"
-function clause is_CSR_accessible(0x180, priv, _) = currentlyEnabled(Ext_S) & not(priv == Supervisor & mstatus[TVM] == 0b1)
+function clause is_CSR_accessible(0x180, priv, _) =
+  if   currentlyEnabled(Ext_S) & not(priv == Supervisor & mstatus[TVM] == 0b1)
+  then CSRAccess_Success()
+  else CSRAccess_Illegal(CSR_Illegal_Satp())
 function clause read_CSR(0x180) = satp
 function clause write_CSR(0x180, value) = { satp = legalize_satp(architecture(Supervisor), satp, value); Ok(satp) }
 


### PR DESCRIPTION
More aggressive version of #1357 

In this version, I overloaded `&` and `|` for `CSRAccessResult` to allow for bitwise operations, which allow me preserve most of the origin check logic.

```sail
currentlyEnabled(Ext_U) & (xlen == 32)
                    |
                    V
CSRRequireExt(Ext_U) & CSRRequireXlen(32)
```

One drawback is that expressions like `CSRRequire(A) | CSRRequire(B)` can't be fully returned unless we allow recursion

```sail
union CSRAccessResult {
	...
	CSRAccessResultOr : (CSRAccessResult, CSRAccessResult)
}
```