### PR TITLE
Require PMA regions to be page-aligned.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -126,6 +126,8 @@
       "len": 64,
       "value": "0x1000"
     },
+    // The locations and sizes of memory regions and their PMAs.  These regions
+    // are required to be aligned to 4K (page) boundaries.
     "regions": [
       // ROM
       {

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -241,13 +241,13 @@ private function check_pma_region(region : PMA_Region) -> bool = {
   // will not change within intra-page accesses.  Although this constraint
   // is not imposed by the specification, most implementations are
   // expected to conform with it.
-  let align : bits(64) = ones(64) << 12;
-  if (region.base & align) != region.base then {
+  if region.base[pagesize_bits - 1 .. 0] != zeros() then {
     print_endline("Memory region starting at " ^ bits_str(region.base) ^ " does not start on a 4K (page) boundary.");
     return false;
   };
-  if (region.size & align) != region.size then {
-    print_endline("Memory region starting at " ^ bits_str(region.base) ^ " does not end on a 4K (page) boundary.");
+  if region.size[pagesize_bits - 1 .. 0] != zeros() then {
+    print_endline("Memory region starting at " ^ bits_str(region.base) ^ " with size " ^ bits_str(region.size) ^ " does not end on a 4K (page) boundary.");
+    return false;
   };
 
   let pma = region.attributes;

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -236,6 +236,20 @@ private function check_vext_config() -> bool = {
 }
 
 private function check_pma_region(region : PMA_Region) -> bool = {
+  // We currently require PMAs to be aligned to page boundaries.  This
+  // simplifies memory protection and alignment checks: PMA properties
+  // will not change within intra-page accesses.  Although this constraint
+  // is not imposed by the specification, most implementations are
+  // expected to conform with it.
+  let align : bits(64) = ones(64) << 12;
+  if (region.base & align) != region.base then {
+    print_endline("Memory region starting at " ^ bits_str(region.base) ^ " does not start on a 4K (page) boundary.");
+    return false;
+  };
+  if (region.size & align) != region.size then {
+    print_endline("Memory region starting at " ^ bits_str(region.base) ^ " does not end on a 4K (page) boundary.");
+  };
+
   let pma = region.attributes;
   // TODO: this could be extended, e.g. to check that read_idempotent => readable, etc.
   match pma.mem_type {


### PR DESCRIPTION
This ensures that PMAs do not change within intra-page accesses; this simplifies PMA checks, and most implementations are expected to conform with this restriction.