### PR TITLE
Use builtin CMake variables to identify compiler

### DIFF
--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -7,16 +7,6 @@ execute_process(
 )
 message(STATUS "Sail version: ${sail_version}")
 
-# The --version is is usually a multiline output; the first line is the most useful.
-execute_process(
-    COMMAND ${CMAKE_CXX_COMPILER} --version
-    OUTPUT_VARIABLE compiler_version_blob
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    COMMAND_ERROR_IS_FATAL ANY
-)
-string(REGEX MATCH "[^\n\r]*" cxx_compiler_version ${compiler_version_blob})
-message(STATUS "CXX compiler version: ${cxx_compiler_version}")
-
 # make version available to emulator
 configure_file(sail_riscv_version.cpp.in sail_riscv_version.cpp @ONLY)
 

--- a/c_emulator/sail_riscv_version.cpp.in
+++ b/c_emulator/sail_riscv_version.cpp.in
@@ -5,6 +5,6 @@ namespace version_info {
 const std::string_view release_version = "@sail_riscv_release_version@";
 const std::string_view git_version = "@sail_riscv_git_version@";
 const std::string_view sail_version = "@sail_version@";
-const std::string_view cxx_compiler_version = "@cxx_compiler_version@";
+const std::string_view cxx_compiler_version = "@CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@";
 
 }


### PR DESCRIPTION
Instead of running the compiler with `--version` to get the compiler version, just use CMake's existing variables.

This is simpler, and it also works with compilers that don't support the `--version` flag like MSVC.

Example result:

    const std::string_view cxx_compiler_version = "MSVC 19.44.35215.0";
