### PR TITLE
add except context for H extension

### DIFF
--- a/model/exceptions/exception_context.sail
+++ b/model/exceptions/exception_context.sail
@@ -1,0 +1,75 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// Model context for synchronous exceptions
+struct ExceptionContext = {
+  // Faulting address or instruction
+  excinfo     : option(xlenbits),
+
+  // H-extension: true if excinfo holds guest-virtual-address
+  // "Field GVA (Guest Virtual Address) is written by the implementation whenever a trap is taken into HS-mode.
+  //  For any trap (breakpoint, address misaligned, access fault, page fault, or guest-page fault) that
+  //  writes a guest virtual address to stval, GVA is set to 1. For any other trap into HS-mode, GVA is set to 0."
+  info_is_gva : bool,
+  // H-extension: faulting guest-physical address
+  excinfo2    : option(xlenbits),
+  // H-extension: transformed instruction or pseudoinstruction
+  excinst     : option(xlenbits),
+
+  // For out-of-tree extensions
+  ext         : option(ext_exception)
+}
+
+// Create contexts for various exception classes
+
+function empty_exception_context() -> ExceptionContext =
+  struct {
+    excinfo     = None(),
+    info_is_gva = false,
+    excinfo2    = None(),
+    excinst     = None(),
+    ext         = None(),
+  }
+
+function mem_exception_context(vaddr : xlenbits, is_gva : bool) -> ExceptionContext =
+  struct {
+    excinfo     = Some(vaddr),
+    info_is_gva = is_gva,
+    excinfo2    = None(),
+    excinst     = None(),
+    ext         = None(),
+  }
+
+function vmem_exception_context(vaddr : xlenbits, is_gva : bool, gpaddr : option(xlenbits), pseudoinst : option(xlenbits)) -> ExceptionContext =
+  struct {
+    excinfo     = Some(vaddr),
+    info_is_gva = is_gva,
+    excinfo2    = gpaddr,
+    excinst     = pseudoinst,
+    ext         = None(),
+  }
+
+function instr_exception_context(inst : xlenbits, tval_has_ill_inst_bits : bool) -> ExceptionContext =
+  struct {
+    excinfo     = if tval_has_ill_inst_bits then Some(inst) else None(),
+    info_is_gva = false,
+    excinfo2    = None(),
+    excinst     = None(),
+    ext         = None(),
+  }
+
+// For out-of-tree extensions
+val ext_exception_context : forall ('ext : Type) . ('ext) -> ExceptionContext
+function ext_exception_context(ext) =
+  struct {
+    excinfo     = None(),
+    info_is_gva = false,
+    excinfo2    = None(),
+    excinst     = None(),
+    ext         = None(),
+  }

--- a/model/extensions/A/zaamo_insts.sail
+++ b/model/extensions/A/zaamo_insts.sail
@@ -69,10 +69,10 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
   };
 
   if not(is_aligned_addr(vaddr, width))
-  then return Memory_Exception(vaddr, E_SAMO_Addr_Align());
+  then return memory_exception(vaddr, E_SAMO_Addr_Align());
 
   let addr : physaddr = match translateAddr(vaddr, LoadStore(Data, Data)) {
-    Err(e, _) => return Memory_Exception(vaddr, e),
+    Err((e, c), _) => return Memory_Exception(e, c),
     Ok(addr, _) => addr,
   };
 
@@ -82,9 +82,9 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
   let rs2_val : bits('width * 8) = if width <= xlen_bytes then trunc(X(rs2)) else trunc(X_pair(rs2));
 
   let loaded : bits('width * 8) = match mem_write_ea(addr, width, aq & rl, rl, true) {
-    Err(e) => return Memory_Exception(vaddr, e),
+    Err(e) => return memory_exception(vaddr, e),
     Ok(_)  => match mem_read(LoadStore(Data, Data), addr, width, aq, aq & rl, true) {
-      Err(e)     => return Memory_Exception(vaddr, e),
+      Err(e)     => return memory_exception(vaddr, e),
       Ok(loaded) => loaded,
     },
   };
@@ -118,7 +118,7 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
       RETIRE_SUCCESS
     },
     Ok(false) => internal_error(__FILE__, __LINE__, "AMO got false from mem_write_value"),
-    Err(e)    => Memory_Exception(vaddr, e),
+    Err(e)    => memory_exception(vaddr, e),
   }
 }
 

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -60,7 +60,7 @@ function jump_to(target : xlenbits) -> ExecutionResult = {
   // If it is not 4-byte aligned and compressed instructions are
   // not enabled then raise an alignment exception.
   if bit_to_bool(target[1]) & not(currentlyEnabled(Ext_Zca))
-  then return Memory_Exception(Virtaddr(target), E_Fetch_Addr_Align());
+  then return memory_exception(Virtaddr(target), E_Fetch_Addr_Align());
 
   set_next_pc(target);
   RETIRE_SUCCESS
@@ -526,12 +526,8 @@ function clause execute ECALL() = {
     VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
     VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   };
-  let t : sync_exception = struct {
-    trap    = trap,
-    excinfo = (None() : option(xlenbits)),
-    ext     = None(),
-  };
-  Trap(cur_privilege, CTL_TRAP(t), PC)
+  let c : ExceptionContext = empty_exception_context();
+  Trap(cur_privilege, CTL_TRAP(trap, c), PC)
 }
 
 mapping clause assembly = ECALL() <-> "ecall"
@@ -588,7 +584,7 @@ mapping clause encdec = EBREAK()
   <-> 0b000000000001 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
 
 function clause execute EBREAK() =
-  Memory_Exception(Virtaddr(PC), E_Breakpoint(Brk_Software))
+  memory_exception(Virtaddr(PC), E_Breakpoint(Brk_Software))
 
 mapping clause assembly = EBREAK() <-> "ebreak"
 

--- a/model/extensions/Zicbom/zicbom_insts.sail
+++ b/model/extensions/Zicbom/zicbom_insts.sail
@@ -107,7 +107,7 @@ function process_clean_inval(rs1 : regidx, _cbop : cbop_zicbom) -> ExecutionResu
             _ => None(),
           }
         },
-        Err(e, _) => Some(e)
+        Err((e, _), _) => Some(e)
       };
       // "If access to the cache block is not permitted, a cache-block management
       //  instruction raises a store page fault or store guest-page fault exception
@@ -130,7 +130,7 @@ function process_clean_inval(rs1 : regidx, _cbop : cbop_zicbom) -> ExecutionResu
           // was encoded in the instruction. We subtract the negative offset
           // (add the positive offset) to get it. Normally this will be
           // equal to rs1, but pointer masking can change that.
-          Memory_Exception(vaddr - negative_offset, e)
+          memory_exception(vaddr - negative_offset, e)
         }
       }
     }

--- a/model/extensions/Zicboz/zicboz_insts.sail
+++ b/model/extensions/Zicboz/zicboz_insts.sail
@@ -44,15 +44,15 @@ function clause execute ZICBOZ(rs1) = {
           // was encoded in the instruction. We subtract the negative offset
           // (add the positive offset) to get it. Normally this will be
           // equal to rs1, but pointer masking can change that.
-          Err(e, _) => Memory_Exception(vaddr - negative_offset, e),
+          Err((e, _), _) => memory_exception(vaddr - negative_offset, e),
           Ok(paddr, _) => {
             match mem_write_ea(paddr, cache_block_size, false, false, false) {
-              Err(e) => Memory_Exception(vaddr - negative_offset, e),
+              Err(e) => memory_exception(vaddr - negative_offset, e),
               Ok(_)  => {
                 match mem_write_value(paddr, cache_block_size, zeros(), false, false, false) {
                   Ok(true)  => RETIRE_SUCCESS,
                   Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                  Err(e)    => Memory_Exception(vaddr - negative_offset, e)
+                  Err(e)    => memory_exception(vaddr - negative_offset, e)
                 }
               }
             }

--- a/model/extensions/cfi/zicfilp_insts.sail
+++ b/model/extensions/cfi/zicfilp_insts.sail
@@ -6,10 +6,15 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // =======================================================================================
 
-function make_landing_pad_exception() -> sync_exception =
-  struct { trap    = E_Software_Check(),
-           excinfo = Some(zero_extend(software_check_cause(SWC_LANDING_PAD_FAULT))),
-           ext     = None() }
+function make_landing_pad_exception() -> ctl_result =
+  CTL_TRAP(E_Software_Check(),
+           struct{
+            excinfo = Some(zero_extend(software_check_cause(SWC_LANDING_PAD_FAULT))),
+            info_is_gva = false,
+            excinfo2    = None(),
+            excinst     = None(),
+            ext         = None(),
+           })
 
 union clause instruction = LPAD : (landing_pad_label)
 
@@ -23,7 +28,7 @@ function clause execute LPAD(lpl) = {
     let unaligned_pc = get_arch_pc()[1 .. 0] != 0b00;
     let label_mismatch = X(Regno(7))[31 .. 12] != lpl & lpl != zeros();
     if unaligned_pc | label_mismatch then {
-      Trap(cur_privilege, CTL_TRAP(make_landing_pad_exception()), PC)
+      Trap(cur_privilege, make_landing_pad_exception(), PC)
     } else {
       reset_elp();
       RETIRE_SUCCESS

--- a/model/postlude/fetch.sail
+++ b/model/postlude/fetch.sail
@@ -25,16 +25,16 @@ function fetch() -> FetchResult = {
   };
 
   if   (PC[0] != bitzero | (PC[1] != bitzero & not(currentlyEnabled(Ext_Zca))))
-  then return F_Error(E_Fetch_Addr_Align(), PC);
+  then return F_Error(E_Fetch_Addr_Align(), mem_exception_context(PC, false));
 
   match translateAddr(Virtaddr(PC), InstructionFetch()) {
-    Err(e, _)    => F_Error(e, PC),
+    Err(e, _)    => F_Error(e),
     Ok(ppclo, _) => {
       // split instruction fetch into 16-bit granules to handle RVC, as
       // well as to generate precise fault addresses in any fetch
       // exceptions.
       match mem_read(InstructionFetch(), ppclo, 2, false, false, false) {
-        Err(e)  => F_Error(e, PC),
+        Err(e)  => F_Error(e, mem_exception_context(PC, false)),
         Ok(ilo) =>
           if   isRVC(ilo)
           then F_RVC(ilo)
@@ -47,10 +47,10 @@ function fetch() -> FetchResult = {
             };
 
             match translateAddr(Virtaddr(PC_hi), InstructionFetch()) {
-              Err(e, _)    => F_Error(e, PC_hi),
+              Err(e, _)    => F_Error(e),
               Ok(ppchi, _) =>
                 match mem_read(InstructionFetch(), ppchi, 2, false, false, false) {
-                  Err(e)  => F_Error(e, PC_hi),
+                  Err(e)  => F_Error(e, mem_exception_context(PC, false)),
                   Ok(ihi) => F_Base(append(ihi, ilo))
                 }
             }

--- a/model/postlude/fetch_rvfi.sail
+++ b/model/postlude/fetch_rvfi.sail
@@ -20,10 +20,10 @@ function rvfi_fetch() -> FetchResult = {
 
   // Then check PC alignment
   if   (PC[0] != bitzero | (PC[1] != bitzero & not(currentlyEnabled(Ext_Zca))))
-  then return F_Error(E_Fetch_Addr_Align(), PC);
+  then return F_Error(E_Fetch_Addr_Align(), mem_exception_context(PC, false));
 
   match translateAddr(Virtaddr(PC), InstructionFetch()) {
-    Err(e, _) => return F_Error(e, PC),
+    Err(e, _) => return F_Error(e),
     Ok(_, _)  => (),
   };
 
@@ -40,7 +40,7 @@ function rvfi_fetch() -> FetchResult = {
   };
 
   match translateAddr(Virtaddr(PC_hi), InstructionFetch()) {
-    Err(e, _) => F_Error(e, PC),
+    Err(e, _) => F_Error(e),
     Ok(_, _)  => F_Base(i)
   }
 }

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -13,7 +13,7 @@ register hart_state : HartState = HART_ACTIVE()
 union Step = {
   Step_Pending_Interrupt  : (InterruptType, Privilege),
   Step_Ext_Fetch_Failure  : ext_fetch_addr_error,
-  Step_Fetch_Failure      : (virtaddr, ExceptionType),
+  Step_Fetch_Failure      : (ExceptionType, ExceptionContext),
   Step_Execute            : (ExecutionResult, instbits),
   Step_Waiting            : WaitReason,
 }
@@ -93,7 +93,7 @@ function run_hart_active(step_no: nat) -> Step = {
       // extension error
       F_Ext_Error(e)   => Step_Ext_Fetch_Failure(e),
       // standard error
-      F_Error(e, addr) => Step_Fetch_Failure(Virtaddr(addr), e),
+      F_Error(e, c) => Step_Fetch_Failure(e, c),
       // non-error cases:
       F_RVC(h) => {
         sail_instr_announce(h);
@@ -107,7 +107,7 @@ function run_hart_active(step_no: nat) -> Step = {
         // When ELP is set to LP_EXPECTED, the next instruction needs to be
         // the non-RVC `LPAD` instruction.
         if is_landing_pad_expected() then {
-          let r = Trap(cur_privilege, CTL_TRAP(make_landing_pad_exception()), PC);
+          let r = Trap(cur_privilege, make_landing_pad_exception(), PC);
           Step_Execute(r, instbits)
         }
         // check for RVC once here instead of every RVC execute clause.
@@ -135,7 +135,7 @@ function run_hart_active(step_no: nat) -> Step = {
         // the instruction stream is not LPAD, then a software check
         // exception with a landing pad fault code is thrown.
         if is_landing_pad_expected() & not(is_lpad_instruction(instruction)) then {
-          let r = Trap(cur_privilege, CTL_TRAP(make_landing_pad_exception()), PC);
+          let r = Trap(cur_privilege, make_landing_pad_exception(), PC);
           Step_Execute(r, instbits)
         } else {
           nextPC = PC + 4;
@@ -205,15 +205,15 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
       handle_interrupt(intr, priv)
     },
     Step_Ext_Fetch_Failure(e) => ext_handle_fetch_check_error(e),
-    Step_Fetch_Failure(vaddr, e) => handle_exception(bits_of(vaddr), e),
+    Step_Fetch_Failure(e, c) => handle_exception(e, c),
     Step_Waiting(_) => assert(hart_is_waiting(hart_state), "cannot be Waiting in a non-Wait state"),
     Step_Execute(Retire_Success(), _) => assert(hart_is_active(hart_state)),
     // This case was handled above when processing the fetch result.
     Step_Execute(ExecuteAs(_), _) => assert(false),
     // standard errors
     Step_Execute(Trap(priv, ctl, pc), _) => set_next_pc(exception_handler(priv, ctl, pc)),
-    Step_Execute(Memory_Exception(vaddr, e), _) => handle_exception(bits_of(vaddr), e),
-    Step_Execute(Illegal_Instruction(), instbits) => handle_exception(zero_extend(instbits), E_Illegal_Instr()),
+    Step_Execute(Memory_Exception(e, c), _) => handle_exception(e, c),
+    Step_Execute(Illegal_Instruction(), instbits) => handle_exception(E_Illegal_Instr(), instr_exception_context(zero_extend(instbits), false)),
     Step_Execute(Enter_Wait(wr), instbits) => {
       if wait_is_nop(wr) then {
         // This is the same as the RETIRE_OK case.

--- a/model/postlude/step_common.sail
+++ b/model/postlude/step_common.sail
@@ -48,5 +48,5 @@ union FetchResult = {
   F_Ext_Error : ext_fetch_addr_error,      // For extensions
   F_Base      : word,                      // Base ISA
   F_RVC       : half,                      // Compressed ISA
-  F_Error     : (ExceptionType, xlenbits)  // standard exception and PC
+  F_Error     : (ExceptionType, ExceptionContext)  // standard exception and PC
 }

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -47,6 +47,7 @@ exceptions {
   files
     exceptions/sys_exceptions.sail,
     exceptions/sync_exception.sail,
+    exceptions/exception_context.sail,
 }
 
 pmp {
@@ -102,7 +103,7 @@ extensions {
       files extensions/A/aext_types.sail
     }
     Zaamo {
-      requires sys, A_types
+      requires sys, exceptions, A_types
       files extensions/A/zaamo_insts.sail
     }
     Zalrsc {
@@ -351,7 +352,7 @@ extensions {
       files extensions/Zicbom/zicbom_types.sail
     }
     Zicbom_insts {
-      requires sys, Zicbom_types
+      requires sys, exceptions, Zicbom_types
       files extensions/Zicbom/zicbom_insts.sail
     }
   }
@@ -370,7 +371,7 @@ extensions {
   }
 
   Zicboz {
-    requires sys
+    requires sys, exceptions
     files extensions/Zicboz/zicboz_insts.sail
   }
 

--- a/model/sys/insts_begin.sail
+++ b/model/sys/insts_begin.sail
@@ -29,7 +29,7 @@ union ExecutionResult = {
   // Did not retire for a standard reason.
   Illegal_Instruction            : unit,
   Trap                           : (Privilege, ctl_result, xlenbits),
-  Memory_Exception               : (virtaddr, ExceptionType),
+  Memory_Exception               : (ExceptionType, ExceptionContext),
 
   // Did not retire for custom reason.
   Ext_CSR_Check_Failure          : unit,
@@ -37,6 +37,15 @@ union ExecutionResult = {
   Ext_DataAddr_Check_Failure     : ext_data_addr_error,
   Ext_XRET_Priv_Failure          : unit,
 }
+
+function memory_exception(vaddr : virtaddr, e : ExceptionType) -> ExecutionResult =
+  Memory_Exception(e, struct {
+    excinfo     = Some(bits_of(vaddr)),
+    info_is_gva = false,
+    excinfo2    = None(),
+    excinst     = None(),
+    ext         = None(),
+  })
 
 // To ease the introduction of `ExecutionResult`, this global
 // definition is temporarily used instead of the previous

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -118,7 +118,7 @@ function dispatchInterrupt(priv : Privilege) -> option((InterruptType, Privilege
 // types of privilege transitions
 
 union ctl_result = {
-  CTL_TRAP : sync_exception,
+  CTL_TRAP : (ExceptionType, ExceptionContext),
   CTL_SRET : unit,
   CTL_MRET : unit,
 }
@@ -152,7 +152,7 @@ function track_trap(p : Privilege) -> unit = {
 }
 
 // handle exceptional ctl flow by updating nextPC and operating privilege
-function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info : option(xlenbits), ext : option(ext_exception))
+function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, context : ExceptionContext)
                      -> xlenbits = {
   let is_interrupt = trapCause_is_interrupt(c);
   let cause        = trapCause_bits(c);
@@ -162,7 +162,7 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
   if   get_config_print_exception() | get_config_print_interrupt()
   then print_log("handling " ^ to_str(c)
                       ^ " at priv " ^ to_str(del_priv)
-                      ^ " with tval " ^ bits_str(tval(info)));
+                      ^ " with tval " ^ bits_str(tval(context.excinfo)));
 
   if hartSupports(Ext_Zicfilp) then zicfilp_preserve_elp_on_trap(del_priv);
 
@@ -174,12 +174,12 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
       mstatus[MPIE] = mstatus[MIE];
       mstatus[MIE]  = 0b0;
       mstatus[MPP]  = privLevel_to_bits(cur_privilege);
-      mtval         = tval(info);
+      mtval         = tval(context.excinfo);
       mepc          = pc;
 
       cur_privilege = del_priv;
 
-      handle_trap_extension(del_priv, pc, ext);
+      handle_trap_extension(del_priv, pc, context.ext);
 
       track_trap(del_priv);
 
@@ -200,12 +200,12 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
         VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
         VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
       };
-      stval           = tval(info);
+      stval           = tval(context.excinfo);
       sepc            = pc;
 
       cur_privilege   = del_priv;
 
-      handle_trap_extension(del_priv, pc, ext);
+      handle_trap_extension(del_priv, pc, context.ext);
 
       track_trap(del_priv);
 
@@ -220,12 +220,12 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
 function exception_handler(cur_priv : Privilege, ctl : ctl_result,
                            pc: xlenbits) -> xlenbits = {
   match ctl {
-    CTL_TRAP(e) => {
-      let del_priv = exception_delegatee(e.trap, cur_priv);
+    CTL_TRAP(e, c) => {
+      let del_priv = exception_delegatee(e, cur_priv);
       if   get_config_print_exception()
       then print_log("trapping from " ^ to_str(cur_priv) ^ " to " ^ to_str(del_priv)
-                          ^ " to handle " ^ to_str(e.trap));
-      trap_handler(del_priv, Exception(e.trap), pc, e.excinfo, e.ext)
+                          ^ " to handle " ^ to_str(e));
+      trap_handler(del_priv, Exception(e), pc, c)
     },
     CTL_MRET()  => {
       let prev_priv = cur_privilege;
@@ -297,15 +297,13 @@ function xtval_exception_value(e : ExceptionType, excinfo : xlenbits) -> option(
   } then Some(excinfo) else None()
 }
 
-function handle_exception(xtval : xlenbits, e : ExceptionType) -> unit = {
-  let t : sync_exception = struct { trap    = e,
-                                    excinfo = xtval_exception_value(e, xtval),
-                                    ext     = None() };
-  set_next_pc(exception_handler(cur_privilege, CTL_TRAP(t), PC))
+function handle_exception(e : ExceptionType, c : ExceptionContext) -> unit = {
+  let c = {c with ext = None() };
+  set_next_pc(exception_handler(cur_privilege, CTL_TRAP(e, c), PC))
 }
 
 function handle_interrupt(i : InterruptType, del_priv : Privilege) -> unit =
-  set_next_pc(trap_handler(del_priv, Interrupt(i), PC, None(), None()))
+  set_next_pc(trap_handler(del_priv, Interrupt(i), PC, empty_exception_context()))
 
 // Reset misa to enable the maximal set of supported extensions.
 function reset_misa() -> unit = {

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -376,7 +376,7 @@ function get_satp forall 'v, is_sv_mode('v). (
 function translateAddr(
   vAddr : virtaddr,
   ac    : MemoryAccessType(ext_access_type),
-) -> TR_Result(physaddr, ExceptionType) = {
+) -> TR_Result(physaddr, (ExceptionType, ExceptionContext)) = {
 
   // Effective privilege takes into account mstatus.PRV, mstatus.MPP
   // See sys_regs.sail for effectivePrivilege() and cur_privilege
@@ -397,7 +397,7 @@ function translateAddr(
 
   let svAddr = bits_of(vAddr)[sv_width - 1 .. 0];
   if bits_of(vAddr) != sign_extend(svAddr) then {
-    Err(translationException(ac, PTW_Invalid_Addr()), init_ext_ptw)
+    Err((translationException(ac, PTW_Invalid_Addr()), translationExcContext(PTW_Invalid_Addr(), zero_extend(bits_of(vAddr)))), init_ext_ptw)
   } else {
     let mxr    = mstatus[MXR] == 0b1;
     let do_sum = mstatus[SUM] == 0b1;
@@ -424,7 +424,7 @@ function translateAddr(
         // the assertion above.
         Ok(Physaddr(zero_extend(paddr)), ext_ptw)
       },
-      Err(f, ext_ptw)  => Err(translationException(ac, f), ext_ptw)
+      Err(f, ext_ptw)  => Err((translationException(ac, f), translationExcContext(f, zero_extend(bits_of(vAddr)))), ext_ptw)
     }
   }
 }

--- a/model/sys/vmem_ptw.sail
+++ b/model/sys/vmem_ptw.sail
@@ -68,3 +68,11 @@ function translationException(a : MemoryAccessType(ext_access_type),
     (InstructionFetch(), _)               => E_Fetch_Page_Fault()
   }
 }
+
+function translationExcContext(e : PTW_Error, vaddr : bits(64))
+                                -> ExceptionContext = {
+  match e {
+    PTW_Ext_Error(e)  => ext_exception_context(e),
+    _ => vmem_exception_context(truncate(vaddr, xlen), false, None(), None()),
+  }
+}

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -126,10 +126,10 @@ function vmem_read_addr(vaddr, offset, width, acc, aq, rl, res) = {
     // "LR faults like a normal load, even though it's in the AMO major opcode space."
     // - Andrew Waterman, isa-dev, 10 Jul 2018.
     if   not(is_aligned_addr(vaddr, width))
-    then return Err(Memory_Exception(vaddr, E_Load_Addr_Align()));
+    then return Err(memory_exception(vaddr, E_Load_Addr_Align()));
   } else {
     if check_misaligned(vaddr, width)
-    then return Err(Memory_Exception(vaddr, E_Load_Addr_Align()));
+    then return Err(memory_exception(vaddr, E_Load_Addr_Align()));
   };
 
   // If the load is misaligned or an allowed misaligned access, split into `n`
@@ -147,10 +147,10 @@ function vmem_read_addr(vaddr, offset, width, acc, aq, rl, res) = {
     let offset = i;
     let vaddr = vaddr + (offset * bytes);
     match translateAddr(Virtaddr(vaddr), acc) {
-      Err(e, _) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+      Err((e, c), _) => return Err(Memory_Exception(e, c)),
 
       Ok(paddr, _) => match mem_read(acc, paddr, bytes, aq, rl, res) {
-        Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+        Err(e) => return Err(memory_exception(Virtaddr(vaddr), e)),
 
         Ok(v) => {
           if res then {
@@ -181,7 +181,7 @@ val vmem_write_addr : forall 'width, is_mem_width('width).
 
 function vmem_write_addr(vaddr, width, data, acc, aq, rl, res) = {
   if   check_misaligned(vaddr, width)
-  then return Err(Memory_Exception(vaddr, E_SAMO_Addr_Align()));
+  then return Err(memory_exception(vaddr, E_SAMO_Addr_Align()));
 
   // If the store is misaligned or an allowed misaligned access, split into `n`
   // (single-copy-atomic) memory operations, each of `bytes` width. If the store is
@@ -198,7 +198,7 @@ function vmem_write_addr(vaddr, width, data, acc, aq, rl, res) = {
     let offset = i;
     let vaddr = vaddr + (offset * bytes);
     match translateAddr(Virtaddr(vaddr), acc) {
-      Err(e, _) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+      Err((e, c), _) => return Err(Memory_Exception(e, c)),
 
       // NOTE: Currently, we only announce the effective address if address translation is successful.
       // This may need revisiting, particularly in the misaligned case.
@@ -207,12 +207,12 @@ function vmem_write_addr(vaddr, width, data, acc, aq, rl, res) = {
         if res & not(match_reservation(bits_of(paddr))) then {
           write_success = false
         } else match mem_write_ea(paddr, bytes, aq, rl, res) {
-          Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+          Err(e) => return Err(memory_exception(Virtaddr(vaddr), e)),
 
           Ok(()) => {
             let write_value = data[(8 * (offset + 1) * bytes) - 1 .. 8 * offset * bytes];
             match mem_write_value(paddr, bytes, write_value, aq, rl, res) {
-              Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+              Err(e) => return Err(memory_exception(Virtaddr(vaddr), e)),
               Ok(s)  => write_success = write_success & s,
             }
           }


### PR DESCRIPTION
Since the trap handling of H extension requires bringing corresponding information to the handler during address translation and other process, this PR is submitted to add the corresponding interface first.