### PR TITLE
Add a flag to the address translator to enable a pure lookup.

### DIFF
--- a/c_emulator/riscv_callbacks_if.cpp
+++ b/c_emulator/riscv_callbacks_if.cpp
@@ -102,7 +102,8 @@ void callbacks_if::ptw_start_callback(
   [[maybe_unused]] hart::Model &model,
   [[maybe_unused]] uint64_t vpn,
   [[maybe_unused]] hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
-  [[maybe_unused]] hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+  [[maybe_unused]] hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege,
+  [[maybe_unused]] bool is_pure_lookup
 ) {
 }
 
@@ -110,14 +111,16 @@ void callbacks_if::ptw_step_callback(
   [[maybe_unused]] hart::Model &model,
   [[maybe_unused]] int64_t level,
   [[maybe_unused]] sbits pte_addr,
-  [[maybe_unused]] uint64_t pte
+  [[maybe_unused]] uint64_t pte,
+  [[maybe_unused]] bool is_pure_lookup
 ) {
 }
 
 void callbacks_if::ptw_success_callback(
   [[maybe_unused]] hart::Model &model,
   [[maybe_unused]] uint64_t final_ppn,
-  [[maybe_unused]] int64_t level
+  [[maybe_unused]] int64_t level,
+  [[maybe_unused]] bool is_pure_lookup
 ) {
 }
 
@@ -125,7 +128,8 @@ void callbacks_if::ptw_fail_callback(
   [[maybe_unused]] hart::Model &model,
   [[maybe_unused]] hart::zPTW_Error error_type,
   [[maybe_unused]] int64_t level,
-  [[maybe_unused]] sbits pte_addr
+  [[maybe_unused]] sbits pte_addr,
+  [[maybe_unused]] bool is_pure_lookup
 ) {
 }
 

--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -55,14 +55,21 @@ public:
     hart::Model &model,
     uint64_t vpn,
     hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
-    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege,
+    bool is_pure_lookup
   );
 
-  virtual void ptw_step_callback(hart::Model &model, int64_t level, sbits pte_addr, uint64_t pte);
+  virtual void ptw_step_callback(hart::Model &model, int64_t level, sbits pte_addr, uint64_t pte, bool is_pure_lookup);
 
-  virtual void ptw_success_callback(hart::Model &model, uint64_t final_ppn, int64_t level);
+  virtual void ptw_success_callback(hart::Model &model, uint64_t final_ppn, int64_t level, bool is_pure_lookup);
 
-  virtual void ptw_fail_callback(hart::Model &model, hart::zPTW_Error error_type, int64_t level, sbits pte_addr);
+  virtual void ptw_fail_callback(
+    hart::Model &model,
+    hart::zPTW_Error error_type,
+    int64_t level,
+    sbits pte_addr,
+    bool is_pure_lookup
+  );
 
   virtual void tlb_add_callback(
     hart::Model &model,

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -116,9 +116,10 @@ void log_callbacks::ptw_start_callback(
   hart::Model &model,
   uint64_t vpn,
   hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
-  hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+  hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege,
+  bool is_pure_lookup
 ) {
-  if (trace_log != nullptr && config_print_ptw) {
+  if (trace_log != nullptr && config_print_ptw && !is_pure_lookup) {
     sail_string str_ac, str_pr;
     CREATE(sail_string)(&str_ac);
     CREATE(sail_string)(&str_pr);
@@ -130,8 +131,14 @@ void log_callbacks::ptw_start_callback(
   }
 }
 
-void log_callbacks::ptw_step_callback(hart::Model & /*model*/, int64_t level, sbits pte_addr, uint64_t pte) {
-  if (trace_log != nullptr && config_print_ptw) {
+void log_callbacks::ptw_step_callback(
+  hart::Model & /*model*/,
+  int64_t level,
+  sbits pte_addr,
+  uint64_t pte,
+  bool is_pure_lookup
+) {
+  if (trace_log != nullptr && config_print_ptw && !is_pure_lookup) {
     fprintf(
       trace_log,
       "PTW: Step, level=%" PRId64 ", pte=0x%" PRIX64 ", pte_addr=0x%" PRIX64 "\n",
@@ -142,8 +149,13 @@ void log_callbacks::ptw_step_callback(hart::Model & /*model*/, int64_t level, sb
   }
 }
 
-void log_callbacks::ptw_success_callback(hart::Model & /*model*/, uint64_t final_ppn, int64_t level) {
-  if (trace_log != nullptr && config_print_ptw) {
+void log_callbacks::ptw_success_callback(
+  hart::Model & /*model*/,
+  uint64_t final_ppn,
+  int64_t level,
+  bool is_pure_lookup
+) {
+  if (trace_log != nullptr && config_print_ptw && !is_pure_lookup) {
     fprintf(trace_log, "PTW: Success, final_ppn=0x%" PRIx64 ", level=%" PRId64 "\n", final_ppn, level);
   }
 }
@@ -152,9 +164,10 @@ void log_callbacks::ptw_fail_callback(
   hart::Model &model,
   struct hart::zPTW_Error error_type,
   int64_t level,
-  sbits pte_addr
+  sbits pte_addr,
+  bool is_pure_lookup
 ) {
-  if (trace_log != nullptr && config_print_ptw) {
+  if (trace_log != nullptr && config_print_ptw && !is_pure_lookup) {
     sail_string str_et;
     CREATE(sail_string)(&str_et);
     model.zptw_error_to_str(&str_et, error_type);

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -31,15 +31,17 @@ public:
     hart::Model &model,
     uint64_t vpn,
     hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
-    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege,
+    bool is_pure_lookup
   ) override;
-  void ptw_step_callback(hart::Model &model, int64_t level, sbits pte_addr, uint64_t pte) override;
-  void ptw_success_callback(hart::Model &model, uint64_t final_ppn, int64_t level) override;
+  void ptw_step_callback(hart::Model &model, int64_t level, sbits pte_addr, uint64_t pte, bool is_pure_lookup) override;
+  void ptw_success_callback(hart::Model &model, uint64_t final_ppn, int64_t level, bool is_pure_lookup) override;
   void ptw_fail_callback(
     hart::Model &model,
     struct hart::zPTW_Error error_type,
     int64_t level,
-    sbits pte_addr
+    sbits pte_addr,
+    bool is_pure_lookup
   ) override;
   void tlb_add_callback(
     hart::Model &model,

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -154,31 +154,32 @@ unit ModelImpl::instret_callback(unit) {
 unit ModelImpl::ptw_start_callback(
   uint64_t vpn,
   hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
-  hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+  hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege,
+  bool is_pure_lookup
 ) {
   for (auto c : m_callbacks) {
-    c->ptw_start_callback(*this, vpn, access_type, privilege);
+    c->ptw_start_callback(*this, vpn, access_type, privilege, is_pure_lookup);
   }
   return UNIT;
 }
 
-unit ModelImpl::ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte) {
+unit ModelImpl::ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte, bool is_pure_lookup) {
   for (auto c : m_callbacks) {
-    c->ptw_step_callback(*this, level, pte_addr, pte);
+    c->ptw_step_callback(*this, level, pte_addr, pte, is_pure_lookup);
   }
   return UNIT;
 }
 
-unit ModelImpl::ptw_success_callback(uint64_t final_ppn, int64_t level) {
+unit ModelImpl::ptw_success_callback(uint64_t final_ppn, int64_t level, bool is_pure_lookup) {
   for (auto c : m_callbacks) {
-    c->ptw_success_callback(*this, final_ppn, level);
+    c->ptw_success_callback(*this, final_ppn, level, is_pure_lookup);
   }
   return UNIT;
 }
 
-unit ModelImpl::ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sbits pte_addr) {
+unit ModelImpl::ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sbits pte_addr, bool is_pure_lookup) {
   for (auto c : m_callbacks) {
-    c->ptw_fail_callback(*this, error_type, level, pte_addr);
+    c->ptw_fail_callback(*this, error_type, level, pte_addr, is_pure_lookup);
   }
   return UNIT;
 }

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -63,15 +63,17 @@ private:
   unit ptw_start_callback(
     uint64_t vpn,
     hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
-    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege,
+    bool is_pure_lookup
   ) override;
-  unit ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte) override;
-  unit ptw_success_callback(uint64_t final_ppn, int64_t level) override;
-  unit ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sbits pte_addr) override;
+  unit ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte, bool is_pure_lookup) override;
+  unit ptw_success_callback(uint64_t final_ppn, int64_t level, bool is_pure_lookup) override;
+  unit ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sbits pte_addr, bool is_pure_lookup) override;
   unit tlb_add_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, uint64_t index) override;
   unit tlb_flush_begin_callback(unit) override;
   unit tlb_flush_callback(uint64_t index) override;
   unit tlb_flush_end_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb) override;
+
   // Provides entropy for the scalar cryptography extension.
   mach_bits plat_get_16_random_bits(unit) override;
 

--- a/c_emulator/riscv_platform_if.cpp
+++ b/c_emulator/riscv_platform_if.cpp
@@ -92,7 +92,8 @@ unit PlatformInterface::instret_callback(unit) {
 unit PlatformInterface::ptw_start_callback(
   [[maybe_unused]] uint64_t vpn,
   [[maybe_unused]] hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
-  [[maybe_unused]] hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+  [[maybe_unused]] hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege,
+  [[maybe_unused]] bool is_pure_lookup
 ) {
   return UNIT;
 }
@@ -100,17 +101,23 @@ unit PlatformInterface::ptw_start_callback(
 unit PlatformInterface::ptw_step_callback(
   [[maybe_unused]] int64_t level,
   [[maybe_unused]] sbits pte_addr,
-  [[maybe_unused]] uint64_t pte
+  [[maybe_unused]] uint64_t pte,
+  [[maybe_unused]] bool is_pure_lookup
 ) {
   return UNIT;
 }
-unit PlatformInterface::ptw_success_callback([[maybe_unused]] uint64_t final_ppn, [[maybe_unused]] int64_t level) {
+unit PlatformInterface::ptw_success_callback(
+  [[maybe_unused]] uint64_t final_ppn,
+  [[maybe_unused]] int64_t level,
+  [[maybe_unused]] bool is_pure_lookup
+) {
   return UNIT;
 }
 unit PlatformInterface::ptw_fail_callback(
   [[maybe_unused]] hart::zPTW_Error error_type,
   [[maybe_unused]] int64_t level,
-  [[maybe_unused]] sbits pte_addr
+  [[maybe_unused]] sbits pte_addr,
+  [[maybe_unused]] bool is_pure_lookup
 ) {
   return UNIT;
 }

--- a/c_emulator/riscv_platform_if.h
+++ b/c_emulator/riscv_platform_if.h
@@ -56,11 +56,12 @@ public:
   virtual unit ptw_start_callback(
     uint64_t vpn,
     hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
-    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege,
+    bool is_pure_lookup
   );
-  virtual unit ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte);
-  virtual unit ptw_success_callback(uint64_t final_ppn, int64_t level);
-  virtual unit ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sbits pte_addr);
+  virtual unit ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte, bool is_pure_lookup);
+  virtual unit ptw_success_callback(uint64_t final_ppn, int64_t level, bool is_pure_lookup);
+  virtual unit ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sbits pte_addr, bool is_pure_lookup);
 
   virtual unit tlb_add_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, uint64_t index);
   virtual unit tlb_flush_begin_callback(unit);

--- a/model/sys/callbacks.sail
+++ b/model/sys/callbacks.sail
@@ -14,16 +14,16 @@
 // the types (hart::zPrivilege etc.) in a separate header to hart::Model.
 // See https://github.com/rems-project/sail/issues/1560
 
-val ptw_start_callback = pure {cpp: "ptw_start_callback"} : (/* vpn */ bits(64), /* access type */ MemoryAccessType(mem_payload), /* privilege */ (Privilege, unit)) -> unit
+val ptw_start_callback = pure {cpp: "ptw_start_callback"} : (/* vpn */ bits(64), /* access type */ MemoryAccessType(mem_payload), /* privilege */ (Privilege, unit), /* is_pure_lookup */ bool) -> unit
 function ptw_start_callback(_) = ()
 
-val ptw_step_callback = pure {cpp: "ptw_step_callback"} : (/* level */ range(0, 4), /* pte_addr */ physaddrbits, /* pte */ bits(64)) -> unit
+val ptw_step_callback = pure {cpp: "ptw_step_callback"} : (/* level */ range(0, 4), /* pte_addr */ physaddrbits, /* pte */ bits(64), /* is_pure_lookup */ bool) -> unit
 function ptw_step_callback(_) = ()
 
-val ptw_success_callback = pure {cpp: "ptw_success_callback"} : (/* final_ppn */ bits(64), /* level */ range(0, 4)) -> unit
+val ptw_success_callback = pure {cpp: "ptw_success_callback"} : (/* final_ppn */ bits(64), /* level */ range(0, 4), /* is_pure_lookup */ bool) -> unit
 function ptw_success_callback(_) = ()
 
-val ptw_fail_callback = pure {cpp: "ptw_fail_callback"} : (/* error_type */ PTW_Error, /* level */ range(0, 4), /* pte_addr */ physaddrbits) -> unit
+val ptw_fail_callback = pure {cpp: "ptw_fail_callback"} : (/* error_type */ PTW_Error, /* level */ range(0, 4), /* pte_addr */ physaddrbits, /* is_pure_lookup */ bool) -> unit
 function ptw_fail_callback(_) = ()
 
 // Instruction retire callback.  This allows tracking retires without using

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -94,6 +94,7 @@ private val pt_walk : forall 'v, is_sv_mode('v) . (
   ppn_bits('v),                 // Base PPN (`a` in the spec).
   level_range('v),              // Tree level for this recursive call (`i` in the spec).
   bool,                         // global translation,
+  bool,                         // do a pure lookup without side-effects
   ext_ptw                       // ext_ptw
 ) -> PTW_Result('v)
 
@@ -108,9 +109,10 @@ function pt_walk(
   pt_base,
   level,
   global,
+  do_pure_lookup,
   ext_ptw,
 ) = {
-  ptw_start_callback(zero_extend(vpn), access, (priv, ()));
+  ptw_start_callback(zero_extend(vpn), access, (priv, ()), do_pure_lookup);
 
   // Extract the PPN component for this level; 10 bits on Sv32, otherwise 9.
   let 'vpn_i_size = if 'v == 32 then 10 else 9;
@@ -131,18 +133,18 @@ function pt_walk(
   // Read this-level PTE from mem (Step 2 of VATP)
   match read_pte(pte_addr, 2 ^ log_pte_size_bytes) {
     Err(_)  => {
-      ptw_fail_callback(PTW_No_Access(), level, bits_of(pte_addr));
+      ptw_fail_callback(PTW_No_Access(), level, bits_of(pte_addr), do_pure_lookup);
       Err(PTW_No_Access(), ext_ptw)
     },
     Ok(pte) => {
-      ptw_step_callback(level, bits_of(pte_addr), zero_extend(pte));
+      ptw_step_callback(level, bits_of(pte_addr), zero_extend(pte), do_pure_lookup);
 
       let pte_flags = Mk_PTE_Flags(pte[7 .. 0]);
       let pte_ext   = ext_bits_of_PTE(pte);
 
       if pte_is_invalid(pte_flags, pte_ext) then {
         // Step 3 of VATP.
-        ptw_fail_callback(PTW_Invalid_PTE(), level, bits_of(pte_addr));
+        ptw_fail_callback(PTW_Invalid_PTE(), level, bits_of(pte_addr), do_pure_lookup);
         Err(PTW_Invalid_PTE(), ext_ptw)
       }
       else {
@@ -153,10 +155,10 @@ function pt_walk(
           // Non-Leaf PTE
           if level > 0 then
             // follow the pointer to walk next level (i.e., go to Step 2)
-            pt_walk(sv_width, vpn, access, priv, mxr, do_sum, ppn, level - 1, global, ext_ptw)
+            pt_walk(sv_width, vpn, access, priv, mxr, do_sum, ppn, level - 1, global, do_pure_lookup, ext_ptw)
           else {
             // level 0 PTE, but contains a pointer instead of a leaf
-            ptw_fail_callback(PTW_Invalid_PTE(), level, bits_of(pte_addr));
+            ptw_fail_callback(PTW_Invalid_PTE(), level, bits_of(pte_addr), do_pure_lookup);
             Err(PTW_Invalid_PTE(), ext_ptw)
           }
         } else {
@@ -167,14 +169,14 @@ function pt_walk(
             let low_bits = ppn_size_bits * level;
             if   ppn[low_bits - 1 .. 0] != zeros()
             then {
-              ptw_fail_callback(PTW_Misaligned(), level, bits_of(pte_addr));
+              ptw_fail_callback(PTW_Misaligned(), level, bits_of(pte_addr), do_pure_lookup);
               return Err(PTW_Misaligned(), ext_ptw);
             };
           };
           // Steps 6, 7 and 8 of VATP.
           match check_PTE_permission(access, priv, mxr, do_sum, pte_flags, pte_ext, ext_ptw) {
             PTE_Check_Failure(ext_ptw, pte_failure) => {
-              ptw_fail_callback(ext_get_ptw_error(pte_failure), level, bits_of(pte_addr));
+              ptw_fail_callback(ext_get_ptw_error(pte_failure), level, bits_of(pte_addr), do_pure_lookup);
               Err(ext_get_ptw_error(pte_failure), ext_ptw)
             },
             PTE_Check_Success(ext_ptw) => {
@@ -199,7 +201,7 @@ function pt_walk(
 
               let pbmt = if menvcfg[PBMTE] == 0b0 then PBMT_PMA else page_based_mem_type(pte_ext[PBMT]);
 
-              ptw_success_callback(zero_extend(ppn), level);
+              ptw_success_callback(zero_extend(ppn), level, do_pure_lookup);
 
               Ok(struct {ppn=ppn, pte=pte, pteAddr=pte_addr, level=level, pbmt=pbmt, global=global}, ext_ptw)
             }
@@ -210,7 +212,7 @@ function pt_walk(
   }
 }
 
-termination_measure pt_walk(_,_,_,_,_,_,_,level,_, _) = level
+termination_measure pt_walk(_,_,_,_,_,_,_,level,_, _, _) = level
 
 // ****************************************************************
 // Architectural SATP CSR
@@ -276,16 +278,17 @@ type TR_Result('paddr : Type, 'failure : Type) = result(('paddr, page_based_mem_
 // part of RISC-V architecture spec (see TLB NOTE above).
 // Translate on TLB hit, and maintenance of PTE in TLB
 private function translate_TLB_hit forall 'v, is_sv_mode('v) . (
-  sv_width  : int('v),
-  _asid     : asidbits,
-  vpn       : vpn_bits('v),
-  access    : MemoryAccessType(mem_payload),
-  priv      : Privilege,
-  mxr       : bool,
-  do_sum    : bool,
-  ext_ptw   : ext_ptw,
-  tlb_index : tlb_index_range,
-  ent       : TLB_Entry,
+  sv_width       : int('v),
+  _asid          : asidbits,
+  vpn            : vpn_bits('v),
+  access         : MemoryAccessType(mem_payload),
+  priv           : Privilege,
+  mxr            : bool,
+  do_sum         : bool,
+  do_pure_lookup : bool,
+  ext_ptw        : ext_ptw,
+  tlb_index      : tlb_index_range,
+  ent            : TLB_Entry,
 ) -> TR_Result(ppn_bits('v), PTW_Error) = {
 
   let pte_size  = if sv_width == 32 then 4 else 8;
@@ -298,7 +301,9 @@ private function translate_TLB_hit forall 'v, is_sv_mode('v) . (
   match pte_check {
     PTE_Check_Failure(ext_ptw, pte_failure) =>
       Err(ext_get_ptw_error(pte_failure), ext_ptw),
-    PTE_Check_Success(ext_ptw) =>
+    PTE_Check_Success(ext_ptw) => {
+      if do_pure_lookup then return Ok(tlb_get_ppn(sv_width, ent, vpn), tlb_get_pbmt(ent), ext_ptw);
+
       // Step 9 of VATP.
       match update_and_write_pte(ent.pteAddr, pte_size, pte, access) {
         Ok(Some(pte)) => {
@@ -309,31 +314,35 @@ private function translate_TLB_hit forall 'v, is_sv_mode('v) . (
         Ok(None()) => Ok(tlb_get_ppn(sv_width, ent, vpn), tlb_get_pbmt(ent), ext_ptw),
         Err(PTW_PTE_Needs_Update()) => Err(PTW_PTE_Needs_Update(), ext_ptw),
         Err(e) => Err(e, ext_ptw),
-      },
+      }
+    },
   }
 }
 
 // Translate on TLB miss (do a page-table walk)
 private function translate_TLB_miss forall 'v, is_sv_mode('v) . (
-  sv_width : int('v),
-  asid     : asidbits,
-  base_ppn : ppn_bits('v),
-  vpn      : vpn_bits('v),
-  access   : MemoryAccessType(mem_payload),
-  priv     : Privilege,
-  mxr      : bool,
-  do_sum   : bool,
-  ext_ptw  : ext_ptw,
+  sv_width       : int('v),
+  asid           : asidbits,
+  base_ppn       : ppn_bits('v),
+  vpn            : vpn_bits('v),
+  access         : MemoryAccessType(mem_payload),
+  priv           : Privilege,
+  mxr            : bool,
+  do_sum         : bool,
+  do_pure_lookup : bool,
+  ext_ptw        : ext_ptw,
 ) -> TR_Result(ppn_bits('v), PTW_Error) = {
   let initial_level = if 'v == 32 then 1 else (if 'v == 39 then 2 else (if 'v == 48 then 3 else 4));
 
   // Step 2 of VATP occurs in pt_walk().
   let 'pte_size = if sv_width == 32 then 4 else 8;
   let ptw_result = pt_walk(sv_width, vpn, access, priv, mxr, do_sum,
-                           base_ppn, initial_level, false, ext_ptw);
+                           base_ppn, initial_level, false, do_pure_lookup, ext_ptw);
   match ptw_result {
     Err(f, ext_ptw) => Err(f, ext_ptw),
     Ok(struct {ppn, pte, pteAddr, level, pbmt, global}, ext_ptw) => {
+      if do_pure_lookup then return Ok(ppn, pbmt, ext_ptw);
+
       let ext_pte = ext_bits_of_PTE(pte);
 
       // Step 9 of VATP.
@@ -365,23 +374,24 @@ mapping satp_mode_width : SATPMode <-> {32, 39, 48, 57} = {
 }
 
 private function translate forall 'v, is_sv_mode('v) . (
-  sv_width : int('v),
-  asid     : asidbits,
-  base_ppn : ppn_bits('v),
-  vpn      : vpn_bits('v),
-  access   : MemoryAccessType(mem_payload),
-  priv     : Privilege,
-  mxr      : bool,
-  do_sum   : bool,
-  ext_ptw  : ext_ptw,
+  sv_width       : int('v),
+  asid           : asidbits,
+  base_ppn       : ppn_bits('v),
+  vpn            : vpn_bits('v),
+  access         : MemoryAccessType(mem_payload),
+  priv           : Privilege,
+  mxr            : bool,
+  do_sum         : bool,
+  do_pure_lookup : bool,
+  ext_ptw        : ext_ptw,
 ) -> TR_Result(ppn_bits('v), PTW_Error) = {
   // On first reading, assume lookup_TLB returns None(), since TLBs
   // are not part of RISC-V archticture spec (see TLB NOTE above)
   match lookup_TLB(sv_width, asid, vpn) {
     Some(index, ent) => translate_TLB_hit(sv_width, asid, vpn, access, priv,
-                                          mxr, do_sum, ext_ptw, index, ent),
+                                          mxr, do_sum, do_pure_lookup, ext_ptw, index, ent),
     None()           => translate_TLB_miss(sv_width, asid, base_ppn, vpn, access, priv,
-                                           mxr, do_sum, ext_ptw),
+                                           mxr, do_sum, do_pure_lookup, ext_ptw),
   }
 }
 
@@ -396,12 +406,13 @@ private function get_satp forall 'v, is_sv_mode('v). (
   if sv_width == 32 then satp[31 .. 0] else satp
 }
 
-// Top-level addr-translation function
-// PUBLIC: invoked from instr-fetch, atomics and CBOs
-// [postlude/fetch.sail, A/zaamo_insts.sail, Zicbo{zm}/zicbo{zm}_insts.sail].
-function translateAddr(
+// addr-translation implementation. In addition to implementing normal
+// address translation (do_pure_lookup=false), it can also be used to
+// lookup the physical address without any side-effects (do_pure_lookup=true).
+private function translateAddr_impl(
   vAddr : virtaddr,
   access : MemoryAccessType(mem_payload),
+  do_pure_lookup : bool,
 ) -> TR_Result(physaddr, ExceptionType) = {
 
   // Effective privilege takes into account mstatus.PRV, mstatus.MPP
@@ -446,6 +457,7 @@ function translateAddr(
                         base_ppn,
                         svAddr[sv_width - 1 .. pagesize_bits],
                         access, effPriv, mxr, do_sum,
+                        do_pure_lookup,
                         init_ext_ptw);
     // Fixup result PA or exception
     match res {
@@ -463,6 +475,23 @@ function translateAddr(
     }
   }
 }
+
+// Top-level addr-translation function
+// PUBLIC: invoked from instr-fetch, atomics and CBOs
+// [postlude/fetch.sail, A/zaamo_insts.sail, Zicbo{zm}/zicbo{zm}_insts.sail].
+function translateAddr(
+  vAddr : virtaddr,
+  access : MemoryAccessType(mem_payload),
+) -> TR_Result(physaddr, ExceptionType) =
+  translateAddr_impl(vAddr, access, false)
+
+// Top-level address lookup function.  This does not perform _any_ side-effects
+// (updating A/D bits or modifying the TLB).
+function lookupAddr(
+  vAddr : virtaddr,
+  access : MemoryAccessType(mem_payload),
+) -> TR_Result(physaddr, ExceptionType) =
+  translateAddr_impl(vAddr, access, true)
 
 // ****************************************************************
 // Initialize Virtual Memory state


### PR DESCRIPTION
A pure lookup enables the translation of virtual addresses to physical addresses without any side-effects (e.g. PTE writes, TLB updates).  This is sometimes needed to handle misalignment e.g. to lookup the MAG PMA for a virtual address, or check whether a misaligned atomic could complete except for the misalignment (for software emulation).  This can also be useful for Ziccif when ILEN is increased to 48 or higher.

To make the Sail code cleaner, the C++ PTW callbacks are passed a parameter to indicate whether they are being called for such a lookup.  This is currently used to suppress PTW trace logging in this case.

C++ callbacks for PTE reads during a lookup are still called. These should be bracketed by the PTW callbacks, so they could in theory be handled correctly.  But the logging callbacks currently don't handle this.