### PR TITLE
Make the physical memory write helpers require an explicit access-type argument.

### DIFF
--- a/model/core/vmem_types.sail
+++ b/model/core/vmem_types.sail
@@ -43,8 +43,6 @@ mapping mem_payload_str : mem_payload <-> string = {
   ShadowStack <-> ".ss",
 }
 
-let default_write_acc : mem_payload = Data
-
 function accessType_to_str(access : MemoryAccessType(mem_payload)) -> string =
   match access {
     Load(p)             => "R" ^ mem_payload_str(p),

--- a/model/extensions/A/zaamo_insts.sail
+++ b/model/extensions/A/zaamo_insts.sail
@@ -120,7 +120,7 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
     then X(rd) = sign_extend(loaded)
     else X_pair(rd) = sign_extend(loaded);
     RETIRE_SUCCESS
-  } else match mem_write_value(addr, width, sign_extend(result), aq & rl, rl, true) {
+  } else match mem_write_value(addr, width, sign_extend(result), access, aq & rl, rl, true) {
     Ok(true)  => {
       if width <= xlen_bytes
       then X(rd) = sign_extend(loaded)

--- a/model/extensions/Zicboz/zicboz_insts.sail
+++ b/model/extensions/Zicboz/zicboz_insts.sail
@@ -50,7 +50,7 @@ function clause execute ZICBOZ(rs1) = {
             match mem_write_ea(paddr, cache_block_size, false, false, false) {
               Err(e) => Memory_Exception(vaddr - negative_offset, e),
               Ok(_)  => {
-                match mem_write_value(paddr, cache_block_size, zeros(), false, false, false) {
+                match mem_write_value(paddr, cache_block_size, zeros(), access, false, false, false) {
                   Ok(true)  => RETIRE_SUCCESS,
                   Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                   Err(e)    => Memory_Exception(vaddr - negative_offset, e)

--- a/model/extensions/cfi/zicfiss_insts.sail
+++ b/model/extensions/cfi/zicfiss_insts.sail
@@ -202,7 +202,7 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
   // This constraint is ensured by the instruction decode clause.
   assert('width == 4 | (xlen == 64 & width == 8));
   let write_val : bits('width * 8) = X(rs2)['width * 8 - 1 .. 0];
-  match mem_write_value(paddr, width, write_val, aq & rl, rl, true) {
+  match mem_write_value(paddr, width, write_val, access, aq & rl, rl, true) {
     Ok(true)  => X(rd) = sign_extend(mem_val),
     Ok(false) => internal_error(__FILE__, __LINE__, "AMOSWAP_SS got false from mem_write_value"),
     Err(e)    => return Memory_Exception(vaddr, e),

--- a/model/sys/mem.sail
+++ b/model/sys/mem.sail
@@ -94,9 +94,7 @@ private function pmaCheck forall 'n, 0 < 'n <= max_mem_access .
           let canAccess : bool = match access {
             InstructionFetch()     => attributes.executable,
             Load(Data)             => {assert(not(res_or_con)); attributes.readable},
-            // TODO: assert(not(res_or_con)). This requires a slight refactor of the mem_write_* APIs,
-            // since the use of the default Store access conflicts with the passed in aq/rl/con flags.
-            Store(Data)            => attributes.writable,
+            Store(Data)            => {assert(not(res_or_con)); attributes.writable},
             // For LR/SC, we currently don't differentiate between the presence (RsrvEventual)
             // or absence (RsrvNonEventual) of an eventual success guarantee.
             LoadReserved(Data)     => {assert(res_or_con); attributes.readable & attributes.reservability != RsrvNone},
@@ -302,21 +300,20 @@ function mem_write_value_priv_meta (paddr, width, value, access, priv, meta, aq,
   }
 }
 
-// Memory write with explicit Privilege, implicit MemoryAccessType and metadata
-val mem_write_value_priv : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), Privilege, bool, bool, bool) -> MemoryOpResult(bool)
-function mem_write_value_priv (paddr, width, value, priv, aq, rl, con) =
-  mem_write_value_priv_meta(paddr, width, value, Store(default_write_acc), priv, default_meta, aq, rl, con)
+// Memory write with explicit Privilege and MemoryAccessType, and implicit metadata
+val mem_write_value_priv : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), Privilege, MemoryAccessType(mem_payload), bool, bool, bool) -> MemoryOpResult(bool)
+function mem_write_value_priv (paddr, width, value, priv, access, aq, rl, con) =
+  mem_write_value_priv_meta(paddr, width, value, access, priv, default_meta, aq, rl, con)
 
-// Memory write with explicit metadata and MemoryAccessType, implicit and Privilege
-val mem_write_value_meta : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), mem_payload, mem_meta, bool, bool, bool) -> MemoryOpResult(bool)
-function mem_write_value_meta (paddr, width, value, payload, meta, aq, rl, con) = {
-  let access = Store(payload);
+// Memory write with explicit metadata and MemoryAccessType, and implicit Privilege
+val mem_write_value_meta : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), MemoryAccessType(mem_payload), mem_meta, bool, bool, bool) -> MemoryOpResult(bool)
+function mem_write_value_meta (paddr, width, value, access, meta, aq, rl, con) = {
   let ep = effectivePrivilege(access, mstatus, cur_privilege);
   mem_write_value_priv_meta(paddr, width, value, access, ep, meta, aq, rl, con)
 }
 
-// Memory write with default MemoryAccessType, Privilege, and metadata
-val mem_write_value : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), bool, bool, bool) -> MemoryOpResult(bool)
-function mem_write_value (paddr, width, value, aq, rl, con) = {
-  mem_write_value_meta(paddr, width, value, default_write_acc, default_meta, aq, rl, con)
+// Memory write with explicit MemoryAccessType, default metadata and implicit Privilege
+val mem_write_value : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), MemoryAccessType(mem_payload), bool, bool, bool) -> MemoryOpResult(bool)
+function mem_write_value (paddr, width, value, access, aq, rl, con) = {
+  mem_write_value_meta(paddr, width, value, access, default_meta, aq, rl, con)
 }

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -45,7 +45,7 @@ private function write_pte forall 'n, 'n in {4, 8} . (
   pte_size : int('n),
   pte      : bits('n * 8),
 ) -> MemoryOpResult(bool) =
-  mem_write_value_priv(paddr, pte_size, pte, Supervisor, false, false, false)
+  mem_write_value_priv(paddr, pte_size, pte, Supervisor, Store(Data), false, false, false)
 
 // Read a Page Table Entry.
 private function read_pte forall 'n, 'n in {4, 8} . (

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -222,7 +222,7 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
 
           Ok(()) => {
             let write_value = data[(8 * (offset + 1) * bytes) - 1 .. 8 * offset * bytes];
-            match mem_write_value(paddr, bytes, write_value, aq, rl, res) {
+            match mem_write_value(paddr, bytes, write_value, access, aq, rl, res) {
               Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
               Ok(s)  => write_success = write_success & s,
             }


### PR DESCRIPTION
The use of an implicit `Store(Data)` for the writes of atomic accesses prevented an assert that an explicit Store was not an atomic access.

The need for this assert can be removed when the flags for an atomic access are embedded in the access type.