### PR TITLE
Extend memory layout validation to include MMIO devices and the DTB.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -121,7 +121,8 @@
       // loads the resulting `xtval` may depend on this setting.
       "order_decreasing": false
     },
-    // Address to write DTB to (if provided).
+    // Address to write DTB to (if provided). This must be in a suitable memory
+    // region (see `memory.regions`).
     "dtb_address": {
       "len": 64,
       "value": "0x1000"
@@ -227,7 +228,7 @@
     // 6 for Za64rs and 7 for Za128rs.  In all cases, it must be less than or equal to 12.
     "reservation_set_size_exp": 3,
     "clint": {
-      // This must be in a suitable memory region (see `memory.regions`).
+      // This must be in a suitable IO memory region (see `memory.regions`).
       "base": 33554432,
       "size": 786432
     },

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -315,9 +315,28 @@ private function check_pma_regions(regions : list(PMA_Region), prev_base : bits(
     },
   }
 
-// Return true iff [addr, addr+size) is fully contained in a single configured PMA memory region.
+// Return true iff [addr, addr+size) is fully contained in a single configured PMA memory region of the specified type.
+function within_configured_pma_memory(component : string, mem_type_opt : option(MemoryRegionType), addr : bits(64), size : bits(64)) -> bool = {
+  var valid : bool = true;
+  match (matching_pma_region_bits_range(pma_regions, addr, size), mem_type_opt) {
+    (None(), _) => {
+      valid = false;
+      print_endline("The " ^ component ^ " for the platform is not in a defined memory region.");
+    },
+    (Some(region), Some(mem_type)) => {
+      if region.attributes.mem_type != mem_type then {
+        valid = false;
+        print_endline("The " ^ component ^ " for the platform is in a memory region starting at " ^ bits_str(region.base) ^ " which is not a " ^ to_str(mem_type) ^ " region.");
+      }
+    },
+    (Some(_), _) => (),
+  };
+  valid
+}
+
 private function dtb_within_configured_pma_memory(addr : bits(64), size : bits(64)) -> bool =
-  is_some(matching_pma_region_bits_range(pma_regions, addr, size))
+  // Allow DTBs to be in main memory or IO memory (e.g. ROM).
+  within_configured_pma_memory("DTB", None(), addr, size)
 
 // Check that all memory regions are sorted and don't overlap, and that PMAs are compatible with enabled extensions.
 private function check_mem_layout() -> bool =
@@ -332,7 +351,14 @@ private function check_mem_layout() -> bool =
       ssccptr  = config extensions.Ssccptr.supported,
       svadu    = config extensions.Svadu.supported,
     };
-    check_pma_regions(pma_regions, zeros(), zeros(), check_opts, false)
+    let pmas_ok  = check_pma_regions(pma_regions, zeros(), zeros(), check_opts, false);
+    let clint_ok = within_configured_pma_memory("CLINT (platform.clint)", Some(IOMemory),
+                                                to_bits_checked(config platform.clint.base : int),
+                                                to_bits_checked(config platform.clint.size : int));
+    let sig_ok   = within_configured_pma_memory("simple interrupt generator (platform.simple_interrupt_generator)", Some(IOMemory),
+                                                to_bits_checked(config platform.simple_interrupt_generator.base : int),
+                                                zero_extend(plat_sig_size));
+    pmas_ok & clint_ok & sig_ok
   }
 
 private function check_pmp() -> bool = {

--- a/model/sys/pma.sail
+++ b/model/sys/pma.sail
@@ -85,6 +85,11 @@ mapping misaligned_fault_str : misaligned_fault <-> string = {
 overload to_str = {misaligned_fault_str}
 
 enum MemoryRegionType = { MainMemory, IOMemory }
+mapping memory_region_type_str : MemoryRegionType <-> string = {
+  MainMemory <-> "main memory",
+  IOMemory   <-> "IO memory",
+}
+overload to_str = {memory_region_type_str}
 
 // Physical Memory Attributes for a region.
 struct PMA = {


### PR DESCRIPTION
This ensures that the CLINT and the custom simple interrupt generator are placed in an IO PMA region, and that the DTB is in a configured region.  The constraints on the DTB are looser since it could be in a ROM (an IO region) or main memory.