### PR TITLE
Speed up PMP checks

### DIFF
--- a/model/pmp/pmp_control.sail
+++ b/model/pmp/pmp_control.sail
@@ -118,6 +118,11 @@ function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
 
   if sys_pmp_count == 0 then return None();
 
+  if pmp_active_count == 0 then return (
+    if priv == Machine then None()
+    else Some(accessFaultFromAccessType(access))
+  );
+
   let width : xlenbits = to_bits(width);
 
   // TODO for accesses of type CacheAccess:
@@ -128,11 +133,12 @@ function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
   // block, and if write permission is granted by the PMP access
   // control bits, read permission shall also be granted."
 
+  var prev_pmpaddr : xlenbits = zeros();
   foreach (i from 0 to sys_pmp_count - 1) {
-    let prev_pmpaddr = if i > 0 then pmpReadAddrReg(i - 1) else zeros();
+    let cur_pmpaddr = pmpaddr_n_eff[i];
     let cfg = pmpcfg_n[i];
 
-    match pmpMatchAddr(addr, width, cfg, pmpReadAddrReg(i), prev_pmpaddr) {
+    match pmpMatchAddr(addr, width, cfg, cur_pmpaddr, prev_pmpaddr) {
       PMP_NoMatch      => (),
       PMP_PartialMatch => return Some(accessFaultFromAccessType(access)),
       PMP_Match        => return (
@@ -141,6 +147,7 @@ function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
         else Some(accessFaultFromAccessType(access))
       ),
     };
+    prev_pmpaddr = cur_pmpaddr
   };
   if priv == Machine then None() else Some(accessFaultFromAccessType(access))
 }
@@ -149,6 +156,8 @@ function reset_pmp() -> unit = {
   foreach (i from 0 to 63) {
     // On reset the PMP register's A and L bits are set to 0 unless the platform
     // mandates a different value.
-    pmpcfg_n[i] = [pmpcfg_n[i] with A = pmpAddrMatchType_encdec(OFF), L = 0b0];
+    pmpcfg_n[i]     = [pmpcfg_n[i] with A = pmpAddrMatchType_encdec(OFF), L = 0b0];
+    pmpaddr_n_eff[i] = zeros();
   };
+  pmp_active_count = 0
 }

--- a/model/pmp/pmp_control.sail
+++ b/model/pmp/pmp_control.sail
@@ -134,7 +134,7 @@ function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
   // control bits, read permission shall also be granted."
 
   var prev_pmpaddr : xlenbits = zeros();
-  foreach (i from 0 to sys_pmp_count - 1) {
+  foreach (i from 0 to sys_pmp_usable_count - 1) {
     let cur_pmpaddr = pmpaddr_n_eff[i];
     let cfg = pmpcfg_n[i];
 
@@ -156,7 +156,7 @@ function reset_pmp() -> unit = {
   foreach (i from 0 to 63) {
     // On reset the PMP register's A and L bits are set to 0 unless the platform
     // mandates a different value.
-    pmpcfg_n[i]     = [pmpcfg_n[i] with A = pmpAddrMatchType_encdec(OFF), L = 0b0];
+    pmpcfg_n[i] = [pmpcfg_n[i] with A = pmpAddrMatchType_encdec(OFF), L = 0b0];
     pmpaddr_n_eff[i] = zeros();
   };
   pmp_active_count = 0

--- a/model/pmp/pmp_regs.sail
+++ b/model/pmp/pmp_regs.sail
@@ -20,6 +20,9 @@ let sys_pmp_usable_count : range(0, 64) = config memory.pmp.usable_count
 // G=0 -> 4 bytes, G=10 -> 4096 bytes.
 let sys_pmp_grain : range(0, 63) = config memory.pmp.grain
 
+// Number of active PMP entries
+register pmp_active_count : nat
+
 // PMP configuration entries
 
 private enum PmpAddrMatchType = {OFF, TOR, NA4, NAPOT}
@@ -43,6 +46,8 @@ bitfield Pmpcfg_ent : bits(8) = {
 
 register pmpcfg_n : vector(64, Pmpcfg_ent)
 register pmpaddr_n : vector(64, xlenbits)
+// Cached effective PMP addresses
+register pmpaddr_n_eff : vector(64, xlenbits)
 
 // Packing and unpacking pmpcfg regs for xlen-width accesses
 
@@ -87,6 +92,17 @@ private function pmpReadAddrReg(n : range(0, 63)) -> xlenbits = {
 
     _ => addr,
   }
+}
+
+// Update cached PMP effective addresses and active entry count (after CSR writes)
+private function pmpUpdateCache() -> unit = {
+  pmp_active_count = 0;
+  foreach (i from 0 to sys_pmp_count - 1) {
+    pmpaddr_n_eff[i] = pmpReadAddrReg(i);
+    if pmpAddrMatchType_encdec(pmpcfg_n[i][A]) != OFF then {
+      pmp_active_count = pmp_active_count + 1;
+    }
+  };
 }
 
 // Helpers to handle locked entries
@@ -138,7 +154,7 @@ private function pmpWriteCfgReg(n : range(0, 15), v : xlenbits) -> unit = {
     foreach (i from 0 to 3) {
       let idx = n*4 + i;
       if idx < sys_pmp_usable_count then
-        pmpcfg_n[idx]  = pmpWriteCfg(pmpcfg_n[idx],  v[8*i+7 .. 8*i]);
+        pmpcfg_n[idx] = pmpWriteCfg(pmpcfg_n[idx], v[8*i+7 .. 8*i]);
     }
   }
   else {
@@ -146,9 +162,10 @@ private function pmpWriteCfgReg(n : range(0, 15), v : xlenbits) -> unit = {
     foreach (i from 0 to 7) {
       let idx = n*4 + i;
       if idx < sys_pmp_usable_count then
-        pmpcfg_n[idx]  = pmpWriteCfg(pmpcfg_n[idx],  v[8*i+7 .. 8*i]);
+        pmpcfg_n[idx] = pmpWriteCfg(pmpcfg_n[idx], v[8*i+7 .. 8*i]);
     }
-  }
+  };
+  pmpUpdateCache()
 }
 
 private function pmpWriteAddr(locked: bool, tor_locked: bool, reg: xlenbits, v: xlenbits) -> xlenbits =
@@ -164,6 +181,7 @@ private function pmpWriteAddrReg(n : range(0, 63), v : xlenbits) -> unit = {
       pmpaddr_n[n],
       v,
     );
+  pmpUpdateCache()
 }
 
 // PMP CSRs


### PR DESCRIPTION
Speed up PMP checks by caching effective addresses and skipping check when no entries active.

pmpReadAddrReg() was being called on every memory access to compute the effective address, despite PMP registers almost never changing at runtime. This adds two optimizations:

1. Precompute and cache the effective address for each PMP entry on every CSR write

2. Track the number of active entries and fast-exit pmpCheck when none are configured

Measured 7-9% overall KIPS improvement on a Linux boot workload.