### PR TITLE
Remove obsolete TODO from pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,10 @@ repos:
     hooks:
       - id: trailing-whitespace
         # Do not strip trailing whitespace from patches or SVG images.
-        # TODO: the objdump outputs should probably not be part of the repo.
-        exclude: '.*\.(diff|dump|patch|svg)'
+        exclude: '.*\.(diff|patch|svg)'
       - id: end-of-file-fixer
         # Do not strip trailing newlines from patches or SVG images.
-        # TODO: the objdump outputs should probably not be part of the repo.
-        exclude: '.*\.(diff|dump|patch|svg)'
+        exclude: '.*\.(diff|patch|svg)'
       - id: check-yaml
       - id: check-added-large-files
       - id: check-executables-have-shebangs


### PR DESCRIPTION
We no longer have objdump outputs in the repository.