### PR TITLE
Implement `Memory_Exception` as a `Trap`.

### DIFF
--- a/model/extensions/A/zaamo_insts.sail
+++ b/model/extensions/A/zaamo_insts.sail
@@ -82,10 +82,10 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
   };
 
   if not(is_aligned_addr(vaddr, width))
-  then return Memory_Exception(vaddr, E_SAMO_Addr_Align());
+  then return memory_exception(vaddr, E_SAMO_Addr_Align());
 
   let (addr, pbmt) : (physaddr, page_based_mem_type) = match translateAddr(vaddr, access) {
-    Err(e, _) => return Memory_Exception(vaddr, e),
+    Err(e, _) => return memory_exception(vaddr, e),
     Ok(addr, pbmt, _) => (addr, pbmt),
   };
 
@@ -95,9 +95,9 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
   let rs2_val : bits('width * 8) = if width <= xlen_bytes then trunc(X(rs2)) else trunc(X_pair(rs2));
 
   let loaded : bits('width * 8) = match mem_write_ea(addr, width, aq & rl, rl, true) {
-    Err(e) => return Memory_Exception(vaddr, e),
+    Err(e) => return memory_exception(vaddr, e),
     Ok(_)  => match mem_read(access, pbmt, addr, width, aq, aq & rl, true) {
-      Err(e)     => return Memory_Exception(vaddr, e),
+      Err(e)     => return memory_exception(vaddr, e),
       Ok(loaded) => loaded,
     },
   };
@@ -131,7 +131,7 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
       RETIRE_SUCCESS
     },
     Ok(false) => internal_error(__FILE__, __LINE__, "AMO got false from mem_write_value"),
-    Err(e)    => Memory_Exception(vaddr, e),
+    Err(e)    => memory_exception(vaddr, e),
   }
 }
 

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -60,7 +60,7 @@ function jump_to(target : xlenbits) -> ExecutionResult = {
   // If it is not 4-byte aligned and compressed instructions are
   // not enabled then raise an alignment exception.
   if bit_to_bool(target[1]) & not(currentlyEnabled(Ext_Zca))
-  then return Memory_Exception(Virtaddr(target), E_Fetch_Addr_Align());
+  then return memory_exception(Virtaddr(target), E_Fetch_Addr_Align());
 
   set_next_pc(target);
   RETIRE_SUCCESS

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -535,7 +535,7 @@ mapping clause encdec = ECALL()
   <-> 0b000000000000 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
 
 function clause execute ECALL() = {
-  let trap : ExceptionType = match cur_privilege {
+  let exc_type : ExceptionType = match cur_privilege {
     User              => E_U_EnvCall(),
     Supervisor        => E_S_EnvCall(),
     Machine           => E_M_EnvCall(),
@@ -543,11 +543,11 @@ function clause execute ECALL() = {
     VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   };
   let t : sync_exception = struct {
-    trap    = trap,
+    trap    = exc_type,
     excinfo = None(),
     ext     = None(),
   };
-  Trap(cur_privilege, CTL_TRAP(t), PC)
+  trap(t)
 }
 
 mapping clause assembly = ECALL() <-> "ecall"
@@ -603,10 +603,8 @@ union clause instruction = EBREAK : unit
 mapping clause encdec = EBREAK()
   <-> 0b000000000001 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
 
-function clause execute EBREAK() = {
-  let trap = E_Breakpoint(Brk_Software);
-  Trap(cur_privilege, CTL_TRAP(make_sync_exception(trap, PC)), PC)
-}
+function clause execute EBREAK() =
+  trap(make_sync_exception(E_Breakpoint(Brk_Software), PC))
 
 mapping clause assembly = EBREAK() <-> "ebreak"
 

--- a/model/extensions/Zicbom/zicbom_insts.sail
+++ b/model/extensions/Zicbom/zicbom_insts.sail
@@ -90,13 +90,13 @@ private function process_clean_inval(rs1 : regidx, cbop : cbop_zicbom) -> Execut
           // Check PMA and PMP access controls.
           let ep = effectivePrivilege(access, mstatus, cur_privilege);
           match phys_access_check(access, pbmt, ep, paddr, cache_block_size, false) {
-            Some(e) => Memory_Exception(vaddr_for_error, e),
+            Some(e) => memory_exception(vaddr_for_error, e),
             // If there is no error, the model has no caches so there's no
             // more action required.
             None()  => RETIRE_SUCCESS
           }
         },
-        Err(e, _) => Memory_Exception(vaddr_for_error, e),
+        Err(e, _) => memory_exception(vaddr_for_error, e),
       }
     }
   }

--- a/model/extensions/Zicboz/zicboz_insts.sail
+++ b/model/extensions/Zicboz/zicboz_insts.sail
@@ -49,15 +49,15 @@ function clause execute ZICBOZ(rs1) = {
         // was encoded in the instruction. We subtract the negative offset
         // (add the positive offset) to get it. Normally this will be
         // equal to rs1, but pointer masking can change that.
-        Err(e, _) => Memory_Exception(vaddr - negative_offset, e),
+        Err(e, _) => memory_exception(vaddr - negative_offset, e),
         Ok(paddr, pbmt, _) => {
           match mem_write_ea(paddr, cache_block_size, false, false, false) {
-            Err(e) => Memory_Exception(vaddr - negative_offset, e),
+            Err(e) => memory_exception(vaddr - negative_offset, e),
             Ok(_)  => {
               match mem_write_value(paddr, cache_block_size, zeros(), access, pbmt, false, false, false) {
                 Ok(true)  => RETIRE_SUCCESS,
                 Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                Err(e)    => Memory_Exception(vaddr - negative_offset, e)
+                Err(e)    => memory_exception(vaddr - negative_offset, e),
               }
             }
           }

--- a/model/extensions/cfi/zicfilp_insts.sail
+++ b/model/extensions/cfi/zicfilp_insts.sail
@@ -21,7 +21,7 @@ function clause execute LPAD(lpl) = {
     let unaligned_pc = get_arch_pc()[1 .. 0] != 0b00;
     let label_mismatch = X(Regno(7))[31 .. 12] != lpl & lpl != zeros();
     if unaligned_pc | label_mismatch then {
-      Trap(cur_privilege, CTL_TRAP(make_landing_pad_exception()), PC)
+      trap(make_landing_pad_exception())
     } else {
       reset_elp();
       RETIRE_SUCCESS

--- a/model/extensions/cfi/zicfiss_insts.sail
+++ b/model/extensions/cfi/zicfiss_insts.sail
@@ -36,7 +36,7 @@ function clause execute SSPUSH(rs2) = {
   // TODO: get the dynamic xlen here.
   let width = xlen_bytes;
   if not(is_aligned_addr(vaddr, width))
-  then return Memory_Exception(vaddr, E_SAMO_Access_Fault());
+  then return memory_exception(vaddr, E_SAMO_Access_Fault());
 
   match vmem_write_addr(vaddr, width, X(rs2), Store(ShadowStack), false, false, false) {
     Ok(_)  => { ssp = vaddr_bits;
@@ -83,7 +83,7 @@ function clause execute SSPOPCHK(rs1) = {
   // TODO: get the dynamic xlen here.
   let width = xlen_bytes;
   if not(is_aligned_addr(ssp_addr, width))
-  then return Memory_Exception(ssp_addr, E_SAMO_Access_Fault());
+  then return memory_exception(ssp_addr, E_SAMO_Access_Fault());
 
   match vmem_read_addr(ssp_addr, width, Load(ShadowStack), false, false, false) {
     Ok(data) => {
@@ -176,11 +176,11 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
   // "The same exception options [as AMOs in the A extension] apply if
   // the address is not naturally aligned."
   if not(is_aligned_addr(vaddr, width))
-  then return Memory_Exception(vaddr, E_SAMO_Addr_Align());
+  then return memory_exception(vaddr, E_SAMO_Access_Fault());
 
   let (paddr, pbmt) : (physaddr, page_based_mem_type) = match translateAddr(vaddr, access) {
     Ok(addr, pbmt, _) => (addr, pbmt),
-    Err(e, _)   => return Memory_Exception(vaddr, e),
+    Err(e, _)   => return memory_exception(vaddr, e),
   };
 
   // The `aq` and `rl` flags follow the AMO model in Zaamo: "Just as
@@ -190,9 +190,9 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
 
   let 'width = width;
   let mem_val : bits('width * 8) = match mem_write_ea(paddr, width, aq & rl, rl, true) {
-    Err(e) => return Memory_Exception(vaddr, e),
+    Err(e) => return memory_exception(vaddr, e),
     Ok(_)  => match mem_read(access, pbmt, paddr, width, aq, aq & rl, true) {
-      Err(e) => return Memory_Exception(vaddr, e),
+      Err(e) => return memory_exception(vaddr, e),
       Ok(v)  => v,
     },
   };
@@ -203,7 +203,7 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
   match mem_write_value(paddr, width, write_val, access, pbmt, aq & rl, rl, true) {
     Ok(true)  => X(rd) = sign_extend(mem_val),
     Ok(false) => internal_error(__FILE__, __LINE__, "AMOSWAP_SS got false from mem_write_value"),
-    Err(e)    => return Memory_Exception(vaddr, e),
+    Err(e)    => return memory_exception(vaddr, e),
   };
 
   RETIRE_SUCCESS

--- a/model/extensions/cfi/zicfiss_insts.sail
+++ b/model/extensions/cfi/zicfiss_insts.sail
@@ -176,7 +176,7 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
   // "The same exception options [as AMOs in the A extension] apply if
   // the address is not naturally aligned."
   if not(is_aligned_addr(vaddr, width))
-  then return memory_exception(vaddr, E_SAMO_Access_Fault());
+  then return memory_exception(vaddr, E_SAMO_Addr_Align());
 
   let (paddr, pbmt) : (physaddr, page_based_mem_type) = match translateAddr(vaddr, access) {
     Ok(addr, pbmt, _) => (addr, pbmt),

--- a/model/extensions/cfi/zicfiss_insts.sail
+++ b/model/extensions/cfi/zicfiss_insts.sail
@@ -88,7 +88,7 @@ function clause execute SSPOPCHK(rs1) = {
   match vmem_read_addr(ssp_addr, width, Load(ShadowStack), false, false, false) {
     Ok(data) => {
       if X(rs1) != data then {
-        Trap(cur_privilege, CTL_TRAP(make_shadow_stack_exception()), PC)
+        trap(make_shadow_stack_exception())
       } else {
         ssp = ssp + width;
         csr_write_callback("ssp", ssp);

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -215,7 +215,6 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
     Step_Execute(ExecuteAs(_), _) => internal_error(__FILE__, __LINE__, "Multiple chained ExecuteAs (only one redirection is supported)."),
     // standard errors
     Step_Execute(Trap(priv, ctl, pc), _) => set_next_pc(exception_handler(priv, ctl, pc)),
-    Step_Execute(Memory_Exception(vaddr, e), _) => handle_exception(bits_of(vaddr), e),
     Step_Execute(Illegal_Instruction(), instbits) => handle_exception(zero_extend(instbits), E_Illegal_Instr()),
     // NOTE: Virtual instructions exception cannot be triggered until Hypervisor integration is complete.
     Step_Execute(Virtual_Instruction(), instbits) => handle_exception(zero_extend(instbits), E_Virtual_Instr()),

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -109,7 +109,7 @@ private function run_hart_active(step_no: nat) -> Step = {
       // When ELP is set to LP_EXPECTED, the next instruction needs to be
       // the non-RVC `LPAD` instruction.
       if is_landing_pad_expected() then {
-        let r = Trap(cur_privilege, CTL_TRAP(make_landing_pad_exception()), PC);
+        let r = trap(make_landing_pad_exception());
         Step_Execute(r, instbits)
       }
       // check for RVC once here instead of every RVC execute clause.
@@ -137,7 +137,7 @@ private function run_hart_active(step_no: nat) -> Step = {
       // the instruction stream is not LPAD, then a software check
       // exception with a landing pad fault code is thrown.
       if is_landing_pad_expected() & not(is_lpad_instruction(instruction)) then {
-        let r = Trap(cur_privilege, CTL_TRAP(make_landing_pad_exception()), PC);
+        let r = trap(make_landing_pad_exception());
         Step_Execute(r, instbits)
       } else {
         nextPC = PC + 4;

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -104,7 +104,7 @@ extensions {
       files extensions/A/aext_types.sail
     }
     Zaamo {
-      requires core, sys, exceptions, A_types
+      requires core, sys, A_types
       files extensions/A/zaamo_insts.sail
     }
     Zalrsc {
@@ -404,7 +404,7 @@ extensions {
       files extensions/Zicbom/zicbom_types.sail
     }
     Zicbom_insts {
-      requires core, exceptions, sys, Zicbom_types
+      requires core, sys, Zicbom_types
       files extensions/Zicbom/zicbom_insts.sail
     }
   }
@@ -435,7 +435,7 @@ extensions {
   }
 
   Zicboz {
-    requires core, exceptions, sys
+    requires core, sys
     files extensions/Zicboz/zicboz_insts.sail
   }
 

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -104,7 +104,7 @@ extensions {
       files extensions/A/aext_types.sail
     }
     Zaamo {
-      requires core, sys, A_types
+      requires core, sys, exceptions, A_types
       files extensions/A/zaamo_insts.sail
     }
     Zalrsc {
@@ -404,7 +404,7 @@ extensions {
       files extensions/Zicbom/zicbom_types.sail
     }
     Zicbom_insts {
-      requires core, sys, Zicbom_types
+      requires core, exceptions, sys, Zicbom_types
       files extensions/Zicbom/zicbom_insts.sail
     }
   }
@@ -435,7 +435,7 @@ extensions {
   }
 
   Zicboz {
-    requires core, sys
+    requires core, exceptions, sys
     files extensions/Zicboz/zicboz_insts.sail
   }
 

--- a/model/sys/insts_begin.sail
+++ b/model/sys/insts_begin.sail
@@ -50,6 +50,13 @@ union ExecutionResult = {
 
 let RETIRE_SUCCESS : ExecutionResult = Retire_Success()
 
+// Trap helpers
+
+function trap(exc : sync_exception) -> ExecutionResult =
+  Trap(cur_privilege, CTL_TRAP(exc), PC)
+
+function memory_exception(vaddr : virtaddr, exc : ExceptionType) -> ExecutionResult =
+  trap(make_sync_exception(exc, bits_of(vaddr)))
 
 // returns whether an instruction was retired, used for computing minstret
 val execute : instruction -> ExecutionResult
@@ -70,6 +77,3 @@ scattered mapping encdec_compressed
 // unmatched encodings decode to an illegal instruction.
 union clause instruction = ILLEGAL : word
 union clause instruction = C_ILLEGAL : half
-
-function memory_exception(vaddr : virtaddr, exc : ExceptionType) -> ExecutionResult =
-  Trap(cur_privilege, CTL_TRAP(make_sync_exception(exc, bits_of(vaddr))), PC)

--- a/model/sys/insts_begin.sail
+++ b/model/sys/insts_begin.sail
@@ -35,7 +35,6 @@ union ExecutionResult = {
   Illegal_Instruction            : unit,
   Virtual_Instruction            : unit,
   Trap                           : (Privilege, ctl_result, xlenbits),
-  Memory_Exception               : (virtaddr, ExceptionType),
 
   // Did not retire for custom reason.
   Ext_CSR_Check_Failure          : unit,
@@ -71,3 +70,6 @@ scattered mapping encdec_compressed
 // unmatched encodings decode to an illegal instruction.
 union clause instruction = ILLEGAL : word
 union clause instruction = C_ILLEGAL : half
+
+function memory_exception(vaddr : virtaddr, exc : ExceptionType) -> ExecutionResult =
+  Trap(cur_privilege, CTL_TRAP(make_sync_exception(exc, bits_of(vaddr))), PC)

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -128,12 +128,12 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
     // that the access can be emulated (the OS/firmware can transparently break
     // it down into multiple aligned accesses) which isn't the case for LR/SC
     // in normal implementations.
-    if res then return Err(Memory_Exception(vaddr, E_Load_Access_Fault()));
+    if res then return Err(memory_exception(vaddr, E_Load_Access_Fault()));
     // This models CPUs that don't support any misaligned access at all.
     // Even if the CPU does support misaligned accesses, it might be that the PMA doesn't support
     // misaligned accesses so you can still get a fault later, but this will
     // be after address translation.
-    if not(plat_enable_misaligned_access) then return Err(Memory_Exception(vaddr, E_Load_Addr_Align()));
+    if not(plat_enable_misaligned_access) then return Err(memory_exception(vaddr, E_Load_Addr_Align()));
   };
 
   // If the load is misaligned or an allowed misaligned access, split into `n`
@@ -151,11 +151,10 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
     let offset = i;
     let vaddr = vaddr + (offset * bytes);
     match translateAddr(Virtaddr(vaddr), access) {
-      Err(e, _) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+      Err(e, _) => return Err(memory_exception(Virtaddr(vaddr), e)),
 
       Ok(paddr, pbmt, _) => match mem_read(access, pbmt, paddr, bytes, aq, rl, res) {
-        Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
-
+        Err(e) => return Err(memory_exception(Virtaddr(vaddr), e)),
         Ok(v) => {
           if res then {
             load_reservation(bits_of(paddr), width)
@@ -186,8 +185,8 @@ val vmem_write_addr : forall 'width, is_mem_width('width).
 function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
   // See comments in vmem_read_addr for an explanation of this check.
   if not(is_aligned_addr(vaddr, width)) then {
-    if res then return Err(Memory_Exception(vaddr, E_SAMO_Access_Fault()));
-    if not(plat_enable_misaligned_access) then return Err(Memory_Exception(vaddr, E_SAMO_Addr_Align()));
+    if res then return Err(memory_exception(vaddr, E_SAMO_Access_Fault()));
+    if not(plat_enable_misaligned_access) then return Err(memory_exception(vaddr, E_SAMO_Addr_Align()));
   };
 
   // If the store is misaligned or an allowed misaligned access, split into `n`
@@ -205,7 +204,7 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
     let offset = i;
     let vaddr = vaddr + (offset * bytes);
     match translateAddr(Virtaddr(vaddr), access) {
-      Err(e, _) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+      Err(e, _) => return Err(memory_exception(Virtaddr(vaddr), e)),
 
       // NOTE: Currently, we only announce the effective address if address translation is successful.
       // This may need revisiting, particularly in the misaligned case.
@@ -221,16 +220,16 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
           // access-fault exception."
           let effPriv = effectivePrivilege(access, mstatus, cur_privilege);
           match phys_access_check(access, pbmt, effPriv, paddr, bytes, true) {
-            Some(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+            Some(e) => return Err(memory_exception(Virtaddr(vaddr), e)),
             None()  => write_success = false,
           }
         } else match mem_write_ea(paddr, bytes, aq, rl, res) {
-          Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+          Err(e) => return Err(memory_exception(Virtaddr(vaddr), e)),
 
           Ok(()) => {
             let write_value = data[(8 * (offset + 1) * bytes) - 1 .. 8 * offset * bytes];
             match mem_write_value(paddr, bytes, write_value, access, pbmt, aq, rl, res) {
-              Err(e) => return Err(Memory_Exception(Virtaddr(vaddr), e)),
+              Err(e) => return Err(memory_exception(Virtaddr(vaddr), e)),
               Ok(s)  => write_success = write_success & s,
             }
           }


### PR DESCRIPTION
This removes the `MemoryException` variant of `ExecutionResult` since it was handled as a trap anyway.

Add `memory_exception` and `trap` helpers to return common execution results.