### PR TITLE
Adapt the release workflow to use the common `sail-setup` action.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,20 +64,7 @@ jobs:
       - name: Install dependencies (Linux)
         if: startsWith(matrix.os, 'ubuntu')
         run: |
-          dnf update -y --enablerepo=devel
-          dnf install -y --enablerepo=devel \
-              pkg-config \
-              gmp-static \
-              libstdc++-static \
-              curl \
-              git \
-              make \
-              gcc \
-              gcc-c++ \
-              cmake \
-              ninja-build
-          curl --location --output sail.tar.gz https://github.com/rems-project/sail/releases/download/$SAIL_VERSION/sail-$(uname)-$(arch).tar.gz
-          tar --directory=/usr/local --strip-components=1 --extract --file sail.tar.gz
+          dnf install -y git
 
       # TODO: Mac
       # - name: Install dependencies (Mac)
@@ -85,7 +72,13 @@ jobs:
       #   run: |
       #     brew install --force --overwrite ...
 
-      - uses: actions/checkout@v6
+      - name: Check out repository code
+        uses: actions/checkout@v6
+
+      - name: Common setup
+        uses: ./.github/actions/sail-setup
+        with:
+          cmake-version: "3.20.0"
 
       - name: Build simulator
         run: |


### PR DESCRIPTION
This is a pretty minor change, and only affects package installation.
