### PR TITLE
Optionally enable link-time optimization via CheckIPOSupported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,15 @@ jobs:
           # Ninja is used because the CMake Makefile generator doesn't
           # build top-level targets in parallel unfortunately.
           # First party tests cannot be built in the Rocky container due to lack of a suitable toolchain.
-          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWARNINGS_AS_ERRORS=TRUE -DFIRST_PARTY_TESTS=${{ matrix.first_party_tests }} -DENABLE_RISCV_TESTS=TRUE -DENABLE_RISCV_ARCH_TESTS=TRUE -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE $CLANG_FLAG
+          cmake -S . -B build -GNinja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DWARNINGS_AS_ERRORS=TRUE \
+            -DFIRST_PARTY_TESTS=${{ matrix.first_party_tests }} \
+            -DENABLE_RISCV_TESTS=TRUE \
+            -DENABLE_RISCV_ARCH_TESTS=TRUE \
+            -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE \
+            -DENABLE_LTO=TRUE \
+            $CLANG_FLAG
           ninja -C build all generated_sail_riscv_docs generated_smt_rv64d generated_smt_rv32d
 
       - name: Run tests
@@ -110,7 +118,7 @@ jobs:
 
       - name: Build simulator
         run: |
-          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_LTO=TRUE
           ninja -C build
 
       - name: Restore cache (linux image)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Build simulator
         run: |
           git config --global --add safe.directory '*'
-          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DSTATIC=TRUE -DENABLE_RISCV_TESTS=TRUE -DENABLE_RISCV_ARCH_TESTS=TRUE -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE
+          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DSTATIC=TRUE -DENABLE_RISCV_TESTS=TRUE -DENABLE_RISCV_ARCH_TESTS=TRUE -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE -DENABLE_LTO=TRUE
           cd build
           ninja all
           ctest -j2

--- a/.github/workflows/run-full-tests.yml
+++ b/.github/workflows/run-full-tests.yml
@@ -42,7 +42,7 @@ jobs:
           install-clang: "true"
       - name: Build simulator
         run: |
-          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_${{ matrix.TEST_SUITE }}=TRUE
+          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_${{ matrix.TEST_SUITE }}=TRUE -DENABLE_LTO=TRUE
           ninja -C build all
       - name: Run tests
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,12 @@ endif()
 option(DOWNLOAD_GMP "Download libgmp and build the library locally instead of using a system installation" OFF)
 if (DOWNLOAD_GMP)
     include(ExternalProject)
+    # Build GMP with LTO when ENABLE_LTO is on.
+    if (ENABLE_LTO)
+        set(GMP_CFLAGS "CFLAGS=-std=c11 -O3 -flto=auto -ffat-lto-objects")
+    else()
+        set(GMP_CFLAGS "CFLAGS=-std=c11")
+    endif()
     ExternalProject_Add(
         gmp
         URL https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz https://ftpmirror.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz
@@ -129,13 +135,14 @@ if (DOWNLOAD_GMP)
             --enable-static
             --with-pic
             # Newer compilers default to C23 which causes GMP build errors.
-            CFLAGS=-std=c11
+            "${GMP_CFLAGS}"
         # The libgmp.a output is created by the install step but since GMP::GMP
         # depends on the entire ExternalProject build, we can pretend it is
         # created by the build.
         # TODO: Once we depend on CMake 3.26, use INSTALL_BYPRODUCTS
         BUILD_BYPRODUCTS "<INSTALL_DIR>/lib/libgmp.a"
     )
+
     ExternalProject_Get_property(gmp INSTALL_DIR)
     add_library(GMP::GMP STATIC IMPORTED GLOBAL)
     # Work around `Imported target "GMP::GMP" includes non-existent path`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,8 +121,8 @@ if (DOWNLOAD_GMP)
     # Build GMP with LTO when ENABLE_LTO is on, using the same toolchain and
     # IPO flags as the main project so the LTO bytecode is compatible.
     if (ENABLE_LTO)
-        string(REPLACE ";" " " GMP_LTO_CFLAGS "${CMAKE_C_COMPILE_OPTIONS_IPO}")
-        string(REPLACE ";" " " GMP_LTO_LDFLAGS "${CMAKE_C_LINK_OPTIONS_IPO}")
+        list(JOIN CMAKE_C_COMPILE_OPTIONS_IPO " " GMP_LTO_CFLAGS)
+        list(JOIN CMAKE_C_LINK_OPTIONS_IPO " " GMP_LTO_LDFLAGS)
         set(GMP_EXTRA_CONFIGURE_ARGS
             "CFLAGS=-std=c11 -O3 ${GMP_LTO_CFLAGS}"
             "LDFLAGS=${GMP_LTO_LDFLAGS}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,11 +118,19 @@ endif()
 option(DOWNLOAD_GMP "Download libgmp and build the library locally instead of using a system installation" OFF)
 if (DOWNLOAD_GMP)
     include(ExternalProject)
-    # Build GMP with LTO when ENABLE_LTO is on.
+    # Build GMP with LTO when ENABLE_LTO is on, using the same toolchain and
+    # IPO flags as the main project so the LTO bytecode is compatible.
     if (ENABLE_LTO)
-        set(GMP_CFLAGS "CFLAGS=-std=c11 -O3 -flto=auto -ffat-lto-objects")
+        string(REPLACE ";" " " GMP_LTO_CFLAGS "${CMAKE_C_COMPILE_OPTIONS_IPO}")
+        string(REPLACE ";" " " GMP_LTO_LDFLAGS "${CMAKE_C_LINK_OPTIONS_IPO}")
+        set(GMP_EXTRA_CONFIGURE_ARGS
+            "CFLAGS=-std=c11 -O3 ${GMP_LTO_CFLAGS}"
+            "LDFLAGS=${GMP_LTO_LDFLAGS}"
+            "CC=${CMAKE_C_COMPILER}"
+            "CXX=${CMAKE_CXX_COMPILER}"
+        )
     else()
-        set(GMP_CFLAGS "CFLAGS=-std=c11")
+        set(GMP_EXTRA_CONFIGURE_ARGS "CFLAGS=-std=c11")
     endif()
     ExternalProject_Add(
         gmp
@@ -135,7 +143,7 @@ if (DOWNLOAD_GMP)
             --enable-static
             --with-pic
             # Newer compilers default to C23 which causes GMP build errors.
-            "${GMP_CFLAGS}"
+            ${GMP_EXTRA_CONFIGURE_ARGS}
         # The libgmp.a output is created by the install step but since GMP::GMP
         # depends on the entire ExternalProject build, we can pretend it is
         # created by the build.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,13 +51,17 @@ set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 # Enable link-time optimization globally. This allows the linker to inline
 # Sail runtime helpers (eq_bits, add_bits_int, etc.) into the generated
 # model code, which is the dominant cost in the simulator hot path.
-include(CheckIPOSupported)
-check_ipo_supported(RESULT lto_supported OUTPUT lto_error)
-if (lto_supported)
-    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
-    message(STATUS "LTO enabled globally")
-else()
-    message(STATUS "LTO not supported: ${lto_error}")
+# Disabled by default because it can make compile times worse.
+option(ENABLE_LTO "Enable link-time optimization" FALSE)
+if (ENABLE_LTO)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT lto_supported OUTPUT lto_error)
+    if (lto_supported)
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+        message(STATUS "LTO enabled")
+    else()
+        message(FATAL_ERROR "LTO requested but not supported: ${lto_error}")
+    endif()
 endif()
 
 # Don't allow undefined symbols. This is generally a pain.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,18 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 # Generally it just simplifies everything for a negligible performance cost.
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
+# Enable link-time optimization globally. This allows the linker to inline
+# Sail runtime helpers (eq_bits, add_bits_int, etc.) into the generated
+# model code, which is the dominant cost in the simulator hot path.
+include(CheckIPOSupported)
+check_ipo_supported(RESULT lto_supported OUTPUT lto_error)
+if (lto_supported)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+    message(STATUS "LTO enabled globally")
+else()
+    message(STATUS "LTO not supported: ${lto_error}")
+endif()
+
 # Don't allow undefined symbols. This is generally a pain.
 include(CheckLinkerFlag)
 

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -5,6 +5,13 @@
     supported for platforms that do not contain these MMIO devices;
     see `platform.clint.supported` and `platform.simple_interrupt_generator.supported`.
 
+- Performance improvements:
+  - https://github.com/riscv/sail-riscv/pull/1692 : Optional `ENABLE_LTO`
+    build option. When enabled, applies link-time optimization to both the
+    simulator and the bundled libgmp, with performance improvements
+    (e.g. Linux boot time reduced by up to ~50%). Off by default to keep
+    incremental builds fast, enabled in CI and release builds.
+
 # Release notes for version 0.11
 
 - Updates to the [configuration file](../config/config.json.in):


### PR DESCRIPTION
Adds an opt-in `ENABLE_LTO` CMake option that allows the linker to aggressively inline functions into the generated model code, and compiles GMP with link-time optimization as well.

Off by default to keep incremental builds fast during local development. Enabled in the CI and release workflows.

Can reduce runtime by up to ~50% on Linux boot (from ~4m25s to ~2m11s, locally tested with GCC 15.2.0), with similar improvements observed across other workloads.