### PR TITLE
Plumb trap_reason from Sail traps into C callbacks

### DIFF
--- a/c_emulator/riscv_callbacks_if.cpp
+++ b/c_emulator/riscv_callbacks_if.cpp
@@ -85,10 +85,10 @@ void callbacks_if::redirect_callback([[maybe_unused]] hart::Model &model, [[mayb
 }
 
 void callbacks_if::trap_callback(
-  [[maybe_unused]] hart::Model &model,
-  [[maybe_unused]] bool is_interrupt,
-  [[maybe_unused]] fbits cause
-) {
+    [[maybe_unused]] hart::Model &model, [[maybe_unused]] bool is_interrupt,
+    [[maybe_unused]] fbits cause,
+    [[maybe_unused]] const hart::zTrapReason &reason)
+{
 }
 
 // Page table walk callbacks

--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -9,6 +9,7 @@ class Model;
 struct zMemoryAccessTypezIuzK;
 struct ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9;
 struct zPTW_Error;
+struct zTrapReason;
 
 } // namespace hart
 
@@ -44,7 +45,8 @@ public:
 
   virtual void redirect_callback(hart::Model &model, sbits new_pc);
 
-  virtual void trap_callback(hart::Model &model, bool is_interrupt, fbits cause);
+  virtual void trap_callback(hart::Model &model, bool is_interrupt, fbits cause,
+                             const hart::zTrapReason &reason);
 
   // Page table walk callbacks
   virtual void ptw_start_callback(

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -158,3 +158,19 @@ void log_callbacks::ptw_fail_callback(
     KILL(sail_string)(&str_et);
   }
 }
+
+void log_callbacks::trap_callback(hart::Model &model, bool is_interrupt,
+                                  fbits cause, const hart::zTrapReason &reason)
+{
+  if (trace_log != nullptr) {
+    sail_string str_r;
+    CREATE(sail_string)(&str_r);
+
+    model.ztrap_reason_to_str(&str_r, reason);
+
+    fprintf(trace_log, "trap: is_interrupt=%d cause=0x%" PRIx64 " reason=%s\n",
+            (int)is_interrupt, (uint64_t)cause, str_r);
+
+    KILL(sail_string)(&str_r);
+  }
+}

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -24,19 +24,17 @@ public:
   void vreg_write_callback(hart::Model &model, unsigned reg, lbits value) override;
   // Page table walk callback
   void ptw_start_callback(
-    hart::Model &model,
-    uint64_t vpn,
-    hart::zMemoryAccessTypezIuzK access_type,
-    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
-  ) override;
-  void ptw_step_callback(hart::Model &model, int64_t level, sbits pte_addr, uint64_t pte) override;
-  void ptw_success_callback(hart::Model &model, uint64_t final_ppn, int64_t level) override;
-  void ptw_fail_callback(
-    hart::Model &model,
-    struct hart::zPTW_Error error_type,
-    int64_t level,
-    sbits pte_addr
-  ) override;
+      hart::Model &model, uint64_t vpn,
+      hart::zMemoryAccessTypezIuzK access_type,
+      hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege) override;
+  void ptw_step_callback(hart::Model &model, int64_t level, sbits pte_addr,
+                         uint64_t pte) override;
+  void ptw_success_callback(hart::Model &model, uint64_t final_ppn,
+                            int64_t level) override;
+  void ptw_fail_callback(hart::Model &model, struct hart::zPTW_Error error_type,
+                         int64_t level, sbits pte_addr) override;
+  void trap_callback(hart::Model &model, bool is_interrupt, fbits cause,
+                     const hart::zTrapReason &reason) override;
 
 private:
   bool config_print_reg;

--- a/c_emulator/riscv_callbacks_rvfi.cpp
+++ b/c_emulator/riscv_callbacks_rvfi.cpp
@@ -36,7 +36,10 @@ void rvfi_callbacks::xreg_full_write_callback(hart::Model &model, const_sail_str
   }
 }
 
-void rvfi_callbacks::trap_callback(hart::Model &model, bool is_interrupt, fbits cause) {
+void rvfi_callbacks::trap_callback(
+    hart::Model &model, bool is_interrupt, fbits cause,
+    [[maybe_unused]] const hart::zTrapReason &reason)
+{
   (void)is_interrupt;
   (void)cause;
   if (config_enable_rvfi) {

--- a/c_emulator/riscv_callbacks_rvfi.h
+++ b/c_emulator/riscv_callbacks_rvfi.h
@@ -6,9 +6,14 @@ class rvfi_callbacks : public callbacks_if {
 
 public:
   // callbacks_if
-  void mem_write_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
-  void mem_read_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
-  void mem_exception_callback(hart::Model &model, sbits paddr, uint64_t num_of_exception) override;
-  void xreg_full_write_callback(hart::Model &model, const_sail_string abi_name, sbits reg, sbits value) override;
-  void trap_callback(hart::Model &model, bool is_interrupt, fbits cause) override;
+  void mem_write_callback(hart::Model &model, const char *type, sbits paddr,
+                          uint64_t width, lbits value) override;
+  void mem_read_callback(hart::Model &model, const char *type, sbits paddr,
+                         uint64_t width, lbits value) override;
+  void mem_exception_callback(hart::Model &model, sbits paddr,
+                              uint64_t num_of_exception) override;
+  void xreg_full_write_callback(hart::Model &model, const_sail_string abi_name,
+                                sbits reg, sbits value) override;
+  void trap_callback(hart::Model &model, bool is_interrupt, fbits cause,
+                     const hart::zTrapReason &reason) override;
 };

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -121,9 +121,11 @@ unit ModelImpl::redirect_callback(sbits new_pc) {
   return UNIT;
 }
 
-unit ModelImpl::trap_callback(bool is_interrupt, fbits cause) {
+unit ModelImpl::trap_callback(bool is_interrupt, fbits cause,
+                              const hart::zTrapReason &reason)
+{
   for (auto c : m_callbacks) {
-    c->trap_callback(*this, is_interrupt, cause);
+    c->trap_callback(*this, is_interrupt, cause, reason);
   }
   return UNIT;
 }

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -11,6 +11,10 @@
 extern FILE *trace_log;
 extern int term_fd;
 void plat_term_write_impl(char c);
+namespace hart {
+class Model;
+struct zTrapReason;
+}
 
 // Model wrapped with an implementation of its platform callbacks.
 class ModelImpl final : public hart::Model {
@@ -41,7 +45,8 @@ private:
   unit vreg_write_callback(unsigned reg, lbits value) override;
   unit pc_write_callback(sbits new_pc) override;
   unit redirect_callback(sbits new_pc) override;
-  unit trap_callback(bool is_interrupt, fbits cause) override;
+  unit trap_callback(bool is_interrupt, fbits cause,
+                     const hart::zTrapReason &reason) override;
 
   // Page table walk callbacks
   unit ptw_start_callback(

--- a/c_emulator/riscv_platform_if.cpp
+++ b/c_emulator/riscv_platform_if.cpp
@@ -77,7 +77,10 @@ unit PlatformInterface::redirect_callback([[maybe_unused]] sbits new_pc) {
   return UNIT;
 }
 
-unit PlatformInterface::trap_callback([[maybe_unused]] bool is_interrupt, [[maybe_unused]] fbits cause) {
+unit PlatformInterface::trap_callback(
+    [[maybe_unused]] bool is_interrupt, [[maybe_unused]] fbits cause,
+    [[maybe_unused]] const hart::zTrapReason &reason)
+{
   return UNIT;
 }
 

--- a/c_emulator/riscv_platform_if.h
+++ b/c_emulator/riscv_platform_if.h
@@ -11,9 +11,8 @@ class Model;
 struct zMemoryAccessTypezIuzK;
 struct ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9;
 struct zPTW_Error;
-
-} // namespace hart
-
+struct zTrapReason;
+}
 // The Model class derives from this one so when Sail calls C callback
 // functions it actually calls methods of this class. However they are
 // virtual functions so they actually call the Platform implementations
@@ -47,7 +46,8 @@ public:
 
   virtual unit redirect_callback(sbits new_pc);
 
-  virtual unit trap_callback(bool is_interrupt, fbits cause);
+  virtual unit trap_callback(bool is_interrupt, fbits cause,
+                             const hart::zTrapReason &reason);
 
   // Page table walk callbacks
   virtual unit ptw_start_callback(

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -126,6 +126,7 @@ add_custom_command(
         --c-preserve rvfi_trap
         # Preserve to_str functions.
         --c-preserve ptw_error_to_str
+        --c-preserve trap_reason_to_str
         # Input files.
         ${SAIL_MODULES}
         ${project_file}

--- a/model/core/callbacks.sail
+++ b/model/core/callbacks.sail
@@ -53,8 +53,8 @@ function redirect_callback(_) = ()
 
 /// Called on interrupts and exceptions. The exc_code does not include the 'interrupt' bit which is
 /// in a separate bool.
-val trap_callback = pure {cpp: "trap_callback"} : (/* is_interrupt */ bool, /* interrupt/exception cause */ exc_code) -> unit
-function trap_callback(_) = ()
+val trap_callback = pure {cpp: "trap_callback"} : (/* is_interrupt */ bool, /* interrupt/exception cause */ exc_code, /* reason */ TrapReason) -> unit
+function trap_callback(_, _, _) = ()
 
 // Overloads for easier use of callbacks
 function csr_name_write_callback(name : string, value : xlenbits) -> unit = {

--- a/model/core/types_ext.sail
+++ b/model/core/types_ext.sail
@@ -43,6 +43,36 @@ let init_ext_ptw : ext_ptw = ()
 
 type ext_ptw_fail = unit
 
+union TrapReason = {
+  Trap_Reason_Unclassified                 : unit,
+
+  Access_Not_In_Physical_Memory            : unit,
+
+  Trap_Reason_Invalid_Source_Addr          : unit,
+  Trap_Reason_No_PTE                       : unit,
+  Trap_Reason_No_Permission                : unit,
+  Trap_Reason_Misaligned_Superpage         : unit,
+  Trap_Reason_PTE_Update_Needed_But_Disabled : unit,
+
+  Invalid_Pte_Reserved_Bits_Nonzero        : (physaddrbits, xlenbits),
+
+  Trap_Reason_Ext_PTW_Error                : unit
+}
+
+function trap_reason_to_str(r : TrapReason) -> string = {
+  match r {
+    Trap_Reason_Unclassified() => "unclassified",
+    Access_Not_In_Physical_Memory() => "access-not-in-physical-memory",
+    Trap_Reason_Invalid_Source_Addr() => "invalid-source-addr",
+    Trap_Reason_No_PTE() => "no-pte",
+    Trap_Reason_No_Permission() => "no-permission",
+    Trap_Reason_Misaligned_Superpage() => "misaligned-superpage",
+    Trap_Reason_PTE_Update_Needed_But_Disabled() => "pte-update-needed-but-disabled",
+    Invalid_Pte_Reserved_Bits_Nonzero(_, _) => "invalid-pte-reserved-bits-nonzero",
+    Trap_Reason_Ext_PTW_Error() => "extension-ptw-error"
+  }
+}
+
 // This type can be used for custom errors for page-table-walks,
 // and values in this type are typically generated from the final
 // result of the ext_ptw at the end of the walk.

--- a/model/extensions/A/zaamo_insts.sail
+++ b/model/extensions/A/zaamo_insts.sail
@@ -69,10 +69,10 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
   };
 
   if not(is_aligned_addr(vaddr, width))
-  then return Memory_Exception(vaddr, E_SAMO_Addr_Align());
+  then return Memory_Exception(vaddr, (E_SAMO_Addr_Align(), Trap_Reason_Unclassified()));
 
   let addr : physaddr = match translateAddr(vaddr, LoadStore(Data, Data)) {
-    Err(e, _) => return Memory_Exception(vaddr, e),
+    Err((e, r), _) => return Memory_Exception(vaddr, (e, r)),
     Ok(addr, _) => addr,
   };
 
@@ -82,9 +82,9 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
   let rs2_val : bits('width * 8) = if width <= xlen_bytes then trunc(X(rs2)) else trunc(X_pair(rs2));
 
   let loaded : bits('width * 8) = match mem_write_ea(addr, width, aq & rl, rl, true) {
-    Err(e) => return Memory_Exception(vaddr, e),
+    Err(e) => return Memory_Exception(vaddr, (e, Trap_Reason_Unclassified())),
     Ok(_)  => match mem_read(LoadStore(Data, Data), addr, width, aq, aq & rl, true) {
-      Err(e)     => return Memory_Exception(vaddr, e),
+      Err(e)     => return Memory_Exception(vaddr, (e, Trap_Reason_Unclassified())),
       Ok(loaded) => loaded,
     },
   };
@@ -118,7 +118,7 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
       RETIRE_SUCCESS
     },
     Ok(false) => internal_error(__FILE__, __LINE__, "AMO got false from mem_write_value"),
-    Err(e)    => Memory_Exception(vaddr, e),
+    Err(e)    => Memory_Exception(vaddr, (e, Trap_Reason_Unclassified())),
   }
 }
 

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -60,7 +60,7 @@ function jump_to(target : xlenbits) -> ExecutionResult = {
   // If it is not 4-byte aligned and compressed instructions are
   // not enabled then raise an alignment exception.
   if bit_to_bool(target[1]) & not(currentlyEnabled(Ext_Zca))
-  then return Memory_Exception(Virtaddr(target), E_Fetch_Addr_Align());
+  then return Memory_Exception(Virtaddr(target), (E_Fetch_Addr_Align(), Trap_Reason_Unclassified()));
 
   set_next_pc(target);
   RETIRE_SUCCESS
@@ -604,7 +604,7 @@ mapping clause encdec = EBREAK()
   <-> 0b000000000001 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
 
 function clause execute EBREAK() =
-  Memory_Exception(Virtaddr(PC), E_Breakpoint(Brk_Software))
+  Memory_Exception(Virtaddr(PC), (E_Breakpoint(Brk_Software), Trap_Reason_Unclassified()))
 
 mapping clause assembly = EBREAK() <-> "ebreak"
 

--- a/model/extensions/Zicbom/zicbom_insts.sail
+++ b/model/extensions/Zicbom/zicbom_insts.sail
@@ -107,7 +107,7 @@ private function process_clean_inval(rs1 : regidx, _cbop : cbop_zicbom) -> Execu
             _ => None(),
           }
         },
-        Err(e, _) => Some(e)
+        Err((e, _r), _) => Some(e)
       };
       // "If access to the cache block is not permitted, a cache-block management
       //  instruction raises a store page fault or store guest-page fault exception
@@ -130,7 +130,7 @@ private function process_clean_inval(rs1 : regidx, _cbop : cbop_zicbom) -> Execu
           // was encoded in the instruction. We subtract the negative offset
           // (add the positive offset) to get it. Normally this will be
           // equal to rs1, but pointer masking can change that.
-          Memory_Exception(vaddr - negative_offset, e)
+          Memory_Exception(vaddr - negative_offset, (e, Trap_Reason_Unclassified()))
         }
       }
     }

--- a/model/extensions/Zicboz/zicboz_insts.sail
+++ b/model/extensions/Zicboz/zicboz_insts.sail
@@ -44,15 +44,15 @@ function clause execute ZICBOZ(rs1) = {
           // was encoded in the instruction. We subtract the negative offset
           // (add the positive offset) to get it. Normally this will be
           // equal to rs1, but pointer masking can change that.
-          Err(e, _) => Memory_Exception(vaddr - negative_offset, e),
+         Err((e, r), _) => Memory_Exception(vaddr - negative_offset, (e, r)),
           Ok(paddr, _) => {
             match mem_write_ea(paddr, cache_block_size, false, false, false) {
-              Err(e) => Memory_Exception(vaddr - negative_offset, e),
+              Err(e) => Memory_Exception(vaddr - negative_offset, (e, Trap_Reason_Unclassified())),
               Ok(_)  => {
                 match mem_write_value(paddr, cache_block_size, zeros(), false, false, false) {
                   Ok(true)  => RETIRE_SUCCESS,
                   Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                  Err(e)    => Memory_Exception(vaddr - negative_offset, e)
+                  Err(e)    => Memory_Exception(vaddr - negative_offset, (e, Trap_Reason_Unclassified()))
                 }
               }
             }

--- a/model/postlude/fetch.sail
+++ b/model/postlude/fetch.sail
@@ -28,7 +28,7 @@ private function fetch() -> FetchResult = {
   then return F_Error(E_Fetch_Addr_Align(), PC);
 
   match translateAddr(Virtaddr(PC), InstructionFetch()) {
-    Err(e, _)    => F_Error(e, PC),
+    Err((e, _r), _)    => F_Error(e, PC),
     Ok(ppclo, _) => {
       // split instruction fetch into 16-bit granules to handle RVC, as
       // well as to generate precise fault addresses in any fetch
@@ -47,7 +47,7 @@ private function fetch() -> FetchResult = {
             };
 
             match translateAddr(Virtaddr(PC_hi), InstructionFetch()) {
-              Err(e, _)    => F_Error(e, PC_hi),
+              Err((e, _r), _)    => F_Error(e, PC_hi),
               Ok(ppchi, _) =>
                 match mem_read(InstructionFetch(), ppchi, 2, false, false, false) {
                   Err(e)  => F_Error(e, PC_hi),

--- a/model/postlude/fetch_rvfi.sail
+++ b/model/postlude/fetch_rvfi.sail
@@ -23,7 +23,7 @@ private function rvfi_fetch() -> FetchResult = {
   then return F_Error(E_Fetch_Addr_Align(), PC);
 
   match translateAddr(Virtaddr(PC), InstructionFetch()) {
-    Err(e, _) => return F_Error(e, PC),
+    Err((e, _r), _) => return F_Error(e, PC),
     Ok(_, _)  => (),
   };
 
@@ -40,7 +40,7 @@ private function rvfi_fetch() -> FetchResult = {
   };
 
   match translateAddr(Virtaddr(PC_hi), InstructionFetch()) {
-    Err(e, _) => F_Error(e, PC),
+    Err((e, _r), _) => F_Error(e, PC),
     Ok(_, _)  => F_Base(i)
   }
 }

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -13,7 +13,7 @@ register hart_state : HartState = HART_ACTIVE()
 private union Step = {
   Step_Pending_Interrupt  : (InterruptType, Privilege),
   Step_Ext_Fetch_Failure  : ext_fetch_addr_error,
-  Step_Fetch_Failure      : (virtaddr, ExceptionType),
+  Step_Fetch_Failure      : (virtaddr, (ExceptionType, TrapReason)),
   Step_Execute            : (ExecutionResult, instbits),
   Step_Waiting            : WaitReason,
 }
@@ -93,7 +93,7 @@ private function run_hart_active(step_no: nat) -> Step = {
       // extension error
       F_Ext_Error(e)   => Step_Ext_Fetch_Failure(e),
       // standard error
-      F_Error(e, addr) => Step_Fetch_Failure(Virtaddr(addr), e),
+      F_Error(e, addr) => Step_Fetch_Failure(Virtaddr(addr), (e, Trap_Reason_Unclassified())),
       // non-error cases:
       F_RVC(h) => {
         sail_instr_announce(h);
@@ -205,14 +205,15 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
       handle_interrupt(intr, priv)
     },
     Step_Ext_Fetch_Failure(e) => ext_handle_fetch_check_error(e),
-    Step_Fetch_Failure(vaddr, e) => handle_exception(bits_of(vaddr), e),
+    Step_Fetch_Failure(vaddr, (e, r)) => handle_exception_with_reason(bits_of(vaddr), e, r),
     Step_Waiting(_) => assert(hart_is_waiting(hart_state), "cannot be Waiting in a non-Wait state"),
     Step_Execute(Retire_Success(), _) => assert(hart_is_active(hart_state)),
     // This case was handled above when processing the fetch result.
     Step_Execute(ExecuteAs(_), _) => assert(false),
     // standard errors
     Step_Execute(Trap(priv, ctl, pc), _) => set_next_pc(exception_handler(priv, ctl, pc)),
-    Step_Execute(Memory_Exception(vaddr, e), _) => handle_exception(bits_of(vaddr), e),
+    Step_Execute(Memory_Exception(vaddr, (e, r)), _) =>
+      handle_exception_with_reason(bits_of(vaddr), e, r),
     Step_Execute(Illegal_Instruction(), instbits) => handle_exception(zero_extend(instbits), E_Illegal_Instr()),
     Step_Execute(Enter_Wait(wr), instbits) => {
       if wait_is_nop(wr) then {

--- a/model/sys/insts_begin.sail
+++ b/model/sys/insts_begin.sail
@@ -29,7 +29,7 @@ union ExecutionResult = {
   // Did not retire for a standard reason.
   Illegal_Instruction            : unit,
   Trap                           : (Privilege, ctl_result, xlenbits),
-  Memory_Exception               : (virtaddr, ExceptionType),
+  Memory_Exception : (virtaddr, (ExceptionType, TrapReason)),
 
   // Did not retire for custom reason.
   Ext_CSR_Check_Failure          : unit,

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -115,6 +115,8 @@ function dispatchInterrupt(priv : Privilege) -> option((InterruptType, Privilege
   }
 }
 
+register pending_trap_reason : TrapReason = Trap_Reason_Unclassified()
+
 // types of privilege transitions
 
 union ctl_result = {
@@ -152,12 +154,13 @@ function track_trap(p : Privilege) -> unit = {
 }
 
 // handle exceptional ctl flow by updating nextPC and operating privilege
-function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info : option(xlenbits), ext : option(ext_exception))
-                     -> xlenbits = {
+function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits,
+                      info : option(xlenbits), ext : option(ext_exception),
+                      reason : TrapReason) -> xlenbits = {
   let is_interrupt = trapCause_is_interrupt(c);
   let cause        = trapCause_bits(c);
 
-  trap_callback(is_interrupt, cause);
+  trap_callback(is_interrupt, cause, reason);
 
   if   get_config_print_exception() | get_config_print_interrupt()
   then print_log("handling " ^ to_str(c)
@@ -225,7 +228,9 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
       if   get_config_print_exception()
       then print_log("trapping from " ^ to_str(cur_priv) ^ " to " ^ to_str(del_priv)
                           ^ " to handle " ^ to_str(e.trap));
-      trap_handler(del_priv, Exception(e.trap), pc, e.excinfo, e.ext)
+      let r = pending_trap_reason;
+      pending_trap_reason = Trap_Reason_Unclassified();
+      trap_handler(del_priv, Exception(e.trap), pc, e.excinfo, e.ext, r)
     },
     CTL_MRET()  => {
       let prev_priv = cur_privilege;
@@ -297,15 +302,20 @@ function xtval_exception_value(e : ExceptionType, excinfo : xlenbits) -> option(
   } then Some(excinfo) else None()
 }
 
-function handle_exception(xtval : xlenbits, e : ExceptionType) -> unit = {
-  let t : sync_exception = struct { trap    = e,
-                                    excinfo = xtval_exception_value(e, xtval),
-                                    ext     = None() };
+function handle_exception_with_reason(xtval : xlenbits, e : ExceptionType, reason : TrapReason) -> unit = {
+  pending_trap_reason = reason;
+  let t : sync_exception =
+    struct { trap    = e,
+             excinfo = xtval_exception_value(e, xtval),
+             ext     = None() };
   set_next_pc(exception_handler(cur_privilege, CTL_TRAP(t), PC))
 }
 
+function handle_exception(xtval : xlenbits, e : ExceptionType) -> unit =
+  handle_exception_with_reason(xtval, e, Trap_Reason_Unclassified())
+
 function handle_interrupt(i : InterruptType, del_priv : Privilege) -> unit =
-  set_next_pc(trap_handler(del_priv, Interrupt(i), PC, None(), None()))
+  set_next_pc(trap_handler(del_priv, Interrupt(i), PC, None(), None(), Trap_Reason_Unclassified()))
 
 // Reset misa to enable the maximal set of supported extensions.
 function reset_misa() -> unit = {

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -365,7 +365,7 @@ private function get_satp forall 'v, is_sv_mode('v). (
 function translateAddr(
   vAddr : virtaddr,
   ac    : MemoryAccessType(ext_access_type),
-) -> TR_Result(physaddr, ExceptionType) = {
+) -> TR_Result(physaddr, (ExceptionType, TrapReason)) = {
 
   // Effective privilege takes into account mstatus.PRV, mstatus.MPP
   // See sys_regs.sail for effectivePrivilege() and cur_privilege
@@ -386,7 +386,7 @@ function translateAddr(
 
   let svAddr = bits_of(vAddr)[sv_width - 1 .. 0];
   if bits_of(vAddr) != sign_extend(svAddr) then {
-    Err(translationException(ac, PTW_Invalid_Addr()), init_ext_ptw)
+    Err((translationException(ac, PTW_Invalid_Addr()), ptw_error_to_trap_reason(PTW_Invalid_Addr())), init_ext_ptw)
   } else {
     let mxr    = mstatus[MXR] == 0b1;
     let do_sum = mstatus[SUM] == 0b1;
@@ -413,7 +413,10 @@ function translateAddr(
         // the assertion above.
         Ok(Physaddr(zero_extend(paddr)), ext_ptw)
       },
-      Err(f, ext_ptw)  => Err(translationException(ac, f), ext_ptw)
+      Err(f, ext_ptw) => {
+        let exc = translationException(ac, f);
+        Err((exc, ptw_error_to_trap_reason(f)), ext_ptw)
+      }
     }
   }
 }

--- a/model/sys/vmem_ptw.sail
+++ b/model/sys/vmem_ptw.sail
@@ -14,7 +14,7 @@
 
 // Failure modes for address-translation/page-table-walks
 private union PTW_Error = {
-  PTW_Invalid_Addr     : unit,          // invalid source address
+  PTW_Invalid_Addr : unit,           // invalid source address
   PTW_No_Access        : unit,          // physical memory access error for a PTE
   PTW_Invalid_PTE      : unit,
   PTW_No_Permission    : unit,
@@ -35,6 +35,33 @@ private function ptw_error_to_str(e : PTW_Error) -> string = {
   }
 }
 
+function ptw_error_to_trap_reason(e : PTW_Error) -> TrapReason = {
+  match e {
+    PTW_No_Access() =>
+      Access_Not_In_Physical_Memory(),
+
+    PTW_Invalid_Addr() =>
+      Trap_Reason_Invalid_Source_Addr(),
+
+    PTW_Invalid_PTE() =>
+      Trap_Reason_No_PTE(),
+
+    PTW_No_Permission() =>
+      Trap_Reason_No_Permission(),
+
+    PTW_Misaligned() =>
+      Trap_Reason_Misaligned_Superpage(),
+
+    PTW_PTE_Needs_Update() =>
+      Trap_Reason_PTE_Update_Needed_But_Disabled(),
+
+    PTW_Ext_Error(_) =>
+      Trap_Reason_Ext_PTW_Error()
+  }
+}
+
+
+// PUBLIC
 overload to_str = {ptw_error_to_str}
 
 // hook for (non-standard) extensions to customize errors reported by page-table

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -126,10 +126,10 @@ function vmem_read_addr(vaddr, offset, width, acc, aq, rl, res) = {
     // "LR faults like a normal load, even though it's in the AMO major opcode space."
     // - Andrew Waterman, isa-dev, 10 Jul 2018.
     if   not(is_aligned_addr(vaddr, width))
-    then return Err(Memory_Exception(vaddr, E_Load_Addr_Align()));
+    then return Err(Memory_Exception(vaddr, (E_Load_Addr_Align(), Trap_Reason_Unclassified())));
   } else {
     if check_misaligned(vaddr, width)
-    then return Err(Memory_Exception(vaddr, E_Load_Addr_Align()));
+    then return Err(Memory_Exception(vaddr, (E_Load_Addr_Align(), Trap_Reason_Unclassified())));
   };
 
   // If the load is misaligned or an allowed misaligned access, split into `n`
@@ -147,10 +147,10 @@ function vmem_read_addr(vaddr, offset, width, acc, aq, rl, res) = {
     let offset = i;
     let vaddr = vaddr + (offset * bytes);
     match translateAddr(Virtaddr(vaddr), acc) {
-      Err(e, _) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+      Err((e, r), _) => return Err(Memory_Exception(Virtaddr(vaddr), (e, r))),
 
       Ok(paddr, _) => match mem_read(acc, paddr, bytes, aq, rl, res) {
-        Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+        Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), (e, Trap_Reason_Unclassified()))),
 
         Ok(v) => {
           if res then {
@@ -181,7 +181,7 @@ val vmem_write_addr : forall 'width, is_mem_width('width).
 
 function vmem_write_addr(vaddr, width, data, acc, aq, rl, res) = {
   if   check_misaligned(vaddr, width)
-  then return Err(Memory_Exception(vaddr, E_SAMO_Addr_Align()));
+  then return Err(Memory_Exception(vaddr, (E_SAMO_Addr_Align(), Trap_Reason_Unclassified())));
 
   // If the store is misaligned or an allowed misaligned access, split into `n`
   // (single-copy-atomic) memory operations, each of `bytes` width. If the store is
@@ -198,7 +198,7 @@ function vmem_write_addr(vaddr, width, data, acc, aq, rl, res) = {
     let offset = i;
     let vaddr = vaddr + (offset * bytes);
     match translateAddr(Virtaddr(vaddr), acc) {
-      Err(e, _) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+      Err((e, r), _) => return Err(Memory_Exception(Virtaddr(vaddr), (e, r))),
 
       // NOTE: Currently, we only announce the effective address if address translation is successful.
       // This may need revisiting, particularly in the misaligned case.
@@ -207,12 +207,12 @@ function vmem_write_addr(vaddr, width, data, acc, aq, rl, res) = {
         if res & not(match_reservation(bits_of(paddr))) then {
           write_success = false
         } else match mem_write_ea(paddr, bytes, aq, rl, res) {
-          Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+          Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), (e, Trap_Reason_Unclassified()))),
 
           Ok(()) => {
             let write_value = data[(8 * (offset + 1) * bytes) - 1 .. 8 * offset * bytes];
             match mem_write_value(paddr, bytes, write_value, aq, rl, res) {
-              Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+              Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), (e, Trap_Reason_Unclassified()))),
               Ok(s)  => write_success = write_success & s,
             }
           }


### PR DESCRIPTION
Adds a `trap_reason` field to Sail traps and exposes it to the C/C++ callback interface so that the emulator can log more detailed reasons for traps.

Main changes:
- Introduce a debug-only `trap_reason` union and add `reason : trap_reason` to `sync_exception`.
- Add `handle_exception_with_reason(xtval, e, reason)` and keep the existing `handle_exception` as a wrapper using `Trap_reason_none()`.
- Extend `trap_handler`, `exception_handler` and `trap_callback` to take and propagate a `trap_reason`.
- Expose `struct ztrap_reason` from `sail_riscv_model.h` as `typedef struct ztrap_reason trap_reason` and update the C/C++ `trap_callback(bool, fbits, trap_reason)` interface.
- For `Step_Fetch_Failure` and `Step_Execute(Memory_Exception(...))`, pass `Access_not_in_physical_memory()` as an initial example reason.
- `log_callbacks::trap_callback` prints both the trap cause and `reason` for debugging.

Testing:
- Rebuilt `sail_riscv_sim` successfully.
- Ran a small ELF that triggers an instruction fetch access fault and observed:
  `trap: is_interrupt=0 cause=1` and `reason: access_not_in_physical_memory` in the log.
