### PR TITLE
Simplify xret by moving their logic to their execute clauses

### DIFF
--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -626,6 +626,7 @@ function clause execute SRET() = {
                         ^ " to " ^ to_str(cur_privilege));
 
     set_next_pc(prepare_xret_target(Supervisor));
+    
     xret_callback(false);
     RETIRE_SUCCESS
   }

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -626,7 +626,7 @@ function clause execute SRET() = {
                         ^ " to " ^ to_str(cur_privilege));
 
     set_next_pc(prepare_xret_target(Supervisor));
-    
+
     xret_callback(false);
     RETIRE_SUCCESS
   }

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -564,7 +564,24 @@ function clause execute MRET() = {
   else if not(ext_check_xret_priv(Machine))
   then Ext_XRET_Priv_Failure()
   else {
-    set_next_pc(exception_handler(cur_privilege, CTL_MRET(), PC));
+    let prev_priv = cur_privilege;
+    mstatus[MIE]  = mstatus[MPIE];
+    mstatus[MPIE] = 0b1;
+    cur_privilege = privLevel_bits(mstatus[MPP], 0b0); // TODO: use mstatus[MPV] if hypervisor enabled
+    mstatus[MPP]  = privLevel_to_bits(if currentlyEnabled(Ext_U) then User else Machine);
+    if   cur_privilege != Machine
+    then mstatus[MPRV] = 0b0;
+
+    if   hartSupports(Ext_Zicfilp)
+    then zicfilp_restore_elp_on_xret(mRET, cur_privilege);
+
+    long_csr_write_callback("mstatus", "mstatush", mstatus.bits);
+
+    if   get_config_print_exception()
+    then print_log("ret-ing from " ^ to_str(prev_priv) ^ " to " ^ to_str(cur_privilege));
+
+    set_next_pc(prepare_xret_target(Machine));
+
     xret_callback(true);
     RETIRE_SUCCESS
   }
@@ -591,7 +608,24 @@ function clause execute SRET() = {
   else if not(ext_check_xret_priv (Supervisor))
   then Ext_XRET_Priv_Failure()
   else {
-    set_next_pc(exception_handler(cur_privilege, CTL_SRET(), PC));
+    let prev_priv = cur_privilege;
+    mstatus[SIE]  = mstatus[SPIE];
+    mstatus[SPIE] = 0b1;
+    cur_privilege = if mstatus[SPP] == 0b1 then Supervisor else User;
+    mstatus[SPP]  = 0b0;
+    if   cur_privilege != Machine
+    then mstatus[MPRV] = 0b0;
+
+    if   hartSupports(Ext_Zicfilp)
+    then zicfilp_restore_elp_on_xret(sRET, cur_privilege);
+
+    long_csr_write_callback("mstatus", "mstatush", mstatus.bits);
+
+    if   get_config_print_exception()
+    then print_log("ret-ing from " ^ to_str(prev_priv)
+                        ^ " to " ^ to_str(cur_privilege));
+
+    set_next_pc(prepare_xret_target(Supervisor));
     xret_callback(false);
     RETIRE_SUCCESS
   }

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -214,7 +214,7 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
     // is more than one ExecuteAs indirection we'll get to here. This isn't supported.
     Step_Execute(ExecuteAs(_), _) => internal_error(__FILE__, __LINE__, "Multiple chained ExecuteAs (only one redirection is supported)."),
     // standard errors
-    Step_Execute(Trap(priv, ctl, pc), _) => set_next_pc(exception_handler(priv, ctl, pc)),
+    Step_Execute(Trap(priv, exc, pc), _) => set_next_pc(exception_handler(priv, exc, pc)),
     Step_Execute(Illegal_Instruction(), instbits) => handle_exception(zero_extend(instbits), E_Illegal_Instr()),
     // NOTE: Virtual instructions exception cannot be triggered until Hypervisor integration is complete.
     Step_Execute(Virtual_Instruction(), instbits) => handle_exception(zero_extend(instbits), E_Virtual_Instr()),

--- a/model/sys/insts_begin.sail
+++ b/model/sys/insts_begin.sail
@@ -34,7 +34,7 @@ union ExecutionResult = {
   // Did not retire for a standard reason.
   Illegal_Instruction            : unit,
   Virtual_Instruction            : unit,
-  Trap                           : (Privilege, ctl_result, xlenbits),
+  Trap                           : (Privilege, sync_exception, xlenbits),
 
   // Did not retire for custom reason.
   Ext_CSR_Check_Failure          : unit,
@@ -53,7 +53,7 @@ let RETIRE_SUCCESS : ExecutionResult = Retire_Success()
 // Trap helpers
 
 function trap(exc : sync_exception) -> ExecutionResult =
-  Trap(cur_privilege, CTL_TRAP(exc), PC)
+  Trap(cur_privilege, exc, PC)
 
 function memory_exception(vaddr : virtaddr, exc : ExceptionType) -> ExecutionResult =
   trap(make_sync_exception(exc, bits_of(vaddr)))

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -136,14 +136,6 @@ function dispatchInterrupt(priv : Privilege) -> option((InterruptType, Privilege
   }
 }
 
-// types of privilege transitions
-
-union ctl_result = {
-  CTL_TRAP : sync_exception,
-  CTL_SRET : unit,
-  CTL_MRET : unit,
-}
-
 // trap value
 
 function tval(excinfo : option(xlenbits)) -> xlenbits = {
@@ -238,58 +230,13 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
   };
 }
 
-function exception_handler(cur_priv : Privilege, ctl : ctl_result,
-                           pc: xlenbits) -> xlenbits = {
-  match ctl {
-    CTL_TRAP(e) => {
-      let del_priv = exception_delegatee(e.trap, cur_priv);
-      if   get_config_print_exception()
-      then print_log("trapping from " ^ to_str(cur_priv) ^ " to " ^ to_str(del_priv)
-                          ^ " to handle " ^ to_str(e.trap));
-      trap_handler(del_priv, Exception(e.trap), pc, e.excinfo, e.ext)
-    },
-    CTL_MRET()  => {
-      let prev_priv = cur_privilege;
-      mstatus[MIE]  = mstatus[MPIE];
-      mstatus[MPIE] = 0b1;
-      cur_privilege = privLevel_bits(mstatus[MPP], 0b0); // TODO: use mstatus[MPV] if hypervisor enabled
-      mstatus[MPP]  = privLevel_to_bits(if currentlyEnabled(Ext_U) then User else Machine);
-      if   cur_privilege != Machine
-      then mstatus[MPRV] = 0b0;
-
-      if   hartSupports(Ext_Zicfilp)
-      then zicfilp_restore_elp_on_xret(mRET, cur_privilege);
-
-      long_csr_write_callback("mstatus", "mstatush", mstatus.bits);
-
-      if   get_config_print_exception()
-      then print_log("ret-ing from " ^ to_str(prev_priv) ^ " to " ^ to_str(cur_privilege));
-
-      prepare_xret_target(Machine)
-    },
-    CTL_SRET()  => {
-      let prev_priv = cur_privilege;
-      mstatus[SIE]  = mstatus[SPIE];
-      mstatus[SPIE] = 0b1;
-      cur_privilege = if mstatus[SPP] == 0b1 then Supervisor else User;
-      mstatus[SPP]  = 0b0;
-      if   cur_privilege != Machine
-      then mstatus[MPRV] = 0b0;
-
-      if   hartSupports(Ext_Zicfilp)
-      then zicfilp_restore_elp_on_xret(sRET, cur_privilege);
-
-      long_csr_write_callback("mstatus", "mstatush", mstatus.bits);
-
-      if   get_config_print_exception()
-      then print_log("ret-ing from " ^ to_str(prev_priv)
-                          ^ " to " ^ to_str(cur_privilege));
-
-      prepare_xret_target(Supervisor)
-    },
-  }
+function exception_handler(cur_priv : Privilege, exc : sync_exception, pc : xlenbits) -> xlenbits = {
+  let del_priv = exception_delegatee(exc.trap, cur_priv);
+  if   get_config_print_exception()
+  then print_log("trapping from " ^ to_str(cur_priv) ^ " to " ^ to_str(del_priv)
+                      ^ " to handle " ^ to_str(exc.trap));
+  trap_handler(del_priv, Exception(exc.trap), pc, exc.excinfo, exc.ext)
 }
-
 // Compute the value to write to mtval on a trap.
 function xtval_exception_value(e : ExceptionType, excinfo : xlenbits) -> option(xlenbits) = {
   if match e {
@@ -328,10 +275,8 @@ function make_sync_exception(e : ExceptionType, xtval : xlenbits) -> sync_except
            excinfo = xtval_exception_value(e, xtval),
            ext     = None() }
 
-function handle_exception(xtval : xlenbits, e : ExceptionType) -> unit = {
-  let t = make_sync_exception(e, xtval);
-  set_next_pc(exception_handler(cur_privilege, CTL_TRAP(t), PC))
-}
+function handle_exception(xtval : xlenbits, e : ExceptionType) -> unit =
+  set_next_pc(exception_handler(cur_privilege, make_sync_exception(e, xtval), PC))
 
 function handle_interrupt(i : InterruptType, del_priv : Privilege) -> unit =
   set_next_pc(trap_handler(del_priv, Interrupt(i), PC, None(), None()))


### PR DESCRIPTION
This simplifies how xrets are handled by moving their code from `exception_handler()` to the `execute` clauses. This is easier to follow, makes more sense (xrets are not exceptions), and will make including the xret code in the ISA manual easier.

Fixes #1658