### PR TITLE
Enable release builds for Mac

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,9 @@ jobs:
             os: ubuntu-24.04-arm
             container: rockylinux:8.9.20231119
 
-          # TODO: Mac. We need a Mac binary release of the Sail compiler first.
-          # - name: mac-arm64
-          #   os: macos-latest
-          #   container: ""
+          - name: mac-arm64
+            os: macos-latest
+            container: ""
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
@@ -66,12 +65,6 @@ jobs:
         run: |
           dnf install -y git
 
-      # TODO: Mac
-      # - name: Install dependencies (Mac)
-      #   if: startsWith(matrix.os, 'macos')
-      #   run: |
-      #     brew install --force --overwrite ...
-
       - name: Check out repository code
         uses: actions/checkout@v6
 
@@ -86,7 +79,7 @@ jobs:
           cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DSTATIC=TRUE -DENABLE_RISCV_TESTS=TRUE -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE
           cd build
           ninja all
-          ctest
+          ctest -j2
           cpack
 
       - name: Build JSON and HTML
@@ -169,6 +162,7 @@ jobs:
           files: |
             release-Linux-x86_64/sail-riscv-Linux-x86_64.tar.gz
             release-Linux-aarch64/sail-riscv-Linux-aarch64.tar.gz
+            release-mac-arm64/sail-riscv-mac-arm64.tar.gz
             release-Linux-x86_64/model/sail_riscv_model.json
             release-Linux-x86_64/model/sail_riscv_html.tgz
           fail_on_unmatched_files: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ if(POLICY CMP0135)
     cmake_policy(SET CMP0135 OLD)
 endif()
 
+# This sets -mmacosx-version-min. It must be done before project() (see the CMake docs).
+set (CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
+
 include(cmake/project_version.cmake)
 project(sail-riscv
   VERSION ${sail_riscv_release_version}
@@ -80,16 +83,16 @@ if (STATIC)
         list(INSERT CMAKE_FIND_LIBRARY_SUFFIXES 0 .lib .a)
     else()
         set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
+
         check_linker_flag(CXX "-static-libstdc++" HAVE_STATIC_LIBSTDCXX)
-        if (NOT HAVE_STATIC_LIBSTDCXX)
-            message(FATAL_ERROR "Building with -DSTATIC=TRUE requires static C++ std library installation")
+        if (HAVE_STATIC_LIBSTDCXX)
+            add_link_options(-static-libstdc++)
         endif()
-        add_link_options(-static-libstdc++)
+
         check_linker_flag(CXX "-static-libgcc" HAVE_STATIC_LIBGCC)
-        if (NOT HAVE_STATIC_LIBGCC)
-            message(FATAL_ERROR "Building with -DSTATIC=TRUE requires static libgcc installation")
+        if (HAVE_STATIC_LIBGCC)
+            add_link_options(-static-libgcc)
         endif()
-        add_link_options(-static-libgcc)
     endif()
 endif()
 

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -3,6 +3,8 @@
 - The following extensions have been added:
   - Zicfiss
 
+- A Mac ARM binary release is now available.
+
 - Important issues addressed and bugs fixed:
   - https://github.com/riscv/sail-riscv/issues/1553 : Sail exceptions were not usefully shown in the execution trace
   - https://github.com/riscv/sail-riscv/issues/1560 : Updates to `mip` were not captured in the trace file


### PR DESCRIPTION
Build Mac binary releases in addition to Linux. Since the Sail compiler Mac binary release isn't quite ready this uses Sail from OPAM.

This required one fix: don't use `-static-libstdc++` or `-static-libgcc` for non-GCC compilers. Mac uses AppleClang which doesn't support these flags. The resulting binary depends on these libraries, which I think is kind of unavoidable on Mac:

    /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1900.180.0)
    /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)

I also increased the parallelism of ctest since by default it is 1, which takes a long time. I think the default Github runners are 2-core.