### PR TITLE
Fix location of the `hartSupports_measure` function.

### DIFF
--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -19,25 +19,6 @@ scattered mapping extensionName
 val hartSupports : extension -> bool
 scattered function hartSupports
 
-function hartSupports_measure(ext : extension) -> int =
-  match ext {
-    Ext_D => 1, // > F
-    Ext_Sstvecd => 1, // > S
-    Ext_Ssu64xl => 1, // > S
-    Ext_Zvkn => 1, // > Zvkned
-    Ext_Zvks => 1, // > Zvksed
-
-    Ext_C => 2, // > D
-    Ext_Zvknc => 2, // > Zvkn
-    Ext_Zvkng => 2, // > Zvkn
-    Ext_Zvksc => 2, // > Zvks
-    Ext_Zvksg => 2, // > Zvks
-
-    _ => 0,
-  }
-
-termination_measure hartSupports(ext) = hartSupports_measure(ext)
-
 // Function used to determine if an extension is currently enabled in the model.
 // This means an extension is supported, *and* any necessary bits are set in the
 // relevant CSRs (misa, mstatus, etc.) to enable its use. It is possible for some
@@ -495,6 +476,29 @@ function clause hartSupports(Ext_Svrsw60t59b) = config extensions.Svrsw60t59b.su
 enum clause extension = Ext_Smcntrpmf
 mapping clause extensionName = Ext_Smcntrpmf <-> "smcntrpmf"
 function clause hartSupports(Ext_Smcntrpmf) = config extensions.Smcntrpmf.supported
+
+// When adding a new extension X, we need to make sure that if X being supported
+// depends on Y being supported, then the value associated to X is _greater_ than
+// the value associated to Y. The default value is 0.
+
+function hartSupports_measure(ext : extension) -> int =
+  match ext {
+    Ext_D => 1, // > F
+    Ext_Sstvecd => 1, // > S
+    Ext_Ssu64xl => 1, // > S
+    Ext_Zvkn => 1, // > Zvkned
+    Ext_Zvks => 1, // > Zvksed
+
+    Ext_C => 2, // > D
+    Ext_Zvknc => 2, // > Zvkn
+    Ext_Zvkng => 2, // > Zvkn
+    Ext_Zvksc => 2, // > Zvks
+    Ext_Zvksg => 2, // > Zvks
+
+    _ => 0,
+  }
+
+termination_measure hartSupports(ext) = hartSupports_measure(ext)
 
 // When adding a new extension X, we need to make sure that if X being enabled
 // depends on Y being enabled, then the value associated to X is _greater_ than


### PR DESCRIPTION
It was defined in a location that seems to have preceded the compiler's knowledge of all the variants of the `extension` enum, resulting in redundant match warnings from the latest Sail compiler:
```
Warning: Redundant case core/extensions.sail:25.4-15:
25 |    Ext_Sstvecd => 1, // > S
   |    ^---------^
   |
This match case is never used

Warning: Redundant case core/extensions.sail:26.4-15:
26 |    Ext_Ssu64xl => 1, // > S
   |    ^---------^
   |
This match case is never used
...
```
and so on, due to the first match pattern `Ext_D` being treated as a variable that made all subsequent matches redundant.

This moves the function next to `currentlyEnabled_measure` and adds comments.