### PR TITLE
Add option to control reservation invalidation by same-hart stores.

### DIFF
--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -48,6 +48,10 @@ void ModelImpl::set_reservation_require_exact_addr_match(bool require_exact_addr
   m_reservation_require_exact_addr = require_exact_addr;
 }
 
+void ModelImpl::set_reservation_invalidate_on_same_hart_store(bool invalidate_on_same_hart_store) {
+  m_reservation_invalidate_on_same_hart_store = invalidate_on_same_hart_store;
+}
+
 void ModelImpl::print_current_exception() {
   if (current_exception != nullptr) {
     zprint_exception(*current_exception);
@@ -65,6 +69,9 @@ unit ModelImpl::mem_write_callback(const char *type, sbits paddr, uint64_t width
   for (auto c : m_callbacks) {
     c->mem_write_callback(*this, type, paddr, width, value);
   }
+  if (m_reservation_invalidate_on_same_hart_store && match_reservation(paddr)) {
+    cancel_reservation(UNIT);
+  };
   return UNIT;
 }
 unit ModelImpl::mem_read_callback(const char *type, sbits paddr, uint64_t width, lbits value) {

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -24,6 +24,7 @@ public:
   void set_enable_experimental_extensions(bool en);
   void set_reservation_set_size_exp(uint64_t exponent);
   void set_reservation_require_exact_addr_match(bool require_exact_addr_match);
+  void set_reservation_invalidate_on_same_hart_store(bool invalidate_on_same_hart_store);
 
   void set_config_print_instr(bool on);
   void set_config_print_clint(bool on);
@@ -119,6 +120,7 @@ private:
 
   uint64_t m_reservation_set_addr_mask = 0;
   bool m_reservation_require_exact_addr = false;
+  bool m_reservation_invalidate_on_same_hart_store = false;
 
   bool m_enable_experimental_extensions = false;
 

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -427,6 +427,9 @@ void init_platform_constants(ModelImpl &model) {
   model.set_reservation_require_exact_addr_match(
     get_config_bool({"platform", "reservation", "require_exact_reservation_addr"})
   );
+  model.set_reservation_invalidate_on_same_hart_store(
+    get_config_bool({"platform", "reservation", "invalidate_on_same_hart_store"})
+  );
 }
 
 void init_sail(ModelImpl &model, uint64_t elf_entry, const char *config_file) {

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -286,7 +286,12 @@
       // address as the matching Load-Reserve in order to succeed, regardless of the
       // configured reservation set size.  This controls whether such an exact address
       // match is required for a Store-Conditional to succeed.
-      "require_exact_reservation_addr": false
+      "require_exact_reservation_addr": false,
+      // Some implementations (e.g. SiFive U74) also invalidate the
+      // reservation on stores from the same hart.  If this is set to `true`, the
+      // model invalidates the reservation if a store from the same hart lies within
+      // the reservation set.
+      "invalidate_on_same_hart_store": false
     },
     "clint": {
       // Whether the platform contains a CLINT.

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -4,6 +4,10 @@
   - The CLINT and simple interrupt generator can be marked as not
     supported for platforms that do not contain these MMIO devices;
     see `platform.clint.supported` and `platform.simple_interrupt_generator.supported`.
+  - An option to control whether reservations can be cancelled by stores
+    by the same hart to the reservation set has been added; see
+    `platform.reservation.invalidate_on_same_hart_store`. This defaults
+    to false to match previous behavior.
 
 # Release notes for version 0.11
 

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -26,6 +26,12 @@ let plat_cache_block_size_exp : range(0, 12) = config platform.cache_block_size_
 // their LR operands (4 bytes for LR.W, 8 bytes for LR.D).
 let plat_reservation_set_size_exp : range(2, 12) = config platform.reservation.reservation_set_size_exp
 
+// The following reservation options are used for reservation state
+// management by the external harness; they are not used within the Sail code.
+// They appear here so that their names and types are reflected in the config schema.
+let plat_reservation_require_exact_addr_match : bool = config platform.reservation.require_exact_reservation_addr
+let plat_reservation_invalidate_on_same_hart_store : bool = config platform.reservation.invalidate_on_same_hart_store
+
 // The exceptions that a misaligned access could generate.  For
 // example, a misaligned LR/SC always raises an exception.
 enum misaligned_exception = { AccessFault, AlignmentException }


### PR DESCRIPTION
The spec does not require this behaviour but it is allowed (because reservations can be spuriously invalidated at any point). Although in general it is not possible to match the SC failure in the model with all hart implementations, some real RISC-V implementations do have this behaviour so this expands the number of real harts we can match.

Fixes #1678.