### PR TITLE
Refactor riscv_sim.cpp by moving initialization and driver logic into dedicated files

### DIFF
--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -28,6 +28,10 @@ add_custom_target(generated_config_schema DEPENDS config_schema.h)
 add_library(riscv_model
     elf_loader.cpp
     elf_loader.h
+    simulator.cpp
+    simulator.h
+    riscv_sim_utils.cpp
+    riscv_sim_utils.h
     riscv_callbacks_if.cpp
     riscv_callbacks_if.h
     riscv_platform_if.cpp

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -5,66 +5,34 @@
 #include <ctype.h>
 #include <errno.h>
 #include <exception>
-#include <fcntl.h>
 #include <iostream>
 #include <optional>
 #include <stdexcept>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <unistd.h>
 #include <vector>
 
 #include "CLI11.hpp"
 #include "elf_loader.h"
 #include "jsoncons/config/version.hpp"
 #include "jsoncons/json.hpp"
-#include "rts.h"
+#include "riscv_sim_utils.h"
 #include "sail.h"
 #include "sail_config.h"
-#include "symbol_table.h"
 #ifdef SAILCOV
 #include "sail_coverage.h"
 #endif
 #include "config_utils.h"
 #include "file_utils.h"
-#include "riscv_callbacks_log.h"
-#include "riscv_callbacks_rvfi.h"
 #include "riscv_model_impl.h"
-#include "rvfi_dii.h"
 #include "sail_riscv_version.h"
-#include "traploop_detector.h"
+#include "simulator.h"
 
-using std::chrono::duration_cast;
-using std::chrono::milliseconds;
-using std::chrono::steady_clock;
-
-namespace {
-
-std::optional<rvfi_handler> rvfi;
-
-// The address of the HTIF tohost port, if it is enabled.
-std::optional<uint64_t> htif_tohost_address;
-
-rvfi_callbacks rvfi_cbs;
-
-uint64_t mem_sig_start = 0;
-uint64_t mem_sig_end = 0;
-
-steady_clock::time_point init_start;
-steady_clock::time_point init_end;
-
-uint64_t total_insns = 0;
 #ifdef SAILCOV
+namespace {
 char *sailcov_file = nullptr;
-#endif
-
 } // namespace
-
-FILE *trace_log = stdout;
+#endif
 
 static void print_dts(ModelImpl &model) {
   char *dts = nullptr;
@@ -90,12 +58,11 @@ static void print_build_info() {
   std::cout << "JSONCONS: " << jsoncons::version() << std::endl;
 }
 
-static jsoncons::json parse_json_or_exit(const std::string &json_text, const std::string &source_desc) {
+static jsoncons::json parse_json(const std::string &json_text, const std::string &source_desc) {
   try {
     return jsoncons::json::parse(json_text);
   } catch (const jsoncons::json_exception &e) {
-    std::cerr << "JSON parse error in " << source_desc << ":\n" << e.what() << "\n\n";
-    exit(EXIT_FAILURE);
+    throw riscv_sim::ConfigError("JSON parse error in " + source_desc + ":\n" + e.what());
   }
 }
 
@@ -329,99 +296,6 @@ static CLIOptions parse_cli(int argc, char **argv) {
   return opts;
 }
 
-uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file) {
-  ELF elf = ELF::open(filename);
-
-  switch (elf.architecture()) {
-  case Architecture::RV32:
-    if (model.zxlen != 32) {
-      fprintf(stderr, "32-bit ELF not supported by RV%" PRIu64 " model.\n", model.zxlen);
-      exit(EXIT_FAILURE);
-    }
-    break;
-  case Architecture::RV64:
-    if (model.zxlen != 64) {
-      fprintf(stderr, "64-bit ELF not supported by RV%" PRIu64 " model.\n", model.zxlen);
-      exit(EXIT_FAILURE);
-    }
-    break;
-  }
-
-  // Load into memory.
-  elf.load([](uint64_t address, const uint8_t *data, uint64_t length) {
-    // TODO: We could definitely improve on rts.c's memory implementation
-    // (which is O(N^2)) and writing one byte at a time here.
-    for (uint64_t i = 0; i < length; ++i) {
-      write_mem(address + i, data[i]);
-    }
-  });
-
-  // Load the entire symbol table.
-  const auto symbols = elf.symbols();
-
-  // Save reversed symbol table for log symbolization.
-  // If multiple symbols from different ELF files have the same value the first
-  // one wins.
-  const auto reversed_symbols = reverse_symbol_table(symbols);
-  g_symbols.insert(reversed_symbols.begin(), reversed_symbols.end());
-
-  if (main_file) {
-    // Only scan for test-signature/htif symbols in the main ELF file.
-
-    const auto &tohost = symbols.find("tohost");
-    if (tohost == symbols.end()) {
-      fprintf(stderr, "Unable to locate tohost symbol; disabling HTIF.\n");
-      htif_tohost_address = std::nullopt;
-    } else {
-      htif_tohost_address = tohost->second;
-      fprintf(stdout, "HTIF located at 0x%0" PRIx64 "\n", *htif_tohost_address);
-    }
-    // Locate test-signature locations if any.
-    const auto &begin_sig = symbols.find("begin_signature");
-    if (begin_sig != symbols.end()) {
-      fprintf(stdout, "begin_signature: 0x%0" PRIx64 "\n", begin_sig->second);
-      mem_sig_start = begin_sig->second;
-    }
-    const auto &end_sig = symbols.find("end_signature");
-    if (end_sig != symbols.end()) {
-      fprintf(stdout, "end_signature: 0x%0" PRIx64 "\n", end_sig->second);
-      mem_sig_end = end_sig->second;
-    }
-  }
-
-  return elf.entry();
-}
-
-void write_dtb_to_rom(ModelImpl &model, const std::vector<uint8_t> &dtb) {
-  uint64_t addr = get_config_uint64({"memory", "dtb_address"});
-  uint64_t size = static_cast<uint64_t>(dtb.size());
-
-  // Overflow check for addr + size - 1
-  uint64_t end = addr + size - 1;
-  if (end < addr) {
-    fprintf(stderr, "DTB address/size overflow: addr=0x%0" PRIx64 ", size=0x%0" PRIx64 "\n", addr, size);
-    exit(EXIT_FAILURE);
-  }
-
-  // Validate DTB range against configured PMA memory regions.
-  if (!model.zdtb_within_configured_pma_memory(addr, size)) {
-    fprintf(
-      stderr,
-      "DTB does not fit in any configured PMA memory region: "
-      "addr=0x%0" PRIx64 ", size=0x%0" PRIx64 " (end=0x%0" PRIx64 ")\n"
-      "Hint: adjust memory.dtb_address or memory.regions in the config.\n",
-      addr,
-      size,
-      end
-    );
-    exit(EXIT_FAILURE);
-  }
-
-  for (uint8_t d : dtb) {
-    write_mem(addr++, d);
-  }
-}
-
 void init_platform_constants(ModelImpl &model) {
   model.set_reservation_set_size_exp(get_config_uint64({"platform", "reservation", "reservation_set_size_exp"}));
   model.set_reservation_require_exact_addr_match(
@@ -429,235 +303,7 @@ void init_platform_constants(ModelImpl &model) {
   );
 }
 
-void init_sail(ModelImpl &model, uint64_t elf_entry, const char *config_file) {
-  // zset_pc_reset_address must be called before zinit_model
-  // because reset happens inside init_model().
-  model.zset_pc_reset_address(elf_entry);
-  if (htif_tohost_address.has_value()) {
-    model.zenable_htif(*htif_tohost_address);
-  }
-  model.zinit_model(config_file != nullptr ? config_file : "");
-  model.zinit_boot_requirements(UNIT);
-}
-
-/* reinitialize to clear state and memory, typically across tests runs */
-void reinit_sail(ModelImpl &model, uint64_t elf_entry, const char *config_file) {
-  model.model_fini();
-  model.model_init();
-  init_sail(model, elf_entry, config_file);
-}
-
-void write_signature(const std::string &file, unsigned signature_granularity) {
-  if (mem_sig_start >= mem_sig_end) {
-    fprintf(
-      stderr,
-      "Invalid signature region [0x%0" PRIx64 ",0x%0" PRIx64 "] to %s.\n",
-      mem_sig_start,
-      mem_sig_end,
-      file.c_str()
-    );
-    return;
-  }
-  FILE *f = fopen(file.c_str(), "w");
-  if (!f) {
-    fprintf(stderr, "Cannot open file '%s': %s\n", file.c_str(), strerror(errno));
-    return;
-  }
-  /* write out words depending on signature granularity in signature area */
-  for (uint64_t addr = mem_sig_start; addr < mem_sig_end; addr += signature_granularity) {
-    /* most-significant byte first */
-    for (int i = signature_granularity - 1; i >= 0; i--) {
-      uint8_t byte = (uint8_t)read_mem(addr + i);
-      fprintf(f, "%02x", byte);
-    }
-    fprintf(f, "\n");
-  }
-  fclose(f);
-}
-
-void close_logs() {
-#ifdef SAILCOV
-  if (sail_coverage_exit() != 0) {
-    fprintf(stderr, "Could not write coverage information!\n");
-    exit(EXIT_FAILURE);
-  }
-#endif
-  if (trace_log != stdout) {
-    fclose(trace_log);
-  }
-}
-
-void finish(ModelImpl &model, const CLIOptions &opts) {
-  // Don't write a signature if there was an internal Sail exception.
-  if (!model.have_exception && !opts.sig_file.empty()) {
-    write_signature(opts.sig_file, opts.signature_granularity);
-  }
-
-  // `model_fini()` exits with failure if there was a Sail exception.
-  model.model_fini();
-
-  if (opts.do_show_times) {
-    auto run_end = steady_clock::now();
-    uint64_t init_msecs = duration_cast<milliseconds>(init_end - init_start).count();
-    uint64_t exec_msecs = duration_cast<milliseconds>(run_end - init_end).count();
-    uint64_t kips = total_insns / exec_msecs;
-    fprintf(stderr, "Initialization:   %" PRIu64 " ms\n", init_msecs);
-    fprintf(stderr, "Execution:        %" PRIu64 " ms\n", exec_msecs);
-    fprintf(stderr, "Instructions:     %" PRIu64 "\n", total_insns);
-    fprintf(stderr, "Performance:      %" PRIu64 " kIPS\n", kips);
-  }
-  close_logs();
-  exit(EXIT_SUCCESS);
-}
-
-void flush_logs() {
-  fflush(stderr);
-  fflush(stdout);
-  fflush(trace_log);
-}
-
-void run_sail(ModelImpl &model, const CLIOptions &opts, traploop_detector &loop_detector) {
-  bool is_waiting = false;
-  // The emulator tick increments time by 1 at every step, so the number
-  // of steps to wait is equal to the needed increment in the time CSR.
-  uint64_t max_wait_steps = get_config_uint64({"platform", "max_time_to_wait"});
-  uint64_t wait_steps_remaining = 0;
-
-  /* initialize the step number */
-  mach_int step_no = 0;
-  uint64_t insn_cnt = 0;
-
-  uint64_t insns_per_tick = get_config_uint64({"platform", "instructions_per_tick"});
-
-  auto interval_start = steady_clock::now();
-
-  while (!model.zhtif_done && (opts.insn_limit == 0 || total_insns < opts.insn_limit)) {
-    if (rvfi.has_value()) {
-      switch (rvfi->pre_step(opts.config_print_rvfi)) {
-      case RVFI_prestep_continue:
-        continue;
-      case RVFI_prestep_eof:
-        rvfi = std::nullopt;
-        return;
-      case RVFI_prestep_end_trace:
-        return;
-      case RVFI_prestep_ok:
-        break;
-      }
-    }
-
-    model.call_pre_step_callbacks(is_waiting);
-
-    { /* run a Sail step */
-      sail_int sail_step;
-      CREATE(sail_int)(&sail_step);
-      CONVERT_OF(sail_int, mach_int)(&sail_step, step_no);
-      is_waiting = model.ztry_step(sail_step, wait_steps_remaining == 0);
-      KILL(sail_int)(&sail_step);
-
-      if (model.have_exception) {
-        model.print_current_exception();
-        break;
-      }
-      if (opts.config_print_instr) {
-        flush_logs();
-      }
-      if (rvfi) {
-        rvfi->send_trace(opts.config_print_rvfi);
-      }
-      if (is_waiting) {
-        if (wait_steps_remaining == 0) {
-          wait_steps_remaining = max_wait_steps;
-        } else {
-          --wait_steps_remaining;
-        }
-      } else {
-        wait_steps_remaining = 0;
-      }
-    }
-
-    model.call_post_step_callbacks(is_waiting);
-
-    if (!is_waiting) {
-      if (opts.config_print_step) {
-        fprintf(trace_log, "\n");
-      }
-      step_no++;
-      insn_cnt++;
-      total_insns++;
-    }
-
-    if (opts.do_show_times && (total_insns & 0xfffff) == 0) {
-      const auto now = steady_clock::now();
-      const auto interval = now - interval_start;
-      interval_start = now;
-
-      uint64_t kips = 0x100000 / duration_cast<milliseconds>(interval).count();
-      fprintf(stdout, "kips: %" PRIu64 "\n", kips);
-    }
-
-    if (model.zhtif_done) {
-      /* check exit code */
-      if (model.zhtif_exit_code == 0) {
-        fprintf(stdout, "SUCCESS\n");
-      } else {
-        fprintf(stdout, "FAILURE: %" PRIi64 "\n", model.zhtif_exit_code);
-        exit(EXIT_FAILURE);
-      }
-    }
-
-    if (insn_cnt == insns_per_tick) {
-      insn_cnt = 0;
-      model.ztick_clock(UNIT);
-    } else if (wait_steps_remaining > 0) {
-      model.ztick_clock(UNIT);
-    }
-
-    if (loop_detector.loop_detected()) {
-      fprintf(
-        stdout,
-        "FAILURE: possible trap loop detected with MEPC=0x%" PRIx64 " and SEPC=0x%" PRIx64 "\n",
-        loop_detector.mepc(),
-        loop_detector.sepc()
-      );
-      exit(EXIT_FAILURE);
-    }
-  }
-
-  // This is reached if there is a Sail exception, HTIF has indicated
-  // successful completion, or the instruction limit has been reached.
-  finish(model, opts);
-}
-
-void init_logs(const CLIOptions &opts) {
-  if (!opts.term_log.empty() &&
-      (term_fd = open(opts.term_log.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IRGRP | S_IROTH | S_IWUSR)) <
-        0) {
-    fprintf(stderr, "Cannot create terminal log '%s': %s\n", opts.term_log.c_str(), strerror(errno));
-    exit(EXIT_FAILURE);
-  }
-
-  if (!opts.trace_log_path.empty()) {
-    trace_log = fopen(opts.trace_log_path.c_str(), "w+");
-    if (trace_log == nullptr) {
-      fprintf(stderr, "Cannot create trace log '%s': %s\n", opts.trace_log_path.c_str(), strerror(errno));
-      exit(EXIT_FAILURE);
-    }
-  }
-
-#ifdef SAILCOV
-  if (!sailcov_file.empty()) {
-    sail_set_coverage_file(sailcov_file.c_str());
-  }
-#endif
-}
-
-int inner_main(int argc, char **argv) {
-
-  CLIOptions opts = parse_cli(argc, argv);
-
-  ModelImpl model;
-
+std::optional<int> handle_early_print_modes(const CLIOptions &opts) {
   if (opts.do_print_version) {
     std::cout << version_info::release_version << std::endl;
     return EXIT_SUCCESS;
@@ -667,52 +313,44 @@ int inner_main(int argc, char **argv) {
     return EXIT_SUCCESS;
   }
   if (opts.do_print_default_config) {
-    printf("%s", opts.use_rv32_default ? get_default_rv32_config() : get_default_config());
+    std::cout << (opts.use_rv32_default ? get_default_rv32_config() : get_default_config());
     return EXIT_SUCCESS;
   }
   if (opts.do_print_config_schema) {
-    printf("%s", get_config_schema());
+    std::cout << get_config_schema();
     return EXIT_SUCCESS;
   }
-  if (opts.rvfi_dii_port != 0) {
-    rvfi.emplace(opts.rvfi_dii_port, model);
-  }
-  if (opts.do_show_times) {
-    fprintf(stderr, "will show execution times on completion.\n");
-  }
-  if (!opts.term_log.empty()) {
-    fprintf(stderr, "using %s for terminal output.\n", opts.term_log.c_str());
-  }
-  if (!opts.sig_file.empty()) {
-    fprintf(stderr, "using %s for test-signature output.\n", opts.sig_file.c_str());
-  }
-  if (opts.signature_granularity != DEFAULT_SIGNATURE_GRANULARITY) {
-    fprintf(stderr, "setting signature-granularity to %d bytes\n", opts.signature_granularity);
-  }
-  if (opts.config_enable_experimental_extensions) {
-    fprintf(stderr, "enabling unratified extensions.\n");
-    model.set_enable_experimental_extensions(true);
-  }
-  if (!opts.trace_log_path.empty()) {
-    fprintf(stderr, "using %s for trace output.\n", opts.trace_log_path.c_str());
+  return std::nullopt;
+}
+
+std::optional<int> handle_late_print_modes(const CLIOptions &opts, ModelImpl &model) {
+  // Validate the configuration, exit if that's all we were asked to do
+  // or if the validation failed.
+  bool config_is_valid = model.zconfig_is_valid(UNIT);
+  std::string s = config_is_valid ? "valid" : "invalid";
+  if (!config_is_valid || opts.do_validate_config) {
+    if (opts.config_file.empty()) {
+      std::cerr << "Default configuration is " << s << ".\n";
+    } else {
+      std::cerr << "Configuration in " << opts.config_file << " is " << s << ".\n";
+    }
+    return config_is_valid ? EXIT_SUCCESS : EXIT_FAILURE;
   }
 
-  model.set_config_print_instr(opts.config_print_instr);
-  model.set_config_print_clint(opts.config_print_clint);
-  model.set_config_print_exception(opts.config_print_exception);
-  model.set_config_print_interrupt(opts.config_print_interrupt);
-  model.set_config_print_htif(opts.config_print_htif);
-  model.set_config_print_pma(opts.config_print_pma);
-  model.set_config_rvfi(rvfi.has_value());
-  model.set_config_use_abi_names(opts.config_use_abi_names);
-
-  model.set_config_print_step(opts.config_print_step);
-
-  traploop_detector loop_detector;
-  if (!opts.disable_trap_loop_detection) {
-    model.register_callback(&loop_detector);
+  // Print a device tree or an ISA string only after the configuration
+  // is validated above.
+  if (opts.do_print_dts) {
+    print_dts(model);
+    return EXIT_SUCCESS;
   }
+  if (opts.do_print_isa) {
+    print_isa(model);
+    return EXIT_SUCCESS;
+  }
+  return std::nullopt;
+}
 
+void load_and_init_config(const CLIOptions &opts, ModelImpl &model) {
   std::string config_json_string;
   if (!opts.config_file.empty()) {
     config_json_string = read_file_to_string(opts.config_file);
@@ -723,10 +361,10 @@ int inner_main(int argc, char **argv) {
   // Check json config and merge overrides
   const std::string base_source_desc =
     opts.config_file.empty() ? "default configuration" : "configuration file " + opts.config_file;
-  jsoncons::json config_json = parse_json_or_exit(config_json_string, base_source_desc);
+  jsoncons::json config_json = parse_json(config_json_string, base_source_desc);
   for (const auto &override_path : opts.config_overrides) {
     std::string override_json_string = read_file_to_string(override_path);
-    jsoncons::json override_item = parse_json_or_exit(override_json_string, "override file " + override_path);
+    jsoncons::json override_item = parse_json(override_json_string, "override file " + override_path);
     deep_merge_json(config_json, override_item);
   }
 
@@ -747,101 +385,180 @@ int inner_main(int argc, char **argv) {
   // Initialize the model.
   sail_config_set_string(config_json_string.c_str());
 
-  // Initialize platform.
+  // Initialize platform. Must run before model_init(), these values are
+  // read during initialization.
   init_platform_constants(model);
 
   model.model_init();
+}
 
-  // Validate the configuration; exit if that's all we were asked to do
-  // or if the validation failed.
-  {
-    bool config_is_valid = model.zconfig_is_valid(UNIT);
-    const char *s = config_is_valid ? "valid" : "invalid";
-    if (!config_is_valid || opts.do_validate_config) {
-      if (opts.config_file.empty()) {
-        fprintf(stderr, "Default configuration is %s.\n", s);
-      } else {
-        fprintf(stderr, "Configuration in %s is %s.\n", opts.config_file.c_str(), s);
-      }
-      return config_is_valid ? EXIT_SUCCESS : EXIT_FAILURE;
-    }
+int inner_main(int argc, char **argv) {
+  CLIOptions opts = parse_cli(argc, argv);
+  ModelImpl model;
+
+  if (auto code = handle_early_print_modes(opts)) {
+    return *code;
   }
 
-  // Print a device tree or an ISA string only after the configuration
-  // is validated above.
-  if (opts.do_print_dts) {
-    print_dts(model);
-    return EXIT_SUCCESS;
+  if (opts.do_show_times) {
+    fprintf(stderr, "will show execution times on completion.\n");
   }
-  if (opts.do_print_isa) {
-    print_isa(model);
-    return EXIT_SUCCESS;
+  if (!opts.term_log.empty()) {
+    fprintf(stderr, "using %s for terminal output.\n", opts.term_log.c_str());
+  }
+  if (!opts.sig_file.empty()) {
+    fprintf(stderr, "using %s for test-signature output.\n", opts.sig_file.c_str());
+  }
+  if (opts.signature_granularity != DEFAULT_SIGNATURE_GRANULARITY) {
+    fprintf(stderr, "setting signature-granularity to %d bytes\n", opts.signature_granularity);
+  }
+  if (opts.config_enable_experimental_extensions) {
+    fprintf(stderr, "enabling unratified extensions.\n");
+    model.set_enable_experimental_extensions(true);
+  }
+  if (!opts.trace_log_path.empty()) {
+    fprintf(stderr, "using %s for trace output.\n", opts.trace_log_path.c_str());
+  }
+
+  const bool use_rvfi = (opts.rvfi_dii_port != 0);
+
+  model.set_config_print_instr(opts.config_print_instr);
+  model.set_config_print_clint(opts.config_print_clint);
+  model.set_config_print_exception(opts.config_print_exception);
+  model.set_config_print_interrupt(opts.config_print_interrupt);
+  model.set_config_print_htif(opts.config_print_htif);
+  model.set_config_print_pma(opts.config_print_pma);
+  model.set_config_rvfi(use_rvfi);
+  model.set_config_use_abi_names(opts.config_use_abi_names);
+  model.set_config_print_step(opts.config_print_step);
+
+  load_and_init_config(opts, model);
+
+  if (auto code = handle_late_print_modes(opts, model)) {
+    return *code;
   }
 
   // If we get here, we need to have ELF files to run (except in RVFI mode).
-  if (opts.elfs.empty() && !rvfi.has_value()) {
+  if (opts.elfs.empty() && !use_rvfi) {
     fprintf(stderr, "No elf file provided.\n");
     return EXIT_FAILURE;
   }
 
-  init_logs(opts);
-  log_callbacks log_cbs(
-    opts.config_print_gpr,
-    opts.config_print_fpr,
-    opts.config_print_vreg,
-    opts.config_print_csr,
-    opts.config_print_mem_access,
-    opts.config_print_ptw,
-    opts.config_print_tlb,
-    opts.config_use_abi_names,
-    trace_log
-  );
-  model.register_callback(&log_cbs);
-
-  init_start = steady_clock::now();
-
-  if (rvfi.has_value()) {
-    if (!rvfi->setup_socket(opts.config_print_rvfi)) {
-      return 1;
-    }
-    model.register_callback(&rvfi_cbs);
-  }
-
+  // DTB
   if (!opts.dtb_file.empty()) {
     fprintf(stderr, "using %s as DTB file.\n", opts.dtb_file.c_str());
-    write_dtb_to_rom(model, read_file(opts.dtb_file));
+    riscv_sim::write_dtb_to_rom(model, read_file(opts.dtb_file), get_config_uint64({"memory", "dtb_address"}));
   }
 
-  uint64_t entry = rvfi.has_value() ? rvfi->get_entry() : load_sail(model, opts.elfs[0], /*main_file=*/true);
+  // Load ELFs
+  riscv_sim::LoadResult main_load;
+  if (!use_rvfi) {
+    main_load = riscv_sim::load_sail(model, opts.elfs[0], true);
+  }
 
+  // Config simulator
+  riscv_sim::SimulatorConfig sim_cfg;
+  sim_cfg.insn_limit = opts.insn_limit;
+  sim_cfg.max_time_to_wait = get_config_uint64({"platform", "max_time_to_wait"});
+  sim_cfg.insns_per_tick = get_config_uint64({"platform", "instructions_per_tick"});
+  sim_cfg.trace_instr = opts.config_print_instr;
+  sim_cfg.trace_step = opts.config_print_step;
+  sim_cfg.trace_rvfi = opts.config_print_rvfi;
+  sim_cfg.show_times = opts.do_show_times;
+  sim_cfg.trace_gpr = opts.config_print_gpr;
+  sim_cfg.trace_fpr = opts.config_print_fpr;
+  sim_cfg.trace_vreg = opts.config_print_vreg;
+  sim_cfg.trace_csr = opts.config_print_csr;
+  sim_cfg.trace_mem_access = opts.config_print_mem_access;
+  sim_cfg.trace_ptw = opts.config_print_ptw;
+  sim_cfg.trace_tlb = opts.config_print_tlb;
+  sim_cfg.use_abi_names = opts.config_use_abi_names;
+  sim_cfg.sig_file = opts.sig_file;
+  sim_cfg.sig_granularity = opts.signature_granularity;
+  sim_cfg.sig_start = main_load.sig_start;
+  sim_cfg.sig_end = main_load.sig_end;
+  sim_cfg.trace_log_path = opts.trace_log_path;
+  sim_cfg.term_log_path = opts.term_log;
+  sim_cfg.rvfi_dii_port = opts.rvfi_dii_port;
+  sim_cfg.enable_trap_loop_detection = !opts.disable_trap_loop_detection;
+
+  // Initialize simulator (opens logs, sockets, registers callbacks)
+  riscv_sim::Simulator simulator(model, sim_cfg);
+
+#ifdef SAILCOV
+  if (!sailcov_file.empty()) {
+    sail_set_coverage_file(sailcov_file.c_str());
+  }
+#endif
+
+  // Resolve entry, load remaining ELFs, init sail
+  uint64_t entry = use_rvfi ? simulator.rvfi_entry() : main_load.entry;
   fprintf(stdout, "Entry point: 0x%" PRIx64 "\n", entry);
 
-  // Load any additional ELF files into memory. If RVFI was NOT used skip
-  // the first one because it was loaded above.
-  for (auto it = opts.elfs.cbegin() + (rvfi.has_value() ? 0 : 1); it != opts.elfs.cend(); it++) {
+  for (auto it = opts.elfs.cbegin() + (use_rvfi ? 0 : 1); it != opts.elfs.cend(); ++it) {
     fprintf(stdout, "Loading additional ELF file %s.\n", it->c_str());
-    (void)load_sail(model, *it, /*main_file=*/false);
+    (void)riscv_sim::load_sail(model, *it, false);
   }
 
-  init_sail(model, entry, opts.config_file.c_str());
+  riscv_sim::init_sail(model, entry, main_load.htif_tohost, opts.config_file.c_str());
 
-  init_end = steady_clock::now();
-
-  do {
-    run_sail(model, opts, loop_detector);
-    // `run_sail` only returns in the case of rvfi.
-    if (rvfi) {
-      /* Reset for next test */
-      reinit_sail(model, entry, opts.config_file.c_str());
-      loop_detector.reset();
+  // Run loop
+  int exit_code = EXIT_SUCCESS;
+  bool keep_running = true;
+  while (keep_running) {
+    auto result = simulator.run();
+    switch (result.status) {
+    case riscv_sim::RunStatus::HtifSuccess:
+      fprintf(stdout, "SUCCESS\n");
+      keep_running = false;
+      break;
+    case riscv_sim::RunStatus::HtifFailure:
+      fprintf(stdout, "FAILURE: %" PRIu64 "\n", result.htif_exit_code);
+      exit_code = EXIT_FAILURE;
+      keep_running = false;
+      break;
+    case riscv_sim::RunStatus::TrapLoop:
+      fprintf(
+        stdout,
+        "FAILURE: possible trap loop detected with MEPC=0x%" PRIx64 " and SEPC=0x%" PRIx64 "\n",
+        result.mepc,
+        result.sepc
+      );
+      exit_code = EXIT_FAILURE;
+      keep_running = false;
+      break;
+    case riscv_sim::RunStatus::SailException:
+    case riscv_sim::RunStatus::InstructionLimit:
+    case riscv_sim::RunStatus::RvfiEof:
+      keep_running = false;
+      break;
+    case riscv_sim::RunStatus::RvfiEndTrace:
+      if (use_rvfi) {
+        simulator.reset_for_next_run(entry, main_load.htif_tohost, opts.config_file.c_str());
+      } else {
+        keep_running = false;
+      }
+      break;
     }
-  } while (rvfi);
+  }
 
+  // Finish
+  if (!model.have_exception) {
+    simulator.write_signature();
+  }
   model.model_fini();
-  flush_logs();
-  close_logs();
+  if (sim_cfg.show_times) {
+    simulator.print_times();
+  }
 
-  return EXIT_SUCCESS;
+#ifdef SAILCOV
+  if (sail_coverage_exit() != 0) {
+    fprintf(stderr, "Could not write coverage information!\n");
+    exit_code = EXIT_FAILURE;
+  }
+#endif
+
+  return exit_code;
 }
 
 int main(int argc, char **argv) {

--- a/c_emulator/riscv_sim_utils.cpp
+++ b/c_emulator/riscv_sim_utils.cpp
@@ -1,0 +1,120 @@
+#include "riscv_sim_utils.h"
+#include "elf_loader.h"
+#include "rts.h"
+#include "symbol_table.h"
+#include <stdexcept>
+
+namespace riscv_sim {
+
+LoadResult load_sail(ModelImpl &model, const std::string &filename, bool main_file) {
+  ELF elf = ELF::open(filename);
+
+  switch (elf.architecture()) {
+  case Architecture::RV32:
+    if (model.zxlen != 32) {
+      throw ConfigError("32-bit ELF not supported by RV" + std::to_string(model.zxlen) + " model.");
+    }
+    break;
+  case Architecture::RV64:
+    if (model.zxlen != 64) {
+      throw ConfigError("64-bit ELF not supported by RV" + std::to_string(model.zxlen) + " model.");
+    }
+    break;
+  }
+
+  // Load into memory.
+  elf.load([](uint64_t address, const uint8_t *data, uint64_t length) {
+    // TODO: We could definitely improve on rts.c's memory implementation
+    // (which is O(N^2)) and writing one byte at a time here.
+    for (uint64_t i = 0; i < length; ++i) {
+      write_mem(address + i, data[i]);
+    }
+  });
+
+  // Load the entire symbol table.
+  const auto symbols = elf.symbols();
+
+  // Save reversed symbol table for log symbolization.
+  // If multiple symbols from different ELF files have the same value the first
+  // one wins.
+  const auto reversed_symbols = reverse_symbol_table(symbols);
+  g_symbols.insert(reversed_symbols.begin(), reversed_symbols.end());
+
+  LoadResult result;
+  result.entry = elf.entry();
+
+  if (main_file) {
+    // Only scan for test-signature/htif symbols in the main ELF file.
+    const auto &tohost = symbols.find("tohost");
+    if (tohost == symbols.end()) {
+      fprintf(stderr, "Unable to locate tohost symbol; disabling HTIF.\n");
+    } else {
+      result.htif_tohost = tohost->second;
+      fprintf(stdout, "HTIF located at 0x%0" PRIx64 "\n", *result.htif_tohost);
+    }
+    const auto &begin_sig = symbols.find("begin_signature");
+    if (begin_sig != symbols.end()) {
+      fprintf(stdout, "begin_signature: 0x%0" PRIx64 "\n", begin_sig->second);
+      result.sig_start = begin_sig->second;
+    }
+    const auto &end_sig = symbols.find("end_signature");
+    if (end_sig != symbols.end()) {
+      fprintf(stdout, "end_signature: 0x%0" PRIx64 "\n", end_sig->second);
+      result.sig_end = end_sig->second;
+    }
+  }
+
+  return result;
+}
+
+void init_sail(ModelImpl &model, uint64_t elf_entry, std::optional<uint64_t> htif_tohost, const char *config_file) {
+  // zset_pc_reset_address must be called before zinit_model
+  // because reset happens inside init_model().
+  model.zset_pc_reset_address(elf_entry);
+  if (htif_tohost.has_value()) {
+    model.zenable_htif(*htif_tohost);
+  }
+  model.zinit_model(config_file != nullptr ? config_file : "");
+  model.zinit_boot_requirements(UNIT);
+}
+
+// reinitialize to clear state and memory, typically across tests runs
+void reinit_sail(ModelImpl &model, uint64_t elf_entry, std::optional<uint64_t> htif_tohost, const char *config_file) {
+  model.model_fini();
+  model.model_init();
+  init_sail(model, elf_entry, htif_tohost, config_file);
+}
+
+void write_dtb_to_rom(ModelImpl &model, const std::vector<uint8_t> &dtb, uint64_t addr) {
+  uint64_t size = static_cast<uint64_t>(dtb.size());
+
+  // Overflow check for addr + size - 1
+  uint64_t end = addr + size - 1;
+  if (end < addr) {
+    char buf[128];
+    snprintf(buf, sizeof(buf), "DTB address/size overflow: addr=0x%" PRIx64 ", size=0x%" PRIx64, addr, size);
+    throw ConfigError(buf);
+  }
+
+  // Validate DTB range against configured PMA memory regions.
+  if (!model.zdtb_within_configured_pma_memory(addr, size)) {
+    char buf[256];
+    snprintf(
+      buf,
+      sizeof(buf),
+      "DTB does not fit in any configured PMA memory region: "
+      "addr=0x%" PRIx64 ", size=0x%" PRIx64 " (end=0x%" PRIx64 "). "
+      "Hint: adjust memory.dtb_address or memory.regions in the config.",
+      addr,
+      size,
+      end
+    );
+    throw ConfigError(buf);
+  }
+
+  for (uint8_t d : dtb) {
+    write_mem(addr++, d);
+  }
+}
+
+} // namespace riscv_sim

--- a/c_emulator/riscv_sim_utils.h
+++ b/c_emulator/riscv_sim_utils.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "riscv_model_impl.h"
+#include <cstdint>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace riscv_sim {
+
+class ConfigError : public std::runtime_error {
+public:
+  using std::runtime_error::runtime_error;
+};
+
+struct LoadResult {
+  uint64_t entry;
+  std::optional<uint64_t> htif_tohost;
+  std::optional<uint64_t> sig_start;
+  std::optional<uint64_t> sig_end;
+};
+
+LoadResult load_sail(ModelImpl &model, const std::string &filename, bool main_file);
+void init_sail(ModelImpl &model, uint64_t elf_entry, std::optional<uint64_t> htif_tohost, const char *config_file);
+void reinit_sail(ModelImpl &model, uint64_t elf_entry, std::optional<uint64_t> htif_tohost, const char *config_file);
+void write_dtb_to_rom(ModelImpl &model, const std::vector<uint8_t> &dtb, uint64_t addr);
+
+} // namespace riscv_sim

--- a/c_emulator/simulator.cpp
+++ b/c_emulator/simulator.cpp
@@ -1,0 +1,273 @@
+#include "simulator.h"
+
+#include <cerrno>
+#include <chrono>
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+#include <optional>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "riscv_callbacks_log.h"
+#include "riscv_callbacks_rvfi.h"
+#include "riscv_model_impl.h"
+#include "rts.h"
+#include "rvfi_dii.h"
+#include "sail.h"
+#include "traploop_detector.h"
+
+extern int term_fd;
+
+// Global trace_log used by riscv_model_impl. Lives here so any main that
+// links against this library gets it for free.
+FILE *trace_log = stdout;
+
+namespace riscv_sim {
+
+using std::chrono::duration_cast;
+using std::chrono::milliseconds;
+using std::chrono::steady_clock;
+
+struct Simulator::Impl {
+  ModelImpl &model;
+  SimulatorConfig cfg;
+
+  bool owns_trace_log = false;
+  std::optional<rvfi_handler> rvfi;
+  std::optional<log_callbacks> log_cbs;
+  rvfi_callbacks rvfi_cbs;
+  traploop_detector loop_detector;
+
+  uint64_t total_insns = 0;
+  steady_clock::time_point init_start;
+  steady_clock::time_point init_end;
+
+  Impl(ModelImpl &m, const SimulatorConfig &c) : model(m), cfg(c) {
+  }
+};
+
+Simulator::Simulator(ModelImpl &model, const SimulatorConfig &cfg) : impl_(std::make_unique<Impl>(model, cfg)) {
+
+  impl_->init_start = steady_clock::now();
+
+  if (!cfg.term_log_path.empty()) {
+    term_fd = open(cfg.term_log_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IRGRP | S_IROTH | S_IWUSR);
+    if (term_fd < 0) {
+      throw ConfigError("Cannot create terminal log '" + cfg.term_log_path + "': " + std::strerror(errno));
+    }
+  }
+
+  if (!cfg.trace_log_path.empty()) {
+    trace_log = std::fopen(cfg.trace_log_path.c_str(), "w+");
+    if (trace_log == nullptr) {
+      trace_log = stdout;
+      throw ConfigError("Cannot create trace log '" + cfg.trace_log_path + "': " + std::strerror(errno));
+    }
+    impl_->owns_trace_log = true;
+  }
+
+  if (cfg.rvfi_dii_port != 0) {
+    impl_->rvfi.emplace(cfg.rvfi_dii_port, model);
+    if (!impl_->rvfi->setup_socket(cfg.trace_rvfi)) {
+      throw ConfigError("RVFI socket setup failed");
+    }
+    model.register_callback(&impl_->rvfi_cbs);
+  }
+
+  if (cfg.enable_trap_loop_detection) {
+    model.register_callback(&impl_->loop_detector);
+  }
+
+  impl_->log_cbs.emplace(
+    cfg.trace_gpr,
+    cfg.trace_fpr,
+    cfg.trace_vreg,
+    cfg.trace_csr,
+    cfg.trace_mem_access,
+    cfg.trace_ptw,
+    cfg.trace_tlb,
+    cfg.use_abi_names,
+    trace_log
+  );
+  model.register_callback(&*impl_->log_cbs);
+
+  impl_->init_end = steady_clock::now();
+}
+
+Simulator::~Simulator() {
+  if (impl_->owns_trace_log && trace_log != stdout) {
+    std::fclose(trace_log);
+    trace_log = stdout;
+  }
+  if (term_fd >= 0) {
+    close(term_fd);
+    term_fd = -1;
+  }
+}
+
+RunResult Simulator::run() {
+  auto &m = impl_->model;
+  auto &cfg = impl_->cfg;
+
+  bool is_waiting = false;
+  // The emulator tick increments time by 1 at every step, so the number
+  // of steps to wait is equal to the needed increment in the time CSR.
+  const uint64_t max_wait_steps = cfg.max_time_to_wait;
+  uint64_t wait_steps_remaining = 0;
+
+  // initialize the step number
+  mach_int step_no = 0;
+  uint64_t insn_cnt = 0;
+
+  const uint64_t insns_per_tick = cfg.insns_per_tick;
+
+  auto interval_start = steady_clock::now();
+
+  while (!m.zhtif_done && (cfg.insn_limit == 0 || impl_->total_insns < cfg.insn_limit)) {
+    if (impl_->rvfi.has_value()) {
+      switch (impl_->rvfi->pre_step(cfg.trace_rvfi)) {
+      case RVFI_prestep_continue:
+        continue;
+      case RVFI_prestep_eof:
+        return {RunStatus::RvfiEof};
+      case RVFI_prestep_end_trace:
+        return {RunStatus::RvfiEndTrace};
+      case RVFI_prestep_ok:
+        break;
+      }
+    }
+
+    m.call_pre_step_callbacks(is_waiting);
+
+    { // run a Sail step
+      sail_int sail_step;
+      CREATE(sail_int)(&sail_step);
+      CONVERT_OF(sail_int, mach_int)(&sail_step, step_no);
+      is_waiting = m.ztry_step(sail_step, wait_steps_remaining == 0);
+      KILL(sail_int)(&sail_step);
+
+      if (m.have_exception) {
+        m.print_current_exception();
+        return {RunStatus::SailException};
+      }
+      if (cfg.trace_instr) {
+        std::fflush(stderr);
+        std::fflush(stdout);
+        std::fflush(trace_log);
+      }
+      if (impl_->rvfi) {
+        impl_->rvfi->send_trace(cfg.trace_rvfi);
+      }
+      if (is_waiting) {
+        if (wait_steps_remaining == 0) {
+          wait_steps_remaining = max_wait_steps;
+        } else {
+          --wait_steps_remaining;
+        }
+      } else {
+        wait_steps_remaining = 0;
+      }
+    }
+
+    m.call_post_step_callbacks(is_waiting);
+
+    if (!is_waiting) {
+      if (cfg.trace_step) {
+        std::fprintf(trace_log, "\n");
+      }
+      step_no++;
+      insn_cnt++;
+      impl_->total_insns++;
+    }
+
+    if (cfg.show_times && (impl_->total_insns & 0xfffff) == 0) {
+      const auto now = steady_clock::now();
+      const auto interval = now - interval_start;
+      interval_start = now;
+
+      uint64_t kips = 0x100000 / duration_cast<milliseconds>(interval).count();
+      std::fprintf(stdout, "kips: %" PRIu64 "\n", kips);
+    }
+
+    if (m.zhtif_done) {
+      // check exit code
+      if (m.zhtif_exit_code == 0) {
+        return {RunStatus::HtifSuccess};
+      } else {
+        return {RunStatus::HtifFailure, m.zhtif_exit_code};
+      }
+    }
+
+    if (insn_cnt == insns_per_tick) {
+      insn_cnt = 0;
+      m.ztick_clock(UNIT);
+    } else if (wait_steps_remaining > 0) {
+      m.ztick_clock(UNIT);
+    }
+
+    if (impl_->loop_detector.loop_detected()) {
+      return {RunStatus::TrapLoop, 0, impl_->loop_detector.mepc(), impl_->loop_detector.sepc()};
+    }
+  }
+
+  // This is reached if there is a Sail exception, HTIF has indicated
+  // successful completion, or the instruction limit has been reached.
+  return {RunStatus::InstructionLimit};
+}
+
+void Simulator::write_signature() {
+  if (impl_->cfg.sig_file.empty()) {
+    return;
+  }
+  if (!impl_->cfg.sig_start.has_value() || !impl_->cfg.sig_end.has_value() ||
+      *impl_->cfg.sig_start >= *impl_->cfg.sig_end) {
+    std::fprintf(stderr, "Invalid signature region to %s.\n", impl_->cfg.sig_file.c_str());
+    return;
+  }
+  FILE *f = std::fopen(impl_->cfg.sig_file.c_str(), "w");
+  if (!f) {
+    std::fprintf(stderr, "Cannot open file '%s': %s\n", impl_->cfg.sig_file.c_str(), std::strerror(errno));
+    return;
+  }
+  // write out words depending on signature granularity in signature area
+  const unsigned gran = impl_->cfg.sig_granularity;
+  for (uint64_t addr = *impl_->cfg.sig_start; addr < *impl_->cfg.sig_end; addr += gran) {
+    // most-significant byte first
+    for (int i = static_cast<int>(gran) - 1; i >= 0; i--) {
+      uint8_t byte = (uint8_t)read_mem(addr + i);
+      std::fprintf(f, "%02x", byte);
+    }
+    std::fprintf(f, "\n");
+  }
+  std::fclose(f);
+}
+
+void Simulator::reset_for_next_run(uint64_t entry, std::optional<uint64_t> htif_tohost, const char *config_file) {
+  reinit_sail(impl_->model, entry, htif_tohost, config_file);
+  impl_->loop_detector.reset();
+  impl_->total_insns = 0;
+}
+
+uint64_t Simulator::rvfi_entry() const {
+  return impl_->rvfi->get_entry();
+}
+
+void Simulator::print_times() const {
+  auto run_end = steady_clock::now();
+  uint64_t init_msecs = duration_cast<milliseconds>(impl_->init_end - impl_->init_start).count();
+  uint64_t exec_msecs = duration_cast<milliseconds>(run_end - impl_->init_end).count();
+  uint64_t kips = exec_msecs > 0 ? impl_->total_insns / exec_msecs : 0;
+  std::fprintf(stderr, "Initialization:   %" PRIu64 " ms\n", init_msecs);
+  std::fprintf(stderr, "Execution:        %" PRIu64 " ms\n", exec_msecs);
+  std::fprintf(stderr, "Instructions:     %" PRIu64 "\n", impl_->total_insns);
+  std::fprintf(stderr, "Performance:      %" PRIu64 " kIPS\n", kips);
+}
+
+uint64_t Simulator::total_insns() const {
+  return impl_->total_insns;
+}
+
+} // namespace riscv_sim

--- a/c_emulator/simulator.h
+++ b/c_emulator/simulator.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "riscv_sim_utils.h"
+
+class ModelImpl;
+
+namespace riscv_sim {
+
+enum class RunStatus {
+  HtifSuccess,
+  HtifFailure,
+  TrapLoop,
+  SailException,
+  InstructionLimit,
+  RvfiEof,
+  RvfiEndTrace,
+};
+
+struct RunResult {
+  RunStatus status;
+  uint64_t htif_exit_code = 0;
+  uint64_t mepc = 0;
+  uint64_t sepc = 0;
+};
+
+struct SimulatorConfig {
+  // Simulation loop control
+  uint64_t insn_limit = 0;
+  uint64_t max_time_to_wait = 0;
+  uint64_t insns_per_tick = 1;
+
+  // Trace options
+  bool trace_instr = false;
+  bool trace_step = false;
+  bool trace_rvfi = false;
+  bool trace_gpr = false;
+  bool trace_fpr = false;
+  bool trace_vreg = false;
+  bool trace_csr = false;
+  bool trace_mem_access = false;
+  bool trace_ptw = false;
+  bool trace_tlb = false;
+
+  bool use_abi_names = false;
+  bool show_times = false;
+
+  // Signature region
+  std::optional<uint64_t> sig_start;
+  std::optional<uint64_t> sig_end;
+  std::string sig_file;
+  unsigned sig_granularity = 4;
+
+  // Simulator trace output, empty = stdout
+  std::string trace_log_path;
+  // HTIF Console output, empty = no terminal log file
+  std::string term_log_path;
+
+  // RVFI (0 = disabled)
+  unsigned rvfi_dii_port = 0;
+
+  bool enable_trap_loop_detection = true;
+};
+
+class Simulator {
+public:
+  Simulator(ModelImpl &model, const SimulatorConfig &cfg);
+  ~Simulator();
+
+  Simulator(const Simulator &) = delete;
+  Simulator &operator=(const Simulator &) = delete;
+
+  RunResult run();
+
+  void write_signature();
+  void reset_for_next_run(uint64_t entry, std::optional<uint64_t> htif_tohost, const char *config_file);
+
+  // Only valid if rvfi_dii_port was non-zero.
+  uint64_t rvfi_entry() const;
+
+  void print_times() const;
+
+  uint64_t total_insns() const;
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace riscv_sim


### PR DESCRIPTION
As of today it is impractical to link against the model because riscv_sim.cpp is quite messy, relies on global state, and contains runtime logic that is coupled with its own main(). This commit pulls the run loop, callback setup, etc. into new files (simulator.h/cpp and riscv_sim_utils.h/cpp) so other binaries can link against the model and drive the simulator without copying main's setup code.

A few notable changes:

- A new defined simulator class that owns the run loop and its setup (logs, callbacks, etc.).
- Library code no longer calls exit(), run() returns a RunStatus/RunResult, and setup paths throw ConfigError. Main (inner_main()) handles termination.
- Eliminate global state by grouping related state into structs and passing them explicitly through function interfaces.
- load_sail returns its results as a struct instead of writing globals.
- inner_main split into a few named helpers.

Open this as a draft pull request for now.