### PR TITLE
Use ExecuteAs to make execute non-recursive

### DIFF
--- a/model/extensions/FD/zcd_insts.sail
+++ b/model/extensions/FD/zcd_insts.sail
@@ -16,7 +16,7 @@ mapping clause encdec_compressed = C_FLDSP(uimm, rd)
 
 function clause execute C_FLDSP(uimm, rd) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
-  execute(LOAD_FP(imm, sp, rd, 8))
+  ExecuteAs(LOAD_FP(imm, sp, rd, 8))
 }
 
 mapping clause assembly = C_FLDSP(uimm, rd)
@@ -31,7 +31,7 @@ mapping clause encdec_compressed = C_FSDSP(uimm, rs2)
 
 function clause execute C_FSDSP(uimm, rs2) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
-  execute(STORE_FP(imm, rs2, sp, 8))
+  ExecuteAs(STORE_FP(imm, rs2, sp, 8))
 }
 
 mapping clause assembly = C_FSDSP(uimm, rs2)
@@ -48,7 +48,7 @@ function clause execute C_FLD(uimm, rsc, rdc) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
   let rd = cfregidx_to_fregidx(rdc);
   let rs = creg2reg_idx(rsc);
-  execute(LOAD_FP(imm, rs, rd, 8))
+  ExecuteAs(LOAD_FP(imm, rs, rd, 8))
 }
 
 mapping clause assembly = C_FLD(uimm, rsc, rdc)
@@ -65,7 +65,7 @@ function clause execute C_FSD(uimm, rsc1, rsc2) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
   let rs1 = creg2reg_idx(rsc1);
   let rs2 = cfregidx_to_fregidx(rsc2);
-  execute(STORE_FP(imm, rs2, rs1, 8))
+  ExecuteAs(STORE_FP(imm, rs2, rs1, 8))
 }
 
 mapping clause assembly = C_FSD(uimm, rsc1, rsc2)

--- a/model/extensions/FD/zcf_insts.sail
+++ b/model/extensions/FD/zcf_insts.sail
@@ -16,7 +16,7 @@ mapping clause encdec_compressed = C_FLWSP(uimm, rd)
 
 function clause execute C_FLWSP(imm, rd) = {
   let imm : bits(12) = zero_extend(imm @ 0b00);
-  execute(LOAD_FP(imm, sp, rd, 4))
+  ExecuteAs(LOAD_FP(imm, sp, rd, 4))
 }
 
 mapping clause assembly = C_FLWSP(imm, rd)
@@ -32,7 +32,7 @@ mapping clause encdec_compressed = C_FSWSP(uimm, rs2)
 
 function clause execute C_FSWSP(uimm, rs2) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
-  execute(STORE_FP(imm, rs2, sp, 4))
+  ExecuteAs(STORE_FP(imm, rs2, sp, 4))
 }
 
 mapping clause assembly = C_FSWSP(uimm, rs2)
@@ -50,7 +50,7 @@ function clause execute C_FLW(uimm, rsc, rdc) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   let rd = cfregidx_to_fregidx(rdc);
   let rs = creg2reg_idx(rsc);
-  execute(LOAD_FP(imm, rs, rd, 4))
+  ExecuteAs(LOAD_FP(imm, rs, rd, 4))
 }
 
 mapping clause assembly = C_FLW(uimm, rsc, rdc)
@@ -68,7 +68,7 @@ function clause execute C_FSW(uimm, rsc1, rsc2) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   let rs1 = creg2reg_idx(rsc1);
   let rs2 = cfregidx_to_fregidx(rsc2);
-  execute(STORE_FP(imm, rs2, rs1, 4))
+  ExecuteAs(STORE_FP(imm, rs2, rs1, 4))
 }
 
 mapping clause assembly = C_FSW(uimm, rsc1, rsc2)

--- a/model/extensions/Svinval/svinval_insts.sail
+++ b/model/extensions/Svinval/svinval_insts.sail
@@ -15,7 +15,7 @@ mapping clause encdec = SINVAL_VMA(rs1, rs2)
   when currentlyEnabled(Ext_Svinval)
 
 function clause execute SINVAL_VMA(rs1, rs2) = {
-  execute(SFENCE_VMA(rs1, rs2))
+  ExecuteAs(SFENCE_VMA(rs1, rs2))
 }
 
 mapping clause assembly = SINVAL_VMA(rs1, rs2)

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -209,8 +209,10 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
     Step_Fetch_Failure(vaddr, e) => handle_exception(bits_of(vaddr), e),
     Step_Waiting(_) => assert(hart_is_waiting(hart_state), "cannot be Waiting in a non-Wait state"),
     Step_Execute(Retire_Success(), _) => assert(hart_is_active(hart_state)),
-    // This case was handled above when processing the fetch result.
-    Step_Execute(ExecuteAs(_), _) => assert(false),
+    // We only support one level of ExecuteAs redirection, primarily intended
+    // for compressed instructions (though it can be used elsewhere). If there
+    // is more than one ExecuteAs indirection we'll get to here. This isn't supported.
+    Step_Execute(ExecuteAs(_), _) => internal_error(__FILE__, __LINE__, "Multiple chained ExecuteAs (only one redirection is supported)."),
     // standard errors
     Step_Execute(Trap(priv, ctl, pc), _) => set_next_pc(exception_handler(priv, ctl, pc)),
     Step_Execute(Memory_Exception(vaddr, e), _) => handle_exception(bits_of(vaddr), e),

--- a/model/sys/insts_begin.sail
+++ b/model/sys/insts_begin.sail
@@ -18,7 +18,12 @@ union ExecutionResult = {
   Retire_Success                 : unit,
 
   // The instruction is a compressed instruction, and should be
-  // executed as an uncompressed instruction.
+  // executed as an uncompressed instruction. This can be used
+  // for non-compressed instructions too but we only support
+  // one level of indirection. This avoids making the execute()
+  // function recursive, which is helpful for some backends,
+  // and allows Sail to generate faster C/C++ code by avoiding
+  // reallocation.
   ExecuteAs                      : instruction,
 
   // An instruction such as WFI, WRS.{STO,NTO}


### PR DESCRIPTION
Currently execute() is recursive due to these remaining calls that we apparently missed. I verified that with these changes Sail now considers it to be non-recursive, and consequently it can hoist GMP allocations outside of the function. This should be a little faster, though I did not measure a significant speedup.