### PR TITLE
Add riscv,cbo{m,z,p}-block-size properties to the device tree

### DIFF
--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -658,6 +658,7 @@ let extensions_ordered_for_isa_string = [
 
   // Z extensions, ordered by category and then alphabetically.
   // Zi
+  Ext_Zic64b,
   Ext_Zibi,
   Ext_Zicbom,
   Ext_Zicbop,

--- a/model/postlude/device_tree.sail
+++ b/model/postlude/device_tree.sail
@@ -119,6 +119,15 @@ private function generate_dts_memories(pmas : list(PMA_Region)) -> string =
     }
   }
 
+// Generates a `riscv,<prefix>-block-size` property line if the corresponding
+// cache-block extension is supported. The size is 2^plat_cache_block_size_exp
+// bytes, the same value used by the Zicbom/Zicboz/Zicbop instruction semantics.
+private function generate_cbo_block_size(prefix : string, ext : extension) -> string = {
+  if hartSupports(ext)
+  then "      riscv," ^ prefix ^ "-block-size = <" ^ dec_str(2 ^ plat_cache_block_size_exp) ^ ">;\n"
+  else ""
+}
+
 function generate_dts() -> string = {
   let clock_freq : nat = config platform.clock_frequency;
 
@@ -156,6 +165,9 @@ function generate_dts() -> string = {
 ^ "      riscv,isa = \"" ^ generate_isa_string(Canonical_Lowercase) ^ "\";\n"
 ^ "      riscv,isa-extensions = " ^ generate_isa_string(DeviceTree_ISA_Extensions) ^ ";\n"
 ^ "      mmu-type = \"riscv," ^ mmu_type() ^ "\";\n"
+^ generate_cbo_block_size("cbom", Ext_Zicbom)
+^ generate_cbo_block_size("cboz", Ext_Zicboz)
+^ generate_cbo_block_size("cbop", Ext_Zicbop)
 ^ "      clock-frequency = <" ^ dec_str(clock_freq) ^ ">;\n"
 ^ "      CPU0_intc: interrupt-controller {\n"
 ^ "        #address-cells = <2>;\n"


### PR DESCRIPTION
The device tree generator lists Zicbom/Zicboz/Zicbop in riscv,isa, but omits the corresponding block-size properties, which causes Linux to disable these extensions at boot. This change emits the appropriate properties in the device tree when the extensions are supported, using 2^plat_cache_block_size_exp to match the instruction semantics.

At the same time add Zic64b to both the device tree ISA string and the extension list.