### PR TITLE
Add configurable per-class trap policy for non-zero vstart

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -414,7 +414,23 @@
       // The maximum index EEW for indexed vector addressing mode, as
       // a power of 2.  This must be at least 3 but must not exceed
       // the supported ELEN.
-      "max_index_eew_exp": @CONFIG__V__ELEN_EXP@
+      "max_index_eew_exp": @CONFIG__V__ELEN_EXP@,
+      "vstart": {
+        // The vector specification permits implementations to raise an
+        // illegal instruction exception when `vstart` is non-zero for
+        // instructions that cannot produce such a `vstart` value through
+        // normal execution.
+        "zero_required": {
+          // Whether vector arithmetic instructions raise an illegal instruction
+          // exception when `vstart` is non-zero. This also governs instructions
+          // from the Zvbb, Zvbc, Zvabd, Zvfbfmin, and Zvfbfwma extensions.
+          "arith": true,
+          // Whether the vector scalar move instructions (vmv.x.s, vmv.s.x,
+          // vfmv.f.s and vfmv.s.f) raise an illegal instruction exception when
+          // `vstart` is non-zero.
+          "scalar_move": true,
+        }
+      }
     },
     "B": {
       "supported": true

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -428,7 +428,7 @@
           // Whether the vector scalar move instructions (vmv.x.s, vmv.s.x,
           // vfmv.f.s and vfmv.s.f) raise an illegal instruction exception when
           // `vstart` is non-zero.
-          "scalar_move": true,
+          "scalar_move": true
         }
       }
     },

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -22,6 +22,18 @@
   - The WFI instruction can be optionally made available to User mode;
     see `platform.wfi_available_to_user_mode`. This is set to false
     by default for backwards compatibility.
+  - New option `extensions.V.vstart.zero_required.arith` (default `true`)
+    controls whether vector arithmetic instructions raise an illegal instruction
+    exception when vstart is non-zero. This option also governs instructions from
+    the Zvbb, Zvbc, Zvabd, Zvfbfmin, and Zvfbfwma extensions. The default value of
+    true introduces a backward-incompatible change compared to previous versions,
+    but can be changed to preserve the earlier behaviour.
+  - New option `extensions.V.vstart.zero_required.scalar_move` (default
+    `true`) controls whether the scalar move instructions (`vmv.x.s`,
+    `vmv.s.x`, `vfmv.f.s`, `vfmv.s.f`) raise an illegal instruction exception
+    when `vstart` is non-zero. The default value of true introduces a backward-
+    incompatible change compared to previous versions, but can be changed to
+    preserve the earlier behaviour.
 
 - Performance improvements:
   - https://github.com/riscv/sail-riscv/pull/1692 : Optional `ENABLE_LTO`

--- a/model/extensions/V/vext_arith_insts.sail
+++ b/model/extensions/V/vext_arith_insts.sail
@@ -66,7 +66,8 @@ function clause execute VVTYPE(funct6, vm, vs2, vs1, vd) = {
 
   let vs1_emul_pow = if funct6 == VV_VRGATHEREI16 then 4 + LMUL_pow - SEW_pow else LMUL_pow;
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_overlap(vs1, vd, vs1_emul_pow, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      src_dst_overlap
@@ -213,9 +214,10 @@ function clause execute NVSTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
-      not(valid_reg_group(vs1, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
+     not(valid_reg_group(vs1, LMUL_pow))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -288,9 +290,10 @@ function clause execute NVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
-      not(valid_reg_group(vs1, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
+     not(valid_reg_group(vs1, LMUL_pow))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -361,7 +364,8 @@ function clause execute MASKTYPEV(vs2, vs1, vd) = {
   let num_elem      = get_num_elem(LMUL_pow, SEW); // max(VLMAX,VLEN/SEW))
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); // VLMAX
 
-  if illegal_vd_masked(vd) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_vd_masked(vd)  |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
@@ -412,7 +416,8 @@ function clause execute MOVETYPEV(vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_vd_unmasked()  |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -477,7 +482,8 @@ function clause execute VXTYPE(funct6, vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -603,8 +609,9 @@ function clause execute NXSTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -677,8 +684,9 @@ function clause execute NXTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -759,7 +767,9 @@ function clause execute VXSG(funct6, vm, vs2, rs1, vd) = {
     VX_VSLIDEDOWN => false,
     VX_VRGATHER   => vd == vs2,
   };
-  if illegal_normal(vd, vm) |
+
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
      src_dst_overlap
@@ -835,7 +845,8 @@ function clause execute MASKTYPEX(vs2, rs1, vd) = {
   let num_elem      = get_num_elem(LMUL_pow, SEW); // max(VLMAX,VLEN/SEW))
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); // VLMAX
 
-  if illegal_vd_masked(vd) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_vd_masked(vd)  |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -885,7 +896,7 @@ function clause execute MOVETYPEX(rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() | not(valid_reg_group(vd, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) | illegal_vd_unmasked() | not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -940,7 +951,8 @@ function clause execute VITYPE(funct6, vm, vs2, simm, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -1042,8 +1054,9 @@ function clause execute NISTYPE(funct6, vm, vs2, uimm, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -1116,8 +1129,9 @@ function clause execute NITYPE(funct6, vm, vs2, uimm, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -1198,7 +1212,8 @@ function clause execute VISG(funct6, vm, vs2, simm, vd) = {
     VI_VSLIDEDOWN => false,
     VI_VRGATHER   => vd == vs2,
   };
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
      src_dst_overlap
@@ -1274,7 +1289,8 @@ function clause execute MASKTYPEI(vs2, simm, vd) = {
   let num_elem      = get_num_elem(LMUL_pow, SEW); // max(VLMAX,VLEN/SEW))
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); // VLMAX
 
-  if illegal_vd_masked(vd) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_vd_masked(vd)  |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -1324,7 +1340,7 @@ function clause execute MOVETYPEI(vd, simm) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() | not(valid_reg_group(vd, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) | illegal_vd_unmasked() | not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -1387,7 +1403,8 @@ function clause execute VMVRTYPE(vs2, nreg, vd) = {
     8 => 3,
   };
 
-  if illegal_vd_unmasked() |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_vd_unmasked()  |
      not(valid_reg_group(vs2, EMUL_pow)) |
      not(valid_reg_group(vd, EMUL_pow))
   then return Illegal_Instruction();
@@ -1448,7 +1465,8 @@ function clause execute MVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
@@ -1573,7 +1591,8 @@ function clause execute MVVMATYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
@@ -1644,9 +1663,10 @@ function clause execute WVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -1722,9 +1742,10 @@ function clause execute WVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-      not(valid_reg_group(vs2, LMUL_pow_widen))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_reg_group(vs2, LMUL_pow_widen))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -1794,9 +1815,10 @@ function clause execute WMVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -1875,8 +1897,9 @@ function clause execute VEXTTYPE(funct6, vm, vs2, vd) = {
   let LMUL_pow_div = LMUL_pow - SEW_frac_pow;
   let SEW_div = SEW / (2 ^ SEW_frac_pow);
 
-  if  illegal_variable_width(vd, vm, SEW_div, LMUL_pow_div) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow_div, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_div, LMUL_pow_div) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow_div, LMUL_pow))
   then return Illegal_Instruction();
 
   assert(SEW_div >= 8);
@@ -1937,7 +1960,9 @@ function clause execute VMVXS(vs2, rd) = {
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
-  if illegal_vd_unmasked() then return Illegal_Instruction();
+  if illegal_vstart(VSTART_SCALAR_MOVE) |
+     illegal_vd_unmasked()
+  then return Illegal_Instruction();
 
   assert(num_elem > 0);
 
@@ -1974,11 +1999,10 @@ function clause execute MVVCOMPRESS(vs2, vs1, vd) = {
   let LMUL_pow    = get_lmul_pow();
   let num_elem    = get_num_elem(LMUL_pow, SEW);
 
-  // vcompress should always be executed with a vstart of 0
-  if start_element != 0 |
+  if illegal_vstart(VSTART_MANDATORY) |
+     illegal_vd_unmasked() |
      vs1 == vd |
      vs2 == vd |
-     illegal_vd_unmasked() |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -2058,7 +2082,8 @@ function clause execute MVXTYPE(funct6, vm, vs2, rs1, vd) = {
   // register group does not overlap the source vector register
   // group. Otherwise, the instruction encoding is reserved."
   let src_dst_overlap = funct6 == MVX_VSLIDE1UP & vs2 == vd;
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
      src_dst_overlap
@@ -2191,7 +2216,8 @@ function clause execute MVXMATYPE(funct6, vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -2262,8 +2288,9 @@ function clause execute WVXTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -2339,7 +2366,8 @@ function clause execute WXTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_group(vs2, LMUL_pow_widen)) |
      not(valid_reg_group(vd, LMUL_pow_widen))
   then return Illegal_Instruction();
@@ -2412,8 +2440,9 @@ function clause execute WMVXTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -2472,7 +2501,9 @@ function clause execute VMVSX(rs1, vd) = {
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
-  if illegal_vd_unmasked() then return Illegal_Instruction();
+  if illegal_vstart(VSTART_SCALAR_MOVE) |
+     illegal_vd_unmasked()
+  then return Illegal_Instruction();
 
   assert(num_elem > 0);
 

--- a/model/extensions/V/vext_fp_insts.sail
+++ b/model/extensions/V/vext_fp_insts.sail
@@ -39,7 +39,8 @@ function clause execute FVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
@@ -124,7 +125,8 @@ function clause execute FVVMATYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
@@ -203,9 +205,10 @@ function clause execute FWVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
 
   assert(SEW >= 16 & SEW_widen <= 64);
@@ -275,9 +278,10 @@ function clause execute FWVVMATYPE(funct6, vm, vs1, vs2, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
 
   assert(SEW >= 16 & SEW_widen <= 64);
@@ -346,9 +350,10 @@ function clause execute FWVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
-      not(valid_reg_group(vs2, LMUL_pow_widen))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
+     not(valid_reg_group(vs2, LMUL_pow_widen))
   then return Illegal_Instruction();
 
   assert(SEW >= 16 & SEW_widen <= 64);
@@ -415,7 +420,8 @@ function clause execute VFUNARY0(vm, vs2, vfunary0, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -539,8 +545,9 @@ function clause execute VFWUNARY0(vm, vs2, vfwunary0, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
 
   assert(SEW >= 8 & SEW_widen <= 64);
@@ -675,8 +682,9 @@ function clause execute VFNUNARY0(vm, vs2, vfnunary0, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
   then return Illegal_Instruction();
 
   assert(SEW != 64);
@@ -815,7 +823,8 @@ function clause execute VFUNARY1(vm, vs2, vfunary1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -899,7 +908,7 @@ function clause execute VFMVFS(vs2, rd) = {
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
-  if illegal_fp_vd_unmasked(SEW, rm_3b) | SEW > flen
+  if illegal_vstart(VSTART_SCALAR_MOVE) | illegal_fp_vd_unmasked(SEW, rm_3b) | SEW > flen
   then return Illegal_Instruction();
 
   assert(num_elem > 0 & SEW != 8);
@@ -957,7 +966,8 @@ function clause execute FVFTYPE(funct6, vm, vs2, rs1, vd) = {
   // group. Otherwise, the instruction encoding is reserved."
   let src_dst_overlap = funct6 == VF_VSLIDE1UP & vs2 == vd;
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
      src_dst_overlap
@@ -1056,7 +1066,8 @@ function clause execute FVFMATYPE(funct6, vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_normal(vd, vm, SEW, rm_3b) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -1134,8 +1145,9 @@ function clause execute FWVFTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
 
   assert(SEW >= 16 & SEW_widen <= 64);
@@ -1205,8 +1217,9 @@ function clause execute FWVFMATYPE(funct6, vm, rs1, vs2, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
-      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
 
   assert(SEW >= 16 & SEW_widen <= 64);
@@ -1275,7 +1288,8 @@ function clause execute FWFTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_group(vs2, LMUL_pow_widen)) |
      not(valid_reg_group(vd, LMUL_pow_widen))
   then return Illegal_Instruction();
@@ -1342,7 +1356,8 @@ function clause execute VFMERGE(vs2, rs1, vd) = {
   let num_elem      = get_num_elem(LMUL_pow, SEW); // max(VLMAX,VLEN/SEW))
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); // VLMAX
 
-  if illegal_fp_vd_masked(vd, SEW, rm_3b) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_vd_masked(vd, SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -1397,7 +1412,8 @@ function clause execute VFMV(rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_vd_unmasked(SEW, rm_3b) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_vd_unmasked(SEW, rm_3b) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
 
@@ -1441,7 +1457,7 @@ function clause execute VFMVSF(rs1, vd) = {
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
-  if illegal_fp_vd_unmasked(SEW, rm_3b) then return Illegal_Instruction();
+  if illegal_vstart(VSTART_SCALAR_MOVE) | illegal_fp_vd_unmasked(SEW, rm_3b) then return Illegal_Instruction();
 
   assert(num_elem > 0 & SEW != 8);
 

--- a/model/extensions/V/vext_fp_red_insts.sail
+++ b/model/extensions/V/vext_fp_red_insts.sail
@@ -34,7 +34,8 @@ function clause execute RFVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let rm_3b       = fcsr[FRM];
   let num_elem_vd = get_num_elem(0, SEW); // vd regardless of LMUL setting
 
-  if illegal_fp_reduction(SEW, rm_3b) |
+  if illegal_vstart(VSTART_MANDATORY)     |
+     illegal_fp_reduction(SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
 
@@ -110,7 +111,8 @@ function clause execute RFWVVTYPE(_funct6, vm, vs2, vs1, vd) = {
   let rm_3b       = fcsr[FRM];
   let SEW_widen   = SEW * 2;
 
-  if illegal_fp_widening_reduction(SEW, rm_3b, SEW_widen) |
+  if illegal_vstart(VSTART_MANDATORY) |
+     illegal_fp_widening_reduction(SEW, rm_3b, SEW_widen) |
      not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
 

--- a/model/extensions/V/vext_fp_utils_insts.sail
+++ b/model/extensions/V/vext_fp_utils_insts.sail
@@ -43,13 +43,12 @@ function illegal_fp_variable_width(vd : vregidx, vm : bits(1), SEW : sew_bitsize
 
 // e. Normal check for floating-point reduction instructions
 function illegal_fp_reduction(SEW : sew_bitsize, rm_3b : bits(3)) -> bool = {
-  not(valid_vtype()) | not(assert_vstart(0)) | not(valid_fp_op(SEW, rm_3b))
+  not(valid_vtype()) | not(valid_fp_op(SEW, rm_3b))
 }
 
 // f. Variable width check for floating-point widening reduction instructions
 function illegal_fp_widening_reduction(SEW : sew_bitsize, rm_3b : bits(3), EEW : nat) -> bool = {
-  not(valid_vtype()) | not(assert_vstart(0)) | not(valid_fp_op(SEW, rm_3b)) |
-  not(EEW >= 8 & EEW <= elen)
+  illegal_fp_reduction(SEW, rm_3b) | not(EEW >= 8 & EEW <= elen)
 }
 
 // Floating point classification functions

--- a/model/extensions/V/vext_fp_vm_insts.sail
+++ b/model/extensions/V/vext_fp_vm_insts.sail
@@ -34,7 +34,8 @@ function clause execute FVVMTYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_vd_unmasked(SEW, rm_3b) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_vd_unmasked(SEW, rm_3b) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
@@ -107,7 +108,8 @@ function clause execute FVFMTYPE(funct6, vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_fp_vd_unmasked(SEW, rm_3b) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_fp_vd_unmasked(SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
 

--- a/model/extensions/V/vext_mask_insts.sail
+++ b/model/extensions/V/vext_mask_insts.sail
@@ -34,7 +34,7 @@ function clause execute MMTYPE(funct6, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let num_elem = vlen;
 
-  if illegal_vd_unmasked() then return Illegal_Instruction();
+  if illegal_vd_unmasked() | illegal_vstart(VSTART_ARITH) then return Illegal_Instruction();
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -94,7 +94,7 @@ mapping clause encdec = VCPOP_M(vm, vs2, rd)
 function clause execute VCPOP_M(vm, vs2, rd) = {
   let num_elem = vlen;
 
-  if illegal_vd_unmasked() | not(assert_vstart(0)) then return Illegal_Instruction();
+  if illegal_vd_unmasked() | illegal_vstart(VSTART_MANDATORY) then return Illegal_Instruction();
 
   let 'n = num_elem;
 
@@ -125,7 +125,7 @@ mapping clause encdec = VFIRST_M(vm, vs2, rd)
 function clause execute VFIRST_M(vm, vs2, rd) = {
   let num_elem = vlen;
 
-  if illegal_vd_unmasked() | not(assert_vstart(0)) then return Illegal_Instruction();
+  if illegal_vd_unmasked() | illegal_vstart(VSTART_MANDATORY) then return Illegal_Instruction();
 
   let 'n = num_elem;
 
@@ -159,7 +159,7 @@ function clause execute VMSBF_M(vm, vs2, vd) = {
   let SEW      = get_sew();
   let num_elem = vlen;
 
-  if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
+  if illegal_vstart(VSTART_MANDATORY) | illegal_normal(vd, vm) | vd == vs2
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -203,7 +203,7 @@ function clause execute VMSIF_M(vm, vs2, vd) = {
   let SEW      = get_sew();
   let num_elem = vlen;
 
-  if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
+  if illegal_vstart(VSTART_MANDATORY) | illegal_normal(vd, vm) | vd == vs2
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -247,7 +247,7 @@ function clause execute VMSOF_M(vm, vs2, vd) = {
   let SEW      = get_sew();
   let num_elem = vlen;
 
-  if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
+  if illegal_vstart(VSTART_MANDATORY) | illegal_normal(vd, vm) | vd == vs2
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -296,8 +296,8 @@ function clause execute VIOTA_M(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
-     not(assert_vstart(0)) |
+  if illegal_vstart(VSTART_MANDATORY) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vd, LMUL_pow)) |
      vd == vs2
   then return Illegal_Instruction();
@@ -344,7 +344,7 @@ function clause execute VID_V(vm, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) | not(valid_reg_group(vd, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) | illegal_normal(vd, vm) | not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
 
   let 'n = num_elem;

--- a/model/extensions/V/vext_mem_insts.sail
+++ b/model/extensions/V/vext_mem_insts.sail
@@ -60,7 +60,7 @@ function clause execute VLSEGTYPE(nf, vm, rs1, width, vd) = {
 
   assert(-3 <= EMUL_pow & EMUL_pow <= 3);
 
-  if illegal_load(vd, vm, nf, EEW, EMUL_pow) | not(valid_reg_group(vd, EMUL_pow))
+  if illegal_vstart(VSTART_LOAD_STORE) | illegal_load(vd, vm, nf, EEW, EMUL_pow) | not(valid_reg_group(vd, EMUL_pow))
   then return Illegal_Instruction();
 
   let num_elem = get_num_elem(EMUL_pow, EEW); // # of element of each register group
@@ -120,7 +120,7 @@ function clause execute VLSEGFFTYPE(nf, vm, rs1, width, vd) = {
 
   assert(-3 <= EMUL_pow & EMUL_pow <= 3);
 
-  if illegal_load(vd, vm, nf, EEW, EMUL_pow) | not(valid_reg_group(vd, EMUL_pow))
+  if illegal_vstart(VSTART_LOAD_STORE) | illegal_load(vd, vm, nf, EEW, EMUL_pow) | not(valid_reg_group(vd, EMUL_pow))
   then return Illegal_Instruction();
 
   let num_elem = get_num_elem(EMUL_pow, EEW);
@@ -197,7 +197,7 @@ function clause execute VSSEGTYPE(nf, vm, rs1, width, vs3) = {
 
   assert(-3 <= EMUL_pow & EMUL_pow <= 3);
 
-  if illegal_store(nf, EEW, EMUL_pow) | not(valid_reg_group(vs3, EMUL_pow))
+  if illegal_vstart(VSTART_LOAD_STORE) | illegal_store(nf, EEW, EMUL_pow) | not(valid_reg_group(vs3, EMUL_pow))
   then return Illegal_Instruction();
 
   let num_elem = get_num_elem(EMUL_pow, EEW);
@@ -254,7 +254,7 @@ function clause execute VLSSEGTYPE(nf, vm, rs2, rs1, width, vd) = {
 
   assert(-3 <= EMUL_pow & EMUL_pow <= 3);
 
-  if illegal_load(vd, vm, nf, EEW, EMUL_pow) | not(valid_reg_group(vd, EMUL_pow))
+  if illegal_vstart(VSTART_LOAD_STORE) | illegal_load(vd, vm, nf, EEW, EMUL_pow) | not(valid_reg_group(vd, EMUL_pow))
   then return Illegal_Instruction();
 
   let num_elem = get_num_elem(EMUL_pow, EEW);
@@ -315,7 +315,7 @@ function clause execute VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3) = {
 
   assert(-3 <= EMUL_pow & EMUL_pow <= 3);
 
-  if illegal_store(nf, EEW, EMUL_pow) | not(valid_reg_group(vs3, EMUL_pow))
+  if illegal_vstart(VSTART_LOAD_STORE) | illegal_store(nf, EEW, EMUL_pow) | not(valid_reg_group(vs3, EMUL_pow))
   then return Illegal_Instruction();
 
   let num_elem = get_num_elem(EMUL_pow, EEW);
@@ -373,7 +373,7 @@ function clause execute VLXSEGTYPE(nf, vm, vs2, rs1, width, vd, _mop) = {
   let EMUL_data_pow = get_lmul_pow();
   let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
 
-  if illegal_indexed_load(vd, vm, nf, 2 ^ EEW_index_pow, EMUL_index_pow, EMUL_data_pow) |
+  if illegal_vstart(VSTART_LOAD_STORE) | illegal_indexed_load(vd, vm, nf, 2 ^ EEW_index_pow, EMUL_index_pow, EMUL_data_pow) |
      not(valid_reg_overlap(vs2, vd, EMUL_index_pow, EMUL_data_pow))
   then return Illegal_Instruction();
 
@@ -440,7 +440,8 @@ function clause execute VSXSEGTYPE(nf, vm, vs2, rs1, width, vs3, _mop) = {
 
   assert(num_elem > 0);
 
-  if illegal_indexed_store(nf, 2 ^ EEW_index_pow, EMUL_index_pow, EMUL_data_pow) |
+  if illegal_vstart(VSTART_LOAD_STORE) |
+     illegal_indexed_store(nf, 2 ^ EEW_index_pow, EMUL_index_pow, EMUL_data_pow) |
      not(valid_reg_group(vs2, EMUL_index_pow)) |
      not(valid_reg_group(vs3, EMUL_data_pow))
   then return Illegal_Instruction();
@@ -489,7 +490,7 @@ mapping clause encdec = VLRETYPE(nf, rs1, width, vd)
      | (currentlyEnabled(Ext_Zve64x) & vlewidth_pow(width) <= 6)
 
 function clause execute VLRETYPE(nf, rs1, width, vd) = {
-  if not(valid_whole_register(vd, nf)) then return Illegal_Instruction();
+  if illegal_vstart(VSTART_LOAD_STORE) | not(valid_whole_register(vd, nf)) then return Illegal_Instruction();
 
   let EEW_pow = vlewidth_pow(width);
   let load_width_bytes = 2 ^ (EEW_pow - 3);
@@ -546,7 +547,7 @@ mapping clause encdec = VSRETYPE(nf, rs1, vs3)
   when currentlyEnabled(Ext_Zve32x)
 
 function clause execute VSRETYPE(nf, rs1, vs3) = {
-  if not(valid_whole_register(vs3, nf)) then return Illegal_Instruction();
+  if illegal_vstart(VSTART_LOAD_STORE) | not(valid_whole_register(vs3, nf)) then return Illegal_Instruction();
 
   let load_width_bytes = 1;
   let EEW = 8;
@@ -618,7 +619,7 @@ function clause execute VMTYPE(rs1, vd_or_vs3, op) = {
   let evl : int = if vl_val % 8 == 0 then vl_val / 8 else vl_val / 8 + 1; // the effective vector length is evl=ceil(vl/8)
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
-  if illegal_vd_unmasked() then return Illegal_Instruction();
+  if illegal_vstart(VSTART_LOAD_STORE) | illegal_vd_unmasked() then return Illegal_Instruction();
 
   assert(evl >= 0);
   let start_element : nat = match get_start_element() {

--- a/model/extensions/V/vext_red_insts.sail
+++ b/model/extensions/V/vext_red_insts.sail
@@ -29,7 +29,7 @@ function clause execute RIVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let SEW_widen = SEW * 2;
 
-  if illegal_widening_reduction(SEW_widen) | not(valid_reg_group(vs2, LMUL_pow))
+  if illegal_vstart(VSTART_MANDATORY) | illegal_widening_reduction(SEW_widen) | not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
 
   assert(SEW_widen <= 64);
@@ -104,7 +104,7 @@ function clause execute RMVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let num_elem_vs = get_num_elem(LMUL_pow, SEW);
   let num_elem_vd = get_num_elem(0, SEW); // vd regardless of LMUL setting
 
-  if illegal_reduction() | not(valid_reg_group(vs2, LMUL_pow))
+  if illegal_vstart(VSTART_MANDATORY) | illegal_reduction() | not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
 
   if unsigned(vl) == 0 then return RETIRE_SUCCESS; // if vl=0, no operation is performed

--- a/model/extensions/V/vext_utils_insts.sail
+++ b/model/extensions/V/vext_utils_insts.sail
@@ -16,6 +16,46 @@ mapping maybe_vmask : string <-> bits(1) = {
   sep() ^ "v0.t"  <-> 0b0
 }
 
+// Check for vstart value
+function assert_vstart(i : int) -> bool = {
+  unsigned(vstart) == i
+}
+
+let vstart_arith_zero_required : bool = config extensions.V.vstart.zero_required.arith
+let vstart_scalar_move_zero_required : bool = config extensions.V.vstart.zero_required.scalar_move
+
+// Returns true if the instruction should raise an illegal instruction
+// exception due to a non-zero vstart, depending on the instruction class.
+//
+// VSTART_ARITH       - Standard arithmetic instructions. The model never
+//                  produces a non-zero vstart for these instructions, so
+//                  the spec permits trapping on a non-zero vstart. This
+//                  is configurable via `extensions.V.vstart.zero_required.arith`.
+//
+// VSTART_LOAD_STORE  - Memory instructions (loads, stores, segment, indexed,
+//                  fault-only-first, whole-register, and mask load/store).
+//                  These always allow any vstart value since vstart is
+//                  required for trap resumption. Never traps.
+//
+// VSTART_SCALAR_MOVE - Scalar move instructions (vmv.x.s, vmv.s.x, vfmv.f.s,
+//                  vfmv.s.f). Both trapping and not trapping on a non-zero
+//                  vstart are permitted, see https://github.com/riscv/riscv-isa-manual/issues/2564
+//                  Configurable via `extensions.V.vstart.zero_required.scalar_move`
+//
+// VSTART_MANDATORY   - Instructions where the spec explicitly requires an
+//                  illegal instruction exception when vstart is non-zero:
+//                  all reductions, vcompress, vcpop.m, vfirst.m,
+//                  vmsbf/sif/sof.m, and viota.m. Always traps, not
+//                  configurable.
+function illegal_vstart(cls : vstart_class) -> bool = {
+  match cls {
+    VSTART_ARITH       => vstart_arith_zero_required & not(assert_vstart(0)),
+    VSTART_LOAD_STORE  => false,
+    VSTART_SCALAR_MOVE => vstart_scalar_move_zero_required & not(assert_vstart(0)),
+    VSTART_MANDATORY   => not(assert_vstart(0))
+  }
+}
+
 // Check for valid EEW and EMUL values in:
 //
 // 1. vector widening/narrowing instructions
@@ -30,11 +70,6 @@ function valid_eew_emul(EEW : nat, EMUL_pow : int) -> bool = {
 // 2. vset{i}vl{i} and whole-register loads, stores, and moves do not depend upon vtype.
 function valid_vtype() -> bool = {
   vtype[vill] == 0b0
-}
-
-// Check for vstart value
-function assert_vstart(i : int) -> bool = {
-  unsigned(vstart) == i
 }
 
 // Check for valid destination register when vector masking is enabled:
@@ -186,14 +221,13 @@ function illegal_variable_width(vd : vregidx, vm : bits(1), SEW_new : nat, LMUL_
 
 // e. Normal check for reduction instructions:
 //  The destination vector register can overlap the source operands, including the mask register.
-//  Vector reduction operations raise an illegal instruction exception if vstart is non-zero.
 function illegal_reduction() -> bool = {
-  not(valid_vtype()) | not(assert_vstart(0))
+  not(valid_vtype())
 }
 
 // f. Variable width check for widening reduction instructions
 function illegal_widening_reduction(EEW : nat) -> bool = {
-  not(valid_vtype()) | not(assert_vstart(0)) | not(EEW >= 8 & EEW <= elen)
+  illegal_reduction() | not(EEW >= 8 & EEW <= elen)
 }
 
 // g. Non-indexed load instruction check

--- a/model/extensions/V/vext_vm_insts.sail
+++ b/model/extensions/V/vext_vm_insts.sail
@@ -32,7 +32,8 @@ function clause execute VVMTYPE(funct6, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_vd_unmasked()  |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
@@ -95,7 +96,8 @@ function clause execute VVMCTYPE(funct6, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_vd_unmasked()  |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
@@ -157,7 +159,8 @@ function clause execute VVMSTYPE(funct6, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_masked(vd) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_vd_masked(vd)  |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
@@ -225,7 +228,8 @@ function clause execute VVCMPTYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_vd_unmasked()  |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
@@ -296,7 +300,7 @@ function clause execute VXMTYPE(funct6, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) | illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -357,7 +361,7 @@ function clause execute VXMCTYPE(funct6, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) | illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -417,7 +421,8 @@ function clause execute VXMSTYPE(funct6, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_masked(vd) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_vd_masked(vd)  |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -486,7 +491,7 @@ function clause execute VXCMPTYPE(funct6, vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) | illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -558,7 +563,7 @@ function clause execute VIMTYPE(funct6, vs2, simm, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) | illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -616,7 +621,7 @@ function clause execute VIMCTYPE(funct6, vs2, simm, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) | illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -673,7 +678,8 @@ function clause execute VIMSTYPE(funct6, vs2, simm, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_masked(vd) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_vd_masked(vd)  |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -738,7 +744,7 @@ function clause execute VICMPTYPE(funct6, vm, vs2, simm, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH) | illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
 
   let 'n = num_elem;

--- a/model/extensions/V/vreg_type.sail
+++ b/model/extensions/V/vreg_type.sail
@@ -142,3 +142,11 @@ enum fvfmfunct6   = { VFM_VMFEQ, VFM_VMFLE, VFM_VMFLT, VFM_VMFNE, VFM_VMFGT, VFM
 enum vmlsop       = { VLM, VSM }
 
 enum indexed_mop  = { INDEXED_UNORDERED, INDEXED_ORDERED }
+
+// Classifies vector instructions by their vstart trap policy
+enum vstart_class = {
+  VSTART_ARITH,       // vector arithmetic: trap on nonzero vstart (configurable)
+  VSTART_LOAD_STORE,  // memory ops: always accept any vstart
+  VSTART_SCALAR_MOVE, // vmv.x.s, vfmv.f.s etc: always accept any vstart
+  VSTART_MANDATORY    // reductions, vcompress, etc.: always trap on nonzero vstart
+}

--- a/model/extensions/Zvabd/zvabd_insts.sail
+++ b/model/extensions/Zvabd/zvabd_insts.sail
@@ -27,7 +27,7 @@ function clause execute VABS_V(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then return Illegal_Instruction();
+  if illegal_vstart(VSTART_ARITH) | illegal_normal(vd, vm) then return Illegal_Instruction();
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -72,7 +72,7 @@ function clause execute ZVABDTYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) then return Illegal_Instruction();
+  if illegal_vstart(VSTART_ARITH) | illegal_normal(vd, vm) then return Illegal_Instruction();
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -129,7 +129,8 @@ function clause execute ZVWABDATYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+  if  illegal_vstart(VSTART_ARITH) |
+      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();

--- a/model/extensions/bfloat16/zvfbfmin_insts.sail
+++ b/model/extensions/bfloat16/zvfbfmin_insts.sail
@@ -24,7 +24,8 @@ function clause execute (VFNCVTBF16_F_F_W(vm, vs2, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
+  if  illegal_vstart(VSTART_ARITH) |
+      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow))
   then return Illegal_Instruction();
 
@@ -77,7 +78,8 @@ function clause execute (VFWCVTBF16_F_F_V(vm, vs2, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
+  if  illegal_vstart(VSTART_ARITH) |
+      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
 

--- a/model/extensions/bfloat16/zvfbfwma_insts.sail
+++ b/model/extensions/bfloat16/zvfbfwma_insts.sail
@@ -24,7 +24,8 @@ function clause execute VFWMACCBF16_VV(vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
+  if  illegal_vstart(VSTART_ARITH) |
+      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
@@ -79,7 +80,8 @@ function clause execute VFWMACCBF16_VF(vm, vs2, rs1, vd) = {
 
   assert(LMUL_pow_widen <= 3);
 
-  if  illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
+  if  illegal_vstart(VSTART_ARITH) |
+      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
 

--- a/model/extensions/vector_crypto/zvbb_insts.sail
+++ b/model/extensions/vector_crypto/zvbb_insts.sail
@@ -24,7 +24,8 @@ function clause execute VANDN_VV(vm, vs1, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
@@ -68,7 +69,8 @@ function clause execute VANDN_VX(vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -111,7 +113,8 @@ function clause execute VBREV_V(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -157,7 +160,8 @@ function clause execute VBREV8_V(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -200,7 +204,8 @@ function clause execute VREV8_V(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -243,7 +248,8 @@ function clause execute VCLZ_V(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -287,7 +293,8 @@ function clause execute VCTZ_V(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -331,7 +338,8 @@ function clause execute VCPOP_V(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -379,7 +387,8 @@ function clause execute VROL_VV(vm, vs1, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
@@ -424,7 +433,8 @@ function clause execute VROL_VX(vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -468,7 +478,8 @@ function clause execute VROR_VV(vm, vs1, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
@@ -513,7 +524,8 @@ function clause execute VROR_VX(vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -557,7 +569,8 @@ function clause execute VROR_VI(vm, vs2, uimm, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -602,7 +615,8 @@ function clause execute VWSLL_VV(vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+  if  illegal_vstart(VSTART_ARITH) |
+      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
@@ -655,7 +669,8 @@ function clause execute VWSLL_VX(vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+  if  illegal_vstart(VSTART_ARITH) |
+      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
 
@@ -706,7 +721,8 @@ function clause execute VWSLL_VI(vm, vs2, uimm, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if  illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+  if  illegal_vstart(VSTART_ARITH) |
+      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
       not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen))
   then return Illegal_Instruction();
 

--- a/model/extensions/vector_crypto/zvbc_insts.sail
+++ b/model/extensions/vector_crypto/zvbc_insts.sail
@@ -22,7 +22,8 @@ function clause execute VCLMUL_VV(vm, vs2, vs1, vd) = {
   let SEW       = get_sew();
   let LMUL_pow  = get_lmul_pow();
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
@@ -67,7 +68,8 @@ function clause execute VCLMUL_VX(vm, vs2, rs1, vd) = {
   let SEW       = get_sew();
   let LMUL_pow  = get_lmul_pow();
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -111,7 +113,8 @@ function clause execute VCLMULH_VV(vm, vs2, vs1, vd) = {
   let SEW       = get_sew();
   let LMUL_pow  = get_lmul_pow();
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
@@ -156,7 +159,8 @@ function clause execute VCLMULH_VX(vm, vs2, rs1, vd) = {
   let SEW       = get_sew();
   let LMUL_pow  = get_lmul_pow();
 
-  if illegal_normal(vd, vm) |
+  if illegal_vstart(VSTART_ARITH) |
+     illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();


### PR DESCRIPTION
Adds a `vstart_class` enum and `illegal_vstart()` helper classifying
each vector instruction's vstart trap policy:

 - `VSTART_ARITH`       — trap on non-zero vstart, configurable via `extensions.V.vstart.zero_required.arith` (default `true`)
 - `VSTART_LOAD_STORE`  — never traps (vstart needed for trap resumption)
 - `VSTART_SCALAR_MOVE` — trap on non-zero vstart, configurable via `extensions.V.vstart.zero_required.scalar_move` (default `true`)
 - `VSTART_MANDATORY`   — always traps on non-zero vstart (spec-required: reductions, vcompress, vcpop/vfirst/vmsbf/vmsif/vmsof/viota.m)

The model only produces a non-zero vstart on load/store faults, so the specification permits arithmetic and scalar-move instructions to trap on any non-zero vstart. By default, arithmetic and scalar-move instructions
trap on a non-zero vstart. The arithmetic and scalar-move defaults introduce a backward-incompatible change. Both defaults can be configured to match the behaviour of a different implementation.

The element-wise vector crypto instructions (Zvbb, Zvbc) and the Zvabd and bfloat16 vector instructions share the arithmetic policy. Element-group vector crypto keeps its own EGS-alignment rules.

The previous inline `assert_vstart(0)` checks in reduction helpers and mandatory-trap instructions are replaced with `illegal_vstart(VSTART_MANDATORY)`.

Partially addresses https://github.com/riscv/sail-riscv/issues/1104 (stricter vstart bounds checking remains a
follow-up).