### PR TITLE
Use a consistent name for variables of MemoryAccessType.

### DIFF
--- a/model/core/addr_checks.sail
+++ b/model/core/addr_checks.sail
@@ -45,7 +45,7 @@ type ext_data_addr_error = unit
 
 // Default data addr is just base register + immediate offset (may be zero).
 // Extensions might override and add additional checks.
-function ext_data_get_addr(base : regidx, offset : xlenbits, _acc : MemoryAccessType(ext_access_type), _width : mem_access_width)
+function ext_data_get_addr(base : regidx, offset : xlenbits, _access : MemoryAccessType(ext_access_type), _width : mem_access_width)
          -> Ext_DataAddr_Check(ext_data_addr_error) =
   let addr = Virtaddr(X(base) + offset) in
   Ext_DataAddr_OK(addr)

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -105,8 +105,8 @@ union MemoryAccessType ('a : Type) = {
 enum CSRAccessType = { CSRRead, CSRWrite, CSRReadWrite }
 
 // Some features only affect loads/stores; not instruction fetch.
-function is_load_store forall ('a : Type) . (ac : MemoryAccessType('a)) -> bool =
-  match ac {
+function is_load_store forall ('a : Type) . (access : MemoryAccessType('a)) -> bool =
+  match access {
     Load(_)             => true,
     Store(_)            => true,
     LoadStore(_)        => true,

--- a/model/core/vmem_types.sail
+++ b/model/core/vmem_types.sail
@@ -37,8 +37,8 @@ let Data  : ext_access_type = ()
 
 let default_write_acc : ext_access_type = Data
 
-function accessType_to_str(a : MemoryAccessType(ext_access_type)) -> string =
-  match (a) {
+function accessType_to_str(access : MemoryAccessType(ext_access_type)) -> string =
+  match access {
     Load(_)            => "R",
     Store(_)           => "W",
     LoadStore(_, _)    => "RW",

--- a/model/pmp/pmp_control.sail
+++ b/model/pmp/pmp_control.sail
@@ -9,8 +9,8 @@
 
 // permission checks
 
-private function pmpCheckRWX(ent : Pmpcfg_ent, acc : MemoryAccessType(ext_access_type)) -> bool =
-  match acc {
+private function pmpCheckRWX(ent : Pmpcfg_ent, access : MemoryAccessType(ext_access_type)) -> bool =
+  match access {
     Load(_)            => ent[R] == 0b1,
     Store(_)           => ent[W] == 0b1,
     LoadStore(_)       => ent[R] == 0b1 & ent[W] == 0b1,
@@ -80,8 +80,8 @@ private function pmpMatchAddr(
 
 // priority checks
 
-private function accessToFault(acc : MemoryAccessType(ext_access_type)) -> ExceptionType =
-  match acc {
+private function accessToFault(access : MemoryAccessType(ext_access_type)) -> ExceptionType =
+  match access {
     Load(_)            => E_Load_Access_Fault(),
     Store(_)           => E_SAMO_Access_Fault(),
     LoadStore(_)       => E_SAMO_Access_Fault(),
@@ -91,7 +91,7 @@ private function accessToFault(acc : MemoryAccessType(ext_access_type)) -> Excep
 function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
   addr : physaddr,
   width : int('n),
-  acc : MemoryAccessType(ext_access_type),
+  access : MemoryAccessType(ext_access_type),
   priv : Privilege,
 ) -> option(ExceptionType) = {
 
@@ -105,15 +105,15 @@ function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
 
     match pmpMatchAddr(addr, width, cfg, pmpReadAddrReg(i), prev_pmpaddr) {
       PMP_NoMatch      => (),
-      PMP_PartialMatch => return Some(accessToFault(acc)),
+      PMP_PartialMatch => return Some(accessToFault(access)),
       PMP_Match        => return (
-        if pmpCheckRWX(cfg, acc) | (priv == Machine & not(pmpLocked(cfg)))
+        if pmpCheckRWX(cfg, access) | (priv == Machine & not(pmpLocked(cfg)))
         then None()
-        else Some(accessToFault(acc))
+        else Some(accessToFault(access))
       ),
     };
   };
-  if priv == Machine then None() else Some(accessToFault(acc))
+  if priv == Machine then None() else Some(accessToFault(access))
 }
 
 function reset_pmp() -> unit = {

--- a/model/sys/mem.sail
+++ b/model/sys/mem.sail
@@ -72,15 +72,15 @@ function write_kind_of_flags (aq : bool, rl : bool, con : bool) -> write_kind =
     (true,  false, true)  => internal_error(__FILE__, __LINE__, "Store-conditional with acquire semantics should be unreachable"),
   }
 
-private function accessFaultFromAccessType(accTy : MemoryAccessType(ext_access_type)) -> ExceptionType =
-  match accTy {
+private function accessFaultFromAccessType(access : MemoryAccessType(ext_access_type)) -> ExceptionType =
+  match access {
     InstructionFetch() => E_Fetch_Access_Fault(),
     Load(_)            => E_Load_Access_Fault(),
     _                  => E_SAMO_Access_Fault(),
   }
 
-private function alignmentFaultFromAccessType(accTy : MemoryAccessType(ext_access_type)) -> ExceptionType =
-  match accTy {
+private function alignmentFaultFromAccessType(access : MemoryAccessType(ext_access_type)) -> ExceptionType =
+  match access {
     InstructionFetch() => E_Fetch_Addr_Align(),
     Load(_)            => E_Load_Addr_Align(),
     _                  => E_SAMO_Addr_Align(),
@@ -90,22 +90,22 @@ private function pmaCheck forall 'n, 0 < 'n <= max_mem_access .
 (
   paddr      : physaddr,
   width      : int('n),
-  accTy      : MemoryAccessType(ext_access_type),
+  access     : MemoryAccessType(ext_access_type),
   res_or_con : bool,
 )  -> option(ExceptionType) = {
   match matching_pma(pma_regions, paddr, width) {
     None() => {
-      Some(accessFaultFromAccessType(accTy))
+      Some(accessFaultFromAccessType(access))
     },
     Some(struct { attributes, _ }) => {
       let misaligned = not(is_aligned_addr(paddr, width));
       // Check if we need to raise an exception for misalignment.
       match attributes.misaligned_fault {
-        AccessFault if misaligned => return Some(accessFaultFromAccessType(accTy)),
-        AlignmentFault if misaligned => return Some(alignmentFaultFromAccessType(accTy)),
+        AccessFault if misaligned => return Some(accessFaultFromAccessType(access)),
+        AlignmentFault if misaligned => return Some(alignmentFaultFromAccessType(access)),
         _ => {
           // Check read/write/execute permissions and PMAs.
-          let canAccess : bool = match accTy {
+          let canAccess : bool = match access {
             InstructionFetch() => attributes.executable,
             Load(_)            => attributes.readable & not(res_or_con & attributes.reservability == RsrvNone),
             Store(_)           => attributes.writable & not(res_or_con & attributes.reservability == RsrvNone),
@@ -121,7 +121,7 @@ private function pmaCheck forall 'n, 0 < 'n <= max_mem_access .
           if get_config_print_pma() & not(canAccess)
           then print_log("PMA check failed for " ^ hex_bits_str(bits_of(paddr)) ^ " PMA " ^ to_str(attributes));
 
-          if canAccess then None() else Some(accessFaultFromAccessType(accTy))
+          if canAccess then None() else Some(accessFaultFromAccessType(access))
         },
       }
     }
@@ -146,14 +146,14 @@ private function highestPriorityAlignmentOrAccessFault  (l : ExceptionType, r : 
 // Check if access is permitted according to PMPs and PMAs.
 // TODO: this can be marked private after https://github.com/riscv/sail-riscv/pull/1405
 function phys_access_check forall 'n, 0 < 'n <= max_mem_access . (
-  typ : MemoryAccessType(ext_access_type),
+  access : MemoryAccessType(ext_access_type),
   priv : Privilege,
   paddr : physaddr,
   width : int('n),
   res_or_con : bool,
 ) -> option(ExceptionType) = {
-  let pmpError : option(ExceptionType) = pmpCheck(paddr, width, typ, priv);
-  let pmaError : option(ExceptionType) = pmaCheck(paddr, width, typ, res_or_con);
+  let pmpError : option(ExceptionType) = pmpCheck(paddr, width, access, priv);
+  let pmaError : option(ExceptionType) = pmaCheck(paddr, width, access, res_or_con);
   match (pmpError, pmaError) {
     (None(), None())     => None(),
     (Some(e), None())    => Some(e),
@@ -164,7 +164,7 @@ function phys_access_check forall 'n, 0 < 'n <= max_mem_access . (
 
 // dispatches to MMIO regions or physical memory regions depending on physical memory map
 private function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (
-  t : MemoryAccessType(ext_access_type),
+  access : MemoryAccessType(ext_access_type),
   priv : Privilege,
   paddr : physaddr,
   width : int('n),
@@ -173,11 +173,11 @@ private function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (
   res: bool,
   meta : bool,
 ) -> MemoryOpResult((bits(8 * 'n), mem_meta)) =
-  match phys_access_check(t, priv, paddr, width, res) {
+  match phys_access_check(access, priv, paddr, width, res) {
     Some(e) => Err(e),
     None() => {
       if   within_mmio_readable(paddr, width)
-      then MemoryOpResult_add_meta(mmio_read(t, paddr, width), default_meta)
+      then MemoryOpResult_add_meta(mmio_read(access, paddr, width), default_meta)
       else {
         let rk = read_kind_of_flags(aq, rl, res);
         Ok(read_ram(rk, paddr, width, meta))
@@ -193,32 +193,32 @@ val mem_read_meta : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(ext_
 val mem_read_priv_meta : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(ext_access_type), Privilege, physaddr, int('n), bool, bool, bool, bool) -> MemoryOpResult((bits(8 * 'n), mem_meta))
 
 // The most generic memory read operation
-function mem_read_priv_meta (typ, priv, paddr, width, aq, rl, res, meta) = {
+function mem_read_priv_meta (access, priv, paddr, width, aq, rl, res, meta) = {
   let result : MemoryOpResult((bits(8 * 'n), mem_meta)) =
     if (aq | res) & not(is_aligned_addr(paddr, width))
     then Err(E_Load_Addr_Align())
     else match (aq, rl, res) {
       (false, true,  false) => throw(Error_not_implemented("load.rl")),
       (false, true,  true)  => throw(Error_not_implemented("lr.rl")),
-      (_, _, _)             => checked_mem_read(typ, priv, paddr, width, aq, rl, res, meta)
+      (_, _, _)             => checked_mem_read(access, priv, paddr, width, aq, rl, res, meta)
     };
   match result {
-    Ok(value, _) => mem_read_callback(to_str(typ), bits_of(paddr), width, value),
+    Ok(value, _) => mem_read_callback(to_str(access), bits_of(paddr), width, value),
     Err(e) => mem_exception_callback(bits_of(paddr), exceptionType_bits(e)),
   };
   result
 }
 
-function mem_read_meta (typ, paddr, width, aq, rl, res, meta) =
-  mem_read_priv_meta(typ, effectivePrivilege(typ, mstatus, cur_privilege), paddr, width, aq, rl, res, meta)
+function mem_read_meta (access, paddr, width, aq, rl, res, meta) =
+  mem_read_priv_meta(access, effectivePrivilege(access, mstatus, cur_privilege), paddr, width, aq, rl, res, meta)
 
 // Specialized mem_read_meta that drops the metadata
-function mem_read_priv (typ, priv, paddr, width, aq, rl, res) =
-  MemoryOpResult_drop_meta(mem_read_priv_meta(typ, priv, paddr, width, aq, rl, res, false))
+function mem_read_priv (access, priv, paddr, width, aq, rl, res) =
+  MemoryOpResult_drop_meta(mem_read_priv_meta(access, priv, paddr, width, aq, rl, res, false))
 
 // Specialized mem_read_priv that operates at the default effective privilege
-function mem_read (typ, paddr, width, aq, rel, res) =
-  mem_read_priv(typ, effectivePrivilege(typ, mstatus, cur_privilege), paddr, width, aq, rel, res)
+function mem_read (access, paddr, width, aq, rel, res) =
+  mem_read_priv(access, effectivePrivilege(access, mstatus, cur_privilege), paddr, width, aq, rel, res)
 
 val mem_write_ea : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bool, bool, bool) -> MemoryOpResult(unit)
 function mem_write_ea (addr, width, aq, rl, con) =
@@ -231,14 +231,14 @@ function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
   paddr : physaddr,
   width : int('n),
   data: bits(8 * 'n),
-  typ : MemoryAccessType(ext_access_type),
+  access : MemoryAccessType(ext_access_type),
   priv : Privilege,
   meta: mem_meta,
   aq : bool,
   rl : bool,
   con : bool,
 ) -> MemoryOpResult(bool) =
-  match phys_access_check(typ, priv, paddr, width, con) {
+  match phys_access_check(access, priv, paddr, width, con) {
     Some(e) => Err(e),
     None() => {
       if   within_mmio_writable(paddr, width)
@@ -256,13 +256,13 @@ function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
 // currently assumed to have the same alignment constraints as their
 // data.
 val mem_write_value_priv_meta : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), MemoryAccessType(ext_access_type), Privilege, mem_meta, bool, bool, bool) -> MemoryOpResult(bool)
-function mem_write_value_priv_meta (paddr, width, value, typ, priv, meta, aq, rl, con) = {
+function mem_write_value_priv_meta (paddr, width, value, access, priv, meta, aq, rl, con) = {
   if (rl | con) & not(is_aligned_addr(paddr, width))
   then Err(E_SAMO_Addr_Align())
   else {
-    let result = checked_mem_write(paddr, width, value, typ, priv, meta, aq, rl, con);
+    let result = checked_mem_write(paddr, width, value, access, priv, meta, aq, rl, con);
     match result {
-      Ok(_) => mem_write_callback(to_str(typ), bits_of(paddr), width, value),
+      Ok(_) => mem_write_callback(to_str(access), bits_of(paddr), width, value),
       Err(e) => mem_exception_callback(bits_of(paddr), exceptionType_bits(e)),
     };
     result
@@ -277,9 +277,9 @@ function mem_write_value_priv (paddr, width, value, priv, aq, rl, con) =
 // Memory write with explicit metadata and MemoryAccessType, implicit and Privilege
 val mem_write_value_meta : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), ext_access_type, mem_meta, bool, bool, bool) -> MemoryOpResult(bool)
 function mem_write_value_meta (paddr, width, value, ext_acc, meta, aq, rl, con) = {
-  let typ = Store(ext_acc);
-  let ep = effectivePrivilege(typ, mstatus, cur_privilege);
-  mem_write_value_priv_meta(paddr, width, value, typ, ep, meta, aq, rl, con)
+  let access = Store(ext_acc);
+  let ep = effectivePrivilege(access, mstatus, cur_privilege);
+  mem_write_value_priv_meta(paddr, width, value, access, ep, meta, aq, rl, con)
 }
 
 // Memory write with default MemoryAccessType, Privilege, and metadata

--- a/model/sys/platform.sail
+++ b/model/sys/platform.sail
@@ -70,7 +70,7 @@ let MTIME_BASE       : physaddrbits = zero_extend(0x0bff8)
 let MTIME_BASE_HI    : physaddrbits = zero_extend(0x0bffc)
 
 private val clint_load : forall 'n, 'n > 0. (MemoryAccessType(ext_access_type), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
-function clint_load(t, Physaddr(addr), width) = {
+function clint_load(access, Physaddr(addr), width) = {
   let addr = addr - plat_clint_base;
   // FIXME: For now, only allow exact aligned access.
   if addr == MSIP_BASE & ('n == 8 | 'n == 4)
@@ -121,7 +121,7 @@ function clint_load(t, Physaddr(addr), width) = {
   else {
     if   get_config_print_clint()
     then print_log("clint[" ^ bits_str(addr) ^ "] -> <not-mapped>");
-    match t {
+    match access {
       InstructionFetch() => Err(E_Fetch_Access_Fault()),
       Load(_)            => Err(E_Load_Access_Fault()),
       _                  => Err(E_SAMO_Access_Fault())
@@ -248,7 +248,7 @@ private function reset_htif () -> unit = {
 // dispatched the address.
 
 private val htif_load : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(ext_access_type), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
-function htif_load(acc, Physaddr(paddr), width) = {
+function htif_load(access, Physaddr(paddr), width) = {
   if   get_config_print_htif()
   then print_log("htif[" ^ hex_bits_str(paddr) ^ "] -> " ^ bits_str(htif_tohost));
 
@@ -264,7 +264,7 @@ function htif_load(acc, Physaddr(paddr), width) = {
   then    Ok(zero_extend(32, htif_tohost[31..0]))  // FIXME: Redundant zero_extend currently required by Lem backend
   else if width == 4 & paddr == base + 4
   then    Ok(zero_extend(32, htif_tohost[63..32])) // FIXME: Redundant zero_extend currently required by Lem backend
-  else match acc {
+  else match access {
     InstructionFetch() => Err(E_Fetch_Access_Fault()),
     Load(_)            => Err(E_Load_Access_Fault()),
     _                  => Err(E_SAMO_Access_Fault())
@@ -345,12 +345,12 @@ function within_mmio_writable forall 'n, 0 < 'n <= max_mem_access . (addr : phys
   then false
   else within_clint(addr, width) | (within_htif_writable(addr, width) & 'n <= 8)
 
-function mmio_read forall 'n, 0 < 'n <= max_mem_access . (t : MemoryAccessType(ext_access_type), paddr : physaddr, width : int('n)) -> MemoryOpResult(bits(8 * 'n)) =
+function mmio_read forall 'n, 0 < 'n <= max_mem_access . (access : MemoryAccessType(ext_access_type), paddr : physaddr, width : int('n)) -> MemoryOpResult(bits(8 * 'n)) =
   if   within_clint(paddr, width)
-  then clint_load(t, paddr, width)
+  then clint_load(access, paddr, width)
   else if within_htif_readable(paddr, width)
-  then htif_load(t, paddr, width)
-  else match t {
+  then htif_load(access, paddr, width)
+  else match access {
     InstructionFetch() => Err(E_Fetch_Access_Fault()),
     Load(_)            => Err(E_Load_Access_Fault()),
     _                  => Err(E_SAMO_Access_Fault())

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -8,8 +8,8 @@
 
 // Machine-mode and supervisor-mode functionality.
 
-function effectivePrivilege(access_type : MemoryAccessType(ext_access_type), m : Mstatus, priv : Privilege) -> Privilege =
-  if   access_type != InstructionFetch() & m[MPRV] == 0b1
+function effectivePrivilege(access : MemoryAccessType(ext_access_type), m : Mstatus, priv : Privilege) -> Privilege =
+  if   access != InstructionFetch() & m[MPRV] == 0b1
   then privLevel_bits(m[MPP], bitzero) // TODO: use m[MPV] if hypervisor enabled
   else priv
 

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -72,7 +72,7 @@ private val pt_walk : forall 'v, is_sv_mode('v) . (
 function pt_walk(
   sv_width,
   vpn,
-  ac,
+  access,
   priv,
   mxr,
   do_sum,
@@ -81,7 +81,7 @@ function pt_walk(
   global,
   ext_ptw,
 ) = {
-  ptw_start_callback(zero_extend(vpn), ac, (priv, ()));
+  ptw_start_callback(zero_extend(vpn), access, (priv, ()));
 
   // Extract the PPN component for this level; 10 bits on Sv32, otherwise 9.
   let 'vpn_i_size = if 'v == 32 then 10 else 9;
@@ -124,7 +124,7 @@ function pt_walk(
           // Non-Leaf PTE
           if level > 0 then
             // follow the pointer to walk next level (i.e., go to Step 2)
-            pt_walk(sv_width, vpn, ac, priv, mxr, do_sum, ppn, level - 1, global, ext_ptw)
+            pt_walk(sv_width, vpn, access, priv, mxr, do_sum, ppn, level - 1, global, ext_ptw)
           else {
               // level 0 PTE, but contains a pointer instead of a leaf
               ptw_fail_callback(PTW_Invalid_PTE(), level, bits_of(pte_addr));
@@ -143,7 +143,7 @@ function pt_walk(
             };
           };
           // Steps 6, 7 (TODO: shadow stack protection), 8 of VATP.
-          match check_PTE_permission(ac, priv, mxr, do_sum, pte_flags, pte_ext, ext_ptw) {
+          match check_PTE_permission(access, priv, mxr, do_sum, pte_flags, pte_ext, ext_ptw) {
             PTE_Check_Failure(ext_ptw, pte_failure) => {
               ptw_fail_callback(ext_get_ptw_error(pte_failure), level, bits_of(pte_addr));
               Err(ext_get_ptw_error(pte_failure), ext_ptw)
@@ -227,7 +227,7 @@ private function translate_TLB_hit forall 'v, is_sv_mode('v) . (
   sv_width  : int('v),
   _asid     : asidbits,
   vpn       : vpn_bits('v),
-  ac        : MemoryAccessType(ext_access_type),
+  access    : MemoryAccessType(ext_access_type),
   priv      : Privilege,
   mxr       : bool,
   do_sum    : bool,
@@ -240,14 +240,14 @@ private function translate_TLB_hit forall 'v, is_sv_mode('v) . (
   let pte       = tlb_get_pte(pte_size, ent);  // Step 2 of VATP.
   let ext_pte   = ext_bits_of_PTE(pte);
   let pte_flags = Mk_PTE_Flags(pte[7 .. 0]);
-  let pte_check = check_PTE_permission(ac, priv, mxr, do_sum, pte_flags,
+  let pte_check = check_PTE_permission(access, priv, mxr, do_sum, pte_flags,
                                        ext_pte, ext_ptw);
 
   match pte_check {
     PTE_Check_Failure(ext_ptw, pte_failure) =>
       Err(ext_get_ptw_error(pte_failure), ext_ptw),
     PTE_Check_Success(ext_ptw) =>
-      match update_PTE_Bits(pte, ac) {
+      match update_PTE_Bits(pte, access) {
         None()     => Ok(tlb_get_ppn(sv_width, ent, vpn), ext_ptw),
         Some(pte') =>
           // Step 9 of VATP. See platform.sail.
@@ -274,7 +274,7 @@ private function translate_TLB_miss forall 'v, is_sv_mode('v) . (
   asid     : asidbits,
   base_ppn : ppn_bits('v),
   vpn      : vpn_bits('v),
-  ac       : MemoryAccessType(ext_access_type),
+  access   : MemoryAccessType(ext_access_type),
   priv     : Privilege,
   mxr      : bool,
   do_sum   : bool,
@@ -284,7 +284,7 @@ private function translate_TLB_miss forall 'v, is_sv_mode('v) . (
 
   // Step 2 of VATP occurs in pt_walk().
   let 'pte_size = if sv_width == 32 then 4 else 8;
-  let ptw_result = pt_walk(sv_width, vpn, ac, priv, mxr, do_sum,
+  let ptw_result = pt_walk(sv_width, vpn, access, priv, mxr, do_sum,
                            base_ppn, initial_level, false, ext_ptw);
   match ptw_result {
     Err(f, ext_ptw) => Err(f, ext_ptw),
@@ -292,7 +292,7 @@ private function translate_TLB_miss forall 'v, is_sv_mode('v) . (
       let ext_pte = ext_bits_of_PTE(pte);
       // Without TLBs, this 'match' expression can be replaced simply
       // by: 'Ok(ppn, ext_ptw)'    (see TLB NOTE above)
-      match update_PTE_Bits(pte, ac) {
+      match update_PTE_Bits(pte, access) {
         None() => {
           add_to_TLB(sv_width, asid, vpn, ppn, pte, pteAddr, level, global);
           Ok(ppn, ext_ptw)
@@ -332,7 +332,7 @@ private function translate forall 'v, is_sv_mode('v) . (
   asid     : asidbits,
   base_ppn : ppn_bits('v),
   vpn      : vpn_bits('v),
-  ac       : MemoryAccessType(ext_access_type),
+  access   : MemoryAccessType(ext_access_type),
   priv     : Privilege,
   mxr      : bool,
   do_sum   : bool,
@@ -341,9 +341,9 @@ private function translate forall 'v, is_sv_mode('v) . (
   // On first reading, assume lookup_TLB returns None(), since TLBs
   // are not part of RISC-V archticture spec (see TLB NOTE above)
   match lookup_TLB(sv_width, asid, vpn) {
-    Some(index, ent) => translate_TLB_hit(sv_width, asid, vpn, ac, priv,
+    Some(index, ent) => translate_TLB_hit(sv_width, asid, vpn, access, priv,
                                           mxr, do_sum, ext_ptw, index, ent),
-    None()           => translate_TLB_miss(sv_width, asid, base_ppn, vpn, ac, priv,
+    None()           => translate_TLB_miss(sv_width, asid, base_ppn, vpn, access, priv,
                                            mxr, do_sum, ext_ptw),
   }
 }
@@ -364,12 +364,12 @@ private function get_satp forall 'v, is_sv_mode('v). (
 // [postlude/fetch.sail, A/zaamo_insts.sail, Zicbo{zm}/zicbo{zm}_insts.sail].
 function translateAddr(
   vAddr : virtaddr,
-  ac    : MemoryAccessType(ext_access_type),
+  access : MemoryAccessType(ext_access_type),
 ) -> TR_Result(physaddr, ExceptionType) = {
 
   // Effective privilege takes into account mstatus.PRV, mstatus.MPP
   // See sys_regs.sail for effectivePrivilege() and cur_privilege
-  let effPriv = effectivePrivilege(ac, mstatus, cur_privilege);
+  let effPriv = effectivePrivilege(access, mstatus, cur_privilege);
 
   let mode = translationMode(effPriv);
 
@@ -386,7 +386,7 @@ function translateAddr(
 
   let svAddr = bits_of(vAddr)[sv_width - 1 .. 0];
   if bits_of(vAddr) != sign_extend(svAddr) then {
-    Err(translationException(ac, PTW_Invalid_Addr()), init_ext_ptw)
+    Err(translationException(access, PTW_Invalid_Addr()), init_ext_ptw)
   } else {
     let mxr    = mstatus[MXR] == 0b1;
     let do_sum = mstatus[SUM] == 0b1;
@@ -399,7 +399,7 @@ function translateAddr(
                         zero_extend(asid),
                         base_ppn,
                         svAddr[sv_width - 1 .. pagesize_bits],
-                        ac, effPriv, mxr, do_sum,
+                        access, effPriv, mxr, do_sum,
                         init_ext_ptw);
     // Fixup result PA or exception
     match res {
@@ -413,7 +413,7 @@ function translateAddr(
         // the assertion above.
         Ok(Physaddr(zero_extend(paddr)), ext_ptw)
       },
-      Err(f, ext_ptw)  => Err(translationException(ac, f), ext_ptw)
+      Err(f, ext_ptw)  => Err(translationException(access, f), ext_ptw)
     }
   }
 }

--- a/model/sys/vmem_pte.sail
+++ b/model/sys/vmem_pte.sail
@@ -109,7 +109,7 @@ union PTE_Check = {
 }
 
 private function check_PTE_permission(
-  ac        : MemoryAccessType(ext_access_type),
+  access    : MemoryAccessType(ext_access_type),
   priv      : Privilege,
   // Make eXecutable Readable
   mxr       : bool,
@@ -129,7 +129,7 @@ private function check_PTE_permission(
     User       => pte_U,
     // SUM allows supervisor mode to access U-mode pages, but only for
     // loads and stores; not instruction fetch.
-    Supervisor => not(pte_U) | (do_sum & is_load_store(ac)),
+    Supervisor => not(pte_U) | (do_sum & is_load_store(access)),
     Machine    => internal_error(__FILE__, __LINE__, "m-mode mem perm check"),
     VirtualUser => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
     VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
@@ -139,7 +139,7 @@ private function check_PTE_permission(
   // (TODO: Step 7 awaits shadow stack implementation (Zicfiss).)
 
   // Step 8 of VATP (see vmem.sail).
-  let access_ok : bool = match ac {
+  let access_ok : bool = match access {
     Load(_)             => pte_R | (pte_X & mxr),
     Store(_)            => pte_W,
     LoadStore(_, _)     => pte_W & (pte_R | (pte_X & mxr)),
@@ -153,13 +153,13 @@ private function check_PTE_permission(
 // Update PTE bits if needed; return new PTE if updated
 private function update_PTE_Bits forall 'pte_size, 'pte_size in {32, 64} . (
   pte : bits('pte_size),
-  a   : MemoryAccessType(ext_access_type),
+  access : MemoryAccessType(ext_access_type),
 ) -> option(bits('pte_size)) = {
   let pte_flags = Mk_PTE_Flags(pte[7 .. 0]);
 
   // Update 'dirty' bit?
   let update_d : bool = (pte_flags[D] == 0b0)
-                        & (match a {
+                        & (match access {
                              InstructionFetch() => false,
                              Load(_)            => false,
                              Store(_)           => true,

--- a/model/sys/vmem_ptw.sail
+++ b/model/sys/vmem_ptw.sail
@@ -49,10 +49,10 @@ private function ext_get_ptw_error(failure : pte_check_failure) -> PTW_Error =
   }
 
 // Convert translation/PTW failures into architectural exceptions
-function translationException(a : MemoryAccessType(ext_access_type),
-                              f : PTW_Error)
+function translationException(access : MemoryAccessType(ext_access_type),
+                              err : PTW_Error)
                              -> ExceptionType = {
-  match (a, f) {
+  match (access, err) {
     (_, PTW_Ext_Error(e))                 => E_Extension(ext_translate_exception(e)),
     (LoadStore(_), PTW_No_Access())       => E_SAMO_Access_Fault(),
     (LoadStore(_), _)                     => E_SAMO_Page_Fault(),

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -120,7 +120,7 @@ val vmem_read_addr : forall 'width, is_mem_width('width).
   (virtaddr, xlenbits, int('width), MemoryAccessType(ext_access_type), bool, bool, bool)
   -> result(bits(8 * 'width), ExecutionResult)
 
-function vmem_read_addr(vaddr, offset, width, acc, aq, rl, res) = {
+function vmem_read_addr(vaddr, offset, width, access, aq, rl, res) = {
   // TODO: Rationalize to use a single alignment definition if possible.
   if res then {
     // "LR faults like a normal load, even though it's in the AMO major opcode space."
@@ -146,10 +146,10 @@ function vmem_read_addr(vaddr, offset, width, acc, aq, rl, res) = {
   repeat {
     let offset = i;
     let vaddr = vaddr + (offset * bytes);
-    match translateAddr(Virtaddr(vaddr), acc) {
+    match translateAddr(Virtaddr(vaddr), access) {
       Err(e, _) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
 
-      Ok(paddr, _) => match mem_read(acc, paddr, bytes, aq, rl, res) {
+      Ok(paddr, _) => match mem_read(access, paddr, bytes, aq, rl, res) {
         Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
 
         Ok(v) => {
@@ -179,7 +179,7 @@ val vmem_write_addr : forall 'width, is_mem_width('width).
   (virtaddr, int('width), bits(8 * 'width), MemoryAccessType(ext_access_type), bool, bool, bool)
   -> result(bool, ExecutionResult)
 
-function vmem_write_addr(vaddr, width, data, acc, aq, rl, res) = {
+function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
   if   check_misaligned(vaddr, width)
   then return Err(Memory_Exception(vaddr, E_SAMO_Addr_Align()));
 
@@ -197,7 +197,7 @@ function vmem_write_addr(vaddr, width, data, acc, aq, rl, res) = {
   repeat {
     let offset = i;
     let vaddr = vaddr + (offset * bytes);
-    match translateAddr(Virtaddr(vaddr), acc) {
+    match translateAddr(Virtaddr(vaddr), access) {
       Err(e, _) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
 
       // NOTE: Currently, we only announce the effective address if address translation is successful.
@@ -237,28 +237,28 @@ val vmem_read : forall 'width, is_mem_width('width).
   (regidx, xlenbits, int('width), MemoryAccessType(ext_access_type), bool, bool, bool)
   -> result(bits(8 * 'width), ExecutionResult)
 
-function vmem_read(rs, offset, width, acc, aq, rl, res) = {
+function vmem_read(rs, offset, width, access, aq, rl, res) = {
   // Get the address, X(rs1) + offset.
   // Extensions might perform additional checks on address validity.
-  let vaddr : virtaddr = match ext_data_get_addr(rs, offset, acc, width) {
+  let vaddr : virtaddr = match ext_data_get_addr(rs, offset, access, width) {
     Ext_DataAddr_OK(vaddr) => vaddr,
     Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
   };
 
-  vmem_read_addr(vaddr, offset, width, acc, aq, rl, res)
+  vmem_read_addr(vaddr, offset, width, access, aq, rl, res)
 }
 
 val vmem_write : forall 'width, is_mem_width('width).
   (regidx, xlenbits, int('width), bits(8 * 'width), MemoryAccessType(ext_access_type), bool, bool, bool)
   -> result(bool, ExecutionResult)
 
-function vmem_write(rs_addr, offset, width, data, acc, aq, rl, res) = {
+function vmem_write(rs_addr, offset, width, data, access, aq, rl, res) = {
   // Get the address, X(rs_addr) + offset.
   // Extensions might perform additional checks on address validity.
-  let vaddr : virtaddr = match ext_data_get_addr(rs_addr, offset, acc, width) {
+  let vaddr : virtaddr = match ext_data_get_addr(rs_addr, offset, access, width) {
     Ext_DataAddr_OK(vaddr) => vaddr,
     Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
   };
 
-  vmem_write_addr(vaddr, width, data, acc, aq, rl, res)
+  vmem_write_addr(vaddr, width, data, access, aq, rl, res)
 }


### PR DESCRIPTION
This makes the code a bit more readable.