### PR TITLE
Get semicolon-separated list of source files from Sail

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -29,6 +29,9 @@ set(project_file "riscv.sail_project")
 # Reconfigure if the project file changes.
 set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${project_file})
 
+# Get a semicolon-separated list of source files. This is not strictly correct
+# because it will fail if a file contains a semicolon, but hopefully that's
+# quite unlikely.
 execute_process(
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND
@@ -36,13 +39,11 @@ execute_process(
         ${project_file}
         --require-version ${SAIL_REQUIRED_VER}
         --all-modules
-        --list-files
-    OUTPUT_VARIABLE sail_list_files
+        --list-files-separated ";"
+    OUTPUT_VARIABLE sail_srcs
     OUTPUT_STRIP_TRAILING_WHITESPACE
     COMMAND_ERROR_IS_FATAL ANY
 )
-
-separate_arguments(sail_srcs UNIX_COMMAND "${sail_list_files}")
 
 ############# C++ #############
 


### PR DESCRIPTION
Instead of getting a space-separated list of source files from the Sail compiler and converting to a CMake list, get a semicolon separated list directly.

This is not strictly correct because it will fail on filenames containing semicolons, but the old code would have failed on filenames containing spaces, so this is an improvement at least.

This is also necessary for it to work at all on Windows, because `UNIX_COMMAND` interprets the backslashes in Windows file paths as escape sequences.