### PR TITLE
Add checks to ensure valid overlaps between vector source register groups.

### DIFF
--- a/model/extensions/V/vext_arith_insts.sail
+++ b/model/extensions/V/vext_arith_insts.sail
@@ -59,18 +59,29 @@ function clause execute VVTYPE(funct6, vm, vs2, vs1, vd) = {
   // source vector register groups, otherwise the instruction encoding
   // is reserved."
 
+  let vs1_emul_pow = if funct6 == VV_VRGATHEREI16 then 4 + LMUL_pow - SEW_pow else LMUL_pow;
+
   // Check for source destination overlaps for vrgather instructions.
-  let src_dst_overlap : bool = if funct6 == VV_VRGATHER | funct6 == VV_VRGATHEREI16
+  let src_dst_overlap : bool = if funct6 == VV_VRGATHER
                                then vs1 == vd | vs2 == vd
+                               else if funct6 == VV_VRGATHEREI16
+                               then not(valid_disjoint_reg_groups(vs1, vd, vs1_emul_pow, LMUL_pow)) | vs2 == vd
                                else false;
 
-  let vs1_emul_pow = if funct6 == VV_VRGATHEREI16 then 4 + LMUL_pow - SEW_pow else LMUL_pow;
+  let src_mask_overlap = not(valid_vm_src_overlap(vm, vs1, SEW)) |
+                         not(valid_vm_src_overlap(vm, vs2, SEW));
+
+  let src_src_overlap : bool = if funct6 == VV_VRGATHEREI16
+                               then not(valid_src_overlap(vs1, 16, vs1_emul_pow, vs2, SEW, LMUL_pow))
+                               else false;
 
   if illegal_vstart(VSTART_ARITH) |
      illegal_normal(vd, vm) |
      not(valid_reg_overlap(vs1, vd, vs1_emul_pow, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     src_dst_overlap
+     src_dst_overlap |
+     src_src_overlap |
+     src_mask_overlap
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -217,7 +228,9 @@ function clause execute NVSTYPE(funct6, vm, vs2, vs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
-     not(valid_reg_group(vs1, LMUL_pow))
+     not(valid_src_overlap(vs2, SEW_widen, LMUL_pow_widen, vs1, SEW, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW_widen))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -293,7 +306,9 @@ function clause execute NVTYPE(funct6, vm, vs2, vs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
-     not(valid_reg_group(vs1, LMUL_pow))
+     not(valid_src_overlap(vs2, SEW_widen, LMUL_pow_widen, vs1, SEW, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW_widen))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -368,7 +383,9 @@ function clause execute MASKTYPEV(vs2, vs1, vd) = {
      illegal_vd_masked(vd)  |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(0b0, vs1, SEW)) |
+     not(valid_vm_src_overlap(0b0, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -485,7 +502,8 @@ function clause execute VXTYPE(funct6, vm, vs2, rs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -611,7 +629,8 @@ function clause execute NXSTYPE(funct6, vm, vs2, rs1, vd) = {
 
   if illegal_vstart(VSTART_ARITH) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
+     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW_widen))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -686,7 +705,8 @@ function clause execute NXTYPE(funct6, vm, vs2, rs1, vd) = {
 
   if illegal_vstart(VSTART_ARITH) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
+     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW_widen))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -772,6 +792,7 @@ function clause execute VXSG(funct6, vm, vs2, rs1, vd) = {
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW)) |
      src_dst_overlap
   then return Illegal_Instruction();
 
@@ -848,7 +869,8 @@ function clause execute MASKTYPEX(vs2, rs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_vd_masked(vd)  |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(0b0, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -954,7 +976,8 @@ function clause execute VITYPE(funct6, vm, vs2, simm, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -1056,7 +1079,8 @@ function clause execute NISTYPE(funct6, vm, vs2, uimm, vd) = {
 
   if illegal_vstart(VSTART_ARITH) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
+     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW_widen))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -1131,7 +1155,8 @@ function clause execute NITYPE(funct6, vm, vs2, uimm, vd) = {
 
   if illegal_vstart(VSTART_ARITH) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
+     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW_widen))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -1216,6 +1241,7 @@ function clause execute VISG(funct6, vm, vs2, simm, vd) = {
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW)) |
      src_dst_overlap
   then return Illegal_Instruction();
 
@@ -1292,7 +1318,8 @@ function clause execute MASKTYPEI(vs2, simm, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_vd_masked(vd)  |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(0b0, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -1469,7 +1496,9 @@ function clause execute MVVTYPE(funct6, vm, vs2, vs1, vd) = {
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -1595,7 +1624,9 @@ function clause execute MVVMATYPE(funct6, vm, vs2, vs1, vd) = {
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -1666,7 +1697,9 @@ function clause execute WVVTYPE(funct6, vm, vs2, vs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -1745,7 +1778,9 @@ function clause execute WVTYPE(funct6, vm, vs2, vs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-     not(valid_reg_group(vs2, LMUL_pow_widen))
+     not(valid_src_overlap(vs2, SEW_widen, LMUL_pow_widen, vs1, SEW, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW_widen))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -1818,7 +1853,9 @@ function clause execute WMVVTYPE(funct6, vm, vs2, vs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -1899,7 +1936,8 @@ function clause execute VEXTTYPE(funct6, vm, vs2, vd) = {
 
   if illegal_vstart(VSTART_ARITH) |
      illegal_variable_width(vd, vm, SEW_div, LMUL_pow_div) |
-     not(valid_reg_overlap(vs2, vd, LMUL_pow_div, LMUL_pow))
+     not(valid_reg_overlap(vs2, vd, LMUL_pow_div, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW_div))
   then return Illegal_Instruction();
 
   assert(SEW_div >= 8);
@@ -2001,10 +2039,9 @@ function clause execute MVVCOMPRESS(vs2, vs1, vd) = {
 
   if illegal_vstart(VSTART_MANDATORY) |
      illegal_vd_unmasked() |
-     vs1 == vd |
+     not(valid_disjoint_reg_groups(vs1, vd, 0, LMUL_pow)) |
      vs2 == vd |
-     not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_src_overlap(vs2, SEW, LMUL_pow, vs1, 1, 0))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -2086,6 +2123,7 @@ function clause execute MVXTYPE(funct6, vm, vs2, rs1, vd) = {
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW)) |
      src_dst_overlap
   then return Illegal_Instruction();
 
@@ -2219,7 +2257,8 @@ function clause execute MVXMATYPE(funct6, vm, vs2, rs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -2290,7 +2329,8 @@ function clause execute WVXTYPE(funct6, vm, vs2, rs1, vd) = {
 
   if illegal_vstart(VSTART_ARITH) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -2369,7 +2409,8 @@ function clause execute WXTYPE(funct6, vm, vs2, rs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_group(vs2, LMUL_pow_widen)) |
-     not(valid_reg_group(vd, LMUL_pow_widen))
+     not(valid_reg_group(vd, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW_widen))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -2442,7 +2483,8 @@ function clause execute WMVXTYPE(funct6, vm, vs2, rs1, vd) = {
 
   if illegal_vstart(VSTART_ARITH) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);

--- a/model/extensions/V/vext_fp_insts.sail
+++ b/model/extensions/V/vext_fp_insts.sail
@@ -43,7 +43,9 @@ function clause execute FVVTYPE(funct6, vm, vs2, vs1, vd) = {
      illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW != 8);
@@ -129,7 +131,9 @@ function clause execute FVVMATYPE(funct6, vm, vs2, vs1, vd) = {
      illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW != 8);
@@ -208,7 +212,9 @@ function clause execute FWVVTYPE(funct6, vm, vs2, vs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW >= 16 & SEW_widen <= 64);
@@ -281,7 +287,9 @@ function clause execute FWVVMATYPE(funct6, vm, vs1, vs2, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW >= 16 & SEW_widen <= 64);
@@ -353,7 +361,9 @@ function clause execute FWVTYPE(funct6, vm, vs2, vs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-     not(valid_reg_group(vs2, LMUL_pow_widen))
+     not(valid_src_overlap(vs2, SEW_widen, LMUL_pow_widen, vs1, SEW, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW_widen))
   then return Illegal_Instruction();
 
   assert(SEW >= 16 & SEW_widen <= 64);
@@ -423,7 +433,8 @@ function clause execute VFUNARY0(vm, vs2, vfunary0, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW != 8);
@@ -547,7 +558,8 @@ function clause execute VFWUNARY0(vm, vs2, vfwunary0, vd) = {
 
   if illegal_vstart(VSTART_ARITH) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
-     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW >= 8 & SEW_widen <= 64);
@@ -684,7 +696,8 @@ function clause execute VFNUNARY0(vm, vs2, vfnunary0, vd) = {
 
   if illegal_vstart(VSTART_ARITH) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
-     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
+     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW_widen))
   then return Illegal_Instruction();
 
   assert(SEW != 64);
@@ -826,7 +839,8 @@ function clause execute VFUNARY1(vm, vs2, vfunary1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW != 8);
@@ -970,6 +984,7 @@ function clause execute FVFTYPE(funct6, vm, vs2, rs1, vd) = {
      illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW)) |
      src_dst_overlap
   then return Illegal_Instruction();
 
@@ -1069,7 +1084,8 @@ function clause execute FVFMATYPE(funct6, vm, vs2, rs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW != 8);
@@ -1147,7 +1163,8 @@ function clause execute FWVFTYPE(funct6, vm, vs2, rs1, vd) = {
 
   if illegal_vstart(VSTART_ARITH) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
-     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW >= 16 & SEW_widen <= 64);
@@ -1219,7 +1236,8 @@ function clause execute FWVFMATYPE(funct6, vm, rs1, vs2, vd) = {
 
   if illegal_vstart(VSTART_ARITH) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
-     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW >= 16 & SEW_widen <= 64);
@@ -1291,7 +1309,8 @@ function clause execute FWFTYPE(funct6, vm, vs2, rs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_group(vs2, LMUL_pow_widen)) |
-     not(valid_reg_group(vd, LMUL_pow_widen))
+     not(valid_reg_group(vd, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW_widen))
   then return Illegal_Instruction();
 
   assert(SEW >= 16 & SEW_widen <= 64);
@@ -1359,7 +1378,8 @@ function clause execute VFMERGE(vs2, rs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_fp_vd_masked(vd, SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(0b0, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW != 8);

--- a/model/extensions/V/vext_fp_red_insts.sail
+++ b/model/extensions/V/vext_fp_red_insts.sail
@@ -34,9 +34,10 @@ function clause execute RFVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let rm_3b       = fcsr[FRM];
   let num_elem_vd = get_num_elem(0, SEW); // vd regardless of LMUL setting
 
-  if illegal_vstart(VSTART_MANDATORY)     |
+  if illegal_vstart(VSTART_MANDATORY) |
      illegal_fp_reduction(SEW, rm_3b) |
-     not(valid_reg_group(vs2, LMUL_pow))
+     not(valid_reg_group(vs2, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW != 8);
@@ -113,7 +114,8 @@ function clause execute RFWVVTYPE(_funct6, vm, vs2, vs1, vd) = {
 
   if illegal_vstart(VSTART_MANDATORY) |
      illegal_fp_widening_reduction(SEW, rm_3b, SEW_widen) |
-     not(valid_reg_group(vs2, LMUL_pow))
+     not(valid_reg_group(vs2, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW >= 16 & SEW_widen <= 64);

--- a/model/extensions/V/vext_fp_vm_insts.sail
+++ b/model/extensions/V/vext_fp_vm_insts.sail
@@ -37,7 +37,9 @@ function clause execute FVVMTYPE(funct6, vm, vs2, vs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_fp_vd_unmasked(SEW, rm_3b) |
      not(valid_reg_group(vs1, LMUL_pow)) |
-     not(valid_reg_group(vs2, LMUL_pow))
+     not(valid_reg_group(vs2, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW != 8);
@@ -110,7 +112,8 @@ function clause execute FVFMTYPE(funct6, vm, vs2, rs1, vd) = {
 
   if illegal_vstart(VSTART_ARITH) |
      illegal_fp_vd_unmasked(SEW, rm_3b) |
-     not(valid_reg_group(vs2, LMUL_pow))
+     not(valid_reg_group(vs2, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW != 8);

--- a/model/extensions/V/vext_mem_insts.sail
+++ b/model/extensions/V/vext_mem_insts.sail
@@ -377,9 +377,15 @@ function clause execute VLXSEGTYPE(nf, vm, vs2, rs1, width, vd, _mop) = {
   let EMUL_data_pow = get_lmul_pow();
   let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
 
+  let index_dst_overlap : bool =
+    if nf == 1
+    then not(valid_reg_overlap(vs2, vd, EMUL_index_pow, EMUL_data_pow))          // non-segment indexed load
+    else not(valid_disjoint_reg_groups(vs2, vd, EMUL_index_pow, EMUL_data_pow)); // segment indexed load
+
   if illegal_vstart(VSTART_LOAD_STORE) |
      illegal_indexed_load(vd, vm, nf, 2 ^ EEW_index_pow, EMUL_index_pow, EMUL_data_pow) |
      not(valid_disjoint_reg_groups(vs2, vd, EMUL_index_pow, EMUL_data_pow)) |
+     index_dst_overlap |
      not(valid_vm_src_overlap(vm, vs2, EEW_index))
   then return Illegal_Instruction();
 

--- a/model/extensions/V/vext_mem_insts.sail
+++ b/model/extensions/V/vext_mem_insts.sail
@@ -315,7 +315,10 @@ function clause execute VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3) = {
 
   assert(-3 <= EMUL_pow & EMUL_pow <= 3);
 
-  if illegal_vstart(VSTART_LOAD_STORE) | illegal_store(nf, EEW, EMUL_pow) | not(valid_reg_group(vs3, EMUL_pow))
+  if illegal_vstart(VSTART_LOAD_STORE) |
+     illegal_store(nf, EEW, EMUL_pow) |
+     not(valid_reg_group(vs3, EMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs3, EEW))
   then return Illegal_Instruction();
 
   let num_elem = get_num_elem(EMUL_pow, EEW);
@@ -367,14 +370,17 @@ mapping clause encdec = VLXSEGTYPE(nf, vm, vs2, rs1, width, vd, mop)
 // only implements the ordered variant, hence `mop` is ignored.
 function clause execute VLXSEGTYPE(nf, vm, vs2, rs1, width, vd, _mop) = {
   let EEW_index_pow = vlewidth_pow(width);
+  let EEW_index = 2 ^ EEW_index_pow;
   let EEW_index_bytes = 2 ^ (EEW_index_pow - 3);
   let EEW_data_pow = get_sew_pow();
   let EEW_data_bytes = get_sew_bytes();
   let EMUL_data_pow = get_lmul_pow();
   let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
 
-  if illegal_vstart(VSTART_LOAD_STORE) | illegal_indexed_load(vd, vm, nf, 2 ^ EEW_index_pow, EMUL_index_pow, EMUL_data_pow) |
-     not(valid_reg_overlap(vs2, vd, EMUL_index_pow, EMUL_data_pow))
+  if illegal_vstart(VSTART_LOAD_STORE) |
+     illegal_indexed_load(vd, vm, nf, 2 ^ EEW_index_pow, EMUL_index_pow, EMUL_data_pow) |
+     not(valid_disjoint_reg_groups(vs2, vd, EMUL_index_pow, EMUL_data_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, EEW_index))
   then return Illegal_Instruction();
 
   let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8);
@@ -431,8 +437,10 @@ mapping clause encdec = VSXSEGTYPE(nf, vm, vs2, rs1, width, vs3, mop)
 // only implements the ordered variant, hence `mop` is ignored.
 function clause execute VSXSEGTYPE(nf, vm, vs2, rs1, width, vs3, _mop) = {
   let EEW_index_pow = vlewidth_pow(width);
+  let EEW_index = 2 ^ EEW_index_pow;
   let EEW_index_bytes = 2 ^ (EEW_index_pow - 3);
   let EEW_data_pow = get_sew_pow();
+  let EEW_data = 2 ^ EEW_data_pow;
   let EEW_data_bytes = get_sew_bytes();
   let EMUL_data_pow = get_lmul_pow();
   let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
@@ -442,8 +450,9 @@ function clause execute VSXSEGTYPE(nf, vm, vs2, rs1, width, vs3, _mop) = {
 
   if illegal_vstart(VSTART_LOAD_STORE) |
      illegal_indexed_store(nf, 2 ^ EEW_index_pow, EMUL_index_pow, EMUL_data_pow) |
-     not(valid_reg_group(vs2, EMUL_index_pow)) |
-     not(valid_reg_group(vs3, EMUL_data_pow))
+     not(valid_src_overlap(vs2, EEW_index, EMUL_index_pow, vs3, EEW_data, EMUL_data_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, EEW_index)) |
+     not(valid_vm_src_overlap(vm, vs3, EEW_data))
   then return Illegal_Instruction();
 
   let EMUL_data_reg = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;

--- a/model/extensions/V/vext_red_insts.sail
+++ b/model/extensions/V/vext_red_insts.sail
@@ -29,7 +29,10 @@ function clause execute RIVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let SEW_widen = SEW * 2;
 
-  if illegal_vstart(VSTART_MANDATORY) | illegal_widening_reduction(SEW_widen) | not(valid_reg_group(vs2, LMUL_pow))
+  if illegal_vstart(VSTART_MANDATORY) |
+     illegal_widening_reduction(SEW_widen) |
+     not(valid_vm_src_overlap(vm, vs2, SEW)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW_widen))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -104,7 +107,11 @@ function clause execute RMVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let num_elem_vs = get_num_elem(LMUL_pow, SEW);
   let num_elem_vd = get_num_elem(0, SEW); // vd regardless of LMUL setting
 
-  if illegal_vstart(VSTART_MANDATORY) | illegal_reduction() | not(valid_reg_group(vs2, LMUL_pow))
+  if illegal_vstart(VSTART_MANDATORY) |
+     illegal_reduction() |
+     not(valid_reg_group(vs2, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW))
   then return Illegal_Instruction();
 
   if unsigned(vl) == 0 then return RETIRE_SUCCESS; // if vl=0, no operation is performed

--- a/model/extensions/V/vext_utils_insts.sail
+++ b/model/extensions/V/vext_utils_insts.sail
@@ -120,6 +120,48 @@ function valid_reg_overlap(rs : vregidx, rd : vregidx, EMUL_pow_rs : int, EMUL_p
   } else true;
 }
 
+function valid_disjoint_reg_groups(rs : vregidx, rd : vregidx, EMUL_pow_rs : int, EMUL_pow_rd : int) -> bool = {
+  let rs_group = if EMUL_pow_rs > 0 then 2 ^ EMUL_pow_rs else 1;
+  let rd_group = if EMUL_pow_rd > 0 then 2 ^ EMUL_pow_rd else 1;
+  let rs_int = unsigned(vregidx_bits(rs));
+  let rd_int = unsigned(vregidx_bits(rd));
+
+  if rs_int % rs_group != 0 | rd_int % rd_group != 0
+  then return false;
+
+  rs_int + rs_group <= rd_int | rs_int >= rd_int + rd_group
+}
+
+// Check for valid overlaps between source register groups: overlaps
+// are not allowed if the EEWs are different for the two groups; a
+// mask register is considered to have EEW of 1. This also checks if
+// the register groups are valid.
+function valid_src_overlap(rs1 : vregidx, EEW_rs1 : nat, EMUL_pow_rs1 : int,
+                           rs2 : vregidx, EEW_rs2 : nat, EMUL_pow_rs2 : int) -> bool = {
+  let rs1_group = if EMUL_pow_rs1 > 0 then 2 ^ EMUL_pow_rs1 else 1;
+  let rs2_group = if EMUL_pow_rs2 > 0 then 2 ^ EMUL_pow_rs2 else 1;
+  let rs1_int = unsigned(vregidx_bits(rs1));
+  let rs2_int = unsigned(vregidx_bits(rs2));
+
+  if rs1_int % rs1_group != 0 | rs2_int % rs2_group != 0
+  then return false;
+
+  if EEW_rs1 == EEW_rs2 then return true;
+
+  rs1_int + rs1_group <= rs2_int | rs2_int + rs2_group <= rs1_int
+}
+
+// Check for valid overlaps between a source register group and the v0
+// mask register; this is a specialization of `valid_src_overlap` for
+// the mask register.
+// TODO: `EEW_rs` is always != 1, but this is unfortunately not
+// guaranteed by the `nat` type.  Once the type of `EEW_rs` is made
+// `sew_bitsize` or similar, the assert could be removed.
+function valid_vm_src_overlap(vm : bits(1), rs : vregidx, EEW_rs : nat) -> bool = {
+  assert(EEW_rs != 1);
+  vm != 0b0 | rs != zvreg
+}
+
 // Check for valid register grouping in vector segment load/store instructions:
 // The EMUL of load vd or store vs3 times the number of fields per segment
 // must not be larger than 8. (EMUL * NFIELDS <= 8)

--- a/model/extensions/V/vext_utils_insts.sail
+++ b/model/extensions/V/vext_utils_insts.sail
@@ -83,10 +83,8 @@ function valid_rd_mask(rd : vregidx, vm : bits(1)) -> bool = {
 
 // Check that a vector register number for a vector register group is
 // a multiple of its EMUL. Fractional EMULs are rounded up to 1.
-function valid_reg_group(r : vregidx, EMUL_pow : int) -> bool = {
-  let reg_group_size = if EMUL_pow > 0 then 2 ^ EMUL_pow else 1;
-  unsigned(vregidx_bits(r)) % reg_group_size == 0
-}
+function valid_reg_group(r : vregidx, EMUL_pow : int) -> bool =
+  (unsigned(vregidx_bits(r)) % (2 ^ max(EMUL_pow, 0))) == 0
 
 // For whole register loads/stores: "The nf field encodes how many
 // vector registers to load and store using the NFIELDS encoding. The
@@ -104,8 +102,8 @@ function valid_whole_register(r : vregidx, nf : nfields_pow2) -> bool = {
 // of the source register group.
 // This also checks that the source and destination register groups are valid.
 function valid_reg_overlap(rs : vregidx, rd : vregidx, EMUL_pow_rs : int, EMUL_pow_rd : int) -> bool = {
-  let rs_group = if EMUL_pow_rs > 0 then 2 ^ EMUL_pow_rs else 1;
-  let rd_group = if EMUL_pow_rd > 0 then 2 ^ EMUL_pow_rd else 1;
+  let rs_group = 2 ^ max(EMUL_pow_rs, 0);
+  let rd_group = 2 ^ max(EMUL_pow_rd, 0);
   let rs_int = unsigned(vregidx_bits(rs));
   let rd_int = unsigned(vregidx_bits(rd));
 
@@ -121,15 +119,15 @@ function valid_reg_overlap(rs : vregidx, rd : vregidx, EMUL_pow_rs : int, EMUL_p
 }
 
 function valid_disjoint_reg_groups(rs : vregidx, rd : vregidx, EMUL_pow_rs : int, EMUL_pow_rd : int) -> bool = {
-  let rs_group = if EMUL_pow_rs > 0 then 2 ^ EMUL_pow_rs else 1;
-  let rd_group = if EMUL_pow_rd > 0 then 2 ^ EMUL_pow_rd else 1;
+  let rs_group = 2 ^ max(EMUL_pow_rs, 0);
+  let rd_group = 2 ^ max(EMUL_pow_rd, 0);
   let rs_int = unsigned(vregidx_bits(rs));
   let rd_int = unsigned(vregidx_bits(rd));
 
   if rs_int % rs_group != 0 | rd_int % rd_group != 0
   then return false;
 
-  rs_int + rs_group <= rd_int | rs_int >= rd_int + rd_group
+  rs_int + rs_group <= rd_int | rd_int + rd_group <= rs_int
 }
 
 // Check for valid overlaps between source register groups: overlaps
@@ -138,8 +136,8 @@ function valid_disjoint_reg_groups(rs : vregidx, rd : vregidx, EMUL_pow_rs : int
 // the register groups are valid.
 function valid_src_overlap(rs1 : vregidx, EEW_rs1 : nat, EMUL_pow_rs1 : int,
                            rs2 : vregidx, EEW_rs2 : nat, EMUL_pow_rs2 : int) -> bool = {
-  let rs1_group = if EMUL_pow_rs1 > 0 then 2 ^ EMUL_pow_rs1 else 1;
-  let rs2_group = if EMUL_pow_rs2 > 0 then 2 ^ EMUL_pow_rs2 else 1;
+  let rs1_group = 2 ^ max(EMUL_pow_rs1, 0);
+  let rs2_group = 2 ^ max(EMUL_pow_rs2, 0);
   let rs1_int = unsigned(vregidx_bits(rs1));
   let rs2_int = unsigned(vregidx_bits(rs2));
 

--- a/model/extensions/V/vext_vm_insts.sail
+++ b/model/extensions/V/vext_vm_insts.sail
@@ -35,7 +35,9 @@ function clause execute VVMTYPE(funct6, vs2, vs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_vd_unmasked()  |
      not(valid_reg_group(vs1, LMUL_pow)) |
-     not(valid_reg_group(vs2, LMUL_pow))
+     not(valid_reg_group(vs2, LMUL_pow)) |
+     not(valid_vm_src_overlap(0b0, vs1, SEW)) |
+     not(valid_vm_src_overlap(0b0, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -163,7 +165,9 @@ function clause execute VVMSTYPE(funct6, vs2, vs1, vd) = {
      illegal_vd_masked(vd)  |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(0b0, vs1, SEW)) |
+     not(valid_vm_src_overlap(0b0, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -231,7 +235,9 @@ function clause execute VVCMPTYPE(funct6, vm, vs2, vs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_vd_unmasked()  |
      not(valid_reg_group(vs1, LMUL_pow)) |
-     not(valid_reg_group(vs2, LMUL_pow))
+     not(valid_reg_group(vs2, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -300,7 +306,10 @@ function clause execute VXMTYPE(funct6, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) | illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_vd_unmasked() |
+     not(valid_reg_group(vs2, LMUL_pow)) |
+     not(valid_vm_src_overlap(0b0, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -424,7 +433,8 @@ function clause execute VXMSTYPE(funct6, vs2, rs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_vd_masked(vd)  |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(0b0, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -491,7 +501,10 @@ function clause execute VXCMPTYPE(funct6, vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) | illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_vd_unmasked() |
+     not(valid_reg_group(vs2, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -563,7 +576,10 @@ function clause execute VIMTYPE(funct6, vs2, simm, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) | illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_vd_unmasked() |
+     not(valid_reg_group(vs2, LMUL_pow)) |
+     not(valid_vm_src_overlap(0b0, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -681,7 +697,8 @@ function clause execute VIMSTYPE(funct6, vs2, simm, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_vd_masked(vd)  |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(0b0, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -744,7 +761,10 @@ function clause execute VICMPTYPE(funct6, vm, vs2, simm, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) | illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_vd_unmasked() |
+     not(valid_reg_group(vs2, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;

--- a/model/extensions/Zvabd/zvabd_insts.sail
+++ b/model/extensions/Zvabd/zvabd_insts.sail
@@ -27,7 +27,10 @@ function clause execute VABS_V(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) | illegal_normal(vd, vm) then return Illegal_Instruction();
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
+  then return Illegal_Instruction();
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -72,7 +75,11 @@ function clause execute ZVABDTYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) | illegal_normal(vd, vm) then return Illegal_Instruction();
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
+  then return Illegal_Instruction();
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -132,7 +139,9 @@ function clause execute ZVWABDATYPE(funct6, vm, vs2, vs1, vd) = {
   if  illegal_vstart(VSTART_ARITH) |
       illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+      not(valid_vm_src_overlap(vm, vs1, SEW)) |
+      not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW_widen == 16 | SEW_widen == 32);

--- a/model/extensions/Zvabd/zvabd_insts.sail
+++ b/model/extensions/Zvabd/zvabd_insts.sail
@@ -136,12 +136,12 @@ function clause execute ZVWABDATYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_vstart(VSTART_ARITH) |
-      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
-      not(valid_vm_src_overlap(vm, vs1, SEW)) |
-      not(valid_vm_src_overlap(vm, vs2, SEW))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW_widen == 16 | SEW_widen == 32);

--- a/model/extensions/bfloat16/zvfbfmin_insts.sail
+++ b/model/extensions/bfloat16/zvfbfmin_insts.sail
@@ -24,9 +24,10 @@ function clause execute (VFNCVTBF16_F_F_W(vm, vs2, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_vstart(VSTART_ARITH) |
-      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW_widen))
   then return Illegal_Instruction();
 
   assert(SEW == 16);
@@ -78,9 +79,10 @@ function clause execute (VFWCVTBF16_F_F_V(vm, vs2, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_vstart(VSTART_ARITH) |
-      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW == 16);

--- a/model/extensions/bfloat16/zvfbfwma_insts.sail
+++ b/model/extensions/bfloat16/zvfbfwma_insts.sail
@@ -24,10 +24,12 @@ function clause execute VFWMACCBF16_VV(vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_vstart(VSTART_ARITH) |
-      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW == 16);
@@ -80,9 +82,10 @@ function clause execute VFWMACCBF16_VF(vm, vs2, rs1, vd) = {
 
   assert(LMUL_pow_widen <= 3);
 
-  if  illegal_vstart(VSTART_ARITH) |
-      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW == 16);

--- a/model/extensions/vector_crypto/zvbb_insts.sail
+++ b/model/extensions/vector_crypto/zvbb_insts.sail
@@ -28,7 +28,9 @@ function clause execute VANDN_VV(vm, vs1, vs2, vd) = {
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -72,7 +74,8 @@ function clause execute VANDN_VX(vm, vs2, rs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -116,7 +119,8 @@ function clause execute VBREV_V(vm, vs2, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -163,7 +167,8 @@ function clause execute VBREV8_V(vm, vs2, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -207,7 +212,8 @@ function clause execute VREV8_V(vm, vs2, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -251,7 +257,8 @@ function clause execute VCLZ_V(vm, vs2, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -296,7 +303,8 @@ function clause execute VCTZ_V(vm, vs2, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -341,7 +349,8 @@ function clause execute VCPOP_V(vm, vs2, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -391,7 +400,9 @@ function clause execute VROL_VV(vm, vs1, vs2, vd) = {
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -436,7 +447,8 @@ function clause execute VROL_VX(vm, vs2, rs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -482,7 +494,9 @@ function clause execute VROR_VV(vm, vs1, vs2, vd) = {
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -527,7 +541,8 @@ function clause execute VROR_VX(vm, vs2, rs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -572,7 +587,8 @@ function clause execute VROR_VI(vm, vs2, uimm, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -618,7 +634,9 @@ function clause execute VWSLL_VV(vm, vs2, vs1, vd) = {
   if  illegal_vstart(VSTART_ARITH) |
       illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+      not(valid_vm_src_overlap(vm, vs1, SEW)) |
+      not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -669,9 +687,10 @@ function clause execute VWSLL_VX(vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_vstart(VSTART_ARITH) |
-      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -721,9 +740,10 @@ function clause execute VWSLL_VI(vm, vs2, uimm, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_vstart(VSTART_ARITH) |
-      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);

--- a/model/extensions/vector_crypto/zvbb_insts.sail
+++ b/model/extensions/vector_crypto/zvbb_insts.sail
@@ -631,12 +631,12 @@ function clause execute VWSLL_VV(vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_vstart(VSTART_ARITH) |
-      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
-      not(valid_vm_src_overlap(vm, vs1, SEW)) |
-      not(valid_vm_src_overlap(vm, vs2, SEW))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);

--- a/model/extensions/vector_crypto/zvbc_insts.sail
+++ b/model/extensions/vector_crypto/zvbc_insts.sail
@@ -26,7 +26,9 @@ function clause execute VCLMUL_VV(vm, vs2, vs1, vd) = {
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = get_num_elem(LMUL_pow, SEW);
@@ -71,7 +73,8 @@ function clause execute VCLMUL_VX(vm, vs2, rs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = get_num_elem(LMUL_pow, SEW);
@@ -117,7 +120,9 @@ function clause execute VCLMULH_VV(vm, vs2, vs1, vd) = {
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = get_num_elem(LMUL_pow, SEW);
@@ -162,7 +167,8 @@ function clause execute VCLMULH_VX(vm, vs2, rs1, vd) = {
   if illegal_vstart(VSTART_ARITH) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_reg_group(vd, LMUL_pow))
+     not(valid_reg_group(vd, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
   let 'n = get_num_elem(LMUL_pow, SEW);

--- a/model/extensions/vector_crypto/zvksh_insts.sail
+++ b/model/extensions/vector_crypto/zvksh_insts.sail
@@ -13,7 +13,7 @@ union clause instruction = VSM3ME_VV : (vregidx, vregidx, vregidx)
 $[wavedrom "_ _ _ _ OPMVV _ OP-VE"]
 mapping clause encdec = VSM3ME_VV(vs2, vs1, vd)
   <-> 0b100000 @ 0b1 @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1110111
-   when currentlyEnabled(Ext_Zvksh) & get_sew() == 32 & zvk_check_encdec(256, 8) & zvk_valid_reg_overlap(vs2, vd, get_lmul_pow())
+  when currentlyEnabled(Ext_Zvksh) & get_sew() == 32 & zvk_check_encdec(256, 8) & zvk_valid_reg_overlap(vs2, vd, get_lmul_pow())
 
 function clause execute VSM3ME_VV(vs2, vs1, vd) = {
   let 'SEW     = get_sew();


### PR DESCRIPTION
The spec requires:

> An encoding that would result in the same vector register being read with
> two or more different EEWs, including when the vector register appears at
> different positions within two or more vector register groups, is reserved.

These checks include overlaps between a source register group and the mask vector v0 when masking is in effect.

Currently, the reserved encoding results in an illegal instruction.  This reserved behavior could be parameterized like other reserved behavior in a subsequent PR.

This should fix #1687.