### PR TITLE
c_emulator: validate DTB range against configured PMA regions

### DIFF
--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -304,6 +304,28 @@ uint64_t load_sail(const std::string &filename, bool main_file)
 void write_dtb_to_rom(const std::vector<uint8_t> &dtb)
 {
   uint64_t addr = get_config_uint64({"memory", "dtb_address"});
+  uint64_t size = static_cast<uint64_t>(dtb.size());
+
+  // Overflow check for addr + size - 1
+  uint64_t end = addr + size - 1;
+  if (end < addr) {
+    fprintf(stderr,
+            "DTB address/size overflow: addr=0x%0" PRIx64 ", size=0x%0" PRIx64
+            "\n",
+            addr, size);
+    exit(EXIT_FAILURE);
+  }
+
+  // Validate DTB range against configured PMA memory regions.
+  if (!g_model.zdtb_within_configured_pma_memory(addr, size)) {
+    fprintf(
+        stderr,
+        "DTB does not fit in any configured PMA memory region: "
+        "addr=0x%0" PRIx64 ", size=0x%0" PRIx64 " (end=0x%0" PRIx64 ")\n"
+        "Hint: adjust memory.dtb_address or memory.regions in the config.\n",
+        addr, size, end);
+    exit(EXIT_FAILURE);
+  }
 
   for (uint8_t d : dtb) {
     write_mem(addr++, d);

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -104,6 +104,7 @@ add_custom_command(
         --c-preserve set_pc_reset_address
         --c-preserve generate_dts
         --c-preserve config_is_valid
+        --c-preserve dtb_within_configured_pma_memory
         --c-preserve generate_canonical_isa_string
         # Preserve RVFI functions.
         --c-preserve rvfi_set_instr_packet

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -192,6 +192,10 @@ function check_pma_regions(pmas : list(PMA_Region), prev_base : bits(64), prev_s
     },
   }
 
+// Return true iff [addr, addr+size) is fully contained in a single configured PMA memory region.
+function dtb_within_configured_pma_memory(addr : bits(64), size : bits(64)) -> bool =
+  is_some(matching_pma_bits_range(pma_regions, addr, size))
+
 // Check that all memory regions are sorted and don't overlap.
 function check_mem_layout() -> bool =
   if pma_regions == [||] then {

--- a/model/sys/pma.sail
+++ b/model/sys/pma.sail
@@ -104,16 +104,22 @@ struct PMA_Region = {
   include_in_device_tree : bool,
 }
 
-// Get the first PMA that matches a given address range.
-function matching_pma(pmas : list(PMA_Region), addr : physaddr, width : mem_access_width) -> option(PMA_Region) = {
+// Get the first PMA region that fully contains a given [base, base+size) range.
+function matching_pma_bits_range(pmas : list(PMA_Region), base : bits(64), size : bits(64)) -> option(PMA_Region) = {
   match pmas {
     [||] => None(),
     pma :: rest => {
-      if range_subset(zero_extend(bits_of(addr)), to_bits(width), pma.base, pma.size)
+      if range_subset(base, size, pma.base, pma.size)
       then Some(pma)
-      else matching_pma(rest, addr, width)
-    },
+      else matching_pma_bits_range(rest, base, size)
+    }
   }
+}
+
+// Get the first PMA that matches a given address range.
+// Delegate to matching_pma_bits_range to avoid duplicating the range logic.
+function matching_pma(pmas : list(PMA_Region), addr : physaddr, width : mem_access_width) -> option(PMA_Region) = {
+  matching_pma_bits_range(pmas, zero_extend(bits_of(addr)), to_bits(width))
 }
 
 function pma_attributes_to_str(attr : PMA) -> string =


### PR DESCRIPTION
Add a pre-write check that the DTB range [dtb_address, dtb_address + dtb_size) is fully contained in a single configured memory.regions PMA memory region; otherwise print an error and exit.

Fixes #1308.