### PR TITLE
Make PC a virtaddr

### DIFF
--- a/model/core/mem_addrtype.sail
+++ b/model/core/mem_addrtype.sail
@@ -15,6 +15,8 @@ let physaddrbits_len = sizeof(physaddrbits_len)
 newtype physaddr = Physaddr : physaddrbits
 newtype virtaddr = Virtaddr : xlenbits
 
+function mk_virtaddr(x : xlenbits) -> virtaddr = Virtaddr(x)
+
 function bits_of_physaddr(Physaddr(paddr) : physaddr) -> physaddrbits = paddr
 
 function bits_of_virtaddr(Virtaddr(vaddr) : virtaddr) -> xlenbits = vaddr

--- a/model/core/pc_access.sail
+++ b/model/core/pc_access.sail
@@ -15,7 +15,7 @@
   The value in the PC register is the absolute virtual address of the instruction
   to fetch.
  */
-function get_arch_pc() -> xlenbits = PC
+function get_arch_pc() -> xlenbits = bits_of_virtaddr(PC)
 
 function get_next_pc() -> xlenbits = nextPC
 
@@ -26,6 +26,8 @@ function set_next_pc(pc : xlenbits) -> unit = {
 }
 
 function tick_pc() -> unit = {
-  PC = nextPC;
-  pc_write_callback(PC);
+  PC = mk_virtaddr(nextPC);
+  pc_write_callback(bits_of_virtaddr(PC));
 }
+
+function get_pc_bits() -> xlenbits = bits_of_virtaddr(PC)

--- a/model/core/regs.sail
+++ b/model/core/regs.sail
@@ -8,7 +8,7 @@
 
 // program counter
 
-register PC       : xlenbits
+register PC       : virtaddr = mk_virtaddr(zeros())
 register nextPC   : xlenbits
 
 // Mappings for encoding

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -74,7 +74,7 @@ mapping clause encdec = JAL(imm @ 0b0, rd)
 
 function clause execute JAL(imm, rd) = {
   let link_address = get_next_pc();
-  match jump_to(PC + sign_extend(imm)) {
+  match jump_to(bits_of_virtaddr(PC) + sign_extend(imm)) {
     Retire_Success() => { X(rd) = link_address; Retire_Success() },
     failure => failure,
   }
@@ -123,7 +123,7 @@ function clause execute BTYPE(imm, rs2, rs1, op) = {
     BGEU => X(rs1) >=_u X(rs2)
   };
   if taken
-  then jump_to(PC + sign_extend(imm))
+  then jump_to(bits_of_virtaddr(PC) + sign_extend(imm))
   else RETIRE_SUCCESS
 }
 
@@ -547,7 +547,7 @@ function clause execute ECALL() = {
     excinfo = (None() : option(xlenbits)),
     ext     = None(),
   };
-  Trap(cur_privilege, CTL_TRAP(t), PC)
+  Trap(cur_privilege, CTL_TRAP(t), bits_of_virtaddr(PC))
 }
 
 mapping clause assembly = ECALL() <-> "ecall"
@@ -604,7 +604,7 @@ mapping clause encdec = EBREAK()
   <-> 0b000000000001 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
 
 function clause execute EBREAK() =
-  Memory_Exception(Virtaddr(PC), E_Breakpoint(Brk_Software))
+  Memory_Exception(PC, E_Breakpoint(Brk_Software))
 
 mapping clause assembly = EBREAK() <-> "ebreak"
 

--- a/model/extensions/cfi/zicfilp_insts.sail
+++ b/model/extensions/cfi/zicfilp_insts.sail
@@ -23,7 +23,7 @@ function clause execute LPAD(lpl) = {
     let unaligned_pc = get_arch_pc()[1 .. 0] != 0b00;
     let label_mismatch = X(Regno(7))[31 .. 12] != lpl & lpl != zeros();
     if unaligned_pc | label_mismatch then {
-      Trap(cur_privilege, CTL_TRAP(make_landing_pad_exception()), PC)
+      Trap(cur_privilege, CTL_TRAP(make_landing_pad_exception()), bits_of_virtaddr(PC))
     } else {
       reset_elp();
       RETIRE_SUCCESS

--- a/model/main/main.sail
+++ b/model/main/main.sail
@@ -12,7 +12,7 @@
 function main() : unit -> unit = {
   try {
     init_model("");
-    print_bits("PC = ", PC);
+    print_bits("PC = ", bits_of_virtaddr(PC));
     sail_end_cycle();
     loop()
   } catch {

--- a/model/postlude/fetch.sail
+++ b/model/postlude/fetch.sail
@@ -19,38 +19,43 @@ private function fetch() -> FetchResult = {
   if get_config_rvfi()
   then return rvfi_fetch();
 
-  match ext_fetch_check_pc(PC, PC) {
+  let pc_va   : virtaddr = PC;
+  let pc_bits : xlenbits = bits_of_virtaddr(pc_va);
+
+  match ext_fetch_check_pc(pc_bits, pc_bits) {
     Some(e) => return F_Ext_Error(e),
     None()  => (),
   };
 
-  if   (PC[0] != bitzero | (PC[1] != bitzero & not(currentlyEnabled(Ext_Zca))))
-  then return F_Error(E_Fetch_Addr_Align(), PC);
+  if   (pc_bits[0] != bitzero | (pc_bits[1] != bitzero & not(currentlyEnabled(Ext_Zca))))
+  then return F_Error(E_Fetch_Addr_Align(), pc_bits);
 
-  match translateAddr(Virtaddr(PC), InstructionFetch()) {
-    Err(e, _)    => F_Error(e, PC),
+  match translateAddr(pc_va, InstructionFetch()) {
+    Err(e, _) => F_Error(e, pc_bits),
     Ok(ppclo, _) => {
       // split instruction fetch into 16-bit granules to handle RVC, as
       // well as to generate precise fault addresses in any fetch
       // exceptions.
       match mem_read(InstructionFetch(), ppclo, 2, false, false, false) {
-        Err(e)  => F_Error(e, PC),
+        Err(e)  => F_Error(e, pc_bits),
         Ok(ilo) =>
           if   isRVC(ilo)
           then F_RVC(ilo)
           else {
             // fetch PC check for the next instruction granule
-            let PC_hi = PC + 2;
-            match ext_fetch_check_pc(PC, PC_hi) {
+            let pc_hi_bits : xlenbits = pc_bits + 2;
+            let pc_hi_va   : virtaddr = mk_virtaddr(pc_hi_bits);
+
+            match ext_fetch_check_pc(pc_bits, pc_hi_bits) {
               Some(e) => return F_Ext_Error(e),
               None()  => (),
             };
 
-            match translateAddr(Virtaddr(PC_hi), InstructionFetch()) {
-              Err(e, _)    => F_Error(e, PC_hi),
+            match translateAddr(pc_hi_va, InstructionFetch()) {
+              Err(e, _) => F_Error(e, pc_hi_bits),
               Ok(ppchi, _) =>
                 match mem_read(InstructionFetch(), ppchi, 2, false, false, false) {
-                  Err(e)  => F_Error(e, PC_hi),
+                  Err(e)  => F_Error(e, pc_hi_bits),
                   Ok(ihi) => F_Base(append(ihi, ilo))
                 }
             }

--- a/model/postlude/fetch_rvfi.sail
+++ b/model/postlude/fetch_rvfi.sail
@@ -12,35 +12,40 @@ private function rvfi_fetch() -> FetchResult = {
   rvfi_inst_data[rvfi_mode] = zero_extend(privLevel_to_bits(cur_privilege));
   rvfi_inst_data[rvfi_ixl] = zero_extend(misa[MXL]);
 
+  let pc_va   : virtaddr = PC;
+  let pc_bits : xlenbits = bits_of_virtaddr(pc_va);
+
   // First allow extensions to check pc
-  match ext_fetch_check_pc(PC, PC) {
+  match ext_fetch_check_pc(pc_bits, pc_bits) {
     Some(e) => return F_Ext_Error(e),
     None()  => (),
   };
 
   // Then check PC alignment
-  if   (PC[0] != bitzero | (PC[1] != bitzero & not(currentlyEnabled(Ext_Zca))))
-  then return F_Error(E_Fetch_Addr_Align(), PC);
+  if   (pc_bits[0] != bitzero | (pc_bits[1] != bitzero & not(currentlyEnabled(Ext_Zca))))
+  then return F_Error(E_Fetch_Addr_Align(), pc_bits);
 
-  match translateAddr(Virtaddr(PC), InstructionFetch()) {
-    Err(e, _) => return F_Error(e, PC),
-    Ok(_, _)  => (),
+  match translateAddr(pc_va, InstructionFetch()) {
+    Err(e, _) => return F_Error(e, pc_bits),
+    Ok(_, _)        => (),
   };
 
   let i = rvfi_instruction[rvfi_insn];
-  rvfi_inst_data[rvfi_insn]   = zero_extend(i);
-  if   (i[1 .. 0] != 0b11)
+  rvfi_inst_data[rvfi_insn] = zero_extend(i);
+  if (i[1 .. 0] != 0b11)
   then return F_RVC(i[15 .. 0]);
 
   // fetch PC check for the next instruction granule
-  let PC_hi = PC + 2;
-  match ext_fetch_check_pc(PC, PC_hi) {
+  let pc_hi_bits : xlenbits = pc_bits + 2;
+  let pc_hi_va   : virtaddr = mk_virtaddr(pc_hi_bits);
+
+  match ext_fetch_check_pc(pc_bits, pc_hi_bits) {
     Some(e) => return F_Ext_Error(e),
     None()  => (),
   };
 
-  match translateAddr(Virtaddr(PC_hi), InstructionFetch()) {
-    Err(e, _) => F_Error(e, PC),
-    Ok(_, _)  => F_Base(i)
+  match translateAddr(pc_hi_va, InstructionFetch()) {
+    Err(e, _) => F_Error(e, pc_bits),
+    Ok(_, _)        => F_Base(i)
   }
 }

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -22,7 +22,7 @@ private function run_hart_waiting(_step_no : int, wr: WaitReason, instbits : ins
   // successfully interrupted waits
   if shouldWakeForInterrupt() then {
     if   get_config_print_instr()
-    then print_log("interrupt exit from " ^ wait_name(wr) ^ " state at PC " ^ bits_str(PC));
+    then print_log("interrupt exit from " ^ wait_name(wr) ^ " state at PC " ^ bits_str(bits_of_virtaddr(PC)));
 
     // The waiting instruction retires successfully.  The
     // pending interrupts will be handled in the next step.
@@ -33,14 +33,14 @@ private function run_hart_waiting(_step_no : int, wr: WaitReason, instbits : ins
   match (wr, valid_reservation(), exit_wait) {
     (WAIT_WRS_STO, false, _) => {
       if   get_config_print_instr()
-      then print_log("reservation invalid exit from " ^ wait_name(WAIT_WRS_STO) ^ " state at PC " ^ bits_str(PC));
+      then print_log("reservation invalid exit from " ^ wait_name(WAIT_WRS_STO) ^ " state at PC " ^ bits_str(bits_of_virtaddr(PC)));
 
       hart_state = HART_ACTIVE();
       Step_Execute(Retire_Success(), instbits)
     },
     (WAIT_WRS_NTO, false, _) => {
       if   get_config_print_instr()
-      then print_log("reservation invalid exit from " ^ wait_name(WAIT_WRS_NTO) ^ " state at PC " ^ bits_str(PC));
+      then print_log("reservation invalid exit from " ^ wait_name(WAIT_WRS_NTO) ^ " state at PC " ^ bits_str(bits_of_virtaddr(PC)));
 
       hart_state = HART_ACTIVE();
       Step_Execute(Retire_Success(), instbits)
@@ -48,7 +48,7 @@ private function run_hart_waiting(_step_no : int, wr: WaitReason, instbits : ins
     // Transition out of waiting states as instructed.
     (WAIT_WFI, _, true) => {
       if   get_config_print_instr()
-      then print_log("forced exit from " ^ wait_name(WAIT_WFI) ^ " state at PC " ^ bits_str(PC));
+      then print_log("forced exit from " ^ wait_name(WAIT_WFI) ^ " state at PC " ^ bits_str(bits_of_virtaddr(PC)));
 
       hart_state = HART_ACTIVE();
       // "When TW=1, then if WFI is executed in any
@@ -61,14 +61,14 @@ private function run_hart_waiting(_step_no : int, wr: WaitReason, instbits : ins
     },
     (WAIT_WRS_STO, _, true) => {
       if   get_config_print_instr()
-      then print_log("timed-out exit from " ^ wait_name(WAIT_WRS_STO) ^ " state at PC " ^ bits_str(PC));
+      then print_log("timed-out exit from " ^ wait_name(WAIT_WRS_STO) ^ " state at PC " ^ bits_str(bits_of_virtaddr(PC)));
 
       hart_state = HART_ACTIVE();
       Step_Execute(Retire_Success(), instbits)
     },
     (WAIT_WRS_NTO, _, true) => {
       if   get_config_print_instr()
-      then print_log("timed-out exit from " ^ wait_name(WAIT_WRS_NTO) ^ " state at PC " ^ bits_str(PC));
+      then print_log("timed-out exit from " ^ wait_name(WAIT_WRS_NTO) ^ " state at PC " ^ bits_str(bits_of_virtaddr(PC)));
 
       hart_state = HART_ACTIVE();
       // TODO: This is similar to WFI above for now, but will change to handle
@@ -80,7 +80,7 @@ private function run_hart_waiting(_step_no : int, wr: WaitReason, instbits : ins
     // remain waiting
     (_, _, false) => {
       if   get_config_print_instr()
-      then print_log("remaining in " ^ wait_name(wr) ^ " state at PC " ^ bits_str(PC));
+      then print_log("remaining in " ^ wait_name(wr) ^ " state at PC " ^ bits_str(bits_of_virtaddr(PC)));
       Step_Waiting(wr)
     }
   }
@@ -102,17 +102,17 @@ private function run_hart_active(step_no: nat) -> Step = {
         let instruction = ext_decode_compressed(h);
         if   get_config_print_instr()
         then {
-          print_log_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(PC) ^ " (" ^ bits_str(h) ^ ") " ^ to_str(instruction), zero_extend(PC));
+          print_log_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(bits_of_virtaddr(PC)) ^ " (" ^ bits_str(h) ^ ") " ^ to_str(instruction), zero_extend(bits_of_virtaddr(PC)));
         };
         // When ELP is set to LP_EXPECTED, the next instruction needs to be
         // the non-RVC `LPAD` instruction.
         if is_landing_pad_expected() then {
-          let r = Trap(cur_privilege, CTL_TRAP(make_landing_pad_exception()), PC);
+          let r = Trap(cur_privilege, CTL_TRAP(make_landing_pad_exception()), bits_of_virtaddr(PC));
           Step_Execute(r, instbits)
         }
         // check for RVC once here instead of every RVC execute clause.
         else if currentlyEnabled(Ext_Zca) then {
-          nextPC = PC + 2;
+          nextPC = bits_of_virtaddr(PC) + 2;
           let result : ExecutionResult = match execute(instruction) {
             ExecuteAs(other_inst) => execute(other_inst),
             result => result,
@@ -129,16 +129,16 @@ private function run_hart_active(step_no: nat) -> Step = {
         let instruction = ext_decode(w);
         if   get_config_print_instr()
         then {
-          print_log_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(PC) ^ " (" ^ bits_str(w) ^ ") " ^ to_str(instruction), zero_extend(PC));
+          print_log_instr("[" ^ dec_str(step_no) ^ "] [" ^ to_str(cur_privilege) ^ "]: " ^ bits_str(bits_of_virtaddr(PC)) ^ " (" ^ bits_str(w) ^ ") " ^ to_str(instruction), zero_extend(bits_of_virtaddr(PC)));
         };
         // When ELP is set to LP_EXPECTED, if the next instruction in
         // the instruction stream is not LPAD, then a software check
         // exception with a landing pad fault code is thrown.
         if is_landing_pad_expected() & not(is_lpad_instruction(instruction)) then {
-          let r = Trap(cur_privilege, CTL_TRAP(make_landing_pad_exception()), PC);
+          let r = Trap(cur_privilege, CTL_TRAP(make_landing_pad_exception()),bits_of_virtaddr(PC));
           Step_Execute(r, instbits)
         } else {
-          nextPC = PC + 4;
+          nextPC = bits_of_virtaddr(PC) + 4;
           let result : ExecutionResult = match execute(instruction) {
             ExecuteAs(other_inst) => execute(other_inst),
             result => result,
@@ -211,8 +211,9 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
     // This case was handled above when processing the fetch result.
     Step_Execute(ExecuteAs(_), _) => assert(false),
     // standard errors
-    Step_Execute(Trap(priv, ctl, pc), _) => set_next_pc(exception_handler(priv, ctl, pc)),
-    Step_Execute(Memory_Exception(vaddr, e), _) => handle_exception(bits_of(vaddr), e),
+    Step_Execute(Trap(priv, ctl, pc), _) => set_next_pc(exception_handler(priv, ctl, mk_virtaddr(pc))),
+    Step_Execute(Memory_Exception(vaddr, e), _) =>
+      handle_exception(bits_of(vaddr), e),
     Step_Execute(Illegal_Instruction(), instbits) => handle_exception(zero_extend(instbits), E_Illegal_Instr()),
     Step_Execute(Enter_Wait(wr), instbits) => {
       if wait_is_nop(wr) then {
@@ -221,7 +222,7 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
       } else {
         // Transition into the wait state.
         if   get_config_print_instr()
-        then print_log("entering " ^ wait_name(wr) ^ " state at PC " ^ bits_str(PC));
+        then print_log("entering " ^ wait_name(wr) ^ " state at PC " ^ bits_str(bits_of_virtaddr(PC)));
 
         hart_state = HART_WAITING(wr, instbits);
       }

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -152,8 +152,8 @@ function track_trap(p : Privilege) -> unit = {
 }
 
 // handle exceptional ctl flow by updating nextPC and operating privilege
-function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info : option(xlenbits), ext : option(ext_exception))
-                     -> xlenbits = {
+function trap_handler(del_priv : Privilege, c : TrapCause, pc : virtaddr,
+                      info : option(xlenbits), ext : option(ext_exception)) -> xlenbits = {
   let is_interrupt = trapCause_is_interrupt(c);
   let cause        = trapCause_bits(c);
 
@@ -175,11 +175,11 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
       mstatus[MIE]  = 0b0;
       mstatus[MPP]  = privLevel_to_bits(cur_privilege);
       mtval         = tval(info);
-      mepc          = pc;
+      mepc          = bits_of_virtaddr(pc);
 
       cur_privilege = del_priv;
 
-      handle_trap_extension(del_priv, pc, ext);
+      handle_trap_extension(del_priv, bits_of_virtaddr(pc), ext);
 
       track_trap(del_priv);
 
@@ -201,11 +201,11 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
         VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
       };
       stval           = tval(info);
-      sepc            = pc;
+      sepc            = bits_of_virtaddr(pc);
 
       cur_privilege   = del_priv;
 
-      handle_trap_extension(del_priv, pc, ext);
+      handle_trap_extension(del_priv, bits_of_virtaddr(pc), ext);
 
       track_trap(del_priv);
 
@@ -218,7 +218,7 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
 }
 
 function exception_handler(cur_priv : Privilege, ctl : ctl_result,
-                           pc: xlenbits) -> xlenbits = {
+                           pc : virtaddr) -> xlenbits = {
   match ctl {
     CTL_TRAP(e) => {
       let del_priv = exception_delegatee(e.trap, cur_priv);
@@ -333,10 +333,11 @@ function reset_misa() -> unit = {
 }
 
 // Address to reset PC to on reset.
-register pc_reset_address : xlenbits = zeros()
+register pc_reset_address : virtaddr = mk_virtaddr(zeros())
 // This is called externally to set the PC reset address to the ELF entry point.
 // bits(64) is used because it's easier to deal with in C.
-function set_pc_reset_address(addr : bits(64)) -> unit = pc_reset_address = trunc(addr)
+function set_pc_reset_address(addr : bits(64)) -> unit =
+  pc_reset_address = mk_virtaddr(trunc(addr))
 
 // This function is called on reset, so it should only perform the reset actions
 // described in the "Reset" section of the privileged architecture specification.
@@ -366,7 +367,7 @@ function reset_sys() -> unit = {
 
   // "The pc is set to an implementation-defined reset vector."
   PC = pc_reset_address;
-  nextPC = pc_reset_address;
+  nextPC = bits_of_virtaddr(pc_reset_address);
 
   // "The mcause register is set to a value indicating the cause of the reset."
   // "The mcause values after reset have implementation-specific interpretation,


### PR DESCRIPTION
Change the architectural PC register from xlenbits to virtaddr (a newtype) to better reflect its role as a virtual address.
Add mk_virtaddr : xlenbits -> virtaddr and use bits_of_virtaddr at boundaries (bit-level ops, logging, callbacks, CSRs).
In tick_pc(), commit nextPC:xlenbits into PC:virtaddr.
UpdateRVFI fetch paths to avoid indexing/adding a virtaddr directly: translation uses virtaddr.
Trap/exception flow: trap_handler takes virtaddr and stores mepc/sepc as bits.

Fixes #669 