### PR TITLE
Add configuration flags to enable platforms without CLINT or SIG devices.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -289,15 +289,21 @@
       "require_exact_reservation_addr": false
     },
     "clint": {
-      // This must be in a suitable IO memory region (see `memory.regions`).
+      // Whether the platform contains a CLINT.
+      "supported": true,
+      // If supported, this must be in a suitable IO memory region (see `memory.regions`).
+      // Otherwise, these values can be left as 0.
       "base": 33554432,
       "size": 786432
     },
     // Very simple MMIO device to generate interrupts for testing
     // purposes. See docs/SimpleInterruptGenerator.md for details.
     "simple_interrupt_generator": {
-      // This must be in a suitable IO memory region (see `memory.regions`)
-      // and 4-byte aligned. The size is always 0x20.
+      // Whether the platform contains this device.
+      "supported": true,
+      // If supported, this must be in a suitable IO memory region (see `memory.regions`)
+      // and 4-byte aligned. The size is always 0x20.  If not supported, this can be left
+      // as 0.
       "base": 201326592
     },
     "clock_frequency": 1000000000,

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -1,5 +1,10 @@
 # Release notes for the next version
 
+- Updates to the [configuration file](../config/config.json.in):
+  - The CLINT and simple interrupt generator can be marked as not
+    supported for platforms that do not contain these MMIO devices;
+    see `platform.clint.supported` and `platform.simple_interrupt_generator.supported`.
+
 # Release notes for version 0.11
 
 - Updates to the [configuration file](../config/config.json.in):

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -68,10 +68,12 @@ struct GlobalMisalignedExceptions = {
 let plat_misaligned_access : GlobalMisalignedExceptions = config memory.misaligned.exceptions
 
 // Location of clock-interface, which should match with the spec in the DTB
+let plat_have_clint : bool = config platform.clint.supported
 let plat_clint_base : physaddrbits = to_bits_checked(config platform.clint.base : int)
 let plat_clint_size : physaddrbits = to_bits_checked(config platform.clint.size : int)
 
 // Simple Interrupt Generator. See docs/SimpleInterruptGenerator.md for details.
+let plat_have_sig : bool = config platform.simple_interrupt_generator.supported
 let plat_sig_base : physaddrbits = to_bits_checked(config platform.simple_interrupt_generator.base : int)
 let plat_sig_size : physaddrbits = zero_extend(0x20)
 

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -370,10 +370,14 @@ private function check_mem_layout() -> bool =
       svadu    = config extensions.Svadu.supported,
     };
     let pmas_ok  = check_pma_regions(pma_regions, zeros(), zeros(), check_opts, false);
-    let clint_ok = within_configured_pma_memory("CLINT (platform.clint)", Some(IOMemory),
+    let clint_supported : bool = config platform.clint.supported;
+    let clint_ok = not(clint_supported) |
+                   within_configured_pma_memory("CLINT (platform.clint)", Some(IOMemory),
                                                 to_bits_checked(config platform.clint.base : int),
                                                 to_bits_checked(config platform.clint.size : int));
-    let sig_ok   = within_configured_pma_memory("simple interrupt generator (platform.simple_interrupt_generator)", Some(IOMemory),
+    let sig_supported : bool = config platform.simple_interrupt_generator.supported;
+    let sig_ok   = not(sig_supported) |
+                   within_configured_pma_memory("simple interrupt generator (platform.simple_interrupt_generator)", Some(IOMemory),
                                                 to_bits_checked(config platform.simple_interrupt_generator.base : int),
                                                 zero_extend(plat_sig_size));
     pmas_ok & clint_ok & sig_ok

--- a/model/sys/platform.sail
+++ b/model/sys/platform.sail
@@ -21,6 +21,8 @@ let htif_tohost_size = 8
 function enable_htif(tohost_addr : bits(64)) -> unit = htif_tohost_base = Some(trunc(tohost_addr))
 
 private function within_clint forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : physaddr, width : int('n)) -> bool = {
+  if not(plat_have_clint) then return false;
+
   // To avoid overflow issues when physical memory extends to the end
   // of the addressable range, we need to perform address bound checks
   // on unsigned unbounded integers.
@@ -32,6 +34,8 @@ private function within_clint forall 'n, 0 < 'n <= max_mem_access . (Physaddr(ad
 }
 
 private function within_sig forall 'n, 0 < 'n <= max_mem_access . (Physaddr(addr) : physaddr, width : int('n)) -> bool = {
+  if not(plat_have_sig) then return false;
+
   let addr_int = unsigned(addr);
   let sig_base_int = unsigned(plat_sig_base);
   let sig_size_int = unsigned(plat_sig_size);


### PR DESCRIPTION
Fixes #1685.