### PR TITLE
Add the Ziccif extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ For booting operating system images, see the information under the
 - Zicbom, Zicbop and Zicboz extensions for cache-block management, v1.0
 - Ziccamoa extension for Main memory supports all atomics in Zaamo, v1.0
 - Ziccamoc extension for Main memory supports atomics in Zacas, v1.0
+- Ziccif extension for Main memory supports instruction fetch with atomicity requirement, v1.0
 - Ziccrse extension for Main memory regions with both the cacheability and coherence PMAs must support RsrvEventual, v1.0
 - Zicfilp extension for Landing Pad Control Flow Integrity, v1.0
 - Zicfiss extension for Shadow Stack Control Flow Integrity, v1.0

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -308,6 +308,9 @@
     "Ziccamoc": {
       "supported": true
     },
+    "Ziccif": {
+      "supported": true
+    },
     "Ziccrse": {
       "supported": true
     },

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -19,6 +19,7 @@
 - The following extensions have been added:
   - Ziccamoa
   - Ziccamoc
+  - Ziccif
   - Ziccrse
   - Zicfiss
   - Ssccptr

--- a/doc/ReadingGuide.md
+++ b/doc/ReadingGuide.md
@@ -255,6 +255,24 @@ The `unit_tests` module collects Sail unit tests for the specification.
 The `main` module provides a [`main()`](../model/main/main.sail)
 function that is used in other Sail backends.
 
+### Miscellaneous notes
+
+When implementing atomic accesses (e.g. for AMOs and instructions
+fetches in Ziccif), there are two approaches that can be taken in the
+Sail model. One approach is to implement an atomic memory access
+using a single memory transaction at the lowest level (i.e. in
+[phys_mem_interface.sail](../model/core/phys_mem_interface.sail); this
+is the approach taken in this model. The second approach splits an
+atomic access into multiple smaller intra-instruction memory
+transactions at the level of
+[phys_mem_interface.sail](../model/core/phys_mem_interface.sail);
+however, these would have to be accompanied by additional rules in the
+RVWMO memory model specifying that no other memory accesses can
+intervene in between these transactions. Both approaches are
+observationally equivalent for the C++ emulator since it currently
+implements a single-hart system, but the first approach is preferred
+to simplify the rules in the memory model.
+
 ## Structure of the C++ emulator
 
 The diagram below illustrates how the C++ emulator is built from the

--- a/doc/ReadingGuide.md
+++ b/doc/ReadingGuide.md
@@ -260,15 +260,15 @@ function that is used in other Sail backends.
 When implementing atomic accesses (e.g. for AMOs and instructions
 fetches in Ziccif), there are two approaches that can be taken in the
 Sail model. One approach is to implement an atomic memory access
-using a single memory transaction at the lowest level (i.e. in
+using a single memory operation at the lowest level (i.e. in
 [phys_mem_interface.sail](../model/core/phys_mem_interface.sail); this
 is the approach taken in this model. The second approach splits an
 atomic access into multiple smaller intra-instruction memory
-transactions at the level of
+operations at the level of
 [phys_mem_interface.sail](../model/core/phys_mem_interface.sail);
 however, these would have to be accompanied by additional rules in the
 RVWMO memory model specifying that no other memory accesses can
-intervene in between these transactions. Both approaches are
+intervene in between these operations. Both approaches are
 observationally equivalent for the C++ emulator since it currently
 implements a single-hart system, but the first approach is preferred
 to simplify the rules in the memory model.

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -250,15 +250,20 @@ function clause hartSupports(Ext_Zbs) = config extensions.Zbs.supported
 
 // Main memory supports all atomics in Zaamo
 enum clause extension = Ext_Ziccamoa
-mapping clause extensionName= Ext_Ziccamoa <-> "Ziccamoa"
+mapping clause extensionName= Ext_Ziccamoa <-> "ziccamoa"
 function clause hartSupports(Ext_Ziccamoa) = config extensions.Ziccamoa.supported
 // Main memory supports atomics in Zacas
 enum clause extension = Ext_Ziccamoc
-mapping clause extensionName= Ext_Ziccamoc <-> "Ziccamoc"
+mapping clause extensionName= Ext_Ziccamoc <-> "ziccamoc"
 function clause hartSupports(Ext_Ziccamoc) = config extensions.Ziccamoc.supported
+// Instruction-Fetch Atomicity
+enum clause extension = Ext_Ziccif
+mapping clause extensionName = Ext_Ziccif <-> "ziccif"
+function clause hartSupports(Ext_Ziccif) = config extensions.Ziccif.supported
+function clause currentlyEnabled(Ext_Ziccif) = hartSupports(Ext_Ziccif)
 // Main memory supports forward progress on LR/SC sequences
 enum clause extension = Ext_Ziccrse
-mapping clause extensionName= Ext_Ziccrse <-> "Ziccrse"
+mapping clause extensionName= Ext_Ziccrse <-> "ziccrse"
 function clause hartSupports(Ext_Ziccrse) = config extensions.Ziccrse.supported
 
 // Scalar & Entropy Source Instructions: NIST Suite: AES Decryption
@@ -654,6 +659,7 @@ let extensions_ordered_for_isa_string = [
   Ext_Zicboz,
   Ext_Ziccamoa,
   Ext_Ziccamoc,
+  Ext_Ziccif,
   Ext_Ziccrse,
   Ext_Zicfilp,
   Ext_Zicfiss,

--- a/model/postlude/fetch.sail
+++ b/model/postlude/fetch.sail
@@ -11,14 +11,47 @@
 
 private function isRVC(h : half) -> bool = not(h[1 .. 0] == 0b11)
 
+// This instruction byte fetcher is used for partial fetches, and
+// hence doesn't return the FetchResult type that a full fetcher does.
+// All the bytes fetched go through memory protection and PMA checks;
+// this just barely works for Ziccif with ILEN=32 (bits) since there
+// are no discarded bytes that lie outside protection boundaries.
+// This will have to be generalized when ILEN is increased above 32
+// (e.g. to 48): there could be discarded bytes that straddle
+// protection boundaries in that case, and memory protection and PMA
+// checks do not apply to discarded bytes.
+
+private union FetchBytes_Result('width : Int), 'width >= 0 = {
+  FetchBytes_Ext_Error : ext_fetch_addr_error,
+  FetchBytes_Exception : ExceptionType,
+  FetchBytes_Success   : bits('width * 8),
+}
+
+private function fetch_bytes forall 'n, 'n in {2, 4} . (fetch_start : xlenbits, granule_start : xlenbits, width : int('n)) -> FetchBytes_Result('n) = {
+  match ext_fetch_check_pc(fetch_start, granule_start) {
+    Some(e) => return FetchBytes_Ext_Error(e),
+    None()  => (),
+  };
+
+  let (paddr, pbmt) : (physaddr, page_based_mem_type) = match translateAddr(Virtaddr(granule_start), InstructionFetch()) {
+    Err(e, _)    => return FetchBytes_Exception(e),
+    Ok(paddr, pbmt, _) => (paddr, pbmt),
+  };
+
+  match mem_read(InstructionFetch(), pbmt, paddr, width, false, false, false) {
+    Err(e)    => FetchBytes_Exception(e),
+    Ok(bytes) => FetchBytes_Success(bytes),
+  }
+}
+
 private function fetch() -> FetchResult = {
-  // fetch PC check for extensions: extensions return a transformed PC to fetch,
-  // but any exceptions use the untransformed PC.
   // TODO: Add a parameter to try_step() to allow forcing the fetch result and use that instead.
 
   if get_config_rvfi()
   then return rvfi_fetch();
 
+  // Doing this check here assumes the external fetch checks are higher priority
+  // than the following alignment check.
   match ext_fetch_check_pc(PC, PC) {
     Some(e) => return F_Ext_Error(e),
     None()  => (),
@@ -27,35 +60,28 @@ private function fetch() -> FetchResult = {
   if   (PC[0] != 0b0 | (PC[1] != 0b0 & not(currentlyEnabled(Ext_Zca))))
   then return F_Error(E_Fetch_Addr_Align(), PC);
 
-  match translateAddr(Virtaddr(PC), InstructionFetch()) {
-    Err(e, _) => F_Error(e, PC),
-    Ok(ppclo, pbmt, _) => {
-      // split instruction fetch into 16-bit granules to handle RVC, as
-      // well as to generate precise fault addresses in any fetch
-      // exceptions.
-      match mem_read(InstructionFetch(), pbmt, ppclo, 2, false, false, false) {
-        Err(e)  => F_Error(e, PC),
-        Ok(ilo) =>
-          if   isRVC(ilo)
-          then F_RVC(ilo)
-          else {
-            // fetch PC check for the next instruction granule
-            let PC_hi = PC + 2;
-            match ext_fetch_check_pc(PC, PC_hi) {
-              Some(e) => return F_Ext_Error(e),
-              None()  => (),
-            };
-
-            match translateAddr(Virtaddr(PC_hi), InstructionFetch()) {
-              Err(e, _) => F_Error(e, PC_hi),
-              Ok(ppchi, pbmt, _) =>
-                match mem_read(InstructionFetch(), pbmt, ppchi, 2, false, false, false) {
-                  Err(e)  => F_Error(e, PC_hi),
-                  Ok(ihi) => F_Base(append(ihi, ilo))
-                }
-            }
-          }
-      }
+  // For a PC aligned at ILEN=32, perform an atomic fetch for Ziccif.
+  if is_aligned_addr(Virtaddr(PC), 4) & currentlyEnabled(Ext_Ziccif) then {
+    match fetch_bytes(PC, PC, 4) {
+      FetchBytes_Ext_Error(e)   => F_Ext_Error(e),
+      FetchBytes_Exception(e)   => F_Error(e, PC),
+      FetchBytes_Success(bytes) => if isRVC(bytes[15 .. 0]) then F_RVC(bytes[15 .. 0]) else F_Base(bytes),
+    }
+  } else {
+    // Split instruction fetch into 16-bit granules to handle RVC, as
+    // well as to generate precise fault addresses in any fetch
+    // exceptions.
+    match fetch_bytes(PC, PC, 2) {
+      FetchBytes_Ext_Error(e) => F_Ext_Error(e),
+      FetchBytes_Exception(e) => F_Error(e, PC),
+      FetchBytes_Success(ilo) =>
+        if   isRVC(ilo)
+        then F_RVC(ilo)
+        else match fetch_bytes(PC, PC + 2, 2) {
+          FetchBytes_Ext_Error(e) => F_Ext_Error(e),
+          FetchBytes_Exception(e) => F_Error(e, PC + 2),
+          FetchBytes_Success(ihi) => F_Base(append(ihi, ilo)),
+        },
     }
   }
 }

--- a/model/postlude/fetch.sail
+++ b/model/postlude/fetch.sail
@@ -76,6 +76,13 @@ private function fetch() -> FetchResult = {
   if is_aligned_addr(Virtaddr(PC), 4) & currentlyEnabled(Ext_Ziccif) then {
     match fetch_bytes(PC, PC, 4) {
       FetchBytes_Ext_Error(e)   => F_Ext_Error(e),
+      // If an exception is raised for the upper two bytes but the
+      // instruction is only 16 bits then the exception should be
+      // ignored. In this implementation we avoid situations where
+      // this can happen - the minimum PMP granularity is 4 bytes, and
+      // for simplicity we restrict PMA granularity to 4096
+      // bytes. This situation may still occur if MMIO devices are
+      // incorrectly configured, but this is not checked currently.
       FetchBytes_Exception(e)   => F_Error(e, PC),
       FetchBytes_Success(bytes) => if isRVC(bytes[15 .. 0]) then F_RVC(bytes[15 .. 0]) else F_Base(bytes),
     }

--- a/model/postlude/fetch.sail
+++ b/model/postlude/fetch.sail
@@ -61,6 +61,18 @@ private function fetch() -> FetchResult = {
   then return F_Error(E_Fetch_Addr_Align(), PC);
 
   // For a PC aligned at ILEN=32, perform an atomic fetch for Ziccif.
+  //
+  // NOTE: The atomicity requirements for the fetch can be implemented
+  // in the memory model in two ways: (i) A single memory transaction
+  // in Sail, i.e. the approach followed below, or (ii) multiple smaller
+  // (e.g. 2-byte) fetches, along with rules in the memory model specifying
+  // that nothing can intervene between these smaller
+  // intra-instruction fetches.  The former approach is currently simpler
+  // since it does not require any additional rules in the memory model.
+  // However, if/when ILEN is increased to 48 and higher, it may be that
+  // the complexities around memory protection could be addressed using
+  // smaller fetches and augmenting the memory model with these additional
+  // rules for intra-instruction split fetches.
   if is_aligned_addr(Virtaddr(PC), 4) & currentlyEnabled(Ext_Ziccif) then {
     match fetch_bytes(PC, PC, 4) {
       FetchBytes_Ext_Error(e)   => F_Ext_Error(e),

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -253,6 +253,7 @@ private function check_pma_region(region : PMA_Region) -> bool = {
 private struct pma_check_opts = {
   ziccamoa : bool,
   ziccamoc : bool,
+  ziccif   : bool,
   ziccrse  : bool,
   ssccptr  : bool,
   svadu    : bool,
@@ -285,6 +286,10 @@ private function check_pma_regions(regions : list(PMA_Region), prev_base : bits(
           print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^ atomic_support_str(attributes.atomic_support) ^ " atomicity support, but Ziccamoc is enabled which requires AMOCASQ support.");
           return false;
         };
+        if check_opts.ziccif & not(attributes.executable) then {
+          print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with no instruction fetch support, but Ziccif is enabled which requires this support.");
+          return false;
+        };
         if check_opts.ziccrse & attributes.reservability != RsrvEventual then {
           print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^ reservability_str(attributes.reservability) ^ " reservability support, but Ziccrse is enabled which requires RsrvEventual support.");
           return false;
@@ -314,6 +319,7 @@ private function check_mem_layout() -> bool =
     let check_opts : pma_check_opts = struct {
       ziccamoa = config extensions.Ziccamoa.supported,
       ziccamoc = config extensions.Ziccamoc.supported,
+      ziccif   = config extensions.Ziccif.supported,
       ziccrse  = config extensions.Ziccrse.supported,
       ssccptr  = config extensions.Ssccptr.supported,
       svadu    = config extensions.Svadu.supported,


### PR DESCRIPTION
This updates the fetcher to handle atomic fetches for NAPOT PCs with ILEN=32.  This implementation will have to be updated when ILEN is increased to 48 and above to handle discarded bytes that straddle memory protection boundaries.

This removes an obsolete comment about fetch extension checks returning a transformed PC: they currently return an optional error.