### PR TITLE
Gate ptw_fail_callback on config_print_ptw flag

### DIFF
--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -154,8 +154,7 @@ void log_callbacks::ptw_fail_callback(
   int64_t level,
   sbits pte_addr
 ) {
-  // failed trace is always available
-  if (trace_log != nullptr) {
+  if (trace_log != nullptr && config_print_ptw) {
     sail_string str_et;
     CREATE(sail_string)(&str_et);
     model.zptw_error_to_str(&str_et, error_type);


### PR DESCRIPTION
`ptw_fail_callback` was unconditionally printing PTW failures unlike the other PTW callbacks which are gated on `config_print_ptw`.