### PR TITLE
Create weekly binary release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ on:
         required: false
         type: boolean
   schedule:
-    # Weekly on Mondays at 00:00 UTC
-    - cron: "0 0 * * 1"
+    # Weekly on Mondays at 02:35 UTC
+    - cron: "35 2 * * 1"
 
 permissions:
   id-token: write


### PR DESCRIPTION
Create weekly pre-release Mondays at 02:35 UTC to make it easy to use up-to-date binaries of the model.