### PR TITLE
`hpmcounter{3-31}` do not depend on U

### DIFF
--- a/model/extensions/Zihpm/zihpm.sail
+++ b/model/extensions/Zihpm/zihpm.sail
@@ -251,8 +251,8 @@ function clause write_CSR((0b1011100 /* 0xB80 */ @ index : bits(5), value) if xl
 }
 
 // Hardware Performance Monitoring user mode counters
-function clause is_CSR_accessible((0b1100000 /* 0xC00 */ @ index : bits(5), priv, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & currentlyEnabled(Ext_U) & counter_enabled(unsigned(index), priv) // hpmcounter3..31
-function clause is_CSR_accessible((0b1100100 /* 0xC80 */ @ index : bits(5), priv, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & currentlyEnabled(Ext_U) & xlen == 32 & counter_enabled(unsigned(index), priv) // hpmcounterh3..31
+function clause is_CSR_accessible((0b1100000 /* 0xC00 */ @ index : bits(5), priv, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & counter_enabled(unsigned(index), priv) // hpmcounter3..31
+function clause is_CSR_accessible((0b1100100 /* 0xC80 */ @ index : bits(5), priv, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) & xlen == 32 & counter_enabled(unsigned(index), priv) // hpmcounterh3..31
 
 function clause read_CSR(0b1100000 /* 0xC00 */ @ index : bits(5) if unsigned(index) >= 3) = read_mhpmcounter(hpmidx_from_bits(index))
 function clause read_CSR(0b1100100 /* 0xC80 */ @ index : bits(5) if xlen == 32 & unsigned(index) >= 3) = read_mhpmcounterh(hpmidx_from_bits(index))


### PR DESCRIPTION
The `hpmcounter{3-31}` CSRs are unprivileged CSRs that should be available from any priv mode (contigent on `mcounteren`). They do not require User mode to be implemented. This updates them to match the behavior of `cycle`/`time`/`instret`.

From the spec:
> The Zihpm extension comprises up to 29 additional unprivileged 64-bit hardware performance counters, hpmcounter3-hpmcounter31. When XLEN=32, the upper 32 bits of these performance counters are accessible via additional CSRs hpmcounter3h- hpmcounter31h. The Zihpm extension depends on the Zicsr extension.

Discovered using ACT4 tests.