### PR TITLE
Add first party memory model with support for memory dumps

### DIFF
--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -42,6 +42,10 @@ add_library(riscv_model
     file_utils.h
     symbol_table.cpp
     symbol_table.h
+    mem.cpp
+    mem.h
+    mem_dump.cpp
+    mem_dump.h
     sail_riscv_version.h
     "${CMAKE_CURRENT_BINARY_DIR}/config_schema.h"
     "${CMAKE_CURRENT_BINARY_DIR}/sail_riscv_version.cpp"

--- a/c_emulator/cli_options.cpp
+++ b/c_emulator/cli_options.cpp
@@ -59,6 +59,7 @@ CLIOptions parse_cli(int argc, char **argv) {
 #ifdef SAILCOV
   app.add_option("--sailcov-file", opts.sailcov_file, "Sail coverage output file")->option_text("<file>");
 #endif
+  app.add_flag("--dump-memory", opts.dump_memory, "Dump memory to an ELF file at the end of the test");
 
   app.add_flag("--trace-instr", opts.config_print_instr, "Enable trace output for instruction execution");
   app.add_flag("--trace-ptw", opts.config_print_ptw, "Enable trace output for Page Table walk");

--- a/c_emulator/cli_options.h
+++ b/c_emulator/cli_options.h
@@ -27,6 +27,8 @@ struct CLIOptions {
   std::vector<std::string> elfs;
   uint64_t insn_limit = 0;
 
+  bool dump_memory = false;
+
   std::string sig_file = {};
   unsigned signature_granularity = DEFAULT_SIGNATURE_GRANULARITY;
 

--- a/c_emulator/elf_loader.cpp
+++ b/c_emulator/elf_loader.cpp
@@ -2,8 +2,9 @@
 #include "elfio/elf_types.hpp"
 
 #include <elfio/elfio.hpp>
+#include <memory>
 
-ELF::ELF(std::unique_ptr<ELFIO::elfio> reader) : m_reader(std::move(reader)) {
+ELF::ELF(std::unique_ptr<ELFIO::elfio> elf) : m_elf(std::move(elf)) {
 }
 
 ELF ELF::open(const std::string &filename) {
@@ -20,24 +21,51 @@ ELF ELF::open(const std::string &filename) {
   return ELF(std::move(reader));
 }
 
+ELF ELF::create(Architecture arch) {
+  auto elf = std::make_unique<ELFIO::elfio>();
+
+  // Little Endian.
+  switch (arch) {
+  case Architecture::RV32:
+    elf->create(ELFIO::ELFCLASS32, ELFIO::ELFDATA2LSB);
+    break;
+  case Architecture::RV64:
+    elf->create(ELFIO::ELFCLASS64, ELFIO::ELFDATA2LSB);
+    break;
+  }
+
+  elf->set_machine(ELFIO::EM_RISCV);
+  elf->set_os_abi(ELFIO::ELFOSABI_NONE);
+
+  // Core dump by default.
+  elf->set_type(ELFIO::ET_CORE);
+
+  return ELF(std::move(elf));
+}
+
 Architecture ELF::architecture() const {
-  switch (m_reader->get_class()) {
+  switch (m_elf->get_class()) {
   case ELFIO::ELFCLASS32:
     return Architecture::RV32;
   case ELFIO::ELFCLASS64:
     return Architecture::RV64;
   default:
-    throw std::runtime_error("Unknown ELF class " + std::to_string(m_reader->get_class()));
+    throw std::runtime_error("Unknown ELF class " + std::to_string(m_elf->get_class()));
   }
 }
 
 // Entry point.
 uint64_t ELF::entry() const {
-  return m_reader->get_entry();
+  return m_elf->get_entry();
+}
+
+void ELF::set_entry(uint64_t addr) {
+  m_elf->set_entry(addr);
 }
 
 void ELF::load(std::function<void(uint64_t, const uint8_t *, uint64_t)> writer) const {
-  for (const auto &seg : m_reader->segments) {
+  std::vector<uint8_t> zeros;
+  for (const auto &seg : m_elf->segments) {
     if (seg->get_type() == ELFIO::PT_LOAD) {
       // It's a segment that we should load into memory.
       if (seg->get_file_size() > seg->get_memory_size()) {
@@ -52,7 +80,7 @@ void ELF::load(std::function<void(uint64_t, const uint8_t *, uint64_t)> writer) 
       // If the memory size is greater than the file size the remaining
       // bytes should be zeroed.
       if (seg->get_memory_size() > seg->get_file_size()) {
-        std::vector<uint8_t> zeros(seg->get_memory_size() - seg->get_file_size(), 0);
+        zeros.resize(seg->get_memory_size() - seg->get_file_size(), 0);
         writer(seg->get_physical_address() + seg->get_file_size(), zeros.data(), zeros.size());
       }
     }
@@ -64,9 +92,9 @@ std::map<std::string, uint64_t> ELF::symbols() const {
 
   std::map<std::string, uint64_t> symbolMap;
 
-  const section *symtab = m_reader->sections[".symtab"];
+  const section *symtab = m_elf->sections[".symtab"];
   if (symtab != nullptr) {
-    const_symbol_section_accessor accessor(*m_reader, symtab);
+    const_symbol_section_accessor accessor(*m_elf, symtab);
     unsigned index = 0;
     std::string name;
     Elf64_Addr value = 0;
@@ -85,4 +113,28 @@ std::map<std::string, uint64_t> ELF::symbols() const {
     }
   }
   return symbolMap;
+}
+
+void ELF::add_segment(uint64_t address, const std::vector<uint8_t> &data) {
+  // The ELF format doesn't require this but the ELFIO library only lets
+  // you add segments by adding sections first.
+  ELFIO::section *sec = m_elf->sections.add(".text");
+  sec->set_type(ELFIO::SHT_PROGBITS);
+  sec->set_flags(ELFIO::SHF_ALLOC | ELFIO::SHF_EXECINSTR);
+  sec->set_addr_align(1);
+  sec->set_data(reinterpret_cast<const char *>(data.data()), data.size());
+
+  ELFIO::segment *seg = m_elf->segments.add();
+  seg->set_type(ELFIO::PT_LOAD);
+  seg->set_virtual_address(address);
+  seg->set_physical_address(address);
+  seg->set_flags(ELFIO::PF_R | ELFIO::PF_W | ELFIO::PF_X);
+  seg->set_align(1);
+
+  seg->add_section(sec, 1);
+}
+
+void ELF::save(const std::string &filename) const {
+  std::ofstream file(filename);
+  m_elf->save(file);
 }

--- a/c_emulator/elf_loader.h
+++ b/c_emulator/elf_loader.h
@@ -19,15 +19,21 @@ public:
   // exist or isn't a RISC-V ELF file.
   static ELF open(const std::string &filename);
 
+  // Create an empty RISC-V ELF file.
+  static ELF create(Architecture arch);
+
   // Return the architecture (RV32/64).
   Architecture architecture() const;
 
   // Return the entry point (where execution should begin).
   uint64_t entry() const;
 
+  // Set the entry point.
+  void set_entry(uint64_t addr);
+
   using ElfWriteFn = std::function<void(
     uint64_t,        // address
-    const uint8_t *, // data
+    const uint8_t *, // dataw
     uint64_t         // length
   )>;
 
@@ -41,11 +47,17 @@ public:
   // returned.
   std::map<std::string, uint64_t> symbols() const;
 
+  // Add a segment.
+  void add_segment(uint64_t address, const std::vector<uint8_t> &data);
+
+  // Save the ELF to disk.
+  void save(const std::string &filename) const;
+
 private:
-  explicit ELF(std::unique_ptr<ELFIO::elfio> reader);
+  explicit ELF(std::unique_ptr<ELFIO::elfio> elf);
 
   // Unfortunately there's a bug in ELFIO which means we can't std::move() it,
   // so we have to put it in a unique_ptr.
   // https://github.com/serge1/ELFIO/issues/157
-  std::unique_ptr<ELFIO::elfio> m_reader;
+  std::unique_ptr<ELFIO::elfio> m_elf;
 };

--- a/c_emulator/mem.cpp
+++ b/c_emulator/mem.cpp
@@ -1,0 +1,57 @@
+#include "mem.h"
+
+void Memory::read_bytes(uint64_t addr, uint64_t addr_size, uint8_t *data, std::size_t len) const {
+  const uint64_t addr_mask = addr_size >= 64 ? ~0ull : ~((~0ull) << addr_size);
+  while (len > 0) {
+    addr = addr & addr_mask;
+    auto block_data = block_read(addr / BLOCK_SIZE);
+    do {
+      *data = block_data != nullptr ? (*block_data)[addr % BLOCK_SIZE] : m_uninitialized_value_func(addr);
+      ++addr;
+      ++data;
+      --len;
+    } while (len > 0 && (addr % BLOCK_SIZE) != 0);
+  }
+}
+
+// Write an array of bytes efficiently. Wraps end of memory.
+void Memory::write_bytes(uint64_t addr, uint64_t addr_size, const uint8_t *data, std::size_t len) {
+  const uint64_t addr_mask = addr_size >= 64 ? ~0ull : ~((~0ull) << addr_size);
+  while (len > 0) {
+    addr = addr & addr_mask;
+    auto &block_data = block_write(addr / BLOCK_SIZE);
+    do {
+      block_data[addr % BLOCK_SIZE] = *data;
+      ++addr;
+      ++data;
+      --len;
+    } while (len > 0 && (addr % BLOCK_SIZE) != 0);
+  }
+}
+
+void Memory::set_uninitialized_value(std::function<uint8_t(uint64_t)> func) {
+  m_uninitialized_value_func = func;
+}
+
+std::array<uint8_t, Memory::BLOCK_SIZE> &Memory::block_write(uint64_t block_addr) {
+  auto it = m_blocks.find(block_addr);
+  if (it == m_blocks.end()) {
+    // Initialise block with uninitialized values.
+    std::array<uint8_t, BLOCK_SIZE> new_block;
+    uint64_t base_addr = block_addr * BLOCK_SIZE;
+    for (std::size_t i = 0; i < BLOCK_SIZE; ++i) {
+      new_block[i] = m_uninitialized_value_func(base_addr + i);
+    }
+    auto res = m_blocks.insert({block_addr, new_block});
+    return res.first->second;
+  }
+  return it->second;
+}
+
+const std::array<uint8_t, Memory::BLOCK_SIZE> *Memory::block_read(uint64_t block_addr) const {
+  auto it = m_blocks.find(block_addr);
+  if (it == m_blocks.end()) {
+    return nullptr;
+  }
+  return &it->second;
+}

--- a/c_emulator/mem.h
+++ b/c_emulator/mem.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <functional>
+#include <map>
+
+// Memory model based on std::map storing 16-byte blocks. Larger block sizes
+// did not give any performance improvement.
+//
+// std::map is used rather than std::unordered_map so the written bytes can
+// be iterated through in order in `for_each_byte`.
+//
+// This supports pseudo-random initialisation of the memory via a callback
+// function.
+//
+// Addresses are always 64 bit but you can just use 32-bit values on RV32.
+class Memory {
+public:
+  static constexpr std::size_t BLOCK_SIZE = 16;
+
+  // Read an array of bytes efficiently. Wraps end of memory.
+  void read_bytes(uint64_t addr, uint64_t addr_size, uint8_t *data, std::size_t len) const;
+
+  // Write an array of bytes efficiently. Wraps end of memory.
+  void write_bytes(uint64_t addr, uint64_t addr_size, const uint8_t *data, std::size_t len);
+
+  // Call a function for each byte in memory that has been written. Note
+  // that we only track BLOCK_SIZE chunks of memory so if you ever write one byte
+  // in a block this will be called for all of them.
+  //
+  // If skip_if_equal_uninitialized is true, skip bytes that are equal to the
+  // default uninitialized value (e.g., 0).
+  template <typename F> void for_each_byte(F func, bool skip_if_equal_uninitialized) const {
+    for (const auto &[block_addr, block_data] : m_blocks) {
+      uint64_t addr = block_addr * BLOCK_SIZE;
+      for (std::size_t i = 0; i < BLOCK_SIZE; i++) {
+        if (!skip_if_equal_uninitialized || block_data[i] != m_uninitialized_value_func(addr)) {
+          func(addr, block_data[i]);
+        }
+        ++addr;
+      }
+    }
+  }
+
+  // Set the function to generate uninitialized values based on the address.
+  // Defaults to 0. This can be used to pseudorandomise memory or set
+  // recognisable patterns for debugging e.g. 0xCACACACA.
+  void set_uninitialized_value(std::function<uint8_t(uint64_t)> func);
+
+private:
+  // Get a block of memory, creating it if necessary.
+  std::array<uint8_t, BLOCK_SIZE> &block_write(uint64_t block_addr);
+  // Read a block of memory, returns nullptr if there isn't one at this address.
+  const std::array<uint8_t, BLOCK_SIZE> *block_read(uint64_t block_addr) const;
+
+  std::map<uint64_t, std::array<uint8_t, BLOCK_SIZE>> m_blocks;
+
+  std::function<uint8_t(uint64_t)> m_uninitialized_value_func = [](uint64_t) { return 0; };
+};

--- a/c_emulator/mem_dump.cpp
+++ b/c_emulator/mem_dump.cpp
@@ -1,0 +1,37 @@
+#include "mem_dump.h"
+
+#include "elf_loader.h"
+#include "riscv_model_impl.h"
+
+// Write all memory that has been written to an ELF file.
+// The entry point is set to `entry`.
+void dump_memory_to_elf(ModelImpl &model, const std::string &filename, uint64_t entry) {
+  ELF elf = ELF::create(model.xlen() == 32 ? Architecture::RV32 : Architecture::RV64);
+  elf.set_entry(entry);
+  std::vector<uint8_t> segment;
+  uint64_t segment_addr = 0;
+  model.memory().for_each_byte(
+    [&](uint64_t addr, uint8_t value) {
+      if (segment_addr + segment.size() == addr) {
+        // Add to existing segment.
+        segment.push_back(value);
+      } else {
+        // New segment. Note that although this is correct and adds the minimal
+        // amount of data to the ELF, in some cases where a large number of random
+        // addresses have been written you end up with ELFs with a very large
+        // number of small segments which is quite inefficient.
+        if (!segment.empty()) {
+          elf.add_segment(segment_addr, segment);
+        }
+        segment_addr = addr;
+        segment.clear();
+        segment.push_back(value);
+      }
+    },
+    false
+  );
+  if (!segment.empty()) {
+    elf.add_segment(segment_addr, segment);
+  }
+  elf.save(filename);
+}

--- a/c_emulator/mem_dump.h
+++ b/c_emulator/mem_dump.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+class ModelImpl;
+
+void dump_memory_to_elf(ModelImpl &model, const std::string &filename, uint64_t entry);

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -513,3 +513,59 @@ bool ModelImpl::htif_done() const {
 bool ModelImpl::had_exception() const {
   return have_exception;
 }
+
+void ModelImpl::emulator_read_mem(lbits *data, const uint64_t addr_size, const sbits addr, const mpz_t n) {
+  // The call here comes from `phys_mem_interface.sail` in this repo, then it goes to
+  // `lib/concurrency_interface/read_write_v1.sail` in the Sail repo where you get a call to `write_mem#`
+  // and so on which call these functions.
+  //
+  // `addr_size` will be 32 if physaddrbits is 32 bits, otherwise 64. This is wrong, but we don't
+  // actually need it anyway since `addr_size` is the width of the address, which should be consistent
+  // with `addr.len` - it's only there because Sail needs you to pass that in for its type checking.
+
+  // `n` is the width of the access (which should be consistent with `data->len`). It's provided for the same reason.
+
+  // TODO: I think there's some stuff in the memory interface that incorrectly assumes all memory accesses have 32 or 64
+  // bit addresses.
+  assert(addr.len == addr_size);
+
+  uint64_t data_size = mpz_get_ui(n);
+  data->len = data_size * 8;
+
+  std::vector<uint8_t> output(data_size);
+  m_ram->read_bytes(addr.bits, addr.len, output.data(), output.size());
+
+  mpz_import(*(data->bits), data_size, -1, 1, 0, 0, output.data());
+}
+
+void ModelImpl::emulator_read_mem_ifetch(lbits *data, const uint64_t addr_size, const sbits addr, const mpz_t n) {
+  // Delegate; this isn't treated specially.
+  emulator_read_mem(data, addr_size, addr, n);
+}
+
+void ModelImpl::emulator_read_mem_exclusive(lbits *data, const uint64_t addr_size, const sbits addr, const mpz_t n) {
+  // Delegate; this isn't treated specially.
+  emulator_read_mem(data, addr_size, addr, n);
+}
+
+bool ModelImpl::emulator_write_mem(const uint64_t addr_size, const sbits addr, const mpz_t n, const lbits data) {
+  assert(addr.len == addr_size);
+  assert((data.len % 8) == 0);
+  (void)n;
+
+  std::vector<uint8_t> output(data.len / 8);
+  mpz_export(output.data(), nullptr, -1, 1, 0, 0, *data.bits);
+
+  m_ram->write_bytes(addr.bits, addr.len, output.data(), output.size());
+  return true;
+}
+
+bool ModelImpl::emulator_write_mem_exclusive(
+  const uint64_t addr_size,
+  const sbits addr,
+  const mpz_t n,
+  const lbits data
+) {
+  // Delegate; this isn't treated specially.
+  return emulator_write_mem(addr_size, addr, n, data);
+}

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -8,6 +8,7 @@
 #include <random>
 #include <vector>
 
+#include "mem.h"
 #include "sail.h"
 #include "sail_riscv_model.h"
 
@@ -59,6 +60,18 @@ public:
   void model_init();
   void model_fini();
 
+  // Use to override the memory used for the hart. This could be used for
+  // multicore simulations to set them to use the same memory. Note that
+  // `Memory` is not thread safe and neither is the C++ code Sail generates so
+  // you still can't actually execute the harts in parallel.
+  void set_memory(std::shared_ptr<Memory> mem) {
+    m_ram = mem;
+  }
+
+  Memory &memory() {
+    return *m_ram;
+  }
+
   // string conversions
 
   std::string memory_access_type_to_string(MemoryAccessType access_type);
@@ -98,6 +111,19 @@ private:
 
   // These functions are called by the Sail code.
 
+  // Built-in memory interface from rts.h. We override it here.
+  void emulator_read_mem(lbits *data, const uint64_t addr_size, const sbits addr, const mpz_t n) override;
+  void emulator_read_mem_ifetch(lbits *data, const uint64_t addr_size, const sbits addr, const mpz_t n) override;
+  void emulator_read_mem_exclusive(lbits *data, const uint64_t addr_size, const sbits addr, const mpz_t n) override;
+  bool emulator_write_mem(const uint64_t addr_size, const sbits addr, const mpz_t n, const lbits data) override;
+  bool emulator_write_mem_exclusive(
+    const uint64_t addr_size,
+    const sbits addr,
+    const mpz_t n,
+    const lbits data
+  ) override;
+
+  // Event callbacks defined by the RISC-V Sail model.
   unit fetch_callback(sbits opcode) override;
   unit mem_write_callback(const char *type, sbits paddr, int64_t width, lbits value) override;
   unit mem_read_callback(const char *type, sbits paddr, int64_t width, lbits value) override;
@@ -193,4 +219,8 @@ private:
 
   // Trace log file
   FILE *m_trace_log = stdout;
+
+  // Contents of memory. This is a shared pointer so it can be shared
+  // between multiple ModelImpl instances (e.g., for multiple harts).
+  std::shared_ptr<Memory> m_ram = std::make_shared<Memory>();
 };

--- a/c_emulator/riscv_platform_if.cpp
+++ b/c_emulator/riscv_platform_if.cpp
@@ -8,6 +8,28 @@
 // A better solution is to allow passing in `hart::Model&` to `model_test()`.
 // See https://github.com/rems-project/sail/issues/1556
 
+// Use the built in Sail memory model as the default implementation, so at least
+// memory works for unit tests.
+void PlatformInterface::emulator_read_mem(lbits *data, uint64_t addr_size, sbits addr, const mpz_t n) {
+  ::emulator_read_mem(data, addr_size, addr, n);
+}
+
+void PlatformInterface::emulator_read_mem_ifetch(lbits *data, uint64_t addr_size, sbits addr, const mpz_t n) {
+  ::emulator_read_mem_ifetch(data, addr_size, addr, n);
+}
+
+void PlatformInterface::emulator_read_mem_exclusive(lbits *data, uint64_t addr_size, sbits addr, const mpz_t n) {
+  ::emulator_read_mem_exclusive(data, addr_size, addr, n);
+}
+
+bool PlatformInterface::emulator_write_mem(uint64_t addr_size, sbits addr, const mpz_t n, const lbits data) {
+  return ::emulator_write_mem(addr_size, addr, n, data);
+}
+
+bool PlatformInterface::emulator_write_mem_exclusive(uint64_t addr_size, sbits addr, const mpz_t n, const lbits data) {
+  return ::emulator_write_mem_exclusive(addr_size, addr, n, data);
+}
+
 unit PlatformInterface::fetch_callback([[maybe_unused]] sbits opcode) {
   return UNIT;
 }

--- a/c_emulator/riscv_platform_if.h
+++ b/c_emulator/riscv_platform_if.h
@@ -26,6 +26,13 @@ struct zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9;
 
 class PlatformInterface {
 public:
+  // Built-in memory interface from rts.h (we use our own).
+  virtual void emulator_read_mem(lbits *data, uint64_t addr_size, sbits addr, const mpz_t n);
+  virtual void emulator_read_mem_ifetch(lbits *data, uint64_t addr_size, sbits addr, const mpz_t n);
+  virtual void emulator_read_mem_exclusive(lbits *data, uint64_t addr_size, sbits addr, const mpz_t n);
+  virtual bool emulator_write_mem(uint64_t addr_size, sbits addr, const mpz_t n, const lbits data);
+  virtual bool emulator_write_mem_exclusive(uint64_t addr_size, sbits addr, const mpz_t n, const lbits data);
+
   virtual unit fetch_callback(sbits opcode);
 
   virtual unit mem_write_callback(const char *type, sbits paddr, int64_t width, lbits value);

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -6,6 +6,7 @@
 #include "file_utils.h"
 #include "jsoncons/config/version.hpp"
 #include "jsoncons/json.hpp"
+#include "mem_dump.h"
 #include "riscv_callbacks_rvfi.h"
 #include "riscv_model_impl.h"
 #ifdef SAILCOV
@@ -138,12 +139,8 @@ uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file
   }
 
   // Load into memory.
-  elf.load([](uint64_t address, const uint8_t *data, uint64_t length) {
-    // TODO: We could definitely improve on rts.c's memory implementation
-    // (which is O(N^2)) and writing one byte at a time here.
-    for (uint64_t i = 0; i < length; ++i) {
-      write_mem(address + i, data[i]);
-    }
+  elf.load([&model](uint64_t address, const uint8_t *data, uint64_t length) {
+    model.memory().write_bytes(address, 64, data, length);
   });
 
   // Load the entire symbol table.
@@ -230,7 +227,8 @@ void run_sail(
   const CLIOptions &opts,
   std::shared_ptr<traploop_detector> loop_detector,
   const elf_info &elf_info,
-  run_info &run_info
+  run_info &run_info,
+  uint64_t entry
 ) {
   bool is_waiting = false;
   // The emulator tick increments time by 1 at every step, so the number
@@ -309,6 +307,9 @@ void run_sail(
     }
 
     if (model.htif_done()) {
+      if (opts.dump_memory) {
+        dump_memory_to_elf(model, "dump.elf", entry);
+      }
       /* check exit code */
       if (model.htif_exit_code() == 0) {
         fprintf(stdout, "SUCCESS\n");

--- a/c_emulator/riscv_sim.h
+++ b/c_emulator/riscv_sim.h
@@ -62,7 +62,8 @@ void run_sail(
   const CLIOptions &opts,
   std::shared_ptr<traploop_detector> loop_detector,
   const elf_info &elf_info,
-  run_info &run_info
+  run_info &run_info,
+  uint64_t entry
 );
 
 void finish(ModelImpl &model, const CLIOptions &opts, const elf_info &elf_info, run_info &run_info);

--- a/c_emulator/sail_riscv_sim.cpp
+++ b/c_emulator/sail_riscv_sim.cpp
@@ -1,4 +1,5 @@
 #include "cli_options.h"
+#include "mem_dump.h"
 #include "riscv_callbacks_log.h"
 #include "riscv_model_impl.h"
 #include "riscv_sim.h"
@@ -8,7 +9,7 @@
 
 namespace {
 
-void run_model(CLIOptions &opts, ModelImpl &model, uint64_t, const elf_info &elf_info, run_info &run_info) {
+void run_model(CLIOptions &opts, ModelImpl &model, uint64_t entry, const elf_info &elf_info, run_info &run_info) {
   auto loop_detector = std::make_shared<traploop_detector>();
   if (!opts.disable_trap_loop_detection) {
     model.register_callback(loop_detector);
@@ -28,8 +29,13 @@ void run_model(CLIOptions &opts, ModelImpl &model, uint64_t, const elf_info &elf
   model.register_callback(log_cbs);
 
   do {
-    run_sail(model, opts, loop_detector, elf_info, run_info);
+    run_sail(model, opts, loop_detector, elf_info, run_info, entry);
     // `run_sail` only returns in the case of rvfi.
+
+    if (opts.dump_memory) {
+      dump_memory_to_elf(model, "dump.elf", entry);
+    }
+
     if (run_info.rvfi) {
       /* Reset for next test */
       model.reinit_sail();


### PR DESCRIPTION
Adds a first party memory model and support for dumping memory contents as a core dump (ELF) file.

If you run a test and then dump memory at the end of the test you can run the dump in the emulator again (since the emulator doesn't care if the ELF is a core dump).

The only caveat is it doesn't copy the symbol table to the dump so you don't get `tohost` and the HTIF printing/test ending don't work.

Fixes #1490 