### PR TITLE
Explicitly set the C version when compiling GMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,13 @@ if (DOWNLOAD_GMP)
         URL https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz https://ftpmirror.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz
         URL_HASH SHA256=a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898
         INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/gmp
-        CONFIGURE_COMMAND "<SOURCE_DIR>/configure" "--prefix=<INSTALL_DIR>" --disable-shared --enable-static --with-pic
+        CONFIGURE_COMMAND "<SOURCE_DIR>/configure"
+            "--prefix=<INSTALL_DIR>"
+            --disable-shared
+            --enable-static
+            --with-pic
+            # Newer compilers default to C23 which causes GMP build errors.
+            CFLAGS=-std=c11
         # The libgmp.a output is created by the install step but since GMP::GMP
         # depends on the entire ExternalProject build, we can pretend it is
         # created by the build.


### PR DESCRIPTION
This avoids compilation code due to its `./configure` having buggy code that causes errors with newer C versions.

Fixes #1511