### PR TITLE
Fix fcvt.s.bf16 NaN-boxing returning wrong canonical QNaN

### DIFF
--- a/.github/actions/sail-setup/action.yml
+++ b/.github/actions/sail-setup/action.yml
@@ -33,9 +33,7 @@ runs:
         chmod +x llvm.sh
         CLANG_VERSION=21
         sudo ./llvm.sh $CLANG_VERSION
-        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-$CLANG_VERSION 100
-        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-$CLANG_VERSION 100
-        sudo update-alternatives --install /usr/bin/lld lld /usr/bin/lld-$CLANG_VERSION 100
+        echo "CLANG_VERSION=$CLANG_VERSION" >> $GITHUB_ENV
 
     - name: Install packages (macOS)
       if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,14 @@ jobs:
 
       - name: Build simulators
         run: |
+          # CLANG_VERSION is set by the sail-setup action when install-clang is enabled.
+          CLANG_FLAG=""
+          if [ -n "$CLANG_VERSION" ]; then
+            CLANG_FLAG="-DCLANG_BIN=/usr/bin/clang-$CLANG_VERSION"
+          fi
           # Ninja is used because the CMake Makefile generator doesn't
           # build top-level targets in parallel unfortunately.
-          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWARNINGS_AS_ERRORS=TRUE -DFIRST_PARTY_TESTS=TRUE -DENABLE_RISCV_TESTS=TRUE -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE
+          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWARNINGS_AS_ERRORS=TRUE -DFIRST_PARTY_TESTS=TRUE -DENABLE_RISCV_TESTS=TRUE -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE $CLANG_FLAG
           ninja -C build all generated_sail_riscv_docs generated_smt_rv64d generated_smt_rv32d
 
       - name: Run tests

--- a/model/extensions/FD/fdext_regs.sail
+++ b/model/extensions/FD/fdext_regs.sail
@@ -27,6 +27,7 @@ function canonical_NaN(n) =
     128 => 0b0 @ ones(15) @ 0b1 @ zeros(111),
   }
 
+let canonical_NaN_BF16 : bits(16) = 0x7fc0
 // For backwards compatibility with code that existed before the
 // generic version above.
 function canonical_NaN_H() -> bits(16)  = canonical_NaN(16)
@@ -210,7 +211,12 @@ function wF_bits(Fregidx(i) : fregidx, data: flenbits) -> unit = {
 overload F = {rF_bits, wF_bits, rF, wF}
 
 function rF_BF16(i : fregidx) -> bits(16) = {
-  nan_unbox(F(i))
+  // This is the same as `nan_unbox(F(i))` except that
+  // it returns the correct canonical NaN for BF16.
+  let v = F(i);
+  if v[flen - 1 .. 16] == ones()
+  then v[15 .. 0]
+  else canonical_NaN_BF16
 }
 
 function wF_BF16(i : fregidx, data : bits(16)) -> unit = {

--- a/test/first_party/CMakeLists.txt
+++ b/test/first_party/CMakeLists.txt
@@ -88,6 +88,7 @@ set(common_deps
 )
 
 set(tests
+    "test_bf16_nan_boxing.S"
     "test_hello_world.c"
     "test_max_pmp.c"
     "test_minstret.S"
@@ -118,7 +119,7 @@ foreach (xlen IN ITEMS 32 64)
                 # but it isn't quite usable with Clang directly yet due to some
                 # unsupported supervisor extensions and because Clang requires version
                 # for experimental extensions.
-                -march=rv${xlen}gcv
+                -march=rv${xlen}gcv_zfbfmin
                 # Calling convention to use. Valid values are 'ilp32' or 'lp64' for 32/64-bit,
                 # optionally followed by 'f' or 'd' for hard-float. All combinations are valid.
                 -mabi=${mabi}d

--- a/test/first_party/src/test_bf16_nan_boxing.S
+++ b/test/first_party/src/test_bf16_nan_boxing.S
@@ -1,0 +1,46 @@
+.global main
+main:
+#if __riscv_xlen == 64
+    # Load improperly NaN-boxed bf16 value into f1
+    li t0, 0xffffffff00000000
+    fmv.d.x f1, t0
+
+    # Convert to bf16 and back to fp32
+    fcvt.s.bf16 f2, f1
+
+    # Check result
+    fmv.x.d t1, f2
+    li t2, 0xffffffff7fc00000
+    bne t1, t2, fail
+
+#else
+    # Build improperly NaN-boxed bf16 value on stack
+    addi sp, sp, -8
+
+    li t0, 0x00000000
+    sw t0, 0(sp)
+
+    li t0, 0xffffffff
+    sw t0, 4(sp)
+
+    # Load improperly NaN-boxed value from stack
+    fld f1, 0(sp)
+    addi sp, sp, 8
+
+    # Convert to bf16 and back to fp32
+    fcvt.s.bf16 f2, f1
+
+    # Check result
+    fmv.x.w t1, f2
+    li t2, 0x7fc00000
+    bne t1, t2, fail
+
+#endif
+
+pass:
+    li a0, 0
+    ret
+
+fail:
+    li a0, 1
+    ret


### PR DESCRIPTION
rF_BF16 was using the generic nan_unbox which returns the FP16 canonical
QNaN (0x7e00) for invalid inputs. BF16 has a different format than FP16
and requires its own canonical QNaN (0x7fc0).

Added canonical_NaN_BF16 and updated rF_BF16 to use it directly instead
of the generic nan_unbox.

Additionally, change how Clang is installed in CI by removing the standalone update-alternatives
approach because the default Ubuntu package manager installs a static symlink at /usr/bin/clang
that the alternatives system cannot overwrite. Since the system refuses to replace a file it doesn't
already "own," the environment was staying locked to the older version despite Clang 21 being registered.
Now, we install a newer version of Clang separately and simply pass the the path to the installed Clang version
to CMake as a Clang compiler flag. This way, CMake uses the specified version if the install-clang flag
in the CI workflow is set to true.

Fixes https://github.com/riscv/sail-riscv/issues/1527

Co-authored-by: Jordan Carlin <jordanmcarlin@gmail.com>