### PR TITLE
Isabelle target updates

### DIFF
--- a/handwritten_support/riscv_extras.lem
+++ b/handwritten_support/riscv_extras.lem
@@ -16,8 +16,8 @@ open import Sail2_monadic_combinators
 
 type bitvector = list Sail2_values.bitU
 
-val load_reservation : forall 'abort 'barrier 'cache_op 'fault 'pa 'tlb_op 'translation_summary 'trans_start 'trans_end 'arch_ak 'rv 'e. bitvector -> monad 'abort 'barrier 'cache_op 'fault 'pa 'tlb_op 'translation_summary 'trans_start 'trans_end 'arch_ak 'rv unit 'e
-let load_reservation addr = return ()
+val load_reservation : forall 'abort 'barrier 'cache_op 'fault 'pa 'tlb_op 'translation_summary 'trans_start 'trans_end 'arch_ak 'rv 'e. bitvector -> integer -> monad 'abort 'barrier 'cache_op 'fault 'pa 'tlb_op 'translation_summary 'trans_start 'trans_end 'arch_ak 'rv unit 'e
+let load_reservation addr width = return ()
 
 let match_reservation _ = true
 let cancel_reservation () = return ()
@@ -36,7 +36,7 @@ val plat_get_16_random_bits : forall 'abort 'barrier 'cache_op 'fault 'pa 'tlb_o
 let plat_get_16_random_bits () = choose_bitvector "plat_get_16_random_bits" 16
 declare ocaml target_rep function plat_get_16_random_bits = `Platform.get_16_random_bits`
 
-def sys_enable_experimental_extensions () = false
+let sys_enable_experimental_extensions () = false
 
 val shift_bits_right : bitvector -> bitvector -> bitvector
 let shift_bits_right v m = shiftr v (uint m)

--- a/handwritten_support/riscv_extras_fdext.lem
+++ b/handwritten_support/riscv_extras_fdext.lem
@@ -177,47 +177,47 @@ let softfloat_f64_to_f32 _ _ = fail
 val softfloat_f32_to_bf16: bitvector -> bitvector -> (bitvector * bitvector)
 let softfloat_f32_to_bf16 _ _ = fail
 
-val softfloat_f16_lt : bitvector -> bitvector -> (bitvector * bitvector)
+val softfloat_f16_lt : bitvector -> bitvector -> (bitvector * bool)
 let softfloat_f16_lt _ _ = fail
 
-val softfloat_f16_lt_quiet : bitvector -> bitvector -> (bitvector * bitvector)
+val softfloat_f16_lt_quiet : bitvector -> bitvector -> (bitvector * bool)
 let softfloat_f16_lt_quiet _ _ = fail
 
-val softfloat_f16_le : bitvector -> bitvector -> (bitvector * bitvector)
+val softfloat_f16_le : bitvector -> bitvector -> (bitvector * bool)
 let softfloat_f16_le _ _ = fail
 
-val softfloat_f16_le_quiet : bitvector -> bitvector -> (bitvector * bitvector)
+val softfloat_f16_le_quiet : bitvector -> bitvector -> (bitvector * bool)
 let softfloat_f16_le_quiet _ _ = fail
 
-val softfloat_f16_eq : bitvector -> bitvector -> (bitvector * bitvector)
+val softfloat_f16_eq : bitvector -> bitvector -> (bitvector * bool)
 let softfloat_f16_eq _ _ = fail
 
-val softfloat_f32_lt : bitvector -> bitvector -> (bitvector * bitvector)
+val softfloat_f32_lt : bitvector -> bitvector -> (bitvector * bool)
 let softfloat_f32_lt _ _ = fail
 
-val softfloat_f32_lt_quiet : bitvector -> bitvector -> (bitvector * bitvector)
+val softfloat_f32_lt_quiet : bitvector -> bitvector -> (bitvector * bool)
 let softfloat_f32_lt_quiet _ _ = fail
 
-val softfloat_f32_le : bitvector -> bitvector -> (bitvector * bitvector)
+val softfloat_f32_le : bitvector -> bitvector -> (bitvector * bool)
 let softfloat_f32_le _ _ = fail
 
-val softfloat_f32_le_quiet : bitvector -> bitvector -> (bitvector * bitvector)
+val softfloat_f32_le_quiet : bitvector -> bitvector -> (bitvector * bool)
 let softfloat_f32_le_quiet _ _ = fail
 
-val softfloat_f32_eq : bitvector -> bitvector -> (bitvector * bitvector)
+val softfloat_f32_eq : bitvector -> bitvector -> (bitvector * bool)
 let softfloat_f32_eq _ _ = fail
 
-val softfloat_f64_lt : bitvector -> bitvector -> (bitvector * bitvector)
+val softfloat_f64_lt : bitvector -> bitvector -> (bitvector * bool)
 let softfloat_f64_lt _ _ = fail
 
-val softfloat_f64_lt_quiet : bitvector -> bitvector -> (bitvector * bitvector)
+val softfloat_f64_lt_quiet : bitvector -> bitvector -> (bitvector * bool)
 let softfloat_f64_lt_quiet _ _ = fail
 
-val softfloat_f64_le : bitvector -> bitvector -> (bitvector * bitvector)
+val softfloat_f64_le : bitvector -> bitvector -> (bitvector * bool)
 let softfloat_f64_le _ _ = fail
 
-val softfloat_f64_le_quiet : bitvector -> bitvector -> (bitvector * bitvector)
+val softfloat_f64_le_quiet : bitvector -> bitvector -> (bitvector * bool)
 let softfloat_f64_le_quiet _ _ = fail
 
-val softfloat_f64_eq : bitvector -> bitvector -> (bitvector * bitvector)
+val softfloat_f64_eq : bitvector -> bitvector -> (bitvector * bool)
 let softfloat_f64_eq _ _ = fail

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -519,9 +519,11 @@ foreach (xlen IN ITEMS 32 64)
         OUTPUT "${CMAKE_BINARY_DIR}/isabelle/${arch}/${arch_thy}.thy" "${CMAKE_BINARY_DIR}/isabelle/${arch}/${arch_thy}_types.thy"
         COMMENT "Building Isabelle definitions from Lem definitions (${arch})"
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        # The -no_lifting_toplevel_match_for options avoid unnecessary and expensive use of `fun` on large pattern matches
         COMMAND
             lem
-            -no_lifting_toplevel_match_for ${arch_thy}_types.ast
+            -no_lifting_toplevel_match_for ${arch_thy}_types.instruction
+            -no_lifting_toplevel_match_for ${arch_thy}_types.MemoryAccessType
             -wl ign
             -isa
             -outdir ${CMAKE_BINARY_DIR}/isabelle/${arch}
@@ -530,9 +532,11 @@ foreach (xlen IN ITEMS 32 64)
             ${CMAKE_SOURCE_DIR}/handwritten_support/riscv_extras_fdext.lem
             ${arch}_types.lem
             ${arch}.lem
+        # We need a few workarounds for large datatypes, and a syntax collision
         COMMAND
             sed
-            -e "s/datatype ast/datatype (plugins only: size) ast/"
+            -e "s/datatype extension/datatype (plugins only: size) extension/"
+            -e "s/datatype instruction/datatype (plugins only: size) instruction/"
             -e "s/record( 'asidlen, 'valen, 'palen, 'ptelen) TLB_Entry/record (overloaded) ( 'asidlen, 'valen, 'palen, 'ptelen) TLB_Entry/"
             "${CMAKE_BINARY_DIR}/isabelle/${arch}/${arch_thy}_types.thy"
             >
@@ -541,9 +545,10 @@ foreach (xlen IN ITEMS 32 64)
             mv
             "${CMAKE_BINARY_DIR}/isabelle/${arch}/${arch_thy}_types.thy.new"
             "${CMAKE_BINARY_DIR}/isabelle/${arch}/${arch_thy}_types.thy"
+        # These workarounds are for pattern completeness proofs in monadic functions
         COMMAND
             sed
-            -e "s/by pat_completeness auto/by pat_completeness (auto intro!: let_cong bind_cong result.case_cong)/"
+            -e "s/by pat_completeness auto/by pat_completeness (auto intro!: let_cong bind_cong result.case_cong arg_cong[where f = catch_early_return])/"
             -e "s/WriteRAM_Meta addr width meta/WriteRAM_Meta addr width ()/"
             "${CMAKE_BINARY_DIR}/isabelle/${arch}/${arch_thy}.thy"
             >


### PR DESCRIPTION
* Fix a few handwritten stubs.
* Update type names in large datatype workarounds.
* Generalise the Isabelle pattern completeness tactic a little.

This requires a recent development version of Sail due to some complementary improvements, and also the new release of Lem.

Fixes #1669 