### PR TITLE
Fix builds of tests on some platforms.

### DIFF
--- a/test/first_party/CMakeLists.txt
+++ b/test/first_party/CMakeLists.txt
@@ -38,8 +38,8 @@ if (CLANG_BIN)
 
     # Check if `riscv32` is present in the output
     if (clang_targets MATCHES "riscv32")
-        set(CROSS_COMPILER_COMMAND_RV32 ${CLANG_BIN} --target=riscv32)
-        set(CROSS_COMPILER_COMMAND_RV64 ${CLANG_BIN} --target=riscv64)
+        set(CROSS_COMPILER_COMMAND_RV32 ${CLANG_BIN} --target=riscv32 -fuse-ld=lld)
+        set(CROSS_COMPILER_COMMAND_RV64 ${CLANG_BIN} --target=riscv64 -fuse-ld=lld)
     endif()
 endif()
 


### PR DESCRIPTION
Make clang use lld to avoid errors such as the below, when building tests with a clang that uses the system ld linker
(with the following messages in the build log):

-- Compiling RV32 tests with: /usr/bin/clang;--target=riscv32
-- Compiling RV64 tests with: /usr/bin/clang;--target=riscv64

- Fedora 43/x86-64 with GNU ld version 2.45.1-1.fc43

Error:
/usr/bin/ld: unrecognised emulation mode: elf64lriscv Supported emulations: elf_x86_64 elf32_x86_64 elf_i386 elf_iamcu i386pep i386pe elf64bpf

- Debian forky/aarch64 with GNU ld version 2.45.50.20251209

Error:
/usr/bin/ld: unrecognised emulation mode: elf64lriscv Supported emulations: aarch64linux aarch64elf aarch64elf32 aarch64elf32b aarch64elfb armelf armelfb aarch64linuxb aarch64linux32 aarch64linux32b armelfb_linux_eabi armelf_linux_eabi