### PR TITLE
Rename the `ext_access_type` type to `mem_payload`.

### DIFF
--- a/c_emulator/riscv_callbacks_if.cpp
+++ b/c_emulator/riscv_callbacks_if.cpp
@@ -95,7 +95,7 @@ void callbacks_if::trap_callback(
 void callbacks_if::ptw_start_callback(
   [[maybe_unused]] hart::Model &model,
   [[maybe_unused]] uint64_t vpn,
-  [[maybe_unused]] hart::zMemoryAccessTypezIuzK access_type,
+  [[maybe_unused]] hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
   [[maybe_unused]] hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
 ) {
 }

--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -6,7 +6,7 @@ namespace hart {
 
 class Model;
 
-struct zMemoryAccessTypezIuzK;
+struct zMemoryAccessTypezIEmem_payloadz5zK;
 struct ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9;
 struct zPTW_Error;
 
@@ -50,7 +50,7 @@ public:
   virtual void ptw_start_callback(
     hart::Model &model,
     uint64_t vpn,
-    hart::zMemoryAccessTypezIuzK access_type,
+    hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
     hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
   );
 

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -116,7 +116,7 @@ void log_callbacks::vreg_write_callback(hart::Model &, unsigned reg, lbits value
 void log_callbacks::ptw_start_callback(
   hart::Model &model,
   uint64_t vpn,
-  hart::zMemoryAccessTypezIuzK access_type,
+  hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
   hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
 ) {
   if (trace_log != nullptr && config_print_ptw) {

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -26,7 +26,7 @@ public:
   void ptw_start_callback(
     hart::Model &model,
     uint64_t vpn,
-    hart::zMemoryAccessTypezIuzK access_type,
+    hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
     hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
   ) override;
   void ptw_step_callback(hart::Model &model, int64_t level, sbits pte_addr, uint64_t pte) override;

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -130,7 +130,7 @@ unit ModelImpl::trap_callback(bool is_interrupt, fbits cause) {
 
 unit ModelImpl::ptw_start_callback(
   uint64_t vpn,
-  hart::zMemoryAccessTypezIuzK access_type,
+  hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
   hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
 ) {
   for (auto c : m_callbacks) {

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -46,7 +46,7 @@ private:
   // Page table walk callbacks
   unit ptw_start_callback(
     uint64_t vpn,
-    hart::zMemoryAccessTypezIuzK access_type,
+    hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
     hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
   ) override;
   unit ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte) override;

--- a/c_emulator/riscv_platform_if.cpp
+++ b/c_emulator/riscv_platform_if.cpp
@@ -83,7 +83,7 @@ unit PlatformInterface::trap_callback([[maybe_unused]] bool is_interrupt, [[mayb
 
 unit PlatformInterface::ptw_start_callback(
   [[maybe_unused]] uint64_t vpn,
-  [[maybe_unused]] hart::zMemoryAccessTypezIuzK access_type,
+  [[maybe_unused]] hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
   [[maybe_unused]] hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
 ) {
   return UNIT;

--- a/c_emulator/riscv_platform_if.h
+++ b/c_emulator/riscv_platform_if.h
@@ -8,7 +8,7 @@ namespace hart {
 
 class Model;
 
-struct zMemoryAccessTypezIuzK;
+struct zMemoryAccessTypezIEmem_payloadz5zK;
 struct ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9;
 struct zPTW_Error;
 
@@ -52,7 +52,7 @@ public:
   // Page table walk callbacks
   virtual unit ptw_start_callback(
     uint64_t vpn,
-    hart::zMemoryAccessTypezIuzK access_type,
+    hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
     hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
   );
   virtual unit ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte);

--- a/model/core/addr_checks.sail
+++ b/model/core/addr_checks.sail
@@ -45,7 +45,7 @@ type ext_data_addr_error = unit
 
 // Default data addr is just base register + immediate offset (may be zero).
 // Extensions might override and add additional checks.
-function ext_data_get_addr(base : regidx, offset : xlenbits, _access : MemoryAccessType(ext_access_type), _width : mem_access_width)
+function ext_data_get_addr(base : regidx, offset : xlenbits, _access : MemoryAccessType(mem_payload), _width : mem_access_width)
          -> Ext_DataAddr_Check(ext_data_addr_error) =
   let addr = Virtaddr(X(base) + offset) in
   Ext_DataAddr_OK(addr)

--- a/model/core/mem_type_utils.sail
+++ b/model/core/mem_type_utils.sail
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // =======================================================================================
 
-function accessFaultFromAccessType(access : MemoryAccessType(ext_access_type)) -> ExceptionType =
+function accessFaultFromAccessType(access : MemoryAccessType(mem_payload)) -> ExceptionType =
   match access {
     InstructionFetch() => E_Fetch_Access_Fault(),
     Load(_)            => E_Load_Access_Fault(),
@@ -14,7 +14,7 @@ function accessFaultFromAccessType(access : MemoryAccessType(ext_access_type)) -
     LoadStore(_)       => E_SAMO_Access_Fault(),
   }
 
-function alignmentFaultFromAccessType(access : MemoryAccessType(ext_access_type)) -> ExceptionType =
+function alignmentFaultFromAccessType(access : MemoryAccessType(mem_payload)) -> ExceptionType =
   match access {
     InstructionFetch() => E_Fetch_Addr_Align(),
     Load(_)            => E_Load_Addr_Align(),

--- a/model/core/vmem_types.sail
+++ b/model/core/vmem_types.sail
@@ -28,20 +28,28 @@ type ppn_bits('v), is_sv_mode('v) = bits(if 'v == 32 then 22 else 44)
 // Number of Virtual Page Number bits, depending on the virtual memory mode.
 type vpn_bits('v), is_sv_mode('v) = bits('v - pagesize_bits)
 
+// TODO: For Zicfiss, this enum will be extended with ShadowStack, and
+// for CHERI, this enum can be extended with Cap/Tagged.  This assumes
+// that capabilities cannot be stored to the ShadowStack; this is
+// implied by CHERI and Zicfiss currently being incompatible.
+//
+// If, instead, CHERI and Zicfiss are made compatible, this could perhaps be
+// handled by adding ShadowStack{Load,Store,Atomic} variants to
+// MemoryAccessType and removing the ShadowStack variant here.
 
-// Extensions for memory Accesstype.
+enum mem_payload = { Data }
 
-type ext_access_type = unit
+mapping mem_payload_str : mem_payload <-> string = {
+  Data <-> "",
+}
 
-let Data  : ext_access_type = ()
+let default_write_acc : mem_payload = Data
 
-let default_write_acc : ext_access_type = Data
-
-function accessType_to_str(access : MemoryAccessType(ext_access_type)) -> string =
+function accessType_to_str(access : MemoryAccessType(mem_payload)) -> string =
   match access {
-    Load(_)            => "R",
-    Store(_)           => "W",
-    LoadStore(_, _)    => "RW",
+    Load(p)            => "R" ^ mem_payload_str(p),
+    Store(p)           => "W" ^ mem_payload_str(p),
+    LoadStore(lp, sp)  => "R" ^ mem_payload_str(lp) ^ "W" ^ mem_payload_str(sp),
     InstructionFetch() => "X",
   }
 

--- a/model/pmp/pmp_control.sail
+++ b/model/pmp/pmp_control.sail
@@ -9,7 +9,7 @@
 
 // permission checks
 
-private function pmpCheckRWX(ent : Pmpcfg_ent, access : MemoryAccessType(ext_access_type)) -> bool =
+private function pmpCheckRWX(ent : Pmpcfg_ent, access : MemoryAccessType(mem_payload)) -> bool =
   match access {
     Load(_)            => ent[R] == 0b1,
     Store(_)           => ent[W] == 0b1,
@@ -83,7 +83,7 @@ private function pmpMatchAddr(
 function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
   addr : physaddr,
   width : int('n),
-  access : MemoryAccessType(ext_access_type),
+  access : MemoryAccessType(mem_payload),
   priv : Privilege,
 ) -> option(ExceptionType) = {
 

--- a/model/sys/callbacks.sail
+++ b/model/sys/callbacks.sail
@@ -14,7 +14,7 @@
 // the types (hart::zPrivilege etc.) in a separate header to hart::Model.
 // See https://github.com/rems-project/sail/issues/1560
 
-val ptw_start_callback = pure {cpp: "ptw_start_callback"} : (/* vpn */ bits(64), /* access type */ MemoryAccessType(ext_access_type), /* privilege */ (Privilege, unit)) -> unit
+val ptw_start_callback = pure {cpp: "ptw_start_callback"} : (/* vpn */ bits(64), /* access type */ MemoryAccessType(mem_payload), /* privilege */ (Privilege, unit)) -> unit
 function ptw_start_callback(_) = ()
 
 val ptw_step_callback = pure {cpp: "ptw_step_callback"} : (/* level */ range(0, 4), /* pte_addr */ physaddrbits, /* pte */ bits(64)) -> unit

--- a/model/sys/mem.sail
+++ b/model/sys/mem.sail
@@ -76,7 +76,7 @@ private function pmaCheck forall 'n, 0 < 'n <= max_mem_access .
 (
   paddr      : physaddr,
   width      : int('n),
-  access     : MemoryAccessType(ext_access_type),
+  access     : MemoryAccessType(mem_payload),
   res_or_con : bool,
 )  -> option(ExceptionType) = {
   match matching_pma(pma_regions, paddr, width) {
@@ -132,7 +132,7 @@ private function highestPriorityAlignmentOrAccessFault  (l : ExceptionType, r : 
 // Check if access is permitted according to PMPs and PMAs.
 // TODO: this can be marked private after https://github.com/riscv/sail-riscv/pull/1405
 function phys_access_check forall 'n, 0 < 'n <= max_mem_access . (
-  access : MemoryAccessType(ext_access_type),
+  access : MemoryAccessType(mem_payload),
   priv : Privilege,
   paddr : physaddr,
   width : int('n),
@@ -150,7 +150,7 @@ function phys_access_check forall 'n, 0 < 'n <= max_mem_access . (
 
 // dispatches to MMIO regions or physical memory regions depending on physical memory map
 private function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (
-  access : MemoryAccessType(ext_access_type),
+  access : MemoryAccessType(mem_payload),
   priv : Privilege,
   paddr : physaddr,
   width : int('n),
@@ -173,10 +173,10 @@ private function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (
 
 // Atomic accesses can be done to MMIO regions, e.g. in kernel access to device registers.
 
-val mem_read      : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(ext_access_type), physaddr, int('n), bool, bool, bool)       -> MemoryOpResult(bits(8 * 'n))
-val mem_read_priv : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(ext_access_type), Privilege, physaddr, int('n), bool, bool, bool)       -> MemoryOpResult(bits(8 * 'n))
-val mem_read_meta : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(ext_access_type), physaddr, int('n), bool, bool, bool, bool) -> MemoryOpResult((bits(8 * 'n), mem_meta))
-val mem_read_priv_meta : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(ext_access_type), Privilege, physaddr, int('n), bool, bool, bool, bool) -> MemoryOpResult((bits(8 * 'n), mem_meta))
+val mem_read      : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(mem_payload), physaddr, int('n), bool, bool, bool)       -> MemoryOpResult(bits(8 * 'n))
+val mem_read_priv : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(mem_payload), Privilege, physaddr, int('n), bool, bool, bool)       -> MemoryOpResult(bits(8 * 'n))
+val mem_read_meta : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(mem_payload), physaddr, int('n), bool, bool, bool, bool) -> MemoryOpResult((bits(8 * 'n), mem_meta))
+val mem_read_priv_meta : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(mem_payload), Privilege, physaddr, int('n), bool, bool, bool, bool) -> MemoryOpResult((bits(8 * 'n), mem_meta))
 
 // The most generic memory read operation
 function mem_read_priv_meta (access, priv, paddr, width, aq, rl, res, meta) = {
@@ -217,7 +217,7 @@ function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
   paddr : physaddr,
   width : int('n),
   data: bits(8 * 'n),
-  access : MemoryAccessType(ext_access_type),
+  access : MemoryAccessType(mem_payload),
   priv : Privilege,
   meta: mem_meta,
   aq : bool,
@@ -241,7 +241,7 @@ function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
 // Memory write with an explicit metadata value.  Metadata writes are
 // currently assumed to have the same alignment constraints as their
 // data.
-val mem_write_value_priv_meta : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), MemoryAccessType(ext_access_type), Privilege, mem_meta, bool, bool, bool) -> MemoryOpResult(bool)
+val mem_write_value_priv_meta : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), MemoryAccessType(mem_payload), Privilege, mem_meta, bool, bool, bool) -> MemoryOpResult(bool)
 function mem_write_value_priv_meta (paddr, width, value, access, priv, meta, aq, rl, con) = {
   if (rl | con) & not(is_aligned_addr(paddr, width))
   then Err(E_SAMO_Addr_Align())
@@ -261,9 +261,9 @@ function mem_write_value_priv (paddr, width, value, priv, aq, rl, con) =
   mem_write_value_priv_meta(paddr, width, value, Store(default_write_acc), priv, default_meta, aq, rl, con)
 
 // Memory write with explicit metadata and MemoryAccessType, implicit and Privilege
-val mem_write_value_meta : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), ext_access_type, mem_meta, bool, bool, bool) -> MemoryOpResult(bool)
-function mem_write_value_meta (paddr, width, value, ext_acc, meta, aq, rl, con) = {
-  let access = Store(ext_acc);
+val mem_write_value_meta : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), mem_payload, mem_meta, bool, bool, bool) -> MemoryOpResult(bool)
+function mem_write_value_meta (paddr, width, value, payload, meta, aq, rl, con) = {
+  let access = Store(payload);
   let ep = effectivePrivilege(access, mstatus, cur_privilege);
   mem_write_value_priv_meta(paddr, width, value, access, ep, meta, aq, rl, con)
 }

--- a/model/sys/platform.sail
+++ b/model/sys/platform.sail
@@ -69,7 +69,7 @@ let MTIMECMP_BASE_HI : physaddrbits = zero_extend(0x04004)
 let MTIME_BASE       : physaddrbits = zero_extend(0x0bff8)
 let MTIME_BASE_HI    : physaddrbits = zero_extend(0x0bffc)
 
-private val clint_load : forall 'n, 'n > 0. (MemoryAccessType(ext_access_type), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
+private val clint_load : forall 'n, 'n > 0. (MemoryAccessType(mem_payload), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
 function clint_load(access, Physaddr(addr), width) = {
   let addr = addr - plat_clint_base;
   // FIXME: For now, only allow exact aligned access.
@@ -243,7 +243,7 @@ private function reset_htif () -> unit = {
 // we'll assume here that physical memory model has correctly
 // dispatched the address.
 
-private val htif_load : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(ext_access_type), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
+private val htif_load : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(mem_payload), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
 function htif_load(access, Physaddr(paddr), width) = {
   if   get_config_print_htif()
   then print_log("htif[" ^ hex_bits_str(paddr) ^ "] -> " ^ bits_str(htif_tohost));
@@ -337,7 +337,7 @@ function within_mmio_writable forall 'n, 0 < 'n <= max_mem_access . (addr : phys
   then false
   else within_clint(addr, width) | (within_htif_writable(addr, width) & 'n <= 8)
 
-function mmio_read forall 'n, 0 < 'n <= max_mem_access . (access : MemoryAccessType(ext_access_type), paddr : physaddr, width : int('n)) -> MemoryOpResult(bits(8 * 'n)) =
+function mmio_read forall 'n, 0 < 'n <= max_mem_access . (access : MemoryAccessType(mem_payload), paddr : physaddr, width : int('n)) -> MemoryOpResult(bits(8 * 'n)) =
   if   within_clint(paddr, width)
   then clint_load(access, paddr, width)
   else if within_htif_readable(paddr, width)

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -8,7 +8,7 @@
 
 // Machine-mode and supervisor-mode functionality.
 
-function effectivePrivilege(access : MemoryAccessType(ext_access_type), m : Mstatus, priv : Privilege) -> Privilege =
+function effectivePrivilege(access : MemoryAccessType(mem_payload), m : Mstatus, priv : Privilege) -> Privilege =
   if   access != InstructionFetch() & m[MPRV] == 0b1
   then privLevel_bits(m[MPP], bitzero) // TODO: use m[MPV] if hypervisor enabled
   else priv

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -58,7 +58,7 @@ private function read_pte forall 'n, 'n in {4, 8} . (
 private val pt_walk : forall 'v, is_sv_mode('v) . (
   int('v),                      // Sv32, Sv39, Sv48, Sv57
   vpn_bits('v),                 // Virtual Page Number
-  MemoryAccessType(ext_access_type),  // Memory Load/Store/LoadStore/InstructionFetch
+  MemoryAccessType(mem_payload),  // Memory Load/Store/LoadStore/InstructionFetch
   Privilege,                    // User/Supervisor/Machine
   bool,                         // mstatus.MXR
   bool,                         // do_sum
@@ -227,7 +227,7 @@ private function translate_TLB_hit forall 'v, is_sv_mode('v) . (
   sv_width  : int('v),
   _asid     : asidbits,
   vpn       : vpn_bits('v),
-  access    : MemoryAccessType(ext_access_type),
+  access    : MemoryAccessType(mem_payload),
   priv      : Privilege,
   mxr       : bool,
   do_sum    : bool,
@@ -274,7 +274,7 @@ private function translate_TLB_miss forall 'v, is_sv_mode('v) . (
   asid     : asidbits,
   base_ppn : ppn_bits('v),
   vpn      : vpn_bits('v),
-  access   : MemoryAccessType(ext_access_type),
+  access   : MemoryAccessType(mem_payload),
   priv     : Privilege,
   mxr      : bool,
   do_sum   : bool,
@@ -332,7 +332,7 @@ private function translate forall 'v, is_sv_mode('v) . (
   asid     : asidbits,
   base_ppn : ppn_bits('v),
   vpn      : vpn_bits('v),
-  access   : MemoryAccessType(ext_access_type),
+  access   : MemoryAccessType(mem_payload),
   priv     : Privilege,
   mxr      : bool,
   do_sum   : bool,
@@ -364,7 +364,7 @@ private function get_satp forall 'v, is_sv_mode('v). (
 // [postlude/fetch.sail, A/zaamo_insts.sail, Zicbo{zm}/zicbo{zm}_insts.sail].
 function translateAddr(
   vAddr : virtaddr,
-  access : MemoryAccessType(ext_access_type),
+  access : MemoryAccessType(mem_payload),
 ) -> TR_Result(physaddr, ExceptionType) = {
 
   // Effective privilege takes into account mstatus.PRV, mstatus.MPP

--- a/model/sys/vmem_pte.sail
+++ b/model/sys/vmem_pte.sail
@@ -109,7 +109,7 @@ union PTE_Check = {
 }
 
 private function check_PTE_permission(
-  access    : MemoryAccessType(ext_access_type),
+  access    : MemoryAccessType(mem_payload),
   priv      : Privilege,
   // Make eXecutable Readable
   mxr       : bool,
@@ -153,7 +153,7 @@ private function check_PTE_permission(
 // Update PTE bits if needed; return new PTE if updated
 private function update_PTE_Bits forall 'pte_size, 'pte_size in {32, 64} . (
   pte : bits('pte_size),
-  access : MemoryAccessType(ext_access_type),
+  access : MemoryAccessType(mem_payload),
 ) -> option(bits('pte_size)) = {
   let pte_flags = Mk_PTE_Flags(pte[7 .. 0]);
 

--- a/model/sys/vmem_ptw.sail
+++ b/model/sys/vmem_ptw.sail
@@ -49,7 +49,7 @@ private function ext_get_ptw_error(failure : pte_check_failure) -> PTW_Error =
   }
 
 // Convert translation/PTW failures into architectural exceptions
-function translationException(access : MemoryAccessType(ext_access_type),
+function translationException(access : MemoryAccessType(mem_payload),
                               err : PTW_Error)
                              -> ExceptionType = {
   match (access, err) {

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -117,7 +117,7 @@ function check_misaligned(vaddr : virtaddr, width : word_width) -> bool = {
 }
 
 val vmem_read_addr : forall 'width, is_mem_width('width).
-  (virtaddr, xlenbits, int('width), MemoryAccessType(ext_access_type), bool, bool, bool)
+  (virtaddr, xlenbits, int('width), MemoryAccessType(mem_payload), bool, bool, bool)
   -> result(bits(8 * 'width), ExecutionResult)
 
 function vmem_read_addr(vaddr, offset, width, access, aq, rl, res) = {
@@ -176,7 +176,7 @@ function vmem_read_addr(vaddr, offset, width, access, aq, rl, res) = {
 termination_measure vmem_read_addr repeat n
 
 val vmem_write_addr : forall 'width, is_mem_width('width).
-  (virtaddr, int('width), bits(8 * 'width), MemoryAccessType(ext_access_type), bool, bool, bool)
+  (virtaddr, int('width), bits(8 * 'width), MemoryAccessType(mem_payload), bool, bool, bool)
   -> result(bool, ExecutionResult)
 
 function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
@@ -234,7 +234,7 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
 termination_measure vmem_write_addr repeat n
 
 val vmem_read : forall 'width, is_mem_width('width).
-  (regidx, xlenbits, int('width), MemoryAccessType(ext_access_type), bool, bool, bool)
+  (regidx, xlenbits, int('width), MemoryAccessType(mem_payload), bool, bool, bool)
   -> result(bits(8 * 'width), ExecutionResult)
 
 function vmem_read(rs, offset, width, access, aq, rl, res) = {
@@ -249,7 +249,7 @@ function vmem_read(rs, offset, width, access, aq, rl, res) = {
 }
 
 val vmem_write : forall 'width, is_mem_width('width).
-  (regidx, xlenbits, int('width), bits(8 * 'width), MemoryAccessType(ext_access_type), bool, bool, bool)
+  (regidx, xlenbits, int('width), bits(8 * 'width), MemoryAccessType(mem_payload), bool, bool, bool)
   -> result(bool, ExecutionResult)
 
 function vmem_write(rs_addr, offset, width, data, access, aq, rl, res) = {


### PR DESCRIPTION
This was initially introduced as a hook for CHERI to override as an external (`ext_`) extension.  However, this type can also be used to support memory accesses for standard extensions such as Zicfiss (and possibly others in addition to CHERI). The type is also  redefined to an `enum` (from `unit`) to support these forthcoming extensions.