### PR TITLE
Simplify `translationException`

### DIFF
--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -300,6 +300,64 @@ function sw_check_code_to_bits (c : SWCheckCodes) -> xlenbits =
     LANDING_PAD_FAULT  => zero_extend(0b010),
   }
 
+union AccessException = {
+  AccessExceptionLoad  : unit,
+  AccessExceptionSAMO  : unit,
+  AccessExceptionFetch : unit,
+}
+
+function AccessType_to_AccessException forall 'a . (access : MemoryAccessType('a)) -> AccessException = {
+  match access {
+    Atomic(_)                   => AccessExceptionSAMO(),
+    Load(_)                     => AccessExceptionLoad(),
+    LoadReserved(_)             => AccessExceptionLoad(),
+    Store(_)                    => AccessExceptionSAMO(),
+    StoreConditional(_)         => AccessExceptionSAMO(),
+    InstructionFetch(_)         => AccessExceptionFetch(),
+
+    // Though prefetches don't raise exceptions, we return a nominal
+    // exception here to propagate the failed address translation to
+    // the execute of the calling instruction so that it can decide
+    // whether to actually proceed with a prefetch.
+    CacheAccess(CB_manage(_))   => AccessExceptionSAMO(),
+    CacheAccess(CB_zero())      => AccessExceptionSAMO(),
+    CacheAccess(CB_prefetch(p)) => match p {
+      PREFETCH_R => AccessExceptionLoad(),
+      PREFETCH_W => AccessExceptionSAMO(),
+      PREFETCH_I => AccessExceptionFetch(),
+    }
+  }
+}
+
+function AccessException_to_E_Addr_Align(e: AccessException) -> ExceptionType =
+  match e {
+    AccessExceptionLoad(_)  => E_Load_Addr_Align(),
+    AccessExceptionSAMO(_)  => E_SAMO_Addr_Align(),
+    AccessExceptionFetch(_) => E_Fetch_Addr_Align(),
+  }
+
+function AccessException_to_E_Access_Fault(e : AccessException) -> ExceptionType =
+  match e {
+    AccessExceptionLoad(_)  => E_Load_Access_Fault(),
+    AccessExceptionSAMO(_)  => E_SAMO_Access_Fault(),
+    AccessExceptionFetch(_) => E_Fetch_Access_Fault(),
+  }
+
+function AccessException_to_E_Page_Fault(e : AccessException) -> ExceptionType =
+  match e {
+    AccessExceptionLoad(_)  => E_Load_Page_Fault(),
+    AccessExceptionSAMO(_)  => E_SAMO_Page_Fault(),
+    AccessExceptionFetch(_) => E_Fetch_Page_Fault(),
+  }
+
+// TODO: Wait for Hypervisor Extension
+// function AccessException_to_E_GPage_Fault(e : AccessException) -> ExceptionType =
+//   match e {
+//     AccessExceptionLoad(_)  => E_Load_GPage_Fault(),
+//     AccessExceptionSAMO(_)  => E_SAMO_GPage_Fault(),
+//     AccessExceptionFetch(_) => E_Fetch_GPage_Fault(),
+//   }
+
 // An architectural trap can be caused by either an interrupt or an exception
 
 union TrapCause = {

--- a/model/sys/vmem_ptw.sail
+++ b/model/sys/vmem_ptw.sail
@@ -49,41 +49,18 @@ private function ext_get_ptw_error(failure : pte_check_failure) -> PTW_Error =
   }
 
 // Convert translation/PTW failures into architectural exceptions
-function translationException(access : MemoryAccessType(mem_payload),
-                              err : PTW_Error)
-                             -> ExceptionType = {
+function translationException(
+  access : MemoryAccessType(mem_payload),
+  err : PTW_Error
+) -> ExceptionType = {
   match (access, err) {
-    (_, PTW_Ext_Error(e))                        => E_Extension(ext_translate_exception(e)),
-    (Atomic(_), PTW_No_Access())                 => E_SAMO_Access_Fault(),
-    (Atomic(_), _)                               => E_SAMO_Page_Fault(),
-    (Load(_), PTW_No_Access())                   => E_Load_Access_Fault(),
-    (Load(_), _)                                 => E_Load_Page_Fault(),
-    (LoadReserved(_), PTW_No_Access())           => E_Load_Access_Fault(),
-    (LoadReserved(_), _)                         => E_Load_Page_Fault(),
-    (Store(_), PTW_No_Access())                  => E_SAMO_Access_Fault(),
-    (Store(_), _)                                => E_SAMO_Page_Fault(),
-    (StoreConditional(_), PTW_No_Access())       => E_SAMO_Access_Fault(),
-    (StoreConditional(_), _)                     => E_SAMO_Page_Fault(),
-    (InstructionFetch(), PTW_No_Access())        => E_Fetch_Access_Fault(),
-    (InstructionFetch(), _)                      => E_Fetch_Page_Fault(),
-
-    (CacheAccess(CB_manage(_)), PTW_No_Access()) => E_SAMO_Access_Fault(),
-    (CacheAccess(CB_manage(_)), _)               => E_SAMO_Page_Fault(),
-    (CacheAccess(CB_zero()), PTW_No_Access())    => E_SAMO_Access_Fault(),
-    (CacheAccess(CB_zero()), _)                  => E_SAMO_Page_Fault(),
-    // Though prefetches don't raise exceptions, we return a nominal
-    // exception here to propagate the failed address translation to
-    // the execute of the calling instruction so that it can decide
-    // whether to actually proceed with a prefetch.
-    (CacheAccess(CB_prefetch(p)), PTW_No_Access()) => match p {
-      PREFETCH_R => E_Load_Access_Fault(),
-      PREFETCH_W => E_SAMO_Access_Fault(),
-      PREFETCH_I => E_Fetch_Access_Fault(),
-    },
-    (CacheAccess(CB_prefetch(p)), _) => match p {
-      PREFETCH_R => E_Load_Page_Fault(),
-      PREFETCH_W => E_SAMO_Page_Fault(),
-      PREFETCH_I => E_Fetch_Page_Fault(),
-    },
-  }
+    (_, PTW_Ext_Error(e)) => E_Extension(ext_translate_exception(e)),
+    (t, e) => {
+      let t = AccessType_to_AccessException(t);
+      match e {
+        PTW_No_Access() => AccessException_to_E_Access_Fault(t),
+        _               => AccessException_to_E_Page_Fault(t),
+      }
+    }
+  };
 }


### PR DESCRIPTION
Introduce an new Enum AccessException:

```sail
union AccessException = {
  AccessExceptionLoad  : unit,
  AccessExceptionSAMO  : unit,
  AccessExceptionFetch : unit,
}
```

to simplify the translation from `AccessType` to `ExceptionType`.