### PR TITLE
Bump os-boot Linux and GCC versions

### DIFF
--- a/os-boot/linux/gcc.url
+++ b/os-boot/linux/gcc.url
@@ -1,1 +1,1 @@
-https://toolchains.bootlin.com/downloads/releases/toolchains/riscv64-lp64d/tarballs/riscv64-lp64d--glibc--stable-2024.05-1.tar.xz
+https://toolchains.bootlin.com/downloads/releases/toolchains/riscv64-lp64d/tarballs/riscv64-lp64d--glibc--stable-2025.08-1.tar.xz

--- a/os-boot/linux/linux.url
+++ b/os-boot/linux/linux.url
@@ -1,1 +1,1 @@
-https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.15.4.tar.xz
+https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.18.2.tar.xz


### PR DESCRIPTION
- Update Linux kernel to 6.18.2
- Update GCC toolchain to Bootlin 2025.08