### PR TITLE
Legalize xret privilege with respect to misa.

### DIFF
--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -238,6 +238,17 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
   };
 }
 
+private function legalize_xret_privilege(p : Privilege) -> Privilege =
+  match p {
+    Machine           => Machine,
+    // If S-mode is not legal, then go to M-mode.
+    Supervisor        => if currentlyEnabled(Ext_S) then Supervisor else Machine,
+    // If U-mode is not legal, nor is S-mode.
+    User              => if currentlyEnabled(Ext_U) then User else Machine,
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+  }
+
 function exception_handler(cur_priv : Privilege, ctl : ctl_result,
                            pc: xlenbits) -> xlenbits = {
   match ctl {
@@ -252,7 +263,8 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
       let prev_priv = cur_privilege;
       mstatus[MIE]  = mstatus[MPIE];
       mstatus[MPIE] = 0b1;
-      cur_privilege = privLevel_bits(mstatus[MPP], 0b0); // TODO: use mstatus[MPV] if hypervisor enabled
+      cur_privilege = legalize_xret_privilege(privLevel_bits(mstatus[MPP], 0b0)); // TODO: use mstatus[MPV] if hypervisor enabled
+      // "xPP is set to the least-privileged supported mode (U if U-mode is implemented, else M)."
       mstatus[MPP]  = privLevel_to_bits(if currentlyEnabled(Ext_U) then User else Machine);
       if   cur_privilege != Machine
       then mstatus[MPRV] = 0b0;
@@ -271,8 +283,9 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
       let prev_priv = cur_privilege;
       mstatus[SIE]  = mstatus[SPIE];
       mstatus[SPIE] = 0b1;
-      cur_privilege = if mstatus[SPP] == 0b1 then Supervisor else User;
-      mstatus[SPP]  = 0b0;
+      cur_privilege = legalize_xret_privilege(if mstatus[SPP] == 0b1 then Supervisor else User);
+      // "xPP is set to the least-privileged supported mode (U if U-mode is implemented, else M)."
+      mstatus[SPP]  = if currentlyEnabled(Ext_U) then 0b0 else 0b1;
       if   cur_privilege != Machine
       then mstatus[MPRV] = 0b0;
 
@@ -282,8 +295,7 @@ function exception_handler(cur_priv : Privilege, ctl : ctl_result,
       long_csr_write_callback("mstatus", "mstatush", mstatus.bits);
 
       if   get_config_print_exception()
-      then print_log("ret-ing from " ^ to_str(prev_priv)
-                          ^ " to " ^ to_str(cur_privilege));
+      then print_log("ret-ing from " ^ to_str(prev_priv) ^ " to " ^ to_str(cur_privilege));
 
       prepare_xret_target(Supervisor)
     },
@@ -347,8 +359,8 @@ function reset_misa() -> unit = {
   misa[E] = bool_to_bit(base_E_enabled);
   misa[I] = ~(misa[E]);
 
-  if   hartSupports(Ext_F) & hartSupports(Ext_Zfinx)
-  then internal_error(__FILE__, __LINE__, "F and Zfinx cannot both be enabled!");
+  // This should be guaranteed by config validation.
+  assert(not(hartSupports(Ext_F) & hartSupports(Ext_Zfinx)));
 
   // We currently support both F and D
   misa[F]   = bool_to_bit(hartSupports(Ext_F));      // single-precision

--- a/test/first_party/CMakeLists.txt
+++ b/test/first_party/CMakeLists.txt
@@ -94,6 +94,7 @@ set(tests
     "test_misaligned_vector_register_groups.S"
     "test_pmp_access.c"
     "test_phys_perms_on_failing_sc.S"
+    "test_mret_u.S"
 )
 
 

--- a/test/first_party/src/test_mret_u.S
+++ b/test/first_party/src/test_mret_u.S
@@ -1,0 +1,103 @@
+#include "common/encoding.h"
+
+.global main
+main:
+  # This test ensures we can't mret into U when misa.U is clear.
+
+  # Save return address in temporary register we're not using.
+  mv s1, ra
+
+#define MISA_U 20
+#define MISA_S 18
+
+  # Check if misa.U is writable.
+
+  csrr s2, misa
+  li s3, 1 << MISA_U
+
+  # Try to toggle misa.U
+  srli t0, s2, MISA_U
+  andi t0, t0, 1
+  beqz t0, try_set_u
+try_clear_u:
+  # This also clears misa.S if that is set.
+  csrc misa, s3
+  j check_immut
+try_set_u:
+  csrs misa, s3
+check_immut:
+  # Compare with the original value.  If there is no change,
+  # pass the test since misa.U is read-only and this test is
+  # irrelevant.
+  csrr t0, misa
+  beq t0, s2, pass
+
+set_u:
+  # Ensure that misa.U is set.  This will make
+  # mstatus.MPP legal below.
+  csrs misa, s3
+
+set_mstatus_mpp:
+  # Set mstatus.MPP to U.
+  li s4, MSTATUS_MPP
+  not t1, s4
+  csrr t0, mstatus
+  and t0, t0, t1
+  csrw mstatus, t0
+
+clear_u:
+  # Now clear misa.U.
+  csrc misa, s3
+
+  # misa.S should be zero.
+  csrr t0, misa
+  srli t0, t0, MISA_S
+  andi t0, t0, 1
+  bnez t0, fail
+
+  # A breakpoint will be used to trap into M-mode.  This
+  # will be handled in M-mode, since medeleg is irrelevant
+  # now that S-mode has been disabled.
+
+test:
+  # Set execution address for U-mode.
+  la t0, user_space
+  csrw mepc, t0
+  # Save old trap-handler
+  csrr s5, mtvec
+  # Tap to check_mstatus
+  la t0, check_mstatus
+  csrw mtvec, t0
+  mret
+user_space:
+  # To get `cur_privilege`, trap using a breakpoint
+  # and then check mstatus.MPP.
+  ebreak
+  nop
+
+check_mstatus:
+  # Restore old trap-handler
+  csrw mtvec, s5
+  # Check cause
+  csrr t0, mcause
+  li t1, CAUSE_BREAKPOINT
+  bne t0, t1, fail
+  # Check trap origin
+  csrr t0, mepc
+  la t1, user_space
+  bne t0, t1, fail
+  # Check mstatus.MPP
+  csrr t0, mstatus
+  and t0, t0, s4
+  # If zero, we were in U-mode.
+  beqz t0, fail
+
+pass:
+  li a0, 0
+  mv ra, s1
+  ret
+
+fail:
+  li a0, 1
+  mv ra, s1
+  ret


### PR DESCRIPTION
Check `misa` for enabled privilege modes at `xret`, since modifications to `misa` might have disabled the privileges in `mstatus.{MPP, SPP}`.  Add a test for this case.

This leaves handling of misa.U == 0 for later, to be addressed with the other misa bits.

While here, use an assert in place of an internal error as it should have been caught by config validation.

Fixes #1522.