### PR TITLE
Tweak trap loop detector heuristic.

### DIFF
--- a/c_emulator/riscv_callbacks_if.cpp
+++ b/c_emulator/riscv_callbacks_if.cpp
@@ -94,6 +94,9 @@ void callbacks_if::trap_callback(
 void callbacks_if::xret_callback([[maybe_unused]] hart::Model &model, [[maybe_unused]] bool is_mret) {
 }
 
+void callbacks_if::instret_callback([[maybe_unused]] hart::Model &model) {
+}
+
 // Page table walk callbacks
 void callbacks_if::ptw_start_callback(
   [[maybe_unused]] hart::Model &model,

--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -48,6 +48,8 @@ public:
 
   virtual void xret_callback(hart::Model &model, bool is_mret);
 
+  virtual void instret_callback(hart::Model &model);
+
   // Page table walk callbacks
   virtual void ptw_start_callback(
     hart::Model &model,

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -140,6 +140,13 @@ unit ModelImpl::xret_callback(bool is_mret) {
   return UNIT;
 }
 
+unit ModelImpl::instret_callback(unit) {
+  for (auto c : m_callbacks) {
+    c->instret_callback(*this);
+  }
+  return UNIT;
+}
+
 unit ModelImpl::ptw_start_callback(
   uint64_t vpn,
   hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -56,6 +56,7 @@ private:
   unit redirect_callback(sbits new_pc) override;
   unit trap_callback(bool is_interrupt, fbits cause) override;
   unit xret_callback(bool is_mret) override;
+  unit instret_callback(unit) override;
 
   // Page table walk callbacks
   unit ptw_start_callback(

--- a/c_emulator/riscv_platform_if.cpp
+++ b/c_emulator/riscv_platform_if.cpp
@@ -85,6 +85,10 @@ unit PlatformInterface::xret_callback([[maybe_unused]] bool is_mret) {
   return UNIT;
 }
 
+unit PlatformInterface::instret_callback(unit) {
+  return UNIT;
+}
+
 unit PlatformInterface::ptw_start_callback(
   [[maybe_unused]] uint64_t vpn,
   [[maybe_unused]] hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,

--- a/c_emulator/riscv_platform_if.h
+++ b/c_emulator/riscv_platform_if.h
@@ -50,6 +50,7 @@ public:
 
   virtual unit trap_callback(bool is_interrupt, fbits cause);
   virtual unit xret_callback(bool is_mret);
+  virtual unit instret_callback(unit);
 
   // Page table walk callbacks
   virtual unit ptw_start_callback(

--- a/c_emulator/traploop_detector.cpp
+++ b/c_emulator/traploop_detector.cpp
@@ -7,34 +7,46 @@ traploop_detector::traploop_detector() {
   reset();
 }
 
+void traploop_detector::reset_loop() {
+  mepc_at_first_trap = 0;
+  sepc_at_first_trap = 0;
+  instret_at_last_trap = 0;
+  nested_trap_count = 0;
+}
+
 void traploop_detector::reset() {
-  trap_count = 0;
-  trap_mepc = 0;
-  trap_sepc = 0;
-  xret_count = 0;
+  instret = 0;
+  reset_loop();
 }
 
 void traploop_detector::trap_callback(hart::Model &model, bool, fbits) {
-  trap_count++;
-  trap_mepc = model.zmepc.bits;
-  trap_sepc = model.zsepc.bits;
+  if (nested_trap_count == 0) {
+    mepc_at_first_trap = model.zmepc.bits;
+    sepc_at_first_trap = model.zsepc.bits;
+  }
+  nested_trap_count++;
+  instret_at_last_trap = instret;
 }
 
 void traploop_detector::xret_callback(hart::Model &, bool) {
-  xret_count++;
+  reset_loop();
 }
 
-bool traploop_detector::loop_detected() {
-  // It would be very unusual to have xrets exceeding trap-count by a
-  // large amount.  Should this be handled as well?
-  uint64_t diff = (trap_count > xret_count) ? trap_count - xret_count : 0;
-  return (diff > trap_count_threshold);
+void traploop_detector::instret_callback(hart::Model &) {
+  instret++;
+  if ((instret_at_last_trap != 0) & (instret - instret_at_last_trap > instrets_to_reset_loop)) {
+    reset_loop();
+  }
+}
+
+bool traploop_detector::loop_detected() const {
+  return nested_trap_count > nested_trap_count_threshold;
 }
 
 uint64_t traploop_detector::mepc() const {
-  return trap_mepc;
+  return mepc_at_first_trap;
 }
 
 uint64_t traploop_detector::sepc() const {
-  return trap_sepc;
+  return sepc_at_first_trap;
 }

--- a/c_emulator/traploop_detector.cpp
+++ b/c_emulator/traploop_detector.cpp
@@ -7,16 +7,11 @@ traploop_detector::traploop_detector() {
   reset();
 }
 
-void traploop_detector::reset_loop() {
+void traploop_detector::reset() {
   mepc_at_first_trap = 0;
   sepc_at_first_trap = 0;
-  instret_at_last_trap = 0;
+  instrets_since_last_trap = 0;
   nested_trap_count = 0;
-}
-
-void traploop_detector::reset() {
-  instret = 0;
-  reset_loop();
 }
 
 void traploop_detector::trap_callback(hart::Model &model, bool, fbits) {
@@ -25,17 +20,19 @@ void traploop_detector::trap_callback(hart::Model &model, bool, fbits) {
     sepc_at_first_trap = model.zsepc.bits;
   }
   nested_trap_count++;
-  instret_at_last_trap = instret;
+  instrets_since_last_trap = 0;
 }
 
 void traploop_detector::xret_callback(hart::Model &, bool) {
-  reset_loop();
+  reset();
 }
 
 void traploop_detector::instret_callback(hart::Model &) {
-  instret++;
-  if ((instret_at_last_trap != 0) & (instret - instret_at_last_trap > instrets_to_reset_loop)) {
-    reset_loop();
+  if (nested_trap_count != 0) {
+    instrets_since_last_trap++;
+    if (instrets_since_last_trap > instrets_to_reset_loop) {
+      reset();
+    }
   }
 }
 

--- a/c_emulator/traploop_detector.h
+++ b/c_emulator/traploop_detector.h
@@ -19,18 +19,15 @@ public:
   void instret_callback(hart::Model &model) override;
 
 private:
-  void reset_loop();
-
-  uint64_t instret;
-  uint64_t mepc_at_first_trap;
-  uint64_t sepc_at_first_trap;
-  uint64_t instret_at_last_trap;
-  uint32_t nested_trap_count;
+  uint64_t mepc_at_first_trap = 0;
+  uint64_t sepc_at_first_trap = 0;
+  uint32_t instrets_since_last_trap = 0;
+  uint32_t nested_trap_count = 0;
 
   // A trap loop is detected if the nested trap count goes higher than
   // this threshold.
   const uint32_t nested_trap_count_threshold = 10;
   // If instrets since the last trap exceed this, a tight nested trap loop
   // is unlikely and the detector is reset.
-  const uint64_t instrets_to_reset_loop = 20;
+  const uint32_t instrets_to_reset_loop = 20;
 };

--- a/c_emulator/traploop_detector.h
+++ b/c_emulator/traploop_detector.h
@@ -29,7 +29,7 @@ private:
 
   // A trap loop is detected if the nested trap count goes higher than
   // this threshold.
-  const uint64_t nested_trap_count_threshold = 10;
+  const uint32_t nested_trap_count_threshold = 10;
   // If instrets since the last trap exceed this, a tight nested trap loop
   // is unlikely and the detector is reset.
   const uint64_t instrets_to_reset_loop = 20;

--- a/c_emulator/traploop_detector.h
+++ b/c_emulator/traploop_detector.h
@@ -7,7 +7,7 @@ class traploop_detector : public callbacks_if {
 public:
   explicit traploop_detector();
 
-  bool loop_detected();
+  bool loop_detected() const;
   void reset();
 
   uint64_t mepc() const;
@@ -16,11 +16,21 @@ public:
   // callbacks_if
   void trap_callback(hart::Model &model, bool is_interrupt, fbits cause) override;
   void xret_callback(hart::Model &model, bool is_mret) override;
+  void instret_callback(hart::Model &model) override;
 
 private:
-  uint64_t trap_count = 0;
-  uint64_t trap_mepc = 0;
-  uint64_t trap_sepc = 0;
-  uint64_t xret_count = 0;
-  const uint64_t trap_count_threshold = 10;
+  void reset_loop();
+
+  uint64_t instret;
+  uint64_t mepc_at_first_trap;
+  uint64_t sepc_at_first_trap;
+  uint64_t instret_at_last_trap;
+  uint32_t nested_trap_count;
+
+  // A trap loop is detected if the nested trap count goes higher than
+  // this threshold.
+  const uint64_t nested_trap_count_threshold = 10;
+  // If instrets since the last trap exceed this, a tight nested trap loop
+  // is unlikely and the detector is reset.
+  const uint64_t instrets_to_reset_loop = 20;
 };

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -264,6 +264,9 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
 
       // For step extensions
       ext_post_step_hook();
+
+      if retired then instret_callback();
+
       // Return that we have stepped and are not waiting.
       false
     }

--- a/model/sys/callbacks.sail
+++ b/model/sys/callbacks.sail
@@ -25,3 +25,8 @@ function ptw_success_callback(_) = ()
 
 val ptw_fail_callback = pure {cpp: "ptw_fail_callback"} : (/* error_type */ PTW_Error, /* level */ range(0, 4), /* pte_addr */ physaddrbits) -> unit
 function ptw_fail_callback(_) = ()
+
+// Instruction retire callback.  This allows tracking retires without using
+// minstret, since that is only conditionally incremented on retires.
+val instret_callback = pure {cpp: "instret_callback"} : (unit) -> unit
+function instret_callback() = ()


### PR DESCRIPTION
The previous heuristic did not suffice for a few ACT4 tests where the trap count grew slowly but steadily over the xret count.

Adjust by introducing an instruction retired callback and resetting the loop detector when a sufficient number of instructions have retired since the last trap.

This still catches tight trap loops but allows the above tests to complete successfully.