### PR TITLE
add ConcurrencyInterfaceV1 as required by Nov lean nightly toolchain

### DIFF
--- a/handwritten_support/RiscvExtrasExecutable.lean
+++ b/handwritten_support/RiscvExtrasExecutable.lean
@@ -10,6 +10,7 @@ import THE_MODULE_NAME.Sail.Sail
 import THE_MODULE_NAME.Defs
 
 open Sail
+open ConcurrencyInterfaceV1
 
 def print_bits (_ : String) (_ : BitVec n) : Unit := ()
 def print_string (_ : String) (_ : String) : Unit := ()


### PR DESCRIPTION
The leanprover/lean4:nightly-2025-11-18 toolchain requires the ConcurrencyInterfaceV1 namespace to use Arch.