### PR TITLE
Add the Zicclsm extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ For booting operating system images, see the information under the
 - Ziccamoa extension for Main memory supports all atomics in Zaamo, v1.0
 - Ziccamoc extension for Main memory supports atomics in Zacas, v1.0
 - Ziccif extension for Main memory supports instruction fetch with atomicity requirement, v1.0
+- Zicclsm extension for Main memory misaligned accesses, v1.0
 - Ziccrse extension for Main memory regions with both the cacheability and coherence PMAs must support RsrvEventual, v1.0
 - Zicfilp extension for Landing Pad Control Flow Integrity, v1.0
 - Zicfiss extension for Shadow Stack Control Flow Integrity, v1.0

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -375,6 +375,9 @@
     "Ziccif": {
       "supported": true
     },
+    "Zicclsm": {
+      "supported": true
+    },
     "Ziccrse": {
       "supported": true
     },

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -33,6 +33,7 @@
   - Ziccamoa
   - Ziccamoc
   - Ziccif
+  - Zicclsm
   - Ziccrse
   - Zicfiss
   - Ssccptr

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -261,6 +261,11 @@ enum clause extension = Ext_Ziccif
 mapping clause extensionName = Ext_Ziccif <-> "ziccif"
 function clause hartSupports(Ext_Ziccif) = config extensions.Ziccif.supported
 function clause currentlyEnabled(Ext_Ziccif) = hartSupports(Ext_Ziccif)
+// Main memory misaligned accesses
+enum clause extension = Ext_Zicclsm
+mapping clause extensionName = Ext_Zicclsm <-> "zicclsm"
+function clause hartSupports(Ext_Zicclsm) = config extensions.Zicclsm.supported
+function clause currentlyEnabled(Ext_Zicclsm) = hartSupports(Ext_Zicclsm)
 // Main memory supports forward progress on LR/SC sequences
 enum clause extension = Ext_Ziccrse
 mapping clause extensionName= Ext_Ziccrse <-> "ziccrse"
@@ -660,6 +665,7 @@ let extensions_ordered_for_isa_string = [
   Ext_Ziccamoa,
   Ext_Ziccamoc,
   Ext_Ziccif,
+  Ext_Zicclsm,
   Ext_Ziccrse,
   Ext_Zicfilp,
   Ext_Zicfiss,

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -42,6 +42,12 @@ function optional_misaligned_exception_str(opt_e : option(misaligned_exception))
   }
 overload to_str = {optional_misaligned_exception_str}
 
+function misaligned_exception_is_access_fault(e : option(misaligned_exception)) -> bool =
+  match e {
+    Some(AccessFault) => true,
+    _                 => false,
+  }
+
 // Some misaligned accesses could proceed or generate exceptions.
 // When used in the global (pre-address translation) configuration,
 // `None` indicates that the handling is deferred to the underlying

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -268,6 +268,7 @@ private struct pma_check_opts = {
   ziccamoa : bool,
   ziccamoc : bool,
   ziccif   : bool,
+  zicclsm  : bool,
   ziccrse  : bool,
   ssccptr  : bool,
   svadu    : bool,
@@ -303,6 +304,16 @@ private function check_pma_regions(regions : list(PMA_Region), prev_base : bits(
         if check_opts.ziccif & not(attributes.executable) then {
           print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with no instruction fetch support, but Ziccif is enabled which requires this support.");
           return false;
+        };
+        if check_opts.zicclsm then {
+          if not(is_none(attributes.misaligned_exceptions.load_store)) then {
+            print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with exceptions for misaligned scalar loads/stores, but Zicclsm is enabled which requires no exceptions for such accesses.");
+            return false;
+          };
+          if not(is_none(attributes.misaligned_exceptions.vector)) then {
+            print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with exceptions for misaligned vector loads/stores, but Zicclsm is enabled which requires no exceptions for such accesses.");
+            return false;
+          };
         };
         if check_opts.ziccrse & attributes.reservability != RsrvEventual then {
           print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^ reservability_str(attributes.reservability) ^ " reservability support, but Ziccrse is enabled which requires RsrvEventual support.");
@@ -353,6 +364,7 @@ private function check_mem_layout() -> bool =
       ziccamoa = config extensions.Ziccamoa.supported,
       ziccamoc = config extensions.Ziccamoc.supported,
       ziccif   = config extensions.Ziccif.supported,
+      zicclsm  = config extensions.Zicclsm.supported,
       ziccrse  = config extensions.Ziccrse.supported,
       ssccptr  = config extensions.Ssccptr.supported,
       svadu    = config extensions.Svadu.supported,
@@ -492,6 +504,16 @@ private function check_extension_param_constraints() -> bool = {
     print_endline("The A or Zalrsc extensions are enabled, but the reservation set size of 2^" ^ dec_str(plat_reservation_set_size_exp) ^
                   " is too small; it should be at least 2^" ^ dec_str(min_rss_exp) ^
                   " for the LR/SC operands on this platform.");
+  };
+  if (config extensions.Zicclsm.supported : bool) then {
+    if not(is_none((config memory.misaligned.exceptions : GlobalMisalignedExceptions).load_store)) then {
+      valid = false;
+      print_endline("The Zicclsm extension is enabled, but misaligned scalar loads/stores raise misaligned exceptions before address translation (as per `memory.misaligned.exceptions.load_store`); Zicclsm requires no exceptions for such accesses.");
+    };
+    if not(is_none((config memory.misaligned.exceptions : GlobalMisalignedExceptions).vector)) then {
+      valid = false;
+      print_endline("The Zicclsm extension is enabled, but misaligned vector loads/stores raise misaligned exceptions before address translation (as per `memory.misaligned.exceptions.vector`); Zicclsm requires no exceptions for such accesses.");
+    };
   };
   valid
 }

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -255,7 +255,7 @@ private function check_pma_region(region : PMA_Region) -> bool = {
   match pma.mem_type {
     MainMemory =>
       if not(pma.readable & pma.writable & pma.read_idempotent & pma.write_idempotent) then {
-        print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is marked as MainMemory but is not readable, read-idempotent, writable, and write-idempotent.");
+        print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is marked as " ^ to_str(pma.mem_type) ^ " but is not readable, read-idempotent, writable, and write-idempotent.");
         return false;
       },
     IOMemory =>
@@ -294,11 +294,11 @@ private function check_pma_regions(regions : list(PMA_Region), prev_base : bits(
       let attributes = region.attributes;
       if attributes.mem_type == MainMemory & attributes.cacheable & attributes.coherent then {
         if check_opts.ziccamoa & attributes.atomic_support < AMOArithmetic then {
-          print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^ atomic_support_str(attributes.atomic_support) ^ " atomicity support, but Ziccamoa is enabled which requires AMOArithmetic support.");
+          print_endline("Main memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^ atomic_support_str(attributes.atomic_support) ^ " atomicity support, but Ziccamoa is enabled which requires AMOArithmetic support.");
           return false;
         };
         if check_opts.ziccamoc & attributes.atomic_support != AMOCASQ then {
-          print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^ atomic_support_str(attributes.atomic_support) ^ " atomicity support, but Ziccamoc is enabled which requires AMOCASQ support.");
+          print_endline("Main memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^ atomic_support_str(attributes.atomic_support) ^ " atomicity support, but Ziccamoc is enabled which requires AMOCASQ support.");
           return false;
         };
         if check_opts.ziccif & not(attributes.executable) then {
@@ -307,20 +307,20 @@ private function check_pma_regions(regions : list(PMA_Region), prev_base : bits(
         };
         if check_opts.zicclsm then {
           if misaligned_exception_is_access_fault(attributes.misaligned_exceptions.load_store) then {
-            print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with access faults for misaligned scalar loads/stores, but Zicclsm is enabled which requires no exceptions or only misaligned exceptions for such accesses.");
+            print_endline("Main memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with access faults for misaligned scalar loads/stores, but Zicclsm is enabled which requires no exceptions or only misaligned exceptions for such accesses.");
             return false;
           };
           if misaligned_exception_is_access_fault(attributes.misaligned_exceptions.vector) then {
-            print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with access faults for misaligned vector loads/stores, but Zicclsm is enabled which requires no exceptions or only misaligned exceptions for such accesses.");
+            print_endline("Main memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with access faults for misaligned vector loads/stores, but Zicclsm is enabled which requires no exceptions or only misaligned exceptions for such accesses.");
             return false;
           };
         };
         if check_opts.ziccrse & attributes.reservability != RsrvEventual then {
-          print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^ reservability_str(attributes.reservability) ^ " reservability support, but Ziccrse is enabled which requires RsrvEventual support.");
+          print_endline("Main memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^ reservability_str(attributes.reservability) ^ " reservability support, but Ziccrse is enabled which requires RsrvEventual support.");
           return false;
         };
         if check_opts.ssccptr & not(attributes.supports_pte_read) then {
-          print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable without hardware page-table read support, but Ssccptr is enabled which requires this support.");
+          print_endline("Main memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable without hardware page-table read support, but Ssccptr is enabled which requires this support.");
           return false;
         };
       };

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -306,12 +306,12 @@ private function check_pma_regions(regions : list(PMA_Region), prev_base : bits(
           return false;
         };
         if check_opts.zicclsm then {
-          if not(is_none(attributes.misaligned_exceptions.load_store)) then {
-            print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with exceptions for misaligned scalar loads/stores, but Zicclsm is enabled which requires no exceptions for such accesses.");
+          if misaligned_exception_is_access_fault(attributes.misaligned_exceptions.load_store) then {
+            print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with access faults for misaligned scalar loads/stores, but Zicclsm is enabled which requires no exceptions or only misaligned exceptions for such accesses.");
             return false;
           };
-          if not(is_none(attributes.misaligned_exceptions.vector)) then {
-            print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with exceptions for misaligned vector loads/stores, but Zicclsm is enabled which requires no exceptions for such accesses.");
+          if misaligned_exception_is_access_fault(attributes.misaligned_exceptions.vector) then {
+            print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with access faults for misaligned vector loads/stores, but Zicclsm is enabled which requires no exceptions or only misaligned exceptions for such accesses.");
             return false;
           };
         };
@@ -506,13 +506,13 @@ private function check_extension_param_constraints() -> bool = {
                   " for the LR/SC operands on this platform.");
   };
   if (config extensions.Zicclsm.supported : bool) then {
-    if not(is_none((config memory.misaligned.exceptions : GlobalMisalignedExceptions).load_store)) then {
+    if misaligned_exception_is_access_fault((config memory.misaligned.exceptions : GlobalMisalignedExceptions).load_store) then {
       valid = false;
-      print_endline("The Zicclsm extension is enabled, but misaligned scalar loads/stores raise misaligned exceptions before address translation (as per `memory.misaligned.exceptions.load_store`); Zicclsm requires no exceptions for such accesses.");
+      print_endline("The Zicclsm extension is enabled, but misaligned scalar loads/stores raise access faults before address translation (as per `memory.misaligned.exceptions.load_store`); Zicclsm requires no exceptions or only misaligned exceptions for such accesses.");
     };
-    if not(is_none((config memory.misaligned.exceptions : GlobalMisalignedExceptions).vector)) then {
+    if misaligned_exception_is_access_fault((config memory.misaligned.exceptions : GlobalMisalignedExceptions).vector) then {
       valid = false;
-      print_endline("The Zicclsm extension is enabled, but misaligned vector loads/stores raise misaligned exceptions before address translation (as per `memory.misaligned.exceptions.vector`); Zicclsm requires no exceptions for such accesses.");
+      print_endline("The Zicclsm extension is enabled, but misaligned vector loads/stores raise access faults before address translation (as per `memory.misaligned.exceptions.vector`); Zicclsm requires no exceptions or only misaligned exceptions for such accesses.");
     };
   };
   valid

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -27,14 +27,14 @@
 // performs misaligned accesses.
 let sys_misaligned_order_decreasing : bool = config memory.misaligned.order_decreasing
 
-// This is an external option that, when true, causes all misaligned accesses
-// to be split into single byte operations.  Otherwise, misaligned accesses
+// This is an external option that, when true, causes misaligned load/store accesses
+// to be split into single byte operations.  Otherwise, such misaligned accesses
 // are split into multiple accesses of smaller widths such that each of the latter
 // accesses is aligned.
 let sys_misaligned_byte_by_byte : bool = config memory.misaligned.byte_by_byte
 
 // This is an external option that returns an integer N, such that
-// when N is greater than zero, misaligned accesses to physical memory
+// when N is greater than zero, misaligned load/store accesses to physical memory
 // (as atomic events) are allowed provided the access occurs within a
 // naturally aligned 2^N byte region. If the access spans more than one of these
 // regions it will be split into multiple memory operations.


### PR DESCRIPTION
Adds the Zicclsm extension as specified in RVA23: "Misaligned loads and stores to main memory regions with both the cacheability and coherence PMAs must be supported."

