### PR TITLE
Centralize memory-access-to-fault conversions.

### DIFF
--- a/model/core/mem_type_utils.sail
+++ b/model/core/mem_type_utils.sail
@@ -1,0 +1,23 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+function accessFaultFromAccessType(access : MemoryAccessType(ext_access_type)) -> ExceptionType =
+  match access {
+    InstructionFetch() => E_Fetch_Access_Fault(),
+    Load(_)            => E_Load_Access_Fault(),
+    Store(_)           => E_SAMO_Access_Fault(),
+    LoadStore(_)       => E_SAMO_Access_Fault(),
+  }
+
+function alignmentFaultFromAccessType(access : MemoryAccessType(ext_access_type)) -> ExceptionType =
+  match access {
+    InstructionFetch() => E_Fetch_Addr_Align(),
+    Load(_)            => E_Load_Addr_Align(),
+    Store(_)           => E_SAMO_Addr_Align(),
+    LoadStore(_)       => E_SAMO_Addr_Align(),
+  }

--- a/model/pmp/pmp_control.sail
+++ b/model/pmp/pmp_control.sail
@@ -80,14 +80,6 @@ private function pmpMatchAddr(
 
 // priority checks
 
-private function accessToFault(access : MemoryAccessType(ext_access_type)) -> ExceptionType =
-  match access {
-    Load(_)            => E_Load_Access_Fault(),
-    Store(_)           => E_SAMO_Access_Fault(),
-    LoadStore(_)       => E_SAMO_Access_Fault(),
-    InstructionFetch() => E_Fetch_Access_Fault(),
-  }
-
 function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
   addr : physaddr,
   width : int('n),
@@ -105,15 +97,15 @@ function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
 
     match pmpMatchAddr(addr, width, cfg, pmpReadAddrReg(i), prev_pmpaddr) {
       PMP_NoMatch      => (),
-      PMP_PartialMatch => return Some(accessToFault(access)),
+      PMP_PartialMatch => return Some(accessFaultFromAccessType(access)),
       PMP_Match        => return (
         if pmpCheckRWX(cfg, access) | (priv == Machine & not(pmpLocked(cfg)))
         then None()
-        else Some(accessToFault(access))
+        else Some(accessFaultFromAccessType(access))
       ),
     };
   };
-  if priv == Machine then None() else Some(accessToFault(access))
+  if priv == Machine then None() else Some(accessFaultFromAccessType(access))
 }
 
 function reset_pmp() -> unit = {

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -28,6 +28,7 @@ core {
     core/types_ext.sail,
     core/types.sail,
     core/vmem_types.sail,
+    core/mem_type_utils.sail,
     core/csr_begin.sail,
     core/callbacks.sail,
     core/reg_type.sail,

--- a/model/sys/mem.sail
+++ b/model/sys/mem.sail
@@ -72,20 +72,6 @@ function write_kind_of_flags (aq : bool, rl : bool, con : bool) -> write_kind =
     (true,  false, true)  => internal_error(__FILE__, __LINE__, "Store-conditional with acquire semantics should be unreachable"),
   }
 
-private function accessFaultFromAccessType(access : MemoryAccessType(ext_access_type)) -> ExceptionType =
-  match access {
-    InstructionFetch() => E_Fetch_Access_Fault(),
-    Load(_)            => E_Load_Access_Fault(),
-    _                  => E_SAMO_Access_Fault(),
-  }
-
-private function alignmentFaultFromAccessType(access : MemoryAccessType(ext_access_type)) -> ExceptionType =
-  match access {
-    InstructionFetch() => E_Fetch_Addr_Align(),
-    Load(_)            => E_Load_Addr_Align(),
-    _                  => E_SAMO_Addr_Align(),
-  }
-
 private function pmaCheck forall 'n, 0 < 'n <= max_mem_access .
 (
   paddr      : physaddr,

--- a/model/sys/platform.sail
+++ b/model/sys/platform.sail
@@ -121,11 +121,7 @@ function clint_load(access, Physaddr(addr), width) = {
   else {
     if   get_config_print_clint()
     then print_log("clint[" ^ bits_str(addr) ^ "] -> <not-mapped>");
-    match access {
-      InstructionFetch() => Err(E_Fetch_Access_Fault()),
-      Load(_)            => Err(E_Load_Access_Fault()),
-      _                  => Err(E_SAMO_Access_Fault())
-    }
+    Err(accessFaultFromAccessType(access))
   }
 }
 
@@ -264,11 +260,7 @@ function htif_load(access, Physaddr(paddr), width) = {
   then    Ok(zero_extend(32, htif_tohost[31..0]))  // FIXME: Redundant zero_extend currently required by Lem backend
   else if width == 4 & paddr == base + 4
   then    Ok(zero_extend(32, htif_tohost[63..32])) // FIXME: Redundant zero_extend currently required by Lem backend
-  else match access {
-    InstructionFetch() => Err(E_Fetch_Access_Fault()),
-    Load(_)            => Err(E_Load_Access_Fault()),
-    _                  => Err(E_SAMO_Access_Fault())
-  }
+  else    Err(accessFaultFromAccessType(access))
 }
 
 private val htif_store : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
@@ -350,11 +342,7 @@ function mmio_read forall 'n, 0 < 'n <= max_mem_access . (access : MemoryAccessT
   then clint_load(access, paddr, width)
   else if within_htif_readable(paddr, width)
   then htif_load(access, paddr, width)
-  else match access {
-    InstructionFetch() => Err(E_Fetch_Access_Fault()),
-    Load(_)            => Err(E_Load_Access_Fault()),
-    _                  => Err(E_SAMO_Access_Fault())
-  }
+  else Err(accessFaultFromAccessType(access))
 
 function mmio_write forall 'n, 0 < 'n <= max_mem_access . (paddr : physaddr, width : int('n), data: bits(8 * 'n)) -> MemoryOpResult(bool) =
   if   within_clint(paddr, width)


### PR DESCRIPTION
There were multiple conversions scattered around the model. Some used wild-cards, making it easy to miss correct handling when adding a new memory access type, or causing duplicated effort when changing memory access handling.
