### PR TITLE
Fix model compilation

### DIFF
--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -429,6 +429,7 @@ extensions {
   }
 
   Ssqosid {
+    requires core
     files extensions/Ssqosid/ssqosid.sail
   }
 


### PR DESCRIPTION
This fixes a compilation error introduced by the previous commit. The issue was caused because of a race between adding Ssqosid and refactoring the memory access type.

The Ssqosid commit added an extension to the project file, and the memory access type commit needed to modify that to add `requires core`, however since there was no git conflict it was merged based on an earlier passing CI run.

The merge queue is supposed to catch these kinds of races however it seems to be misconfigured in some way.

Separately, there's a bug in the Sail compiler that meant that the missing `requires core` causes weird invalid SMT generation rather than a `foo is not visible` error message.

See #1493 