### PR TITLE
Support more general symbolic excution in isla

### DIFF
--- a/model/core/regs.sail
+++ b/model/core/regs.sail
@@ -232,7 +232,90 @@ function wX_bits(Regidx(i) : regidx, data : xlenbits) -> unit = {
   wX(Regno(unsigned(i))) = data
 }
 
-overload X = {rX_bits, wX_bits, rX, wX}
+$ifdef SYMBOLIC
+register x0 : regtype
+
+let GPRs : vector(32, dec, register(xlenbits)) = [
+	ref x31,
+    ref x30,
+    ref x29,
+    ref x28,
+    ref x27,
+    ref x26,
+    ref x25,
+    ref x24,
+    ref x23,
+    ref x22,
+    ref x21,
+    ref x20,
+    ref x19,
+    ref x18,
+    ref x17,
+    ref x16,
+    ref x15,
+    ref x14,
+    ref x13,
+    ref x12,
+    ref x11,
+    ref x10,
+    ref x9,
+    ref x8,
+    ref x7,
+    ref x6,
+    ref x5,
+    ref x4,
+    ref x3,
+    ref x2,
+    ref x1,
+    ref x0
+]
+
+register __isla_vector_gpr: bool = false
+
+val rX_from_vector = monadic "read_register_from_vector" : forall 'n, 0 <= 'n <= 31. (int('n), vector(32, dec, register(xlenbits))) -> xlenbits
+
+val get_X_bits : regidx -> xlenbits effect {rreg}
+
+function get_X_bits(Regidx(i) : regidx) = if __isla_vector_gpr then rX_from_vector(unsigned(i), GPRs) else rX_bits(Regidx(i))
+
+val get_X : regno -> xlenbits effect {rreg}
+
+function get_X(Regno(r) : regno) = if __isla_vector_gpr then rX_from_vector(r, GPRs) else rX(Regno(r))
+
+val wX_from_vector = monadic "write_register_from_vector" : forall 'n, 0 <= 'n <= 31. (int('n), xlenbits, vector(32, dec, register(xlenbits))) -> unit
+
+val set_X_bits : (regidx, xlenbits) -> unit effect {wreg}
+
+function set_X_bits(Regidx(i) : regidx, data : xlenbits) = {
+    if __isla_vector_gpr then wX_from_vector(unsigned(i), data, GPRs) else wX_bits(Regidx(i), data)
+}
+
+val set_X : (regno, xlenbits) -> unit effect {wreg}
+
+function set_X(Regno(r) : regno, v) = {
+    if __isla_vector_gpr then wX_from_vector(r, v, GPRs) else wX(Regno(r), v)
+}
+$else
+val get_X_bits : regidx -> xlenbits effect {rreg}
+
+function get_X_bits(Regidx(i) : regidx) = rX_bits(Regidx(i))
+
+val get_X : regno -> xlenbits effect {rreg}
+
+function get_X(Regno(r) : regno) = rX(Regno(r))
+
+val set_X_bits : (regidx, xlenbits) -> unit effect {wreg}
+
+function set_X_bits(Regidx(i) : regidx, data : xlenbits) = {
+    wX_bits(Regidx(i), data)
+}
+
+val set_X : (regno, xlenbits) -> unit effect {wreg}
+
+function set_X(Regno(r) : regno, v) = wX(Regno(r), v)
+$endif
+
+overload X = {get_X_bits, set_X_bits, get_X, set_X}
 
 // X_pair accesses a pair of registers. If the index is x0 then
 // it acts as if both registers in the pair are x0.

--- a/model/core/regs.sail
+++ b/model/core/regs.sail
@@ -236,7 +236,7 @@ $ifdef SYMBOLIC
 register x0 : regtype
 
 let GPRs : vector(32, dec, register(xlenbits)) = [
-  ref x31,
+    ref x31,
     ref x30,
     ref x29,
     ref x28,
@@ -267,7 +267,7 @@ let GPRs : vector(32, dec, register(xlenbits)) = [
     ref x3,
     ref x2,
     ref x1,
-    ref x0
+	ref x0,
 ]
 
 register __isla_vector_gpr: bool = false
@@ -276,25 +276,29 @@ val rX_from_vector = monadic "read_register_from_vector" : forall 'n, 0 <= 'n <=
 
 val get_X_bits : regidx -> xlenbits effect {rreg}
 
-function get_X_bits(Regidx(i) : regidx) = if __isla_vector_gpr then rX_from_vector(unsigned(i), GPRs) else rX_bits(Regidx(i))
-
 val get_X : regno -> xlenbits effect {rreg}
 
-function get_X(Regno(r) : regno) = if __isla_vector_gpr then rX_from_vector(r, GPRs) else rX(Regno(r))
+function get_X(Regno(r) : regno) = if __isla_vector_gpr then match r {
+    0 => zero_reg,
+    _ => rX_from_vector(r, GPRs),
+  } else rX(Regno(r))
+
+function get_X_bits(Regidx(i) : regidx) = if __isla_vector_gpr then get_X(Regno(unsigned(i))) else rX_bits(Regidx(i))
 
 val wX_from_vector = monadic "write_register_from_vector" : forall 'n, 0 <= 'n <= 31. (int('n), xlenbits, vector(32, dec, register(xlenbits))) -> unit
 
 val set_X_bits : (regidx, xlenbits) -> unit effect {wreg}
 
-function set_X_bits(Regidx(i) : regidx, data : xlenbits) = {
-    if __isla_vector_gpr then wX_from_vector(unsigned(i), data, GPRs) else wX_bits(Regidx(i), data)
-}
-
 val set_X : (regno, xlenbits) -> unit effect {wreg}
 
 function set_X(Regno(r) : regno, v) = {
-    if __isla_vector_gpr then wX_from_vector(r, v, GPRs) else wX(Regno(r), v)
+    if __isla_vector_gpr then match r {
+        0 => (),
+        _ => wX_from_vector(r, v, GPRs),
+      } else wX(Regno(r), v)
 }
+
+function set_X_bits(Regidx(i) : regidx, data : xlenbits) = if __isla_vector_gpr then set_X(Regno(unsigned(i)), data) else wX_bits(Regidx(i), data)
 $else
 val get_X_bits : regidx -> xlenbits effect {rreg}
 
@@ -306,13 +310,11 @@ function get_X(Regno(r) : regno) = rX(Regno(r))
 
 val set_X_bits : (regidx, xlenbits) -> unit effect {wreg}
 
-function set_X_bits(Regidx(i) : regidx, data : xlenbits) = {
-    wX_bits(Regidx(i), data)
-}
-
 val set_X : (regno, xlenbits) -> unit effect {wreg}
 
 function set_X(Regno(r) : regno, v) = wX(Regno(r), v)
+
+function set_X_bits(Regidx(i) : regidx, data : xlenbits) = set_X(Regno(unsigned(i)), data)
 $endif
 
 overload X = {get_X_bits, set_X_bits, get_X, set_X}

--- a/model/core/regs.sail
+++ b/model/core/regs.sail
@@ -236,7 +236,7 @@ $ifdef SYMBOLIC
 register x0 : regtype
 
 let GPRs : vector(32, dec, register(xlenbits)) = [
-	ref x31,
+  ref x31,
     ref x30,
     ref x29,
     ref x28,

--- a/model/extensions/FD/fdext_regs.sail
+++ b/model/extensions/FD/fdext_regs.sail
@@ -208,7 +208,88 @@ function wF_bits(Fregidx(i) : fregidx, data: flenbits) -> unit = {
   wF(Fregno(unsigned(i))) = data
 }
 
-overload F = {rF_bits, wF_bits, rF, wF}
+$ifdef SYMBOLIC
+let FPRs : vector(32, dec, register(flenbits)) = [
+    ref f31,
+    ref f30,
+    ref f29,
+    ref f28,
+    ref f27,
+    ref f26,
+    ref f25,
+    ref f24,
+    ref f23,
+    ref f22,
+    ref f21,
+    ref f20,
+    ref f19,
+    ref f18,
+    ref f17,
+    ref f16,
+    ref f15,
+    ref f14,
+    ref f13,
+    ref f12,
+    ref f11,
+    ref f10,
+    ref f9,
+    ref f8,
+    ref f7,
+    ref f6,
+    ref f5,
+    ref f4,
+    ref f3,
+    ref f2,
+    ref f1,
+    ref f0
+]
+
+register __isla_vector_fpr: bool = false
+
+val rF_from_vector = monadic "read_register_from_vector" : forall 'n, 0 <= 'n <= 31. (int('n), vector(32, dec, register(flenbits))) -> flenbits
+
+val get_F_bits : fregidx -> flenbits effect {rreg}
+
+function get_F_bits(Fregidx(i) : fregidx) = if __isla_vector_fpr then rF_from_vector(unsigned(i), FPRs) else rF_bits(Fregidx(i))
+
+val get_F : fregno -> flenbits effect {rreg}
+
+function get_F(Fregno(r) : fregno) = if __isla_vector_fpr then rF_from_vector(r, FPRs) else rF(Fregno(r))
+
+val wF_from_vector = monadic "write_register_from_vector" : forall 'n, 0 <= 'n <= 31. (int('n), flenbits, vector(32, dec, register(flenbits))) -> unit
+
+val set_F_bits : (fregidx, flenbits) -> unit effect {wreg}
+
+function set_F_bits(Fregidx(i) : fregidx, data : flenbits) = {
+    if __isla_vector_fpr then wF_from_vector(unsigned(i), data, FPRs) else wF_bits(Fregidx(i), data)
+}
+
+val set_F : (fregno, flenbits) -> unit effect {wreg}
+
+function set_F(Fregno(r) : fregno, v) = {
+    if __isla_vector_fpr then wF_from_vector(r, v, FPRs) else wF(Fregno(r), v)
+}
+$else
+val get_F_bits : fregidx -> flenbits effect {rreg}
+
+function get_F_bits(Fregidx(i) : fregidx) = rF_bits(Fregidx(i))
+
+val get_F : fregno -> flenbits effect {rreg}
+
+function get_F(Fregno(r) : fregno) = rF(Fregno(r))
+
+val set_F_bits : (fregidx, flenbits) -> unit effect {wreg}
+
+function set_F_bits(Fregidx(i) : fregidx, data : flenbits) = {
+    wF_bits(Fregidx(i), data)
+}
+
+val set_F : (fregno, flenbits) -> unit effect {wreg}
+
+function set_F(Fregno(r) : fregno, v) = wF(Fregno(r), v)
+$endif
+
+overload F = {get_F_bits, set_F_bits, get_F, set_F}
 
 function rF_BF16(i : fregidx) -> bits(16) = {
   // This is the same as `nan_unbox(F(i))` except that

--- a/model/extensions/V/vext_regs.sail
+++ b/model/extensions/V/vext_regs.sail
@@ -188,7 +188,88 @@ function wV_bits(i: vregidx, data: vlenbits) -> unit = {
   wV(vregidx_to_vregno(i)) = data
 }
 
-overload V = {rV_bits, wV_bits, rV, wV}
+$ifdef SYMBOLIC
+let VPRs : vector(32, dec, register(vlenbits)) = [
+    ref vr31,
+    ref vr30,
+    ref vr29,
+    ref vr28,
+    ref vr27,
+    ref vr26,
+    ref vr25,
+    ref vr24,
+    ref vr23,
+    ref vr22,
+    ref vr21,
+    ref vr20,
+    ref vr19,
+    ref vr18,
+    ref vr17,
+    ref vr16,
+    ref vr15,
+    ref vr14,
+    ref vr13,
+    ref vr12,
+    ref vr11,
+    ref vr10,
+    ref vr9,
+    ref vr8,
+    ref vr7,
+    ref vr6,
+    ref vr5,
+    ref vr4,
+    ref vr3,
+    ref vr2,
+    ref vr1,
+    ref vr0
+]
+
+register __isla_vector_vpr: bool = false
+
+val rV_from_vector = monadic "read_register_from_vector" : forall 'n, 0 <= 'n <= 31. (int('n), vector(32, dec, register(vlenbits))) -> vlenbits
+
+val get_V_bits : vregidx -> vlenbits effect {rreg}
+
+function get_V_bits(i: vregidx) = if __isla_vector_vpr then rV_from_vector(unsigned(vregidx_bits(i)), VPRs) else rV_bits(i)
+
+val get_V : vregno -> vlenbits effect {rreg}
+
+function get_V(Vregno(r) : vregno) = if __isla_vector_vpr then rV_from_vector(r, VPRs) else rV(Vregno(r))
+
+val wV_from_vector = monadic "write_register_from_vector" : forall 'n, 0 <= 'n <= 31. (int('n), vlenbits, vector(32, dec, register(vlenbits))) -> unit
+
+val set_V_bits : (vregidx, vlenbits) -> unit effect {wreg}
+
+function set_V_bits(i: vregidx, data : vlenbits) = {
+    if __isla_vector_vpr then wV_from_vector(unsigned(vregidx_bits(i)), data, VPRs) else wV_bits(i, data)
+}
+
+val set_V : (vregno, vlenbits) -> unit effect {wreg}
+
+function set_V(Vregno(r) : vregno, v) = {
+    if __isla_vector_vpr then wV_from_vector(r, v, VPRs) else wV(Vregno(r), v)
+}
+$else
+val get_V_bits : vregidx -> vlenbits effect {rreg}
+
+function get_V_bits(i: vregidx) = rV_bits(i)
+
+val get_V : vregno -> vlenbits effect {rreg}
+
+function get_V(Vregno(r) : vregno) = rV(Vregno(r))
+
+val set_V_bits : (vregidx, vlenbits) -> unit effect {wreg}
+
+function set_V_bits(i: vregidx, data : vlenbits) = {
+    wV_bits(i, data)
+}
+
+val set_V : (vregno, vlenbits) -> unit effect {wreg}
+
+function set_V(Vregno(r) : vregno, v) = wV(Vregno(r), v)
+$endif
+
+overload V = {get_V_bits, set_V_bits, get_V, set_V}
 
 function init_vregs() -> unit = {
   let zero_vreg : vlenbits = zeros();


### PR DESCRIPTION
For reasons discussed  in [rems-project/isla #98](https://github.com/rems-project/isla/issues/98#issuecomment-3932167807) and #1557 .

Referring to the Arm adaption at [https://github.com/rems-project/sail-arm/blob/master/arm-v9.4-a/src/v8_base.sail#L2256](https://github.com/rems-project/sail-arm/blob/master/arm-v9.4-a/src/v8_base.sail#L2256), I made changes to make registers interchangeable, thereby supporting more general symbolic execution in Isla.

However, there remains an issue: when vectorizing, `register x0` needs to be included in the vector table due to grammar constraints, but it should never actually be used. BTW, the `read_register_from_vector` function is implemented in isla.
