### PR TITLE
Add Hypervisor interrupt causes

### DIFF
--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -444,14 +444,18 @@ function is_fiom_active() -> bool = {
 // interrupt processing state
 
 bitfield Minterrupts : xlenbits = {
-  MEI : 11, // external interrupts
-  SEI : 9,
+  SGEI : 12, // Supervisor guest external interrupt
+  MEI  : 11, // Machine external interrupt
+  VSEI : 10, // Virtual Supervisor external interrupt
+  SEI  : 9,  // Supervisor external interrupt
 
-  MTI : 7,  // timers interrupts
-  STI : 5,
+  MTI  : 7,  // Timer interrupt
+  VSTI : 6,  // Virtual supervisor timer interrupt
+  STI  : 5,  // Supervisor timer interrupt
 
-  MSI : 3,  // software interrupts
-  SSI : 1,
+  MSI  : 3,  // Software interrupt
+  VSSI : 2,  // Virtual supervisor software interrupt
+  SSI  : 1,  // Supervisor software interrupt
 }
 
 private function legalize_mip(o : Minterrupts, v : xlenbits) -> Minterrupts = {

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -120,50 +120,50 @@ type is_mem_width('w) = 'w in {1, 2, 4, 8}
 enum InterruptType = {
   I_U_Software,
   I_S_Software,
+  I_VS_Software,
   I_M_Software,
-  // I_VS_Software,
   I_U_Timer,
   I_S_Timer,
-  // I_VS_Timer,
+  I_VS_Timer,
   I_M_Timer,
   I_U_External,
   I_S_External,
-  // I_VS_External,
+  I_VS_External,
   I_M_External,
-  // I_G_External,
+  I_SG_External,
 }
 
 mapping interruptType_bits : InterruptType <-> exc_code = {
-  I_U_Software <-> 0b000000, // 0
-  I_S_Software <-> 0b000001, // 1
-  // I_VS_Software <-> 0b00010, // 2
-  I_M_Software <-> 0b000011, // 3
-  I_U_Timer    <-> 0b000100, // 4
-  I_S_Timer    <-> 0b000101, // 5
-  // I_VS_Timer    <-> 0b00110, // 6
-  I_M_Timer    <-> 0b000111, // 7
-  I_U_External <-> 0b001000, // 8
-  I_S_External <-> 0b001001, // 9
-  // I_VS_External <-> 0b001010, // 10
-  I_M_External <-> 0b001011, // 11
-  // I_G_External  <-> 0b001100, // 12
+  I_U_Software   <-> 0b000000, // 0
+  I_S_Software   <-> 0b000001, // 1
+  I_VS_Software  <-> 0b000010, // 2
+  I_M_Software   <-> 0b000011, // 3
+  I_U_Timer      <-> 0b000100, // 4
+  I_S_Timer      <-> 0b000101, // 5
+  I_VS_Timer     <-> 0b000110, // 6
+  I_M_Timer      <-> 0b000111, // 7
+  I_U_External   <-> 0b001000, // 8
+  I_S_External   <-> 0b001001, // 9
+  I_VS_External  <-> 0b001010, // 10
+  I_M_External   <-> 0b001011, // 11
+  I_SG_External  <-> 0b001100, // 12
 }
 
 function interruptType_to_str(i : InterruptType) -> string =
   match (i) {
     I_U_Software  => "user-software-interrupt",
     I_S_Software  => "supervisor-software-interrupt",
-    // I_VS_Software => "virtual-supervisor-software-interrupt",
+    I_VS_Software => "virtual-supervisor-software-interrupt",
     I_M_Software  => "machine-software-interrupt",
     I_U_Timer     => "user-timer-interrupt",
     I_S_Timer     => "supervisor-timer-interrupt",
-    // I_VS_Timer    => "virtual-supervisor-timer-interrupt",
+    I_VS_Timer    => "virtual-supervisor-timer-interrupt",
     I_M_Timer     => "machine-timer-interrupt",
     I_U_External  => "user-external-interrupt",
     I_S_External  => "supervisor-external-interrupt",
-    // I_VS_External => "virtual-supervisor-external-interrupt",
+    I_VS_External => "virtual-supervisor-external-interrupt",
     I_M_External  => "machine-external-interrupt",
-    // I_G_External  => "guest-external-interrupt"
+    I_SG_External => "supervisor guest-external-interrupt"
   }
 
 overload to_str = {interruptType_to_str}


### PR DESCRIPTION
Add interrupt causes for the hypervisor extension.

The new interrupt bits are defined, but are not yet writable via mip/mie. Full interrupt handling will be implemented once the hypervisor CSRs are in place.