### PR TITLE
Fix the first party linker map to be more consistent with the default config.

### DIFF
--- a/test/first_party/src/common/crt0.S
+++ b/test/first_party/src/common/crt0.S
@@ -162,7 +162,7 @@ reset_handler:
 //   1 (terminal): if command is 0, terminal input (unimplemented in Sail)
 //                 if command is 1, terminal output (write lowest byte of payload)
 
-.section .bss.mmio
+.section .bss.mmio.htif
 
 // HTIF devices.
 

--- a/test/first_party/src/common/link.ld
+++ b/test/first_party/src/common/link.ld
@@ -5,10 +5,13 @@ __STACK_SIZE = 0x2000;
 
 MEMORY
 {
-  /* Main RAM. Chosen for compatibility with SPIKE's default options. */
-  if_ram (wxa) : org = 0x80000000, len = 512m
+  /* Match the default configuration in config.json.in, which is roughly based on Spike. */
   /* MMIO peripherals. */
-  if_mmio (wa) : org = 0xa0000000, len = 512k
+  if_clint (wa) : org = 0x2000000, len = 768k
+  if_htif (wa)  : org = 0x20c0000, len = 512k
+
+  /* Main RAM. */
+  if_ram (wxa) : org = 0x80000000, len = 512m
 }
 
 SECTIONS
@@ -50,5 +53,5 @@ SECTIONS
 
   /* MMIO devices. PMA must make this uncacheable (doesn't
      matter in Sail because there are no caches). */
-  .bss.mmio : { *(.bss.mmio) } >if_mmio
+  .bss.mmio.htif : { *(.bss.mmio.htif) } >if_htif
 }

--- a/test/first_party/src/test_phys_perms_on_failing_sc.S
+++ b/test/first_party/src/test_phys_perms_on_failing_sc.S
@@ -11,11 +11,10 @@ main:
   # Set up PMP bounds for a region.  This requires us to restrict the global
   # permissions set in crt0.S:init_pmp.  The linker script sets the RAM region
   # to start at 0x80000000 with a size of 512m, while the default RAM size in the
-  # PMA config is 128m, so use the smaller one. To fit in a 32-bit range for RV32, take
-  # the last page of RAM as the test region, and shrink the computed size of RAM.
+  # PMA config is 2g, so use the smaller one.
   # Assume a PMP grain of 0 as in the default config.
 #define RAM_START 0x80000000
-#define RAM_SIZE  (0x80000000 - 0x1000)
+#define RAM_SIZE  0x20000000
   # The forbidden test region starts beyond RAM.
 #define TEST_REGION_START (RAM_START + RAM_SIZE)
 #define TEST_REGION_PMP_ADDR (TEST_REGION_START >> PMP_SHIFT)


### PR DESCRIPTION
Since HTIF/MMIO are now before RAM, we can reduce the RAM size used for the test_phys_perms_on_failing_sc test.  Previously, that test used an artificially large RAM size to include the HTIF so that the test could terminate.  This should also help any future tests that need to test using PMP restrictions.