### PR TITLE
Refactor CSR access checking to handle virtual-instruction exceptions.

### DIFF
--- a/model/core/csr_access.sail
+++ b/model/core/csr_access.sail
@@ -1,0 +1,58 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// When hypervisor is enabled, `Supervisor` (HS-mode) and
+// `VirtualSupervisor` (VS-mode) privileges are encoded as `0b01` in
+// `privLevel_bits()`, but the CSR addresses for hypervisor and VS
+// CSRs encode the required privilege as `0b10`.  This overrides
+// the encoding in `privLevel_bits()` for the purposes of CSR privilege
+// checks.
+private function privLevel_to_CSR_privbits(p : Privilege) -> nom_priv_bits =
+  match p {
+    User              => 0b00,
+    VirtualUser       => 0b00,
+    // Note that this `if` is not strictly necessary. We could return
+    // 0b10 unconditionally if other checks ensure that hypervisor
+    // CSRs do not exist if H is not enabled.
+    Supervisor        => if currentlyEnabled(Ext_H) then 0b10 else 0b01,
+    VirtualSupervisor => 0b01,
+    Machine           => 0b11,
+  }
+
+function csrAccess(csr : csreg) -> csrRW = csr[11..10]
+function csrPriv(csr : csreg) -> nom_priv_bits = csr[9..8]
+
+// Check that the CSR access is made with sufficient privilege.
+function check_CSR_priv(csr : csreg, p : Privilege) -> bool =
+  privLevel_to_CSR_privbits(p) >=_u csrPriv(csr)
+
+// Check that the CSR access isn't a write to a read-only CSR.
+function check_CSR_access_type(csr : csreg, access : CSRAccessType) -> bool =
+  not((access == CSRWrite | access == CSRReadWrite) & (csrAccess(csr) == 0b11))
+
+// Combine the two checks into a default access check.
+function default_CSR_access_allowed(csr : csreg, p : Privilege, access : CSRAccessType) -> bool =
+  check_CSR_priv(csr, p) & check_CSR_access_type(csr, access)
+
+// This is the default CSR access checker which implements HS-qualified checks
+// by default.  It cannot be used for CSRs that do not use HS-qualification.
+function check_CSR_access(csr : csreg, p : Privilege, access : CSRAccessType, condition : bool) -> result(unit, csr_access_failure) = {
+  if not(condition) then return Err(CSR_Access_Illegal);
+
+  // Stateen defaults to allowing CSRs that are not gated by the xstateen registers.
+  if not(stateen_allows_CSR_access(csr, p, access)) then {
+    return Err(if privLevel_is_virtual(p) & stateen_allows_CSR_access(csr, Supervisor, access)
+               then CSR_Access_Virtual else CSR_Access_Illegal)
+  };
+
+  if default_CSR_access_allowed(csr, p, access)
+  then return Ok(());
+
+  Err(if privLevel_is_virtual(p) & default_CSR_access_allowed(csr, Supervisor, access)
+      then CSR_Access_Virtual else CSR_Access_Illegal)
+}

--- a/model/core/csr_begin.sail
+++ b/model/core/csr_begin.sail
@@ -15,9 +15,17 @@ scattered mapping csr_name_map
 function csr_name(csr : csreg) -> string = csr_name_map(csr)
 overload to_str = {csr_name}
 
-// returns whether a CSR exists
-val is_CSR_accessible : (csreg, Privilege, CSRAccessType) -> bool
+// CSR access control
+enum csr_access_failure = { CSR_Access_Illegal, CSR_Access_Virtual }
+
+// returns the result of a CSR access check
+// TODO: change the function name
+val is_CSR_accessible : (csreg, Privilege, CSRAccessType) -> result(unit, csr_access_failure)
 scattered function is_CSR_accessible
+
+// declaration of functions in `extensions/Stateen/stateen_access_checks.sail`.
+val stateen_allows_CSR_access : (csreg, Privilege, CSRAccessType) -> bool
+scattered function stateen_allows_CSR_access
 
 // returns the value of the CSR if it is defined
 val read_CSR : csreg -> xlenbits

--- a/model/core/interrupt_regs.sail
+++ b/model/core/interrupt_regs.sail
@@ -102,11 +102,16 @@ mapping clause csr_name_map = 0x302  <-> "medeleg"
 mapping clause csr_name_map = 0x312  <-> "medelegh"
 mapping clause csr_name_map = 0x303  <-> "mideleg"
 
-function clause is_CSR_accessible(0x304, _, _) = true // mie
-function clause is_CSR_accessible(0x344, _, _) = true // mip
-function clause is_CSR_accessible(0x302, _, _) = currentlyEnabled(Ext_S) // medeleg
-function clause is_CSR_accessible(0x312, _, _) = currentlyEnabled(Ext_S) & xlen == 32 // medelegh
-function clause is_CSR_accessible(0x303, _, _) = currentlyEnabled(Ext_S) // mideleg
+function clause is_CSR_accessible(0x304, p, access_type) = // mie
+  check_CSR_access(0x304, p, access_type, true)
+function clause is_CSR_accessible(0x344, p, access_type) = // mip
+  check_CSR_access(0x344, p, access_type, true)
+function clause is_CSR_accessible(0x302, p, access_type) = // medeleg
+  check_CSR_access(0x302, p, access_type, currentlyEnabled(Ext_S))
+function clause is_CSR_accessible(0x312, p, access_type) = // medelegh
+  check_CSR_access(0x312, p, access_type, currentlyEnabled(Ext_S) & xlen == 32)
+function clause is_CSR_accessible(0x303, p, access_type) = // mideleg
+  check_CSR_access(0x303, p, access_type, currentlyEnabled(Ext_S))
 
 function clause read_CSR(0x304) = mie.bits
 function clause read_CSR(0x344) = mip.bits
@@ -168,7 +173,8 @@ private function legalize_sip(m : Minterrupts, d : Minterrupts, v : xlenbits) ->
 }
 
 mapping clause csr_name_map = 0x144  <-> "sip"
-function clause is_CSR_accessible(0x144, _, _) = currentlyEnabled(Ext_S) // sip
+function clause is_CSR_accessible(0x144, p, access_type) = // sip
+  check_CSR_access(0x144, p, access_type, currentlyEnabled(Ext_S))
 function clause read_CSR(0x144) = lower_mip(mip, mideleg).bits
 function clause write_CSR(0x144, value) = { mip = legalize_sip(mip, mideleg, value); Ok(lower_mip(mip, mideleg).bits) }
 
@@ -188,6 +194,7 @@ private function legalize_sie(m : Minterrupts, d : Minterrupts, v : xlenbits) ->
 }
 
 mapping clause csr_name_map = 0x104  <-> "sie"
-function clause is_CSR_accessible(0x104, _, _) = currentlyEnabled(Ext_S) // sie
+function clause is_CSR_accessible(0x104, p, access_type) =  // sie
+  check_CSR_access(0x104, p, access_type, currentlyEnabled(Ext_S))
 function clause read_CSR(0x104) = lower_mie(mie, mideleg).bits
 function clause write_CSR(0x104, value) = { mie = legalize_sie(mie, mideleg, value); Ok(lower_mie(mie, mideleg).bits) }

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -124,7 +124,8 @@ private function legalize_misa(m : Misa, v : xlenbits) -> Misa = {
 }
 
 mapping clause csr_name_map = 0x301  <-> "misa"
-function clause is_CSR_accessible(0x301, _, _) = true // misa
+function clause is_CSR_accessible(0x301, p, access_type) = // misa
+  check_CSR_access(0x301, p, access_type, true)
 function clause read_CSR(0x301) = misa.bits
 function clause write_CSR(0x301, value) = { misa = legalize_misa(misa, value); Ok(misa.bits) }
 
@@ -269,8 +270,10 @@ register mstatus : Mstatus = {
 mapping clause csr_name_map = 0x300  <-> "mstatus"
 mapping clause csr_name_map = 0x310  <-> "mstatush"
 
-function clause is_CSR_accessible(0x300, _, _) = true // mstatus
-function clause is_CSR_accessible(0x310, _, _) = xlen == 32 // mstatush
+function clause is_CSR_accessible(0x300, p, access_type) = // mstatus
+  check_CSR_access(0x300, p, access_type, true)
+function clause is_CSR_accessible(0x310, p, access_type) = // mstatush
+  check_CSR_access(0x310, p, access_type, xlen == 32)
 
 function clause read_CSR(0x300) = mstatus.bits[xlen - 1 .. 0]
 function clause read_CSR(0x310 if xlen == 32) = mstatus.bits[63 .. 32]
@@ -331,8 +334,10 @@ mapping clause csr_name_map = 0x747  <-> "mseccfg"
 mapping clause csr_name_map = 0x757  <-> "mseccfgh"
 
 // "mseccfg exists if Zkr is implemented, or if it is required by other processor features."
-function clause is_CSR_accessible(0x747, _, _) = currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp) // mseccfg
-function clause is_CSR_accessible(0x757, _, _) = (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp)) & xlen == 32 // mseccfgh
+function clause is_CSR_accessible(0x747, p, access_type) = // mseccfg
+  check_CSR_access(0x747, p, access_type, currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp))
+function clause is_CSR_accessible(0x757, p, access_type) =  // mseccfgh
+  check_CSR_access(0x757, p, access_type, (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp)) & xlen == 32)
 
 function clause read_CSR(0x747) = mseccfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x757 if xlen == 32) = mseccfg.bits[63 .. 32]
@@ -442,12 +447,12 @@ mapping clause csr_name_map = 0x30A  <-> "menvcfg"
 mapping clause csr_name_map = 0x31A  <-> "menvcfgh"
 mapping clause csr_name_map = 0x10A  <-> "senvcfg"
 
-function clause is_CSR_accessible(0x30A, _, _) = currentlyEnabled(Ext_U) // menvcfg
-function clause is_CSR_accessible(0x31A, _, _) = currentlyEnabled(Ext_U) & (xlen == 32) // menvcfgh
-
-// This should ideally also check `xstateen.ENVCFG`, but due to module
-// interdependency issues, that is handled by `stateen_allows_CSR_access`.
-function clause is_CSR_accessible(0x10A, _, _) = currentlyEnabled(Ext_S) // senvcfg
+function clause is_CSR_accessible(0x30A, p, access_type) = // menvcfg
+  check_CSR_access(0x30A, p, access_type, currentlyEnabled(Ext_U))
+function clause is_CSR_accessible(0x31A, p, access_type) = // menvcfgh
+  check_CSR_access(0x31A, p, access_type, currentlyEnabled(Ext_U) & xlen == 32)
+function clause is_CSR_accessible(0x10A, p, access_type) = // senvcfg
+  check_CSR_access(0x10A, p, access_type, currentlyEnabled(Ext_S))
 
 function clause read_CSR(0x30A) = menvcfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x31A if xlen == 32) = menvcfg.bits[63 .. 32]
@@ -498,7 +503,8 @@ bitfield Mcause : xlenbits = {
 }
 register mcause : Mcause
 mapping clause csr_name_map = 0x342  <-> "mcause"
-function clause is_CSR_accessible(0x342, _, _) = true // mcause
+function clause is_CSR_accessible(0x342, p, access_type) = // mcause
+  check_CSR_access(0x342, p, access_type, true)
 function clause read_CSR(0x342) = mcause.bits
 function clause write_CSR(0x342, value) = { mcause.bits = value; Ok(mcause.bits) }
 
@@ -545,8 +551,10 @@ register mscratch : xlenbits
 mapping clause csr_name_map = 0x343  <-> "mtval"
 mapping clause csr_name_map = 0x340  <-> "mscratch"
 
-function clause is_CSR_accessible(0x343, _, _) = true // mtval
-function clause is_CSR_accessible(0x340, _, _) = true // mscratch
+function clause is_CSR_accessible(0x343, p, access_type) = // mtval
+  check_CSR_access(0x343, p, access_type, true)
+function clause is_CSR_accessible(0x340, p, access_type) = // mscratch
+  check_CSR_access(0x340, p, access_type, true)
 
 function clause read_CSR(0x343) = mtval
 function clause read_CSR(0x340) = mscratch
@@ -574,7 +582,8 @@ private function legalize_scounteren(_c : Counteren, v : xlenbits) -> Counteren 
 
 register scounteren : Counteren
 mapping clause csr_name_map = 0x106  <-> "scounteren"
-function clause is_CSR_accessible(0x106, _, _) = currentlyEnabled(Ext_S) // scounteren
+function clause is_CSR_accessible(0x106, p, access_type) = // scounteren
+  check_CSR_access(0x106, p, access_type, currentlyEnabled(Ext_S))
 function clause read_CSR(0x106) = zero_extend(scounteren.bits)
 function clause write_CSR(0x106, value) = { scounteren = legalize_scounteren(scounteren, value); Ok(zero_extend(scounteren.bits)) }
 
@@ -586,10 +595,10 @@ function legalize_mcounteren(_c : Counteren, v : xlenbits) -> Counteren = {
 
 register mcounteren : Counteren
 mapping clause csr_name_map = 0x306  <-> "mcounteren"
-function clause is_CSR_accessible(0x306, _, _) = currentlyEnabled(Ext_U) // mcounteren
+function clause is_CSR_accessible(0x306, p, access_type) = // mcounteren
+  check_CSR_access(0x306, p, access_type, currentlyEnabled(Ext_U))
 function clause read_CSR(0x306) = zero_extend(mcounteren.bits)
 function clause write_CSR(0x306, value) = { mcounteren = legalize_mcounteren(mcounteren, value); Ok(zero_extend(mcounteren.bits)) }
-
 
 // mcountinhibit
 bitfield Counterin : bits(32) = {
@@ -606,7 +615,8 @@ private function legalize_mcountinhibit(_c : Counterin, v : xlenbits) -> Counter
 
 register mcountinhibit : Counterin
 mapping clause csr_name_map = 0x320  <-> "mcountinhibit"
-function clause is_CSR_accessible(0x320, _, _) = true // mcountinhibit
+function clause is_CSR_accessible(0x320, p, access_type) = // mcountinhibit
+  check_CSR_access(0x320, p, access_type, true)
 function clause read_CSR(0x320) = zero_extend(mcountinhibit.bits)
 function clause write_CSR(0x320, value) = { mcountinhibit = legalize_mcountinhibit(mcountinhibit, value); Ok(zero_extend(mcountinhibit.bits)) }
 
@@ -642,11 +652,16 @@ mapping clause csr_name_map = 0xF13  <-> "mimpid"
 mapping clause csr_name_map = 0xF14  <-> "mhartid"
 mapping clause csr_name_map = 0xF15  <-> "mconfigptr"
 
-function clause is_CSR_accessible(0xf11, _, _) = true // mvendorid
-function clause is_CSR_accessible(0xf12, _, _) = true // marchdid
-function clause is_CSR_accessible(0xf13, _, _) = true // mimpid
-function clause is_CSR_accessible(0xf14, _, _) = true // mhartid
-function clause is_CSR_accessible(0xf15, _, _) = true // mconfigptr
+function clause is_CSR_accessible(0xF11, p, access_type) = // mvendorid
+  check_CSR_access(0xF11, p, access_type, true)
+function clause is_CSR_accessible(0xF12, p, access_type) = // marchdid
+  check_CSR_access(0xF12, p, access_type, true)
+function clause is_CSR_accessible(0xF13, p, access_type) = // mimpid
+  check_CSR_access(0xF13, p, access_type, true)
+function clause is_CSR_accessible(0xF14, p, access_type) = // mhartid
+  check_CSR_access(0xF14, p, access_type, true)
+function clause is_CSR_accessible(0xF15, p, access_type) = // mconfigptr
+  check_CSR_access(0xF15, p, access_type, true)
 
 function clause read_CSR(0xF11) = zero_extend(mvendorid)
 function clause read_CSR(0xF12) = marchid
@@ -718,7 +733,9 @@ private function legalize_sstatus(m : Mstatus, v : xlenbits) -> Mstatus = {
 }
 
 mapping clause csr_name_map = 0x100  <-> "sstatus"
-function clause is_CSR_accessible(0x100, _, _) = currentlyEnabled(Ext_S) // sstatus
+function clause is_CSR_accessible(0x100, p, access_type) = // sstatus
+  check_CSR_access(0x100, p, access_type, currentlyEnabled(Ext_S))
+
 function clause read_CSR(0x100) = lower_mstatus(mstatus).bits[xlen - 1 .. 0]
 function clause write_CSR(0x100, value) = { mstatus = legalize_sstatus(mstatus, value); Ok(lower_mstatus(mstatus).bits[xlen - 1 .. 0]) }
 
@@ -733,9 +750,12 @@ mapping clause csr_name_map = 0x140  <-> "sscratch"
 mapping clause csr_name_map = 0x142  <-> "scause"
 mapping clause csr_name_map = 0x143  <-> "stval"
 
-function clause is_CSR_accessible(0x140, _, _) = currentlyEnabled(Ext_S) // sscratch
-function clause is_CSR_accessible(0x142, _, _) = currentlyEnabled(Ext_S) // scause
-function clause is_CSR_accessible(0x143, _, _) = currentlyEnabled(Ext_S) // stval
+function clause is_CSR_accessible(0x140, p, access_type) = // sscratch
+  check_CSR_access(0x140, p, access_type, currentlyEnabled(Ext_S))
+function clause is_CSR_accessible(0x142, p, access_type) = // scause
+  check_CSR_access(0x142, p, access_type, currentlyEnabled(Ext_S))
+function clause is_CSR_accessible(0x143, p, access_type) = // stval
+  check_CSR_access(0x143, p, access_type, currentlyEnabled(Ext_S))
 
 function clause read_CSR(0x140) = sscratch
 function clause read_CSR(0x142) = scause.bits
@@ -803,7 +823,8 @@ mapping clause csr_name_map = 0x7a1  <-> "tdata1"
 mapping clause csr_name_map = 0x7a2  <-> "tdata2"
 mapping clause csr_name_map = 0x7a3  <-> "tdata3"
 
-function clause is_CSR_accessible(0x7a0, _, _) = true
+function clause is_CSR_accessible(0x7a0, p, access_type) = // tselect
+  check_CSR_access(0x7a0, p, access_type, true)
 function clause read_CSR(0x7a0) = ~(tselect)  // this indicates we don't have any trigger support
 function clause write_CSR(0x7a0, value) = { tselect = value; Ok(tselect) }
 
@@ -839,13 +860,7 @@ function feature_enabled_for_priv(p : Privilege, machine_enable_bit : bits(1), s
                        else FEATURE_ENABLED,
 }
 
-// Backward-compatible wrapper around feature_enabled_for_priv for callers that
-// do not yet distinguish between illegal-instruction and virtual-instruction
-// exceptions. Required for upcoming Hypervisor extension support.
-function feature_enabled_for_priv_bool(p : Privilege, m : bits(1), s : bits(1), h : bits(1)) -> bool =
-  feature_enabled_for_priv(p, m, s, h) == FEATURE_ENABLED
-
 // Return true if the counter is enabled.
 // TODO: Pass hcounteren.bits[index] once hcounteren is implemented.
-function counter_enabled(index: range(0, 31), priv : Privilege) -> bool =
-  feature_enabled_for_priv_bool(priv, mcounteren.bits[index], scounteren.bits[index], 0b0)
+function counter_enabled(index: range(0, 31), priv : Privilege) -> FeatureEnabledResult =
+  feature_enabled_for_priv(priv, mcounteren.bits[index], scounteren.bits[index], 0b0)

--- a/model/exceptions/sys_exceptions.sail
+++ b/model/exceptions/sys_exceptions.sail
@@ -85,10 +85,14 @@ mapping clause csr_name_map = 0x141  <-> "sepc"
 mapping clause csr_name_map = 0x305  <-> "mtvec"
 mapping clause csr_name_map = 0x341  <-> "mepc"
 
-function clause is_CSR_accessible(0x105, _, _) = currentlyEnabled(Ext_S) // stvec
-function clause is_CSR_accessible(0x141, _, _) = currentlyEnabled(Ext_S) // sepc
-function clause is_CSR_accessible(0x305, _, _) = true // mtvec
-function clause is_CSR_accessible(0x341, _, _) = true // mepc
+function clause is_CSR_accessible(0x105, p, access_type) = // stvec
+  check_CSR_access(0x105, p, access_type, currentlyEnabled(Ext_S))
+function clause is_CSR_accessible(0x141, p, access_type) = // sepc
+  check_CSR_access(0x141, p, access_type, currentlyEnabled(Ext_S))
+function clause is_CSR_accessible(0x305, p, access_type) = // mtvec
+  check_CSR_access(0x305, p, access_type, true)
+function clause is_CSR_accessible(0x341, p, access_type) = // mepc
+  check_CSR_access(0x341, p, access_type, true)
 
 function clause read_CSR(0x105) = get_stvec()
 function clause read_CSR(0x141) = get_xepc(Supervisor)

--- a/model/extensions/FD/fdext_control.sail
+++ b/model/extensions/FD/fdext_control.sail
@@ -26,9 +26,12 @@ mapping clause csr_name_map = 0x003  <-> "fcsr"
 
 // These should ideally also check `xstateen.FCSR`, but due to module
 // interdependency issues, that is handled by `stateen_allows_CSR_access`.
-function clause is_CSR_accessible (0x001, _, _) = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
-function clause is_CSR_accessible (0x002, _, _) = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
-function clause is_CSR_accessible (0x003, _, _) = currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx)
+function clause is_CSR_accessible (0x001, p, access_type) =
+  check_CSR_access(0x001, p, access_type, currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx))
+function clause is_CSR_accessible (0x002, p, access_type) =
+  check_CSR_access(0x002, p, access_type, currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx))
+function clause is_CSR_accessible (0x003, p, access_type) =
+  check_CSR_access(0x003, p, access_type, currentlyEnabled(Ext_F) | currentlyEnabled(Ext_Zfinx))
 
 function clause read_CSR (0x001) = zero_extend(fcsr[FFLAGS])
 function clause read_CSR (0x002) = zero_extend(fcsr[FRM])

--- a/model/extensions/K/zkr_control.sail
+++ b/model/extensions/K/zkr_control.sail
@@ -41,17 +41,24 @@ private function write_seed_csr () -> xlenbits = zeros()
 
 // CSR mapping
 mapping clause csr_name_map = 0x015  <-> "seed"
-function clause is_CSR_accessible(0x015, priv, access_type) =
-  currentlyEnabled(Ext_Zkr) &
-  // Read-only access is not allowed.
-  (access_type != CSRRead) &
-  (match priv {
-    Machine => true,
-    Supervisor => mseccfg[SSEED] == 0b1,
-    User => mseccfg[USEED] == 0b1,
-    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    VirtualUser => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-  })
+
+// This implements the "Entropy Source Access Control" Table in the manual.
+function clause is_CSR_accessible(0x015, priv, access_type) = {
+  if not(currentlyEnabled(Ext_Zkr)) | access_type == CSRRead
+  then return Err(CSR_Access_Illegal);
+
+  match priv {
+    Machine           => Ok(()),
+    User              => if mseccfg[USEED] == 0b1 then Ok(()) else Err(CSR_Access_Illegal),
+    Supervisor        => if mseccfg[SSEED] == 0b1 then Ok(()) else Err(CSR_Access_Illegal),
+    VirtualSupervisor => Err(if mseccfg[SSEED] == 0b1
+                             then (if access_type == CSRReadWrite then CSR_Access_Virtual else CSR_Access_Illegal)
+                             else CSR_Access_Illegal),
+    VirtualUser       => Err(if mseccfg[SSEED] == 0b1
+                             then (if access_type == CSRReadWrite then CSR_Access_Virtual else CSR_Access_Illegal)
+                             else CSR_Access_Illegal),
+  }
+}
 
 function clause read_CSR(0x015) = read_seed_csr()
 function clause write_CSR(0x015, _value) = Ok(write_seed_csr())

--- a/model/extensions/Smcntrpmf/smcntrpmf.sail
+++ b/model/extensions/Smcntrpmf/smcntrpmf.sail
@@ -28,10 +28,14 @@ mapping clause csr_name_map = 0x721  <-> "mcyclecfgh"
 mapping clause csr_name_map = 0x322  <-> "minstretcfg"
 mapping clause csr_name_map = 0x722  <-> "minstretcfgh"
 
-function clause is_CSR_accessible(0x321, _, _) = currentlyEnabled(Ext_Smcntrpmf) // mcyclecfg
-function clause is_CSR_accessible(0x721, _, _) = currentlyEnabled(Ext_Smcntrpmf) & xlen == 32 // mcyclecfgh
-function clause is_CSR_accessible(0x322, _, _) = currentlyEnabled(Ext_Smcntrpmf) // minstretcfg
-function clause is_CSR_accessible(0x722, _, _) = currentlyEnabled(Ext_Smcntrpmf) & xlen == 32 // minstretcfgh
+function clause is_CSR_accessible(0x321, p, access_type) = // mcyclecfg
+  check_CSR_access(0x321, p, access_type, currentlyEnabled(Ext_Smcntrpmf))
+function clause is_CSR_accessible(0x721, p, access_type) = // mcyclecfgh
+  check_CSR_access(0x721, p, access_type, currentlyEnabled(Ext_Smcntrpmf) & xlen == 32)
+function clause is_CSR_accessible(0x322, p, access_type) = // minstretcfg
+  check_CSR_access(0x322, p, access_type, currentlyEnabled(Ext_Smcntrpmf))
+function clause is_CSR_accessible(0x722, p, access_type) = // minstretcfgh
+  check_CSR_access(0x722, p, access_type, currentlyEnabled(Ext_Smcntrpmf) & xlen == 32)
 
 function clause read_CSR(0x321) = mcyclecfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x721 if xlen == 32) = mcyclecfg.bits[63 .. 32]

--- a/model/extensions/Sscofpmf/sscofpmf.sail
+++ b/model/extensions/Sscofpmf/sscofpmf.sail
@@ -48,7 +48,8 @@ private function write_mhpmeventh(index : hpmidx, value : bits(32)) -> unit =
   mhpmevent[index] = legalize_hpmevent(Mk_HpmEvent(value @ mhpmevent[index].bits[31 .. 0]))
 
 // mhpmevent3..31h
-function clause is_CSR_accessible((0b0111001 /* 0x720 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Sscofpmf) & (xlen == 32)
+function clause is_CSR_accessible((0b0111001 /* 0x720 */ @ index : bits(5), priv, access_type) if unsigned(index) >= 3) =
+  check_CSR_access(0b0111001 /* 0x720 */ @ index, priv, access_type, currentlyEnabled(Ext_Sscofpmf) & (xlen == 32))
 function clause read_CSR(0b0111001 /* 0x720 */ @ index : bits(5) if xlen == 32 & unsigned(index) >= 3) = read_mhpmeventh(hpmidx_from_bits(index))
 function clause write_CSR((0b0111001 /* 0x720 */ @ index : bits(5), value) if xlen == 32 & unsigned(index) >= 3) = {
   let index = hpmidx_from_bits(index);
@@ -78,6 +79,11 @@ private function get_scountovf(priv : Privilege) -> bits(32) = {
 }
 
 // scountovf
-function clause is_CSR_accessible(0xDA0, _, _) = currentlyEnabled(Ext_Sscofpmf) & currentlyEnabled(Ext_S)
+// TODO: For implementations that support Smcdeleg/Ssccfg, Sscofpmf, and the H extension, when
+// menvcfg.CDE=1, attempts to read scountovf from VS-mode or VU-mode raise a virtual instruction
+// exception
+function clause is_CSR_accessible(0xDA0, priv, access_type) =
+  check_CSR_access(0xDA0, priv, access_type, currentlyEnabled(Ext_Sscofpmf) & currentlyEnabled(Ext_S))
+
 function clause read_CSR(0xDA0) = zero_extend(get_scountovf(cur_privilege))
 // scountovf is read-only.

--- a/model/extensions/Ssqosid/ssqosid.sail
+++ b/model/extensions/Ssqosid/ssqosid.sail
@@ -31,7 +31,14 @@ register srmcfg : Srmcfg
 // Ssqosid - Quality-of-Service (Qos) Identifiers
 mapping clause csr_name_map = 0x181  <-> "srmcfg"
 
-function clause is_CSR_accessible(0x181, _, _) = currentlyEnabled(Ext_Ssqosid)
+function clause is_CSR_accessible(0x181, priv, access_type) = {
+  // When Smstateen is not implemented, VS/VU accesses always raise
+  // virtual-instruction exceptions.
+  if privLevel_is_virtual(priv) & not(currentlyEnabled(Ext_Smstateen))
+  then return Err(CSR_Access_Virtual);
+
+  check_CSR_access(0x181, priv, access_type, currentlyEnabled(Ext_Ssqosid))
+}
 
 function clause read_CSR(0x181) = srmcfg.bits
 

--- a/model/extensions/Sstc/sstc.sail
+++ b/model/extensions/Sstc/sstc.sail
@@ -10,16 +10,34 @@
 mapping clause csr_name_map = 0x14D  <-> "stimecmp"
 mapping clause csr_name_map = 0x15D  <-> "stimecmph"
 
-function sstc_CSRs_accessible(priv : Privilege) -> bool =
-    priv == Machine | (priv == Supervisor & mcounteren[TM] == 0b1 & menvcfg[STCE] == 0b1)
+function sstc_CSRs_check_access(priv : Privilege) -> result(unit, csr_access_failure) =
+  match priv {
+    Machine => Ok(()),
+    Supervisor => if mcounteren[TM] == 0b1 & menvcfg[STCE] == 0b1
+                  then Ok(()) else Err(CSR_Access_Illegal),
+    VirtualSupervisor =>
+      // This CSR address is proxying vstimecmp.
+      if not(mcounteren[TM] == 0b1 & menvcfg[STCE] == 0b1)
+      then return Err(CSR_Access_Illegal)
+      else
+        // TODO: use the below instead for hypervisor
+        // if not(hcounteren[TM] == 0b1 & henvcfg[STCE] == 0b1)
+        // then return Err(CSR_Access_Virtual)
+        // else Ok(())
+        Err(CSR_Access_Illegal),
+    User => Err(CSR_Access_Illegal),
+    VirtualUser => Err(CSR_Access_Illegal),
+  }
 
-function clause is_CSR_accessible(0x14D, priv, _) =
-    currentlyEnabled(Ext_S) & currentlyEnabled(Ext_Sstc) &
-    sstc_CSRs_accessible(priv)
+function clause is_CSR_accessible(0x14D, priv, _access) =
+  if not(currentlyEnabled(Ext_S) & currentlyEnabled(Ext_Sstc))
+  then return Err(CSR_Access_Illegal)
+  else sstc_CSRs_check_access(priv)
 
-function clause is_CSR_accessible(0x15D, priv, _) =
-    currentlyEnabled(Ext_S) & currentlyEnabled(Ext_Sstc) & xlen == 32 &
-    sstc_CSRs_accessible(priv)
+function clause is_CSR_accessible(0x15D, priv, _access) =
+  if not(currentlyEnabled(Ext_S) & currentlyEnabled(Ext_Sstc) & xlen == 32)
+  then Err(CSR_Access_Illegal)
+  else sstc_CSRs_check_access(priv)
 
 function clause read_CSR(0x14D) = stimecmp[xlen - 1 .. 0]
 function clause read_CSR(0x15D if xlen == 32) = stimecmp[63 .. 32]

--- a/model/extensions/Stateen/stateen_access_checks.sail
+++ b/model/extensions/Stateen/stateen_access_checks.sail
@@ -12,54 +12,48 @@
 // defined using a scattered definition; however, this creates a
 // module dependency problem, especially for registers like
 // `senvcfg` where there would be a cyclic dependency between Core and
-// Sstateen.  Instead, for now, all the Stateen checks are centralized
-// into the below function.
-// TODO: refactor the Core module to prevent such cyclic dependencies;
-// this would ideally allow the below checks to be inlined into the
-// `is_CSR_accessible` function.
+// Sstateen.
+//
+// Instead, a scattered definition is declared in Core along with the
+// other CSR-related scattered definitions, and its clauses are
+// implemented below.  This may also enable building the model without
+// the Stateen module.
 
-function stateen_allows_CSR_access(csr : csreg, priv : Privilege, _access_type : CSRAccessType) -> bool =
-  match (csr, priv) {
-    // hstateen0
-    (0x60C, priv) => check_stateen_bit(priv, STATEEN_SE, 0),
-    // hstateen0h
-    (0x61C, priv) => check_stateen_bit(priv, STATEEN_SE, 0),
-    // hstateen1
-    (0x60D, priv) => check_stateen_bit(priv, STATEEN_SE, 1),
-    // hstateen1h
-    (0x61D, priv) => check_stateen_bit(priv, STATEEN_SE, 1),
-    // hstateen2
-    (0x60E, priv) => check_stateen_bit(priv, STATEEN_SE, 2),
-    // hstateen2h
-    (0x61E, priv) => check_stateen_bit(priv, STATEEN_SE, 2),
-    // hstateen3
-    (0x60F, priv) => check_stateen_bit(priv, STATEEN_SE, 3),
-    // hstateen3h
-    (0x61F, priv) => check_stateen_bit(priv, STATEEN_SE, 3),
+// hstateen0
+function clause stateen_allows_CSR_access(0x60C, priv, _) = check_stateen_bit(priv, STATEEN_SE, 0)
+// hstateen0h
+function clause stateen_allows_CSR_access(0x61C, priv, _) = check_stateen_bit(priv, STATEEN_SE, 0)
+// hstateen1
+function clause stateen_allows_CSR_access(0x60D, priv, _) = check_stateen_bit(priv, STATEEN_SE, 1)
+// hstateen1h
+function clause stateen_allows_CSR_access(0x61D, priv, _) = check_stateen_bit(priv, STATEEN_SE, 1)
+// hstateen2
+function clause stateen_allows_CSR_access(0x60E, priv, _) = check_stateen_bit(priv, STATEEN_SE, 2)
+// hstateen2h
+function clause stateen_allows_CSR_access(0x61E, priv, _) = check_stateen_bit(priv, STATEEN_SE, 2)
+// hstateen3
+function clause stateen_allows_CSR_access(0x60F, priv, _) = check_stateen_bit(priv, STATEEN_SE, 3)
+// hstateen3h
+function clause stateen_allows_CSR_access(0x61F, priv, _) = check_stateen_bit(priv, STATEEN_SE, 3)
 
-    // sstateen0
-    (0x10C, priv) => check_stateen_bit(priv, STATEEN_SE, 0),
-    // sstateen1
-    (0x10D, priv) => check_stateen_bit(priv, STATEEN_SE, 1),
-    // sstateen2
-    (0x10E, priv) => check_stateen_bit(priv, STATEEN_SE, 2),
-    // sstateen3
-    (0x10F, priv) => check_stateen_bit(priv, STATEEN_SE, 3),
+// sstateen0
+function clause stateen_allows_CSR_access(0x10C, priv, _) = check_stateen_bit(priv, STATEEN_SE, 0)
+// sstateen1
+function clause stateen_allows_CSR_access(0x10D, priv, _) = check_stateen_bit(priv, STATEEN_SE, 1)
+// sstateen2
+function clause stateen_allows_CSR_access(0x10E, priv, _) = check_stateen_bit(priv, STATEEN_SE, 2)
+// sstateen3
+function clause stateen_allows_CSR_access(0x10F, priv, _) = check_stateen_bit(priv, STATEEN_SE, 3)
 
-    // senvcfg
-    (0x10A, priv) => check_stateen_bit(priv, STATEEN_ENVCFG, 0),
+// senvcfg
+function clause stateen_allows_CSR_access(0x10A, priv, _) = check_stateen_bit(priv, STATEEN_ENVCFG, 0)
 
-    // srmcfg
-    (0x181, priv) => check_stateen_bit(priv, STATEEN_SRMCFG, 0),
+// srmcfg
+function clause stateen_allows_CSR_access(0x181, priv, _) = check_stateen_bit(priv, STATEEN_SRMCFG, 0)
 
-    // fflags
-    (0x001, priv) => if hartSupports(Ext_Zfinx) then check_stateen_bit(priv, STATEEN_FCSR, 0) else true,
-    // frm
-    (0x002, priv) => if hartSupports(Ext_Zfinx) then check_stateen_bit(priv, STATEEN_FCSR, 0) else true,
-    // fcsr
-    (0x003, priv) => if hartSupports(Ext_Zfinx) then check_stateen_bit(priv, STATEEN_FCSR, 0) else true,
-
-    // CSRs that are not governed by xstateen are not gated by
-    // this function
-    (_, _)        => true,
-  }
+// fflags
+function clause stateen_allows_CSR_access(0x001, priv, _) = if hartSupports(Ext_Zfinx) then check_stateen_bit(priv, STATEEN_FCSR, 0) else true
+// frm
+function clause stateen_allows_CSR_access(0x002, priv, _) = if hartSupports(Ext_Zfinx) then check_stateen_bit(priv, STATEEN_FCSR, 0) else true
+// fcsr
+function clause stateen_allows_CSR_access(0x003, priv, _) = if hartSupports(Ext_Zfinx) then check_stateen_bit(priv, STATEEN_FCSR, 0) else true

--- a/model/extensions/Stateen/stateen_csrs.sail
+++ b/model/extensions/Stateen/stateen_csrs.sail
@@ -15,14 +15,22 @@ mapping clause csr_name_map = 0x31D <-> "mstateen1h"
 mapping clause csr_name_map = 0x31E <-> "mstateen2h"
 mapping clause csr_name_map = 0x31F <-> "mstateen3h"
 
-function clause is_CSR_accessible(0x30C, _, _) = is_mstateen_accessible()
-function clause is_CSR_accessible(0x30D, _, _) = is_mstateen_accessible()
-function clause is_CSR_accessible(0x30E, _, _) = is_mstateen_accessible()
-function clause is_CSR_accessible(0x30F, _, _) = is_mstateen_accessible()
-function clause is_CSR_accessible(0x31C, _, _) = is_mstateen_accessible() & (xlen == 32)
-function clause is_CSR_accessible(0x31D, _, _) = is_mstateen_accessible() & (xlen == 32)
-function clause is_CSR_accessible(0x31E, _, _) = is_mstateen_accessible() & (xlen == 32)
-function clause is_CSR_accessible(0x31F, _, _) = is_mstateen_accessible() & (xlen == 32)
+function clause is_CSR_accessible(0x30C, p, access_type) =
+  check_CSR_access(0x30C, p, access_type, is_mstateen_accessible())
+function clause is_CSR_accessible(0x30D, p, access_type) =
+  check_CSR_access(0x30D, p, access_type, is_mstateen_accessible())
+function clause is_CSR_accessible(0x30E, p, access_type) =
+  check_CSR_access(0x30E, p, access_type, is_mstateen_accessible())
+function clause is_CSR_accessible(0x30F, p, access_type) =
+  check_CSR_access(0x30F, p, access_type, is_mstateen_accessible())
+function clause is_CSR_accessible(0x31C, p, access_type) =
+  check_CSR_access(0x31C, p, access_type, is_mstateen_accessible() & xlen == 32)
+function clause is_CSR_accessible(0x31D, p, access_type) =
+  check_CSR_access(0x31D, p, access_type, is_mstateen_accessible() & xlen == 32)
+function clause is_CSR_accessible(0x31E, p, access_type) =
+  check_CSR_access(0x31E, p, access_type, is_mstateen_accessible() & xlen == 32)
+function clause is_CSR_accessible(0x31F, p, access_type) =
+  check_CSR_access(0x31F, p, access_type, is_mstateen_accessible() & xlen == 32)
 
 function clause read_CSR(0x30C) = mstateen0.bits[xlen - 1 .. 0]
 function clause read_CSR(0x30D) = mstateen1.bits[xlen - 1 .. 0]
@@ -46,6 +54,16 @@ function clause write_CSR((0x31D, value) if xlen == 32) = { mstateen1 = legalize
 function clause write_CSR((0x31E, value) if xlen == 32) = { mstateen2 = legalize_mstateen2(mstateen2, value @ mstateen2.bits[31 .. 0]); Ok(mstateen2.bits[63 .. 32]) }
 function clause write_CSR((0x31F, value) if xlen == 32) = { mstateen3 = legalize_mstateen3(mstateen3, value @ mstateen3.bits[31 .. 0]); Ok(mstateen3.bits[63 .. 32]) }
 
+private function check_hs_stateen_CSR_access(csr : csreg, p : Privilege, access_type : CSRAccessType, accessible : bool, stateen : bool) -> result(unit, csr_access_failure) = {
+  if not(accessible) then return Err(CSR_Access_Illegal);
+
+  // Accesses to {hs}stateen* registers are valid in HS-mode, hence they are HS-qualified.
+  if not(default_CSR_access_allowed(csr, p, access_type) & stateen)
+  then return Err(if privLevel_is_virtual(p) then CSR_Access_Virtual else CSR_Access_Illegal);
+
+  return Ok(())
+}
+
 mapping clause csr_name_map = 0x60C <-> "hstateen0"
 mapping clause csr_name_map = 0x60D <-> "hstateen1"
 mapping clause csr_name_map = 0x60E <-> "hstateen2"
@@ -55,14 +73,38 @@ mapping clause csr_name_map = 0x61D <-> "hstateen1h"
 mapping clause csr_name_map = 0x61E <-> "hstateen2h"
 mapping clause csr_name_map = 0x61F <-> "hstateen3h"
 
-function clause is_CSR_accessible(0x60C, _, _) = is_hstateen_accessible()
-function clause is_CSR_accessible(0x60D, _, _) = is_hstateen_accessible()
-function clause is_CSR_accessible(0x60E, _, _) = is_hstateen_accessible()
-function clause is_CSR_accessible(0x60F, _, _) = is_hstateen_accessible()
-function clause is_CSR_accessible(0x61C, _, _) = (xlen == 32) & is_hstateen_accessible()
-function clause is_CSR_accessible(0x61D, _, _) = (xlen == 32) & is_hstateen_accessible()
-function clause is_CSR_accessible(0x61E, _, _) = (xlen == 32) & is_hstateen_accessible()
-function clause is_CSR_accessible(0x61F, _, _) = (xlen == 32) & is_hstateen_accessible()
+function clause is_CSR_accessible(0x60C, p, access_type) = {
+  let stateen = stateen_allows_CSR_access(0x60C, p, access_type);
+  check_hs_stateen_CSR_access(0x60C, p, access_type, is_hstateen_accessible(), stateen)
+}
+function clause is_CSR_accessible(0x60D, p, access_type) = {
+  let stateen = stateen_allows_CSR_access(0x60D, p, access_type);
+  check_hs_stateen_CSR_access(0x60D, p, access_type, is_hstateen_accessible(), stateen)
+}
+function clause is_CSR_accessible(0x60E, p, access_type) = {
+  let stateen = stateen_allows_CSR_access(0x60E, p, access_type);
+  check_hs_stateen_CSR_access(0x60E, p, access_type, is_hstateen_accessible(), stateen)
+}
+function clause is_CSR_accessible(0x60F, p, access_type) = {
+  let stateen = stateen_allows_CSR_access(0x60F, p, access_type);
+  check_hs_stateen_CSR_access(0x60F, p, access_type, is_hstateen_accessible(), stateen)
+}
+function clause is_CSR_accessible(0x61C, p, access_type) = {
+  let stateen = stateen_allows_CSR_access(0x61C, p, access_type);
+  check_hs_stateen_CSR_access(0x61C, p, access_type, xlen == 32 & is_hstateen_accessible(), stateen)
+}
+function clause is_CSR_accessible(0x61D, p, access_type) = {
+  let stateen = stateen_allows_CSR_access(0x61D, p, access_type);
+  check_hs_stateen_CSR_access(0x61D, p, access_type, xlen == 32 & is_hstateen_accessible(), stateen)
+}
+function clause is_CSR_accessible(0x61E, p, access_type) = {
+  let stateen = stateen_allows_CSR_access(0x61E, p, access_type);
+  check_hs_stateen_CSR_access(0x61E, p, access_type, xlen == 32 & is_hstateen_accessible(), stateen)
+}
+function clause is_CSR_accessible(0x61F, p, access_type) = {
+  let stateen = stateen_allows_CSR_access(0x61F, p, access_type);
+  check_hs_stateen_CSR_access(0x61F, p, access_type, xlen == 32 & is_hstateen_accessible(), stateen)
+}
 
 function clause read_CSR(0x60C) = (hstateen0.bits & get_hstateen_mask(0))[xlen - 1 .. 0]
 function clause read_CSR(0x60D) = (hstateen1.bits & get_hstateen_mask(1))[xlen - 1 .. 0]
@@ -91,10 +133,22 @@ mapping clause csr_name_map = 0x10D <-> "sstateen1"
 mapping clause csr_name_map = 0x10E <-> "sstateen2"
 mapping clause csr_name_map = 0x10F <-> "sstateen3"
 
-function clause is_CSR_accessible(0x10C, _, _) = is_sstateen_accessible()
-function clause is_CSR_accessible(0x10D, _, _) = is_sstateen_accessible()
-function clause is_CSR_accessible(0x10E, _, _) = is_sstateen_accessible()
-function clause is_CSR_accessible(0x10F, _, _) = is_sstateen_accessible()
+function clause is_CSR_accessible(0x10C, p, access_type) = {
+  let stateen = stateen_allows_CSR_access(0x10C, p, access_type);
+  check_hs_stateen_CSR_access(0x10C, p, access_type, is_sstateen_accessible(), stateen)
+}
+function clause is_CSR_accessible(0x10D, p, access_type) = {
+  let stateen = stateen_allows_CSR_access(0x10D, p, access_type);
+  check_hs_stateen_CSR_access(0x10D, p, access_type, is_sstateen_accessible(), stateen)
+}
+function clause is_CSR_accessible(0x10E, p, access_type) = {
+  let stateen = stateen_allows_CSR_access(0x10E, p, access_type);
+  check_hs_stateen_CSR_access(0x10E, p, access_type, is_sstateen_accessible(), stateen)
+}
+function clause is_CSR_accessible(0x10F, p, access_type) = {
+  let stateen = stateen_allows_CSR_access(0x10F, p, access_type);
+  check_hs_stateen_CSR_access(0x10F, p, access_type, is_sstateen_accessible(), stateen)
+}
 
 function clause read_CSR(0x10C) = { let mask = get_sstateen_mask(0); zero_extend(sstateen0.bits & mask[31..0]) }
 function clause read_CSR(0x10D) = { let mask = get_sstateen_mask(1); zero_extend(sstateen1.bits & mask[31..0]) }

--- a/model/extensions/V/vext_regs.sail
+++ b/model/extensions/V/vext_regs.sail
@@ -307,13 +307,20 @@ mapping clause csr_name_map = 0xC20  <-> "vl"
 mapping clause csr_name_map = 0xC21  <-> "vtype"
 mapping clause csr_name_map = 0xC22  <-> "vlenb"
 
-function clause is_CSR_accessible(0x008, _, _) = currentlyEnabled(Ext_Zve32x) // vstart
-function clause is_CSR_accessible(0x009, _, _) = currentlyEnabled(Ext_Zve32x) // vxsat
-function clause is_CSR_accessible(0x00A, _, _) = currentlyEnabled(Ext_Zve32x) // vxrm
-function clause is_CSR_accessible(0x00F, _, _) = currentlyEnabled(Ext_Zve32x) // vcsr
-function clause is_CSR_accessible(0xC20, _, _) = currentlyEnabled(Ext_Zve32x) // vl
-function clause is_CSR_accessible(0xC21, _, _) = currentlyEnabled(Ext_Zve32x) // vtype
-function clause is_CSR_accessible(0xC22, _, _) = currentlyEnabled(Ext_Zve32x) // vlenb
+function clause is_CSR_accessible(0x008, p, access_type) = // vstart
+  check_CSR_access(0x008, p, access_type, currentlyEnabled(Ext_Zve32x))
+function clause is_CSR_accessible(0x009, p, access_type) = // vxsat
+  check_CSR_access(0x009, p, access_type, currentlyEnabled(Ext_Zve32x))
+function clause is_CSR_accessible(0x00A, p, access_type) = // vxrm
+  check_CSR_access(0x00A, p, access_type, currentlyEnabled(Ext_Zve32x))
+function clause is_CSR_accessible(0x00F, p, access_type) = // vcsr
+  check_CSR_access(0x00F, p, access_type, currentlyEnabled(Ext_Zve32x))
+function clause is_CSR_accessible(0xC20, p, access_type) = // vl
+  check_CSR_access(0xC20, p, access_type, currentlyEnabled(Ext_Zve32x))
+function clause is_CSR_accessible(0xC21, p, access_type) = // vtype
+  check_CSR_access(0xC21, p, access_type, currentlyEnabled(Ext_Zve32x))
+function clause is_CSR_accessible(0xC22, p, access_type) = // vlenb
+  check_CSR_access(0xC22, p, access_type, currentlyEnabled(Ext_Zve32x))
 
 function clause read_CSR(0x008) = vstart
 function clause read_CSR(0x009) = zero_extend(vcsr[vxsat])

--- a/model/extensions/Zicbom/zicbom_insts.sail
+++ b/model/extensions/Zicbom/zicbom_insts.sail
@@ -10,9 +10,6 @@
 
 function clause currentlyEnabled(Ext_Zicbom) = hartSupports(Ext_Zicbom)
 
-// TODO: Pass henvcfg.bits[CBCFE] once henvcfg is implemented.
-private function cbo_clean_flush_enabled(p : Privilege) -> bool = feature_enabled_for_priv_bool(p, menvcfg[CBCFE], read_senvcfg()[CBCFE], 0b0)
-
 // *****************************************************************
 union clause instruction = ZICBOM : (cbop_zicbom, regidx)
 
@@ -105,15 +102,23 @@ private function process_clean_inval(rs1 : regidx, cbop : cbop_zicbom) -> Execut
   }
 }
 
-function clause execute ZICBOM(CBO_CLEAN, rs1) =
-  if   cbo_clean_flush_enabled(cur_privilege)
-  then process_clean_inval(rs1, CBO_CLEAN)
-  else Illegal_Instruction()
+function clause execute ZICBOM(CBO_CLEAN, rs1) = {
+  // TODO: Pass read_henvcfg()[CBCFE] once henvcfg is implemented.
+  match feature_enabled_for_priv(cur_privilege, menvcfg[CBCFE], read_senvcfg()[CBCFE], 0b0) {
+    FEATURE_ENABLED => process_clean_inval(rs1, CBO_CLEAN),
+    FEATURE_ILLEGAL => return Illegal_Instruction(),
+    FEATURE_VIRTUAL => return Virtual_Instruction(),
+  }
+}
 
-function clause execute ZICBOM(CBO_FLUSH, rs1) =
-  if   cbo_clean_flush_enabled(cur_privilege)
-  then process_clean_inval(rs1, CBO_FLUSH)
-  else Illegal_Instruction()
+function clause execute ZICBOM(CBO_FLUSH, rs1) = {
+  // TODO: Pass read_henvcfg()[CBCFE] once henvcfg is implemented.
+  match feature_enabled_for_priv(cur_privilege, menvcfg[CBCFE], read_senvcfg()[CBCFE], 0b0) {
+    FEATURE_ENABLED => process_clean_inval(rs1, CBO_FLUSH),
+    FEATURE_ILLEGAL => return Illegal_Instruction(),
+    FEATURE_VIRTUAL => return Virtual_Instruction(),
+  }
+}
 
 function clause execute ZICBOM(CBO_INVAL, rs1) =
   match cbop_priv_check(cur_privilege) {

--- a/model/extensions/Zicboz/zicboz_insts.sail
+++ b/model/extensions/Zicboz/zicboz_insts.sail
@@ -10,9 +10,6 @@
 
 function clause currentlyEnabled(Ext_Zicboz) = hartSupports(Ext_Zicboz)
 
-// TODO: Pass henvcfg[CBZE] once henvcfg is implemented.
-function cbo_zero_enabled(p : Privilege) -> bool = feature_enabled_for_priv_bool(p, menvcfg[CBZE], read_senvcfg()[CBZE], 0b0)
-
 // *****************************************************************
 union clause instruction = ZICBOZ : (regidx)
 
@@ -25,8 +22,12 @@ mapping clause assembly = ZICBOZ(rs1)
   <-> "cbo.zero" ^ spc() ^ "(" ^ opt_spc() ^ reg_name(rs1) ^ opt_spc() ^ ")"
 
 function clause execute ZICBOZ(rs1) = {
-  if not(cbo_zero_enabled(cur_privilege))
-  then return Illegal_Instruction();
+  // TODO: Pass read_henvcfg()[CBZE] once henvcfg is implemented.
+  match feature_enabled_for_priv(cur_privilege, menvcfg[CBZE][0], read_senvcfg()[CBZE][0], 0b0) {
+    FEATURE_ENABLED => (),
+    FEATURE_ILLEGAL => return Illegal_Instruction(),
+    FEATURE_VIRTUAL => return Virtual_Instruction(),
+  };
 
   let rs1_val = X(rs1);
   let cache_block_size = 2 ^ plat_cache_block_size_exp;

--- a/model/extensions/Zicntr/zicntr_control.sail
+++ b/model/extensions/Zicntr/zicntr_control.sail
@@ -15,12 +15,35 @@ mapping clause csr_name_map = 0xC80  <-> "cycleh"
 mapping clause csr_name_map = 0xC81  <-> "timeh"
 mapping clause csr_name_map = 0xC82  <-> "instreth"
 
-function clause is_CSR_accessible(0xC00, priv, _) = currentlyEnabled(Ext_Zicntr) & counter_enabled(0, priv) // cycle
-function clause is_CSR_accessible(0xC01, priv, _) = currentlyEnabled(Ext_Zicntr) & counter_enabled(1, priv) // time
-function clause is_CSR_accessible(0xC02, priv, _) = currentlyEnabled(Ext_Zicntr) & counter_enabled(2, priv) // instret
-function clause is_CSR_accessible(0xC80, priv, _) = currentlyEnabled(Ext_Zicntr) & xlen == 32 & counter_enabled(0, priv) // cycleh
-function clause is_CSR_accessible(0xC81, priv, _) = currentlyEnabled(Ext_Zicntr) & xlen == 32 & counter_enabled(1, priv) // timeh
-function clause is_CSR_accessible(0xC82, priv, _) = currentlyEnabled(Ext_Zicntr) & xlen == 32 & counter_enabled(2, priv) // instreth
+function unpriv_counter_access_check(priv : Privilege, access : CSRAccessType, index : range(0, 31), require_rv32 : bool) -> result(unit, csr_access_failure) = {
+  // These registers are read-only shadows.
+  if not(currentlyEnabled(Ext_Zicntr)) | (access != CSRRead) | (require_rv32 & xlen != 32)
+  then return Err(CSR_Access_Illegal);
+
+  match counter_enabled(index, priv) {
+    FEATURE_ILLEGAL => Err(CSR_Access_Illegal),
+    FEATURE_VIRTUAL => Err(CSR_Access_Virtual),
+    FEATURE_ENABLED => Ok(()),
+  }
+}
+
+function clause is_CSR_accessible(0xC00, priv, access) =
+  unpriv_counter_access_check(priv, access, 0, false)
+
+function clause is_CSR_accessible(0xC01, priv, access) =
+  unpriv_counter_access_check(priv, access, 1, false)
+
+function clause is_CSR_accessible(0xC02, priv, access) =
+  unpriv_counter_access_check(priv, access, 2, false)
+
+function clause is_CSR_accessible(0xC80, priv, access) =
+  unpriv_counter_access_check(priv, access, 0, true)
+
+function clause is_CSR_accessible(0xC81, priv, access) =
+  unpriv_counter_access_check(priv, access, 1, true)
+
+function clause is_CSR_accessible(0xC82, priv, access) =
+  unpriv_counter_access_check(priv, access, 2, true)
 
 function clause read_CSR(0xC00) = mcycle[(xlen - 1) .. 0]
 function clause read_CSR(0xC01) = mtime[(xlen - 1) .. 0]
@@ -36,10 +59,14 @@ mapping clause csr_name_map = 0xB02  <-> "minstret"
 mapping clause csr_name_map = 0xB80  <-> "mcycleh"
 mapping clause csr_name_map = 0xB82  <-> "minstreth"
 
-function clause is_CSR_accessible(0xB00, _, _) = currentlyEnabled(Ext_Zicntr) // mcycle
-function clause is_CSR_accessible(0xB02, _, _) = currentlyEnabled(Ext_Zicntr) // minstret
-function clause is_CSR_accessible(0xB80, _, _) = currentlyEnabled(Ext_Zicntr) & xlen == 32 // mcycleh
-function clause is_CSR_accessible(0xB82, _, _) = currentlyEnabled(Ext_Zicntr) & xlen == 32 // minstreth
+function clause is_CSR_accessible(0xB00, priv, access_type) = // mcycle
+  check_CSR_access(0xB00, priv, access_type, currentlyEnabled(Ext_Zicntr))
+function clause is_CSR_accessible(0xB02, priv, access_type) = // minstret
+  check_CSR_access(0xB02, priv, access_type, currentlyEnabled(Ext_Zicntr))
+function clause is_CSR_accessible(0xB80, priv, access_type) = // mcycleh
+  check_CSR_access(0xB80, priv, access_type, currentlyEnabled(Ext_Zicntr) & xlen == 32)
+function clause is_CSR_accessible(0xB82, priv, access_type) = // minstreth
+  check_CSR_access(0xB82, priv, access_type, currentlyEnabled(Ext_Zicntr) & xlen == 32)
 
 function clause read_CSR(0xB00) = mcycle[(xlen - 1) .. 0]
 function clause read_CSR(0xB02) = minstret[(xlen - 1) .. 0]

--- a/model/extensions/Zicsr/zicsr_insts.sail
+++ b/model/extensions/Zicsr/zicsr_insts.sail
@@ -41,9 +41,13 @@ function csr_access_type(op : csrop, rd_is_x0 : bool, rs1_imm_is_zero : bool) ->
   }
 
 function doCSR(csr : csreg, rs1_val : xlenbits, rd : regidx, op : csrop, access_type : CSRAccessType) -> ExecutionResult = {
-  if   not(check_CSR(csr, cur_privilege, access_type))
-  then Illegal_Instruction()
-  else if not(ext_check_CSR(csr, cur_privilege, access_type))
+  match is_CSR_accessible(csr, cur_privilege, access_type) {
+    Err(CSR_Access_Illegal) => return Illegal_Instruction(),
+    Err(CSR_Access_Virtual) => return Virtual_Instruction(),
+    Ok()                    => (),
+  };
+
+  if not(ext_check_CSR(csr, cur_privilege, access_type))
   then Ext_CSR_Check_Failure()
   else {
     // A pure write (i.e. CSRRW with rd == 0) should not generate read side-effects.

--- a/model/extensions/Zihpm/zihpm.sail
+++ b/model/extensions/Zihpm/zihpm.sail
@@ -224,7 +224,8 @@ function write_mhpmevent(index : hpmidx, value : xlenbits) -> unit =
   }))
 
 // Hardware Performance Monitoring event selection
-function clause is_CSR_accessible((0b0011001 /* 0x320 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) // mhpmevent3..31
+function clause is_CSR_accessible((0b0011001 /* 0x320 */ @ index : bits(5), priv, access_type) if unsigned(index) >= 3) = // mhpmevent3..31
+  check_CSR_access(0b0011001 @ index, priv, access_type, currentlyEnabled(Ext_Zihpm))
 function clause read_CSR(0b0011001 /* 0x320 */ @ index : bits(5) if unsigned(index) >= 3) = read_mhpmevent(hpmidx_from_bits(index))
 function clause write_CSR((0b0011001 /* 0x320 */ @ index : bits(5), value) if unsigned(index) >= 3) = {
   let index = hpmidx_from_bits(index);
@@ -233,8 +234,10 @@ function clause write_CSR((0b0011001 /* 0x320 */ @ index : bits(5), value) if un
 }
 
 // Hardware Performance Monitoring machine mode counters
-function clause is_CSR_accessible((0b1011000 /* 0xB00 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) // mhpmcounter3..31
-function clause is_CSR_accessible((0b1011100 /* 0xB80 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & xlen == 32 // mhpmcounterh3..31
+function clause is_CSR_accessible((0b1011000 /* 0xB00 */ @ index : bits(5), priv, access_type) if unsigned(index) >= 3) = // mhpmcounter3..31
+  check_CSR_access(0b1011000 @ index, priv, access_type, currentlyEnabled(Ext_Zihpm))
+function clause is_CSR_accessible((0b1011100 /* 0xB80 */ @ index : bits(5), priv, access_type) if unsigned(index) >= 3) = // mhpmcounterh3..31
+  check_CSR_access(0b1011100 @ index, priv, access_type, currentlyEnabled(Ext_Zihpm) & xlen == 32)
 
 function clause read_CSR(0b1011000 /* 0xB00 */ @ index : bits(5) if unsigned(index) >= 3) = read_mhpmcounter(hpmidx_from_bits(index))
 function clause read_CSR(0b1011100 /* 0xB80 */ @ index : bits(5) if xlen == 32 & unsigned(index) >= 3) = read_mhpmcounterh(hpmidx_from_bits(index))
@@ -251,8 +254,18 @@ function clause write_CSR((0b1011100 /* 0xB80 */ @ index : bits(5), value) if xl
 }
 
 // Hardware Performance Monitoring user mode counters
-function clause is_CSR_accessible((0b1100000 /* 0xC00 */ @ index : bits(5), priv, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & currentlyEnabled(Ext_U) & counter_enabled(unsigned(index), priv) // hpmcounter3..31
-function clause is_CSR_accessible((0b1100100 /* 0xC80 */ @ index : bits(5), priv, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & currentlyEnabled(Ext_U) & xlen == 32 & counter_enabled(unsigned(index), priv) // hpmcounterh3..31
+
+private function unpriv_hpm_counter_access_check(priv : Privilege, access : CSRAccessType, index : range(0, 31), require_rv32 : bool) -> result(unit, csr_access_failure) = {
+  if not(currentlyEnabled(Ext_Zihpm)) then return Err(CSR_Access_Illegal);
+
+  unpriv_counter_access_check(priv, access, index, require_rv32)
+}
+
+function clause is_CSR_accessible((0b1100000 /* 0xC00 */ @ index : bits(5), priv, access) if unsigned(index) >= 3) =
+  unpriv_hpm_counter_access_check(priv, access, unsigned(index), false)
+
+function clause is_CSR_accessible((0b1100100 /* 0xC80 */ @ index : bits(5), priv, access) if unsigned(index) >= 3) =
+  unpriv_hpm_counter_access_check(priv, access, unsigned(index), true)
 
 function clause read_CSR(0b1100000 /* 0xC00 */ @ index : bits(5) if unsigned(index) >= 3) = read_mhpmcounter(hpmidx_from_bits(index))
 function clause read_CSR(0b1100100 /* 0xC80 */ @ index : bits(5) if xlen == 32 & unsigned(index) >= 3) = read_mhpmcounterh(hpmidx_from_bits(index))

--- a/model/extensions/cfi/zicfiss_regs.sail
+++ b/model/extensions/cfi/zicfiss_regs.sail
@@ -30,30 +30,40 @@ function zicfiss_xSSE(priv : Privilege) -> bool =
   })
 
 // See "Shadow Stack Pointer (ssp) CSR access control".
-function is_ssp_accessible(priv : Privilege) -> bool =
-  match priv {
-    Machine           => true,
-    // raises illegal instruction otherwise
-    Supervisor        => bool_bit(menvcfg[SSE]),
-    // needs bool_bit(read_henvcfg()[SSE])
-    // raises virtual instruction otherwise
-    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    // needs bool_bit(read_senvcfg()[SSE])
-    // raises virtual instruction otherwise
-    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    // handle the special case of M+U systems
-    // raises illegal instruction otherwise
-    User              => (currentlyEnabled(Ext_S) & bool_bit(read_senvcfg()[SSE])) | bool_bit(menvcfg[SSE])
-  }
+function is_ssp_accessible(priv : Privilege) -> result(unit, csr_access_failure) = {
+  if not(currentlyEnabled(Ext_Zicfiss)) then return Err(CSR_Access_Illegal);
 
+  match priv {
+    Machine           => Ok(()),
+    Supervisor        => if menvcfg[SSE] == 0b0 then Err(CSR_Access_Illegal) else Ok(()),
+    User              => {
+      if menvcfg[SSE] == 0b0 | (currentlyEnabled(Ext_S) & read_senvcfg()[SSE] == 0b0)
+      then return Err(CSR_Access_Illegal);
+      Ok(())
+    },
+    VirtualSupervisor => {
+      if menvcfg[SSE] == 0b0 then return Err(CSR_Access_Illegal);
+      // TODO:
+      // if read_henvcfg()[SSE] == 0b0 then return Err(CSR_Access_Virtual);
+      // Ok(())
+      internal_error(__FILE__, __LINE__, "Hypervisor extension not supported")
+    },
+    VirtualUser       => {
+      if menvcfg[SSE] == 0b0 then return Err(CSR_Access_Illegal);
+      // TODO:
+      // if read_senvcfg[SSE] == 0b0 | read_henvcfg()[SSE] == 0b0 then return Err(CSR_Access_Virtual);
+      // Ok(())
+      internal_error(__FILE__, __LINE__, "Hypervisor extension not supported")
+    }
+  }
+}
 
 register ssp : xlenbits = zeros()
 
 // "There is no high CSR defined as the ssp is always as wide as the
 // XLEN of the current privilege mode."
 mapping clause csr_name_map = 0x011  <-> "ssp"
-// TODO: handle throwing VirtualInstruction when required by `is_ssp_accessible()`.
-function clause is_CSR_accessible(0x011, _, _) = currentlyEnabled(Ext_Zicfiss) & is_ssp_accessible(cur_privilege)
+function clause is_CSR_accessible(0x011, _, _) = is_ssp_accessible(cur_privilege)
 
 // "The bits 1:0 of ssp are read-only zero. If the UXLEN or SXLEN may
 // never be 32, then the bit 2 is also read-only zero."

--- a/model/pmp/pmp_regs.sail
+++ b/model/pmp/pmp_regs.sail
@@ -250,7 +250,8 @@ mapping clause csr_name_map = 0x3EE  <-> "pmpaddr62"
 mapping clause csr_name_map = 0x3EF  <-> "pmpaddr63"
 
 // pmpcfgN
-function clause is_CSR_accessible(0x3A @ idx : bits(4), _, _) = sys_pmp_count > 4 * unsigned(idx) & (idx[0] == 0b0 | xlen == 32)
+function clause is_CSR_accessible(0x3A @ idx : bits(4), p, access_type) =
+  check_CSR_access(0x3A @ idx, p, access_type, sys_pmp_count > 4 * unsigned(idx) & (idx[0] == 0b0 | xlen == 32))
 function clause read_CSR(0x3A @ idx : bits(4) if idx[0] == 0b0 | xlen == 32) = pmpReadCfgReg(unsigned(idx))
 function clause write_CSR((0x3A @ idx : bits(4), value) if idx[0] == 0b0 | xlen == 32) = {
   let idx = unsigned(idx);
@@ -259,10 +260,14 @@ function clause write_CSR((0x3A @ idx : bits(4), value) if idx[0] == 0b0 | xlen 
 }
 
 // pmpaddrN. Unfortunately the PMP index does not nicely align with the CSR index bits.
-function clause is_CSR_accessible(0x3B @ idx : bits(4), _, _) = sys_pmp_count > unsigned(0b00 @ idx)
-function clause is_CSR_accessible(0x3C @ idx : bits(4), _, _) = sys_pmp_count > unsigned(0b01 @ idx)
-function clause is_CSR_accessible(0x3D @ idx : bits(4), _, _) = sys_pmp_count > unsigned(0b10 @ idx)
-function clause is_CSR_accessible(0x3E @ idx : bits(4), _, _) = sys_pmp_count > unsigned(0b11 @ idx)
+function clause is_CSR_accessible(0x3B @ idx : bits(4), p, access_type) =
+  check_CSR_access(0x3B @ idx, p, access_type, sys_pmp_count > unsigned(0b00 @ idx))
+function clause is_CSR_accessible(0x3C @ idx : bits(4), p, access_type) =
+  check_CSR_access(0x3C @ idx, p, access_type, sys_pmp_count > unsigned(0b01 @ idx))
+function clause is_CSR_accessible(0x3D @ idx : bits(4), p, access_type) =
+  check_CSR_access(0x3D @ idx, p, access_type, sys_pmp_count > unsigned(0b10 @ idx))
+function clause is_CSR_accessible(0x3E @ idx : bits(4), p, access_type) =
+  check_CSR_access(0x3E @ idx, p, access_type, sys_pmp_count > unsigned(0b11 @ idx))
 
 function clause read_CSR(0x3B @ idx : bits(4)) = pmpReadAddrReg(unsigned(0b00 @ idx))
 function clause read_CSR(0x3C @ idx : bits(4)) = pmpReadAddrReg(unsigned(0b01 @ idx))

--- a/model/postlude/csr_end.sail
+++ b/model/postlude/csr_end.sail
@@ -9,8 +9,12 @@
 mapping clause csr_name_map = reg <-> hex_bits_12(reg)
 end csr_name_map
 
-function clause is_CSR_accessible(_) = false
+function clause is_CSR_accessible(_) = Err(CSR_Access_Illegal)
 end is_CSR_accessible
+
+// CSRs that are not governed by xstateen are not gated by this function.
+function clause stateen_allows_CSR_access(_, _, _) = true
+end stateen_allows_CSR_access
 
 function clause read_CSR(csr) = {
    // This should be impossible because is_CSR_accessible() should have returned false.

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -30,6 +30,7 @@ core {
     core/vmem_types.sail,
     core/mem_type_utils.sail,
     core/csr_begin.sail,
+    core/csr_access.sail,
     core/callbacks.sail,
     core/reg_type.sail,
     core/regs.sail,
@@ -337,7 +338,7 @@ extensions {
   }
 
   Zihpm {
-    requires core
+    requires core, Zicntr
     files extensions/Zihpm/zihpm.sail
   }
 

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -13,42 +13,8 @@ function effectivePrivilege(access : MemoryAccessType(mem_payload), m : Mstatus,
   then privLevel_bits(m[MPP], 0b0) // TODO: use m[MPV] if hypervisor enabled
   else priv
 
-// CSR access control
-
-function csrAccess(csr : csreg) -> csrRW = csr[11..10]
-function csrPriv(csr : csreg) -> nom_priv_bits = csr[9..8]
-
-// When hypervisor is enabled, `Supervisor` (HS-mode) and
-// `VirtualSupervisor` (VS-mode) privileges are encoded as `0b01` in
-// `privLevel_bits()`, but the CSR addresses for hypervisor and VS
-// CSRs encode the required privilege as `0b10`.  This overrides
-// the encoding in `privLevel_bits()` for the purposes of CSR privilege
-// checks.
-private function privLevel_to_CSR_privbits(p : Privilege) -> nom_priv_bits =
-  match p {
-    User              => 0b00,
-    VirtualUser       => 0b00,
-    // Note that this `if` is not strictly necessary. We could return
-    // 0b10 unconditionally if other checks ensure that hypervisor
-    // CSRs do not exist if H is not enabled.
-    Supervisor        => if currentlyEnabled(Ext_H) then 0b10 else 0b01,
-    VirtualSupervisor => 0b01,
-    Machine           => 0b11,
-  }
-
-// Check that the CSR access is made with sufficient privilege.
-function check_CSR_priv(csr : csreg, p : Privilege) -> bool =
-  privLevel_to_CSR_privbits(p) >=_u csrPriv(csr)
-
-// Check that the CSR access isn't a write to a read-only CSR.
-function check_CSR_access(csr : csreg, access_type : CSRAccessType) -> bool =
-  not((access_type == CSRWrite | access_type == CSRReadWrite) & (csrAccess(csr) == 0b11))
-
-function check_CSR(csr : csreg, p : Privilege, access_type : CSRAccessType) -> bool =
-    check_CSR_priv(csr, p)
-  & check_CSR_access(csr, access_type)
-  & is_CSR_accessible(csr, p, access_type)
-  & stateen_allows_CSR_access(csr, p, access_type)
+function check_CSR(csr : csreg, p : Privilege, access_type : CSRAccessType) -> result(unit, csr_access_failure) =
+  is_CSR_accessible(csr, p, access_type)
 
 // Exception delegation: given an exception and the privilege at which
 // it occurred, returns the privilege at which it should be handled.

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -188,7 +188,8 @@ termination_measure pt_walk(_,_,_,_,_,_,_,level,_, _) = level
 
 register satp : xlenbits
 mapping clause csr_name_map = 0x180  <-> "satp"
-function clause is_CSR_accessible(0x180, priv, _) = currentlyEnabled(Ext_S) & not(priv == Supervisor & mstatus[TVM] == 0b1)
+function clause is_CSR_accessible(0x180, priv, access_type) =
+  check_CSR_access(0x180, priv, access_type, currentlyEnabled(Ext_S) & not(priv == Supervisor & mstatus[TVM] == 0b1))
 function clause read_CSR(0x180) = satp
 function clause write_CSR(0x180, value) = { satp = legalize_satp(architecture(Supervisor), satp, value); Ok(satp) }
 


### PR DESCRIPTION
This changes the return type of `is_CSR_accessible` to specify when virtual-instruction exceptions should be thrown instead of illegal-instruction exceptions.  This was difficult with CSR access checkers that were boolean predicates.

Customized checks are now easier for various CSRs such as `seed`, `stimecmp` and CSRs that do not follow HS-qualification (such as those in Smcsrind/Sscsrind).  The check for `seed` now directly matches its specification in the manual.

Default checkers and helpers are collected in `core/csr_access.sail`. These implement HS-qualification checks for hypervisor support.

Further support for hypervisor is pending integration of the `hcounteren` and `henvcfg` CSRs.

The `is_CSR_accessible` name can be changed in a later PR since it now doesn't return a boolean.

This fixes #1350.