### PR TITLE
Add Simple Interrupt Generator MMIO device for testing purposes

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -165,7 +165,7 @@
         },
         "size": {
           "len": 64,
-          "value": "0x2000000"
+          "value": "0x10000000"
         },
         "attributes": {
           "mem_type": "IOMemory",
@@ -230,6 +230,13 @@
       // This must be in a suitable memory region (see `memory.regions`).
       "base": 33554432,
       "size": 786432
+    },
+    // Very simple MMIO device to generate interrupts for testing
+    // purposes. See docs/SimpleInterruptGenerator.md for details.
+    "simple_interrupt_generator": {
+      // This must be in a suitable IO memory region (see `memory.regions`)
+      // and 4-byte aligned. The size is always 0x20.
+      "base": 201326592
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -66,6 +66,8 @@
   - https://github.com/riscv/sail-riscv/issues/1560 : Updates to `mip` were not captured in the trace file
   - https://github.com/riscv/sail-riscv/issues/1574 : Misaligned store-conditionals didn't raise a misaligned address exception
 
+- A [Simple Interrupt Generator](../doc/SimpleInterruptGenerator.md) MMIO device has been added for testing purposes. This allows generating external and software interrupts that cannot be directly generated from within the hart.
+
 # Release notes for version 0.10
 
 - The highlight of this release is the switch to using the C++ backend

--- a/doc/SimpleInterruptGenerator.md
+++ b/doc/SimpleInterruptGenerator.md
@@ -1,0 +1,123 @@
+# Simple Interrupt Generator
+
+This model includes a very simple MMIO device that allows setting interrupts that are difficult to set via other means (through software or CLINT). This is intended for testing purposes.
+
+This describes version 1.0 of the device. Future versions may add additional features but will be backwards compatible.
+
+## Memory Layout
+
+The device consists only of 4-byte registers, and it must be 4-byte aligned.
+Only naturally aligned 4-byte accesses succeed. Other accesses raise an access fault.
+
+| Offset (Bytes) | Size (Bytes) | Register   | Read    | Write                |
+| -------------- | ------------ | ---------- | ------- | -------------------- |
+| 0              | 4            | `version`  | Version | _ignored_            |
+| 4              | 4            | `platform` | _zeros_ | Set/clear interrupts |
+| 8              | 24           | _reserved_ | _fault_ | _fault_              |
+
+`version`: reads as as the current version (0x00010000 currently). The version is split into major/minor 16-bit integers, so the current version is 1.0. Versioning follows semver, so minor version updates are backwards compatible with existing software, major version updates are not. Writes to `version` are ignored.
+
+`platform`: reads as 0. Writes can be used to set or clear platform-generated interrupts as follows:
+
+| Offset (Bits) | Meaning        |
+| ------------- | -------------- |
+| 0             | _reserved_     |
+| 1             | SSI            |
+| 2             | _reserved_     |
+| 3             | MSI            |
+| 4-8           | _reserved_     |
+| 9             | SEI            |
+| 10            | _reserved_     |
+| 11            | MEI            |
+| 12-30         | _reserved_     |
+| 31            | 1=set, 0=clear |
+
+_Reserved_ bits must be written with 0 otherwise an access fault is raised. In future versions writing 1 may be allowed and have an effect, but writing 0 will have no effect so writing 0 is forwards compatible (with minor version number changes).
+
+Bit 31 controls whether the relevant interrupts are set or cleared.
+
+MEI and MSI control the platform interrupt inputs to the hart, which directly control the corresponding bits in `mip` (there is no way for software running on the hart to set these bits directly). SEI and SSI are slightly more subtle because software on the hart can also write to these bits.
+
+SEI controls the supervisor external platform interrupt input, which is distinct from the software-writable `mip[SEI]` bit. These two values are ORed together when reading `mip` (or `sip`) for CSR reads and to dispatch interrupts, but NOT when reading `mip`/`sip` for the CSR read-modify-write process.
+
+Setting or clearing SSI updates the value in `mip[SSI]`, but in this case there is only one bit of state.
+
+Note that if the target hart does not support supervisor mode then `mip[SSI]` and `mip[SEI]` must be read-only zero. Attempts to set `mip[SSI]` will be ignored. Attempts to set `SEI` _will_ set the external platform interrupt input, but it will not be visible in `mip` while supervisor mode is not supported. If the hart supports mutable `misa[S]` so that supervisor mode can be dynamically enabled, then setting `SEI` to 1 here and _then_ enabling `misa[S]` will result in the interrupt becoming visible.
+
+Space for other registers is reserved for future use. In version 1.0, accessing them raises an access fault.
+
+## Example C++ Code
+
+```cpp
+constexpr uint32_t SIG_SSI = (1 << 1);
+constexpr uint32_t SIG_MSI = (1 << 3);
+constexpr uint32_t SIG_SEI = (1 << 9);
+constexpr uint32_t SIG_MEI = (1 << 11);
+constexpr uint32_t SIG_SET = (1 << 31);
+
+struct SimpleInterruptGenerator {
+    uint32_t version;
+    uint32_t platform;
+    uint32_t reserved[6];
+};
+
+void set_meip(volatile SimpleInterruptGenerator* sig) {
+    uint32_t version = sig->version;
+    uint32_t minor = version & 0xFFFF;
+    uint32_t major = version >> 16;
+    assert(major == 1 && minor >= 0);
+    sig->platform = SIG_SET | SIG_MEI;
+}
+
+// etc.
+```
+
+## Example Assembly Code
+
+```
+.set SIG_SSI, (1 << 1)
+.set SIG_MSI, (1 << 3)
+.set SIG_SEI, (1 << 9)
+.set SIG_MEI, (1 << 11)
+.set SIG_SET, (1 << 31)
+
+.set SIG_REG_OFFSET_VERSION, 0
+.set SIG_REG_OFFSET_PLATFORM, 4
+
+.set SIG_REQUIRED_MAJOR_VERSION, 1
+.set SIG_MINIMUM_MINOR_VERSION, 0
+
+# void set_meip(volatile SimpleInterruptGenerator* sig)
+set_meip:
+    # Load version.
+    lw      t0, SIG_REG_OFFSET_VERSION(a0)
+
+    # t1 = major version
+    srl    t1, t0, 16
+
+    # t0 = minor version.
+    li     t2, 0xFFFF
+    and    t0, t0, t2
+
+    # Check major version matches exactly.
+    li      t2, SIG_REQUIRED_MAJOR_VERSION
+    bne     t1, t2, 1f
+
+    # Check minor version matches minimum.
+    li      t2, SIG_MINIMUM_MINOR_VERSION
+    bltu    t0, t2, 1f
+
+    li      t0, SIG_SET
+    li      t1, SIG_MEI
+    # t0 = SIG_SET | SIG_MEI
+    or      t0, t0, t1
+
+    # Set interrupt.
+    sw      t0, SIG_REG_OFFSET_PLATFORM(a0)
+
+    ret
+
+1:
+    # Assertion failed.
+    ebreak
+```

--- a/model/core/interrupt_regs.sail
+++ b/model/core/interrupt_regs.sail
@@ -91,6 +91,24 @@ private function legalize_medeleg(_o : Medeleg, v : bits(64)) -> Medeleg = {
   [Mk_Medeleg(v) with MEnvCall = 0b0]
 }
 
+// Note that mip's MEIP and SEIP had special handling. MEIP is always
+// read-only zero in mip, and SEIP is software-writable. But there are also
+// external platform MEIP/SEIP inputs that are OR'd into mip when it is
+// read, both for dispatching interrupts, and when writing rd with CSR
+// instructions but NOT when it is used as a value for read-modify-write.
+//
+// For instance if the external platform is asserting SEIP and you do
+// `csrsi mip, 0`, it does NOT change the software-writable value of SEIP to be 1.
+//
+// We could store MEIP here directly since it is never software-writable, but
+// for consistency with SEIP we don't.
+
+// Called whenever we want mip/sip with the external interrupts ORed in.
+// This is the case for a) reading mip/sip, and b) dispatching interrupts.
+// But it is NOT the case for reading mip/sip during a CSR read-modify-write
+// update, therefore we can't just store them directly in the mip register.
+val external_interrupts_pending : unit -> Minterrupts
+
 register mie     : Minterrupts // Enabled
 register mip     : Minterrupts // Pending
 register medeleg : Medeleg     // Exception delegation to S-mode
@@ -108,14 +126,29 @@ function clause is_CSR_accessible(0x302, _, _) = currentlyEnabled(Ext_S) // mede
 function clause is_CSR_accessible(0x312, _, _) = currentlyEnabled(Ext_S) & xlen == 32 // medelegh
 function clause is_CSR_accessible(0x303, _, _) = currentlyEnabled(Ext_S) // mideleg
 
+enum XipReadType = {
+  IncludePlatformInterrupts,
+  ExcludePlatformInterrupts,
+}
+
+function read_mip(read_type : XipReadType) -> Minterrupts =
+  match read_type {
+    IncludePlatformInterrupts => Mk_Minterrupts(mip.bits | external_interrupts_pending().bits),
+    ExcludePlatformInterrupts => mip,
+  }
+
+function write_mip(value : xlenbits) -> unit = {
+  mip = legalize_mip(mip, value);
+}
+
 function clause read_CSR(0x304) = mie.bits
-function clause read_CSR(0x344) = mip.bits
+function clause read_CSR(0x344) = read_mip(ExcludePlatformInterrupts).bits
 function clause read_CSR(0x302) = medeleg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x312 if xlen == 32) = medeleg.bits[63 .. 32]
 function clause read_CSR(0x303) = mideleg.bits
 
 function clause write_CSR(0x304, value) = { mie = legalize_mie(mie, value); Ok(mie.bits) }
-function clause write_CSR(0x344, value) = { mip = legalize_mip(mip, value); Ok(mip.bits) }
+function clause write_CSR(0x344, value) = { write_mip(value); Ok(read_mip(IncludePlatformInterrupts).bits) }
 function clause write_CSR((0x302, value) if xlen == 64) = { medeleg = legalize_medeleg(medeleg, value); Ok(medeleg.bits) }
 function clause write_CSR((0x302, value) if xlen == 32) = { medeleg = legalize_medeleg(medeleg, medeleg.bits[63 .. 32] @ value); Ok(medeleg.bits[31 .. 0]) }
 function clause write_CSR((0x312, value) if xlen == 32) = { medeleg = legalize_medeleg(medeleg, value @ medeleg.bits[31 .. 0]); Ok(medeleg.bits[63 .. 32]) }
@@ -167,10 +200,17 @@ private function legalize_sip(m : Minterrupts, d : Minterrupts, v : xlenbits) ->
   lift_sip(m, d, Mk_Sinterrupts(v))
 }
 
+function read_sip(read_type : XipReadType) -> Sinterrupts =
+  lower_mip(read_mip(read_type), mideleg)
+
+function write_sip(value : xlenbits) -> unit = {
+  mip = legalize_sip(mip, mideleg, value);
+}
+
 mapping clause csr_name_map = 0x144  <-> "sip"
 function clause is_CSR_accessible(0x144, _, _) = currentlyEnabled(Ext_S) // sip
-function clause read_CSR(0x144) = lower_mip(mip, mideleg).bits
-function clause write_CSR(0x144, value) = { mip = legalize_sip(mip, mideleg, value); Ok(lower_mip(mip, mideleg).bits) }
+function clause read_CSR(0x144) = read_sip(ExcludePlatformInterrupts).bits
+function clause write_CSR(0x144, value) = { write_sip(value); Ok(read_sip(IncludePlatformInterrupts).bits) }
 
 // sie
 // Returns the new value of mie from the previous mie (o) and the written sie (s) as delegated by mideleg (d).

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -34,6 +34,10 @@ let plat_enable_misaligned_access : bool = config memory.misaligned.supported
 let plat_clint_base : physaddrbits = to_bits_checked(config platform.clint.base : int)
 let plat_clint_size : physaddrbits = to_bits_checked(config platform.clint.size : int)
 
+// Simple Interrupt Generator. See docs/SimpleInterruptGenerator.md for details.
+let plat_sig_base : physaddrbits = to_bits_checked(config platform.simple_interrupt_generator.base : int)
+let plat_sig_size : physaddrbits = zero_extend(0x20)
+
 let plat_insns_per_tick : nat1 = config platform.instructions_per_tick
 
 // Maximum increment in the time CSR to wait for wait instructions.  This is not

--- a/model/extensions/Zicsr/zicsr_insts.sail
+++ b/model/extensions/Zicsr/zicsr_insts.sail
@@ -49,25 +49,47 @@ function doCSR(csr : csreg, rs1_val : xlenbits, rd : regidx, op : csrop, access_
       then Ext_CSR_Check_Failure()
       else {
         // A pure write (i.e. CSRRW with rd == 0) should not generate read side-effects.
-        let csr_val : xlenbits = if access_type != CSRWrite then read_CSR(csr) else zeros();
-        if access_type != CSRRead then {
-          let new_val : xlenbits = match op {
+        let read_val : xlenbits = if access_type != CSRWrite then read_CSR(csr) else zeros();
+
+        // `read_val` is the value used in the read-modify-write. `dest_val` is the
+        // value written to `rd`. These are almost always the same.
+        //
+        // An exception is mip and sip which have delightfully unique behaviour
+        // for the SEIP bit. The value written into `X(rd)` has the external
+        // platform interrupt bit (e.g. from PLIC) ORed into SEIP. But that
+        // *isn't* the case for the "read" value of the CSR used in the
+        // read-modify write cycle.
+        //
+        // read_CSR() returns read_mip/sip(ExcludePlatformInterrupts) so we
+        // override that here for `dest_val`.
+        //
+        // We treat MEIP the same as SEIP for consistency. It doesn't actually matter
+        // since it is read-only.
+        //
+        let dest_val : xlenbits = match csr {
+          0x344 => read_mip(IncludePlatformInterrupts).bits,
+          0x144 => read_sip(IncludePlatformInterrupts).bits,
+          _ => read_val,
+        };
+
+        if access_type == CSRRead then {
+          csr_read_callback(csr, dest_val);
+          X(rd) = dest_val;
+          RETIRE_SUCCESS
+        } else {
+          let write_val : xlenbits = match op {
             CSRRW => rs1_val,
-            CSRRS => csr_val | rs1_val,
-            CSRRC => csr_val & ~(rs1_val)
+            CSRRS => read_val | rs1_val,
+            CSRRC => read_val & ~(rs1_val)
           };
-          match write_CSR(csr, new_val) {
+          match write_CSR(csr, write_val) {
             Ok(final_val) => {
+              X(rd) = dest_val;
               csr_write_callback(csr, final_val);
-              X(rd) = csr_val;
               RETIRE_SUCCESS
             },
-            Err(()) => Illegal_Instruction()
+            Err(()) => Illegal_Instruction(),
           }
-        } else {
-          csr_read_callback(csr, csr_val);
-          X(rd) = csr_val;
-          RETIRE_SUCCESS
         }
       }
     }

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -479,10 +479,20 @@ private function check_stateen_config() -> bool = {
   valid
 }
 
+private function check_mmio_devices() -> bool = {
+  var valid : bool = true;
+  if plat_sig_base[1 .. 0] != zeros() then {
+    print_endline("platform.simple_interrupt_generator.base is not 4-byte aligned.");
+    valid = false;
+  };
+  valid
+}
+
 function config_is_valid() -> bool = {
     check_privs()
   & check_mmu_config()
   & check_mem_layout()
+  & check_mmio_devices()
   & check_vlen_elen()
   & check_vext_config()
   & check_pmp()

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -64,7 +64,9 @@ sys {
 
   files
     sys/sys_reservation.sail,
+    sys/simple_interrupt_generator_regs.sail,
     sys/sys_control.sail,
+    sys/simple_interrupt_generator.sail,
     sys/platform.sail,
     sys/pma.sail,
     sys/mem.sail,

--- a/model/sys/platform.sail
+++ b/model/sys/platform.sail
@@ -31,6 +31,14 @@ private function within_clint forall 'n, 0 < 'n <= max_mem_access . (Physaddr(ad
   & (addr_int + sizeof('n)) <= (clint_base_int + clint_size_int)
 }
 
+private function within_sig forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : physaddr, width : int('n)) -> bool = {
+  let addr_int = unsigned(addr);
+  let sig_base_int = unsigned(plat_sig_base);
+  let sig_size_int = unsigned(plat_sig_size);
+    sig_base_int <= addr_int
+  & (addr_int + sizeof('n)) <= (sig_base_int + sig_size_int)
+}
+
 private function within_htif_writable forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : physaddr, width : int('n)) -> bool =
   match htif_tohost_base {
     None() => false,
@@ -134,7 +142,7 @@ private function clint_dispatch(mip_was_written : bool) -> unit = {
   if get_config_print_clint()
   then print_log("clint mtime " ^ bits_str(mtime));
   if old_mip != mip.bits | mip_was_written then {
-    csr_write_callback("mip", mip.bits);
+    csr_write_callback("mip", read_mip(IncludePlatformInterrupts).bits);
   };
 }
 
@@ -333,16 +341,18 @@ function htif_store(Physaddr(paddr), width, data) = {
 function within_mmio_readable forall 'n, 0 < 'n <= max_mem_access . (addr : physaddr, width : int('n)) -> bool =
   if get_config_rvfi()
   then false
-  else within_clint(addr, width) | (within_htif_readable(addr, width) & 1 <= 'n)
+  else within_clint(addr, width) | within_sig(addr, width) | (within_htif_readable(addr, width) & 1 <= 'n)
 
 function within_mmio_writable forall 'n, 0 < 'n <= max_mem_access . (addr : physaddr, width : int('n)) -> bool =
   if get_config_rvfi()
   then false
-  else within_clint(addr, width) | (within_htif_writable(addr, width) & 'n <= 8)
+  else within_clint(addr, width) | within_sig(addr, width) | (within_htif_writable(addr, width) & 'n <= 8)
 
 function mmio_read forall 'n, 0 < 'n <= max_mem_access . (access : MemoryAccessType(mem_payload), paddr : physaddr, width : int('n)) -> MemoryOpResult(bits(8 * 'n)) =
   if   within_clint(paddr, width)
   then clint_load(access, paddr, width)
+  else if within_sig(paddr, width)
+  then sig_load(access, paddr, width)
   else if within_htif_readable(paddr, width)
   then htif_load(access, paddr, width)
   else Err(accessFaultFromAccessType(access))
@@ -350,6 +360,8 @@ function mmio_read forall 'n, 0 < 'n <= max_mem_access . (access : MemoryAccessT
 function mmio_write forall 'n, 0 < 'n <= max_mem_access . (paddr : physaddr, width : int('n), data: bits(8 * 'n)) -> MemoryOpResult(bool) =
   if   within_clint(paddr, width)
   then clint_store(paddr, width, data)
+  else if within_sig(paddr, width)
+  then sig_store(paddr, width, data)
   else if within_htif_writable(paddr, width)
   then htif_store(paddr, width, data)
   else Err(E_SAMO_Access_Fault())

--- a/model/sys/simple_interrupt_generator.sail
+++ b/model/sys/simple_interrupt_generator.sail
@@ -1,0 +1,57 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// Register offsets.
+let SIG_VERSION_OFFSET = 0
+let SIG_PLATFORM_OFFSET = 4
+
+private val sig_load : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(mem_payload), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
+function sig_load(access, Physaddr(paddr), width) = {
+  // Version of this MMIO device (1.0 currently).
+  // This follows semver.
+  let VERSION = 0x00010000;
+
+  if width != 4 | paddr[1 .. 0] != zeros()
+  then Err(accessFaultFromAccessType(access))
+  else {
+    if paddr == plat_sig_base + SIG_VERSION_OFFSET
+    then Ok(VERSION)
+    else if paddr == plat_sig_base + SIG_PLATFORM_OFFSET
+    then Ok(zeros())
+    else Err(accessFaultFromAccessType(access))
+  }
+}
+
+private val sig_store : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
+function sig_store(Physaddr(paddr), width, data) = {
+  if width != 4 | paddr[1 .. 0] != zeros()
+  then Err(E_SAMO_Access_Fault())
+  else {
+    if paddr == plat_sig_base + SIG_VERSION_OFFSET
+    then Ok(true)
+    else if paddr == plat_sig_base + SIG_PLATFORM_OFFSET
+    then {
+      let value = data[31];
+      let data = Mk_Minterrupts(zero_extend(data));
+
+      // Reserved bits must currently be written with zeros.
+      if [data with MEI = 0b0, SEI = 0b0, MSI = 0b0, SSI = 0b0].bits[30 .. 0] != zeros()
+      then return Err(E_SAMO_Access_Fault());
+
+      if data[MEI] == 0b1 then sig_meip = value;
+      if data[SEI] == 0b1 then sig_seip = value;
+      if data[MSI] == 0b1 then mip[MSI] = value;
+      // SSI is read-only zero if the hart does not support supervisor mode.
+      if data[SSI] == 0b1 & currentlyEnabled(Ext_S) then mip[SSI] = value;
+
+      csr_write_callback("mip", read_mip(IncludePlatformInterrupts).bits);
+
+      Ok(true)
+    } else Err(E_SAMO_Access_Fault())
+  }
+}

--- a/model/sys/simple_interrupt_generator_regs.sail
+++ b/model/sys/simple_interrupt_generator_regs.sail
@@ -1,0 +1,18 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// The last value written to the Simple Interrupt Generator.
+private register sig_meip : bits(1) = 0b0
+private register sig_seip : bits(1) = 0b0
+
+function external_interrupts_pending() -> Minterrupts =
+  [Mk_Minterrupts(zeros()) with
+    MEI = sig_meip,
+    // SEIP is read-only zero if the hart does not support supervisor mode.
+    SEI = if currentlyEnabled(Ext_S) then sig_seip else 0b0,
+  ]

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -106,8 +106,11 @@ function getPendingSet(priv : Privilege) -> option((xlenbits, Privilege)) = {
   // mideleg can only be non-zero if we support Supervisor mode.
   assert(currentlyEnabled(Ext_S) | mideleg.bits == zeros());
 
-  let pending_m = mip.bits & mie.bits & ~(mideleg.bits);
-  let pending_s = mip.bits & mie.bits & mideleg.bits;
+  // Read mip with the external platform interrupts ORed in.
+  let mip_bits = read_mip(IncludePlatformInterrupts).bits;
+
+  let pending_m = mip_bits & mie.bits & ~(mideleg.bits);
+  let pending_s = mip_bits & mie.bits & mideleg.bits;
 
   let mIE = (priv == Machine    & mstatus[MIE] == 0b1) | priv == Supervisor | priv == User;
   let sIE = (priv == Supervisor & mstatus[SIE] == 0b1) | priv == User;


### PR DESCRIPTION
This change correctly models (hopefully) the behaviour of platform external interrupts, and adds an ad-hoc "Simple Interrupt Generator" MMIO device to set them. Currently it is only used to set MEIP, SEIP, SSIP and MSIP. The reason for supporting this set of interrupt is as follows:

* MEIP - cannot be triggered via any other means.
* SEIP - can be triggered by writing to mip[SEI] but there is additional weird behaviour that means you also need to be able to control the platform SEI input to full test it.
* MTI, STI - can already be triggered via CLINT. Also these are set continuously via CLINT so having two devices set them would be awkward.
* MSI - can be triggered via CLINT but for symmetry with SSI this is also supported.
* SSI - can be triggered via software but the ISA manual also mentions it can be set via the external platform so we want to be able to test this.