### PR TITLE
Add Hypervisor Extension

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -13,17 +13,21 @@
     // `xtval` registers.
     "xtval_nonzero": {
       "illegal_instruction": true,
+      "virtual_instruction": true,
       "software_breakpoint": true,
       "hardware_breakpoint": true,
       "load_address_misaligned": true,
       "load_access_fault": true,
       "load_page_fault": true,
+      "load_guest_page_fault": true,
       "samo_address_misaligned": true,
       "samo_access_fault": true,
       "samo_page_fault": true,
+      "samo_guest_page_fault": true,
       "fetch_address_misaligned": true,
       "fetch_access_fault": true,
       "fetch_page_fault": true,
+      "fetch_guest_page_fault": true,
       "software_check": true,
       "reserved_exceptions": false
     },
@@ -209,6 +213,9 @@
       "supported": true
     },
     "U": {
+      "supported": true
+    },
+    "H": {
       "supported": true
     },
     "Zicbom": {

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -68,7 +68,7 @@ function clause hartSupports(Ext_U) = config extensions.U.supported
 // Hypervisor
 enum clause extension = Ext_H
 mapping clause extensionName = Ext_H <-> "h"
-function clause hartSupports(Ext_H) = false
+function clause hartSupports(Ext_H) = config extensions.H.supported
 
 // Cache block size is 64 bytes
 enum clause extension = Ext_Zic64b

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -170,8 +170,8 @@ bitfield Mstatus : bits(64) = {
   //MDT  : 42,
   MPELP: 41,
 
-  //MPV  : 39,
-  //GVA  : 38,
+  MPV  : 39,
+  GVA  : 38,
 
   MBE  : 37,
   SBE  : 36,
@@ -211,8 +211,8 @@ private function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
   let o = [o with
     // MDT = v[MDT],
     MPELP = if hartSupports(Ext_Zicfilp) then v[MPELP] else 0b0,
-    // MPV = v[MPV],
-    // GVA = v[GVA],
+    MPV = if currentlyEnabled(Ext_H) then v[MPV] else 0b0,
+    GVA = if currentlyEnabled(Ext_H) then v[GVA] else 0b0,
     // We don't currently support changing MBE and SBE.
     // MBE = v[MBE],
     // SBE = v[SBE],
@@ -279,6 +279,51 @@ function clause write_CSR((0x300, value) if xlen == 64) = { mstatus = legalize_m
 function clause write_CSR((0x300, value) if xlen == 32) = { mstatus = legalize_mstatus(mstatus, mstatus.bits[63 .. 32] @ value); Ok(mstatus.bits[31 .. 0]) }
 function clause write_CSR((0x310, value) if xlen == 32) = { mstatus = legalize_mstatus(mstatus, value @ mstatus.bits[31 .. 0]); Ok(mstatus.bits[63 .. 32]) }
 
+// Hypervisor Status Register
+
+bitfield Hstatus : bits(64) = {
+  HUPMM : 49 .. 48,
+  VSXL  : 33 .. 32,
+
+  VTSR  : 22,
+  VTW   : 21,
+  VTVM  : 20,
+  VGEIN : 17 .. 12,
+
+  HU    : 9,
+  SPVP  : 8,
+  SPV   : 7,
+  GVA   : 6,
+  VSBE  : 5
+}
+
+function legalize_hstatus(o : Hstatus, v : bits(64)) -> Hstatus = {
+  let v = Mk_Hstatus(v);
+  [o with
+    VTSR  = v[VTSR],
+    VTW   = v[VTW],
+    VTVM  = v[VTVM],
+    VGEIN = v[VGEIN],
+    HU    = v[HU],
+    SPVP  = v[SPVP],
+    SPV   = v[SPV],
+    GVA   = v[GVA],
+    VSBE  = v[VSBE],
+  ];
+}
+
+register hstatus : Hstatus = [ Mk_Hstatus(zeros()) with
+    // These fields do not exist on RV32 and are read-only zero
+    // if the corresponding mode is not supported.
+    VSXL = architecture_bits(if xlen == 32 then RV32 else RV64)
+  ]
+
+mapping clause csr_name_map = 0x600  <-> "hstatus"
+function clause is_CSR_accessible(0x600, _, _) = currentlyEnabled(Ext_H) // hstatus
+function clause read_CSR(0x600) = hstatus.bits[xlen - 1 .. 0]
+function clause write_CSR((0x600, value)  if xlen == 64) = { hstatus = legalize_hstatus(hstatus, value); Ok(hstatus.bits) }
+function clause write_CSR((0x600, value)  if xlen == 32) = { hstatus = legalize_hstatus(hstatus, hstatus.bits[63 .. 32] @ value); Ok(hstatus.bits[31 .. 0]) }
+
 // architecture and extension checks
 
 function architecture(priv : Privilege) -> Architecture = {
@@ -289,8 +334,8 @@ function architecture(priv : Privilege) -> Architecture = {
     Machine           => misa[MXL],
     Supervisor        => mstatus[SXL],
     User              => mstatus[UXL],
-    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => hstatus[VSXL],
+    VirtualUser       => hstatus[VSXL],
   })
 }
 
@@ -440,6 +485,43 @@ function clause write_CSR((0x30A, value) if xlen == 64) = { menvcfg = legalize_m
 function clause write_CSR((0x31A, value) if xlen == 32) = { menvcfg = legalize_menvcfg(menvcfg, value @ menvcfg.bits[31 .. 0]); Ok(menvcfg.bits[63 .. 32]) }
 function clause write_CSR(0x10A, value) = { senvcfg = legalize_senvcfg(senvcfg, zero_extend(value)); Ok(senvcfg.bits[xlen - 1 .. 0]) }
 
+
+bitfield HEnvcfg : bits(64) = {
+  // Supervisor TimeCmp Extension
+  STCE   : 63,
+  // Page Based Memory Types Extension
+  PBMTE  : 62,
+  // Hardware update of A/D bits Extension
+  ADUE   : 61,
+  // Reserved WPRI bits.
+  wpri_2 : 60 .. 8,
+  // Cache Block Zero instruction Enable
+  CBZE   : 7,
+  // Cache Block Clean and Flush instruction Enable
+  CBCFE  : 6,
+  // Cache Block Invalidate instruction Enable
+  CBIE   : 5 .. 4,
+  // Reserved WPRI bits.
+  wpri_1 : 3,
+  // Landing Pad Enable
+  LPE    : 2,
+  wpri_0 : 1,
+  // Fence of I/O implies Memory
+  FIOM   : 0,
+}
+
+register henvcfg : HEnvcfg
+
+function legalize_henvcfg(o : HEnvcfg, v : bits(64)) -> HEnvcfg = {
+  let v = Mk_HEnvcfg(v);
+  [o with
+    FIOM = if sys_enable_writable_fiom then v[FIOM] else 0b0,
+  ]
+}
+
+mapping clause csr_name_map = 0x60A  <-> "henvcfg"
+mapping clause csr_name_map = 0x61A  <-> "henvcfgh"
+
 // Return whether or not FIOM is currently active, based on the current
 // privilege and the menvcfg/senvcfg settings. This means that I/O fences
 // imply memory fence.
@@ -448,8 +530,8 @@ function is_fiom_active() -> bool = {
     Machine           => false,
     Supervisor        => menvcfg[FIOM] == 0b1,
     User              => (menvcfg[FIOM] | senvcfg[FIOM]) == 0b1,
-    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => henvcfg[FIOM] == 0b1,
+    VirtualUser       => henvcfg[FIOM] == 0b1,
   }
 }
 
@@ -480,6 +562,7 @@ private function legalize_mip(o : Minterrupts, v : xlenbits) -> Minterrupts = {
       // STI is read only if Sstc is enabled and STCE is set (it is equal to stimecmp <= mtime).
       if currentlyEnabled(Ext_Sstc) & menvcfg[STCE] == 0b1 then o[STI] else v[STI]
     ) else 0b0,
+    VSSI = if currentlyEnabled(Ext_H) then v[VSSI] else o[VSSI],
   ]
 }
 
@@ -492,22 +575,42 @@ private function legalize_mie(o : Minterrupts, v : xlenbits) -> Minterrupts = {
     SEI = if currentlyEnabled(Ext_S) then v[SEI] else 0b0,
     STI = if currentlyEnabled(Ext_S) then v[STI] else 0b0,
     SSI = if currentlyEnabled(Ext_S) then v[SSI] else 0b0,
+    SGEI = if currentlyEnabled(Ext_H) then v[SGEI] else o[SGEI],
+    VSEI = if currentlyEnabled(Ext_H) then v[VSEI] else o[VSEI],
+    VSTI = if currentlyEnabled(Ext_H) then v[VSTI] else o[VSTI],
+    VSSI = if currentlyEnabled(Ext_H) then v[VSSI] else o[VSSI],
   ]
 }
 
 private function legalize_mideleg(_o : Minterrupts, v : xlenbits) -> Minterrupts = {
   // M-mode interrupt delegation bits "should" be hardwired to 0.
   // FIXME: needs verification against eventual spec language.
-  [Mk_Minterrupts(v) with MEI = 0b0, MTI = 0b0, MSI = 0b0]
+  let v = Mk_Minterrupts(v);
+  [ v with
+    MEI = 0b0,
+    MTI = 0b0,
+    MSI = 0b0,
+    // VS-mode interrupts are always delegated when the H-extesion is present
+    VSEI = if currentlyEnabled(Ext_H) then 0b1 else v[VSEI],
+    VSTI = if currentlyEnabled(Ext_H) then 0b1 else v[VSTI],
+    VSSI = if currentlyEnabled(Ext_H) then 0b1 else v[VSSI],
+    // If GEILEN > 0, SGEI is always delegated
+    SGEI = if currentlyEnabled(Ext_H) then 0b1 else v[SGEI],
+  ]
 }
 
 // exception processing state
 
 bitfield Medeleg : bits(64) = {
+  SAMO_GPage_Fault  : 23,
+  Virtual_Instr     : 22,
+  Load_GPage_Fault  : 21,
+  Fetch_GPage_Fault : 20,
   SAMO_Page_Fault   : 15,
   Load_Page_Fault   : 13,
   Fetch_Page_Fault  : 12,
   MEnvCall          : 11,
+  VSEnvCall         : 10,
   SEnvCall          : 9,
   UEnvCall          : 8,
   SAMO_Access_Fault : 7,
@@ -656,6 +759,17 @@ function clause is_CSR_accessible(0x106, _, _) = currentlyEnabled(Ext_S) // scou
 function clause read_CSR(0x106) = zero_extend(scounteren.bits)
 function clause write_CSR(0x106, value) = { scounteren = legalize_scounteren(scounteren, value); Ok(zero_extend(scounteren.bits)) }
 
+// hcounteren
+function legalize_hcounteren(c : Counteren, v : xlenbits) -> Counteren = {
+  // no HPM counters yet
+  [c with IR = [v[2]], TM = [v[1]], CY = [v[0]]]
+}
+register hcounteren : Counteren
+mapping clause csr_name_map = 0x606  <-> "hcounteren"
+function clause is_CSR_accessible(0x606, _, _) = currentlyEnabled(Ext_H) // hcounteren
+function clause read_CSR(0x606) = zero_extend(hcounteren.bits)
+function clause write_CSR(0x606, value) = { hcounteren = legalize_hcounteren(hcounteren, value); Ok(zero_extend(hcounteren.bits)) }
+
 // mcounteren
 function legalize_mcounteren(_c : Counteren, v : xlenbits) -> Counteren = {
   let supported_counters = sys_writable_hpm_counters[31 .. 3] @ 0b111;
@@ -795,10 +909,49 @@ private function legalize_sstatus(m : Mstatus, v : xlenbits) -> Mstatus = {
   legalize_mstatus(m, lift_sstatus(m, Mk_Sstatus(zero_extend(v))).bits)
 }
 
+function legalize_vsstatus(o : Sstatus, v : bits(64)) -> Sstatus = {
+  let dirty = extStatus_of_bits(o[FS]) == Dirty | extStatus_of_bits(o[XS]) == Dirty |
+              extStatus_of_bits(o[VS]) == Dirty;
+  let s = Mk_Sstatus(v);
+  [o with
+    SD = bool_to_bit(dirty),
+    UXL = s[UXL],
+    //SDT = s[SDT],
+    SPELP = s[SPELP],
+    MXR = s[MXR],
+    SUM = s[SUM],
+    XS = s[XS],
+    FS = s[FS],
+    VS = s[VS],
+    SPP = s[SPP],
+    SPIE = s[SPIE],
+    SIE = s[SIE],
+  ]
+}
+
+register vsstatus : Sstatus // Virtual Supervisor Status Register
+
 mapping clause csr_name_map = 0x100  <-> "sstatus"
+mapping clause csr_name_map = 0x200  <-> "vsstatus"
+
 function clause is_CSR_accessible(0x100, _, _) = currentlyEnabled(Ext_S) // sstatus
-function clause read_CSR(0x100) = lower_mstatus(mstatus).bits[xlen - 1 .. 0]
-function clause write_CSR(0x100, value) = { mstatus = legalize_sstatus(mstatus, value); Ok(lower_mstatus(mstatus).bits[xlen - 1 .. 0]) }
+function clause is_CSR_accessible(0x200, _, _) = currentlyEnabled(Ext_H) // vsstatus
+
+function clause read_CSR(0x100) = if privLevel_is_virtual(cur_privilege)
+                                  then vsstatus.bits[xlen - 1 .. 0]
+                                  else lower_mstatus(mstatus).bits[xlen - 1 .. 0]
+
+function clause read_CSR(0x200) = vsstatus.bits[xlen - 1 .. 0]
+
+function clause write_CSR(0x100, value) =
+  if privLevel_is_virtual(cur_privilege) then {
+    vsstatus = legalize_vsstatus(vsstatus, zero_extend(value));
+    Ok(vsstatus.bits[xlen - 1 .. 0])
+  } else {
+    mstatus = legalize_sstatus(mstatus, value);
+    Ok(lower_mstatus(mstatus).bits[xlen - 1 .. 0])
+  }
+function clause write_CSR(0x200, value) = { vsstatus = legalize_vsstatus(vsstatus, zero_extend(value)); Ok(vsstatus.bits[xlen - 1 .. 0]) }
 
 
 bitfield Sinterrupts : xlenbits = {
@@ -809,28 +962,24 @@ bitfield Sinterrupts : xlenbits = {
   SSI : 1,  // software interrupts
 }
 
-// sip
-// Provides the sip read view of mip (m) as delegated by mideleg (d).
-private function lower_mip(m : Minterrupts, d : Minterrupts) -> Sinterrupts = {
-  let s : Sinterrupts = Mk_Sinterrupts(zeros());
 
-  [s with
-    SEI = m[SEI] & d[SEI],
-    STI = m[STI] & d[STI],
-    SSI = m[SSI] & d[SSI],
-  ]
-}
+register vstvec   : Mtvec
+register vsscratch : xlenbits
+register vsepc    : xlenbits
+register vscause  : Mcause
+register vstval   : xlenbits
 
-// Provides the sie read view of mie (m) as delegated by mideleg (d).
-private function lower_mie(m : Minterrupts, d : Minterrupts) -> Sinterrupts = {
-  let s : Sinterrupts = Mk_Sinterrupts(zeros());
+mapping clause csr_name_map = 0x240  <-> "vsscratch"
+mapping clause csr_name_map = 0x242  <-> "vscause"
+mapping clause csr_name_map = 0x243  <-> "vstval"
 
-  [s with
-    SEI = m[SEI] & d[SEI],
-    STI = m[STI] & d[STI],
-    SSI = m[SSI] & d[SSI],
-  ]
-}
+function clause is_CSR_accessible(0x240, _, _) = currentlyEnabled(Ext_H) // vscause
+function clause is_CSR_accessible(0x242, _, _) = currentlyEnabled(Ext_H) // vscause
+function clause is_CSR_accessible(0x243, _, _) = currentlyEnabled(Ext_H) // vstval
+
+function clause read_CSR(0x240) = vsscratch
+function clause read_CSR(0x242) = vscause.bits
+function clause read_CSR(0x243) = vstval
 
 // Returns the new value of mip from the previous mip (o) and the written sip (s) as delegated by mideleg (d).
 private function lift_sip(o : Minterrupts, d : Minterrupts, s : Sinterrupts) -> Minterrupts = {
@@ -842,12 +991,6 @@ private function lift_sip(o : Minterrupts, d : Minterrupts, s : Sinterrupts) -> 
 private function legalize_sip(m : Minterrupts, d : Minterrupts, v : xlenbits) -> Minterrupts = {
   lift_sip(m, d, Mk_Sinterrupts(v))
 }
-
-mapping clause csr_name_map = 0x144  <-> "sip"
-function clause is_CSR_accessible(0x144, _, _) = currentlyEnabled(Ext_S) // sip
-function clause read_CSR(0x144) = lower_mip(mip, mideleg).bits
-function clause write_CSR(0x144, value) = { mip = legalize_sip(mip, mideleg, value); Ok(lower_mip(mip, mideleg).bits) }
-
 
 // sie
 // Returns the new value of mie from the previous mie (o) and the written sie (s) as delegated by mideleg (d).
@@ -864,12 +1007,9 @@ private function legalize_sie(m : Minterrupts, d : Minterrupts, v : xlenbits) ->
   lift_sie(m, d, Mk_Sinterrupts(v))
 }
 
-
-mapping clause csr_name_map = 0x104  <-> "sie"
-function clause is_CSR_accessible(0x104, _, _) = currentlyEnabled(Ext_S) // sie
-function clause read_CSR(0x104) = lower_mie(mie, mideleg).bits
-function clause write_CSR(0x104, value) = { mie = legalize_sie(mie, mideleg, value); Ok(lower_mie(mie, mideleg).bits) }
-
+function clause write_CSR(0x240, value) = { vsscratch = value; Ok(vsscratch) }
+function clause write_CSR(0x242, value) = { vscause.bits = value; Ok(vscause.bits) }
+function clause write_CSR(0x243, value) = { vstval = value; Ok(vstval) }
 
 // other non-VM related supervisor state
 register stvec    : Mtvec
@@ -886,18 +1026,25 @@ function clause is_CSR_accessible(0x140, _, _) = currentlyEnabled(Ext_S) // sscr
 function clause is_CSR_accessible(0x142, _, _) = currentlyEnabled(Ext_S) // scause
 function clause is_CSR_accessible(0x143, _, _) = currentlyEnabled(Ext_S) // stval
 
-function clause read_CSR(0x140) = sscratch
-function clause read_CSR(0x142) = scause.bits
-function clause read_CSR(0x143) = stval
+function clause read_CSR(0x140) = if privLevel_is_virtual(cur_privilege) then vsscratch else sscratch
+function clause read_CSR(0x142) = if privLevel_is_virtual(cur_privilege) then vscause.bits else scause.bits
+function clause read_CSR(0x143) = if privLevel_is_virtual(cur_privilege) then vstval else stval
 
-function clause write_CSR(0x140, value) = { sscratch = value; Ok(sscratch) }
-function clause write_CSR(0x142, value) = { scause.bits = value; Ok(scause.bits) }
-function clause write_CSR(0x143, value) = { stval = value; Ok(stval) }
+function clause write_CSR(0x140, value) =
+  if privLevel_is_virtual(cur_privilege)
+  then { vsscratch = value; Ok(vsscratch) }
+  else { sscratch = value; Ok(sscratch) }
+function clause write_CSR(0x142, value) =
+  if privLevel_is_virtual(cur_privilege)
+  then { vscause.bits = value; Ok(vscause.bits) }
+  else { scause.bits = value; Ok(scause.bits) }
+function clause write_CSR(0x143, value) =
+  if privLevel_is_virtual(cur_privilege)
+  then { vstval = value; Ok(vstval) }
+  else { stval = value; Ok(stval) }
 
-//
 // S-mode address translation and protection (satp) layout.
 // The actual satp register is defined in an architecture-specific file.
-
 bitfield Satp64 : bits(64) = {
   Mode : 63 .. 60,
   Asid : 59 .. 44,
@@ -971,14 +1118,471 @@ val get_16_random_bits = impure {
 
 // There are several features that are controlled by machine/supervisor enable
 // bits (m/senvcfg, m/scounteren, etc.). This abstracts that logic.
-function feature_enabled_for_priv(p : Privilege, machine_enable_bit : bits(1), supervisor_enable_bit : bits(1)) -> bool = match p {
+function feature_enabled_for_priv(p : Privilege, machine_enable_bit : bits(1), supervisor_enable_bit : bits(1), hypervisor_enable_bit : bits(1)) -> bool = match p {
   Machine => true,
   Supervisor => machine_enable_bit == 0b1,
   User => machine_enable_bit == 0b1 & (not(currentlyEnabled(Ext_S)) | supervisor_enable_bit == 0b1),
-  VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-  VirtualUser => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+  VirtualSupervisor => machine_enable_bit == 0b1 & hypervisor_enable_bit == 0b1,
+  VirtualUser => machine_enable_bit == 0b1 & hypervisor_enable_bit == 0b1 & supervisor_enable_bit == 0b1,
 }
 
 // Return true if the counter is enabled.
 function counter_enabled(index: range(0, 31), priv : Privilege) -> bool =
-  feature_enabled_for_priv(priv, mcounteren.bits[index], scounteren.bits[index])
+  feature_enabled_for_priv(priv, mcounteren.bits[index], scounteren.bits[index], hcounteren.bits[index])
+
+function clause currentlyEnabled(Ext_H) = hartSupports(Ext_H) & misa[H] == 0b1 & virtual_memory_supported() & currentlyEnabled(Ext_U)
+
+// Hypervisor Trap Delegation (hedeleg and hideleg) Registers
+
+function legalize_hedeleg(o: Medeleg, v: bits(64)) -> Medeleg = {
+  // Mask read-only zero bits
+  [Mk_Medeleg(v) with
+    SAMO_GPage_Fault  = 0b0,
+    Virtual_Instr     = 0b0,
+    Load_GPage_Fault  = 0b0,
+    Fetch_GPage_Fault = 0b0,
+    MEnvCall          = 0b0,
+    VSEnvCall         = 0b0,
+    SEnvCall          = 0b0,
+  ]
+}
+
+// Returns new mie from the previous mie (m) and the written hie (v)
+// Note: Writable bits in sie are read-only zero in hie
+// TODO: Hook to update non-standard portion
+function legalize_hie(m : Minterrupts, v : xlenbits) -> Minterrupts = {
+  let v = Mk_Minterrupts(v);
+  [ m with
+    SGEI = v[SGEI],
+    VSEI = v[VSEI],
+    VSTI = v[VSTI],
+    VSSI = v[VSSI],
+  ]
+}
+
+function legalize_hideleg(h : Minterrupts, v : xlenbits) -> Minterrupts = {
+  let v = Mk_Minterrupts(v);
+  // VS-level interrupts can be delegated
+  [h with SGEI  = v[SGEI],
+     VSEI = v[VSEI],
+     VSTI = v[VSTI],
+     VSSI = v[VSSI],
+  ]
+}
+
+register hedeleg : Medeleg     // Exception delegation to S-mode
+register hideleg : Minterrupts // Interrupt delegation to S-mode
+
+mapping clause csr_name_map = 0x602  <-> "hedeleg"
+mapping clause csr_name_map = 0x612  <-> "hedelegh"
+mapping clause csr_name_map = 0x603  <-> "hideleg"
+
+function clause is_CSR_accessible(0x602, _, _) = currentlyEnabled(Ext_H) // hedeleg
+function clause is_CSR_accessible(0x612, _, _) = currentlyEnabled(Ext_H) & xlen == 32 // hedelegh
+function clause is_CSR_accessible(0x603, _, _) = currentlyEnabled(Ext_H) // hideleg
+
+function clause read_CSR(0x602) = hedeleg.bits[xlen - 1 .. 0]
+function clause read_CSR(0x612 if xlen == 32) = hedeleg.bits[63 .. 32]
+function clause read_CSR(0x603) = hideleg.bits[xlen - 1 .. 0]
+
+function clause write_CSR((0x602, value) if xlen == 64) = { hedeleg = legalize_hedeleg(hedeleg, value); Ok(hedeleg.bits) }
+function clause write_CSR((0x602, value) if xlen == 32) = { hedeleg = legalize_hedeleg(hedeleg, hedeleg.bits[63 .. 32] @ value); Ok(hedeleg.bits[31 .. 0]) }
+function clause write_CSR((0x612, value) if xlen == 32) = { hedeleg = legalize_hedeleg(hedeleg, value @ hedeleg.bits[31 .. 0]); Ok(hedeleg.bits[63 .. 32]) }
+function clause write_CSR(0x603, value) = { hideleg = legalize_hideleg(hideleg, value); Ok(hideleg.bits) }
+
+
+// sip
+// Provides the sip read view of mip (m) as delegated by mideleg (d).
+function lower_mip(m : Minterrupts, d : Minterrupts) -> Sinterrupts = {
+  let s : Sinterrupts = Mk_Sinterrupts(zeros());
+
+  [s with
+    SEI = m[SEI] & d[SEI],
+    STI = m[STI] & d[STI],
+    SSI = m[SSI] & d[SSI],
+  ]
+}
+
+// Provides the sie read view of mie (m) as delegated by mideleg (d).
+function lower_mie(m : Minterrupts, d : Minterrupts) -> Sinterrupts = {
+  let s : Sinterrupts = Mk_Sinterrupts(zeros());
+
+  [s with
+    SEI = m[SEI] & d[SEI],
+    STI = m[STI] & d[STI],
+    SSI = m[SSI] & d[SSI],
+  ]
+}
+
+//! Returns vsie view of mie (m) as delegated by hideleg (d)
+function lower_mie_to_vsie(m : Minterrupts, d : Minterrupts) -> Minterrupts = {
+  let vs = Mk_Minterrupts(zeros());
+  // Standard S-mode bits in vsie are aliases of corresponding VS-mode bits in
+  // hie if delegated by hideleg
+  [vs with
+    SEI = m[VSEI] & d[VSEI],
+    STI = m[VSTI] & d[VSTI],
+    SSI = m[VSSI] & d[VSSI],
+  ]
+}
+
+//  Returns hie view of mie
+// Note: Writable bits in sie are read-only zero in hie
+// TODO: Hook to read non-standard portion
+function lower_mie_to_hie(m : Minterrupts) -> Minterrupts = {
+  [Mk_Minterrupts(zeros()) with
+    SGEI = m[SGEI],
+    VSEI = m[VSEI],
+    VSTI = m[VSTI],
+    VSSI = m[VSSI],
+  ]
+}
+
+//  Returns hip view of mip (m)
+// TODO: Hook to read non-standard portion
+function lower_mip_to_hip(m : Minterrupts) -> Minterrupts = {
+  [Mk_Minterrupts(zeros()) with
+    SGEI = m[SGEI],
+    VSEI = m[VSEI],
+    VSTI = m[VSTI],
+    VSSI = m[VSSI],
+  ]
+}
+
+// Returns hvip view of mip (m)
+// TODO: Hook to read non-standard portion
+function lower_mip_to_hvip(m : Minterrupts) -> Minterrupts = {
+  [Mk_Minterrupts(zeros()) with
+    VSEI = m[VSEI],
+    VSTI = m[VSTI],
+    VSSI = m[VSSI],
+  ]
+}
+// Returns vsip view of mip (m) as delegated by hideleg (d)
+// Standard S-mode bits in vsip are aliases of corresponding VS-mode bits in
+// hip if delegated by hideleg
+function lower_mip_to_vsip(m : Minterrupts, d : Minterrupts) -> Minterrupts = {
+  [Mk_Minterrupts(zeros()) with
+    SEI = m[VSEI] & d[VSEI],
+    STI = m[VSTI] & d[VSTI],
+    SSI = m[VSSI] & d[VSSI],
+  ]
+}
+
+// Returns new mip from the previous mip (m) and the written vsip (v) as delegated by hideleg (d)
+// Since S-mode bits in vsip are aliases for their corresponding VS-mode bits
+// in hip when delegated by hideleg, only vsip.SSIP (hip.VSSIP) might be writable
+function legalize_vsip(m: Minterrupts, d : Minterrupts, v : xlenbits) -> Minterrupts = {
+  let v = Mk_Minterrupts(v);
+  [m with VSSI = v[SSI] & d[VSSI]]
+}
+
+mapping clause csr_name_map = 0x144  <-> "sip"
+function clause is_CSR_accessible(0x144, _, _) = currentlyEnabled(Ext_S) // sip
+function clause read_CSR(0x144) =
+  if privLevel_is_virtual(cur_privilege)
+  then lower_mip_to_vsip(mip, hideleg).bits
+  else lower_mip(mip, mideleg).bits
+function clause write_CSR(0x144, value) =
+  if privLevel_is_virtual(cur_privilege)
+  then { mip = legalize_vsip(mip, hideleg, value); Ok(lower_mip_to_vsip(mip, hideleg).bits) }
+  else { mip = legalize_sip(mip, mideleg, value); Ok(lower_mip(mip, mideleg).bits) }
+
+// Returns new mie from previous mie (m) and the written vsie (v) as delegated by hideleg (d)
+function legalize_vsie(m : Minterrupts, d : Minterrupts, v : xlenbits) -> Minterrupts = {
+  let v = Mk_Minterrupts(v);
+  [m with
+    VSEI = v[SEI] & d[VSEI],
+    VSTI = v[STI] & d[VSTI],
+    VSSI = v[SSI] & d[VSSI],
+  ]
+}
+
+mapping clause csr_name_map = 0x104  <-> "sie"
+function clause is_CSR_accessible(0x104, _, _) = currentlyEnabled(Ext_S) // sie
+function clause read_CSR(0x104) = if privLevel_is_virtual(cur_privilege)
+                                  then lower_mie_to_vsie(mie, hideleg).bits
+                                  else lower_mie(mie, mideleg).bits
+function clause write_CSR(0x104, value) =
+    if privLevel_is_virtual(cur_privilege)
+    then { mie = legalize_vsie(mie, hideleg, value); Ok(lower_mie_to_vsie(mie, hideleg).bits) }
+    else { mie = legalize_sie(mie, mideleg, value); Ok(lower_mie(mie, mideleg).bits) }
+
+// extra machine registers
+register mtinst : xlenbits
+register mtval2 : xlenbits
+
+mapping clause csr_name_map = 0x34A  <-> "mtinst"
+mapping clause csr_name_map = 0x34B  <-> "mtval2"
+
+function clause is_CSR_accessible(0x34A, _, _) = currentlyEnabled(Ext_H) // mtinst
+function clause is_CSR_accessible(0x34B, _, _) = currentlyEnabled(Ext_H) // mtval2
+
+function clause read_CSR(0x34A) = mtinst
+function clause read_CSR(0x34B) = mtval2
+
+function clause write_CSR(0x34A, value) = { mtinst = value; Ok(mtinst) }
+function clause write_CSR(0x34B, value) = { mtval2 = value; Ok(mtval2) }
+
+// Hypervisor Trap Setup
+register hgeie : xlenbits
+
+mapping clause csr_name_map = 0x604  <-> "hie"
+mapping clause csr_name_map = 0x607  <-> "hgeie"
+
+function clause is_CSR_accessible(0x604, _, _) = currentlyEnabled(Ext_H) // hie
+function clause is_CSR_accessible(0x607, _, _) = currentlyEnabled(Ext_H) // hgeie
+
+function legalize_hgeie(v : xlenbits) -> xlenbits = {
+  [v with 0 = bitzero]
+}
+
+function clause read_CSR(0x604) = lower_mie_to_hie(mie).bits
+function clause read_CSR(0x607) = hgeie
+
+function clause write_CSR(0x604, value) = { mie = legalize_hie(mie, value); Ok(lower_mie_to_hie(mie).bits) }
+function clause write_CSR(0x607, value) = { hgeie = legalize_hgeie(value); Ok(hgeie) }
+
+// Hypervisor Trap Handling
+register htval  : xlenbits
+register htinst : xlenbits
+register hgeip : xlenbits
+
+// Returns new mip from the previous mip (m) and the written hip (v)
+// TODO: Hook to update non-standard portion
+function legalize_hip(m : Minterrupts, v : xlenbits) -> Minterrupts = {
+  let v = Mk_Minterrupts(v);
+  [m with VSSI = v[VSSI]]
+}
+
+// Returns new mip from the previous mip (m) and the written hvip (v)
+// TODO: Hook to update non-standard portion
+function legalize_hvip(m: Minterrupts, v : xlenbits) -> Minterrupts = {
+  let v = Mk_Minterrupts(v);
+  [m with
+    VSEI = v[VSEI],
+    VSTI = v[VSTI],
+    VSSI = v[VSSI],
+  ]
+}
+
+mapping clause csr_name_map = 0x643  <-> "htval"
+mapping clause csr_name_map = 0x644  <-> "hip"
+mapping clause csr_name_map = 0x645  <-> "hvip"
+mapping clause csr_name_map = 0x64A  <-> "htinst"
+mapping clause csr_name_map = 0xE12  <-> "hgeip"
+
+function clause is_CSR_accessible(0x643, _, _) = currentlyEnabled(Ext_H) // htval
+function clause is_CSR_accessible(0x644, _, _) = currentlyEnabled(Ext_H) // hip
+function clause is_CSR_accessible(0x645, _, _) = currentlyEnabled(Ext_H) // hvip
+function clause is_CSR_accessible(0x64A, _, _) = currentlyEnabled(Ext_H) // htinst
+function clause is_CSR_accessible(0xE12, _, _) = currentlyEnabled(Ext_H) // hgeip
+
+function clause read_CSR(0x643) = htval
+function clause read_CSR(0x644) = lower_mip_to_hip(mip).bits
+function clause read_CSR(0x645) = lower_mip_to_hvip(mip).bits
+function clause read_CSR(0x64A) = htinst
+function clause read_CSR(0xE12) = hgeip
+
+function clause write_CSR(0x643, value) = { htval = value; Ok(htval) }
+function clause write_CSR(0x644, value) = { mip = legalize_hip(mip, value); Ok(lower_mip_to_hip(mip).bits) }
+function clause write_CSR(0x645, value) = { mip = legalize_hvip(mip, value); Ok(lower_mip_to_hvip(mip).bits) }
+function clause write_CSR(0x64A, value) = { htinst = value; Ok(htinst) }
+// function clause write_CSR(0xE12,     _) = { hgeip } // hgeip is read-only
+
+// Hypervisor Configuration
+
+function clause is_CSR_accessible(0x60A, _, _) = currentlyEnabled(Ext_H) // henvcfg
+function clause is_CSR_accessible(0x61A, _, _) = currentlyEnabled(Ext_H) & xlen == 32 // henvcfgh
+
+function clause read_CSR(0x60A) = henvcfg.bits[xlen - 1 .. 0]
+function clause read_CSR(0x61A if xlen == 32) = henvcfg.bits[63 .. 32]
+
+function clause write_CSR((0x60A, value) if xlen == 32) = { henvcfg = legalize_henvcfg(henvcfg, henvcfg.bits[63 .. 32] @ value); Ok(henvcfg.bits[(xlen - 1) .. 0]) }
+function clause write_CSR((0x60A, value) if xlen == 64) = { henvcfg = legalize_henvcfg(henvcfg, value); Ok(henvcfg.bits[(xlen - 1) .. 0]) }
+function clause write_CSR((0x61A, value) if xlen == 32) = { henvcfg = legalize_henvcfg(henvcfg, value @ henvcfg.bits[31 .. 0]); Ok(henvcfg.bits[63 .. 32])}
+
+// Hypervisor Protection and Translation
+bitfield Hgatp64 : bits(64) = {
+  Mode : 63 .. 60,
+  Vmid : 57 .. 44,
+  PPN  : 43 .. 0
+}
+
+function legalize_hgatp64(a : Architecture, o : bits(64), v : bits(64)) -> bits(64) = {
+  let h = Mk_Hgatp64(v[63 .. 60] @ 0b00 @ v[57 .. 44] @ v[43 .. 2] @ 0b00);
+  match hgatp64Mode_of_bits(a, h[Mode]) {
+    Some(Bare)   => h[Mode] @ zeros(60), // remaining fields should be zero when hgatp.Mode is Bare
+    Some(Sv32x4) => o,                   // Sv32x4 is currently unsupported for hgatp64
+    Some(Sv39x4) => h.bits,
+    Some(Sv48x4) => h.bits,
+    Some(Sv57x4) => o,                   // Sv57x4 is not yet implemented
+    _            => o,                   // (V)S-stage modes are illegal for hgatp
+  }
+}
+
+bitfield Hgatp32 : bits(32) = {
+  Mode : 31,
+  Vmid : 28 .. 22,
+  PPN  : 21 .. 0
+}
+
+function legalize_hgatp32(a : Architecture, o : bits(32), v : bits(32)) -> bits(32) = {
+  let h = Mk_Hgatp32(v[31 .. 31] @ 0b00 @ v[28 .. 22] @ v[21 .. 2] @ 0b00);
+  match hgatp64Mode_of_bits(a, zero_extend(h[Mode])) {
+    None()     => o,
+    Some(Bare) => h[Mode] @ zeros(31), // remaining fields should be zero when hgatp.Mode is Bare
+    Some(_)    => h.bits
+  }
+}
+
+// See riscv_hext_regs.sail for legalize_hgatp{32,64}().
+// WARNING: those functions legalize Mode but not VMID?
+// PUBLIC: invoked from writeCSR() to fixup WARL fields
+function legalize_hgatp(
+  a : Architecture,
+  o : xlenbits,   // previous value of hgatp
+  v : xlenbits    // proposed new value of hgatp
+) -> xlenbits = { // new legal value of hgatp
+  if xlen == 32 then {
+    // The slice and extend ops below are no-ops when xlen==32,
+    // but appease the type-checker when xlen==64 (when this code is not executed!)
+    let o32       : bits(32) = o[31 .. 0];
+    let v32       : bits(32) = v[31 .. 0];
+    let new_hgatp : bits(32) = legalize_hgatp32(a, o32, v32);
+    zero_extend(new_hgatp);
+  } else if xlen == 64 then {
+    // The extend and truncate ops below are no-ops when xlen==64,
+    // but appease the type-checker when xlen==32 (when this code is not executed!)
+    let o64       : bits(64) = zero_extend(o);
+    let v64       : bits(64) = zero_extend(v);
+    let new_hgatp : bits(64) = legalize_hgatp64(a, o64, v64);
+    truncate(new_hgatp, xlen)
+  } else {
+    internal_error(__FILE__, __LINE__, "Unsupported xlen")
+  }
+}
+
+// Debug/Trace Registers
+mapping clause csr_name_map = 0x6A8  <-> "hcontext"
+
+function clause is_CSR_accessible(0x6A8, _, _) = currentlyEnabled(Ext_H) // hcontext
+
+// TODO: Wait for Debug Extension
+
+// Virtual Supervisor Scratch Register
+register vsie : xlenbits
+register vsip : xlenbits
+register vsatp : xlenbits
+
+mapping clause csr_name_map = 0x204  <-> "vsie"
+mapping clause csr_name_map = 0x244  <-> "vsip"
+mapping clause csr_name_map = 0x280  <-> "vsatp"
+
+function clause is_CSR_accessible(0x204, _, _) = currentlyEnabled(Ext_H) // vsie
+function clause is_CSR_accessible(0x244, _, _) = currentlyEnabled(Ext_H) // vsip
+function clause is_CSR_accessible(0x280, _, _) = currentlyEnabled(Ext_H) // vsatp
+
+function clause read_CSR(0x204) = lower_mie_to_vsie(mie, hideleg).bits
+function clause read_CSR(0x244) = lower_mip_to_vsip(mip, hideleg).bits
+function clause read_CSR(0x280) = vsatp
+
+function clause write_CSR(0x204, value) = { mie = legalize_vsie(mie, hideleg, value); Ok(lower_mie_to_vsie(mie, hideleg).bits) }
+function clause write_CSR(0x244, value) = { mip = legalize_vsip(mip, hideleg, value); Ok(lower_mip_to_vsip(mip, hideleg).bits) }
+function clause write_CSR(0x280, value) = { vsatp = value; Ok(vsatp) }
+
+// Hypervisor Counter/Timer Virtualization Registers
+register htimedelta : bits(64)
+
+mapping clause csr_name_map = 0x605  <-> "htimedelta"
+mapping clause csr_name_map = 0x615  <-> "htimedeltah"
+
+function clause is_CSR_accessible(0x605, _, _) = currentlyEnabled(Ext_H) // htimedelta
+function clause is_CSR_accessible(0x615, _, _) = currentlyEnabled(Ext_H) // htimedeltah
+
+function clause read_CSR(0x605) = htimedelta[xlen - 1 .. 0]
+function clause read_CSR(0x615 if xlen == 32) = htimedelta[63 .. 32]
+
+function clause write_CSR(0x605, value) = { htimedelta[(xlen - 1) .. 0] = value; Ok(htimedelta[(xlen - 1) .. 0]) }
+function clause write_CSR((0x615, value) if xlen == 32) = {htimedelta[63 .. 32] = value; Ok(htimedelta[63 .. 32]) }
+
+// Hypervisor State Enable Registers
+mapping clause csr_name_map = 0x60C  <-> "hstateen0"
+mapping clause csr_name_map = 0x60D  <-> "hstateen1"
+mapping clause csr_name_map = 0x60E  <-> "hstateen2"
+mapping clause csr_name_map = 0x60F  <-> "hstateen3"
+mapping clause csr_name_map = 0x61C  <-> "hstateen0h"
+mapping clause csr_name_map = 0x61D  <-> "hstateen1h"
+mapping clause csr_name_map = 0x61E  <-> "hstateen2h"
+mapping clause csr_name_map = 0x61F  <-> "hstateen3h"
+
+function clause is_CSR_accessible(0x60C, _, _) = currentlyEnabled(Ext_H) // hstateen0
+function clause is_CSR_accessible(0x60D, _, _) = currentlyEnabled(Ext_H) // hstateen1
+function clause is_CSR_accessible(0x60E, _, _) = currentlyEnabled(Ext_H) // hstateen2
+function clause is_CSR_accessible(0x60F, _, _) = currentlyEnabled(Ext_H) // hstateen3
+function clause is_CSR_accessible(0x61C, _, _) = currentlyEnabled(Ext_H) & xlen == 32 // hstateen0h
+function clause is_CSR_accessible(0x61D, _, _) = currentlyEnabled(Ext_H) & xlen == 32 // hstateen1h
+function clause is_CSR_accessible(0x61E, _, _) = currentlyEnabled(Ext_H) & xlen == 32 // hstateen2h
+function clause is_CSR_accessible(0x61F, _, _) = currentlyEnabled(Ext_H) & xlen == 32 // hstateen3h
+
+// Virtual Supervisor Indirect
+mapping clause csr_name_map = 0x250  <-> "vsiselect"
+mapping clause csr_name_map = 0x251  <-> "vsireg"
+mapping clause csr_name_map = 0x252  <-> "vsireg1"
+mapping clause csr_name_map = 0x253  <-> "vsireg2"
+mapping clause csr_name_map = 0x254  <-> "vsireg3"
+mapping clause csr_name_map = 0x255  <-> "vsireg4"
+mapping clause csr_name_map = 0x256  <-> "vsireg5"
+mapping clause csr_name_map = 0x257  <-> "vsireg6"
+
+function clause is_CSR_accessible(0x250, _, _) = currentlyEnabled(Ext_H) // "vsiselect"
+function clause is_CSR_accessible(0x251, _, _) = currentlyEnabled(Ext_H) // "vsireg"
+function clause is_CSR_accessible(0x252, _, _) = currentlyEnabled(Ext_H) // "vsireg1"
+function clause is_CSR_accessible(0x253, _, _) = currentlyEnabled(Ext_H) // "vsireg2"
+function clause is_CSR_accessible(0x254, _, _) = currentlyEnabled(Ext_H) // "vsireg3"
+function clause is_CSR_accessible(0x255, _, _) = currentlyEnabled(Ext_H) // "vsireg4"
+function clause is_CSR_accessible(0x256, _, _) = currentlyEnabled(Ext_H) // "vsireg5"
+function clause is_CSR_accessible(0x257, _, _) = currentlyEnabled(Ext_H) // "vsireg6"
+
+// Virtual Supervisor Control Transfer Records Configuration
+mapping clause csr_name_map = 0x24E  <-> "vsctrctl"
+function clause is_CSR_accessible(0x24E, _, _) = currentlyEnabled(Ext_H) // "vsctrctl"
+
+//  Initialize hypervisor extension
+function reset_hext() -> unit = {
+  // Init H-extension specific fields of M-mode CRSs
+  mstatus[MPV] = if currentlyEnabled(Ext_H) & privLevel_is_virtual(cur_privilege) then 0b1 else 0b0;
+  mstatus[GVA] = 0b0;
+
+  mtinst = zeros();
+  mtval2 = zeros();
+
+  mideleg = [mideleg with VSEI = 0b1, VSTI = 0b1, VSSI = 0b1];
+  mideleg = [mideleg with SGEI = 0b1]; // Note: SGEI is "read-only one" only if GEILEN > 0
+
+  // Init H-extension specific HS-mode CSRs
+
+  // Dynamic XLEN changes are not (yet) supported
+  hstatus = [Mk_Hstatus(zeros()) with VSXL = misa[MXL]];
+
+  hedeleg = Mk_Medeleg(zeros());
+  hideleg = Mk_Minterrupts(zeros());
+  hcounteren = Mk_Counteren(zeros());
+  htval = zeros();
+  htval = zeros();
+  hgeie = legalize_hgeie(zeros());
+  hgeip = zeros();
+  henvcfg = Mk_HEnvcfg(zeros());
+  htimedelta = zeros();
+
+  // Init VS-mode CSRs
+  // Dynamic XLEN changes are not (yet) supported
+  vsstatus = [Mk_Sstatus(zeros()) with UXL = misa[MXL]];
+
+  vstvec = Mk_Mtvec(zeros());
+  vsscratch = zeros();
+  vsepc = zeros();
+  vscause = Mk_Mcause(zeros());
+  vstval = zeros();
+  vsatp = zeros();
+}

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -11,8 +11,10 @@
 type half = bits(16)
 type word = bits(32)
 
-// Bit-vector of an uncompressed instruction.
 type instbits = bits(32)
+
+// Bit-vector of an uncompressed instruction.
+register instbits_transformed : bits(32)
 
 type pagesize_bits : Int = 12
 let  pagesize_bits = sizeof(pagesize_bits)
@@ -75,7 +77,7 @@ mapping privLevel_bits : (nom_priv_bits, virt_mode_bit) <-> Privilege = {
   (0b01, 0b0) <-> Supervisor,
   (0b01, 0b1) <-> VirtualSupervisor,
   (0b11, 0b0) <-> Machine,
-  forwards _       => internal_error(__FILE__, __LINE__, "Invalid privilege level or virtual mode"),
+  forwards _   => internal_error(__FILE__, __LINE__, "Invalid privilege level or virtual mode"),
 }
 
 function privLevel_to_bits(p : Privilege) -> nom_priv_bits = { let (p, _) = privLevel_bits(p); p }
@@ -170,7 +172,8 @@ mapping interruptType_bits : InterruptType <-> exc_code = {
   I_SG_External  <-> 0b001100, // 12
 }
 
-function interruptType_to_str(i : InterruptType) -> string =
+val interruptType_to_str : InterruptType -> string
+function interruptType_to_str (i) =
   match (i) {
     I_Reserved_0  => "reserved-interrupt-0",
     I_S_Software  => "supervisor-software-interrupt",
@@ -271,10 +274,10 @@ function exceptionType_to_str(e : ExceptionType) -> string =
     E_M_EnvCall()          => "m-call",
     E_Fetch_Page_Fault()   => "fetch-page-fault",
     E_Load_Page_Fault()    => "load-page-fault",
-    E_Reserved_14()        => "reserved-1",
+    E_Reserved_14()        => "reserved-14",
     E_SAMO_Page_Fault()    => "store/amo-page-fault",
-    E_Reserved_16()        => "reserved-2",
-    E_Reserved_17()        => "reserved-3",
+    E_Reserved_16()        => "reserved-16",
+    E_Reserved_17()        => "reserved-17",
     E_Software_Check()     => "software-check-fault",
     E_Reserved_19()        => "reserved-19",
     E_Fetch_GPage_Fault()  => "fetch-guest-page-fault",
@@ -299,6 +302,87 @@ function sw_check_code_to_bits (c : SWCheckCodes) -> xlenbits =
   match (c) {
     LANDING_PAD_FAULT  => zero_extend(0b010),
   }
+
+// Update exception type with a given memory access type.
+// Note: could probably be modeled in a nicer, more intuitive manner
+
+union AccessExceptionType = {
+  AccessExceptionLoad  : unit,
+  AccessExceptionSAMO  : unit,
+  AccessExceptionFetch : unit,
+}
+
+val AccessType_to_AccessException : forall 'a . (MemoryAccessType('a)) -> AccessExceptionType
+function AccessType_to_AccessException(access) -> AccessExceptionType = {
+  match access {
+    Atomic(_)                  => AccessExceptionSAMO(),
+    Load(_)                    => AccessExceptionLoad(),
+    LoadReserved(_)            => AccessExceptionLoad(),
+    Store(_)                   => AccessExceptionSAMO(),
+    StoreConditional(_)        => AccessExceptionSAMO(),
+    InstructionFetch(_)        => AccessExceptionFetch(),
+
+    CacheAccess(CB_manage(_))  => AccessExceptionSAMO(),
+    CacheAccess(CB_zero())     => AccessExceptionSAMO(),
+    // Though prefetches don't raise exceptions, we return a nominal
+    // exception here to propagate the failed address translation to
+    // the execute of the calling instruction so that it can decide
+    // whether to actually proceed with a prefetch.
+    CacheAccess(CB_prefetch(p)) => match p {
+      PREFETCH_R => AccessExceptionLoad(),
+      PREFETCH_W => AccessExceptionSAMO(),
+      PREFETCH_I => AccessExceptionFetch(),
+    }
+  }
+}
+
+function E_Addr_Align_of_AccessException(e: AccessExceptionType) -> ExceptionType =
+  match e {
+    AccessExceptionLoad(_)  => E_Load_Addr_Align(),
+    AccessExceptionSAMO(_)  => E_SAMO_Addr_Align(),
+    AccessExceptionFetch(_) => E_Fetch_Addr_Align(),
+  }
+
+function E_Access_Fault_of_AccessException(e : AccessExceptionType) -> ExceptionType =
+  match e {
+    AccessExceptionLoad(_)  => E_Load_Access_Fault(),
+    AccessExceptionSAMO(_)  => E_SAMO_Access_Fault(),
+    AccessExceptionFetch(_) => E_Fetch_Access_Fault(),
+  }
+
+function E_Page_Fault_of_AccessException(e : AccessExceptionType) -> ExceptionType =
+  match e {
+    AccessExceptionLoad(_)  => E_Load_Page_Fault(),
+    AccessExceptionSAMO(_)  => E_SAMO_Page_Fault(),
+    AccessExceptionFetch(_) => E_Fetch_Page_Fault(),
+  }
+
+function E_GPage_Fault_of_AccessException(e : AccessExceptionType) -> ExceptionType =
+  match e {
+    AccessExceptionLoad(_)  => E_Load_GPage_Fault(),
+    AccessExceptionSAMO(_)  => E_SAMO_GPage_Fault(),
+    AccessExceptionFetch(_) => E_Fetch_GPage_Fault(),
+  }
+
+val exceptionType_update_AccessType : forall 'a . (ExceptionType, MemoryAccessType('a)) -> ExceptionType
+function exceptionType_update_AccessType(e, a) = {
+  let a = AccessType_to_AccessException(a);
+  match(e) {
+    E_Fetch_Addr_Align()   => E_Addr_Align_of_AccessException(a),
+    E_Load_Addr_Align()    => E_Addr_Align_of_AccessException(a),
+    E_SAMO_Addr_Align()    => E_Addr_Align_of_AccessException(a),
+    E_Fetch_Access_Fault() => E_Access_Fault_of_AccessException(a),
+    E_Load_Access_Fault()  => E_Access_Fault_of_AccessException(a),
+    E_SAMO_Access_Fault()  => E_Access_Fault_of_AccessException(a),
+    E_Fetch_Page_Fault()   => E_Page_Fault_of_AccessException(a),
+    E_Load_Page_Fault()    => E_Page_Fault_of_AccessException(a),
+    E_SAMO_Page_Fault()    => E_Page_Fault_of_AccessException(a),
+    E_Fetch_GPage_Fault()  => E_GPage_Fault_of_AccessException(a),
+    E_Load_GPage_Fault()   => E_GPage_Fault_of_AccessException(a),
+    E_SAMO_GPage_Fault()   => E_GPage_Fault_of_AccessException(a),
+    _ => e // Other exceptions are not access type specific
+  }
+}
 
 // An architectural trap can be caused by either an interrupt or an exception
 
@@ -355,18 +439,63 @@ mapping extStatus_bits : ExtStatus <-> ext_status = {
 function extStatus_to_bits(e : ExtStatus) -> ext_status = extStatus_bits(e)
 function extStatus_of_bits(b : ext_status) -> ExtStatus = extStatus_bits(b)
 
+// address translation stages & modes
+// We model 3 stages:
+//   - Stage_S:  va --> pa  (V=0)
+//   - Stage_VS: va --> gpa (V=1)
+//   - Stage_G:  gpa -> spa (V=1)
+enum AddressTranslationStage = {Stage_S, Stage_VS, Stage_G}
+
+function AddressTranslationStage_to_str(s : AddressTranslationStage) -> string =
+  match s {
+    Stage_S  => "S",
+    Stage_VS => "VS",
+    Stage_G  => "G"
+  }
+
+overload to_str = {AddressTranslationStage_to_str}
+
+type atp64_mode = bits(4)
+type atp32_mode = bits(4)
+
 // supervisor-level address translation modes
 
 type satp_mode = bits(4)
-enum SATPMode = {Bare, Sv32, Sv39, Sv48, Sv57}
+enum XATPMode = {Bare, Sv32, Sv39, Sv48, Sv57, Sv32x4, Sv39x4, Sv48x4, Sv57x4}
 
-function satpMode_of_bits(a : Architecture, m : satp_mode) -> option(SATPMode) =
+mapping XATPMode_str : XATPMode <-> string = {
+  Bare   <-> "Bare",
+  Sv32   <-> "Sv32",
+  Sv39   <-> "Sv39",
+  Sv48   <-> "Sv48",
+  Sv57   <-> "Sv57",
+  Sv32x4 <-> "Sv32x4",
+  Sv39x4 <-> "Sv39x4",
+  Sv48x4 <-> "Sv48x4",
+  Sv57x4 <-> "Sv57x4"
+}
+
+function XATPMode_to_str(m : XATPMode) -> string = XATPMode_str(m)
+
+overload to_str = {XATPMode_to_str}
+
+function satpMode_of_bits(a : Architecture, m : atp64_mode) -> option(XATPMode) =
   match (a, m) {
     (_,    0x0) => Some(Bare),
     (RV32, 0x1) => Some(Sv32),
     (RV64, 0x8) => Some(Sv39),
     (RV64, 0x9) => Some(Sv48),
     (RV64, 0xA) => Some(Sv57),
+    (_, _)      => None()
+  }
+
+function hgatp64Mode_of_bits(a : Architecture, m : atp64_mode) -> option(XATPMode) =
+  match (a, m) {
+    (_,    0x0) => Some(Bare),
+    (RV32, 0x1) => Some(Sv32x4),
+    (RV64, 0x8) => Some(Sv39x4),
+    (RV64, 0x9) => Some(Sv48x4),
+    (RV64, 0xA) => Some(Sv57x4),
     (_, _)      => None()
   }
 

--- a/model/core/vmem_types.sail
+++ b/model/core/vmem_types.sail
@@ -7,8 +7,9 @@
 // =======================================================================================
 
 // Type constraint that checks if 'v is a valid virtual memory mode size.
-type is_sv_mode('v) -> Bool = 'v in {32, 39, 48, 57}
-
+type is_sv_mode('v) -> Bool = if xlen == 32 then 'v in {32} else 'v in {39, 48, 57}
+type is_svx4_mode('v) -> Bool = if xlen == 32 then 'v in {34} else 'v in {41, 50, 59}
+type is_xv_mode('v) -> Bool = if xlen == 32 then 'v in {32, 34} else 'v in {39, 41, 48, 50, 57, 59}
 // Range of possible page levels depending on the virtual memory mode:
 //
 //   Sv32 = range(0, 1)
@@ -16,17 +17,20 @@ type is_sv_mode('v) -> Bool = 'v in {32, 39, 48, 57}
 //   Sv48 = range(0, 3)
 //   Sv57 = range(0, 4)
 //
-type level_range('v), is_sv_mode('v) =
-  range(0, (if 'v == 32 then 1 else (if 'v == 39 then 2 else (if 'v == 48 then 3 else 4))))
+type level_range('v), is_xv_mode('v) =
+  range(0, (if 'v == 32 | 'v == 34 then 1 else (if 'v == 39 | 'v == 41 then 2 else (if 'v == 48 | 'v == 50 then 3 else 4))))
 
 // Size of a Page Table Entry, depending on the virtual memory mode.
-type pte_bits('v), is_sv_mode('v) = bits(if 'v == 32 then 32 else 64)
+type pte_bits('v), is_xv_mode('v) = bits(if 'v == 32 | 'v == 34 then 32 else 64)
+
+// Size of a PTE Address, depending on the virtual memory mode.
+type pte_addr_bits('v), is_xv_mode('v) = bits(if 'v == 32 | 'v == 34 then 34 else 56)
 
 // Number of Physical Page Number bits, depending on the virtual memory mode.
-type ppn_bits('v), is_sv_mode('v) = bits(if 'v == 32 then 22 else 44)
+type ppn_bits('v), is_xv_mode('v) = bits(if 'v == 32 | 'v == 34 then 22 else 44)
 
 // Number of Virtual Page Number bits, depending on the virtual memory mode.
-type vpn_bits('v), is_sv_mode('v) = bits('v - pagesize_bits)
+type vpn_bits('v), is_xv_mode('v) = bits('v - pagesize_bits)
 
 // TODO: For Zicfiss, this enum will be extended with ShadowStack, and
 // for CHERI, this enum can be extended with Cap/Tagged.  This assumes

--- a/model/core/xlen.sail
+++ b/model/core/xlen.sail
@@ -19,11 +19,12 @@ type xlen_bytes : Int = if xlen == 32 then 4 else 8
 // TODO: Allow configuring a lower number of physical address bits.
 // For example it is unlikely that serious RV64 implementations really
 // have 64 physical address bits.
-type physaddrbits_len : Int = if xlen == 32 then 34 else 64
+type physaddrbits_len : Int = if xlen == 32 then 34 else 56
 
 // This is the maximum; designs can implement shorter ASIDLENs.
 // TODO: Allow configuring shorter ASIDLENs.
-type asidlen    : Int = if xlen == 32 then 9 else 16
+type asidlen : Int = if xlen == 32 then 9 else 16
+type vmidlen : Int = if xlen == 32 then 7 else 14
 
 // Variable versions of the above types. Variables and types
 // are disjoint in Sail so they are allowed to have the same name.
@@ -35,3 +36,6 @@ let asidlen = sizeof(asidlen)
 
 type xlenbits = bits(xlen)
 type asidbits = bits(asidlen)
+
+// Currently use 16 to cover both asid and vmid
+type xxidbits = bits(16)

--- a/model/exceptions/sync_exception.sail
+++ b/model/exceptions/sync_exception.sail
@@ -6,10 +6,70 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // =======================================================================================
 
-// model context for synchronous exceptions, parameterized for extensions
+// Model context for synchronous exceptions
+struct ExceptionContext = {
+  // Faulting address or instruction
+  excinfo     : option(xlenbits),
 
-struct sync_exception = {
-  trap    : ExceptionType,
-  excinfo : option(xlenbits),
-  ext     : option(ext_exception)   // for extensions
+  // H-extension: true if excinfo holds guest-virtual-address
+  // "Field GVA (Guest Virtual Address) is written by the implementation whenever a trap is taken into HS-mode.
+  //  For any trap (breakpoint, address misaligned, access fault, page fault, or guest-page fault) that
+  //  writes a guest virtual address to stval, GVA is set to 1. For any other trap into HS-mode, GVA is set to 0."
+  info_is_gva : bool,
+  // H-extension: faulting guest-physical address
+  excinfo2    : option(xlenbits),
+  // H-extension: transformed instruction or pseudoinstruction
+  excinst     : option(xlenbits),
+
+  // For out-of-tree extensions
+  ext         : option(ext_exception)
 }
+
+// Create contexts for various exception classes
+
+function empty_exception_context() -> ExceptionContext =
+  struct {
+    excinfo     = None(),
+    info_is_gva = false,
+    excinfo2    = None(),
+    excinst     = None(),
+    ext         = None(),
+  }
+
+function mem_exception_context(vaddr : xlenbits, is_gva : bool) -> ExceptionContext =
+  struct {
+    excinfo     = Some(vaddr),
+    info_is_gva = is_gva,
+    excinfo2    = None(),
+    excinst     = None(),
+    ext         = None(),
+  }
+
+function vmem_exception_context(vaddr : xlenbits, is_gva : bool, gpaddr : option(xlenbits), pseudoinst : option(xlenbits)) -> ExceptionContext =
+  struct {
+    excinfo     = Some(vaddr),
+    info_is_gva = is_gva,
+    excinfo2    = gpaddr,
+    excinst     = pseudoinst,
+    ext         = None(),
+  }
+
+function instr_exception_context(inst : xlenbits, tval_has_ill_inst_bits : bool) -> ExceptionContext =
+  struct {
+    excinfo     = if tval_has_ill_inst_bits then Some(inst) else None(),
+    info_is_gva = false,
+    excinfo2    = None(),
+    excinst     = None(),
+    ext         = None(),
+  }
+
+// For out-of-tree extensions
+val ext_exception_context : forall ('ext : Type) . ('ext) -> ExceptionContext
+function ext_exception_context(ext) =
+  struct {
+    excinfo     = None(),
+    info_is_gva = false,
+    excinfo2    = None(),
+    excinst     = None(),
+    ext         = None(),
+  }

--- a/model/exceptions/sys_exceptions.sail
+++ b/model/exceptions/sys_exceptions.sail
@@ -23,8 +23,8 @@ function prepare_trap_vector(p : Privilege, cause : Mcause) -> xlenbits = {
     Machine           => mtvec,
     Supervisor        => stvec,
     User              => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
-    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    VirtualSupervisor => vstvec,
   };
   match tvec_addr(tvec, cause) {
     Some(epc) => epc,
@@ -40,11 +40,11 @@ function prepare_trap_vector(p : Privilege, cause : Mcause) -> xlenbits = {
 
 function get_xepc(p : Privilege) -> xlenbits =
   match p {
-    Machine           => align_pc(mepc),
-    Supervisor        => align_pc(sepc),
+    Machine           => { align_pc(mepc) },
+    Supervisor        => { align_pc(sepc) },
     User              => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
-    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    VirtualSupervisor => { align_pc(vsepc) },
   }
 
 function set_xepc(p : Privilege, value : xlenbits) -> xlenbits = {
@@ -53,8 +53,8 @@ function set_xepc(p : Privilege, value : xlenbits) -> xlenbits = {
     Machine           => mepc = target,
     Supervisor        => sepc = target,
     User              => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
-    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    VirtualSupervisor => vsepc = target,
   };
   target
 }
@@ -70,6 +70,9 @@ function get_mtvec() -> xlenbits =
 function get_stvec() -> xlenbits =
   stvec.bits
 
+function get_vstvec() -> xlenbits =
+  vstvec.bits
+
 function set_mtvec(value : xlenbits) -> xlenbits = {
   mtvec = legalize_tvec(mtvec, value);
   mtvec.bits
@@ -80,22 +83,35 @@ function set_stvec(value : xlenbits) -> xlenbits = {
   stvec.bits
 }
 
+function set_vstvec(value : xlenbits) -> xlenbits = {
+  vstvec = legalize_tvec(vstvec, value);
+  vstvec.bits
+}
+
+mapping clause csr_name_map = 0x205  <-> "vstvec"
+mapping clause csr_name_map = 0x241  <-> "vsepc"
 mapping clause csr_name_map = 0x105  <-> "stvec"
 mapping clause csr_name_map = 0x141  <-> "sepc"
 mapping clause csr_name_map = 0x305  <-> "mtvec"
 mapping clause csr_name_map = 0x341  <-> "mepc"
 
+function clause is_CSR_accessible(0x205, _, _) = currentlyEnabled(Ext_H) // vstvec
+function clause is_CSR_accessible(0x241, _, _) = currentlyEnabled(Ext_H) // vsepc
 function clause is_CSR_accessible(0x105, _, _) = currentlyEnabled(Ext_S) // stvec
 function clause is_CSR_accessible(0x141, _, _) = currentlyEnabled(Ext_S) // sepc
 function clause is_CSR_accessible(0x305, _, _) = true // mtvec
 function clause is_CSR_accessible(0x341, _, _) = true // mepc
 
-function clause read_CSR(0x105) = get_stvec()
-function clause read_CSR(0x141) = get_xepc(Supervisor)
+function clause read_CSR(0x205) = vstvec.bits
+function clause read_CSR(0x241) = get_xepc(VirtualSupervisor)
+function clause read_CSR(0x105) = if privLevel_is_virtual(cur_privilege) then get_vstvec() else get_stvec()
+function clause read_CSR(0x141) = get_xepc(if privLevel_is_virtual(cur_privilege) then VirtualSupervisor else Supervisor)
 function clause read_CSR(0x305) = get_mtvec()
 function clause read_CSR(0x341) = get_xepc(Machine)
 
-function clause write_CSR(0x105, value) = { Ok(set_stvec(value)) }
-function clause write_CSR(0x141, value) = { Ok(set_xepc(Supervisor, value)) }
+function clause write_CSR(0x205, value) = { vstvec.bits = value; Ok(vstvec.bits) }
+function clause write_CSR(0x241, value) = { Ok(set_xepc(VirtualSupervisor, value)) }
+function clause write_CSR(0x105, value) = { Ok(if privLevel_is_virtual(cur_privilege) then set_vstvec(value) else set_stvec(value)) }
+function clause write_CSR(0x141, value) = { Ok(set_xepc(if privLevel_is_virtual(cur_privilege) then VirtualSupervisor else Supervisor, value)) }
 function clause write_CSR(0x305, value) = { Ok(set_mtvec(value)) }
 function clause write_CSR(0x341, value) = { Ok(set_xepc(Machine, value)) }

--- a/model/extensions/A/zaamo_insts.sail
+++ b/model/extensions/A/zaamo_insts.sail
@@ -79,10 +79,10 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
   };
 
   if not(is_aligned_addr(vaddr, width))
-  then return Memory_Exception(vaddr, E_SAMO_Addr_Align());
+  then return memory_exception_with_gva(E_SAMO_Addr_Align(), vaddr);
 
   let addr : physaddr = match translateAddr(vaddr, access) {
-    Err(e, _) => return Memory_Exception(vaddr, e),
+    Err((e, c), _) => return Memory_Exception(e, c),
     Ok(addr, _) => addr,
   };
 
@@ -92,9 +92,9 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
   let rs2_val : bits('width * 8) = if width <= xlen_bytes then trunc(X(rs2)) else trunc(X_pair(rs2));
 
   let loaded : bits('width * 8) = match mem_write_ea(addr, width, aq & rl, rl, true) {
-    Err(e) => return Memory_Exception(vaddr, e),
+    Err(e) => return memory_exception_with_gva(e, vaddr),
     Ok(_)  => match mem_read(access, addr, width, aq, aq & rl, true) {
-      Err(e)     => return Memory_Exception(vaddr, e),
+      Err(e)     => return memory_exception_with_gva(e, vaddr),
       Ok(loaded) => loaded,
     },
   };
@@ -128,7 +128,7 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
       RETIRE_SUCCESS
     },
     Ok(false) => internal_error(__FILE__, __LINE__, "AMO got false from mem_write_value"),
-    Err(e)    => Memory_Exception(vaddr, e),
+    Err(e)    => memory_exception_with_gva(e, vaddr),
   }
 }
 

--- a/model/extensions/H/hext_control.sail
+++ b/model/extensions/H/hext_control.sail
@@ -1,0 +1,23 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+function is_trap_write_GVA(c: exc_code) -> bool = match c {
+  // These exceptions write a GVA
+  0b000011  => true, // Breakpoint
+  0b000000  => true, // Fetch Misaligned
+  0b000100  => true, // Load Misaligned
+  0b000110  => true, // Store/AMO Misaligned
+  0b000001  => true, // Fetch Access Fault
+  0b000101  => true, // Load Access Fault
+  0b000111  => true, // Store/AMO Access Fault
+  0b001100  => true, // Fetch Page Fault
+  0b001101  => true, // Load Page Fault
+  0b001111  => true, // Store/AMO Page Fault
+  // All other exceptions do not
+  _                           => false
+}

--- a/model/extensions/H/hext_insts.sail
+++ b/model/extensions/H/hext_insts.sail
@@ -1,10 +1,241 @@
-// =======================================================================================
-// This Sail RISC-V architecture model, comprising all files and
-// directories except where otherwise noted is subject the BSD
-// two-clause license in the LICENSE file.
+//=======================================================================================
+//  This Sail RISC-V architecture model, comprising all files and
+//  directories except where otherwise noted is subject the BSD
+//  two-clause license in the LICENSE file.
 //
-// SPDX-License-Identifier: BSD-2-Clause
-// =======================================================================================
+//  SPDX-License-Identifier: BSD-2-Clause
+//=======================================================================================
 
-// TODO: Ext_H depends on RV32I or RV64I, not RV32E or RV64E.
-function clause currentlyEnabled(Ext_H) = hartSupports(Ext_H) & misa[H] == 0b1 & virtual_memory_supported()
+union clause instruction = HLV : (word_width, bool, regidx, regidx)
+
+mapping clause encdec = HLV(width, is_unsigned, rs1, rd)
+  <-> 0b0110 @ width_enc(width) @ 0b0 @ 0b0000 @ bool_bit(is_unsigned) @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b1110011
+  when currentlyEnabled(Ext_H)
+
+function clause execute(HLV(width, is_unsigned, rs1, rd)) =
+  // Unsigned loads are only valid for widths strictly less than xlen, signed loads also present for widths equal to xlen
+  if (is_unsigned & width >= xlen_bytes) | (width > xlen_bytes)
+  then { Illegal_Instruction() }
+  else if (privLevel_is_virtual(cur_privilege))
+  then { Virtual_Instruction() }
+  else if (cur_privilege == User) & (hstatus[HU] == 0b0)
+  then { Illegal_Instruction() }
+  else {
+    let width_bytes = width;
+    assert(width_bytes <= xlen_bytes);
+    // Extensions can perform additional checks on address validity.
+    match ext_data_get_addr(rs1, zeros(), Load(Data), width_bytes) {
+      Ext_DataAddr_Error(e)  => { Ext_DataAddr_Check_Failure(e) },
+      Ext_DataAddr_OK(vaddr) =>
+        // Address could be misaligned
+        if check_misaligned(vaddr, width)
+        then { memory_exception_with_gva(E_Load_Addr_Align(), vaddr) }
+        // Address translation and protection should be performed as if V=1
+        else match translateAddr_pv(vaddr, Load(Data), privLevel_bits(zero_extend(hstatus[SPVP]), 0b1)) {
+          Err((e, c), _) => { handle_exception(e, c); RETIRE_SUCCESS },
+          Ok(paddr, _) => match mem_read(Load(Data), paddr, width_bytes, false, false, false) {
+            Ok(result) => { X(rd) = extend_value(is_unsigned, result); RETIRE_SUCCESS },
+            Err(e) => { memory_exception_with_gva(e, vaddr) },
+          },
+        }
+    }
+  }
+
+mapping clause assembly = HLV(width, is_unsigned, rs1, rd)
+  <-> "hlv." ^ width_mnemonic(width) ^ maybe_u(is_unsigned) ^ spc() ^ reg_name(rd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
+
+// ******************************************************************
+
+union clause instruction = HLVX : (word_width, regidx, regidx)
+
+mapping clause encdec = HLVX(width, rs1, rd)
+  <-> 0b0110 @ width_enc(width) @ 0b0 @ 0b00011 @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b1110011
+  when currentlyEnabled(Ext_H)
+
+function clause execute(HLVX(width, rs1, rd)) =
+  if privLevel_is_virtual(cur_privilege)
+  then { Virtual_Instruction() }
+  else if (cur_privilege == User) & (hstatus[HU] == 0b0)
+  then { Illegal_Instruction() }
+  else {
+    let width_bytes = width;
+    assert(width_bytes <= xlen_bytes);
+    // Extensions can perform additional checks on address validity.
+    match ext_data_get_addr(rs1, zeros(), Load(Data), width_bytes) {
+    Ext_DataAddr_Error(e)  => { Ext_DataAddr_Check_Failure(e) },
+    Ext_DataAddr_OK(vaddr) =>
+      // Address could be misaligned
+      if check_misaligned(vaddr, width)
+      then { memory_exception_with_gva(E_Load_Addr_Align(), vaddr) }
+      // Address translation and protection should be performed as for an instruction fetch while V=1
+      else match translateAddr_pv(vaddr, InstructionFetch(), privLevel_bits(zero_extend(hstatus[SPVP]), 0b1)) {
+        // Update exception's access type because HLVX should raise load exceptions but translateAddr may return fetch exceptions
+        // TODO: delay all handle_exception to step done
+        Err((e, c), _)  => { handle_exception(exceptionType_update_AccessType(e, Load(Data)), c); RETIRE_SUCCESS },
+        Ok(paddr, _) => match mem_read(Load(Data), paddr, width_bytes, false, false, false) {
+            // AccessType is Read since HLVX should not override pmp
+            Ok(result) => { X(rd) = extend_value(true, result); RETIRE_SUCCESS },
+            Err(e) => { memory_exception_with_gva(e, vaddr) },
+          },
+        }
+    }
+  }
+
+mapping clause assembly = HLVX(width, rs1, rd)
+<-> "hlvx." ^ width_mnemonic(width) ^ "u" ^ spc() ^ reg_name(rd) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
+
+// ******************************************************************
+
+union clause instruction = HSV : (word_width, regidx, regidx)
+
+mapping clause encdec = HSV(width, rs1, rs2)
+  <-> 0b0110 @ width_enc(width) @ 0b1 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b100 @ 0b00000 @ 0b1110011
+  when currentlyEnabled(Ext_H)
+
+function clause execute(HSV(width, rs1, rs2)) =
+  if width > xlen_bytes
+  then { Illegal_Instruction() }
+  else if privLevel_is_virtual(cur_privilege)
+  then { Virtual_Instruction() }
+  else if (cur_privilege == User) & (hstatus[HU] == 0b0)
+  then { Illegal_Instruction() }
+  // Extensions can perform additional checks on address validity.
+  else match ext_data_get_addr(rs1, zeros(), Store(Data), width) {
+    Ext_DataAddr_Error(e)  => { Ext_DataAddr_Check_Failure(e) },
+    Ext_DataAddr_OK(vaddr) =>
+      // Address could be misaligned
+      if check_misaligned(vaddr, width)
+      then { memory_exception_with_gva(E_SAMO_Addr_Align(), vaddr) }
+      // Address translation and protection should be performed as if V=1
+      else match translateAddr_pv(vaddr, Store(Data), privLevel_bits(zero_extend(hstatus[SPVP]), 0b1)) {
+        Err((e, c), _)  => { handle_exception(e, c); RETIRE_SUCCESS },
+        Ok(paddr, _) => {
+          let eares : MemoryOpResult(unit) = mem_write_ea(paddr, width, false, false, false);
+          match (eares) {
+            Err(e) => { memory_exception_with_gva(e, vaddr) },
+            Ok(_) => {
+              let rs2_val = X(rs2);
+              if (width == 8 & xlen < 64) then {
+                internal_error(__FILE__, __LINE__,
+                  "Invalid width = " ^ width_mnemonic(width) ^ ", for hsv"
+                  ^ " with xlen=" ^ dec_str(xlen));
+              };
+              let res : MemoryOpResult(bool) = mem_write_value(paddr, width, rs2_val[8 * width - 1..0],  false, false, false);
+              match (res) {
+                Ok(true)  => RETIRE_SUCCESS,
+                Ok(false) => internal_error(__FILE__, __LINE__, "hsv got false from mem_write_value"),
+                Err(e) => { memory_exception_with_gva(e, vaddr) }
+              }
+            }
+          }
+        },
+      }
+  }
+
+mapping clause assembly = HSV(width, rs1, rs2)
+  <-> "hsv."  ^ width_mnemonic(width) ^ spc() ^ reg_name(rs2) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"
+
+// ******************************************************************
+
+union clause instruction = HFENCE_VVMA : (regidx, regidx)
+
+mapping clause encdec = HFENCE_VVMA(rs1, rs2)
+  <-> 0b0010001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ 0b00000 @ 0b1110011
+  when currentlyEnabled(Ext_H)
+
+function clause execute HFENCE_VVMA(rs1, rs2) = {
+  let addr : option(xlenbits) = if regidx_bits(rs1) == zeros() then None() else Some(X(rs1));
+  let asid : option(xxidbits) = if regidx_bits(rs2) == zeros() then None() else Some(X(rs2)[15 .. 0]);
+  match cur_privilege {
+    VirtualUser       => { Virtual_Instruction() },
+    User              => { Illegal_Instruction() },
+    VirtualSupervisor => { Virtual_Instruction() },
+    Supervisor        => { flush_TLB(asid, Stage_VS, addr); RETIRE_SUCCESS },
+    Machine           => { flush_TLB(asid, Stage_VS, addr); RETIRE_SUCCESS }
+  }
+}
+
+mapping clause assembly = HFENCE_VVMA(rs1, rs2)
+  <-> "hfence.vvma" ^ spc() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
+
+/* ****************************************************************** */
+
+union clause instruction = HFENCE_GVMA : (regidx, regidx)
+
+mapping clause encdec = HFENCE_GVMA(rs1, rs2)
+  <-> 0b0110001 @ encdec_reg(rs2) @ encdec_reg(rs1) @ 0b000 @ 0b00000 @ 0b1110011
+  when currentlyEnabled(Ext_H)
+
+function clause execute HFENCE_GVMA(rs1, rs2) = {
+  let addr : option(xlenbits) = if regidx_bits(rs1) == zeros() then None() else Some(X(rs1));
+  let vmid : option(xxidbits) = if regidx_bits(rs2) == zeros() then None() else Some(X(rs2)[15 .. 0]);
+  match cur_privilege {
+    VirtualUser       => { Virtual_Instruction() },
+    User              => { Illegal_Instruction() },
+    VirtualSupervisor => { Virtual_Instruction() },
+    Supervisor        => match mstatus[TVM] {
+                            0b1 => { Illegal_Instruction() },
+                            0b0 => { flush_TLB(vmid, Stage_G, addr); RETIRE_SUCCESS }
+                        },
+    Machine           => { flush_TLB(vmid, Stage_G, addr); RETIRE_SUCCESS }
+  }
+}
+
+mapping clause assembly = HFENCE_GVMA(rs1, rs2)
+  <-> "hfence.gvma" ^ spc() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
+
+// ******************************************************************
+// Transformed instruction mappings
+
+function clause enc_transformed(LOAD(_, _, rd, uns, width), addr_offset) =
+  0b0000000 @ 0b00000 @ addr_offset @ bool_bit(uns) @ width_enc(width) @ encdec_reg(rd) @ 0b0000011
+
+function clause enc_transformed(C_LW(_, _, rd), addr_offset) = {
+  let expanded_inst = LOAD(zeros(), Regidx(zeros()), creg2reg_idx(rd), false, 4);
+  let transformed_inst = enc_transformed(expanded_inst, addr_offset);
+  [transformed_inst with 1 = bitzero] // Set transformed_inst[1] to 0b0
+}
+
+function clause enc_transformed(C_LD(_, _, rd), addr_offset) = {
+  let expanded_inst = LOAD(zeros(), Regidx(zeros()), creg2reg_idx(rd), false, 8);
+  let transformed_inst = enc_transformed(expanded_inst, addr_offset);
+  [transformed_inst with 1 = bitzero] // Set transformed_inst[1] to 0b0
+}
+
+function clause enc_transformed(LOAD_FP(_, _, rd, size), addr_offset) =
+  0b0000000 @ 0b00000 @ addr_offset @ 0b0 @ width_enc(size) @ encdec_freg(rd) @ 0b0000111
+
+function clause enc_transformed(STORE(_, rs2, _, size), addr_offset) =
+  0b0000000 @ encdec_reg(rs2) @ addr_offset @ 0b0 @ width_enc(size) @ 0b00000 @ 0b0100011
+
+function clause enc_transformed(C_SW(_, _, rs2), addr_offset) = {
+  let expanded_inst = STORE(zeros(), creg2reg_idx(rs2), Regidx(zeros()), 4);
+  let transformed_inst = enc_transformed(expanded_inst, addr_offset);
+  [transformed_inst with 1 = bitzero] // Set transformed_inst[1] to 0b0
+}
+function clause enc_transformed(C_SD(_, _, rs2), addr_offset) = {
+  let expanded_inst = STORE(zeros(), creg2reg_idx(rs2), Regidx(zeros()), 8);
+  let transformed_inst = enc_transformed(expanded_inst, addr_offset);
+  [transformed_inst with 1 = bitzero] // Set transformed_inst[1] to 0b0
+}
+
+function clause enc_transformed(STORE_FP(_, rs2, _, size), addr_offset) =
+  0b0000000 @ encdec_freg(rs2) @ addr_offset @ 0b0 @ width_enc(size) @ 0b00000 @ 0b0100111
+
+function clause enc_transformed(LOADRES(aq, rl, _, size, rd), addr_offset) =
+  0b00010 @ bool_bit(aq) @ bool_bit(rl) @ 0b00000 @ addr_offset @ 0b0 @ width_enc(size) @ encdec_reg(rd) @ 0b0101111
+
+function clause enc_transformed(STORECON(aq, rl, rs2, _, size, rd), addr_offset) =
+  0b00011 @ bool_bit(aq) @ bool_bit(rl) @ encdec_reg(rs2) @ addr_offset @ 0b0 @ width_enc(size) @ encdec_reg(rd) @ 0b0101111
+
+function clause enc_transformed(AMO(op, aq, rl, rs2, _, size, rd), addr_offset) =
+  encdec_amoop(op) @ bool_bit(aq) @ bool_bit(rl) @ encdec_reg(rs2) @ addr_offset @ width_enc_wide(size) @ encdec_reg(rd) @ 0b0101111
+
+function clause enc_transformed(HLV(width, is_unsigned, _, rd), addr_offset) =
+  0b0110 @ width_enc(width) @ 0b0 @ 0b0000 @ bool_bit(is_unsigned) @ addr_offset @ 0b100 @ encdec_reg(rd) @ 0b1110011
+
+function clause enc_transformed(HSV(width, _, rs2), addr_offset) =
+  0b0110 @ width_enc(width) @ 0b1 @ encdec_reg(rs2) @ addr_offset @ 0b100 @ 0b00000 @ 0b1110011
+
+function clause enc_transformed(HLVX(width, _, rd), addr_offset) =
+  0b0110 @ width_enc(width) @ 0b0 @ 0b00011 @ addr_offset @ 0b100 @ encdec_reg(rd) @ 0b1110011

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -60,7 +60,7 @@ function jump_to(target : xlenbits) -> ExecutionResult = {
   // If it is not 4-byte aligned and compressed instructions are
   // not enabled then raise an alignment exception.
   if bit_to_bool(target[1]) & not(currentlyEnabled(Ext_Zca))
-  then return Memory_Exception(Virtaddr(target), E_Fetch_Addr_Align());
+  then return memory_exception_with_gva(E_Fetch_Addr_Align(), Virtaddr(target));
 
   set_next_pc(target);
   RETIRE_SUCCESS
@@ -539,15 +539,11 @@ function clause execute ECALL() = {
     User              => E_U_EnvCall(),
     Supervisor        => E_S_EnvCall(),
     Machine           => E_M_EnvCall(),
-    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualUser       => E_U_EnvCall(),
+    VirtualSupervisor => E_VS_EnvCall(),
   };
-  let t : sync_exception = struct {
-    trap    = trap,
-    excinfo = (None() : option(xlenbits)),
-    ext     = None(),
-  };
-  Trap(cur_privilege, CTL_TRAP(t), PC)
+  let c : ExceptionContext = empty_exception_context();
+  Trap(cur_privilege, CTL_TRAP(trap, c), PC)
 }
 
 mapping clause assembly = ECALL() <-> "ecall"
@@ -578,20 +574,30 @@ mapping clause encdec = SRET()
   <-> 0b0001000 @ 0b00010 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
 
 function clause execute SRET() = {
-  let sret_illegal : bool = match cur_privilege {
-    User              => true,
-    Supervisor        => not(currentlyEnabled(Ext_S)) | mstatus[TSR] == 0b1,
-    Machine           => not(currentlyEnabled(Ext_S)),
-    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+  let sret_illegal : option(ExecutionResult) = match cur_privilege {
+    User              => Some(Illegal_Instruction()),
+    VirtualUser       => Some(Illegal_Instruction()),
+    Supervisor        => if not(currentlyEnabled(Ext_S)) | mstatus[TSR] == 0b1
+                         then Some(Illegal_Instruction())
+                         else None(),
+    VirtualSupervisor => if hstatus[VTSR] == 0b1
+                         then Some(Virtual_Instruction())
+                         else None(),
+    Machine           => if not(currentlyEnabled(Ext_S))
+                         then Some(Illegal_Instruction())
+                         else None(),
   };
-  if   sret_illegal
-  then Illegal_Instruction()
-  else if not(ext_check_xret_priv (Supervisor))
-  then Ext_XRET_Priv_Failure()
-  else {
-    set_next_pc(exception_handler(cur_privilege, CTL_SRET(), PC));
-    RETIRE_SUCCESS
+  match sret_illegal {
+    Some(e) => e,
+    None() => {
+      if not(ext_check_xret_priv (Supervisor))
+      then Ext_XRET_Priv_Failure()
+      else {
+        let pc = exception_handler(cur_privilege, CTL_SRET(), PC);
+        set_next_pc(pc);
+        RETIRE_SUCCESS
+      }
+    }
   }
 }
 
@@ -604,7 +610,7 @@ mapping clause encdec = EBREAK()
   <-> 0b000000000001 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
 
 function clause execute EBREAK() =
-  Memory_Exception(Virtaddr(PC), E_Breakpoint(Brk_Software))
+  memory_exception_with_gva(E_Breakpoint(Brk_Software), Virtaddr(PC))
 
 mapping clause assembly = EBREAK() <-> "ebreak"
 
@@ -620,9 +626,17 @@ function clause execute WFI() =
     Supervisor        => if   mstatus[TW] == 0b1
                          then Illegal_Instruction()
                          else Enter_Wait(WAIT_WFI),
-    User              => Illegal_Instruction(),
-    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    User              => if mstatus[TW] == 0b1 | currentlyEnabled(Ext_S)
+                         then Illegal_Instruction()
+                         else Enter_Wait(WAIT_WFI), // FIXME: WFI is "optionally available for U-mode" according to spec
+    VirtualUser       => if mstatus[TW] == 0b1 | currentlyEnabled(Ext_S)
+                         then Virtual_Instruction()
+                         else Enter_Wait(WAIT_WFI),
+    VirtualSupervisor => if mstatus[TW] == 0b1
+                         then Illegal_Instruction()
+                         else if hstatus[VTW] == 0b1
+                         then Virtual_Instruction() // Maybe bug here
+                         else Enter_Wait(WAIT_WFI),
   }
 
 mapping clause assembly = WFI() <-> "wfi"
@@ -639,16 +653,19 @@ function clause execute SFENCE_VMA(rs1, rs2) = {
   // Note, the Sail model does not currently support Sv32 & SXLEN=32 on RV64.
   // In that case this asidlen would be incorrect because the maximum asidlen
   // is 9 but we always set it to 16 for RV64.
-  let asid = if rs2 != zreg then Some(X(rs2)[asidlen - 1 .. 0]) else None();
+  let asid : option(bits(16)) = if rs2 != zreg then Some(zero_extend(X(rs2)[asidlen - 1 .. 0])) else None();
   match cur_privilege {
     User              => Illegal_Instruction(),
     Supervisor        => match mstatus[TVM] {
                            0b1 => Illegal_Instruction(),
-                           0b0 => { flush_TLB(asid, addr); RETIRE_SUCCESS },
+                           0b0 => { flush_TLB(asid, Stage_S, addr); RETIRE_SUCCESS },
                          },
-    Machine           => { flush_TLB(asid, addr); RETIRE_SUCCESS },
+    Machine           => { flush_TLB(asid, Stage_S, addr); RETIRE_SUCCESS },
     VirtualUser       => Virtual_Instruction(),
-    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => match hstatus[VTVM] {
+                          0b1 => Virtual_Instruction(),
+                          0b0 => { flush_TLB(asid, Stage_VS, addr); RETIRE_SUCCESS },
+                         },
   }
 }
 

--- a/model/extensions/Sstc/sstc.sail
+++ b/model/extensions/Sstc/sstc.sail
@@ -26,3 +26,16 @@ function clause read_CSR(0x15D if xlen == 32) = stimecmp[63 .. 32]
 
 function clause write_CSR(0x14D, value) = { stimecmp[(xlen - 1) .. 0] = value; Ok(stimecmp[xlen - 1 ..0]) }
 function clause write_CSR((0x15D, value) if xlen == 32) = { stimecmp[63 ..32] = value; Ok(stimecmp[63 .. 32]) }
+
+// virtual supervisor timer compare
+mapping clause csr_name_map = 0x24D  <-> "vstimecmp"
+mapping clause csr_name_map = 0x25D  <-> "vstimecmph"
+
+function clause is_CSR_accessible(0x24D, _, _) = currentlyEnabled(Ext_H) // "vstimecmp"
+function clause is_CSR_accessible(0x25D, _, _) = currentlyEnabled(Ext_H) & xlen == 32 // "vstimecmph"
+
+function clause read_CSR(0x24D) = vstimecmp[xlen - 1 .. 0]
+function clause read_CSR(0x25D if xlen == 32) = vstimecmp[63 .. 32]
+
+function clause write_CSR(0x24D, value) = { vstimecmp[(xlen - 1) .. 0] = value; Ok(vstimecmp[xlen - 1 ..0]) }
+function clause write_CSR((0x25D, value) if xlen == 32) = { vstimecmp[63 ..32] = value; Ok(vstimecmp[63 .. 32]) }

--- a/model/extensions/Zicbom/zicbom_insts.sail
+++ b/model/extensions/Zicbom/zicbom_insts.sail
@@ -10,7 +10,7 @@
 
 function clause currentlyEnabled(Ext_Zicbom) = hartSupports(Ext_Zicbom)
 
-private function cbo_clean_flush_enabled(p : Privilege) -> bool = feature_enabled_for_priv(p, menvcfg[CBCFE][0], senvcfg[CBCFE][0])
+private function cbo_clean_flush_enabled(p : Privilege) -> bool = feature_enabled_for_priv(p, menvcfg[CBCFE][0], senvcfg[CBCFE][0], henvcfg[CBCFE][0])
 
 // *****************************************************************
 union clause instruction = ZICBOM : (cbop_zicbom, regidx)
@@ -51,19 +51,30 @@ private enum checked_cbop = {CBOP_ILLEGAL, CBOP_ILLEGAL_VIRTUAL, CBOP_INVAL_FLUS
 // Select the cbop to perform based on the privilege.
 private function cbop_priv_check(p: Privilege) -> checked_cbop = {
   let mCBIE : cbie = encdec_cbie(menvcfg[CBIE]);
-  // TODO: check henvcfg after hypervisor is implemented
   let sCBIE : cbie = if   currentlyEnabled(Ext_S)
                      then encdec_cbie(senvcfg[CBIE])
                      else encdec_cbie(menvcfg[CBIE]);
-  match (p, mCBIE, sCBIE) {
-    (VirtualUser, _, _)       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    (VirtualSupervisor, _, _) => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    (Machine, _,               _              ) => CBOP_INVAL_INVAL,
-    (_,       CBIE_ILLEGAL,    _              ) => CBOP_ILLEGAL,      // (priv_mode != M) && mCBIE == 00
-    (User,    _,               CBIE_ILLEGAL   ) => CBOP_ILLEGAL,      // (priv_mode == U) && sCBIE == 00
-    (_,       CBIE_EXEC_FLUSH, _              ) => CBOP_INVAL_FLUSH,  // (priv_mode != M) && mCBIE == 01
-    (User,    _,               CBIE_EXEC_FLUSH) => CBOP_INVAL_FLUSH,  // (priv_mode == U) && sCBIE == 01
-    _                                           => CBOP_INVAL_INVAL,
+  let hCBIE : cbie = if   currentlyEnabled(Ext_H)
+                     then encdec_cbie(henvcfg[CBIE])
+                     else encdec_cbie(menvcfg[CBIE]);
+  match (p, mCBIE, sCBIE, hCBIE) {
+    (Machine, _, _ , _) => CBOP_INVAL_INVAL,
+
+    (_   , CBIE_ILLEGAL, _, _) => CBOP_ILLEGAL, // (priv_mode != M) && mCBIE == 00
+    (User, _, CBIE_ILLEGAL, _) => CBOP_ILLEGAL, // (priv_mode == U) && sCBIE == 00
+
+    (VirtualSupervisor, _, _, CBIE_ILLEGAL) => CBOP_ILLEGAL_VIRTUAL, // (priv_mode == VS) && hCBIE == 00
+    (VirtualUser      , _, _, CBIE_ILLEGAL) => CBOP_ILLEGAL_VIRTUAL, // (priv_mode == VU) && hCBIE == 00
+    (VirtualUser      , _, CBIE_ILLEGAL, _) => CBOP_ILLEGAL_VIRTUAL, // (priv_mode == VU) && sCBIE == 00
+
+    (_   , CBIE_EXEC_FLUSH, _, _) => CBOP_INVAL_FLUSH,  // (priv_mode != M) && mCBIE == 01
+    (User, _, CBIE_EXEC_FLUSH, _) => CBOP_INVAL_FLUSH,  // (priv_mode == U) && sCBIE == 01
+
+    (VirtualSupervisor, _, _, CBIE_EXEC_FLUSH) => CBOP_INVAL_FLUSH, // (priv_mode == VS) && hCBIE == 01
+    (VirtualUser      , _, _, CBIE_EXEC_FLUSH) => CBOP_INVAL_FLUSH, // (priv_mode == VU) && hCBIE == 01
+    (VirtualUser      , _, CBIE_EXEC_FLUSH, _) => CBOP_INVAL_FLUSH, // (priv_mode == VU) && sCBIE == 01
+
+    _ => CBOP_INVAL_INVAL,
   }
 }
 
@@ -92,13 +103,28 @@ private function process_clean_inval(rs1 : regidx, cbop : cbop_zicbom) -> Execut
           // Check PMA and PMP access controls.
           let ep = effectivePrivilege(access, mstatus, cur_privilege);
           match phys_access_check(access, ep, paddr, cache_block_size, false) {
-            Some(e) => Memory_Exception(vaddr_for_error, e),
+            Some(e) => memory_exception_with_gva(e, vaddr_for_error),
             // If there is no error, the model has no caches so there's no
             // more action required.
             None()  => RETIRE_SUCCESS
           }
         },
-        Err(e, _) => Memory_Exception(vaddr_for_error, e),
+        Err((e, _), _) => {
+          let e : ExceptionType = match e {
+            E_Load_Access_Fault() => E_SAMO_Access_Fault(),
+            E_SAMO_Access_Fault() => E_SAMO_Access_Fault(),
+            E_Load_Page_Fault() => E_SAMO_Page_Fault(),
+            E_SAMO_Page_Fault() => E_SAMO_Page_Fault(),
+            // No other exceptions should be generated since we're not checking
+            // for fetch access and it's can't be misaligned.
+            _ => internal_error(__FILE__, __LINE__, "unexpected exception for cmo.clean/inval"),
+          };
+          // vaddr is the aligned address, but errors report the address that
+          // was encoded in the instruction. We subtract the negative offset
+          // (add the positive offset) to get it. Normally this will be
+          // equal to rs1, but pointer masking can change that.
+          memory_exception_with_gva(e, vaddr_for_error)
+        }
       }
     }
   }
@@ -117,7 +143,7 @@ function clause execute ZICBOM(CBO_FLUSH, rs1) =
 function clause execute ZICBOM(CBO_INVAL, rs1) =
   match cbop_priv_check(cur_privilege) {
     CBOP_ILLEGAL         => Illegal_Instruction(),
-    CBOP_ILLEGAL_VIRTUAL => internal_error(__FILE__, __LINE__, "unimplemented"),
+    CBOP_ILLEGAL_VIRTUAL => Virtual_Instruction(),
     CBOP_INVAL_INVAL     => process_clean_inval(rs1, CBO_INVAL),
     CBOP_INVAL_FLUSH     => process_clean_inval(rs1, CBO_FLUSH),
   }

--- a/model/extensions/Zicboz/zicboz_insts.sail
+++ b/model/extensions/Zicboz/zicboz_insts.sail
@@ -10,7 +10,7 @@
 
 function clause currentlyEnabled(Ext_Zicboz) = hartSupports(Ext_Zicboz)
 
-function cbo_zero_enabled(p : Privilege) -> bool = feature_enabled_for_priv(p, menvcfg[CBZE][0], senvcfg[CBZE][0])
+function cbo_zero_enabled(p : Privilege) -> bool = feature_enabled_for_priv(p, menvcfg[CBZE][0], senvcfg[CBZE][0], henvcfg[CBZE][0])
 
 // *****************************************************************
 union clause instruction = ZICBOZ : (regidx)
@@ -45,15 +45,15 @@ function clause execute ZICBOZ(rs1) = {
           // was encoded in the instruction. We subtract the negative offset
           // (add the positive offset) to get it. Normally this will be
           // equal to rs1, but pointer masking can change that.
-          Err(e, _) => Memory_Exception(vaddr - negative_offset, e),
+          Err((e, _), _) => memory_exception_with_gva(e, vaddr - negative_offset),
           Ok(paddr, _) => {
             match mem_write_ea(paddr, cache_block_size, false, false, false) {
-              Err(e) => Memory_Exception(vaddr - negative_offset, e),
+              Err(e) => memory_exception_with_gva(e, vaddr - negative_offset),
               Ok(_)  => {
                 match mem_write_value(paddr, cache_block_size, zeros(), false, false, false) {
                   Ok(true)  => RETIRE_SUCCESS,
                   Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                  Err(e)    => Memory_Exception(vaddr - negative_offset, e)
+                  Err(e)    => memory_exception_with_gva(e, vaddr - negative_offset)
                 }
               }
             }

--- a/model/extensions/Zicntr/zicntr_control.sail
+++ b/model/extensions/Zicntr/zicntr_control.sail
@@ -23,10 +23,10 @@ function clause is_CSR_accessible(0xC81, priv, _) = currentlyEnabled(Ext_Zicntr)
 function clause is_CSR_accessible(0xC82, priv, _) = currentlyEnabled(Ext_Zicntr) & xlen == 32 & counter_enabled(2, priv) // instreth
 
 function clause read_CSR(0xC00) = mcycle[(xlen - 1) .. 0]
-function clause read_CSR(0xC01) = mtime[(xlen - 1) .. 0]
+function clause read_CSR(0xC01) = (if privLevel_is_virtual(cur_privilege) then mtime + htimedelta else mtime)[(xlen - 1) .. 0]
 function clause read_CSR(0xC02) = minstret[(xlen - 1) .. 0]
 function clause read_CSR(0xC80 if xlen == 32) = mcycle[63 .. 32]
-function clause read_CSR(0xC81 if xlen == 32) = mtime[63 .. 32]
+function clause read_CSR(0xC81 if xlen == 32) = (if privLevel_is_virtual(cur_privilege) then mtime + htimedelta else mtime)[63 .. 32]
 function clause read_CSR(0xC82 if xlen == 32) = minstret[63 .. 32]
 
 

--- a/model/extensions/Zicsr/zicsr_insts.sail
+++ b/model/extensions/Zicsr/zicsr_insts.sail
@@ -42,7 +42,11 @@ function csr_access_type(op : csrop, rd_is_x0 : bool, rs1_imm_is_zero : bool) ->
 
 function doCSR(csr : csreg, rs1_val : xlenbits, rd : regidx, op : csrop, access_type : CSRAccessType) -> ExecutionResult = {
   if   not(check_CSR(csr, cur_privilege, access_type))
-  then Illegal_Instruction()
+  then {
+    if currentlyEnabled(Ext_H) & csr_access_raises_virtual_instr(csr, cur_privilege, access_type)
+    then Virtual_Instruction()
+    else Illegal_Instruction()
+  }
   else if not(ext_check_CSR(csr, cur_privilege, access_type))
   then Ext_CSR_Check_Failure()
   else {

--- a/model/extensions/bfloat16/zvfbfmin_insts.sail
+++ b/model/extensions/bfloat16/zvfbfmin_insts.sail
@@ -1,9 +1,9 @@
 //=======================================================================================
-//  This Sail RISC-V architecture model, comprising all files and
-//  directories except where otherwise noted is subject the BSD
-//  two-clause license in the LICENSE file.
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
 //
-//  SPDX-License-Identifier: BSD-2-Clause
+// SPDX-License-Identifier: BSD-2-Clause
 //=======================================================================================
 
 function clause currentlyEnabled(Ext_Zvfbfmin) = hartSupports(Ext_Zvfbfmin) & currentlyEnabled(Ext_Zve32f)

--- a/model/extensions/cfi/zicfilp_insts.sail
+++ b/model/extensions/cfi/zicfilp_insts.sail
@@ -6,10 +6,15 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // =======================================================================================
 
-function make_landing_pad_exception() -> sync_exception =
-  struct { trap    = E_Software_Check(),
-           excinfo = Some(zero_extend(software_check_cause(SWC_LANDING_PAD_FAULT))),
-           ext     = None() }
+function make_landing_pad_exception() -> ctl_result =
+  CTL_TRAP(E_Software_Check(),
+           struct {
+            excinfo = Some(zero_extend(software_check_cause(SWC_LANDING_PAD_FAULT))),
+            info_is_gva = false,
+            excinfo2    = None(),
+            excinst     = None(),
+            ext         = None(),
+          })
 
 union clause instruction = LPAD : (landing_pad_label)
 
@@ -23,7 +28,7 @@ function clause execute LPAD(lpl) = {
     let unaligned_pc = get_arch_pc()[1 .. 0] != 0b00;
     let label_mismatch = X(Regno(7))[31 .. 12] != lpl & lpl != zeros();
     if unaligned_pc | label_mismatch then {
-      Trap(cur_privilege, CTL_TRAP(make_landing_pad_exception()), PC)
+      Trap(cur_privilege, make_landing_pad_exception(), PC)
     } else {
       reset_elp();
       RETIRE_SUCCESS

--- a/model/extensions/cfi/zicfilp_regs.sail
+++ b/model/extensions/cfi/zicfilp_regs.sail
@@ -27,9 +27,12 @@ function get_xLPE(p : Privilege) -> bool =
     User              => if   currentlyEnabled(Ext_S)
                          then bool_bit(senvcfg[LPE])
                          else bool_bit(menvcfg[LPE]),
-    // TODO: check henvcfg for VS mode
-    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => if   currentlyEnabled(Ext_H)
+                         then bool_bit(henvcfg[LPE])
+                         else bool_bit(menvcfg[LPE]),
+    VirtualUser       => if   currentlyEnabled(Ext_H)
+                         then bool_bit(senvcfg[LPE])
+                         else bool_bit(menvcfg[LPE]),
   }
 
 // This measure needs to be > currentlyEnabled_measure(Ext_S), currently equal
@@ -73,9 +76,9 @@ function zicfilp_preserve_elp_on_trap(x : Privilege) -> unit = {
     Machine           => { mstatus[MPELP] = elp; },
     Supervisor        => { mstatus[SPELP] = elp; },
     User              => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
-    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-};
+    VirtualSupervisor => { vsstatus[SPELP] = elp; },
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+  };
   reset_elp();
 }
 
@@ -91,7 +94,11 @@ function zicfilp_restore_elp_on_xret(xret : xRET_type, y : Privilege) -> unit = 
     },
     sRET => {
       let pelp = mstatus[SPELP];
-      mstatus[SPELP] = landing_pad_bits(NO_LP_EXPECTED);
+      if privLevel_is_virtual(cur_privilege) then {
+        vsstatus[SPELP] = landing_pad_bits(NO_LP_EXPECTED);
+      } else {
+        mstatus[SPELP] = landing_pad_bits(NO_LP_EXPECTED);
+      };
       pelp
     },
   };

--- a/model/postlude/fetch.sail
+++ b/model/postlude/fetch.sail
@@ -25,16 +25,16 @@ private function fetch() -> FetchResult = {
   };
 
   if   (PC[0] != 0b0 | (PC[1] != 0b0 & not(currentlyEnabled(Ext_Zca))))
-  then return F_Error(E_Fetch_Addr_Align(), PC);
+  then return F_Error(E_Fetch_Addr_Align(), mem_exception_context(PC, privLevel_is_virtual(cur_privilege)));
 
   match translateAddr(Virtaddr(PC), InstructionFetch()) {
-    Err(e, _)    => F_Error(e, PC),
+    Err((e, c), _)    => F_Error(e, c),
     Ok(ppclo, _) => {
       // split instruction fetch into 16-bit granules to handle RVC, as
       // well as to generate precise fault addresses in any fetch
       // exceptions.
       match mem_read(InstructionFetch(), ppclo, 2, false, false, false) {
-        Err(e)  => F_Error(e, PC),
+        Err(e)  => F_Error(e, mem_exception_context(PC, privLevel_is_virtual(cur_privilege))),
         Ok(ilo) =>
           if   isRVC(ilo)
           then F_RVC(ilo)
@@ -47,10 +47,10 @@ private function fetch() -> FetchResult = {
             };
 
             match translateAddr(Virtaddr(PC_hi), InstructionFetch()) {
-              Err(e, _)    => F_Error(e, PC_hi),
+              Err((e, c), _)    => F_Error(e, c),
               Ok(ppchi, _) =>
                 match mem_read(InstructionFetch(), ppchi, 2, false, false, false) {
-                  Err(e)  => F_Error(e, PC_hi),
+                  Err(e)  => F_Error(e, mem_exception_context(PC_hi, privLevel_is_virtual(cur_privilege))),
                   Ok(ihi) => F_Base(append(ihi, ilo))
                 }
             }

--- a/model/postlude/fetch_rvfi.sail
+++ b/model/postlude/fetch_rvfi.sail
@@ -20,10 +20,10 @@ private function rvfi_fetch() -> FetchResult = {
 
   // Then check PC alignment
   if   (PC[0] != 0b0 | (PC[1] != 0b0 & not(currentlyEnabled(Ext_Zca))))
-  then return F_Error(E_Fetch_Addr_Align(), PC);
+  then return F_Error(E_Fetch_Addr_Align(), mem_exception_context(PC, privLevel_is_virtual(cur_privilege)));
 
   match translateAddr(Virtaddr(PC), InstructionFetch()) {
-    Err(e, _) => return F_Error(e, PC),
+    Err((e, c), _) => return F_Error(e, c),
     Ok(_, _)  => (),
   };
 
@@ -40,7 +40,7 @@ private function rvfi_fetch() -> FetchResult = {
   };
 
   match translateAddr(Virtaddr(PC_hi), InstructionFetch()) {
-    Err(e, _) => F_Error(e, PC),
+    Err((e, c), _) => F_Error(e, c),
     Ok(_, _)  => F_Base(i)
   }
 }

--- a/model/postlude/insts_end.sail
+++ b/model/postlude/insts_end.sail
@@ -26,6 +26,11 @@ mapping clause assembly = C_ILLEGAL(s) <-> "c.illegal" ^ spc() ^ hex_bits_16(s)
 
 // *****************************************************************
 
+/* All other instructions transform to zero                           */
+function clause enc_transformed(_,_) = zeros()
+
+/* ****************************************************************** */
+
 // End definitions
 end extension
 end extensionName
@@ -36,6 +41,7 @@ end execute
 end assembly
 end encdec
 end encdec_compressed
+end enc_transformed
 
 // Some legal instructions do not have any corresponding assembly, e.g. reserved fences.
 function instruction_to_str(insn : instruction) -> string =

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -13,7 +13,7 @@ register hart_state : HartState = HART_ACTIVE()
 private union Step = {
   Step_Pending_Interrupt  : (InterruptType, Privilege),
   Step_Ext_Fetch_Failure  : ext_fetch_addr_error,
-  Step_Fetch_Failure      : (virtaddr, ExceptionType),
+  Step_Fetch_Failure      : (ExceptionType, ExceptionContext),
   Step_Execute            : (ExecutionResult, instbits),
   Step_Waiting            : WaitReason,
 }
@@ -93,13 +93,14 @@ private function run_hart_active(step_no: nat) -> Step = {
       // extension error
       F_Ext_Error(e)   => Step_Ext_Fetch_Failure(e),
       // standard error
-      F_Error(e, addr) => Step_Fetch_Failure(Virtaddr(addr), e),
+      F_Error(e, c) => Step_Fetch_Failure(e, c),
       // non-error cases:
       F_RVC(h) => {
         sail_instr_announce(h);
         fetch_callback(h);
         let instbits : instbits = zero_extend(h);
         let instruction = ext_decode_compressed(h);
+        instbits_transformed = enc_transformed(instruction, zeros()); // BUG: Address offset may be nonzero for misaligned memory accesses
         if   get_config_print_instr()
         then {
           print_log_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(PC) ^ " (" ^ bits_str(h) ^ ") " ^ to_str(instruction), zero_extend(PC));
@@ -107,7 +108,7 @@ private function run_hart_active(step_no: nat) -> Step = {
         // When ELP is set to LP_EXPECTED, the next instruction needs to be
         // the non-RVC `LPAD` instruction.
         if is_landing_pad_expected() then {
-          let r = Trap(cur_privilege, CTL_TRAP(make_landing_pad_exception()), PC);
+          let r = Trap(cur_privilege, make_landing_pad_exception(), PC);
           Step_Execute(r, instbits)
         }
         // check for RVC once here instead of every RVC execute clause.
@@ -127,6 +128,7 @@ private function run_hart_active(step_no: nat) -> Step = {
         fetch_callback(w);
         let instbits : instbits = zero_extend(w);
         let instruction = ext_decode(w);
+        instbits_transformed = enc_transformed(instruction, zeros()); // BUG: Address offset may be nonzero for misaligned memory accesses
         if   get_config_print_instr()
         then {
           print_log_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(PC) ^ " (" ^ bits_str(w) ^ ") " ^ to_str(instruction), zero_extend(PC));
@@ -135,7 +137,7 @@ private function run_hart_active(step_no: nat) -> Step = {
         // the instruction stream is not LPAD, then a software check
         // exception with a landing pad fault code is thrown.
         if is_landing_pad_expected() & not(is_lpad_instruction(instruction)) then {
-          let r = Trap(cur_privilege, CTL_TRAP(make_landing_pad_exception()), PC);
+          let r = Trap(cur_privilege, make_landing_pad_exception(), PC);
           Step_Execute(r, instbits)
         } else {
           nextPC = PC + 4;
@@ -201,21 +203,21 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
   match step_val {
     Step_Pending_Interrupt(intr, priv) => {
       if   get_config_print_instr()
-      then print_bits("Handling interrupt: ", interruptType_bits(intr));
+      then print_log("Step_Pending_Interrupt: interrupt = " ^ interruptType_to_str(intr));
       handle_interrupt(intr, priv)
     },
     Step_Ext_Fetch_Failure(e) => ext_handle_fetch_check_error(e),
-    Step_Fetch_Failure(vaddr, e) => handle_exception(bits_of(vaddr), e),
+    Step_Fetch_Failure(e, c) => handle_exception(e, c),
     Step_Waiting(_) => assert(hart_is_waiting(hart_state), "cannot be Waiting in a non-Wait state"),
     Step_Execute(Retire_Success(), _) => assert(hart_is_active(hart_state)),
     // This case was handled above when processing the fetch result.
     Step_Execute(ExecuteAs(_), _) => assert(false),
     // standard errors
     Step_Execute(Trap(priv, ctl, pc), _) => set_next_pc(exception_handler(priv, ctl, pc)),
-    Step_Execute(Memory_Exception(vaddr, e), _) => handle_exception(bits_of(vaddr), e),
-    Step_Execute(Illegal_Instruction(), instbits) => handle_exception(zero_extend(instbits), E_Illegal_Instr()),
+    Step_Execute(Memory_Exception(e, c), _) => handle_exception(e, c),
+    Step_Execute(Illegal_Instruction(), instbits) => handle_exception(E_Illegal_Instr(), instr_exception_context(zero_extend(instbits), false)),
     // NOTE: Virtual instructions exception cannot be triggered until Hypervisor integration is complete.
-    Step_Execute(Virtual_Instruction(), instbits) => handle_exception(zero_extend(instbits), E_Virtual_Instr()),
+    Step_Execute(Virtual_Instruction(), instbits) => handle_exception(E_Virtual_Instr(), instr_exception_context(zero_extend(instbits), false)),
     Step_Execute(Enter_Wait(wr), instbits) => {
       if wait_is_nop(wr) then {
         // This is the same as the RETIRE_OK case.

--- a/model/postlude/step_common.sail
+++ b/model/postlude/step_common.sail
@@ -48,5 +48,5 @@ union FetchResult = {
   F_Ext_Error : ext_fetch_addr_error,      // For extensions
   F_Base      : word,                      // Base ISA
   F_RVC       : half,                      // Compressed ISA
-  F_Error     : (ExceptionType, xlenbits)  // standard exception and PC
+  F_Error     : (ExceptionType, ExceptionContext)  // standard exception and PC
 }

--- a/model/prelude/prelude.sail
+++ b/model/prelude/prelude.sail
@@ -215,6 +215,17 @@ function rotate_bits_left (value, shift) = rotatel(value, unsigned(shift))
 overload operator >>> = {rotate_bits_right, rotater}
 overload operator <<< = {rotate_bits_left, rotatel}
 
+/* helpers for bitvector option type */
+
+val some_or : forall 'n, 'n >= 0 . (option(bits('n)), bits('n)) -> bits('n)
+function some_or(o, d) = match o {
+  Some(v) => v,
+  None()  => d,
+}
+
+val some_or_zero : forall 'n, 'n >= 0. (implicit('n), option(bits('n))) -> bits('n)
+function some_or_zero(n, o) = some_or(o, zeros(n))
+
 val reverse_bits : forall 'n, 'n > 0. bits('n) -> bits('n)
 function reverse_bits (xs)  = {
   var ys : bits('n) = zeros();

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -104,7 +104,7 @@ extensions {
       files extensions/A/aext_types.sail
     }
     Zaamo {
-      requires core, sys, A_types
+      requires core, sys, A_types, exceptions
       files extensions/A/zaamo_insts.sail
     }
     Zalrsc {
@@ -171,8 +171,17 @@ extensions {
   H {
     requires core
 
-    files
-      extensions/H/hext_insts.sail
+    H_core {
+      requires exceptions
+      before sys
+      files
+        extensions/H/hext_control.sail,
+    }
+    H_insts {
+      requires sys, H_core, exceptions, I_insts, Zca, FD, Zalrsc, Zaamo
+      files
+        extensions/H/hext_insts.sail,
+    }
   }
 
   // Floating point (F and D extensions)
@@ -380,7 +389,7 @@ extensions {
       files extensions/Zicbom/zicbom_types.sail
     }
     Zicbom_insts {
-      requires core, sys, Zicbom_types
+      requires core, sys, Zicbom_types, exceptions
       files extensions/Zicbom/zicbom_insts.sail
     }
   }
@@ -393,13 +402,13 @@ extensions {
     Zicbop_insts {
       // PREFETCH.{I,R,W} instructions override ORI hints (rd=0)
       before I_insts
-      requires core, sys, Zicbop_types
+      requires core, sys, Zicbop_types, exceptions
       files extensions/Zicbop/zicbop_insts.sail
     }
   }
 
   Zicboz {
-    requires core, sys
+    requires core, sys, exceptions
     files extensions/Zicboz/zicboz_insts.sail
   }
 

--- a/model/sys/insts_begin.sail
+++ b/model/sys/insts_begin.sail
@@ -30,7 +30,7 @@ union ExecutionResult = {
   Illegal_Instruction            : unit,
   Virtual_Instruction            : unit,
   Trap                           : (Privilege, ctl_result, xlenbits),
-  Memory_Exception               : (virtaddr, ExceptionType),
+  Memory_Exception               : (ExceptionType, ExceptionContext),
 
   // Did not retire for custom reason.
   Ext_CSR_Check_Failure          : unit,
@@ -46,6 +46,15 @@ union ExecutionResult = {
 
 let RETIRE_SUCCESS : ExecutionResult = Retire_Success()
 
+function memory_exception_with_gva(e : ExceptionType, vaddr : virtaddr) -> ExecutionResult = {
+  Memory_Exception(e, struct {
+    excinfo     = Some(bits_of(vaddr)),
+    info_is_gva = privLevel_is_virtual(cur_privilege),
+    excinfo2    = None(),
+    excinst     = None(),
+    ext         = None(),
+  })
+}
 
 // returns whether an instruction was retired, used for computing minstret
 val execute : instruction -> ExecutionResult
@@ -59,6 +68,10 @@ scattered mapping encdec
 
 val encdec_compressed : instruction <-> bits(16)
 scattered mapping encdec_compressed
+
+/* Function for transformed instructions as defined in the hypervisor extension */
+val enc_transformed : (instruction, bits(5)) -> bits(32)
+scattered function enc_transformed
 
 // We declare the ILLEGAL/C_ILLEGAL instruction clauses here instead of in
 // insts_end, so that model extensions can make use of them.

--- a/model/sys/platform.sail
+++ b/model/sys/platform.sail
@@ -50,6 +50,9 @@ register mtimecmp : bits(64)
 // Unlike mtimecmp, stimecmp is a real CSR; not memory mapped.
 register stimecmp : bits(64)
 
+// vstimecmp CSR is also a real CSR; not memory mapped.
+register vstimecmp : bits(64)
+
 // CLINT memory-mapped IO
 
 // relative address map:

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -10,7 +10,7 @@
 
 function effectivePrivilege(access : MemoryAccessType(mem_payload), m : Mstatus, priv : Privilege) -> Privilege =
   if   access != InstructionFetch() & m[MPRV] == 0b1
-  then privLevel_bits(m[MPP], 0b0) // TODO: use m[MPV] if hypervisor enabled
+  then privLevel_bits(m[MPP], m[MPV])
   else priv
 
 // CSR access control
@@ -20,11 +20,61 @@ function csrPriv(csr : csreg) -> nom_priv_bits = csr[9..8]
 
 // Check that the CSR access is made with sufficient privilege.
 function check_CSR_priv(csr : csreg, p : Privilege) -> bool =
-  privLevel_to_bits(p) >=_u csrPriv(csr)
+  if currentlyEnabled(Ext_H) & (privLevel_to_bits(p) == 0b01 & privLevel_to_virt_bit(p) == 0b0) then 0b10 >=_u csrPriv(csr)
+  else privLevel_to_bits(p) >=_u csrPriv(csr)
 
 // Check that the CSR access isn't a write to a read-only CSR.
 function check_CSR_access(csr : csreg, access_type : CSRAccessType) -> bool =
   not((access_type == CSRWrite | access_type == CSRReadWrite) & (csrAccess(csr) == 0b11))
+
+// FIXME: The cases below should probably be checked in unittests instead of listed here
+//
+// According to the spec. (V20211203 - Section 9.6), this should happen in the following cases:
+//   [X] in VS-mode, attempts to access a non-high-half counter CSR when the corresponding bit
+//       in hcounteren is 0 and the same bit in mcounteren is 1;
+//   [ ] in VS-mode, if XLEN=32, attempts to access a high-half counter CSR when the
+//       corresponding bit in hcounteren is 0 and the same bit in mcounteren is 1;
+//   [X] in VU-mode, attempts to access a non-high-half counter CSR when the corresponding bit
+//       in either hcounteren or scounteren is 0 and the same bit in mcounteren is 1;
+//   [ ] in VU-mode, if XLEN=32, attempts to access a high-half counter CSR when the
+//       corresponding bit in either hcounteren or scounteren is 0 and the same bit in
+//       mcounteren is 1;
+//   [x] in VS-mode or VU-mode, attempts to access an implemented non-high-half hypervisor CSR
+//       or VS CSR when the same access (read/write) would be allowed in HS-mode, assuming
+//       mstatus.TVM=0;
+//   [ ] in VS-mode or VU-mode, if XLEN=32, attempts to access an implemented high-half
+//       hypervisor CSR or high-half VS CSR when the same access (read/write) to the CSR’s
+//       low-half partner would be allowed in HS-mode, assuming mstatus.TVM=0;
+//   [x] in VU-mode, attempts to access an implemented non-high-half supervisor CSR when the
+//       same access (read/write) would be allowed in HS-mode, assuming mstatus.TVM=0;
+//   [ ] in VU-mode, if XLEN=32, attempts to access an implemented high-half supervisor CSR
+//       when the same access to the CSR’s low-half
+//       partner would be allowed in HS-mode, assuming mstatus.TVM=0;
+//   [ ] in VS-mode, attempts to access satp, when hstatus.VTVM=1
+// Determine if an illegal CSR access should raise a "virtual instruction exception" instead of an "illegal instruction exception"
+function csr_access_raises_virtual_instr(csr : csreg, p : Privilege, access_type : CSRAccessType) -> bool = {
+  if privLevel_to_virt_bit(p) == 0b0
+  then false
+  else is_CSR_accessible(csr, p, access_type) & check_CSR_access(csr, access_type)
+}
+
+/*! Is it legal for mtinst or htinst to hold a transformed instruction on a given fault */
+function exc_causes_transformed_inst_in_xtinst(e : ExceptionType) -> bool =
+  match e {
+    E_Load_Addr_Align()   => true,
+    E_Load_Access_Fault() => true,
+    E_SAMO_Addr_Align()   => true,
+    E_SAMO_Access_Fault() => true,
+    E_Load_Page_Fault()   => true,
+    E_SAMO_Page_Fault()   => true,
+    E_Load_GPage_Fault()  => true,
+    E_SAMO_GPage_Fault()  => true,
+    _                     => false,
+  }
+
+// FIXME: Define proper platform parameter for this
+val plat_xtinst_has_transformed_inst : unit -> bool
+function plat_xtinst_has_transformed_inst() = currentlyEnabled(Ext_H)
 
 function check_CSR(csr : csreg, p : Privilege, access_type : CSRAccessType) -> bool =
     check_CSR_priv(csr, p)
@@ -36,11 +86,15 @@ function check_CSR(csr : csreg, p : Privilege, access_type : CSRAccessType) -> b
 // it occurred, returns the privilege at which it should be handled.
 function exception_delegatee(e : ExceptionType, p : Privilege) -> Privilege = {
   let idx = unsigned(exceptionType_bits(e));
-  let super = bit_to_bool(medeleg.bits[idx]);
-  // TODO: check VS/VU-mode if hypervisor extension enabled
-  let deleg = if currentlyEnabled(Ext_S) & super then Supervisor else Machine;
+  let del_to_hs = bit_to_bool(medeleg.bits[idx]);
+  let del_to_vs = bit_to_bool(hedeleg.bits[idx]);
+  let deleg = if currentlyEnabled(Ext_S) & del_to_hs then
+                if currentlyEnabled(Ext_H) & del_to_vs then
+                  VirtualSupervisor
+                else Supervisor
+              else Machine;
   // We cannot transition to a less-privileged mode.
-  if   privLevel_to_bits(deleg) <_u privLevel_to_bits(p)
+  if (privLevel_to_bits(deleg) <=_u privLevel_to_bits(p)) & (privLevel_to_virt_bit(deleg) >=_u privLevel_to_virt_bit(p))
   then p else deleg
 }
 
@@ -48,13 +102,27 @@ function exception_delegatee(e : ExceptionType, p : Privilege) -> Privilege = {
 // privilege, in the order: external, software, timers.
 function findPendingInterrupt(ip : xlenbits) -> option(InterruptType) = {
   let ip = Mk_Minterrupts(ip);
-  if      ip[MEI] == 0b1 then Some(I_M_External)
-  else if ip[MSI] == 0b1 then Some(I_M_Software)
-  else if ip[MTI] == 0b1 then Some(I_M_Timer)
-  else if ip[SEI] == 0b1 then Some(I_S_External)
-  else if ip[SSI] == 0b1 then Some(I_S_Software)
-  else if ip[STI] == 0b1 then Some(I_S_Timer)
-  else                        None()
+  if      ip[MEI]  == 0b1 then Some(I_M_External)
+  else if ip[MSI]  == 0b1 then Some(I_M_Software)
+  else if ip[MTI]  == 0b1 then Some(I_M_Timer)
+  else if ip[SEI]  == 0b1 then Some(I_S_External)
+  else if ip[SSI]  == 0b1 then Some(I_S_Software)
+  else if ip[STI]  == 0b1 then Some(I_S_Timer)
+  else if ip[SGEI] == 0b1 then Some(I_SG_External)
+  else if ip[VSEI] == 0b1 then Some(I_VS_External)
+  else if ip[VSSI] == 0b1 then Some(I_VS_Software)
+  else if ip[VSTI] == 0b1 then Some(I_VS_Timer)
+  else                         None()
+}
+
+/*! Translate VS-level interrupts to their S-level counterpart */
+function translateVSInterrupts(i : Minterrupts) -> Minterrupts = {
+  let t = i;
+  let t = [[t with SEI = i[VSEI]] with VSEI = 0b0];
+  let t = [[t with SSI = i[VSSI]] with VSSI = 0b0];
+  let t = [[t with STI = i[VSTI]] with VSTI = 0b0];
+  // TODO: add hook for extensions to translate interrupts as well
+  t
 }
 
 // Given the current privilege level, return the pending set
@@ -70,14 +138,18 @@ function getPendingSet(priv : Privilege) -> option((xlenbits, Privilege)) = {
   // mideleg can only be non-zero if we support Supervisor mode.
   assert(currentlyEnabled(Ext_S) | mideleg.bits == zeros());
 
-  let pending_m = mip.bits & mie.bits & ~(mideleg.bits);
-  let pending_s = mip.bits & mie.bits & mideleg.bits;
+  let pending = mip.bits & mie.bits;
+  let pending_m = pending & ~(mideleg.bits);
+  let pending_s = pending & mideleg.bits & ~(hideleg.bits);
+  let pending_vs = pending & mideleg.bits & hideleg.bits;
 
-  let mIE = (priv == Machine    & mstatus[MIE] == 0b1) | priv == Supervisor | priv == User;
-  let sIE = (priv == Supervisor & mstatus[SIE] == 0b1) | priv == User;
+  let mIE  = (priv == Machine &  mstatus[MIE] == 0b1) | priv != Machine;
+  let sIE  = (priv == Supervisor & mstatus[SIE] == 0b1) | priv == User | priv == VirtualSupervisor | priv == VirtualUser;
+  let vsIE = currentlyEnabled(Ext_H) & (priv == VirtualSupervisor & vsstatus[SIE] == 0b1) | priv == VirtualUser;
 
   if      mIE & (pending_m != zeros()) then Some((pending_m, Machine))
   else if sIE & (pending_s != zeros()) then Some((pending_s, Supervisor))
+  else if vsIE & (pending_vs != zeros()) then Some((translateVSInterrupts(Mk_Minterrupts(pending_vs)).bits, VirtualSupervisor))
   else None()
 }
 
@@ -108,29 +180,20 @@ function shouldWakeForInterrupt() -> bool = {
 // handled (if any), and the privilege it should be handled at.
 function dispatchInterrupt(priv : Privilege) -> option((InterruptType, Privilege)) = {
   match getPendingSet(priv) {
-    None()       => None(),
-    Some(ip, p)  => match findPendingInterrupt(ip) {
-                      None()  => None(),
-                      Some(i) => Some((i, p)),
-                    }
+    None()      => None(),
+    Some(ip, p) => match findPendingInterrupt(ip) {
+                     None()  => None(),
+                     Some(i) => Some((i, p))
+                   },
   }
 }
 
 // types of privilege transitions
 
 union ctl_result = {
-  CTL_TRAP : sync_exception,
+  CTL_TRAP : (ExceptionType, ExceptionContext),
   CTL_SRET : unit,
   CTL_MRET : unit,
-}
-
-// trap value
-
-function tval(excinfo : option(xlenbits)) -> xlenbits = {
-  match (excinfo) {
-    Some(e) => e,
-    None()  => zeros()
-  }
 }
 
 function track_trap(p : Privilege) -> unit = {
@@ -146,14 +209,18 @@ function track_trap(p : Privilege) -> unit = {
       csr_write_callback("stval", stval);
       csr_write_callback("sepc", sepc);
     },
-    User              => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
-    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    User              => internal_error(__FILE__, __LINE__, "Invalid privilege level User"),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Invalid privilege level VirtualUser"),
+    VirtualSupervisor => {
+      csr_write_callback("vscause", vscause.bits);
+      csr_write_callback("vstval", vstval);
+      csr_write_callback("vsepc", vsepc);
+    },
   };
 }
 
 // handle exceptional ctl flow by updating nextPC and operating privilege
-function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info : option(xlenbits), ext : option(ext_exception))
+function trap_handler(del_priv : Privilege, pc : xlenbits, c : TrapCause, context : ExceptionContext)
                      -> xlenbits = {
   let is_interrupt = trapCause_is_interrupt(c);
   let cause        = trapCause_bits(c);
@@ -163,7 +230,8 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
   if   get_config_print_exception() | get_config_print_interrupt()
   then print_log("handling " ^ to_str(c)
                       ^ " at priv " ^ to_str(del_priv)
-                      ^ " with tval " ^ bits_str(tval(info)));
+                      ^ " with tval " ^ bits_str(some_or_zero(context.excinfo))
+                      ^ " and tinst " ^ bits_str(some_or_zero(context.excinst)));
 
   if hartSupports(Ext_Zicfilp) then zicfilp_preserve_elp_on_trap(del_priv);
 
@@ -175,12 +243,16 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
       mstatus[MPIE] = mstatus[MIE];
       mstatus[MIE]  = 0b0;
       mstatus[MPP]  = privLevel_to_bits(cur_privilege);
-      mtval         = tval(info);
+      mstatus[MPV]  = if currentlyEnabled(Ext_H) & privLevel_is_virtual(cur_privilege) then 0b1 else 0b0;
+      mstatus[GVA]  = if context.info_is_gva then 0b1 else 0b0;
+      mtval         = some_or_zero(context.excinfo);
       mepc          = pc;
+      mtval2        = some_or_zero(context.excinfo2);
+      mtinst        = some_or_zero(context.excinst);
 
       cur_privilege = del_priv;
 
-      handle_trap_extension(del_priv, pc, ext);
+      handle_trap_extension(del_priv, pc, context.ext);
 
       track_trap(del_priv);
 
@@ -198,42 +270,74 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
         User              => 0b0,
         Supervisor        => 0b1,
         Machine           => internal_error(__FILE__, __LINE__, "invalid privilege for s-mode trap"),
-        VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-        VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+        VirtualUser       => 0b0,
+        VirtualSupervisor => 0b1,
       };
-      stval           = tval(info);
+      hstatus[SPV]    = if currentlyEnabled(Ext_H) & privLevel_is_virtual(cur_privilege) then 0b1 else 0b0;
+      hstatus[SPVP]   = if currentlyEnabled(Ext_H) & privLevel_is_virtual(cur_privilege) then mstatus[SPP] else hstatus[SPVP];
+      hstatus[GVA]    = if currentlyEnabled(Ext_H) then bool_to_bit(context.info_is_gva) else 0b0;
+      stval           = some_or_zero(context.excinfo);
       sepc            = pc;
+      stval           = some_or_zero(context.excinfo);
+      htval           = some_or_zero(context.excinfo2);
+      htinst          = some_or_zero(context.excinst);
 
       cur_privilege   = del_priv;
 
-      handle_trap_extension(del_priv, pc, ext);
+      handle_trap_extension(del_priv, pc, context.ext);
 
       track_trap(del_priv);
 
       prepare_trap_vector(del_priv, scause)
     },
+    VirtualSupervisor => {
+      assert (currentlyEnabled(Ext_H), "Hypervisor extension not supported");
+      vscause[IsInterrupt] = bool_to_bit(is_interrupt);
+      vscause[Cause]       = zero_extend(cause);
+
+      vsstatus[SPIE] = vsstatus[SIE];
+      vsstatus[SIE]  = 0b0;
+      vsstatus[SPP]  = match cur_privilege {
+        User              => 0b0,
+        Supervisor        => 0b1,
+        Machine           => internal_error(__FILE__, __LINE__, "invalid privilege for vs-mode trap"),
+        VirtualUser       => 0b0,
+        VirtualSupervisor => 0b1,
+      };
+      vsepc          = pc;
+      vstval         = some_or_zero(context.excinfo);
+
+      cur_privilege  = del_priv;
+
+      handle_trap_extension(del_priv, pc, context.ext);
+      track_trap(del_priv);
+      prepare_trap_vector(del_priv, vscause)
+    },
     User              => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
-    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
   };
 }
 
 function exception_handler(cur_priv : Privilege, ctl : ctl_result,
                            pc: xlenbits) -> xlenbits = {
   match ctl {
-    CTL_TRAP(e) => {
-      let del_priv = exception_delegatee(e.trap, cur_priv);
+    CTL_TRAP(e, c) => {
+      let del_priv = exception_delegatee(e, cur_priv);
       if   get_config_print_exception()
       then print_log("trapping from " ^ to_str(cur_priv) ^ " to " ^ to_str(del_priv)
-                          ^ " to handle " ^ to_str(e.trap));
-      trap_handler(del_priv, Exception(e.trap), pc, e.excinfo, e.ext)
+                          ^ " to handle " ^ to_str(e));
+      trap_handler(del_priv, pc, Exception(e), c)
     },
     CTL_MRET()  => {
+
       let prev_priv = cur_privilege;
+      cur_privilege = privLevel_bits(mstatus[MPP], mstatus[MPV]);
+
       mstatus[MIE]  = mstatus[MPIE];
       mstatus[MPIE] = 0b1;
-      cur_privilege = privLevel_bits(mstatus[MPP], 0b0); // TODO: use mstatus[MPV] if hypervisor enabled
       mstatus[MPP]  = privLevel_to_bits(if currentlyEnabled(Ext_U) then User else Machine);
+      mstatus[MPV]  = if privLevel_is_virtual(cur_privilege) then 0b1 else 0b0;
+
       if   cur_privilege != Machine
       then mstatus[MPRV] = 0b0;
 
@@ -249,12 +353,25 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
     },
     CTL_SRET()  => {
       let prev_priv = cur_privilege;
-      mstatus[SIE]  = mstatus[SPIE];
-      mstatus[SPIE] = 0b1;
-      cur_privilege = if mstatus[SPP] == 0b1 then Supervisor else User;
-      mstatus[SPP]  = 0b0;
-      if   cur_privilege != Machine
-      then mstatus[MPRV] = 0b0;
+
+      let ret =
+      if privLevel_is_virtual(cur_privilege) then {
+        cur_privilege = privLevel_bits(0b0 @ mstatus[SPP], if currentlyEnabled(Ext_H) then hstatus[SPV] else 0b0);
+        vsstatus[SIE]  = vsstatus[SPIE];
+        vsstatus[SPIE] = 0b1;
+        cur_privilege  = if vsstatus[SPP] == 0b1 then VirtualSupervisor else VirtualUser;
+        vsstatus[SPP]  = 0b0;
+        VirtualSupervisor
+      } else {
+        mstatus[SIE]  = mstatus[SPIE];
+        mstatus[SPIE] = 0b1;
+        cur_privilege = privLevel_bits(0b0 @ mstatus[SPP], if currentlyEnabled(Ext_H) then hstatus[SPV] else 0b0);
+        mstatus[SPP]  = 0b0;
+        hstatus[SPV]  = 0b0;
+        if   cur_privilege != Machine
+        then mstatus[MPRV] = 0b0;
+        Supervisor
+      };
 
       if   hartSupports(Ext_Zicfilp)
       then zicfilp_restore_elp_on_xret(sRET, cur_privilege);
@@ -265,7 +382,7 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
       then print_log("ret-ing from " ^ to_str(prev_priv)
                           ^ " to " ^ to_str(cur_privilege));
 
-      prepare_xret_target(Supervisor)
+      prepare_xret_target(ret)
     },
   }
 }
@@ -303,15 +420,19 @@ function xtval_exception_value(e : ExceptionType, excinfo : xlenbits) -> option(
   } then Some(excinfo) else None()
 }
 
-function handle_exception(xtval : xlenbits, e : ExceptionType) -> unit = {
-  let t : sync_exception = struct { trap    = e,
-                                    excinfo = xtval_exception_value(e, xtval),
-                                    ext     = None() };
-  set_next_pc(exception_handler(cur_privilege, CTL_TRAP(t), PC))
+function handle_exception(e : ExceptionType, c : ExceptionContext) -> unit = {
+                                    // excinfo = xtval_exception_value(e, xtval),
+  let c = {c with excinst = if c.excinst != None()
+                            then c.excinst
+                            else if (plat_xtinst_has_transformed_inst() & exc_causes_transformed_inst_in_xtinst(e))
+                            then Some(zero_extend(instbits_transformed))
+                            else None(),
+                  ext     = None()};
+  set_next_pc(exception_handler(cur_privilege, CTL_TRAP(e, c), PC))
 }
 
 function handle_interrupt(i : InterruptType, del_priv : Privilege) -> unit =
-  set_next_pc(trap_handler(del_priv, Interrupt(i), PC, None(), None()))
+  set_next_pc(trap_handler(del_priv, PC, Interrupt(i), empty_exception_context()))
 
 // Reset misa to enable the maximal set of supported extensions.
 function reset_misa() -> unit = {
@@ -320,6 +441,7 @@ function reset_misa() -> unit = {
   misa[B]   = bool_to_bit(hartSupports(Ext_B));   // Bit-manipulation
   misa[M]   = bool_to_bit(hartSupports(Ext_M));   // integer multiply/divide
   misa[U]   = bool_to_bit(hartSupports(Ext_U));   // user-mode
+  misa[H]   = bool_to_bit(hartSupports(Ext_H));   // hypervisor-mode
   misa[S]   = bool_to_bit(hartSupports(Ext_S));   // supervisor-mode
   misa[V]   = bool_to_bit(hartSupports(Ext_V));   // vector extension
 
@@ -329,6 +451,8 @@ function reset_misa() -> unit = {
 
   if   hartSupports(Ext_F) & hartSupports(Ext_Zfinx)
   then internal_error(__FILE__, __LINE__, "F and Zfinx cannot both be enabled!");
+
+  // TODO: Additions to Hypervisor defined by N extension
 
   // We currently support both F and D
   misa[F]   = bool_to_bit(hartSupports(Ext_F));      // single-precision
@@ -354,6 +478,9 @@ function reset_sys() -> unit = {
   // "The mstatus fields MIE and MPRV are reset to 0."
   mstatus[MIE] = 0b0;
   mstatus[MPRV] = 0b0;
+  // set to little-endian mode
+  mstatus[MBE] = 0b0;
+  mstatus[SBE] = 0b0;
 
   // "If little-endian memory accesses are supported, the mstatus/mstatush field
   // MBE is reset to 0."
@@ -366,6 +493,7 @@ function reset_sys() -> unit = {
 
   // "The misa register is reset to enable the maximal set of supported extensions"
   reset_misa();
+  if currentlyEnabled(Ext_H) then reset_hext();
 
   // "For implementations with the "A" standard extension, there is no valid load reservation."
   cancel_reservation();

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -26,7 +26,7 @@
 // The code in this file is structured and commented so you can easily
 // ignore TLB functionality at first reading.
 
-struct PTW_Output('v : Int), is_sv_mode('v) = {
+struct PTW_Output('v : Int), is_xv_mode('v) = {
   ppn     : ppn_bits('v),
   pte     : pte_bits('v),
   pteAddr : physaddr,
@@ -34,7 +34,7 @@ struct PTW_Output('v : Int), is_sv_mode('v) = {
   global  : bool,
 }
 
-private type PTW_Result('v : Int), is_sv_mode('v) = result((PTW_Output('v), ext_ptw), (PTW_Error, ext_ptw))
+private type PTW_Result('v : Int), is_xv_mode('v) = result((PTW_Output('v), ext_ptw), (PTW_Error, ext_ptw))
 
 // ****************************************************************
 // Page Table Walk (PTW)
@@ -54,66 +54,91 @@ private function read_pte forall 'n, 'n in {4, 8} . (
 ) -> MemoryOpResult(bits(8 * 'n)) =
   mem_read_priv(Load(Data), Supervisor, paddr, pte_size, false, false, false)
 
-// 'v is the virtual address size.
-private val pt_walk : forall 'v, is_sv_mode('v) . (
-  int('v),                      // Sv32, Sv39, Sv48, Sv57
-  vpn_bits('v),                 // Virtual Page Number
-  MemoryAccessType(mem_payload),  // Memory Load{Reserved}/Store{Conditional}/Atomic/InstructionFetch/CacheAccess
-  Privilege,                    // User/Supervisor/Machine
-  bool,                         // mstatus.MXR
-  bool,                         // do_sum
-  ppn_bits('v),                 // Base PPN (`a` in the spec).
-  level_range('v),              // Tree level for this recursive call (`i` in the spec).
-  bool,                         // global translation,
-  ext_ptw                       // ext_ptw
-) -> PTW_Result('v)
+// ****************************************************************
+
+type TR_Result('paddr : Type, 'failure : Type) = result(('paddr, ext_ptw), ('failure, ext_ptw))
+
+private val translate_stage : (
+  bits(64),                          // virtual address
+  MemoryAccessType(mem_payload), // Read/Write/ReadWrite/Execute
+  Privilege,                         // Machine/Supervisor/User
+  AddressTranslationStage,           // S/VS/G
+  ext_ptw,                           // ext_ptw
+) -> TR_Result(physaddr, PTW_Error)
+
+private function translate_PTE_addr forall 'v, is_xv_mode('v) . (
+  sv_width : int('v),
+  stage    : AddressTranslationStage,
+  access   : MemoryAccessType(mem_payload),
+  pte_addr : pte_addr_bits('v),
+  ext_ptw  : ext_ptw
+) -> TR_Result(physaddr, PTW_Error) = {
+  let pa_bits : bits(physaddrbits_len) = match stage {
+    Stage_VS => match translate_stage(zero_extend(pte_addr), access, User, Stage_G, ext_ptw) {
+      Ok(pte_pa, ext_ptw) => (bits_of(pte_pa))[(sizeof(physaddrbits_len) - 1) .. 0],
+      Err(f, ext_ptw) => return Err((PTW_Implicit(ptw_implicit_error(f), zero_extend(pte_addr), access), ext_ptw)),
+    },
+    _  => {
+      assert(length(pte_addr) >= physaddrbits_len);
+      pte_addr[(physaddrbits_len - 1) .. 0]
+    },
+  };
+  Ok((Physaddr(pa_bits), ext_ptw))
+}
 
 // Steps 2-8 of the VATP.
-function pt_walk(
-  sv_width,
-  vpn,
-  access,
-  priv,
-  mxr,
-  do_sum,
-  pt_base,
-  level,
-  global,
-  ext_ptw,
-) = {
+// 'v is the virtual address size.
+private function pt_walk forall 'v, is_xv_mode('v) .(
+  sv_width : int('v),                           // Sv32(x4), Sv39(x4), Sv48(x4), Sv57(x4)
+  vpn      : vpn_bits('v),                      // Virtual Page Number
+  access   : MemoryAccessType(mem_payload),
+  priv     : Privilege,
+  stage    : AddressTranslationStage,
+  mxr      : bool,                              // mstatus.MXR
+  do_sum   : bool,                              // do_sum
+  pt_base  : ppn_bits('v),                      // Base PPN
+  level    : level_range('v),                   // Tree level for this recursive call (`i` in the spec).
+  global   : bool,                              // global translation
+  ext_ptw  : ext_ptw                            // ext_ptw
+) -> PTW_Result('v) = {
   ptw_start_callback(zero_extend(vpn), access, (priv, ()));
 
   // Extract the PPN component for this level; 10 bits on Sv32, otherwise 9.
-  let 'vpn_i_size = if 'v == 32 then 10 else 9;
-  let vpn_i = vpn[(level + 1) * vpn_i_size - 1 .. level * vpn_i_size];
-  let 'log_pte_size_bytes = if 'v == 32 then 2 else 3;
+  let 'vpn_i_size = if 'v == 32 | 'v == 34 then 10 else 9;
+  let 'log_pte_size_bytes = if 'v == 32 | 'v == 34 then 2 else 3;
+  let 'vpn_extened = if 'v == 34 | 'v == 41 | 'v == 50 | 'v == 59 then 1 else 0;
 
-  // Address of PTE in page table. This is 34 bits for Sv32, otherwise 56 bits.
-  let pte_addr = pt_base @ vpn_i @ zeros('log_pte_size_bytes);
+  // TODO: improve this
+  let vpn_begin = level * vpn_i_size;
+  let vpn_end = if 'v - pagesize_bits == (level + 1) * vpn_i_size + 2 // Svx4 root level
+                then 'v - pagesize_bits - 1
+                else (level + 1) * vpn_i_size - 1;
+  // Address of PTE in page table. This is 34 bits for Sv32(x4), otherwise 56 bits.
+  let pte_addr : pte_addr_bits('v) = (pt_base @ zeros(pagesize_bits))
+    + zero_extend(vpn[vpn_end .. vpn_begin] @ zeros('log_pte_size_bytes));
+  // TODO: Any method to move this check to type constraint?
+  assert(length(pte_addr) == physaddrbits_len);
 
+  // Read the PTE physical address
+  let pte_pa : physaddr = match translate_PTE_addr(sv_width, stage, Load(Data), pte_addr, ext_ptw) {
+    Ok(pa, _) => pa,
+    Err(e) => return Err(e),
+  };
 
-  // Convert to a physical address (34 bits for RV32, 64 bits to RV64).
-  // The assertion is required so Sail knows that we can't have a
-  // pte_addr of 56 bits and physaddr of 34 bits (because you can't
-  // use Sv39+ on RV32).
-  assert(sv_width == 32 | xlen == 64);
-  let pte_addr = Physaddr(zero_extend(pte_addr));
-
-  // Read this-level PTE from mem (Step 2 of VATP)
-  match read_pte(pte_addr, 2 ^ log_pte_size_bytes) {
+  match read_pte(pte_pa, 2 ^ log_pte_size_bytes) {
     Err(_)  => {
-      ptw_fail_callback(PTW_No_Access(), level, bits_of(pte_addr));
+      ptw_fail_callback(PTW_No_Access(), level, pte_addr[physaddrbits_len - 1 .. 0]);
       Err(PTW_No_Access(), ext_ptw)
     },
     Ok(pte) => {
-      ptw_step_callback(level, bits_of(pte_addr), zero_extend(pte));
+      ptw_step_callback(level, pte_addr[physaddrbits_len - 1 .. 0], zero_extend(pte));
 
       let pte_flags = Mk_PTE_Flags(pte[7 .. 0]);
       let pte_ext   = ext_bits_of_PTE(pte);
 
       if pte_is_invalid(pte_flags, pte_ext) then {
         // Step 3 of VATP.
-        ptw_fail_callback(PTW_Invalid_PTE(), level, bits_of(pte_addr));
+        ptw_fail_callback(PTW_Invalid_PTE(), level, pte_addr[physaddrbits_len - 1 .. 0]);
         Err(PTW_Invalid_PTE(), ext_ptw)
       }
       else {
@@ -124,28 +149,28 @@ function pt_walk(
           // Non-Leaf PTE
           if level > 0 then
             // follow the pointer to walk next level (i.e., go to Step 2)
-            pt_walk(sv_width, vpn, access, priv, mxr, do_sum, ppn, level - 1, global, ext_ptw)
+            pt_walk(sv_width, vpn, access, priv, stage, mxr, do_sum, ppn, level - 1, global, ext_ptw)
           else {
-              // level 0 PTE, but contains a pointer instead of a leaf
-              ptw_fail_callback(PTW_Invalid_PTE(), level, bits_of(pte_addr));
-              Err(PTW_Invalid_PTE(), ext_ptw)
-            }
+            // level 0 PTE, but contains a pointer instead of a leaf
+            ptw_fail_callback(PTW_Invalid_PTE(), level, pte_addr[physaddrbits_len - 1 .. 0]);
+            Err(PTW_Invalid_PTE(), ext_ptw)
+          }
         } else {
           // Leaf PTE (Step 5 of VATP).
-          let ppn_size_bits = if 'v == 32 then 10 else 9;
+          let ppn_size_bits = if 'v == 32 | 'v == 34 then 10 else 9;
           if level > 0 then {
             // Check for misaligned superpage.
             let low_bits = ppn_size_bits * level;
             if   ppn[low_bits - 1 .. 0] != zeros()
             then {
-              ptw_fail_callback(PTW_Misaligned(), level, bits_of(pte_addr));
+              ptw_fail_callback(PTW_Misaligned(), level, pte_addr[physaddrbits_len - 1 .. 0]);
               return Err(PTW_Misaligned(), ext_ptw);
             };
           };
           // Steps 6, 7 (TODO: shadow stack protection), 8 of VATP.
           match check_PTE_permission(access, priv, mxr, do_sum, pte_flags, pte_ext, ext_ptw) {
             PTE_Check_Failure(ext_ptw, pte_failure) => {
-              ptw_fail_callback(ext_get_ptw_error(pte_failure), level, bits_of(pte_addr));
+              ptw_fail_callback(ext_get_ptw_error(pte_failure), level, pte_addr[physaddrbits_len - 1 .. 0]);
               Err(ext_get_ptw_error(pte_failure), ext_ptw)
             },
             PTE_Check_Success(ext_ptw) => {
@@ -159,7 +184,7 @@ function pt_walk(
               };
               ptw_success_callback(zero_extend(ppn), level);
 
-              Ok(struct {ppn=ppn, pte=pte, pteAddr=pte_addr, level=level, global=global}, ext_ptw)
+              Ok(struct {ppn=ppn, pte=pte, pteAddr=Physaddr(pte_addr[physaddrbits_len - 1 .. 0]), level=level, global=global}, ext_ptw)
             }
           }
         }
@@ -168,67 +193,103 @@ function pt_walk(
   }
 }
 
-termination_measure pt_walk(_,_,_,_,_,_,_,level,_, _) = level
+termination_measure pt_walk(_,_,_,_,_,_,_,_,level,_,_) = level
 
 // ****************************************************************
-// Architectural SATP CSR
+// Architectural SATP/HGATP CSR
 
 register satp : xlenbits
 mapping clause csr_name_map = 0x180  <-> "satp"
 function clause is_CSR_accessible(0x180, priv, _) = currentlyEnabled(Ext_S) & not(priv == Supervisor & mstatus[TVM] == 0b1)
 function clause read_CSR(0x180) = satp
 function clause write_CSR(0x180, value) = { satp = legalize_satp(architecture(Supervisor), satp, value); Ok(satp) }
+function clause write_CSR(0x180, value) =
+  if privLevel_is_virtual(cur_privilege) then {
+    vsatp = legalize_satp(architecture(VirtualSupervisor), vsatp, value); Ok(vsatp)
+  } else {
+    satp = legalize_satp(architecture(Supervisor), satp, value); Ok(satp)
+  }
+
+register hgatp : xlenbits
+mapping clause csr_name_map = 0x680  <-> "hgatp"
+function clause is_CSR_accessible(0x680, _, _) = currentlyEnabled(Ext_H)
+function clause read_CSR(0x680) = hgatp
+function clause write_CSR(0x680, value) = { hgatp = legalize_hgatp(architecture(VirtualSupervisor), hgatp, value); Ok(hgatp) }
 
 // ----------------
-// Fields of SATP
+// Fields of SATP/HGATP
 
 // ASID is 9b in Sv32, 16b in Sv39/Sv48/Sv57
-private val satp_to_asid : forall 'n, 'n in {32, 64}. bits('n) -> bits(if 'n == 32 then 9 else 16)
-function satp_to_asid(satp_val) =
+private function xsatp_to_asid forall 'n, 'n in {32, 64} . (satp_val : bits('n)) -> bits(if 'n == 32 then 9 else 16) =
   if 'n == 32 then Mk_Satp32(satp_val)[Asid] else Mk_Satp64(satp_val)[Asid]
 
-private val satp_to_ppn : forall 'n, 'n in {32, 64}. bits('n) -> bits(if 'n == 32 then 22 else 44)
-function satp_to_ppn(satp_val) =
+private function vsatp_to_asid forall 'n, 'n in {32, 64} . (vsatp_val : bits('n)) -> bits(if 'n == 32 then 9 else 16) =
+  if 'n == 32 then Mk_Satp32(vsatp_val)[Asid] else Mk_Satp64(vsatp_val)[Asid]
+
+private function hgatp_to_mode forall 'n, 'n in {32, 64} . (satp_val : bits('n)) -> bits(if 'n == 32 then 1 else 4) =
+  if 'n == 32 then Mk_Hgatp32(satp_val)[Mode] else Mk_Hgatp64(satp_val)[Mode]
+
+// VMID is 7b in Sv32x4, 14b in Sv39x4/Sv48x4/Sv57x4: we use 14b for both
+private function hgatp_to_vmid forall 'n, 'n in {32, 64}. (hgatp_val : bits('n)) -> bits(if 'n == 32 then 7 else 14) = {
+   if 'n == 32 then Mk_Hgatp32(hgatp_val)[Vmid] else Mk_Hgatp64(hgatp_val)[Vmid]
+}
+
+private function satp_to_ppn forall 'n, 'n in {32, 64} . (satp_val : bits('n)) -> bits(if 'n == 32 then 22 else 44) =
   if 'n == 32 then Mk_Satp32(satp_val)[PPN] else Mk_Satp64(satp_val)[PPN]
 
-// Compute address translation mode from SATP register
-private function translationMode(priv : Privilege) -> SATPMode = {
-  if priv == Machine then Bare
-  else {
-    let arch = architecture(Supervisor);
-    let mbits : satp_mode = match arch {
-      RV64 => {
-        // Can't have an effective architecture of RV64 on RV32.
-        assert(xlen >= 64);
-        Mk_Satp64(satp)[Mode]
-      },
-      RV32 => 0b000 @ Mk_Satp32(satp[31..0])[Mode],
-      RV128 => internal_error(__FILE__, __LINE__, "RV128 not supported"),
+private function vsatp_to_ppn forall 'n, 'n in {32, 64} . (vsatp_val : bits('n)) -> bits(if 'n == 32 then 22 else 44) =
+  if 'n == 32 then Mk_Satp32(vsatp_val)[PPN] else Mk_Satp64(vsatp_val)[PPN]
+
+// Result is 64b to cover both RV32 and RV64 addresses
+private function hgatp_to_ppn forall 'n, 'n in {32, 64}. (hgatp_val : bits('n)) -> bits(if 'n == 32 then 22 else 44) =
+  if 'n == 32 then Mk_Hgatp32(hgatp_val)[PPN] else Mk_Hgatp64(hgatp_val)[PPN]
+
+// ****************************************************************
+// Applicable address translation mode
+
+// Compute address translation mode from SATP/HGATP register
+private function translationMode(priv : Privilege, stage : AddressTranslationStage) -> XATPMode = {
+  // For S- & G-stage, translation mode is based on mstatus.SXL
+  // For VS-stage, translation mode is based on hstatus.VSXL
+  let arch : Architecture = match stage {
+    Stage_VS => architecture(VirtualSupervisor),
+    _        => architecture(Supervisor),
+  };
+
+  let mode =
+    if priv == Machine then
+      Some(Bare)
+    else match (stage, arch, xlen) {
+      (Stage_S,  RV32,  _) => satpMode_of_bits(RV32, zero_extend(Mk_Satp32(satp[31 .. 0])[Mode])),
+      (Stage_S,  RV64, 64) => satpMode_of_bits(RV64, Mk_Satp64(satp)[Mode]),
+      (Stage_VS, RV32,  _) => satpMode_of_bits(RV32, zero_extend(Mk_Satp32(vsatp[31 .. 0])[Mode])),
+      (Stage_VS, RV64, 64) => satpMode_of_bits(RV64, Mk_Satp64(vsatp)[Mode]),
+
+      (Stage_G,  RV32,  _) => hgatp64Mode_of_bits(RV32, zero_extend(Mk_Hgatp32(hgatp[31 .. 0])[Mode])),
+      (Stage_G,  RV64, 64) => hgatp64Mode_of_bits(RV64, Mk_Hgatp64(hgatp)[Mode]),
+
+      _                    => internal_error(__FILE__, __LINE__, "unsupported address translation arch")
     };
-    match satpMode_of_bits(arch, mbits) {
+
+  match mode {
       Some(m) => m,
-      // The model does not support modifying SXL currently so this cannot happen.
-      None()  => internal_error(__FILE__, __LINE__, "invalid translation mode in satp")
-    }
+      None()  => internal_error(__FILE__, __LINE__, "invalid translation mode in xatp")
   }
 }
 
 // ****************************************************************
 // VA to PA translation
 
-// Result of address translation
-
-type TR_Result('paddr : Type, 'failure : Type) = result(('paddr, ext_ptw), ('failure, ext_ptw))
-
+// Translate on TLB hit, and maintenance of PTE in TLB
 // This function can be ignored on first reading since TLBs are not
 // part of RISC-V architecture spec (see TLB NOTE above).
-// Translate on TLB hit, and maintenance of PTE in TLB
-private function translate_TLB_hit forall 'v, is_sv_mode('v) . (
+private function translate_TLB_hit forall 'v, is_xv_mode('v) . (
   sv_width  : int('v),
-  _asid     : asidbits,
+  _asid     : xxidbits,
   vpn       : vpn_bits('v),
   access    : MemoryAccessType(mem_payload),
   priv      : Privilege,
+  stage     : AddressTranslationStage,
   mxr       : bool,
   do_sum    : bool,
   ext_ptw   : ext_ptw,
@@ -236,7 +297,7 @@ private function translate_TLB_hit forall 'v, is_sv_mode('v) . (
   ent       : TLB_Entry,
 ) -> TR_Result(ppn_bits('v), PTW_Error) = {
 
-  let pte_size  = if sv_width == 32 then 4 else 8;
+  let pte_size  = if sv_width == 32 | sv_width == 34 then 4 else 8;
   let pte       = tlb_get_pte(pte_size, ent);  // Step 2 of VATP.
   let ext_pte   = ext_bits_of_PTE(pte);
   let pte_flags = Mk_PTE_Flags(pte[7 .. 0]);
@@ -256,8 +317,12 @@ private function translate_TLB_hit forall 'v, is_sv_mode('v) . (
             Err(PTW_PTE_Needs_Update(), ext_ptw)
           else {
             // Writeback the PTE (which has new A/D bits)
-            write_TLB(tlb_index, tlb_set_pte(ent, pte'));
-            match write_pte(ent.pteAddr, pte_size, pte') {
+            write_TLB(tlb_index, tlb_set_pte(ent, pte'), stage);
+            let pte_pa : physaddr = match translate_PTE_addr(sv_width, stage, Store(Data), bits_of(ent.pteAddr)[(if 'v == 32 | 'v == 34 then 34 else 56) - 1 .. 0], ext_ptw) {
+              Ok(pa, _) => pa,
+              Err(e) => return Err(e),
+            };
+            match write_pte(pte_pa, pte_size, pte') {
               Ok(_)  => (),
               Err(_) => internal_error(__FILE__, __LINE__,
                                        "invalid physical address in TLB")
@@ -269,83 +334,86 @@ private function translate_TLB_hit forall 'v, is_sv_mode('v) . (
 }
 
 // Translate on TLB miss (do a page-table walk)
-private function translate_TLB_miss forall 'v, is_sv_mode('v) . (
+private function translate_TLB_miss forall 'v, is_xv_mode('v) . (
   sv_width : int('v),
-  asid     : asidbits,
+  asid     : xxidbits,
   base_ppn : ppn_bits('v),
   vpn      : vpn_bits('v),
   access   : MemoryAccessType(mem_payload),
   priv     : Privilege,
+  stage    : AddressTranslationStage,
   mxr      : bool,
   do_sum   : bool,
   ext_ptw  : ext_ptw,
 ) -> TR_Result(ppn_bits('v), PTW_Error) = {
-  let initial_level = if 'v == 32 then 1 else (if 'v == 39 then 2 else (if 'v == 48 then 3 else 4));
-
+  let initial_level = if 'v == 32 | 'v == 34 then 1 else (if 'v == 39 | 'v == 41 then 2 else (if 'v == 48 | 'v == 50 then 3 else 4));
   // Step 2 of VATP occurs in pt_walk().
-  let 'pte_size = if sv_width == 32 then 4 else 8;
-  let ptw_result = pt_walk(sv_width, vpn, access, priv, mxr, do_sum,
+  let 'pte_size = if sv_width == 32 | sv_width == 34 then 4 else 8;
+  let ptw_result = pt_walk(sv_width, vpn, access, priv, stage, mxr, do_sum,
                            base_ppn, initial_level, false, ext_ptw);
   match ptw_result {
-    Err(f, ext_ptw) => Err(f, ext_ptw),
+    Err(f, ext_ptw) => {
+      Err(f, ext_ptw)
+    },
     Ok(struct {ppn, pte, pteAddr, level, global}, ext_ptw) => {
       let ext_pte = ext_bits_of_PTE(pte);
       // Without TLBs, this 'match' expression can be replaced simply
       // by: 'Ok(ppn, ext_ptw)'    (see TLB NOTE above)
       match update_PTE_Bits(pte, access) {
         None() => {
-          add_to_TLB(sv_width, asid, vpn, ppn, pte, pteAddr, level, global);
+          add_to_TLB(sv_width, asid, stage, vpn, ppn, pte, pteAddr, level, global);
           Ok(ppn, ext_ptw)
         },
-        Some(pte) =>
+        Some(pte) => {
           // Step 9 of VATP. See platform.sail.
           if not(plat_enable_dirty_update) then
             // pte needs dirty/accessed update but that is not enabled
             Err(PTW_PTE_Needs_Update(), ext_ptw)
           else {
+            let pte_pa : physaddr = match translate_PTE_addr(sv_width, stage, Store(Data), bits_of(pteAddr)[(if 'v == 32 | 'v == 34 then 34 else 56) - 1 .. 0], ext_ptw) {
+              Ok(pa, _) => pa,
+              Err(e) => return Err(e),
+            };
             // Writeback the PTE (which has new A/D bits)
-            match write_pte(pteAddr, pte_size, pte) {
+            match write_pte(pte_pa, pte_size, pte) {
               Ok(_) => {
-                add_to_TLB(sv_width, asid, vpn, ppn, pte, pteAddr, level, global);
+                add_to_TLB(sv_width, asid, stage, vpn, ppn, pte, pteAddr, level, global);
                 Ok(ppn, ext_ptw)
               },
-              Err(_) =>
-                Err(PTW_No_Access(), ext_ptw)
+              Err(e) => Err(PTW_No_Access(), ext_ptw)
             }
           }
         }
       }
     }
+  }
 }
 
 // Mapping the SATPMode to the width integer. Note there is also SvBare
 // and it's an error to call this with SvBare.
-mapping satp_mode_width : SATPMode <-> {32, 39, 48, 57} = {
-  Sv32 <-> 32,
-  Sv39 <-> 39,
-  Sv48 <-> 48,
-  Sv57 <-> 57,
+mapping satp_mode_width : XATPMode <-> {32, 39, 48, 57} = {
+  Sv32   <-> 32,
+  Sv39   <-> 39,
+  Sv48   <-> 48,
+  Sv57   <-> 57,
 }
 
-private function translate forall 'v, is_sv_mode('v) . (
-  sv_width : int('v),
-  asid     : asidbits,
-  base_ppn : ppn_bits('v),
-  vpn      : vpn_bits('v),
-  access   : MemoryAccessType(mem_payload),
-  priv     : Privilege,
-  mxr      : bool,
-  do_sum   : bool,
-  ext_ptw  : ext_ptw,
-) -> TR_Result(ppn_bits('v), PTW_Error) = {
-  // On first reading, assume lookup_TLB returns None(), since TLBs
-  // are not part of RISC-V archticture spec (see TLB NOTE above)
-  match lookup_TLB(sv_width, asid, vpn) {
-    Some(index, ent) => translate_TLB_hit(sv_width, asid, vpn, access, priv,
-                                          mxr, do_sum, ext_ptw, index, ent),
-    None()           => translate_TLB_miss(sv_width, asid, base_ppn, vpn, access, priv,
-                                           mxr, do_sum, ext_ptw),
-  }
+mapping hgatp_mode_width : XATPMode <-> {34, 41, 50, 59} = {
+  Sv32x4 <-> 34,
+  Sv39x4 <-> 41,
+  Sv48x4 <-> 50,
+  Sv57x4 <-> 59,
+}
+
+mapping xatp_mode_width : XATPMode <-> {32, 39, 48, 57, 34, 41, 50, 59} = {
+  Sv32   <-> 32,
+  Sv39   <-> 39,
+  Sv48   <-> 48,
+  Sv57   <-> 57,
+  Sv32x4 <-> 34,
+  Sv39x4 <-> 41,
+  Sv48x4 <-> 50,
+  Sv57x4 <-> 59,
 }
 
 // SATP is represented in the model as an XLEN register (xlenbits), but it's
@@ -359,67 +427,242 @@ private function get_satp forall 'v, is_sv_mode('v). (
   if sv_width == 32 then satp[31 .. 0] else satp
 }
 
-// Top-level addr-translation function
-// PUBLIC: invoked from instr-fetch, atomics and CBOs
-// [postlude/fetch.sail, A/zaamo_insts.sail, Zicbo{zm}/zicbo{zm}_insts.sail].
-function translateAddr(
-  vAddr : virtaddr,
-  access : MemoryAccessType(mem_payload),
-) -> TR_Result(physaddr, ExceptionType) = {
-
-  // Effective privilege takes into account mstatus.PRV, mstatus.MPP
-  // See sys_control.sail for effectivePrivilege() and sys_regs.sail for cur_privilege.
-  let effPriv = effectivePrivilege(access, mstatus, cur_privilege);
-
-  let mode = translationMode(effPriv);
-
-  if mode == Bare then return Ok(Physaddr(zero_extend(bits_of(vAddr))), init_ext_ptw);
-
-  // Sv39 -> 39, etc.
-  let sv_width = satp_mode_width(mode);
-
-  // For Sv32 on RV64, satp is 32 bits (SXLEN), not XLEN.
-  let satp_sxlen = get_satp(sv_width);
-
+function get_vsatp forall 'v, is_sv_mode('v). (
+  sv_width : int('v)
+) -> bits(if 'v == 32 then 32 else 64) = {
   // Cannot use Sv39+ on RV32.
-  assert(sv_width == 32 | xlen == 64);
+  assert('v == 32 | xlen == 64);
+  if sv_width == 32 then vsatp[31 .. 0] else vsatp
+}
 
-  let svAddr = bits_of(vAddr)[sv_width - 1 .. 0];
-  if bits_of(vAddr) != sign_extend(svAddr) then {
-    Err(translationException(access, PTW_Invalid_Addr()), init_ext_ptw)
-  } else {
-    let mxr    = mstatus[MXR] == 0b1;
-    let do_sum = mstatus[SUM] == 0b1;
-    let asid   = satp_to_asid(satp_sxlen);
+function get_hgatp forall 'v, is_svx4_mode('v). (
+  sv_width : int('v)
+) -> bits(if 'v == 34 then 32 else 64) = {
+  // Cannot use Sv39x4+ on RV32.
+  assert('v == 34 | xlen == 64);
+  if sv_width == 34 then hgatp[31 .. 0] else hgatp
+}
 
-    // Step 1 of VATP.
-    let base_ppn = satp_to_ppn(satp_sxlen);
-
-    let res = translate(sv_width,
-                        zero_extend(asid),
-                        base_ppn,
-                        svAddr[sv_width - 1 .. pagesize_bits],
-                        access, effPriv, mxr, do_sum,
-                        init_ext_ptw);
-    // Fixup result PA or exception
-    match res {
-      Ok(ppn, ext_ptw) => {
-        // Step 10 of VATP.
-        // Append the page offset. This is now a 34 or 56 bit address.
-        let paddr = ppn @ bits_of(vAddr)[pagesize_bits - 1 .. 0];
-
-        // On RV64 paddr can be 34 or 56 bits, so we zero extend to 64.
-        // On RV32 paddr can only be 34 bits. Sail knows this due to
-        // the assertion above.
-        Ok(Physaddr(zero_extend(paddr)), ext_ptw)
-      },
-      Err(f, ext_ptw)  => Err(translationException(access, f), ext_ptw)
-    }
+private function translate forall 'v, is_xv_mode('v) . (
+  stage    : AddressTranslationStage,
+  sv_width : int('v),
+  asid     : xxidbits,
+  base_ppn : ppn_bits('v),
+  vpn      : vpn_bits('v),
+  access   : MemoryAccessType(mem_payload),
+  priv     : Privilege,
+  mxr      : bool,
+  do_sum   : bool,
+  ext_ptw  : ext_ptw,
+) -> TR_Result(ppn_bits('v), PTW_Error) = {
+  // On first reading, assume lookup_TLB returns None(), since TLBs
+  // are not part of RISC-V archticture spec (see TLB NOTE above)
+  match lookup_TLB(sv_width, asid, vpn, stage) {
+    Some(index, ent) => {
+      translate_TLB_hit(sv_width, asid, vpn, access, priv, stage,
+                                          mxr, do_sum, ext_ptw, index, ent)
+    },
+    None()           => {
+      translate_TLB_miss(sv_width, asid, base_ppn, vpn, access, priv, stage,
+                                           mxr, do_sum, ext_ptw)
+    },
   }
 }
 
+// PRIVATE: perform address translation for a specific stage
+// Note: translate_stage is used for translation of implicit accesses during page walk
+//       => 'val' declaration should occur before 'function' definition of pt_walk,
+//          the 'function' definition of translate_stage is further down in this file
+// Translate VA -> PA (S-stage), VA -> GPA (VS-stage) or GPA -> SPA(G-stage)
+function translate_stage(
+  vAddr    : bits(64),                      // virtual address
+  access   : MemoryAccessType(mem_payload), // Read/Write/ReadWrite/Execute
+  priv     : Privilege,                     // Machine/Supervisor/User
+  stage    : AddressTranslationStage,       // S/VS/G
+  ext_ptw  : ext_ptw,                       // ext_ptw
+) -> TR_Result(physaddr, PTW_Error) = {
+  let mode = translationMode(priv, stage);
+  if mode == Bare then return Ok(Physaddr(vAddr[physaddrbits_len - 1 .. 0]), init_ext_ptw);
+  match stage {
+    Stage_S => {
+      // Sv39 -> 39, etc.
+      let sv_width = satp_mode_width(mode);
+      assert((xlen == 32 & sv_width == 32) | (xlen == 64 & sv_width != 32));
+      let satp_sxlen = get_satp(sv_width);
+      let svAddr = vAddr[sv_width - 1 .. 0];
+      if vAddr != sign_extend(svAddr) then {
+        // translationException(ac, stage, PTW_Invalid_Addr())
+        return Err(PTW_Invalid_Addr(), init_ext_ptw);
+      };
+
+      let mxr    : bool     = mstatus[MXR] == 0b1;
+      let do_sum : bool     = mstatus[SUM] == 0b1;
+      let asid              = xsatp_to_asid(satp);
+
+      // let ptb    : bits(64) = satp_to_PT_base(satp);
+      let satp_sxlen = get_satp(sv_width);
+      let base_ppn = satp_to_ppn(satp_sxlen);
+      let res = translate(Stage_S,
+                          sv_width,
+                          zero_extend(asid),
+                          base_ppn, // ptb
+                          svAddr[sv_width - 1 .. pagesize_bits],
+                          access,
+                          priv,
+                          mxr,
+                          do_sum,
+                          ext_ptw);
+
+      // Fixup result PA or exception
+      match res {
+        Ok(ppn, ext_ptw) => {
+          // Step 10 of VATP.
+          // Append the page offset. This is now a 34 or 56 bit address.
+          let paddr = ppn @ vAddr[pagesize_bits - 1 .. 0];
+
+          // On RV64 paddr can be 34 or 56 bits, so we zero extend to 64.
+          // On RV32 paddr can only be 34 bits. Sail knows this due to
+          // the assertion above.
+          Ok(Physaddr(zero_extend(paddr)), ext_ptw)
+        },
+        Err(f, ext_ptw)  => {
+          Err(f, ext_ptw)
+        }
+      }
+    },
+    Stage_VS => {
+      let sv_width = satp_mode_width(mode);
+      assert((xlen == 32 & sv_width == 32) | (xlen == 64 & sv_width != 32));
+      let vsatp_sxlen = get_vsatp(sv_width);
+      let svAddr = vAddr[sv_width - 1 .. 0];
+      if vAddr != sign_extend(svAddr) then {
+        return Err(PTW_Invalid_Addr(), init_ext_ptw);
+      };
+
+      let mxr    : bool = mstatus[MXR] == 0b1 | vsstatus[MXR] == 0b1; // HS-level MXR overwrites VS-stage page protections
+      let do_sum : bool = vsstatus[SUM] == 0b1;
+      let asid          = vsatp_to_asid(vsatp);
+      let base_ppn      = vsatp_to_ppn(vsatp_sxlen);
+      let res = translate(Stage_VS,
+                          sv_width,
+                          zero_extend(asid),
+                          base_ppn, // ptb
+                          svAddr[sv_width - 1 .. pagesize_bits],
+                          access,
+                          priv,
+                          mxr,
+                          do_sum,
+                          ext_ptw);
+      // Fixup result PA or exception
+      match res {
+        Ok(ppn, ext_ptw) => {
+          // Step 10 of VATP.
+          // Append the page offset. This is now a 34 or 56 bit address.
+          let paddr = ppn @ vAddr[pagesize_bits - 1 .. 0];
+          // On RV64 paddr can be 34 or 56 bits, so we zero extend to 64.
+          // On RV32 paddr can only be 34 bits. Sail knows this due to
+          // the assertion above.
+          Ok(Physaddr(zero_extend(paddr)), ext_ptw)
+        },
+        Err(f, ext_ptw)  => {
+          Err(f, ext_ptw)
+        }
+      }
+    },
+    Stage_G => {
+      let sv_width = hgatp_mode_width(mode);
+      assert((xlen == 32 & sv_width == 34) | (xlen == 64 & sv_width != 34));
+      let hgatp_sxlen = get_hgatp(sv_width);
+      let svAddr = vAddr[sv_width - 1 .. 0];
+      if vAddr != zero_extend(svAddr) then {
+        return Err(PTW_Invalid_Addr(), init_ext_ptw);
+      };
+
+      let mxr    : bool     = mstatus[MXR] == 0b1;
+      let do_sum : bool     = mstatus[SUM] == 0b1;
+      let vmid   : bits(16) = zero_extend(hgatp_to_vmid(hgatp));
+      let ptb               = hgatp_to_ppn(hgatp_sxlen);
+      let res = translate(Stage_G,
+                          sv_width,
+                          vmid,
+                          ptb,
+                          svAddr[sv_width - 1 .. pagesize_bits],
+                          access,
+                          // All G-stage memory accesses are considered User-level
+                          User,
+                          mxr,
+                          do_sum,
+                          ext_ptw);
+      // Fixup result PA or exception
+      match res {
+        Ok(ppn, ext_ptw) => {
+          // Step 10 of VATP.
+          // Append the page offset. This is now a 34 or 56 bit address.
+          let paddr = ppn @ vAddr[pagesize_bits - 1 .. 0];
+
+          // On RV64 paddr can be 34 or 56 bits, so we zero extend to 64.
+          // On RV32 paddr can only be 34 bits. Sail knows this due to
+          // the assertion above.
+          Ok(Physaddr(zero_extend(paddr)), ext_ptw)
+        },
+        Err(f, ext_ptw)  => {
+          Err(f, ext_ptw)
+        }
+      }
+    },
+  }
+}
+
+
+// Addr-translation function for specific privilege & virtualization mode
+// Invoked from HLV, HSV and HLVX
+function translateAddr_pv(
+  vAddr  : virtaddr,
+  access : MemoryAccessType(mem_payload),
+  priv   : Privilege
+) -> TR_Result(physaddr, (ExceptionType, ExceptionContext)) = {
+
+  let start_is_virt = privLevel_is_virtual(priv);
+  let stage = if start_is_virt then {
+    Stage_VS
+  } else {
+    Stage_S
+  };
+  let vAddr = zero_extend(64, bits_of(vAddr));
+
+  let res = translate_stage(vAddr, access, priv, stage, init_ext_ptw);
+
+  if not(start_is_virt) then match res {
+    Ok(pa, ext_ptw) => Ok(pa, ext_ptw),
+    Err(e, ext_ptw) => Err((translationException(access, Stage_S, e), translationExcContext(e, vAddr, false)), ext_ptw)
+  } else match res {
+    Ok(gpa, ext_ptw) => match translate_stage(zero_extend(bits_of(gpa)), access, priv, Stage_G, ext_ptw) {
+      Ok(spa, ext_ptw) => Ok(spa, ext_ptw),
+      Err(e, ext_ptw) => Err(
+        (translationException(access, Stage_G, e),
+          { translationExcContext(e, vAddr, true) with excinfo2 = Some(zero_extend(bits_of(gpa)[physaddrbits_len - 1 .. 2])) }
+        ),
+        ext_ptw
+      ),
+    },
+    Err(e, ext_ptw) => Err((translationException(access, Stage_VS, e), translationExcContext(e, vAddr, true)), ext_ptw),
+  }
+}
+
+// Top-level addr-translation function
+// Invoked from instr-fetch and load/store/amo
+function translateAddr(
+  vAddr  : virtaddr,
+  access : MemoryAccessType(mem_payload),
+) -> TR_Result(physaddr, (ExceptionType, ExceptionContext)) = {
+
+  // Effective privilege takes into account mstatus.PRV, mstatus.MPP
+  // See sys_regs.sail for effectivePrivilege() and cur_privilege
+  let effPriv = effectivePrivilege(access, mstatus, cur_privilege);
+  translateAddr_pv(vAddr, access, effPriv)
+}
+
 // ****************************************************************
-// Initialize Virtual Memory state
 
 // PUBLIC: invoked from reset() [postlude/model.sail]
 function reset_vmem() -> unit = reset_TLB()

--- a/model/sys/vmem_pte.sail
+++ b/model/sys/vmem_pte.sail
@@ -137,8 +137,8 @@ private function check_PTE_permission(
     // loads and stores; not instruction fetch.
     Supervisor => not(pte_U) | (do_sum & is_load_store(access)),
     Machine    => internal_error(__FILE__, __LINE__, "m-mode mem perm check"),
-    VirtualUser => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualUser => pte_U,
+    VirtualSupervisor => not(pte_U) | (do_sum & is_load_store(access)),
   };
   if not(priv_ok) then return PTE_Check_Failure((), PTE_No_Permission());
 

--- a/model/sys/vmem_ptw.sail
+++ b/model/sys/vmem_ptw.sail
@@ -13,6 +13,16 @@
 // See types_ext.sail for definitions.
 
 // Failure modes for address-translation/page-table-walks
+// Note: Ideally we could use 'PTW_Implicit : (PTW_Error, ...)' in 'PTW_Error' but recursive types are not supported by sail
+private union PTW_Implicit_Error = {
+  PTW_I_Invalid_Addr  : unit,         // invalid source address
+  PTW_I_No_Access     : unit,         // physical memory access error for a PTE
+  PTW_I_Invalid_PTE   : unit,         // invalid page table entry or ptr PTE when level = 0
+  PTW_I_No_Permission : unit,         // insufficient page permissions
+  PTW_I_Misaligned    : unit,         // misaligned superpage
+  PTW_I_PTE_Update    : unit,         // PTE update needed but not enabled
+  PTW_I_Ext_Error     : ext_ptw_error // parameterized for errors from extensions
+}
 private union PTW_Error = {
   PTW_Invalid_Addr     : unit,          // invalid source address
   PTW_No_Access        : unit,          // physical memory access error for a PTE
@@ -20,7 +30,25 @@ private union PTW_Error = {
   PTW_No_Permission    : unit,
   PTW_Misaligned       : unit,          // misaligned superpage
   PTW_PTE_Needs_Update : unit,          // PTE update needed but not enabled
-  PTW_Ext_Error        : ext_ptw_error  // parameterized for errors from extensions
+  PTW_Ext_Error        : ext_ptw_error, // parameterized for errors from extensions
+
+  PTW_Implicit         : (PTW_Implicit_Error,                 // error during implicit access/page-walk
+                          bits(64),                           // faulting address of implicit access/page-walk
+                          MemoryAccessType(mem_payload)), // access type of implicit
+}
+
+// Convert PTW_Error to PTW_Implicit_Error
+function ptw_implicit_error(e : PTW_Error) -> PTW_Implicit_Error = {
+  match e {
+    PTW_Invalid_Addr()     => PTW_I_Invalid_Addr(),
+    PTW_No_Access()        => PTW_I_No_Access(),
+    PTW_Invalid_PTE()      => PTW_I_Invalid_PTE(),
+    PTW_No_Permission()    => PTW_I_No_Permission(),
+    PTW_Misaligned()       => PTW_I_Misaligned(),
+    PTW_PTE_Needs_Update() => PTW_I_PTE_Update(),
+    PTW_Ext_Error()        => PTW_I_Ext_Error(),
+    PTW_Implicit(_, _, _)  => internal_error(__FILE__, __LINE__, "cannot convert implicit PTW error")
+  }
 }
 
 private function ptw_error_to_str(e : PTW_Error) -> string = {
@@ -31,7 +59,8 @@ private function ptw_error_to_str(e : PTW_Error) -> string = {
     PTW_No_Permission()    => "no-permission",
     PTW_Misaligned()       => "misaligned-superpage",
     PTW_PTE_Needs_Update() => "pte-update-needed",
-    PTW_Ext_Error(_)       => "extension-error"
+    PTW_Ext_Error(_)       => "extension-error",
+    PTW_Implicit(_, _, _)  => "implicit-access-error",
   }
 }
 
@@ -48,42 +77,111 @@ private function ext_get_ptw_error(failure : pte_check_failure) -> PTW_Error =
     // TODO: Zicfiss will map PTE_No_Access to PTW_Access
   }
 
-// Convert translation/PTW failures into architectural exceptions
-function translationException(access : MemoryAccessType(mem_payload),
-                              err : PTW_Error)
-                             -> ExceptionType = {
-  match (access, err) {
-    (_, PTW_Ext_Error(e))                        => E_Extension(ext_translate_exception(e)),
-    (Atomic(_), PTW_No_Access())                 => E_SAMO_Access_Fault(),
-    (Atomic(_), _)                               => E_SAMO_Page_Fault(),
-    (Load(_), PTW_No_Access())                   => E_Load_Access_Fault(),
-    (Load(_), _)                                 => E_Load_Page_Fault(),
-    (LoadReserved(_), PTW_No_Access())           => E_Load_Access_Fault(),
-    (LoadReserved(_), _)                         => E_Load_Page_Fault(),
-    (Store(_), PTW_No_Access())                  => E_SAMO_Access_Fault(),
-    (Store(_), _)                                => E_SAMO_Page_Fault(),
-    (StoreConditional(_), PTW_No_Access())       => E_SAMO_Access_Fault(),
-    (StoreConditional(_), _)                     => E_SAMO_Page_Fault(),
-    (InstructionFetch(), PTW_No_Access())        => E_Fetch_Access_Fault(),
-    (InstructionFetch(), _)                      => E_Fetch_Page_Fault(),
+function is_load forall ('a : Type) . (access : MemoryAccessType('a)) -> bool =
+  match access {
+    Load(_)             => true,
+    LoadReserved(_)     => true,
+    StoreConditional(_) => true,
+    Atomic(_)           => true,
+    InstructionFetch(_) => false,
+    CacheAccess(_)      => true,
+  }
 
-    (CacheAccess(CB_manage(_)), PTW_No_Access()) => E_SAMO_Access_Fault(),
-    (CacheAccess(CB_manage(_)), _)               => E_SAMO_Page_Fault(),
-    (CacheAccess(CB_zero()), PTW_No_Access())    => E_SAMO_Access_Fault(),
-    (CacheAccess(CB_zero()), _)                  => E_SAMO_Page_Fault(),
-    // Though prefetches don't raise exceptions, we return a nominal
-    // exception here to propagate the failed address translation to
-    // the execute of the calling instruction so that it can decide
-    // whether to actually proceed with a prefetch.
-    (CacheAccess(CB_prefetch(p)), PTW_No_Access()) => match p {
-      PREFETCH_R => E_Load_Access_Fault(),
-      PREFETCH_W => E_SAMO_Access_Fault(),
-      PREFETCH_I => E_Fetch_Access_Fault(),
+// // Some useful predicates on the kind of memory access
+// function is_load_store forall ('a : Type) . (access : MemoryAccessType('a)) -> bool =
+//   match access {
+//     Load(_)             => true,
+//     Store(_)            => true,
+//     LoadReserved(_)     => true,
+//     StoreConditional(_) => true,
+//     Atomic(_)           => true,
+//     InstructionFetch(_) => false,
+//     CacheAccess(_)      => true,
+//   }
+
+// function is_prefetch_access forall ('a : Type) . (access : MemoryAccessType('a)) -> bool =
+//   match access {
+//     CacheAccess(CB_prefetch(_)) => true,
+//     _ => false,
+//   }
+
+
+function translationPTEErrorToExceptionTypeToPage(
+  t : AccessExceptionType,
+  e : PTW_Error,
+) -> ExceptionType = {
+  match e {
+    PTW_No_Access() => E_Access_Fault_of_AccessException(t),
+    _                 => E_Page_Fault_of_AccessException(t),
+  }
+}
+
+function translationToExceptionTypeToPage(
+  t : AccessExceptionType,
+  e : PTW_Implicit_Error,
+) -> ExceptionType = {
+  match e {
+    PTW_I_No_Access() => E_Access_Fault_of_AccessException(t),
+    _                 => E_GPage_Fault_of_AccessException(t),
+  }
+}
+
+// Convert translation/PTW failures into architectural exceptions
+function translationException(
+  access : MemoryAccessType(mem_payload),
+  stage  : AddressTranslationStage,
+  err    : PTW_Error
+) -> ExceptionType = {
+  let et : ExceptionType = match (access, err) {
+    (_, PTW_Ext_Error(e))       => E_Extension(ext_translate_exception(e)),
+    (_, PTW_Implicit(ei, _, _)) => match (access, ei) { // Report exception for the original access type (of explicit page-walk)
+      (_, PTW_I_Ext_Error(e))                  => E_Extension(ext_translate_exception(e)),
+      (t, e) => translationToExceptionTypeToPage(AccessType_to_AccessException(t), e)
     },
-    (CacheAccess(CB_prefetch(p)), _) => match p {
-      PREFETCH_R => E_Load_Page_Fault(),
-      PREFETCH_W => E_SAMO_Page_Fault(),
-      PREFETCH_I => E_Fetch_Page_Fault(),
+    (t, e) => translationPTEErrorToExceptionTypeToPage(AccessType_to_AccessException(t), e)
+  };
+
+  // Convert exceptions resulting from G-stage page walks to the correct architectural exception:
+  //   - Guest-page-fault exceptions are raised instead of regular page-walk exceptions
+  //   - Any exception is always reported for the original access type
+  if stage == Stage_G then
+    match exceptionType_update_AccessType(et, access) {
+      E_Fetch_Page_Fault() => E_Fetch_GPage_Fault(),
+      E_Load_Page_Fault()  => E_Load_GPage_Fault(),
+      E_SAMO_Page_Fault()  => E_SAMO_GPage_Fault(),
+
+      // Other exceptions should not be converted
+      _ => et
+    }
+  else et
+}
+
+// Build a pseudoinstruction encoding for a given access type and architecture
+private function pseudoinst(ac : MemoryAccessType(mem_payload), arch : Architecture) -> bits(32) = {
+  match (arch, ac) {
+    (RV32, Load(_))  => 0x00002000,
+    (RV32, Store(_)) => 0x00002020,
+    (RV64, Load(_))  => 0x00003000,
+    (RV64, Store(_)) => 0x00003020,
+    (_, _) => internal_error(__FILE__, __LINE__, "Illegal pseudoinst architecture/access type")
+  }
+}
+
+// Build architectural exception context for translation/PTW failures
+private function translationExcContext(e     : PTW_Error,
+                               vaddr : bits(64),
+                               gva   : bool)
+                               -> ExceptionContext = {
+  match e {
+    PTW_Ext_Error(e)            => ext_exception_context(e),
+    PTW_Implicit(e, gpaddr, ac) => {
+      let pinst : option(xlenbits) = match e {
+        PTW_I_No_Access()  => None(),
+        PTW_I_Ext_Error(_) => None(),
+        _                  => Some(zero_extend(pseudoinst(ac, architecture(cur_privilege)))),
+      };
+      vmem_exception_context(truncate(vaddr, xlen), true, Some(truncate(gpaddr >> 2, xlen)), pinst)
     },
+    _ => vmem_exception_context(truncate(vaddr, xlen), gva, None(), None()),
   }
 }

--- a/model/sys/vmem_tlb.sail
+++ b/model/sys/vmem_tlb.sail
@@ -14,15 +14,15 @@
 
 // Maximum number of Virtual/Physical Page Number bits. The same TLB
 // is used for all VM modes so these are the values for Sv57.
-type tlb_vpn_bits : Int = 57 - pagesize_bits
+type tlb_vpn_bits : Int = 59 - pagesize_bits
 let  tlb_vpn_bits = sizeof(tlb_vpn_bits)
 type tlb_ppn_bits : Int = 44
 let  tlb_ppn_bits = sizeof(tlb_ppn_bits)
 
 // We use a single TLB for all virtual memory modes, so it can store up to
 // Sv57-sized entries.
-private struct TLB_Entry = {
-  asid       : asidbits,           // address-space id
+struct TLB_Entry = {
+  asid       : xxidbits,           // address-space id
   global     : bool,               // global translation
   vpn        : bits(tlb_vpn_bits), // Virtual Page Number. SvXX - 12 bits.
   levelMask  : bits(tlb_vpn_bits), // Mask for superpages. The lowest (level * level_bits) bits are 1s.
@@ -43,7 +43,7 @@ function tlb_set_pte forall 'n, 'n in {4, 8}. (
   pte : bits('n * 8),
 ) -> TLB_Entry = { ent with pte=zero_extend(pte) }
 
-function tlb_get_ppn forall 'v, is_sv_mode('v) . (
+function tlb_get_ppn forall 'v, is_xv_mode('v) . (
   sv_width : int('v),
   ent      : TLB_Entry,
   vpn      : vpn_bits('v),
@@ -70,33 +70,44 @@ let  num_tlb_entries_exp = sizeof(num_tlb_entries_exp)
 type num_tlb_entries : Int = 2 ^ num_tlb_entries_exp
 type tlb_index_range = range(0, num_tlb_entries - 1)
 
-private register tlb : vector(num_tlb_entries, option(TLB_Entry)) = vector_init(None())
+// PRIVATE
+register tlb_S  : vector(num_tlb_entries, option(TLB_Entry)) = vector_init(None())
+register tlb_VS : vector(num_tlb_entries, option(TLB_Entry)) = vector_init(None())
+register tlb_G  : vector(num_tlb_entries, option(TLB_Entry)) = vector_init(None())
 
 // Indexed by the lowest bits of the VPN.
-function tlb_hash forall 'v, is_sv_mode('v) . (
+function tlb_hash forall 'v, is_xv_mode('v) . (
   _sv_mode : int('v),
-  vpn     : vpn_bits('v),
+  vpn      : vpn_bits('v),
 ) -> tlb_index_range =
   unsigned(vpn[num_tlb_entries_exp - 1 .. 0])
 
 // PUBLIC: invoked in reset_vmem() [vmem.sail]
-function reset_TLB() -> unit = tlb = vector_init(None())
+function reset_TLB() -> unit = {
+  tlb_S  = vector_init(None());
+  tlb_VS = vector_init(None());
+  tlb_G  = vector_init(None());
+}
 
 // PUBLIC: invoked in translate_TLB_hit() [vmem.sail]
-function write_TLB(index : tlb_index_range, entry : TLB_Entry) -> unit =
-  tlb[index] = Some(entry)
+function write_TLB(index : tlb_index_range, entry : TLB_Entry, stage : AddressTranslationStage) -> unit =
+   match stage {
+    Stage_S  => tlb_S[index]  = Some(entry),
+    Stage_G  => tlb_G[index]  = Some(entry),
+    Stage_VS => tlb_VS[index] = Some(entry),
+  }
 
 private function match_TLB_Entry(
   ent  : TLB_Entry,
-  asid : asidbits,
+  asid : xxidbits,
   vpn  : bits(tlb_vpn_bits),
 ) -> bool =
   (ent.global | (ent.asid == asid)) & (ent.vpn == (vpn & ~(ent.levelMask)))
 
 private function flush_TLB_Entry(
   ent   : TLB_Entry,
-  asid  : option(asidbits),
-  vaddr : option(xlenbits),
+  asid  : option(xxidbits),
+  vaddr : option(bits(64))
 ) -> bool = {
   let asid_matches : bool = match asid {
     Some(asid) => ent.asid == asid & not(ent.global),
@@ -105,7 +116,7 @@ private function flush_TLB_Entry(
   let addr_matches : bool = match vaddr {
     Some(vaddr) => {
       let vaddr : bits(64) = sign_extend(vaddr);
-      ent.vpn == (vaddr[56 .. pagesize_bits] & ~(ent.levelMask))
+      ent.vpn == (vaddr[58 .. pagesize_bits] & ~(ent.levelMask))
     },
     None() => true,
   };
@@ -113,13 +124,19 @@ private function flush_TLB_Entry(
 }
 
 // PUBLIC: invoked in translate() [vmem.sail]
-function lookup_TLB forall 'v, is_sv_mode('v) . (
+function lookup_TLB forall 'v, is_xv_mode('v) . (
   sv_width : int('v),
-  asid     : asidbits,
+  asid     : xxidbits,
   vpn      : vpn_bits('v),
+  stage : AddressTranslationStage,
 ) -> option((tlb_index_range, TLB_Entry)) = {
   let index = tlb_hash('v, vpn);
-  match tlb[index] {
+  let tlb_slot : option(TLB_Entry) = match stage {
+    Stage_S  => tlb_S[index],
+    Stage_G  => tlb_G[index],
+    Stage_VS => tlb_VS[index],
+  };
+  match tlb_slot {
     None() => None(),
     Some(entry) => {
       if match_TLB_Entry(entry, asid, sign_extend(vpn)) then Some((index, entry)) else None()
@@ -128,9 +145,10 @@ function lookup_TLB forall 'v, is_sv_mode('v) . (
 }
 
 // PUBLIC: invoked in translate_TLB_miss() [vmem.sail]
-function add_to_TLB forall 'v, is_sv_mode('v) . (
+function add_to_TLB forall 'v, is_xv_mode('v) . (
   sv_width : int('v),
-  asid     : asidbits,
+  asid     : xxidbits,
+  stage    : AddressTranslationStage,
   vpn      : vpn_bits('v),
   ppn      : ppn_bits('v),
   pte      : pte_bits('v),
@@ -138,7 +156,7 @@ function add_to_TLB forall 'v, is_sv_mode('v) . (
   level    : level_range('v),
   global   : bool,
 ) -> unit = {
-  let shift = level * (if 'v == 32 then 10 else 9);
+  let shift = level * (if 'v == 32 | 'v == 34 then 10 else 9);
   let levelMask = ones(shift);
   // Clear bits below the level.
   let vpn = vpn & ~(zero_extend(levelMask));
@@ -157,17 +175,43 @@ function add_to_TLB forall 'v, is_sv_mode('v) . (
   // lookup_TLB looks it up. For superpages will just end up with the same
   // TLB entry in multiple slots.
   let index = tlb_hash('v, vpn);
-  tlb[index] = Some(entry);
+  match stage {
+    Stage_S  => tlb_S[index]  = Some(entry),
+    Stage_VS => tlb_VS[index] = Some(entry),
+    Stage_G  => tlb_G[index]  = Some(entry),
+  };
 }
 
 // Top-level TLB flush function
 // PUBLIC: invoked from SFENCE_VMA [extensions/I/insts_base.sail]
-function flush_TLB(asid : option(asidbits),
-                   addr : option(xlenbits)) -> unit = {
-  foreach (i from 0 to (length(tlb) - 1)) {
-    match tlb[i] {
-      None()  => (),
-      Some(entry) => if flush_TLB_Entry(entry, asid, addr) then { tlb[i] = None(); },
-    }
+function flush_TLB(
+  xxid : option(xxidbits),
+  stage : AddressTranslationStage,
+  addr : option(xlenbits)
+) -> unit = {
+  let addr_64b : option(bits(64)) =
+    match addr {
+      None()  => None(),
+      Some(a) => Some(zero_extend(a))
+    };
+  match stage {
+    Stage_S  => foreach (i from 0 to (length(tlb_S) - 1)) {
+                  match tlb_S[i] {
+                    Some(e) => if flush_TLB_Entry(e, xxid, addr_64b) then { tlb_S[i] = None(); },
+                    None()  => (),
+                  }
+                },
+    Stage_VS => foreach (i from 0 to (length(tlb_VS) - 1)) {
+                  match tlb_VS[i] {
+                    Some(e) => if flush_TLB_Entry(e, xxid, addr_64b) then { tlb_VS[i] = None(); },
+                    None()  => (),
+                  }
+                },
+    Stage_G  => foreach (i from 0 to (length(tlb_G) - 1)) {
+                  match tlb_G[i] {
+                    Some(e) => if flush_TLB_Entry(e, xxid, addr_64b) then { tlb_G[i] = None(); },
+                    None()  => (),
+                  }
+                }
   }
 }

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -126,10 +126,10 @@ function vmem_read_addr(vaddr, offset, width, access, aq, rl, res) = {
     // "LR faults like a normal load, even though it's in the AMO major opcode space."
     // - Andrew Waterman, isa-dev, 10 Jul 2018.
     if   not(is_aligned_addr(vaddr, width))
-    then return Err(Memory_Exception(vaddr, E_Load_Addr_Align()));
+    then return Err(memory_exception_with_gva(E_Load_Addr_Align(), vaddr));
   } else {
     if check_misaligned(vaddr, width)
-    then return Err(Memory_Exception(vaddr, E_Load_Addr_Align()));
+    then return Err(memory_exception_with_gva(E_Load_Addr_Align(), vaddr));
   };
 
   // If the load is misaligned or an allowed misaligned access, split into `n`
@@ -147,10 +147,10 @@ function vmem_read_addr(vaddr, offset, width, access, aq, rl, res) = {
     let offset = i;
     let vaddr = vaddr + (offset * bytes);
     match translateAddr(Virtaddr(vaddr), access) {
-      Err(e, _) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+      Err((e, c), _) => return Err(Memory_Exception(e, c)),
 
       Ok(paddr, _) => match mem_read(access, paddr, bytes, aq, rl, res) {
-        Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+        Err(e) => return Err(memory_exception_with_gva(e, Virtaddr(vaddr))),
 
         Ok(v) => {
           if res then {
@@ -175,14 +175,29 @@ function vmem_read_addr(vaddr, offset, width, access, aq, rl, res) = {
 // This lets the Rocq extraction know why the repeat loop above terminates
 termination_measure vmem_read_addr repeat n
 
+val vmem_read : forall 'width, is_mem_width('width).
+  (regidx, xlenbits, int('width), MemoryAccessType(mem_payload), bool, bool, bool)
+  -> result(bits(8 * 'width), ExecutionResult)
+
+function vmem_read(rs, offset, width, acc, aq, rl, res) = {
+  // Get the address, X(rs1) + offset.
+  // Extensions might perform additional checks on address validity.
+  let vaddr : virtaddr = match ext_data_get_addr(rs, offset, acc, width) {
+    Ext_DataAddr_OK(vaddr) => vaddr,
+    Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
+  };
+
+  vmem_read_addr(vaddr, offset, width, acc, aq, rl, res)
+}
+
+// This lets the Rocq extraction know why the repeat loop above terminates
+termination_measure vmem_write_addr repeat n
+
 val vmem_write_addr : forall 'width, is_mem_width('width).
   (virtaddr, int('width), bits(8 * 'width), MemoryAccessType(mem_payload), bool, bool, bool)
   -> result(bool, ExecutionResult)
 
 function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
-  if   check_misaligned(vaddr, width)
-  then return Err(Memory_Exception(vaddr, E_SAMO_Addr_Align()));
-
   // If the store is misaligned or an allowed misaligned access, split into `n`
   // (single-copy-atomic) memory operations, each of `bytes` width. If the store is
   // aligned, then `n` = 1 and bytes will remain unchanged.
@@ -198,8 +213,7 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
     let offset = i;
     let vaddr = vaddr + (offset * bytes);
     match translateAddr(Virtaddr(vaddr), access) {
-      Err(e, _) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
-
+      Err((e, c), _) => return Err(Memory_Exception(e, c)),
       // NOTE: Currently, we only announce the effective address if address translation is successful.
       // This may need revisiting, particularly in the misaligned case.
       Ok(paddr, _) => {
@@ -207,12 +221,12 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
         if res & not(match_reservation(bits_of(paddr))) then {
           write_success = false
         } else match mem_write_ea(paddr, bytes, aq, rl, res) {
-          Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+          Err(e) => return Err(memory_exception_with_gva(e, Virtaddr(vaddr))),
 
           Ok(()) => {
             let write_value = data[(8 * (offset + 1) * bytes) - 1 .. 8 * offset * bytes];
             match mem_write_value(paddr, bytes, write_value, aq, rl, res) {
-              Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+              Err(e) => return Err(memory_exception_with_gva(e, Virtaddr(vaddr))),
               Ok(s)  => write_success = write_success & s,
             }
           }
@@ -228,24 +242,6 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
   } until finished;
 
   Ok(write_success)
-}
-
-// This lets the Rocq extraction know why the repeat loop above terminates
-termination_measure vmem_write_addr repeat n
-
-val vmem_read : forall 'width, is_mem_width('width).
-  (regidx, xlenbits, int('width), MemoryAccessType(mem_payload), bool, bool, bool)
-  -> result(bits(8 * 'width), ExecutionResult)
-
-function vmem_read(rs, offset, width, access, aq, rl, res) = {
-  // Get the address, X(rs1) + offset.
-  // Extensions might perform additional checks on address validity.
-  let vaddr : virtaddr = match ext_data_get_addr(rs, offset, access, width) {
-    Ext_DataAddr_OK(vaddr) => vaddr,
-    Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
-  };
-
-  vmem_read_addr(vaddr, offset, width, access, aq, rl, res)
 }
 
 val vmem_write : forall 'width, is_mem_width('width).


### PR DESCRIPTION
### Introduce

- Based on #612 with some refactor
- Also add hypervisor addition for Sstc, Zicfilp, CBO ...

### Test

tests are collected here https://github.com/trdthg/riscv-hypervisor-tests
- [x] https://github.com/trdthg/riscv-hext-asm-tests Basically no modifications, just update submodule. 
- [x] https://github.com/trdthg/riscv-hs-tests The original author didn't maintain it anymore. Fixed some assertions, also added htif support.
- [ ] https://github.com/trdthg/riscv-hyp-tests Only two tests left failed
	- one depends on #1350 , this should be easy to solve
	- another was marked as failed (both spike and sail) by @defermelowie, I haven't checked it out in depth

I would write a CI to distribute binary for them when I have time, like what we did for vector tests

### TODO

So this PR has been checked by multiple test suites, at least from the test situation, there is no big problem with the core address translation. I think it's time to get ready to split this big PR and commit gradually.

There are some areas that need improvement, and I'll list a few of them first. Any refactoring ideas would be greatly appreciated

- This PR refactors the return value of Exception, for example, in the past, when the access an address was failed, we would return an `(ExceptionType, addr)`, but now due to the hypervisor, this PR extends the addr to `ExceptionContext`, now we usually return `(ExceptionType, ExceptionContext)`, The `ExceptionContext` here will be passed from `execute` to `trap_handler`.
- Added 4 x4 variants to satp_mode, it is used in all the code related to address translation, and there is a lot of space for optimization
- For convenience, the virtaddr in the code is represented by bits(64) now, and considering that after the GVA -> GPA conversion, the GPA will continue to be translated to HPA as a VA, I think we need to add more comprehensive type constraints to physaddr and virtaddr

This PR is also constantly updated (you know, rebase to the latest to prevent it from getting too old), and dealing with the few remaining tests, and the refactoring mentioned above

---

## 2026_01_12 UPDATE

Recommended split and review order

- [ ] Other H related
	- [ ] Implement Two Step Translation #1419 
		- [ ] Extend TLB
			- [ ] Extend sv_width
				- [ ] Add H registers #1110
					- [ ] Refactor CSR Access
						- ~#1357~
						- #1402 (this is better)
				- [ ] Extend trap handler #1290
					- [ ] refactor exception #1451
