### PR TITLE
Add configuration for the alignment of the bases of mtvec and stvec.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -38,6 +38,23 @@
       "len": 32,
       "value": "0xFFFF_FFFF"
     },
+    // The `{m,s}tvec.base_alignment` parameters control the alignment
+    // of the trap vector base for each mode.  The alignment is
+    // specified as the power of 2 of the desired byte alignment, and
+    // can range from a minimum of 2 upto a maximum of 24. If
+    // unaligned values are written to these CSRs, the lowest bits
+    // will be zeroed to respect the specified alignment.
+    "mtvec": {
+      "base_alignment": {
+        "direct" : 2,
+        "vectored" : 2
+      }
+    },
+    "stvec": {
+      "base_alignment": {
+        "vectored" : 2
+      }
+    },
     // These settings control whether the specified exceptions
     // cause information to be written into the appropriate
     // `xtval` registers.

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -8,9 +8,8 @@
     by the same hart to the reservation set has been added; see
     `platform.reservation.invalidate_on_same_hart_store`. This defaults
     to false to match previous behavior.
-  - The mode-dependent alignment constraints of the bases of the
-    `mtvec` and `stvec` CSRs can now be specified; see
-    `base.{m,s}tvec.base_alignment`.
+  - The alignment constraints of the bases of the `mtvec` and `stvec`
+    CSRs can now be specified; see `base.{m,s}tvec.base_alignment`.
 
 # Release notes for version 0.11
 

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -8,6 +8,9 @@
     by the same hart to the reservation set has been added; see
     `platform.reservation.invalidate_on_same_hart_store`. This defaults
     to false to match previous behavior.
+  - The mode-dependent alignment constraints of the bases of the
+    `mtvec` and `stvec` CSRs can now be specified; see
+    `base.{m,s}tvec.base_alignment`.
 
 # Release notes for version 0.11
 

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -8,6 +8,12 @@
 
 // Platform-specific configuration parameters.
 
+// Trap vector alignment.
+type tvec_alignment = range(2, 24)
+let plat_mtvec_base_alignment_direct_exp   : tvec_alignment = config base.mtvec.base_alignment.direct
+let plat_mtvec_base_alignment_vectored_exp : tvec_alignment = config base.mtvec.base_alignment.vectored
+let plat_stvec_base_alignment_vectored_exp : tvec_alignment = config base.stvec.base_alignment.vectored
+
 // Cache block size is 2^cache_block_size_exp. Max is `max_mem_access` (4096)
 // because this model performs `cbo.zero` with a single write, and the behaviour
 // with cache blocks larger than a page is not clearly defined.

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -496,7 +496,7 @@ function legalize_tvec(o : Mtvec, v : xlenbits, tvec : tvec_type) -> Mtvec = {
     TV_Direct => v,
     TV_Vector => v,
     _         => match xtvec_mode_reserved_behavior {
-      Xtvec_Fatal => reserved_behavior("Tried to write a reserved value (" ^ dec_str(unsigned(v[Mode])) ^ ") to the MODE field of xtvec."),
+      Xtvec_Fatal => reserved_behavior("Tried to write a reserved value (" ^ dec_str(unsigned(v[Mode])) ^ ") to the MODE field of " ^ tvec_type_str(tvec) ^ "."),
       Xtvec_Ignore => [v with Mode = o[Mode]],
     },
   };

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -476,12 +476,6 @@ function is_fiom_active() -> bool = {
 
 // registers for trap handling
 
-enum tvec_type = {Mtvec, Stvec}
-mapping tvec_type_str : tvec_type <-> string = {
-  Mtvec <-> "mtvec",
-  Stvec <-> "stvec",
-}
-
 bitfield Mtvec : xlenbits = {
   Base : xlen - 1 .. 2,
   Mode : 1 .. 0
@@ -489,25 +483,23 @@ bitfield Mtvec : xlenbits = {
 register mtvec : Mtvec  // Trap Vector
 
 // PUBLIC: invoked from set_{ms}tvec() [exceptions/sys_exceptions.sail]
-function legalize_tvec(o : Mtvec, v : xlenbits, tvec : tvec_type) -> Mtvec = {
+function legalize_tvec(o : Mtvec, v : xlenbits, direct_alignment_exp : tvec_alignment, vectored_alignment_exp : tvec_alignment) -> Mtvec = {
   let v = Mk_Mtvec(v);
   // Legalize mode.
   let v : Mtvec = match trapVectorMode_of_bits(v[Mode]) {
     TV_Direct => v,
     TV_Vector => v,
     _         => match xtvec_mode_reserved_behavior {
-      Xtvec_Fatal => reserved_behavior("Tried to write a reserved value (" ^ dec_str(unsigned(v[Mode])) ^ ") to the MODE field of " ^ tvec_type_str(tvec) ^ "."),
+      Xtvec_Fatal => reserved_behavior("Tried to write a reserved value (" ^ dec_str(unsigned(v[Mode])) ^ ") to the MODE field of xtvec."),
       Xtvec_Ignore => [v with Mode = o[Mode]],
     },
   };
   // Legalize alignment.
-  let base_alignment : tvec_alignment = match (tvec, trapVectorMode_of_bits(v[Mode])) {
-    (Mtvec, TV_Direct)   => plat_mtvec_base_alignment_direct_exp,
-    (Mtvec, TV_Vector)   => plat_mtvec_base_alignment_vectored_exp,
-    (Stvec, TV_Direct)   => 2,
-    (Stvec, TV_Vector)   => plat_stvec_base_alignment_vectored_exp,
-    (_,     TV_Reserved) => // This should never happen due to the check above.
-                            internal_error(__FILE__, __LINE__, "Reserved mode in " ^ tvec_type_str(tvec) ^ "."),
+  let base_alignment : tvec_alignment = match trapVectorMode_of_bits(v[Mode]) {
+    TV_Direct   => direct_alignment_exp,
+    TV_Vector   => vectored_alignment_exp,
+    TV_Reserved => // This should never happen due to the check above.
+                   internal_error(__FILE__, __LINE__, "Reserved mode in xtvec."),
   };
   // v[Base] doesn't contain the lowest 2 bits, and hence is at least 4-byte aligned.
   if base_alignment > 2

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -476,6 +476,12 @@ function is_fiom_active() -> bool = {
 
 // registers for trap handling
 
+enum tvec_type = {Mtvec, Stvec}
+mapping tvec_type_str : tvec_type <-> string = {
+  Mtvec <-> "mtvec",
+  Stvec <-> "stvec",
+}
+
 bitfield Mtvec : xlenbits = {
   Base : xlen - 1 .. 2,
   Mode : 1 .. 0
@@ -483,16 +489,30 @@ bitfield Mtvec : xlenbits = {
 register mtvec : Mtvec  // Trap Vector
 
 // PUBLIC: invoked from set_{ms}tvec() [exceptions/sys_exceptions.sail]
-function legalize_tvec(o : Mtvec, v : xlenbits) -> Mtvec = {
+function legalize_tvec(o : Mtvec, v : xlenbits, tvec : tvec_type) -> Mtvec = {
   let v = Mk_Mtvec(v);
-  match trapVectorMode_of_bits(v[Mode]) {
+  // Legalize mode.
+  let v : Mtvec = match trapVectorMode_of_bits(v[Mode]) {
     TV_Direct => v,
     TV_Vector => v,
     _         => match xtvec_mode_reserved_behavior {
       Xtvec_Fatal => reserved_behavior("Tried to write a reserved value (" ^ dec_str(unsigned(v[Mode])) ^ ") to the MODE field of xtvec."),
       Xtvec_Ignore => [v with Mode = o[Mode]],
     },
-  }
+  };
+  // Legalize alignment.
+  let base_alignment : tvec_alignment = match (tvec, trapVectorMode_of_bits(v[Mode])) {
+    (Mtvec, TV_Direct)   => plat_mtvec_base_alignment_direct_exp,
+    (Mtvec, TV_Vector)   => plat_mtvec_base_alignment_vectored_exp,
+    (Stvec, TV_Direct)   => 2,
+    (Stvec, TV_Vector)   => plat_stvec_base_alignment_vectored_exp,
+    (_,     TV_Reserved) => // This should never happen due to the check above.
+                            internal_error(__FILE__, __LINE__, "Reserved mode in " ^ tvec_type_str(tvec) ^ "."),
+  };
+  // v[Base] doesn't contain the lowest 2 bits, and hence is at least 4-byte aligned.
+  if base_alignment > 2
+  then [v with Base = [v[Base] with (base_alignment - 3) .. 0 = zeros()]]
+  else v;
 }
 
 bitfield Mcause : xlenbits = {

--- a/model/exceptions/sys_exceptions.sail
+++ b/model/exceptions/sys_exceptions.sail
@@ -71,12 +71,12 @@ function get_stvec() -> xlenbits =
   stvec.bits
 
 function set_mtvec(value : xlenbits) -> xlenbits = {
-  mtvec = legalize_tvec(mtvec, value, Mtvec);
+  mtvec = legalize_tvec(mtvec, value, plat_mtvec_base_alignment_direct_exp, plat_mtvec_base_alignment_vectored_exp);
   mtvec.bits
 }
 
 function set_stvec(value : xlenbits) -> xlenbits = {
-  stvec = legalize_tvec(stvec, value, Stvec);
+  stvec = legalize_tvec(stvec, value, 2, plat_stvec_base_alignment_vectored_exp);
   stvec.bits
 }
 

--- a/model/exceptions/sys_exceptions.sail
+++ b/model/exceptions/sys_exceptions.sail
@@ -71,12 +71,12 @@ function get_stvec() -> xlenbits =
   stvec.bits
 
 function set_mtvec(value : xlenbits) -> xlenbits = {
-  mtvec = legalize_tvec(mtvec, value);
+  mtvec = legalize_tvec(mtvec, value, Mtvec);
   mtvec.bits
 }
 
 function set_stvec(value : xlenbits) -> xlenbits = {
-  stvec = legalize_tvec(stvec, value);
+  stvec = legalize_tvec(stvec, value, Stvec);
   stvec.bits
 }
 


### PR DESCRIPTION
The constraints for the direct and vectored modes can be specified independently for mtvec, as powers of 2 upto a maximum of 24.  2^24 should be a reasonable maximum across most RV32 and RV64 implementations. The alignment can similarly be specified for the vectored mode of stvec.

Fixes #1693.