### PR TITLE
Add --trace-tlb trace flag for TLB tracing

### DIFF
--- a/c_emulator/riscv_callbacks_if.cpp
+++ b/c_emulator/riscv_callbacks_if.cpp
@@ -122,3 +122,17 @@ void callbacks_if::ptw_fail_callback(
   [[maybe_unused]] sbits pte_addr
 ) {
 }
+
+void callbacks_if::tlb_add_callback(
+  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
+  [[maybe_unused]] int64_t index
+) {
+}
+
+void callbacks_if::tlb_flush_callback(
+  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
+  [[maybe_unused]] int64_t index
+) {
+}

--- a/c_emulator/riscv_callbacks_if.cpp
+++ b/c_emulator/riscv_callbacks_if.cpp
@@ -126,13 +126,18 @@ void callbacks_if::ptw_fail_callback(
 void callbacks_if::tlb_add_callback(
   [[maybe_unused]] hart::Model &model,
   [[maybe_unused]] hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
-  [[maybe_unused]] int64_t index
+  [[maybe_unused]] uint64_t index
 ) {
 }
 
-void callbacks_if::tlb_flush_callback(
+void callbacks_if::tlb_flush_begin_callback([[maybe_unused]] hart::Model &model) {
+}
+
+void callbacks_if::tlb_flush_callback([[maybe_unused]] hart::Model &model, [[maybe_unused]] uint64_t index) {
+}
+
+void callbacks_if::tlb_flush_end_callback(
   [[maybe_unused]] hart::Model &model,
-  [[maybe_unused]] hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
-  [[maybe_unused]] int64_t index
+  [[maybe_unused]] hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb
 ) {
 }

--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -63,12 +63,12 @@ public:
   virtual void tlb_add_callback(
     hart::Model &model,
     hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
-    int64_t index
+    uint64_t index
   );
 
-  virtual void tlb_flush_callback(
-    hart::Model &model,
-    hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
-    int64_t index
-  );
+  virtual void tlb_flush_begin_callback(hart::Model &model);
+
+  virtual void tlb_flush_callback(hart::Model &model, uint64_t index);
+
+  virtual void tlb_flush_end_callback(hart::Model &model, hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb);
 };

--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -9,7 +9,7 @@ class Model;
 struct zMemoryAccessTypezIEmem_payloadz5zK;
 struct ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9;
 struct zPTW_Error;
-
+struct zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9;
 } // namespace hart
 
 class callbacks_if {
@@ -59,4 +59,16 @@ public:
   virtual void ptw_success_callback(hart::Model &model, uint64_t final_ppn, int64_t level);
 
   virtual void ptw_fail_callback(hart::Model &model, hart::zPTW_Error error_type, int64_t level, sbits pte_addr);
+
+  virtual void tlb_add_callback(
+    hart::Model &model,
+    hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
+    int64_t index
+  );
+
+  virtual void tlb_flush_callback(
+    hart::Model &model,
+    hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
+    int64_t index
+  );
 };

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -192,8 +192,8 @@ static void print_tlb(
     tlb.len
   );
   for (size_t i = 0; i < tlb.len; i++) {
-    bool is_marked = std::find(indices.begin(), indices.end(), i) != indices.end();
-    const char *annotation = is_marked ? (is_flush ? "  <- x flushed" : "  <- + added") : "";
+    bool is_entry_selected = std::find(indices.begin(), indices.end(), i) != indices.end();
+    const char *annotation = is_entry_selected ? (is_flush ? "  <- flushed" : "  <- added") : "";
 
     const auto &entry = tlb.data[i];
     if (entry.kind == hart::Kind_zSomezIRTLB_EntryzK) {

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -1,6 +1,8 @@
 #include "riscv_callbacks_log.h"
 #include "sail_riscv_model.h"
+#include <algorithm>
 #include <inttypes.h>
+#include <vector>
 
 log_callbacks::log_callbacks(
   bool config_print_gpr,
@@ -171,7 +173,7 @@ static void print_tlb(
   FILE *trace_log,
   hart::Model &model,
   hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
-  int64_t index,
+  const std::vector<uint64_t> &indices,
   bool is_flush
 ) {
   fprintf(
@@ -190,6 +192,9 @@ static void print_tlb(
     tlb.len
   );
   for (size_t i = 0; i < tlb.len; i++) {
+    bool is_marked = std::find(indices.begin(), indices.end(), i) != indices.end();
+    const char *annotation = is_marked ? (is_flush ? "  <- x flushed" : "  <- + added") : "";
+
     const auto &entry = tlb.data[i];
     if (entry.kind == hart::Kind_zSomezIRTLB_EntryzK) {
       const auto &e = entry.variants.zSomezIRTLB_EntryzK;
@@ -205,7 +210,7 @@ static void print_tlb(
         e.zlevelMask,
         e.zppn,
         e.zpteAddr.bits,
-        (static_cast<int64_t>(i) == index) ? "  <- + added" : ""
+        annotation
       );
     } else {
       fprintf(
@@ -214,7 +219,7 @@ static void print_tlb(
         "     ║         ----    "
         "     ║%s\n",
         i,
-        (static_cast<int64_t>(i) == index) ? "  <- x flushed" : ""
+        annotation
       );
     }
   }
@@ -226,22 +231,30 @@ static void print_tlb(
   );
 }
 
-void log_callbacks::tlb_flush_callback(
-  hart::Model &model,
-  hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
-  int64_t index
-) {
-  if (trace_log != nullptr && config_print_tlb) {
-    print_tlb(trace_log, model, tlb, index, true);
-  }
-}
-
 void log_callbacks::tlb_add_callback(
   hart::Model &model,
   hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
-  int64_t index
+  uint64_t index
 ) {
   if (trace_log != nullptr && config_print_tlb) {
-    print_tlb(trace_log, model, tlb, index, false);
+    print_tlb(trace_log, model, tlb, {index}, false);
+  }
+}
+
+std::vector<uint64_t> pending_flush_indices;
+
+void log_callbacks::tlb_flush_begin_callback(hart::Model &model) {
+  pending_flush_indices.clear();
+}
+
+void log_callbacks::tlb_flush_callback(hart::Model &model, uint64_t index) {
+  if (config_print_tlb) {
+    pending_flush_indices.push_back(index);
+  }
+}
+
+void log_callbacks::tlb_flush_end_callback(hart::Model &model, hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb) {
+  if (trace_log != nullptr && config_print_tlb && !pending_flush_indices.empty()) {
+    print_tlb(trace_log, model, tlb, pending_flush_indices, true);
   }
 }

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -9,6 +9,7 @@ log_callbacks::log_callbacks(
   bool config_print_csr,
   bool config_print_mem_access,
   bool config_print_ptw,
+  bool config_print_tlb,
   bool config_use_abi_names,
   FILE *trace_log
 ) :
@@ -19,6 +20,7 @@ log_callbacks::log_callbacks(
     config_print_mem_access(config_print_mem_access),
     config_use_abi_names(config_use_abi_names),
     config_print_ptw(config_print_ptw),
+    config_print_tlb(config_print_tlb),
     trace_log(trace_log) {
 }
 
@@ -162,5 +164,84 @@ void log_callbacks::ptw_fail_callback(
       pte_addr.bits
     );
     KILL(sail_string)(&str_et);
+  }
+}
+
+static void print_tlb(
+  FILE *trace_log,
+  hart::Model &model,
+  hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
+  int64_t index,
+  bool is_flush
+) {
+  fprintf(
+    trace_log,
+    "TLB %s [ len=%zu ]\n"
+    "╔═════╦════╦══════════╦══════════════════════╦══════════════════════╦══════════════════════╦══════════════════════"
+    "╦══════════════════════"
+    "╗\n"
+    "║ IDX ║ GL ║   ASID   ║         VPN          ║         PTE          ║     LEVEL_MASK       ║         PPN          "
+    "║       PTE_ADDR       "
+    "║\n"
+    "╠═════╬════╬══════════╬══════════════════════╬══════════════════════╬══════════════════════╬══════════════════════"
+    "╬══════════════════════"
+    "╣\n",
+    is_flush ? "flush" : "add",
+    tlb.len
+  );
+  for (size_t i = 0; i < tlb.len; i++) {
+    const auto &entry = tlb.data[i];
+    if (entry.kind == hart::Kind_zSomezIRTLB_EntryzK) {
+      const auto &e = entry.variants.zSomezIRTLB_EntryzK;
+      fprintf(
+        trace_log,
+        "║ %3zu ║  %c ║ 0x%06" PRIX64 " ║ 0x%018" PRIX64 " ║ 0x%018" PRIX64 " ║ 0x%018" PRIX64 " ║ 0x%018" PRIX64
+        " ║ 0x%018" PRIX64 " ║%s\n",
+        i,
+        e.zglobal ? 'Y' : 'N',
+        e.zasid.bits,
+        e.zvpn,
+        e.zpte,
+        e.zlevelMask,
+        e.zppn,
+        e.zpteAddr.bits,
+        (static_cast<int64_t>(i) == index) ? "  <- + added" : ""
+      );
+    } else {
+      fprintf(
+        trace_log,
+        "║ %3zu ║  - ║   ----   ║         ----         ║         ----         ║         ----         ║         ----    "
+        "     ║         ----    "
+        "     ║%s\n",
+        i,
+        (static_cast<int64_t>(i) == index) ? "  <- x flushed" : ""
+      );
+    }
+  }
+  fprintf(
+    trace_log,
+    "╚═════╩════╩══════════╩══════════════════════╩══════════════════════╩══════════════════════╩══════════════════════"
+    "╩══════════════════════"
+    "╝\n"
+  );
+}
+
+void log_callbacks::tlb_flush_callback(
+  hart::Model &model,
+  hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
+  int64_t index
+) {
+  if (trace_log != nullptr && config_print_tlb) {
+    print_tlb(trace_log, model, tlb, index, true);
+  }
+}
+
+void log_callbacks::tlb_add_callback(
+  hart::Model &model,
+  hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
+  int64_t index
+) {
+  if (trace_log != nullptr && config_print_tlb) {
+    print_tlb(trace_log, model, tlb, index, false);
   }
 }

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -44,13 +44,11 @@ public:
   void tlb_add_callback(
     hart::Model &model,
     hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
-    int64_t index
+    uint64_t index
   ) override;
-  void tlb_flush_callback(
-    hart::Model &model,
-    hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
-    int64_t index
-  ) override;
+  void tlb_flush_begin_callback(hart::Model &model) override;
+  void tlb_flush_callback(hart::Model &model, uint64_t index) override;
+  void tlb_flush_end_callback(hart::Model &model, hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb) override;
 
 private:
   bool config_print_gpr;

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -12,6 +12,7 @@ public:
     bool config_print_csr = true,
     bool config_print_mem_access = true,
     bool config_print_ptw = true,
+    bool config_print_tlb = true,
     bool config_use_abi_names = false,
 
     FILE *trace_log = nullptr
@@ -40,6 +41,16 @@ public:
     int64_t level,
     sbits pte_addr
   ) override;
+  void tlb_add_callback(
+    hart::Model &model,
+    hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
+    int64_t index
+  ) override;
+  void tlb_flush_callback(
+    hart::Model &model,
+    hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
+    int64_t index
+  ) override;
 
 private:
   bool config_print_gpr;
@@ -49,5 +60,6 @@ private:
   bool config_print_mem_access;
   bool config_use_abi_names;
   bool config_print_ptw;
+  bool config_print_tlb;
   FILE *trace_log;
 };

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -165,16 +165,30 @@ unit ModelImpl::ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sb
   return UNIT;
 }
 
-unit ModelImpl::tlb_add_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, int64_t index) {
+unit ModelImpl::tlb_add_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, uint64_t index) {
   for (auto c : m_callbacks) {
     c->tlb_add_callback(*this, tlb, index);
   }
   return UNIT;
 }
 
-unit ModelImpl::tlb_flush_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, int64_t index) {
+unit ModelImpl::tlb_flush_begin_callback(unit) {
   for (auto c : m_callbacks) {
-    c->tlb_flush_callback(*this, tlb, index);
+    c->tlb_flush_begin_callback(*this);
+  }
+  return UNIT;
+}
+
+unit ModelImpl::tlb_flush_callback(uint64_t index) {
+  for (auto c : m_callbacks) {
+    c->tlb_flush_callback(*this, index);
+  }
+  return UNIT;
+}
+
+unit ModelImpl::tlb_flush_end_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb) {
+  for (auto c : m_callbacks) {
+    c->tlb_flush_end_callback(*this, tlb);
   }
   return UNIT;
 }

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -165,6 +165,20 @@ unit ModelImpl::ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sb
   return UNIT;
 }
 
+unit ModelImpl::tlb_add_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, int64_t index) {
+  for (auto c : m_callbacks) {
+    c->tlb_add_callback(*this, tlb, index);
+  }
+  return UNIT;
+}
+
+unit ModelImpl::tlb_flush_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, int64_t index) {
+  for (auto c : m_callbacks) {
+    c->tlb_flush_callback(*this, tlb, index);
+  }
+  return UNIT;
+}
+
 // Provides entropy for the scalar cryptography extension.
 mach_bits ModelImpl::plat_get_16_random_bits(unit) {
   // This function can be changed to support deterministic sequences of

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -65,6 +65,8 @@ private:
   unit ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte) override;
   unit ptw_success_callback(uint64_t final_ppn, int64_t level) override;
   unit ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sbits pte_addr) override;
+  unit tlb_add_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, int64_t index) override;
+  unit tlb_flush_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, int64_t index) override;
   // Provides entropy for the scalar cryptography extension.
   mach_bits plat_get_16_random_bits(unit) override;
 

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -65,8 +65,10 @@ private:
   unit ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte) override;
   unit ptw_success_callback(uint64_t final_ppn, int64_t level) override;
   unit ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sbits pte_addr) override;
-  unit tlb_add_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, int64_t index) override;
-  unit tlb_flush_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, int64_t index) override;
+  unit tlb_add_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, uint64_t index) override;
+  unit tlb_flush_begin_callback(unit) override;
+  unit tlb_flush_callback(uint64_t index) override;
+  unit tlb_flush_end_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb) override;
   // Provides entropy for the scalar cryptography extension.
   mach_bits plat_get_16_random_bits(unit) override;
 

--- a/c_emulator/riscv_platform_if.cpp
+++ b/c_emulator/riscv_platform_if.cpp
@@ -109,15 +109,20 @@ unit PlatformInterface::ptw_fail_callback(
 
 unit PlatformInterface::tlb_add_callback(
   [[maybe_unused]] hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
-  [[maybe_unused]] int64_t level
+  [[maybe_unused]] uint64_t level
 ) {
   return UNIT;
 }
 
-unit PlatformInterface::tlb_flush_callback(
-  [[maybe_unused]] hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
-  [[maybe_unused]] int64_t level
-) {
+unit PlatformInterface::tlb_flush_begin_callback(unit) {
+  return UNIT;
+}
+
+unit PlatformInterface::tlb_flush_callback([[maybe_unused]] uint64_t level) {
+  return UNIT;
+}
+
+unit PlatformInterface::tlb_flush_end_callback([[maybe_unused]] hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb) {
   return UNIT;
 }
 

--- a/c_emulator/riscv_platform_if.cpp
+++ b/c_emulator/riscv_platform_if.cpp
@@ -107,6 +107,20 @@ unit PlatformInterface::ptw_fail_callback(
   return UNIT;
 }
 
+unit PlatformInterface::tlb_add_callback(
+  [[maybe_unused]] hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
+  [[maybe_unused]] int64_t level
+) {
+  return UNIT;
+}
+
+unit PlatformInterface::tlb_flush_callback(
+  [[maybe_unused]] hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
+  [[maybe_unused]] int64_t level
+) {
+  return UNIT;
+}
+
 mach_bits PlatformInterface::plat_get_16_random_bits(unit) {
   return 0;
 }

--- a/c_emulator/riscv_platform_if.h
+++ b/c_emulator/riscv_platform_if.h
@@ -60,8 +60,10 @@ public:
   virtual unit ptw_success_callback(uint64_t final_ppn, int64_t level);
   virtual unit ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sbits pte_addr);
 
-  virtual unit tlb_add_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, int64_t index);
-  virtual unit tlb_flush_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, int64_t index);
+  virtual unit tlb_add_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, uint64_t index);
+  virtual unit tlb_flush_begin_callback(unit);
+  virtual unit tlb_flush_callback(uint64_t index);
+  virtual unit tlb_flush_end_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb);
 
   // Provides entropy for the scalar cryptography extension.
   virtual mach_bits plat_get_16_random_bits(unit);

--- a/c_emulator/riscv_platform_if.h
+++ b/c_emulator/riscv_platform_if.h
@@ -11,6 +11,7 @@ class Model;
 struct zMemoryAccessTypezIEmem_payloadz5zK;
 struct ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9;
 struct zPTW_Error;
+struct zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9;
 
 } // namespace hart
 
@@ -58,6 +59,9 @@ public:
   virtual unit ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte);
   virtual unit ptw_success_callback(uint64_t final_ppn, int64_t level);
   virtual unit ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sbits pte_addr);
+
+  virtual unit tlb_add_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, int64_t index);
+  virtual unit tlb_flush_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, int64_t index);
 
   // Provides entropy for the scalar cryptography extension.
   virtual mach_bits plat_get_16_random_bits(unit);

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -274,7 +274,7 @@ static CLIOptions parse_cli(int argc, char **argv) {
   app.add_flag("--trace-step", opts.config_print_step, "Add a blank line between steps in the trace output");
 
   app.add_flag_callback(
-    "--trace-all",
+    "--trace",
     [&opts] {
       opts.config_print_instr = true;
       opts.config_print_gpr = true;
@@ -289,10 +289,8 @@ static CLIOptions parse_cli(int argc, char **argv) {
       opts.config_print_htif = true;
       opts.config_print_pma = true;
       opts.config_print_step = true;
-      opts.config_print_ptw = true;
-      opts.config_print_tlb = true;
     },
-    "Enable all trace output"
+    "Enable all trace output except TLB and PTW traces"
   );
 
   // All positional arguments are treated as ELF files.  All ELF files

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -157,6 +157,7 @@ struct CLIOptions {
   bool config_print_rvfi = false;
   bool config_print_step = false;
   bool config_print_ptw = false;
+  bool config_print_tlb = false;
 
   bool config_use_abi_names = false;
 
@@ -218,6 +219,7 @@ static CLIOptions parse_cli(int argc, char **argv) {
 
   app.add_flag("--trace-instr", opts.config_print_instr, "Enable trace output for instruction execution");
   app.add_flag("--trace-ptw", opts.config_print_ptw, "Enable trace output for Page Table walk");
+  app.add_flag("--trace-tlb", opts.config_print_tlb, "Enable trace output for TLB adds and flushes");
   app.add_flag(
     "--trace-gpr",
     opts.config_print_gpr,
@@ -288,6 +290,7 @@ static CLIOptions parse_cli(int argc, char **argv) {
       opts.config_print_pma = true;
       opts.config_print_step = true;
       opts.config_print_ptw = true;
+      opts.config_print_tlb = true;
     },
     "Enable all trace output"
   );
@@ -766,6 +769,7 @@ int inner_main(int argc, char **argv) {
     opts.config_print_csr,
     opts.config_print_mem_access,
     opts.config_print_ptw,
+    opts.config_print_tlb,
     opts.config_use_abi_names,
     trace_log
   );

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -33,10 +33,14 @@
   This is a backwards incompatible change, and is required since version 1.12 (also known as version 20211203)
   of the privileged specification.
 
-- A `--rv32` command line option has been added to use a default RV32
-  configuration. This allows emulating RV32 binaries without needing
-  to point to a specific RV32 configuration file. This option cannot
-  be used with the `--config` option.
+- The command line interface has been updated:
+  - A `--rv32` command line option has been added to use a default RV32
+    configuration. This allows emulating RV32 binaries without needing
+    to point to a specific RV32 configuration file. This option cannot
+    be used with the `--config` option.
+  - A new `--trace-tlb` option has been added to enable TLB specific trace output.
+  - The previous `--trace-all` option has been renamed to --trace.
+    `--trace` now enables all trace output except TLB and page table walker (PTW) traces.
 
 - A Mac ARM binary release is now available.
 

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -39,7 +39,7 @@
     to point to a specific RV32 configuration file. This option cannot
     be used with the `--config` option.
   - A new `--trace-tlb` option has been added to enable TLB specific trace output.
-  - The previous `--trace-all` option has been renamed to --trace.
+  - The previous `--trace-all` option has been renamed to `--trace`.
     `--trace` now enables all trace output except TLB and page table walker (PTW) traces.
 
 - A Mac ARM binary release is now available.

--- a/model/sys/vmem_tlb.sail
+++ b/model/sys/vmem_tlb.sail
@@ -81,11 +81,17 @@ type tlb_index_range = range(0, num_tlb_entries - 1)
 
 private register tlb : vector(num_tlb_entries, option(TLB_Entry)) = vector_init(None())
 
-val tlb_flush_callback = pure {cpp: "tlb_flush_callback"} : (vector(num_tlb_entries, option(TLB_Entry)), range(0, num_tlb_entries)) -> unit
-function tlb_flush_callback(_) = ()
-
 val tlb_add_callback = pure {cpp: "tlb_add_callback"} : (vector(num_tlb_entries, option(TLB_Entry)), range(0, num_tlb_entries)) -> unit
 function tlb_add_callback(_) = ()
+
+val tlb_flush_begin_callback = pure {cpp: "tlb_flush_begin_callback"} : unit -> unit
+function tlb_flush_begin_callback(_) = ()
+
+val tlb_flush_callback = pure {cpp: "tlb_flush_callback"} : (range(0, num_tlb_entries)) -> unit
+function tlb_flush_callback(_) = ()
+
+val tlb_flush_end_callback = pure {cpp: "tlb_flush_end_callback"} : (vector(num_tlb_entries, option(TLB_Entry))) -> unit
+function tlb_flush_end_callback(_) = ()
 
 // Indexed by the lowest bits of the VPN.
 function tlb_hash forall 'v, is_sv_mode('v) . (
@@ -177,12 +183,16 @@ function add_to_TLB forall 'v, is_sv_mode('v) . (
 
 // Top-level TLB flush function
 // PUBLIC: invoked from SFENCE_VMA [extensions/I/insts_base.sail]
-function flush_TLB(asid : option(asidbits),
-                   addr : option(xlenbits)) -> unit = {
+function flush_TLB(asid : option(asidbits), addr : option(xlenbits)) -> unit = {
+  tlb_flush_begin_callback();
   foreach (i from 0 to (length(tlb) - 1)) {
     match tlb[i] {
       None()  => (),
-      Some(entry) => if flush_TLB_Entry(entry, asid, addr) then { tlb[i] = None(); tlb_flush_callback(tlb, i)},
+      Some(entry) => if flush_TLB_Entry(entry, asid, addr) then {
+        tlb[i] = None();
+        tlb_flush_callback(i)
+      },
     }
-  }
+  };
+  tlb_flush_end_callback(tlb);
 }

--- a/model/sys/vmem_tlb.sail
+++ b/model/sys/vmem_tlb.sail
@@ -81,6 +81,12 @@ type tlb_index_range = range(0, num_tlb_entries - 1)
 
 private register tlb : vector(num_tlb_entries, option(TLB_Entry)) = vector_init(None())
 
+val tlb_flush_callback = pure {cpp: "tlb_flush_callback"} : (vector(num_tlb_entries, option(TLB_Entry)), range(0, num_tlb_entries)) -> unit
+function tlb_flush_callback(_) = ()
+
+val tlb_add_callback = pure {cpp: "tlb_add_callback"} : (vector(num_tlb_entries, option(TLB_Entry)), range(0, num_tlb_entries)) -> unit
+function tlb_add_callback(_) = ()
+
 // Indexed by the lowest bits of the VPN.
 function tlb_hash forall 'v, is_sv_mode('v) . (
   _sv_mode : int('v),
@@ -166,6 +172,7 @@ function add_to_TLB forall 'v, is_sv_mode('v) . (
                                  ppn       = zero_extend(ppn)};
 
   tlb[index] = Some(entry);
+  tlb_add_callback(tlb, index);
 }
 
 // Top-level TLB flush function
@@ -175,7 +182,7 @@ function flush_TLB(asid : option(asidbits),
   foreach (i from 0 to (length(tlb) - 1)) {
     match tlb[i] {
       None()  => (),
-      Some(entry) => if flush_TLB_Entry(entry, asid, addr) then { tlb[i] = None(); },
+      Some(entry) => if flush_TLB_Entry(entry, asid, addr) then { tlb[i] = None(); tlb_flush_callback(tlb, i)},
     }
   }
 }


### PR DESCRIPTION
Add a --trace-tlb feature to log changes to the TLB. This also changes the `--trace-all` CLI option to just `--trace` and removes especially verbose options that people probably don't want by default.