### PR TITLE
Fix markdown link-check whitelist url.

### DIFF
--- a/.markdown-link-check.config
+++ b/.markdown-link-check.config
@@ -13,7 +13,7 @@
       "reason": "random access issues from github.com CI"
     },
     {
-      "pattern": "^http://www.cl.cam.ac.uk/~pes20/sail/overview-sail.png",
+      "pattern": "^http://www.cl.cam.ac.uk/~pes20/sail/overview-sail.png?",
       "reason": "random access issues from github.com CI"
     }
   ]

--- a/.markdown-link-check.config
+++ b/.markdown-link-check.config
@@ -1,10 +1,6 @@
 {
   "ignorePatterns": [
     {
-      "pattern": "^https://isla-axiomatic.cl.cam.ac.uk",
-      "reason": "expired certificate"
-    },
-    {
       "pattern": "^https://gmplib.org",
       "reason": "access issues from github.com"
     },
@@ -13,7 +9,7 @@
       "reason": "random access issues from github.com CI"
     },
     {
-      "pattern": "^http://www.cl.cam.ac.uk/~pes20/sail/overview-sail.png?",
+      "pattern": "^http://www.cl.cam.ac.uk/~pes20/sail/overview-sail.png\\?raw=true",
       "reason": "random access issues from github.com CI"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ engineer-friendly language, much like earlier vendor pseudocode, but more precis
 Given a Sail specification, the tool can type-check it, generate documentation snippets (in LaTeX or AsciiDoc), generate executable emulators, show specification coverage, generate versions of the ISA for relaxed memory model tools, support automated instruction-sequence test generation, generate theorem-prover definitions for
 interactive proof (in Isabelle, Rocq, and Lean), support proof about binary code (in Islaris), and (in progress) generate a reference ISA model in SystemVerilog that can be used for formal hardware verification.
 
-<img width="800" src="https://www.cl.cam.ac.uk/~pes20/sail/overview-sail.png?">
+<img width="800" src="https://www.cl.cam.ac.uk/~pes20/sail/overview-sail.png?raw=true">
 
 ## Using the Sail RISC-V specification
 


### PR DESCRIPTION
Append what seems to be a missed 'raw=true' specifier after the terminating '?' in the URL for `overview-sail.png` in the README; adjust the whitelist pattern accordingly.  Also re-enable link checks for `isla-axiomatic.cl.cam.ac.uk`.