### PR TITLE
Add unratified Zvabd extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The following unratified extensions are supported and can be enabled using the `
 
 - Zibi extension for conditional branches with immediate operands, v0.6
 
-Zvabd extension for vector absolute difference, v0.5
+Zvabd extension for vector absolute difference, v0.7
 
 **For a list of unsupported extensions and features, see the [Extension Roadmap](https://github.com/riscv/sail-riscv/wiki/Extension-Roadmap).**
 

--- a/README.md
+++ b/README.md
@@ -187,8 +187,7 @@ For booting operating system images, see the information under the
 The following unratified extensions are supported and can be enabled using the `--enable-experimental-extensions` flag:
 
 - Zibi extension for conditional branches with immediate operands, v0.6
-
-Zvabd extension for vector absolute difference, v0.7
+- Zvabd extension for vector absolute difference, v0.7
 
 **For a list of unsupported extensions and features, see the [Extension Roadmap](https://github.com/riscv/sail-riscv/wiki/Extension-Roadmap).**
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ The following unratified extensions are supported and can be enabled using the `
 
 - Zibi extension for conditional branches with immediate operands, v0.6
 
+Zvabd extension for vector absolute difference, v0.5
+
 **For a list of unsupported extensions and features, see the [Extension Roadmap](https://github.com/riscv/sail-riscv/wiki/Extension-Roadmap).**
 
 ## Example RISC-V instruction specifications

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -373,6 +373,9 @@
     "Zhinxmin": {
       "supported": false
     },
+    "Zvabd": {
+      "supported": true
+    },
     "Zvfbfmin": {
       "supported": true
     },

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -11,6 +11,7 @@
 - The following extensions have been added:
   - Za64rs, Za128rs
   - Zic64b
+  - Zvabd
   - Sstvala
   - Sstvecd
   - Ssu64xl

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -319,6 +319,10 @@ function clause hartSupports(Ext_Zve64f) = sizeof(elen_exp) >= 6 & vector_suppor
 enum clause extension = Ext_Zve64x
 mapping clause extensionName = Ext_Zve64x <-> "zve64x"
 function clause hartSupports(Ext_Zve64x) = sizeof(elen_exp) >= 6 & vector_support_level >= Integer
+// Vector Integer Absolute Difference
+enum clause extension = Ext_Zvabd
+mapping clause extensionName = Ext_Zvabd <-> "zvabd"
+function clause hartSupports(Ext_Zvabd) = sys_enable_experimental_extensions() & config extensions.Zvabd.supported
 // Vector BF16 Converts
 enum clause extension = Ext_Zvfbfmin
 mapping clause extensionName = Ext_Zvfbfmin <-> "zvfbfmin"
@@ -659,6 +663,9 @@ let extensions_ordered_for_isa_string = [
   Ext_Zksed,
   Ext_Zksh,
   Ext_Zkt,
+
+  //Zvabd
+  Ext_Zvabd,
 
   // Zvb
   Ext_Zvbb,

--- a/model/extensions/Zvabd/zvabd_insts.sail
+++ b/model/extensions/Zvabd/zvabd_insts.sail
@@ -8,17 +8,20 @@
 
 function clause currentlyEnabled(Ext_Zvabd) = hartSupports(Ext_Zvabd) & currentlyEnabled(Ext_Zve32x)
 
-union clause instruction = VABS_V : (zvabd_vabs_func6, bits(1), vregidx, vregidx)
+// Since the targeted use cases are mostly based on 8-bit and 16-bit integer,
+// `vabd/vabdu/vwabda/vwabdau` are designed for only SEW=8 and SEW=16.
+// Additionally, `vabs` is considered to support all the element sizes
+// as it is quite common used and simple to implement.
+function valid_zvabd_sew(sew : int) -> bool = sew == 8 | sew == 16
 
-$[wavedrom "_ _ _ _ OPMVV _ OP-V"]
-mapping clause encdec = VABS_V(V_VABS, vm, vs2, vd)
+union clause instruction = VABS_V : (bits(1), vregidx, vregidx)
+
+$[wavedrom "funct6 _ _ _ OPMVV _ OP-V"]
+mapping clause encdec = VABS_V(vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvabd)
 
-mapping clause assembly = VABS_V(V_VABS, vm, vs2, vd)
-  <-> "vabs.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
-
-function clause execute VABS_V(funct6, vm, vs2, vd) = {
+function clause execute VABS_V(vm, vs2, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -39,17 +42,17 @@ function clause execute VABS_V(funct6, vm, vs2, vd) = {
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] == 0b1 then {
-      result[i] = match funct6 {
-        V_VABS => to_bits(SEW, abs_int(signed(vs2_val[i])))
-      };
-    }
+    if mask[i] == 0b1 then
+      result[i] = to_bits(SEW, abs_int(signed(vs2_val[i])))
   };
 
   write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }
+
+mapping clause assembly = VABS_V(vm, vs2, vd)
+  <-> "vabs.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
 
 union clause instruction = ZVABDTYPE : (zvabd_vabd_func6, bits(1), vregidx, vregidx, vregidx)
 
@@ -58,18 +61,10 @@ mapping encdec_zvabd_vabd_func6 : zvabd_vabd_func6 <-> bits(6) = {
   VV_VABDU <-> 0b010011
 }
 
-$[wavedrom "_ _ _ _ OPIVV _ OP-V"]
+$[wavedrom "funct6 _ _ _ OPIVV _ OP-V"]
 mapping clause encdec = ZVABDTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_zvabd_vabd_func6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when currentlyEnabled(Ext_Zvabd)
-
-mapping vabd_mnemonic : zvabd_vabd_func6 <-> string = {
-  VV_VABD  <-> "vabd.vv",
-  VV_VABDU <-> "vabdu.vv"
-}
-
-mapping clause assembly = ZVABDTYPE(funct6, vm, vs2, vs1, vd)
-  <-> vabd_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+  when currentlyEnabled(Ext_Zvabd) & valid_zvabd_sew(get_sew())
 
 function clause execute ZVABDTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW      = get_sew();
@@ -106,25 +101,25 @@ function clause execute ZVABDTYPE(funct6, vm, vs2, vs1, vd) = {
   RETIRE_SUCCESS
 }
 
+mapping vabd_mnemonic : zvabd_vabd_func6 <-> string = {
+  VV_VABD  <-> "vabd.vv",
+  VV_VABDU <-> "vabdu.vv"
+}
+
+mapping clause assembly = ZVABDTYPE(funct6, vm, vs2, vs1, vd)
+  <-> vabd_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
 union clause instruction = ZVWABDATYPE : (zvabd_vwabda_func6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_zvabd_vwabda_func6 : zvabd_vwabda_func6 <-> bits(6) = {
-  VV_VWABDACC  <-> 0b010101,
-  VV_VWABDACCU <-> 0b010110
+  VV_VWABDA  <-> 0b010101,
+  VV_VWABDAU <-> 0b010110
 }
 
-$[wavedrom "_ _ _ _ OPIVV _ OP-V"]
+$[wavedrom "funct6 _ _ _ OPIVV _ OP-V"]
 mapping clause encdec = ZVWABDATYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_zvabd_vwabda_func6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when currentlyEnabled(Ext_Zvabd)
-
-mapping vwabda_mnemonic : zvabd_vwabda_func6 <-> string = {
-  VV_VWABDACC  <-> "vwabdacc.vv",
-  VV_VWABDACCU <-> "vwabdaccu.vv"
-}
-
-mapping clause assembly = ZVWABDATYPE(funct6, vm, vs2, vs1, vd)
-  <-> vwabda_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+  when currentlyEnabled(Ext_Zvabd) & valid_zvabd_sew(get_sew())
 
 function clause execute ZVWABDATYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW      = get_sew();
@@ -138,7 +133,7 @@ function clause execute ZVWABDATYPE(funct6, vm, vs2, vs1, vd) = {
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
 
-  assert(SEW_widen <= 64);
+  assert(SEW_widen == 16 | SEW_widen == 32);
   assert(LMUL_pow_widen <= 3);
 
   let 'n = num_elem;
@@ -159,11 +154,11 @@ function clause execute ZVWABDATYPE(funct6, vm, vs2, vs1, vd) = {
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == 0b1 then {
       result[i] = match funct6 {
-        VV_VWABDACC  => {
+        VV_VWABDA  => {
           let diff = signed(vs2_val[i]) - signed(vs1_val[i]);
           to_bits_unsafe(SEW_widen, signed(vd_val[i]) + abs_int(diff))
         },
-        VV_VWABDACCU => {
+        VV_VWABDAU => {
           let abs_diff = if unsigned(vs2_val[i]) >= unsigned(vs1_val[i])
                          then unsigned(vs2_val[i] - vs1_val[i])
                          else unsigned(vs1_val[i] - vs2_val[i]);
@@ -177,3 +172,11 @@ function clause execute ZVWABDATYPE(funct6, vm, vs2, vs1, vd) = {
   set_vstart(zeros());
   RETIRE_SUCCESS
 }
+
+mapping vwabda_mnemonic : zvabd_vwabda_func6 <-> string = {
+  VV_VWABDA  <-> "vwabda.vv",
+  VV_VWABDAU <-> "vwabdau.vv"
+}
+
+mapping clause assembly = ZVWABDATYPE(funct6, vm, vs2, vs1, vd)
+  <-> vwabda_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)

--- a/model/extensions/Zvabd/zvabd_insts.sail
+++ b/model/extensions/Zvabd/zvabd_insts.sail
@@ -12,7 +12,7 @@ function clause currentlyEnabled(Ext_Zvabd) = hartSupports(Ext_Zvabd) & currentl
 // `vabd/vabdu/vwabda/vwabdau` are designed for only SEW=8 and SEW=16.
 // Additionally, `vabs` is considered to support all the element sizes
 // as it is quite common used and simple to implement.
-function valid_zvabd_sew(sew : int) -> bool = sew == 8 | sew == 16
+private function valid_zvabd_sew(sew : int) -> bool = sew == 8 | sew == 16
 
 union clause instruction = VABS_V : (bits(1), vregidx, vregidx)
 

--- a/model/extensions/Zvabd/zvabd_insts.sail
+++ b/model/extensions/Zvabd/zvabd_insts.sail
@@ -1,0 +1,179 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+function clause currentlyEnabled(Ext_Zvabd) = hartSupports(Ext_Zvabd) & currentlyEnabled(Ext_Zve32x)
+
+union clause instruction = VABS_V : (zvabd_vabs_func6, bits(1), vregidx, vregidx)
+
+$[wavedrom "_ _ _ _ OPMVV _ OP-V"]
+mapping clause encdec = VABS_V(V_VABS, vm, vs2, vd)
+  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
+  when currentlyEnabled(Ext_Zvabd)
+
+mapping clause assembly = VABS_V(V_VABS, vm, vs2, vd)
+  <-> "vabs.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+
+function clause execute VABS_V(funct6, vm, vs2, vd) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if illegal_normal(vd, vm) then return Illegal_Instruction();
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return Illegal_Instruction()
+  };
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == 0b1 then {
+      result[i] = match funct6 {
+        V_VABS => to_bits(SEW, abs_int(signed(vs2_val[i])))
+      };
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  set_vstart(zeros());
+  RETIRE_SUCCESS
+}
+
+union clause instruction = ZVABDTYPE : (zvabd_vabd_func6, bits(1), vregidx, vregidx, vregidx)
+
+mapping encdec_zvabd_vabd_func6 : zvabd_vabd_func6 <-> bits(6) = {
+  VV_VABD  <-> 0b010001,
+  VV_VABDU <-> 0b010011
+}
+
+$[wavedrom "_ _ _ _ OPIVV _ OP-V"]
+mapping clause encdec = ZVABDTYPE(funct6, vm, vs2, vs1, vd)
+  <-> encdec_zvabd_vabd_func6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
+  when currentlyEnabled(Ext_Zvabd)
+
+mapping vabd_mnemonic : zvabd_vabd_func6 <-> string = {
+  VV_VABD  <-> "vabd.vv",
+  VV_VABDU <-> "vabdu.vv"
+}
+
+mapping clause assembly = ZVABDTYPE(funct6, vm, vs2, vs1, vd)
+  <-> vabd_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+function clause execute ZVABDTYPE(funct6, vm, vs2, vs1, vd) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if illegal_normal(vd, vm) then return Illegal_Instruction();
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
+  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return Illegal_Instruction()
+  };
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == 0b1 then {
+      result[i] = match funct6 {
+        VV_VABD  => to_bits(SEW, abs_int(signed(vs2_val[i]) - signed(vs1_val[i]))),
+        VV_VABDU => to_bits(SEW, abs_int(unsigned(vs2_val[i]) - unsigned(vs1_val[i])))
+      };
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  set_vstart(zeros());
+  RETIRE_SUCCESS
+}
+
+union clause instruction = ZVWABDATYPE : (zvabd_vwabda_func6, bits(1), vregidx, vregidx, vregidx)
+
+mapping encdec_zvabd_vwabda_func6 : zvabd_vwabda_func6 <-> bits(6) = {
+  VV_VWABDACC  <-> 0b010101,
+  VV_VWABDACCU <-> 0b010110
+}
+
+$[wavedrom "_ _ _ _ OPIVV _ OP-V"]
+mapping clause encdec = ZVWABDATYPE(funct6, vm, vs2, vs1, vd)
+  <-> encdec_zvabd_vwabda_func6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
+  when currentlyEnabled(Ext_Zvabd)
+
+mapping vwabda_mnemonic : zvabd_vwabda_func6 <-> string = {
+  VV_VWABDACC  <-> "vwabdacc.vv",
+  VV_VWABDACCU <-> "vwabdaccu.vv"
+}
+
+mapping clause assembly = ZVWABDATYPE(funct6, vm, vs2, vs1, vd)
+  <-> vwabda_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+function clause execute ZVWABDATYPE(funct6, vm, vs2, vs1, vd) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+
+  if illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
+      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  then return Illegal_Instruction();
+
+  assert(SEW_widen <= 64);
+  assert(LMUL_pow_widen <= 3);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
+  let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return Illegal_Instruction()
+  };
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == 0b1 then {
+      result[i] = match funct6 {
+        VV_VWABDACC  => {
+          let diff = signed(vs2_val[i]) - signed(vs1_val[i]);
+          to_bits_unsafe(SEW_widen, signed(vd_val[i]) + abs_int(diff))
+        },
+        VV_VWABDACCU => {
+          let abs_diff = if unsigned(vs2_val[i]) >= unsigned(vs1_val[i])
+                         then unsigned(vs2_val[i] - vs1_val[i])
+                         else unsigned(vs1_val[i] - vs2_val[i]);
+          to_bits_unsafe(SEW_widen, unsigned(vd_val[i]) + abs_diff)
+        }
+      };
+    }
+  };
+
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  set_vstart(zeros());
+  RETIRE_SUCCESS
+}

--- a/model/extensions/Zvabd/zvabd_insts.sail
+++ b/model/extensions/Zvabd/zvabd_insts.sail
@@ -12,7 +12,7 @@ function clause currentlyEnabled(Ext_Zvabd) = hartSupports(Ext_Zvabd) & currentl
 // `vabd/vabdu/vwabda/vwabdau` are designed for only SEW=8 and SEW=16.
 // Additionally, `vabs` is considered to support all the element sizes
 // as it is quite common used and simple to implement.
-private function valid_zvabd_sew(sew : int) -> bool = sew == 8 | sew == 16
+private function valid_zvabd_sew(sew : sew_bitsize) -> bool = sew == 8 | sew == 16
 
 union clause instruction = VABS_V : (bits(1), vregidx, vregidx)
 
@@ -20,6 +20,7 @@ $[wavedrom "funct6 _ _ _ OPMVV _ OP-V"]
 mapping clause encdec = VABS_V(vm, vs2, vd)
   <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvabd)
+    & ((get_sew() <= 32) | (currentlyEnabled(Ext_Zve64x) & get_sew() <= 64))
 
 function clause execute VABS_V(vm, vs2, vd) = {
   let SEW      = get_sew();
@@ -61,7 +62,7 @@ mapping encdec_zvabd_vabd_func6 : zvabd_vabd_func6 <-> bits(6) = {
   VV_VABDU <-> 0b010011
 }
 
-$[wavedrom "funct6 _ _ _ OPIVV _ OP-V"]
+$[wavedrom "funct6 _ _ _ OPMVV _ OP-V"]
 mapping clause encdec = ZVABDTYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_zvabd_vabd_func6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvabd) & valid_zvabd_sew(get_sew())
@@ -116,7 +117,7 @@ mapping encdec_zvabd_vwabda_func6 : zvabd_vwabda_func6 <-> bits(6) = {
   VV_VWABDAU <-> 0b010110
 }
 
-$[wavedrom "funct6 _ _ _ OPIVV _ OP-V"]
+$[wavedrom "funct6 _ _ _ OPMVV _ OP-V"]
 mapping clause encdec = ZVWABDATYPE(funct6, vm, vs2, vs1, vd)
   <-> encdec_zvabd_vwabda_func6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
   when currentlyEnabled(Ext_Zvabd) & valid_zvabd_sew(get_sew())
@@ -128,7 +129,7 @@ function clause execute ZVWABDATYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();

--- a/model/extensions/Zvabd/zvabd_types.sail
+++ b/model/extensions/Zvabd/zvabd_types.sail
@@ -6,6 +6,5 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // =======================================================================================
 
-enum zvabd_vabs_func6 = {V_VABS}
 enum zvabd_vabd_func6 = {VV_VABD, VV_VABDU}
-enum zvabd_vwabda_func6 = {VV_VWABDACC, VV_VWABDACCU}
+enum zvabd_vwabda_func6 = {VV_VWABDA, VV_VWABDAU}

--- a/model/extensions/Zvabd/zvabd_types.sail
+++ b/model/extensions/Zvabd/zvabd_types.sail
@@ -1,0 +1,11 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+enum zvabd_vabs_func6 = {V_VABS}
+enum zvabd_vabd_func6 = {VV_VABD, VV_VABDU}
+enum zvabd_vwabda_func6 = {VV_VWABDACC, VV_VWABDACCU}

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -304,6 +304,19 @@ extensions {
     }
   }
 
+  Zvabd {
+    requires core
+
+    Zvabd_types {
+      before sys
+      files extensions/Zvabd/zvabd_types.sail
+    }
+    Zvabd_insts {
+      requires sys, V, Zvabd_types
+      files extensions/Zvabd/zvabd_insts.sail
+    }
+  }
+
   // Control and Status Register (CSR) Instructions
   Zicsr {
     requires core


### PR DESCRIPTION
Implement the integer vector absolute difference extension
 as defined in the Fast-Track Proposal: https://riscv.atlassian.net/wiki/spaces/VXXX/pages/166690866/Fast-Track+Proposal+for+integer+vector+absolute+difference+instructions
Spec: https://github.com/riscv/integer-vector-absolute-difference/releases/