### PR TITLE
Update test suite release to add the newly released ACT 4.0.0 tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           # Ninja is used because the CMake Makefile generator doesn't
           # build top-level targets in parallel unfortunately.
           # First party tests cannot be built in the Rocky container due to lack of a suitable toolchain.
-          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWARNINGS_AS_ERRORS=TRUE -DFIRST_PARTY_TESTS=${{ matrix.first_party_tests }} -DENABLE_RISCV_TESTS=TRUE -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE $CLANG_FLAG
+          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWARNINGS_AS_ERRORS=TRUE -DFIRST_PARTY_TESTS=${{ matrix.first_party_tests }} -DENABLE_RISCV_TESTS=TRUE -DENABLE_RISCV_ARCH_TESTS=TRUE -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE $CLANG_FLAG
           ninja -C build all generated_sail_riscv_docs generated_smt_rv64d generated_smt_rv32d
 
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Build simulator
         run: |
           git config --global --add safe.directory '*'
-          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DSTATIC=TRUE -DENABLE_RISCV_TESTS=TRUE -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE
+          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DSTATIC=TRUE -DENABLE_RISCV_TESTS=TRUE -DENABLE_RISCV_ARCH_TESTS=TRUE -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE
           cd build
           ninja all
           ctest -j2

--- a/.github/workflows/run-full-tests.yml
+++ b/.github/workflows/run-full-tests.yml
@@ -22,6 +22,7 @@ jobs:
         TEST_SUITE:
           [
             RISCV_TESTS,
+            RISCV_ARCH_TESTS,
             RISCV_VECTOR_TESTS_V128_E32,
             RISCV_VECTOR_TESTS_V128_E64,
             RISCV_VECTOR_TESTS_V256_E32,

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -59,6 +59,8 @@
     improvements for superpage-heavy workloads (e.g. Linux boot time reduced
     by ~71%).
 
+- Testing in CI now includes the ACT4 test suite from `riscv/riscv-arch-test`.
+
 - Important issues addressed and bugs fixed:
   - https://github.com/riscv/sail-riscv/issues/1553 : Sail exceptions were not usefully shown in the execution trace
   - https://github.com/riscv/sail-riscv/issues/1560 : Updates to `mip` were not captured in the trace file

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake options for test downloads
 set(TEST_DOWNLOAD_URL "https://github.com/riscv-software-src/sail-riscv-tests/releases/download" CACHE STRING "Base URL to download precompiled riscv-tests and riscv-vector-tests from")
-set(TEST_DOWNLOAD_VERSION "2026-03-24" CACHE STRING "Version of precompiled tests to download")
+set(TEST_DOWNLOAD_VERSION "2026-04-17" CACHE STRING "Version of precompiled tests to download")
 
 # Function to download and extract test files
 function(download_riscv_tests DOWNLOAD_PATH TARBALL_NAME DOWNLOAD_URL)
@@ -110,6 +110,39 @@ if(ENABLE_RISCV_TESTS)
                 COMMAND
                     $<TARGET_FILE:sail_riscv_sim>
                     # Use ELEN=XLEN. These tests don't use vector so it doesn't actually matter.
+                    --config "${CMAKE_BINARY_DIR}/config/rv${xlen}d_v256_e${xlen}.json"
+                    ${elf}
+            )
+        endforeach()
+    endforeach()
+endif()
+
+# Download and add RISC-V arch tests.
+option(ENABLE_RISCV_ARCH_TESTS "Enable riscv-arch-tests" OFF)
+
+if(ENABLE_RISCV_ARCH_TESTS)
+    set(TARBALL_NAME "riscv-arch-tests")
+    set(DOWNLOAD_PATH "${CMAKE_CURRENT_BINARY_DIR}/${TEST_DOWNLOAD_VERSION}")
+    set(DOWNLOAD_URL "${TEST_DOWNLOAD_URL}/${TEST_DOWNLOAD_VERSION}/${TARBALL_NAME}.tar.gz")
+
+    download_riscv_tests(
+        "${DOWNLOAD_PATH}"
+        "${TARBALL_NAME}"
+        "${DOWNLOAD_URL}"
+    )
+
+    foreach(xlen IN ITEMS 32 64)
+        file(GLOB_RECURSE elf_list CONFIGURE_DEPENDS LIST_DIRECTORIES false
+           "${DOWNLOAD_PATH}/${TARBALL_NAME}/sail-rv${xlen}-max/*.elf"
+        )
+        foreach(elf IN LISTS elf_list)
+            file(RELATIVE_PATH elf_name "${CMAKE_CURRENT_BINARY_DIR}" ${elf})
+            add_test(
+                # `elf_name` includes xlen so we don't need to add any details.
+                NAME "${elf_name}"
+                COMMAND
+                    $<TARGET_FILE:sail_riscv_sim>
+                    # Use ELEN=XLEN. These tests don't yet use vector so it doesn't matter.
                     --config "${CMAKE_BINARY_DIR}/config/rv${xlen}d_v256_e${xlen}.json"
                     ${elf}
             )

--- a/test/README.md
+++ b/test/README.md
@@ -1,10 +1,12 @@
 ## Test Suites
 
-The simulator supports multiple test suites that are downloaded on-demand during the CMake configure step:
+The simulator supports multiple test suites that are downloaded on-demand during the CMake configure step. Precompiled binaries are downloaded from [sail-riscv-tests releases](https://github.com/riscv-software-src/sail-riscv-tests/releases/).
 
-- **Standard RISC-V Tests** from the [`riscv-tests`](https://github.com/riscv-software-src/riscv-tests) repository: Basic pre-compiled ELFs with fundamental ISA tests. Enabled by default (can be disabled with `-DENABLE_RISCV_TESTS=OFF`). Precompiled binaries are downloaded from [sail-riscv-tests releases](https://github.com/riscv-software-src/sail-riscv-tests/releases/).
+- **Standard RISC-V Tests** from the [`riscv-tests`](https://github.com/riscv-software-src/riscv-tests) repository: Basic pre-compiled ELFs with fundamental ISA tests. Enabled by default (can be disabled with `-DENABLE_RISCV_TESTS=OFF`).
 
-- **RISC-V Vector Extension Tests** from the [`riscv-vector-tests`](https://github.com/chipsalliance/riscv-vector-tests) repository: Comprehensive vector extension tests enabled with CMake options like `-DENABLE_RISCV_VECTOR_TESTS_V256_E32=ON` for specific VLEN/ELEN configurations (supported combinations: V128_E32, V128_E64, V256_E32, V256_E64, V512_E32, V512_E64). Precompiled binaries are downloaded from [sail-riscv-tests releases](https://github.com/riscv-software-src/sail-riscv-tests/releases).
+- **RISC-V Vector Extension Tests** from the [`riscv-vector-tests`](https://github.com/chipsalliance/riscv-vector-tests) repository: Comprehensive vector extension tests enabled with CMake options like `-DENABLE_RISCV_VECTOR_TESTS_V256_E32=ON` for specific VLEN/ELEN configurations (supported combinations: V128_E32, V128_E64, V256_E32, V256_E64, V512_E32, V512_E64).
+
+- **RISC-V Architectural Certification Tests** from the [`riscv-arch-test`](https://github.com/riscv/riscv-arch-test) repository: Tests designed to certify that a design faithfully implements the RISC-V specification (can be enabled with `-DENABLE_RISCV_ARCH_TESTS=TRUE`).
 
 ## Local Test Directory
 


### PR DESCRIPTION
ACT 4.0.0 release notes:
https://github.com/riscv/riscv-arch-test/releases/tag/4.0.0

Update the CMake targets, test/README and CI/Release workflows.

```
$ ./compare-releases.py -p releases/2026-03-24 -c releases/2026-04-17
riscv-tests has 655 test files, with 0 added to and 0 removed from the previous release.
riscv-arch-tests with 1526 tests was added.
riscv-vector-tests-v128x32 has 1944 test files, with 0 added to and 0 removed from the previous release.
riscv-vector-tests-v128x64 has 3042 test files, with 0 added to and 0 removed from the previous release.
riscv-vector-tests-v256x32 has 1945 test files, with 0 added to and 0 removed from the previous release.
riscv-vector-tests-v256x64 has 3043 test files, with 0 added to and 0 removed from the previous release.
riscv-vector-tests-v512x32 has 1945 test files, with 0 added to and 0 removed from the previous release.
riscv-vector-tests-v512x64 has 3043 test files, with 0 added to and 0 removed from the previous release.
```

Though ACT tests use the Sail RISC-V model to generate expected results, having this test suite in CI ensures that the development versions of the Sail model continue to give the same results as before.