### PR TITLE
Fail CI if one of the jobs fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,8 @@ jobs:
   # This is here so that the "Status checks that are required" Github
   # option doesn't need to list all of the matrix jobs (it doesn't seem
   # to work if you just specify the job ID of the matrix itself).
+  # A skipped job is considered passing by GitHub, so this job needs to
+  # always run and then checks the results of all of the jobs it depends on.
   ci_pass:
     runs-on: ubuntu-latest
     needs: [build, linux]
@@ -152,5 +154,4 @@ jobs:
         if: "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}"
         run: exit 1
       - name: exit success
-        if: "${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}"
         run: exit 0


### PR DESCRIPTION
Another attempt at preventing PRs that fail CI from merging. Apparently GitHub considers skipped jobs as passing, and the `ci_pass` job was getting skipped when one of the jobs it depended on failed.