### PR TITLE
Add a configuration option for exact matches on reservation addresses for LR/SC.

### DIFF
--- a/c_emulator/config_utils.cpp
+++ b/c_emulator/config_utils.cpp
@@ -64,6 +64,22 @@ uint64_t get_config_uint64(const std::vector<const char *> &keypath) {
   );
 }
 
+bool get_config_bool(const std::vector<const char *> &keypath) {
+  sail_config_json json = sail_config_get(keypath.size(), keypath.data());
+
+  if (json == nullptr) {
+    throw std::runtime_error("Failed to find configuration option '" + keypath_to_str(keypath) + "'.");
+  }
+
+  if (sail_config_is_bool(json)) {
+    return sail_config_unwrap_bool(json);
+  }
+
+  throw std::runtime_error(
+    "Configuration option '" + keypath_to_str(keypath) + "' could not be parsed as a boolean.\n"
+  );
+}
+
 const char *get_default_config() {
   return DEFAULT_JSON;
 }

--- a/c_emulator/config_utils.h
+++ b/c_emulator/config_utils.h
@@ -11,6 +11,8 @@
 // is ignored (-3 will be read as 3).
 uint64_t get_config_uint64(const std::vector<const char *> &keypath);
 
+bool get_config_bool(const std::vector<const char *> &keypath);
+
 const char *get_default_config();
 const char *get_default_rv32_config();
 

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -44,6 +44,10 @@ void ModelImpl::set_reservation_set_size_exp(uint64_t exponent) {
   m_reservation_set_addr_mask = ~((1 << exponent) - 1);
 }
 
+void ModelImpl::set_reservation_require_exact_addr_match(bool require_exact_addr) {
+  m_reservation_require_exact_addr = require_exact_addr;
+}
+
 void ModelImpl::print_current_exception() {
   if (current_exception != nullptr) {
     zprint_exception(*current_exception);
@@ -220,6 +224,7 @@ mach_bits ModelImpl::plat_get_16_random_bits(unit) {
 // `cancel_reservation()`.
 
 unit ModelImpl::load_reservation(sbits addr, uint64_t width) {
+  m_reservation_addr = addr.bits;
   m_reservation = addr.bits & m_reservation_set_addr_mask;
   m_reservation_valid = true;
 
@@ -230,8 +235,9 @@ unit ModelImpl::load_reservation(sbits addr, uint64_t width) {
 }
 
 bool ModelImpl::match_reservation(sbits addr) {
-  return m_reservation_valid &&
-         (m_reservation & m_reservation_set_addr_mask) == (addr.bits & m_reservation_set_addr_mask);
+  return m_reservation_valid && (m_reservation_require_exact_addr ? (addr.bits == m_reservation_addr)
+                                                                  : (m_reservation & m_reservation_set_addr_mask) ==
+                                                                      (addr.bits & m_reservation_set_addr_mask));
 }
 
 unit ModelImpl::cancel_reservation(unit) {

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -23,6 +23,7 @@ public:
 
   void set_enable_experimental_extensions(bool en);
   void set_reservation_set_size_exp(uint64_t exponent);
+  void set_reservation_require_exact_addr_match(bool require_exact_addr_match);
 
   void set_config_print_instr(bool on);
   void set_config_print_clint(bool on);
@@ -113,9 +114,11 @@ private:
   std::vector<callbacks_if *> m_callbacks;
 
   uint64_t m_reservation = 0;
+  uint64_t m_reservation_addr = 0;
   bool m_reservation_valid = false;
 
   uint64_t m_reservation_set_addr_mask = 0;
+  bool m_reservation_require_exact_addr = false;
 
   bool m_enable_experimental_extensions = false;
 

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -424,6 +424,7 @@ void write_dtb_to_rom(ModelImpl &model, const std::vector<uint8_t> &dtb) {
 
 void init_platform_constants(ModelImpl &model) {
   model.set_reservation_set_size_exp(get_config_uint64({"platform", "reservation_set_size_exp"}));
+  model.set_reservation_require_exact_addr_match(get_config_bool({"platform", "require_exact_reservation_addr"}));
 }
 
 void init_sail(ModelImpl &model, uint64_t elf_entry, const char *config_file) {

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -423,8 +423,10 @@ void write_dtb_to_rom(ModelImpl &model, const std::vector<uint8_t> &dtb) {
 }
 
 void init_platform_constants(ModelImpl &model) {
-  model.set_reservation_set_size_exp(get_config_uint64({"platform", "reservation_set_size_exp"}));
-  model.set_reservation_require_exact_addr_match(get_config_bool({"platform", "require_exact_reservation_addr"}));
+  model.set_reservation_set_size_exp(get_config_uint64({"platform", "reservation", "reservation_set_size_exp"}));
+  model.set_reservation_require_exact_addr_match(
+    get_config_bool({"platform", "reservation", "require_exact_reservation_addr"})
+  );
 }
 
 void init_sail(ModelImpl &model, uint64_t elf_entry, const char *config_file) {

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -281,6 +281,11 @@
     // It must be at least 2 on RV32 and 3 on RV64 to support Zalrsc.  It must not be more than
     // 6 for Za64rs and 7 for Za128rs.  In all cases, it must be less than or equal to 12.
     "reservation_set_size_exp": 3,
+    // Some implementations (e.g. Spike) require the Store-Conditional to provide the same
+    // address of the matching Load-Reserve in order to succeed, regardless of the
+    // configured reservation set size.  This controls whether such an exact address
+    // match is required for a Store-Conditional to succeed.
+    "require_exact_reservation_addr": false,
     "clint": {
       // This must be in a suitable IO memory region (see `memory.regions`).
       "base": 33554432,

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -283,7 +283,7 @@
       // 6 for Za64rs and 7 for Za128rs.  In all cases, it must be less than or equal to 12.
       "reservation_set_size_exp": 3,
       // Some implementations (e.g. Spike) require the Store-Conditional to provide the same
-      // address of the matching Load-Reserve in order to succeed, regardless of the
+      // address as the matching Load-Reserve in order to succeed, regardless of the
       // configured reservation set size.  This controls whether such an exact address
       // match is required for a Store-Conditional to succeed.
       "require_exact_reservation_addr": false

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -277,15 +277,17 @@
     "hartid": 0,
     // Cache block size, specified as a power of 2.
     "cache_block_size_exp": 6,
-    // This specifies both the size and alignment of the reservation set, specified as a power of 2.
-    // It must be at least 2 on RV32 and 3 on RV64 to support Zalrsc.  It must not be more than
-    // 6 for Za64rs and 7 for Za128rs.  In all cases, it must be less than or equal to 12.
-    "reservation_set_size_exp": 3,
-    // Some implementations (e.g. Spike) require the Store-Conditional to provide the same
-    // address of the matching Load-Reserve in order to succeed, regardless of the
-    // configured reservation set size.  This controls whether such an exact address
-    // match is required for a Store-Conditional to succeed.
-    "require_exact_reservation_addr": false,
+    "reservation": {
+      // This specifies both the size and alignment of the reservation set, specified as a power of 2.
+      // It must be at least 2 on RV32 and 3 on RV64 to support Zalrsc.  It must not be more than
+      // 6 for Za64rs and 7 for Za128rs.  In all cases, it must be less than or equal to 12.
+      "reservation_set_size_exp": 3,
+      // Some implementations (e.g. Spike) require the Store-Conditional to provide the same
+      // address of the matching Load-Reserve in order to succeed, regardless of the
+      // configured reservation set size.  This controls whether such an exact address
+      // match is required for a Store-Conditional to succeed.
+      "require_exact_reservation_addr": false
+    },
     "clint": {
       // This must be in a suitable IO memory region (see `memory.regions`).
       "base": 33554432,

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -28,6 +28,11 @@
     `attributes.misaligned_exceptions` field of each region under
     `memory.regions`; `attributes.misaligned_exceptions` replaces the
     earlier `attributes.misaligned_fault` property.
+  - A new `platform.require_exact_reservation_addr` parameter controls
+    whether Store-Conditional instructions are required to provide the
+    same address of the matching Load-Reserve in order to succeed.
+    This defaults to `false` to match earlier behavior, but can be set
+    to `true` to match some implementations such as Spike.
 
 - The following extensions have been added:
   - Ziccamoa

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -28,11 +28,13 @@
     `attributes.misaligned_exceptions` field of each region under
     `memory.regions`; `attributes.misaligned_exceptions` replaces the
     earlier `attributes.misaligned_fault` property.
-  - A new `platform.require_exact_reservation_addr` parameter controls
+  - A new `platform.reservation.require_exact_reservation_addr` parameter controls
     whether Store-Conditional instructions are required to provide the
     same address of the matching Load-Reserve in order to succeed.
     This defaults to `false` to match earlier behavior, but can be set
-    to `true` to match some implementations such as Spike.
+    to `true` to match some implementations such as Spike. The earlier
+    `platform.reservation_set_size_exp` parameter has moved to
+    `platform.reservation.reservation_set_size_exp`.
 
 - The following extensions have been added:
   - Ziccamoa

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -30,7 +30,7 @@
     earlier `attributes.misaligned_fault` property.
   - A new `platform.reservation.require_exact_reservation_addr` parameter controls
     whether Store-Conditional instructions are required to provide the
-    same address of the matching Load-Reserve in order to succeed.
+    same address as the matching Load-Reserve in order to succeed.
     This defaults to `false` to match earlier behavior, but can be set
     to `true` to match some implementations such as Spike. The earlier
     `platform.reservation_set_size_exp` parameter has moved to

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -24,7 +24,7 @@ let plat_cache_block_size_exp : range(0, 12) = config platform.cache_block_size_
 // `max_mem_access` (4096) because larger sizes are unrealistic.
 // Reservation sets are also naturally aligned. Reservation sets need to subsume
 // their LR operands (4 bytes for LR.W, 8 bytes for LR.D).
-let plat_reservation_set_size_exp : range(2, 12) = config platform.reservation_set_size_exp
+let plat_reservation_set_size_exp : range(2, 12) = config platform.reservation.reservation_set_size_exp
 
 // The exceptions that a misaligned access could generate.  For
 // example, a misaligned LR/SC always raises an exception.


### PR DESCRIPTION
This enables configuration of the Sail model to match the behavior of implementations such as Spike.