### PR TITLE
Add missing `csr_write_callback` in `accrue_fflags`

### DIFF
--- a/model/extensions/FD/fdext_regs.sail
+++ b/model/extensions/FD/fdext_regs.sail
@@ -437,5 +437,7 @@ function accrue_fflags(flags : bits(5)) -> unit = {
   then {
     fcsr[FFLAGS] = f;
     dirty_fd_context_if_present();
-  }
+  };
+  csr_write_callback("fflags", zero_extend(fcsr[FFLAGS]));
+  csr_write_callback("fcsr", zero_extend(fcsr.bits));
 }


### PR DESCRIPTION
This currently works the same way as other implicit CSR write callbacks - it is always called when the CSR may potentially be changed. In future we may add configuration options, e.g. to allow distinguishing the cases where no new flags need to be set, or when they do but they're already set.