### PR TITLE
Add support for Smdbltrp (double trap)

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -613,6 +613,15 @@
     "Smcntrpmf": {
       "supported": true
     },
+    // The double trap extensions are not enabled by default because
+    // mstatus[MDT] is reset to 1, which means unless your boot code zeroes
+    // it the first trap you take will be an unexpected double trap.
+    "Smdbltrp": {
+      "supported": false
+    },
+    "Ssdbltrp": {
+      "supported": false
+    },
     "Svbare": {
       "supported": true,
       "sfence_vma_illegal_if_svbare_only": true

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -777,6 +777,15 @@
     "Smcntrpmf": {
       "supported": true
     },
+    // The double trap extensions are not enabled by default because
+    // mstatus[MDT] is reset to 1, which means unless your boot code zeroes
+    // it the first trap you take will be an unexpected double trap.
+    "Smdbltrp": {
+      "supported": false
+    },
+    "Ssdbltrp": {
+      "supported": false
+    },
     "Svbare": {
       "supported": true,
       "sfence_vma_illegal_if_svbare_only": true

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -534,11 +534,20 @@ function clause hartSupports(Ext_Svvptc) = config extensions.Svvptc.supported
 enum clause extension = Ext_Smcntrpmf
 mapping clause extensionName = Ext_Smcntrpmf <-> "smcntrpmf"
 function clause hartSupports(Ext_Smcntrpmf) = config extensions.Smcntrpmf.supported
+// Double Trap (Machine)
+enum clause extension = Ext_Smdbltrp
+mapping clause extensionName = Ext_Smdbltrp <-> "smdbltrp"
+function clause hartSupports(Ext_Smdbltrp) = config extensions.Smdbltrp.supported
+function clause currentlyEnabled(Ext_Smdbltrp) = hartSupports(Ext_Smdbltrp)
 // Machine-mode view of the state-enable extension
 enum clause extension = Ext_Smstateen
 mapping clause extensionName = Ext_Smstateen <-> "smstateen"
 function clause hartSupports(Ext_Smstateen) = config extensions.Stateen.Smstateen.supported
 
+// Double Trap (Supervisor)
+enum clause extension = Ext_Ssdbltrp
+mapping clause extensionName = Ext_Ssdbltrp <-> "ssdbltrp"
+function clause hartSupports(Ext_Ssdbltrp) = config extensions.Ssdbltrp.supported
 // QoS identifiers
 enum clause extension = Ext_Ssqosid
 mapping clause extensionName = Ext_Ssqosid <-> "ssqosid"

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -549,11 +549,19 @@ enum clause extension = Ext_Smnpm
 mapping clause extensionName = Ext_Smnpm <-> "smnpm"
 function clause hartSupports(Ext_Smnpm) = config extensions.Smnpm.supported : bool & (xlen == 64)
 function clause currentlyEnabled(Ext_Smnpm) = hartSupports(Ext_Smnpm)
+// Double Trap (Machine)
+enum clause extension = Ext_Smdbltrp
+mapping clause extensionName = Ext_Smdbltrp <-> "smdbltrp"
+function clause hartSupports(Ext_Smdbltrp) = config extensions.Smdbltrp.supported
+function clause currentlyEnabled(Ext_Smdbltrp) = hartSupports(Ext_Smdbltrp)
 // Machine-mode view of the state-enable extension
 enum clause extension = Ext_Smstateen
 mapping clause extensionName = Ext_Smstateen <-> "smstateen"
 function clause hartSupports(Ext_Smstateen) = config extensions.Stateen.Smstateen.supported
-
+// Double Trap (Supervisor)
+enum clause extension = Ext_Ssdbltrp
+mapping clause extensionName = Ext_Ssdbltrp <-> "ssdbltrp"
+function clause hartSupports(Ext_Ssdbltrp) = config extensions.Ssdbltrp.supported
 // QoS identifiers
 enum clause extension = Ext_Ssqosid
 mapping clause extensionName = Ext_Ssqosid <-> "ssqosid"

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -167,7 +167,7 @@ function have_nominal_privLevel(priv : nom_priv_bits) -> bool =
 bitfield Mstatus : bits(64) = {
   SD   : xlen - 1,
 
-  //MDT  : 42,
+  MDT  : 42,
   MPELP: 41,
 
   //MPV  : 39,
@@ -179,7 +179,7 @@ bitfield Mstatus : bits(64) = {
   SXL  : 35 .. 34,
   UXL  : 33 .. 32,
 
-  //SDT  : 24,
+  SDT  : 24,
   SPELP: 23,
   TSR  : 22,
   TW   : 21,
@@ -209,7 +209,7 @@ private function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
   let v = Mk_Mstatus(v);
 
   let o = [o with
-    // MDT = v[MDT],
+    MDT = if currentlyEnabled(Ext_Smdbltrp) then v[MDT] else 0b0,
     MPELP = if hartSupports(Ext_Zicfilp) then v[MPELP] else 0b0,
     // MPV = v[MPV],
     // GVA = v[GVA],
@@ -219,7 +219,7 @@ private function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
     // We don't support dynamic changes to SXL and UXL.
     // SXL = if xlen == 64 then v[SXL] else o[SXL],
     // UXL = if xlen == 64 then v[UXL] else o[UXL],
-    // SDT = v[SDT],
+    SDT = if currentlyEnabled(Ext_Ssdbltrp) & currentlyEnabled(Ext_S) then v[SDT] else 0b0,
     SPELP = if hartSupports(Ext_Zicfilp) then v[SPELP] else 0b0,
     TSR = if currentlyEnabled(Ext_S) then v[TSR] else 0b0,
     TW = if currentlyEnabled(Ext_U) then v[TW] else 0b0,
@@ -242,8 +242,9 @@ private function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
     VS = if not(hartSupports(Ext_Zve32x)) then 0b00 else v[VS],
     MPIE = v[MPIE],
     SPIE = if currentlyEnabled(Ext_S) then v[SPIE] else 0b0,
-    MIE = v[MIE],
-    SIE = if currentlyEnabled(Ext_S) then v[SIE] else 0b0,
+    // "When the MDT bit is set to 1 by an explicit CSR write, the MIE (Machine Interrupt Enable) bit is cleared to 0."
+    MIE = if not(currentlyEnabled(Ext_Smdbltrp) & v[MDT] == 0b1) then v[MIE] else 0b0,
+    SIE = if not(currentlyEnabled(Ext_Ssdbltrp) & v[SDT] == 0b1) & currentlyEnabled(Ext_S) then v[SIE] else 0b0,
   ];
 
   // Set dirty bit to OR of other status bits.
@@ -358,6 +359,8 @@ bitfield MEnvcfg : bits(64) = {
   PBMTE  : 62,
   // Svadu
   ADUE   : 61,
+  // Double Trap
+  DTE    : 59,
   // Cache Block Zero instruction Enable
   CBZE   : 7,
   // Cache Block Clean and Flush instruction Enable
@@ -406,6 +409,7 @@ private function legalize_menvcfg(o : MEnvcfg, v : bits(64)) -> MEnvcfg = {
     CBCFE = if currentlyEnabled(Ext_Zicbom) then v[CBCFE] else 0b0,
     CBIE = if currentlyEnabled(Ext_Zicbom) then legalize_xenvcfg_cbie(v[CBIE]) else 0b00,
     STCE = if currentlyEnabled(Ext_Sstc) then v[STCE] else 0b0,
+    DTE = if hartSupports(Ext_Ssdbltrp) then v[DTE] else 0b0,
     ADUE = if currentlyEnabled(Ext_Svadu) then v[ADUE] else 0b0,
     PBMTE = if currentlyEnabled(Ext_Svpbmt) then v[PBMTE] else 0b0,
     // Other extensions are not implemented yet so all other fields are read only zero.
@@ -473,6 +477,8 @@ function is_fiom_active() -> bool = {
     VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   }
 }
+
+function clause currentlyEnabled(Ext_Ssdbltrp) = menvcfg[DTE] == 0b1
 
 // registers for trap handling
 
@@ -543,18 +549,23 @@ function align_pc(addr : xlenbits) -> xlenbits = {
 // auxiliary exception registers
 
 register mtval    : xlenbits
+register mtval2   : xlenbits
 register mscratch : xlenbits
 
 mapping clause csr_name_map = 0x343  <-> "mtval"
+mapping clause csr_name_map = 0x34B  <-> "mtval2"
 mapping clause csr_name_map = 0x340  <-> "mscratch"
 
 function clause is_CSR_accessible(0x343, _, _) = true // mtval
+function clause is_CSR_accessible(0x34B, _, _) = hartSupports(Ext_H) | hartSupports(Ext_Smdbltrp) // mtval2
 function clause is_CSR_accessible(0x340, _, _) = true // mscratch
 
 function clause read_CSR(0x343) = mtval
+function clause read_CSR(0x34B) = mtval2
 function clause read_CSR(0x340) = mscratch
 
 function clause write_CSR(0x343, value) = { mtval = value; Ok(mtval) }
+function clause write_CSR(0x34B, value) = { mtval2 = value; Ok(mtval2) }
 function clause write_CSR(0x340, value) = { mscratch = value; Ok(mscratch) }
 
 // counters
@@ -664,7 +675,7 @@ bitfield Sstatus : bits(64) = {
   SD    : xlen - 1,
 
   UXL   : 33 .. 32,
-//  SDT   : 24,
+  SDT   : 24,
   SPELP : 23,
   MXR   : 19,
   SUM   : 18,
@@ -683,7 +694,8 @@ private function lower_mstatus(m : Mstatus) -> Sstatus = {
   [s with
     SD = m[SD],
     UXL = m[UXL],
-    //SDT = m[SDT],
+    // If Ssdbltrp is disabled via menvcfg[DTE] then status[SDT] is read-only zero.
+    SDT = if currentlyEnabled(Ext_Ssdbltrp) then m[SDT] else 0b0,
     SPELP = m[SPELP],
     MXR = m[MXR],
     SUM = m[SUM],
@@ -703,7 +715,7 @@ private function lift_sstatus(m : Mstatus, s : Sstatus) -> Mstatus = {
   [m with
     SD = bool_to_bit(dirty),
     UXL = s[UXL],
-    //SDT = s[SDT],
+    SDT = s[SDT],
     SPELP = s[SPELP],
     MXR = s[MXR],
     SUM = s[SUM],

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -167,7 +167,7 @@ function have_nominal_privLevel(priv : nom_priv_bits) -> bool =
 bitfield Mstatus : bits(64) = {
   SD   : xlen - 1,
 
-  //MDT  : 42,
+  MDT  : 42,
   MPELP: 41,
 
   //MPV  : 39,
@@ -179,7 +179,7 @@ bitfield Mstatus : bits(64) = {
   SXL  : 35 .. 34,
   UXL  : 33 .. 32,
 
-  //SDT  : 24,
+  SDT  : 24,
   SPELP: 23,
   TSR  : 22,
   TW   : 21,
@@ -209,7 +209,7 @@ private function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
   let v = Mk_Mstatus(v);
 
   let o = [o with
-    // MDT = v[MDT],
+    MDT = if currentlyEnabled(Ext_Smdbltrp) then v[MDT] else 0b0,
     MPELP = if hartSupports(Ext_Zicfilp) then v[MPELP] else 0b0,
     // MPV = v[MPV],
     // GVA = v[GVA],
@@ -219,7 +219,11 @@ private function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
     // We don't support dynamic changes to SXL and UXL.
     // SXL = if xlen == 64 then v[SXL] else o[SXL],
     // UXL = if xlen == 64 then v[UXL] else o[UXL],
-    // SDT = v[SDT],
+    // If Ssdbltrp is disabled via menvcfg[DTE] then status[SDT] is read-only zero.
+    // TODO: This zeroing should happen when reading mstatus, not just when
+    // lowering it to sstatus. This will require a `read_mstatus()` function
+    // for read_CSR(0x300) instead of just returning mstatus.bits directly.
+    SDT = if currentlyEnabled(Ext_Ssdbltrp) & currentlyEnabled(Ext_S) then v[SDT] else 0b0,
     SPELP = if hartSupports(Ext_Zicfilp) then v[SPELP] else 0b0,
     TSR = if currentlyEnabled(Ext_S) then v[TSR] else 0b0,
     TW = if currentlyEnabled(Ext_U) then v[TW] else 0b0,
@@ -238,8 +242,9 @@ private function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
     SPP = if currentlyEnabled(Ext_S) then v[SPP] else 0b0,
     MPIE = v[MPIE],
     SPIE = if currentlyEnabled(Ext_S) then v[SPIE] else 0b0,
-    MIE = v[MIE],
-    SIE = if currentlyEnabled(Ext_S) then v[SIE] else 0b0,
+    // "When the MDT bit is set to 1 by an explicit CSR write, the MIE (Machine Interrupt Enable) bit is cleared to 0."
+    MIE = if not(currentlyEnabled(Ext_Smdbltrp) & v[MDT] == 0b1) then v[MIE] else 0b0,
+    SIE = if not(currentlyEnabled(Ext_Ssdbltrp) & v[SDT] == 0b1) & currentlyEnabled(Ext_S) then v[SIE] else 0b0,
   ];
 
   // TODO: When dynamic SXL/UXL changes are supported,
@@ -363,6 +368,8 @@ bitfield MEnvcfg : bits(64) = {
   PBMTE  : 62,
   // Svadu
   ADUE   : 61,
+  // Double Trap
+  DTE    : 59,
   // Pointer Masking Extension
   PMM    : 33 .. 32,
   // Cache Block Zero instruction Enable
@@ -417,6 +424,7 @@ private function legalize_menvcfg(o : MEnvcfg, v : bits(64)) -> MEnvcfg = {
     CBCFE = if currentlyEnabled(Ext_Zicbom) then v[CBCFE] else 0b0,
     CBIE = if currentlyEnabled(Ext_Zicbom) then legalize_xenvcfg_cbie(v[CBIE]) else 0b00,
     STCE = if currentlyEnabled(Ext_Sstc) then v[STCE] else 0b0,
+    DTE = if hartSupports(Ext_Ssdbltrp) then v[DTE] else 0b0,
     PMM = if currentlyEnabled(Ext_Smnpm) & is_supported_pmm(PM_SMNPM, pmm_mode(v[PMM])) then v[PMM] else o[PMM],
     ADUE = if currentlyEnabled(Ext_Svadu) then v[ADUE] else 0b0,
     PBMTE = if currentlyEnabled(Ext_Svpbmt) then v[PBMTE] else 0b0,
@@ -486,6 +494,8 @@ function is_fiom_active() -> bool = {
     VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   }
 }
+
+function clause currentlyEnabled(Ext_Ssdbltrp) = menvcfg[DTE] == 0b1
 
 // registers for trap handling
 
@@ -575,18 +585,23 @@ function align_pc(addr : xlenbits) -> xlenbits = {
 // auxiliary exception registers
 
 register mtval    : xlenbits
+register mtval2   : xlenbits
 register mscratch : xlenbits
 
 mapping clause csr_name_map = 0x343  <-> "mtval"
+mapping clause csr_name_map = 0x34B  <-> "mtval2"
 mapping clause csr_name_map = 0x340  <-> "mscratch"
 
 function clause is_CSR_accessible(0x343, _, _) = true // mtval
+function clause is_CSR_accessible(0x34B, _, _) = hartSupports(Ext_H) | hartSupports(Ext_Smdbltrp) // mtval2
 function clause is_CSR_accessible(0x340, _, _) = true // mscratch
 
 function clause read_CSR(0x343) = mtval
+function clause read_CSR(0x34B) = mtval2
 function clause read_CSR(0x340) = mscratch
 
 function clause write_CSR(0x343, value) = { mtval = value; Ok(mtval) }
+function clause write_CSR(0x34B, value) = { mtval2 = value; Ok(mtval2) }
 function clause write_CSR(0x340, value) = { mscratch = value; Ok(mscratch) }
 
 // counters
@@ -698,7 +713,7 @@ bitfield Sstatus : bits(64) = {
   SD    : xlen - 1,
 
   UXL   : 33 .. 32,
-//  SDT   : 24,
+  SDT   : 24,
   SPELP : 23,
   MXR   : 19,
   SUM   : 18,
@@ -717,7 +732,8 @@ private function lower_mstatus(m : Mstatus) -> Sstatus = {
   [s with
     SD = m[SD],
     UXL = m[UXL],
-    //SDT = m[SDT],
+    // If Ssdbltrp is disabled via menvcfg[DTE] then status[SDT] is read-only zero.
+    SDT = if currentlyEnabled(Ext_Ssdbltrp) then m[SDT] else 0b0,
     SPELP = m[SPELP],
     MXR = m[MXR],
     SUM = m[SUM],
@@ -737,7 +753,7 @@ private function lift_sstatus(m : Mstatus, s : Sstatus) -> Mstatus = {
   [m with
     SD = bool_to_bit(dirty),
     UXL = s[UXL],
-    //SDT = s[SDT],
+    SDT = s[SDT],
     SPELP = s[SPELP],
     MXR = s[MXR],
     SUM = s[SUM],

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -220,7 +220,7 @@ union ExceptionType = {
   E_Load_Page_Fault    : unit,
   E_Reserved_14        : unit,
   E_SAMO_Page_Fault    : unit,
-  E_Reserved_16        : unit,
+  E_Double_Trap        : unit,
   E_Reserved_17        : unit,
   E_Software_Check     : unit,
   E_Reserved_19        : unit,
@@ -249,7 +249,7 @@ mapping exceptionType_bits : ExceptionType <-> exc_code = {
   E_Load_Page_Fault()    <-> 0b001101, // 13
   E_Reserved_14()        <-> 0b001110, // 14
   E_SAMO_Page_Fault()    <-> 0b001111, // 15
-  E_Reserved_16()        <-> 0b010000, // 16
+  E_Double_Trap()        <-> 0b010000, // 16
   E_Reserved_17()        <-> 0b010001, // 17
   E_Software_Check()     <-> 0b010010, // 18
   E_Reserved_19()        <-> 0b010011, // 19
@@ -283,7 +283,7 @@ function exceptionType_to_str(e : ExceptionType) -> string =
     E_Load_Page_Fault()    => "load-page-fault",
     E_Reserved_14()        => "reserved-1",
     E_SAMO_Page_Fault()    => "store/amo-page-fault",
-    E_Reserved_16()        => "reserved-2",
+    E_Double_Trap()        => "double-trap",
     E_Reserved_17()        => "reserved-3",
     E_Software_Check()     => "software-check-fault",
     E_Reserved_19()        => "reserved-19",

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -222,7 +222,7 @@ union ExceptionType = {
   E_Load_Page_Fault    : unit,
   E_Reserved_14        : unit,
   E_SAMO_Page_Fault    : unit,
-  E_Reserved_16        : unit,
+  E_Double_Trap        : unit,
   E_Reserved_17        : unit,
   E_Software_Check     : unit,
   E_Reserved_19        : unit,
@@ -251,7 +251,7 @@ mapping exceptionType_bits : ExceptionType <-> exc_code = {
   E_Load_Page_Fault()    <-> 0b001101, // 13
   E_Reserved_14()        <-> 0b001110, // 14
   E_SAMO_Page_Fault()    <-> 0b001111, // 15
-  E_Reserved_16()        <-> 0b010000, // 16
+  E_Double_Trap()        <-> 0b010000, // 16
   E_Reserved_17()        <-> 0b010001, // 17
   E_Software_Check()     <-> 0b010010, // 18
   E_Reserved_19()        <-> 0b010011, // 19
@@ -285,7 +285,7 @@ function exceptionType_to_str(e : ExceptionType) -> string =
     E_Load_Page_Fault()    => "load-page-fault",
     E_Reserved_14()        => "reserved-1",
     E_SAMO_Page_Fault()    => "store/amo-page-fault",
-    E_Reserved_16()        => "reserved-2",
+    E_Double_Trap()        => "double-trap",
     E_Reserved_17()        => "reserved-3",
     E_Software_Check()     => "software-check-fault",
     E_Reserved_19()        => "reserved-19",

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -553,6 +553,30 @@ function clause execute ECALL() = {
 mapping clause assembly = ECALL() <-> "ecall"
 
 // *****************************************************************
+
+/// Called on MRET or SRET to update the mstatus MDT and SDT double trap bits.
+// prev_priv, new_priv are the privilege modes before and after the xRET respectively.
+function update_mstatus_dbltrap(prev_priv : Privilege, new_priv : Privilege) -> unit = {
+  // "The MRET and SRET instructions, when executed in M-mode, set the MDT bit to 0."
+  if currentlyEnabled(Ext_Smdbltrp) & prev_priv == Machine
+  then mstatus[MDT] = 0b1;
+
+  // For M-mode: ""
+  // For S-mode:
+  if currentlyEnabled(Ext_Ssdbltrp) & (match prev_priv {
+    // "If the new privilege mode is U, VS, or VU, then sstatus.SDT is also set to 0."
+    Machine           => new_priv == User | new_priv == VirtualSupervisor | new_priv == VirtualUser,
+    // "An SRET instruction sets the SDT bit to 0."
+    Supervisor        => true,
+    User              => internal_error(__FILE__, __LINE__, "xRET cannot be executed in user mode"),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+  })
+  then mstatus[SDT] = 0b0;
+
+  // TODO: Set vsstatus[SDT] = 0 when hypervisor is supported.
+}
+
 union clause instruction = MRET : unit
 
 mapping clause encdec = MRET()
@@ -571,6 +595,8 @@ function clause execute MRET() = {
     mstatus[MPP]  = privLevel_to_bits(if currentlyEnabled(Ext_U) then User else Machine);
     if   cur_privilege != Machine
     then mstatus[MPRV] = 0b0;
+
+    update_mstatus_dbltrap(prev_priv, cur_privilege);
 
     if   hartSupports(Ext_Zicfilp)
     then zicfilp_restore_elp_on_xret(mRET, cur_privilege);
@@ -615,6 +641,8 @@ function clause execute SRET() = {
     mstatus[SPP]  = 0b0;
     if   cur_privilege != Machine
     then mstatus[MPRV] = 0b0;
+
+    update_mstatus_dbltrap(prev_priv, cur_privilege);
 
     if   hartSupports(Ext_Zicfilp)
     then zicfilp_restore_elp_on_xret(sRET, cur_privilege);

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -557,6 +557,36 @@ function clause execute ECALL() = {
 mapping clause assembly = ECALL() <-> "ecall"
 
 // *****************************************************************
+
+/// Called on MRET or SRET to update the mstatus MDT and SDT double trap bits.
+// prev_priv, new_priv are the privilege modes before and after the xRET respectively.
+function xret_update_mstatus_dbltrap(prev_priv : Privilege, new_priv : Privilege) -> unit = {
+  // MRET or SRET clear mstatus[MDT] when executed in machine mode.
+  if currentlyEnabled(Ext_Smdbltrp) & prev_priv == Machine
+  then mstatus[MDT] = 0b0;
+
+  if currentlyEnabled(Ext_Ssdbltrp) & (match prev_priv {
+    // "If the Ssdbltrp extension is also implemented, and the new privilege mode
+    // is U, VS, or VU, then sstatus.⁠SDT is also set to 0."
+    Machine           => new_priv == User | new_priv == VirtualSupervisor | new_priv == VirtualUser,
+    // "An SRET instruction sets the SDT bit to 0."
+    //
+    // Note, because it says that in the "Supervisor-Level ISA" section
+    // it only applies when in supervisor mode. This isn't stated in the ISA
+    // manual as far as I can see but see this Github comment:
+    // https://github.com/riscv/riscv-isa-manual/issues/2870#issuecomment-4238414283
+    //
+    // We don't need to consider MRET from supervisor mode because that is illegal.
+    Supervisor        => true,
+    User              => internal_error(__FILE__, __LINE__, "xRET cannot be executed in user mode"),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+  })
+  then mstatus[SDT] = 0b0;
+
+  // TODO: Set vsstatus[SDT] = 0 when hypervisor is supported.
+}
+
 union clause instruction = MRET : unit
 
 mapping clause encdec = MRET()
@@ -575,6 +605,8 @@ function clause execute MRET() = {
     mstatus[MPP]  = privLevel_to_bits(if currentlyEnabled(Ext_U) then User else Machine);
     if   cur_privilege != Machine
     then mstatus[MPRV] = 0b0;
+
+    xret_update_mstatus_dbltrap(prev_priv, cur_privilege);
 
     if   hartSupports(Ext_Zicfilp)
     then zicfilp_restore_elp_on_xret(mRET, cur_privilege);
@@ -619,6 +651,8 @@ function clause execute SRET() = {
     mstatus[SPP]  = 0b0;
     if   cur_privilege != Machine
     then mstatus[MPRV] = 0b0;
+
+    xret_update_mstatus_dbltrap(prev_priv, cur_privilege);
 
     if   hartSupports(Ext_Zicfilp)
     then zicfilp_restore_elp_on_xret(sRET, cur_privilege);

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -196,9 +196,48 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
                       ^ " at priv " ^ to_str(del_priv)
                       ^ " with tval " ^ bits_str(tval(info)));
 
+  // If an unexpected double trap exception is taken in machine mode then we
+  // must not update any architectural state. This must therefore be before
+  // zicfilp_preserve_elp_on_trap(). The spec is unclear for supervisor mode
+  // but it seems likely the intention was for the trap to be redirected
+  // to machine mode also without any other architectural state updates.
+  match del_priv {
+    Machine => {
+      if currentlyEnabled(Ext_Smdbltrp) then {
+        if mstatus[MDT] == 0b0
+        then mstatus[MDT] = 0b1
+        else {
+          // Unexpected trap. In this implementation we currently just assert.
+          // TODO: This should probably actually be a return from try_step() with
+          // a special "double trap" result.
+          assert(false, "Unexpected double trap in machine mode");
+        };
+      };
+    },
+    Supervisor => {
+      if currentlyEnabled(Ext_Ssdbltrp) then {
+        if mstatus[SDT] == 0b0
+        then mstatus[SDT] = 0b1
+        else {
+          // Unexpected trap. Deliver double trap exception to machine mode.
+          // mcause is set to the double trap exception and mtval2 is set to
+          // the original cause.
+          mtval2 = [Mk_Mcause(zeros()) with
+            IsInterrupt = bool_to_bit(is_interrupt),
+            Cause = zero_extend(cause),
+          ].bits;
+          return trap_handler(Machine, Exception(E_Double_Trap()), pc, info, ext);
+        };
+      };
+    },
+    User              => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+  };
+
   if hartSupports(Ext_Zicfilp) then zicfilp_preserve_elp_on_trap(del_priv);
 
-  match (del_priv) {
+  match del_priv {
     Machine => {
       mcause[IsInterrupt] = bool_to_bit(is_interrupt);
       mcause[Cause]       = zero_extend(cause);
@@ -281,9 +320,11 @@ function xtval_exception_value(e : ExceptionType, excinfo : xlenbits) -> option(
     E_VS_EnvCall() => false,
     E_M_EnvCall()  => false,
     E_Extension(_) => true,
+    // Double trap exceptions should not be raised directly so we should never
+    // get to this point - they will use the result of the underlying trap.
+    E_Double_Trap() => internal_error(__FILE__, __LINE__, "Double trap exception should not be directly raised"),
     // the rest are all reserved exceptions
     E_Reserved_14() => reserved_exceptions_write_xtval,
-    E_Reserved_16() => reserved_exceptions_write_xtval,
     E_Reserved_17() => reserved_exceptions_write_xtval,
     E_Reserved_19() => reserved_exceptions_write_xtval,
   } then Some(excinfo) else None()
@@ -341,6 +382,9 @@ function reset_sys() -> unit = {
   // "The mstatus fields MIE and MPRV are reset to 0."
   mstatus[MIE] = 0b0;
   mstatus[MPRV] = 0b0;
+
+  // "Upon reset, the MDT field is set to 1."
+  if hartSupports(Ext_Smdbltrp) then mstatus[MDT] = 0b1;
 
   // "If little-endian memory accesses are supported, the mstatus/mstatush field
   // MBE is reset to 0."

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -185,9 +185,15 @@ function track_trap(p : Privilege, is_interrupt : bool, cause : exc_code) -> uni
   trap_callback(is_interrupt, cause);
 }
 
-// handle exceptional ctl flow by updating nextPC and operating privilege
-function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info : option(xlenbits), ext : option(ext_exception))
-                     -> xlenbits = {
+// Handle traps, after we have checked for double traps.
+function trap_handler_inner(
+  del_priv : Privilege,
+  c : TrapCause,
+  pc : xlenbits,
+  info : option(xlenbits),
+  ext : option(ext_exception),
+) -> xlenbits = {
+
   let is_interrupt = trapCause_is_interrupt(c);
   let cause        = trapCause_bits(c);
 
@@ -198,7 +204,7 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
 
   if hartSupports(Ext_Zicfilp) then zicfilp_preserve_elp_on_trap(del_priv);
 
-  match (del_priv) {
+  match del_priv {
     Machine => {
       mcause[IsInterrupt] = bool_to_bit(is_interrupt);
       mcause[Cause]       = zero_extend(cause);
@@ -249,6 +255,60 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
   };
 }
 
+// Handle a trap but check for double traps first.
+function trap_handler(
+  del_priv : Privilege,
+  c : TrapCause,
+  pc : xlenbits,
+  info : option(xlenbits),
+  ext : option(ext_exception),
+) -> xlenbits = {
+
+  let is_interrupt = trapCause_is_interrupt(c);
+  let cause        = trapCause_bits(c);
+
+  // If an unexpected double trap exception is taken in machine mode then we
+  // must not update any architectural state. This must therefore be before
+  // anything else.
+  match del_priv {
+    Machine => {
+      if currentlyEnabled(Ext_Smdbltrp) then {
+        if mstatus[MDT] == 0b0
+        then mstatus[MDT] = 0b1
+        else {
+          // Unexpected trap. When Srnmi is not implemented (currently unsupported)
+          // we enter a "critical-error" state where execution ceases.
+          // In this implementation we currently just assert.
+          // TODO: This should probably actually be a return from try_step() with
+          // a special "double trap" result. Or possibly an exception.
+          assert(false, "Unexpected double trap in machine mode");
+        };
+      };
+    },
+    Supervisor => {
+      if currentlyEnabled(Ext_Ssdbltrp) then {
+        if mstatus[SDT] == 0b0
+        then mstatus[SDT] = 0b1
+        else {
+          // Unexpected trap. Deliver double trap exception to machine mode.
+          // mcause is set to the double trap exception and mtval2 is set to
+          // the original cause.
+          mtval2 = [Mk_Mcause(zeros()) with
+            IsInterrupt = bool_to_bit(is_interrupt),
+            Cause = zero_extend(cause),
+          ].bits;
+          return trap_handler_inner(Machine, Exception(E_Double_Trap()), pc, info, ext);
+        };
+      };
+    },
+    User              => internal_error(__FILE__, __LINE__, "Invalid privilege level"),
+    VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+    VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
+  };
+
+  trap_handler_inner(del_priv, c, pc, info, ext)
+}
+
 function exception_handler(cur_priv : Privilege, exc : sync_exception, pc : xlenbits) -> xlenbits = {
   let del_priv = exception_delegatee(exc.trap, cur_priv);
   if   get_config_print_exception()
@@ -281,9 +341,11 @@ function xtval_exception_value(e : ExceptionType, excinfo : xlenbits) -> option(
     E_VS_EnvCall() => false,
     E_M_EnvCall()  => false,
     E_Extension(_) => true,
+    // Double trap exceptions should not be raised directly so we should never
+    // get to this point - they will use the result of the underlying trap.
+    E_Double_Trap() => internal_error(__FILE__, __LINE__, "Double trap exception should not be directly raised"),
     // the rest are all reserved exceptions
     E_Reserved_14() => reserved_exceptions_write_xtval,
-    E_Reserved_16() => reserved_exceptions_write_xtval,
     E_Reserved_17() => reserved_exceptions_write_xtval,
     E_Reserved_19() => reserved_exceptions_write_xtval,
   } then Some(excinfo) else None()
@@ -341,6 +403,9 @@ function reset_sys() -> unit = {
   // "The mstatus fields MIE and MPRV are reset to 0."
   mstatus[MIE] = 0b0;
   mstatus[MPRV] = 0b0;
+
+  // "Upon reset, the MDT field is set to 1."
+  if hartSupports(Ext_Smdbltrp) then mstatus[MDT] = 0b1;
 
   // Though {ms}tvec are unspecified on reset, their mode should hold
   // a supported value when read.


### PR DESCRIPTION
This adds support for the Smdbltrp and Ssdbltrp extensions which allow detecting and handling double traps.

When a double trap in machine mode is detected the hart is supposed to halt execution and raise an error to the platform. For now, for simplicity I've just used an assertion. In future we should probably change this to return from try_step() in a way that indicates to C++ that there has been a double trap.

The Smdbltrap extension requires the `mtval2` CSR (also used by hypervisor) so I added that too.