### PR TITLE
Flush stdout in flush_logs function

### DIFF
--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -393,6 +393,7 @@ void finish() {
 void flush_logs(void) {
   if (config_print_instr) {
     fflush(stderr);
+    fflush(stdout);
     fflush(trace_log);
   }
 }


### PR DESCRIPTION
`stdout` was not being flushed, so mesasges like `HTIF located at ...` appeared after any actual console output.

Before:
```
using /home/jcarlin/riscv-projects/riscv-arch-test/work-ref/common/build/rv32i/I/I-add-00.sig for test-signature output.
using /home/jcarlin/riscv-projects/riscv-arch-test/work-ref/common/build/rv32i/I/I-add-00.sig.trace for trace output.

RVCP-SUMMARY: Test File "I-add-00.S": PASSED

HTIF located at 0x5000
begin_signature: 0xd250
end_signature: 0xeb80
Entry point: 0x100
SUCCESS
```

After:
```
using /home/jcarlin/riscv-projects/riscv-arch-test/work-ref/common/build/rv32i/I/I-add-00.sig for test-signature output.
using /home/jcarlin/riscv-projects/riscv-arch-test/work-ref/common/build/rv32i/I/I-add-00.sig.trace for trace output.
HTIF located at 0x5000
begin_signature: 0xd250
end_signature: 0xeb80
Entry point: 0x100

RVCP-SUMMARY: Test File "I-add-00.S": PASSED

SUCCESS
```