### PR TITLE
Detect potentially infinite trap loops.

### DIFF
--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -75,6 +75,8 @@ add_executable(sail_riscv_sim
     riscv_callbacks_log.h
     riscv_callbacks_rvfi.cpp
     riscv_callbacks_rvfi.h
+    traploop_detector.cpp
+    traploop_detector.h
 )
 
 # The generated C model is not warnings-clean, silence them.

--- a/c_emulator/riscv_callbacks_if.cpp
+++ b/c_emulator/riscv_callbacks_if.cpp
@@ -91,6 +91,9 @@ void callbacks_if::trap_callback(
 ) {
 }
 
+void callbacks_if::xret_callback([[maybe_unused]] hart::Model &model, [[maybe_unused]] bool is_mret) {
+}
+
 // Page table walk callbacks
 void callbacks_if::ptw_start_callback(
   [[maybe_unused]] hart::Model &model,

--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -46,6 +46,8 @@ public:
 
   virtual void trap_callback(hart::Model &model, bool is_interrupt, fbits cause);
 
+  virtual void xret_callback(hart::Model &model, bool is_mret);
+
   // Page table walk callbacks
   virtual void ptw_start_callback(
     hart::Model &model,

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -133,6 +133,13 @@ unit ModelImpl::trap_callback(bool is_interrupt, fbits cause) {
   return UNIT;
 }
 
+unit ModelImpl::xret_callback(bool is_mret) {
+  for (auto c : m_callbacks) {
+    c->xret_callback(*this, is_mret);
+  }
+  return UNIT;
+}
+
 unit ModelImpl::ptw_start_callback(
   uint64_t vpn,
   hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -55,6 +55,7 @@ private:
   unit pc_write_callback(sbits new_pc) override;
   unit redirect_callback(sbits new_pc) override;
   unit trap_callback(bool is_interrupt, fbits cause) override;
+  unit xret_callback(bool is_mret) override;
 
   // Page table walk callbacks
   unit ptw_start_callback(

--- a/c_emulator/riscv_platform_if.cpp
+++ b/c_emulator/riscv_platform_if.cpp
@@ -81,6 +81,10 @@ unit PlatformInterface::trap_callback([[maybe_unused]] bool is_interrupt, [[mayb
   return UNIT;
 }
 
+unit PlatformInterface::xret_callback([[maybe_unused]] bool is_mret) {
+  return UNIT;
+}
+
 unit PlatformInterface::ptw_start_callback(
   [[maybe_unused]] uint64_t vpn,
   [[maybe_unused]] hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,

--- a/c_emulator/riscv_platform_if.h
+++ b/c_emulator/riscv_platform_if.h
@@ -49,6 +49,7 @@ public:
   virtual unit redirect_callback(sbits new_pc);
 
   virtual unit trap_callback(bool is_interrupt, fbits cause);
+  virtual unit xret_callback(bool is_mret);
 
   // Page table walk callbacks
   virtual unit ptw_start_callback(

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -610,7 +610,7 @@ void run_sail(ModelImpl &model, const CLIOptions &opts, traploop_detector &loop_
       model.ztick_clock(UNIT);
     }
 
-    if (!is_waiting && loop_detector.loop_detected()) {
+    if (loop_detector.loop_detected()) {
       fprintf(
         stdout,
         "FAILURE: possible trap loop detected with MEPC=0x%" PRIx64 " and SEPC=0x%" PRIx64 "\n",

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -36,6 +36,7 @@
 #include "riscv_model_impl.h"
 #include "rvfi_dii.h"
 #include "sail_riscv_version.h"
+#include "traploop_detector.h"
 
 using std::chrono::duration_cast;
 using std::chrono::milliseconds;
@@ -127,6 +128,7 @@ struct CLIOptions {
   bool do_print_isa = false;
 
   bool use_rv32_default = false;
+  bool disable_trap_loop_detection = false;
   std::string config_file;
   std::vector<std::string> config_overrides;
   std::string term_log;
@@ -186,6 +188,11 @@ static CLIOptions parse_cli(int argc, char **argv) {
   );
   app.add_flag("--use-abi-names", opts.config_use_abi_names, "Use ABI register names in trace log");
   app.add_flag("--rv32", opts.use_rv32_default, "Use the default RV32 configuration");
+  app.add_flag(
+    "--disable-trap-loop-detection",
+    opts.disable_trap_loop_detection,
+    "Disable detection of potentially infinite trap loops"
+  );
 
   app.add_option("--device-tree-blob", opts.dtb_file, "Device tree blob file")
     ->check(CLI::ExistingFile)
@@ -506,7 +513,7 @@ void flush_logs() {
   fflush(trace_log);
 }
 
-void run_sail(ModelImpl &model, const CLIOptions &opts) {
+void run_sail(ModelImpl &model, const CLIOptions &opts, traploop_detector &loop_detector) {
   bool is_waiting = false;
   // The emulator tick increments time by 1 at every step, so the number
   // of steps to wait is equal to the needed increment in the time CSR.
@@ -602,6 +609,16 @@ void run_sail(ModelImpl &model, const CLIOptions &opts) {
     } else if (wait_steps_remaining > 0) {
       model.ztick_clock(UNIT);
     }
+
+    if (!is_waiting && loop_detector.loop_detected()) {
+      fprintf(
+        stdout,
+        "FAILURE: possible trap loop detected with MEPC=0x%" PRIx64 " and SEPC=0x%" PRIx64 "\n",
+        loop_detector.mepc(),
+        loop_detector.sepc()
+      );
+      exit(EXIT_FAILURE);
+    }
   }
 
   // This is reached if there is a Sail exception, HTIF has indicated
@@ -687,6 +704,11 @@ int inner_main(int argc, char **argv) {
   model.set_config_use_abi_names(opts.config_use_abi_names);
 
   model.set_config_print_step(opts.config_print_step);
+
+  traploop_detector loop_detector;
+  if (!opts.disable_trap_loop_detection) {
+    model.register_callback(&loop_detector);
+  }
 
   std::string config_json_string;
   if (!opts.config_file.empty()) {
@@ -803,11 +825,12 @@ int inner_main(int argc, char **argv) {
   init_end = steady_clock::now();
 
   do {
-    run_sail(model, opts);
+    run_sail(model, opts, loop_detector);
     // `run_sail` only returns in the case of rvfi.
     if (rvfi) {
       /* Reset for next test */
       reinit_sail(model, entry, opts.config_file.c_str());
+      loop_detector.reset();
     }
   } while (rvfi);
 

--- a/c_emulator/traploop_detector.cpp
+++ b/c_emulator/traploop_detector.cpp
@@ -1,0 +1,38 @@
+#include "traploop_detector.h"
+#include "sail_riscv_model.h"
+#include <cstdlib>
+#include <inttypes.h>
+
+traploop_detector::traploop_detector() {
+  reset();
+}
+
+void traploop_detector::reset() {
+  trap_count = 0;
+  trap_mepc = 0;
+  trap_sepc = 0;
+  xret_count = 0;
+}
+
+void traploop_detector::trap_callback(hart::Model &model, bool, fbits) {
+  trap_count++;
+  trap_mepc = model.zmepc.bits;
+  trap_sepc = model.zsepc.bits;
+}
+
+void traploop_detector::xret_callback(hart::Model &, bool) {
+  xret_count++;
+}
+
+bool traploop_detector::loop_detected() {
+  uint64_t diff = (trap_count > xret_count) ? trap_count - xret_count : xret_count - trap_count;
+  return (diff > trap_count_threshold);
+}
+
+uint64_t traploop_detector::mepc() const {
+  return trap_mepc;
+}
+
+uint64_t traploop_detector::sepc() const {
+  return trap_sepc;
+}

--- a/c_emulator/traploop_detector.cpp
+++ b/c_emulator/traploop_detector.cpp
@@ -25,7 +25,9 @@ void traploop_detector::xret_callback(hart::Model &, bool) {
 }
 
 bool traploop_detector::loop_detected() {
-  uint64_t diff = (trap_count > xret_count) ? trap_count - xret_count : xret_count - trap_count;
+  // It would be very unusual to have xrets exceeding trap-count by a
+  // large amount.  Should this be handled as well?
+  uint64_t diff = (trap_count > xret_count) ? trap_count - xret_count : 0;
   return (diff > trap_count_threshold);
 }
 

--- a/c_emulator/traploop_detector.h
+++ b/c_emulator/traploop_detector.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "riscv_callbacks_if.h"
+#include "sail.h"
+
+class traploop_detector : public callbacks_if {
+
+public:
+  explicit traploop_detector();
+
+  bool loop_detected();
+  void reset();
+
+  uint64_t mepc() const;
+  uint64_t sepc() const;
+
+  // callbacks_if
+  void trap_callback(hart::Model &model, bool is_interrupt, fbits cause) override;
+  void xret_callback(hart::Model &model, bool is_mret) override;
+
+private:
+  uint64_t trap_count = 0;
+  uint64_t trap_mepc = 0;
+  uint64_t trap_sepc = 0;
+  uint64_t xret_count = 0;
+  const uint64_t trap_count_threshold = 10;
+};

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -33,14 +33,22 @@
   This is a backwards incompatible change, and is required since version 1.12 (also known as version 20211203)
   of the privileged specification.
 
+- The emulator tries to detect some potentially infinite trap loops using
+  the difference between the traps generated and `xret` instructions
+  executed by the hart. If such a potential loop is detected, the
+  emulator exits with an error. This detection is enabled by default,
+  and a command line option has been added to disable it (see below).
+
 - The command line interface has been updated:
-  - A `--rv32` command line option has been added to use a default RV32
+  - A `--rv32` option has been added to use a default RV32
     configuration. This allows emulating RV32 binaries without needing
     to point to a specific RV32 configuration file. This option cannot
     be used with the `--config` option.
   - A new `--trace-tlb` option has been added to enable TLB specific trace output.
   - The previous `--trace-all` option has been renamed to `--trace`.
     `--trace` now enables all trace output except TLB and page table walker (PTW) traces.
+  - A `--disable-trap-loop-detection` option has been added to disable
+    the default detection of trap loops.
 
 - A Mac ARM binary release is now available.
 

--- a/model/core/callbacks.sail
+++ b/model/core/callbacks.sail
@@ -56,6 +56,9 @@ function redirect_callback(_) = ()
 val trap_callback = pure {cpp: "trap_callback"} : (/* is_interrupt */ bool, /* interrupt/exception cause */ exc_code) -> unit
 function trap_callback(_) = ()
 
+/// Called on xrets (mret <=> true, sret <=> false).
+val xret_callback = pure {cpp: "xret_callback"} : (/* is_mret */ bool) -> unit
+
 // Overloads for easier use of callbacks
 function csr_name_write_callback(name : string, value : xlenbits) -> unit = {
   let csr = csr_name_map(name);

--- a/model/core/callbacks.sail
+++ b/model/core/callbacks.sail
@@ -58,6 +58,7 @@ function trap_callback(_) = ()
 
 /// Called on xrets (mret <=> true, sret <=> false).
 val xret_callback = pure {cpp: "xret_callback"} : (/* is_mret */ bool) -> unit
+function xret_callback(_) = ()
 
 // Overloads for easier use of callbacks
 function csr_name_write_callback(name : string, value : xlenbits) -> unit = {

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -564,8 +564,8 @@ function clause execute MRET() = {
   else if not(ext_check_xret_priv(Machine))
   then Ext_XRET_Priv_Failure()
   else {
-    xret_callback(true);
     set_next_pc(exception_handler(cur_privilege, CTL_MRET(), PC));
+    xret_callback(true);
     RETIRE_SUCCESS
   }
 }
@@ -591,8 +591,8 @@ function clause execute SRET() = {
   else if not(ext_check_xret_priv (Supervisor))
   then Ext_XRET_Priv_Failure()
   else {
-    xret_callback(false);
     set_next_pc(exception_handler(cur_privilege, CTL_SRET(), PC));
+    xret_callback(false);
     RETIRE_SUCCESS
   }
 }

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -564,6 +564,7 @@ function clause execute MRET() = {
   else if not(ext_check_xret_priv(Machine))
   then Ext_XRET_Priv_Failure()
   else {
+    xret_callback(true);
     set_next_pc(exception_handler(cur_privilege, CTL_MRET(), PC));
     RETIRE_SUCCESS
   }
@@ -590,6 +591,7 @@ function clause execute SRET() = {
   else if not(ext_check_xret_priv (Supervisor))
   then Ext_XRET_Priv_Failure()
   else {
+    xret_callback(false);
     set_next_pc(exception_handler(cur_privilege, CTL_SRET(), PC));
     RETIRE_SUCCESS
   }

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -153,7 +153,7 @@ function tval(excinfo : option(xlenbits)) -> xlenbits = {
   }
 }
 
-function track_trap(p : Privilege) -> unit = {
+function track_trap(p : Privilege, is_interrupt : bool, cause : exc_code) -> unit = {
   long_csr_write_callback("mstatus", "mstatush", mstatus.bits);
   match (p) {
     Machine => {
@@ -170,6 +170,8 @@ function track_trap(p : Privilege) -> unit = {
     VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
     VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   };
+
+  trap_callback(is_interrupt, cause);
 }
 
 // handle exceptional ctl flow by updating nextPC and operating privilege
@@ -177,8 +179,6 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
                      -> xlenbits = {
   let is_interrupt = trapCause_is_interrupt(c);
   let cause        = trapCause_bits(c);
-
-  trap_callback(is_interrupt, cause);
 
   if   get_config_print_exception() | get_config_print_interrupt()
   then print_log("handling " ^ to_str(c)
@@ -202,7 +202,7 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
 
       handle_trap_extension(del_priv, pc, ext);
 
-      track_trap(del_priv);
+      track_trap(del_priv, is_interrupt, cause);
 
       prepare_trap_vector(del_priv, mcause)
     },
@@ -228,7 +228,7 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
 
       handle_trap_extension(del_priv, pc, ext);
 
-      track_trap(del_priv);
+      track_trap(del_priv, is_interrupt, cause);
 
       prepare_trap_vector(del_priv, scause)
     },


### PR DESCRIPTION
This helps in automated tested environments where an infinite loop caused by a failing test can cause issues.

An `xret_callback` is used in combination with the existing `trap_callback` to detect trap loops.  The `trap_callback` is now called after the state changes due to the trap are visible.