### PR TITLE
Add configuration option for reserved behavior  `pmpcfg with r=0, w=1`

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -29,13 +29,13 @@
     },
     "reserved_behavior": {
       // The configuration option determines how to handle the reserved behavior `amocas_odd_registers`.
-      // "Fatal"  – raise a Sail exception, stopping execution.
-      // "Illegal" – treat it as an illegal instruction.
-      "amocas_odd_register": "Illegal",
+      // "AMOCAS_Fatal"  – raise a Sail exception, stopping execution.
+      // "AMOCAS_Illegal" – treat it as an illegal instruction.
+      "amocas_odd_register": "AMOCAS_Illegal",
       // The configuration option determines how to handle the reserved behavior `pmpcfg_with_R0W1`.
-      // "Fatal"  – raise a Sail exception, stopping execution.
-      // "ClearPermissions" – convert a PMP entry with R=0, W=1 to R=0, W=0, X=0.
-      "pmpcfg_write_only": "Pmp_ClearPermissions"
+      // "PMP_Fatal"  – raise a Sail exception, stopping execution.
+      // "PMP_ClearPermissions" – convert a PMP entry with R=0, W=1 to R=0, W=0, X=0.
+      "pmpcfg_write_only": "PMP_ClearPermissions"
     }
   },
   "memory": {

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -57,30 +57,26 @@ let reserved_exceptions_write_xtval : bool = config base.xtval_nonzero.reserved_
 
 // Defines the policy for handling reserved behaviors.
 enum AmocasOddRegisterReservedBehavior = {
-  Fatal,
-  Illegal,
+  AMOCAS_Fatal,
+  AMOCAS_Illegal,
 }
 
 mapping AmocasOddRegisterReservedBehavior_str : AmocasOddRegisterReservedBehavior <-> string = {
-  Fatal   <-> "Fatal",
-  Illegal <-> "Illegal",
+  AMOCAS_Fatal   <-> "AMOCAS_Fatal",
+  AMOCAS_Illegal <-> "AMOCAS_Illegal",
 }
 overload to_str = {AmocasOddRegisterReservedBehavior_str}
 
-// The configuration option determines how to handle the reserved behavior `amocas_odd_registers`.
-// "Fatal"   – raise a Sail exception, stopping execution.
-// "Illegal" – treat it as an illegal instruction.
-let amocas_odd_register_reserved_behavior : AmocasOddRegisterReservedBehavior = config base.reserved_behavior.amocas_odd_register
-
 enum PmpWriteOnlyReservedBehavior = {
-  Pmp_Fatal,
-  Pmp_ClearPermissions,
+  PMP_Fatal,
+  PMP_ClearPermissions,
 }
 
 mapping PmpWriteOnlyReservedBehavior_str : PmpWriteOnlyReservedBehavior <-> string = {
-  Pmp_Fatal <-> "Pmp_Fatal",
-  Pmp_ClearPermissions <-> "Pmp_ClearPermissions",
+  PMP_Fatal <-> "PMP_Fatal",
+  PMP_ClearPermissions <-> "PMP_ClearPermissions",
 }
 overload to_str = {PmpWriteOnlyReservedBehavior_str}
 
+let amocas_odd_register_reserved_behavior : AmocasOddRegisterReservedBehavior = config base.reserved_behavior.amocas_odd_register
 let pmp_write_only_reserved_behavior : PmpWriteOnlyReservedBehavior = config base.reserved_behavior.pmpcfg_write_only

--- a/model/extensions/A/zaamo_insts.sail
+++ b/model/extensions/A/zaamo_insts.sail
@@ -33,8 +33,8 @@ private function amo_encoding_valid(width : word_width_wide, op : amoop, Regidx(
       &
       (if   rs2[0] == bitone | rd[0] == bitone
        then match amocas_odd_register_reserved_behavior {
-         Fatal   => reserved_behavior("AMOCAS.D/Q used odd-numbered register"),
-         Illegal => false,
+         AMOCAS_Fatal   => reserved_behavior("AMOCAS.D/Q used odd-numbered register"),
+         AMOCAS_Illegal => false,
        }
        else true)
     )))

--- a/model/pmp/pmp_regs.sail
+++ b/model/pmp/pmp_regs.sail
@@ -108,8 +108,8 @@ private function pmpWriteCfg(cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent =
     // 2. R, W and X are all set to 0.
     let cfg = if cfg[W] == 0b1 & cfg[R] == 0b0 then (
       match pmp_write_only_reserved_behavior {
-        Pmp_Fatal => reserved_behavior("pmpcfg with R=0,W=1"),
-        Pmp_ClearPermissions => [cfg with X = 0b0, W = 0b0, R = 0b0],
+        PMP_Fatal => reserved_behavior("pmpcfg with R=0,W=1"),
+        PMP_ClearPermissions => [cfg with X = 0b0, W = 0b0, R = 0b0],
       }
     ) else cfg;
 


### PR DESCRIPTION
Add configuration option for reserved behavior pmpcfg with R=0 and W=1.

It allows two options: a fatal error that stops the simulation, or setting it to R=0, W=0, X=0 as the default choice.

See  #775