### PR TITLE
Fix CSR privilege check for hypervisor mode.

### DIFF
--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -28,6 +28,9 @@ private function privLevel_to_CSR_privbits(p : Privilege) -> nom_priv_bits =
   match p {
     User              => 0b00,
     VirtualUser       => 0b00,
+    // Note that this `if` is not strictly necessary. We could return
+    // 0b10 unconditionally if other checks ensure that hypervisor
+    // CSRs do not exist if H is not enabled.
     Supervisor        => if currentlyEnabled(Ext_H) then 0b10 else 0b01,
     VirtualSupervisor => 0b01,
     Machine           => 0b11,


### PR DESCRIPTION
When hypervisor is enabled, `Supervisor` (HS-mode) and `VirtualSupervisor` (VS-mode) privileges are encoded as `0b01` in `privLevel_bits()`, but the CSR addresses for hypervisor and VS CSRs encode the required privilege as `0b10`.  Define a private function to correct for this when checking privilege.

Fixes #1503.