### PR TITLE
Strengthen some before statements in sail_project file

### DIFF
--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -7,7 +7,7 @@ prelude {
 }
 
 core {
-  requires prelude, Zicbop_types
+  requires prelude, A_types, Zicbop_types, Zicbom_types
 
   files
     core/xlen.sail,
@@ -100,7 +100,6 @@ extensions {
 
   A {
     A_types {
-      before core
       files extensions/A/aext_types.sail
     }
     Zaamo {
@@ -389,7 +388,6 @@ extensions {
 
   Zicbom {
     Zicbom_types {
-      before core
       files extensions/Zicbom/zicbom_types.sail
     }
     Zicbom_insts {


### PR DESCRIPTION
Some of the extensions were using `before core` to make sure their types are available in the core type definitions. This is however not intended - the well-formedness checking of types in Sail was slightly too weak, and was only checking that the types exist, but not checking if they have been explicitly brought into scope via a `requires` statement. I plan on fixing this in Sail, but this PR will need to be merged first to avoid breaking the model.

Note that this doesn't have to be done for the new Zibi extension, as that only needs the type to be used by the `instruction` clause inside `Zibi`.