### PR TITLE
Add explicit main/IO memory PMA

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -138,6 +138,7 @@
           "value": "0x1000"
         },
         "attributes": {
+          "mem_type" : "IOMemory",
           "cacheable": true,
           "coherent": false,
           "executable": false,
@@ -165,6 +166,7 @@
           "value": "0x2000000"
         },
         "attributes": {
+          "mem_type": "IOMemory",
           "cacheable": false,
           "coherent": true,
           "executable": false,
@@ -192,6 +194,7 @@
           "value": "0x80000000"
         },
         "attributes": {
+          "mem_type": "MainMemory",
           "cacheable": true,
           "coherent": true,
           "executable": true,

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -258,7 +258,7 @@ private function check_pma_regions(regions : list(PMA_Region), prev_base : bits(
         return false;
       };
       let attributes = region.attributes;
-      if pma_is_main_memory(attributes) & attributes.cacheable & attributes.coherent then {
+      if memory_region_type(attributes) == MainMemory & attributes.cacheable & attributes.coherent then {
         if check_opts.ziccamoa & attributes.atomic_support < AMOArithmetic then {
           print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^ atomic_support_str(attributes.atomic_support) ^ " atomicity support, but Ziccamoa is enabled which requires AMOArithmetic support.");
           return false;

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -235,6 +235,21 @@ private function check_vext_config() -> bool = {
   valid;
 }
 
+private function check_pma_region(region : PMA_Region) -> bool = {
+  let pma = region.attributes;
+  // TODO: this could be extended, e.g. to check that read_idempotent => readable, etc.
+  match pma.mem_type {
+    MainMemory =>
+      if not(pma.readable & pma.writable & pma.read_idempotent & pma.write_idempotent) then {
+        print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is marked as MainMemory but is not readable, read-idempotent, writable, and write-idempotent.");
+        return false;
+      },
+    IOMemory =>
+      (),
+  };
+  true
+}
+
 private struct pma_check_opts = {
   ziccamoa : bool,
   ziccamoc : bool,
@@ -257,8 +272,11 @@ private function check_pma_regions(regions : list(PMA_Region), prev_base : bits(
                       bits_str(prev_base) ^ " and ending at " ^ bits_str(prev_base + prev_size) ^ ".");
         return false;
       };
+
+      if not(check_pma_region(region)) then return false;
+
       let attributes = region.attributes;
-      if memory_region_type(attributes) == MainMemory & attributes.cacheable & attributes.coherent then {
+      if attributes.mem_type == MainMemory & attributes.cacheable & attributes.coherent then {
         if check_opts.ziccamoa & attributes.atomic_support < AMOArithmetic then {
           print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^ atomic_support_str(attributes.atomic_support) ^ " atomicity support, but Ziccamoa is enabled which requires AMOArithmetic support.");
           return false;

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -244,48 +244,48 @@ private struct pma_check_opts = {
 }
 
 // Return true if a list of PMA regions are sorted and don't overlap, and the specified extension checks are satisfied.
-private function check_pma_regions(pmas : list(PMA_Region), prev_base : bits(64), prev_size : bits(64), check_opts : pma_check_opts, found_valid_svadu_pma : bool) -> bool =
-  match pmas {
+private function check_pma_regions(regions : list(PMA_Region), prev_base : bits(64), prev_size : bits(64), check_opts : pma_check_opts, found_valid_svadu_pma : bool) -> bool =
+  match regions {
     [||] => if check_opts.svadu & not(found_valid_svadu_pma) then {
         print_endline("The Svadu extension is enabled but no memory region supports hardware page-table writes: Svadu requires at least one region provide this support.");
         false
       } else true,
-    pma :: rest => {
-      if pma.base <_u prev_base + prev_size then {
-        print_endline("Memory region starting at " ^ bits_str(pma.base) ^
+    region :: rest => {
+      if region.base <_u prev_base + prev_size then {
+        print_endline("Memory region starting at " ^ bits_str(region.base) ^
                       " is not above the end of the previous region starting at " ^
                       bits_str(prev_base) ^ " and ending at " ^ bits_str(prev_base + prev_size) ^ ".");
         return false;
       };
-      let attributes = pma.attributes;
-      if attributes.cacheable & attributes.coherent then {
+      let attributes = region.attributes;
+      if pma_is_main_memory(attributes) & attributes.cacheable & attributes.coherent then {
         if check_opts.ziccamoa & attributes.atomic_support < AMOArithmetic then {
-          print_endline("Memory region starting at " ^ bits_str(pma.base) ^ " is coherent and cacheable with " ^ atomic_support_str(attributes.atomic_support) ^ " atomicity support, but Ziccamoa is enabled which requires AMOArithmetic support.");
+          print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^ atomic_support_str(attributes.atomic_support) ^ " atomicity support, but Ziccamoa is enabled which requires AMOArithmetic support.");
           return false;
         };
         if check_opts.ziccamoc & attributes.atomic_support != AMOCASQ then {
-          print_endline("Memory region starting at " ^ bits_str(pma.base) ^ " is coherent and cacheable with " ^ atomic_support_str(attributes.atomic_support) ^ " atomicity support, but Ziccamoc is enabled which requires AMOCASQ support.");
+          print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^ atomic_support_str(attributes.atomic_support) ^ " atomicity support, but Ziccamoc is enabled which requires AMOCASQ support.");
           return false;
         };
         if check_opts.ziccrse & attributes.reservability != RsrvEventual then {
-          print_endline("Memory region starting at " ^ bits_str(pma.base) ^ " is coherent and cacheable with " ^ reservability_str(attributes.reservability) ^ " reservability support, but Ziccrse is enabled which requires RsrvEventual support.");
+          print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^ reservability_str(attributes.reservability) ^ " reservability support, but Ziccrse is enabled which requires RsrvEventual support.");
           return false;
         };
         if check_opts.ssccptr & not(attributes.supports_pte_read) then {
-          print_endline("Memory region starting at " ^ bits_str(pma.base) ^ " is coherent and cacheable without hardware page-table read support, but Ssccptr is enabled which requires this support.");
+          print_endline("Memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable without hardware page-table read support, but Ssccptr is enabled which requires this support.");
           return false;
         };
       };
 
       let found_valid_svadu_pma = found_valid_svadu_pma | (attributes.supports_pte_write & attributes.reservability == RsrvEventual);
 
-      check_pma_regions(rest, pma.base, pma.size, check_opts, found_valid_svadu_pma)
+      check_pma_regions(rest, region.base, region.size, check_opts, found_valid_svadu_pma)
     },
   }
 
 // Return true iff [addr, addr+size) is fully contained in a single configured PMA memory region.
-function dtb_within_configured_pma_memory(addr : bits(64), size : bits(64)) -> bool =
-  is_some(matching_pma_bits_range(pma_regions, addr, size))
+private function dtb_within_configured_pma_memory(addr : bits(64), size : bits(64)) -> bool =
+  is_some(matching_pma_region_bits_range(pma_regions, addr, size))
 
 // Check that all memory regions are sorted and don't overlap, and that PMAs are compatible with enabled extensions.
 private function check_mem_layout() -> bool =

--- a/model/sys/mem.sail
+++ b/model/sys/mem.sail
@@ -80,7 +80,7 @@ private function pmaCheck forall 'n, 0 < 'n <= max_mem_access .
   pbmt       : page_based_mem_type,
   res_or_con : bool,
 )  -> option(ExceptionType) = {
-  match matching_pma(pma_regions, paddr, width) {
+  match matching_pma_region(pma_regions, paddr, width) {
     None() => {
       Some(accessFaultFromAccessType(access))
     },

--- a/model/sys/pma.sail
+++ b/model/sys/pma.sail
@@ -84,6 +84,8 @@ mapping misaligned_fault_str : misaligned_fault <-> string = {
 }
 overload to_str = {misaligned_fault_str}
 
+enum MemoryRegionType = { MainMemory, IOMemory }
+
 // Physical Memory Attributes for a region.
 struct PMA = {
   // These have no effect on the model currently but they are affected
@@ -114,9 +116,14 @@ struct PMA = {
   // TODO: Memory Ordering PMA
 }
 
-// TODO: Add Memory Ordering
-function pma_is_main_memory(attributes : PMA) -> bool =
-  attributes.readable & attributes.read_idempotent & attributes.writable & attributes.write_idempotent
+// Technically you can have a region that satisfies these properties
+// but is still declared as IOMemory but we don't support that yet.
+// TODO: We should add an explicit memory type PMA rather than inferring this.
+// TODO: Consider memory ordering if that PMA is added.
+function memory_region_type(pma : PMA) -> MemoryRegionType =
+  if pma.readable & pma.writable & pma.read_idempotent & pma.write_idempotent
+  then MainMemory
+  else IOMemory
 
 // A PMA can be overridden by page-based memory types.
 // TODO: specify alignment for IO regions.

--- a/model/sys/pma.sail
+++ b/model/sys/pma.sail
@@ -114,6 +114,10 @@ struct PMA = {
   // TODO: Memory Ordering PMA
 }
 
+// TODO: Add Memory Ordering
+function pma_is_main_memory(attributes : PMA) -> bool =
+  attributes.readable & attributes.read_idempotent & attributes.writable & attributes.write_idempotent
+
 // A PMA can be overridden by page-based memory types.
 // TODO: specify alignment for IO regions.
 function override_PMA(pma : PMA, pbmt : page_based_mem_type) -> PMA =
@@ -143,21 +147,21 @@ struct PMA_Region = {
 }
 
 // Get the first PMA region that fully contains a given [base, base+size) range.
-function matching_pma_bits_range(pmas : list(PMA_Region), base : bits(64), size : bits(64)) -> option(PMA_Region) = {
-  match pmas {
+function matching_pma_region_bits_range(regions : list(PMA_Region), base : bits(64), size : bits(64)) -> option(PMA_Region) = {
+  match regions {
     [||] => None(),
-    pma :: rest => {
-      if range_subset(base, size, pma.base, pma.size)
-      then Some(pma)
-      else matching_pma_bits_range(rest, base, size)
+    region :: rest => {
+      if range_subset(base, size, region.base, region.size)
+      then Some(region)
+      else matching_pma_region_bits_range(rest, base, size)
     }
   }
 }
 
-// Get the first PMA that matches a given address range.
-// Delegate to matching_pma_bits_range to avoid duplicating the range logic.
-function matching_pma(pmas : list(PMA_Region), addr : physaddr, width : mem_access_width) -> option(PMA_Region) = {
-  matching_pma_bits_range(pmas, zero_extend(bits_of(addr)), to_bits(width))
+// Get the first PMA region that matches a given address range.
+// Delegate to matching_pma_region_bits_range to avoid duplicating the range logic.
+function matching_pma_region(regions : list(PMA_Region), addr : physaddr, width : mem_access_width) -> option(PMA_Region) = {
+  matching_pma_region_bits_range(regions, zero_extend(bits_of(addr)), to_bits(width))
 }
 
 function pma_attributes_to_str(attr : PMA) -> string =

--- a/model/sys/pma.sail
+++ b/model/sys/pma.sail
@@ -88,6 +88,7 @@ enum MemoryRegionType = { MainMemory, IOMemory }
 
 // Physical Memory Attributes for a region.
 struct PMA = {
+  mem_type         : MemoryRegionType,
   // These have no effect on the model currently but they are affected
   // by PBMT so they need to be here if the resulting PMA is verified.
   cacheable        : bool,
@@ -116,26 +117,19 @@ struct PMA = {
   // TODO: Memory Ordering PMA
 }
 
-// Technically you can have a region that satisfies these properties
-// but is still declared as IOMemory but we don't support that yet.
-// TODO: We should add an explicit memory type PMA rather than inferring this.
-// TODO: Consider memory ordering if that PMA is added.
-function memory_region_type(pma : PMA) -> MemoryRegionType =
-  if pma.readable & pma.writable & pma.read_idempotent & pma.write_idempotent
-  then MainMemory
-  else IOMemory
-
 // A PMA can be overridden by page-based memory types.
 // TODO: specify alignment for IO regions.
 function override_PMA(pma : PMA, pbmt : page_based_mem_type) -> PMA =
   match pbmt {
     PBMT_PMA => pma,
     // TODO: return a weakly-ordered PMA
-    PBMT_NC  => {pma with cacheable = false,
+    PBMT_NC  => {pma with mem_type = MainMemory,
+                          cacheable = false,
                           read_idempotent = true,
                           write_idempotent = true},
     // TODO: return a strongly ordered PMA
-    PBMT_IO  => {pma with cacheable = false,
+    PBMT_IO  => {pma with mem_type = IOMemory,
+                          cacheable = false,
                           read_idempotent = false,
                           write_idempotent = false},
   }
@@ -172,6 +166,7 @@ function matching_pma_region(regions : list(PMA_Region), addr : physaddr, width 
 }
 
 function pma_attributes_to_str(attr : PMA) -> string =
+  (match attr.mem_type { MainMemory => " main-memory", IOMemory => " io-memory", }) ^
   (if attr.cacheable then " cacheable" else "") ^
   (if attr.coherent then " coherent" else "") ^
   (if attr.executable then " executable" else "") ^


### PR DESCRIPTION
Add a memory type attribute to distinguish main memory and IO memory. The other attributes are checked for consistency with the memory type. It is also used for PBMT.

Also fix some confusing variable naming that conflated 'PMA' with 'PMA_Region'.