### PR TITLE
Add unratified Zvqwdota8i extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ The following unratified extensions are supported and can be enabled using the `
 
 - Zibi extension for conditional branches with immediate operands, v0.6
 - Zvabd extension for vector absolute difference, v0.7
+- Zvqwdota8i extension for vector quad-widening 8-bit integer dot-product, v0.2
 
 **For a list of unsupported extensions and features, see the [Extension Roadmap](https://github.com/riscv/sail-riscv/wiki/Extension-Roadmap).**
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ The following unratified extensions are supported and can be enabled using the `
 
 - Zibi extension for conditional branches with immediate operands, v0.6
 - Zvabd extension for vector absolute difference, v0.7
+- Zvqwdota8i extension for vector quad-widening 8-bit integer dot-product, v0.2
 
 **For a list of unsupported extensions and features, see the [Extension Roadmap](https://github.com/riscv/sail-riscv/wiki/Extension-Roadmap).**
 

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -553,6 +553,9 @@
     "Zvabd": {
       "supported": true
     },
+    "Zvqwdota8i": {
+      "supported": true
+    },
     "Zvfbfmin": {
       "supported": true
     },

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -743,6 +743,9 @@
     "Zvabd": {
       "supported": true
     },
+    "Zvqwdota8i": {
+      "supported": true
+    },
     "Zvfbfmin": {
       "supported": true
     },

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -1,5 +1,13 @@
 # Release notes for the next version
 
+- The following unratified extensions have been added:
+  - Zvqwdota8i: vector quad-widening 8-bit integer dot-product
+    (`vqwdotau.vv`, `vqwdotas.vv`), from the proposed Zvdota family
+    (https://github.com/aswaterman/riscv-misc/blob/main/isa/ldot-bdot/ldot-bdot.adoc).
+    Initial implementation pins vs1 to unsigned (the spec's
+    `vtype.altfmt=0` case) until Zvfbfa
+    (https://github.com/riscv/sail-riscv/pull/1581) lands.
+
 - Updates to the [configuration file](../config/config.json.in):
   - The CLINT and simple interrupt generator can be marked as not
     supported for platforms that do not contain these MMIO devices;

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -3,6 +3,14 @@
 - The following extensions have been added:
   - H
 
+- The following unratified extensions have been added:
+  - Zvqwdota8i: vector quad-widening 8-bit integer dot-product
+    (`vqwdotau.vv`, `vqwdotas.vv`), from the proposed Zvdota family
+    (https://github.com/aswaterman/riscv-misc/blob/main/isa/ldot-bdot/ldot-bdot.adoc).
+    Initial implementation pins vs1 to unsigned (the spec's
+    `vtype.altfmt=0` case) until Zvfbfa
+    (https://github.com/riscv/sail-riscv/pull/1581) lands.
+
 - Updates to the [configuration file](../config/config.json.in):
   - Whether each bit of `hcounteren` is writable or read-only zero can
     be specified, see `base.hcounteren_writable_bits`.
@@ -119,7 +127,6 @@ extension.
     simulator and the bundled libgmp, with performance improvements
     (e.g. Linux boot time reduced by up to ~50%). This is off by default to keep
     incremental builds fast, enabled in CI and release builds.
-
 - Updates to the [configuration file](../config/config.json.in):
   - The CLINT and simple interrupt generator can be marked as not
     supported for platforms that do not contain these MMIO devices;

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -350,6 +350,11 @@ function clause hartSupports(Ext_Zve64x) = sizeof(elen_exp) >= 6 & vector_suppor
 enum clause extension = Ext_Zvabd
 mapping clause extensionName = Ext_Zvabd <-> "zvabd"
 function clause hartSupports(Ext_Zvabd) = sys_enable_experimental_extensions() & config extensions.Zvabd.supported
+// Vector Quad-Widening 8-bit Integer Dot-Product (unratified, v0.2)
+// https://github.com/aswaterman/riscv-misc/blob/main/isa/ldot-bdot/ldot-bdot.adoc
+enum clause extension = Ext_Zvqwdota8i
+mapping clause extensionName = Ext_Zvqwdota8i <-> "zvqwdota8i"
+function clause hartSupports(Ext_Zvqwdota8i) = sys_enable_experimental_extensions() & config extensions.Zvqwdota8i.supported
 // Vector BF16 Converts
 enum clause extension = Ext_Zvfbfmin
 mapping clause extensionName = Ext_Zvfbfmin <-> "zvfbfmin"
@@ -728,6 +733,9 @@ let extensions_ordered_for_isa_string = [
 
   //Zvabd
   Ext_Zvabd,
+
+  //Zvqwdota8i
+  Ext_Zvqwdota8i,
 
   // Zvb
   Ext_Zvbb,

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -355,6 +355,11 @@ function clause hartSupports(Ext_Zve64x) = sizeof(elen_exp) >= 6 & vector_suppor
 enum clause extension = Ext_Zvabd
 mapping clause extensionName = Ext_Zvabd <-> "zvabd"
 function clause hartSupports(Ext_Zvabd) = sys_enable_experimental_extensions() & config extensions.Zvabd.supported
+// Vector Quad-Widening 8-bit Integer Dot-Product (unratified, v0.2)
+// https://github.com/aswaterman/riscv-misc/blob/main/isa/ldot-bdot/ldot-bdot.adoc
+enum clause extension = Ext_Zvqwdota8i
+mapping clause extensionName = Ext_Zvqwdota8i <-> "zvqwdota8i"
+function clause hartSupports(Ext_Zvqwdota8i) = sys_enable_experimental_extensions() & config extensions.Zvqwdota8i.supported
 // Vector BF16 Converts
 enum clause extension = Ext_Zvfbfmin
 mapping clause extensionName = Ext_Zvfbfmin <-> "zvfbfmin"
@@ -768,6 +773,9 @@ let extensions_ordered_for_isa_string = [
 
   //Zvabd
   Ext_Zvabd,
+
+  //Zvqwdota8i
+  Ext_Zvqwdota8i,
 
   // Zvb
   Ext_Zvbb,

--- a/model/extensions/Zvqwdota8i/zvqwdota8i_insts.sail
+++ b/model/extensions/Zvqwdota8i/zvqwdota8i_insts.sail
@@ -1,0 +1,104 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// Zvqwdota8i: Quad-widening 8-bit integer dot-product (unratified, v0.2).
+// Two instructions, both in major opcode 0x77 (OP-VE) with funct3=000:
+//   vqwdotau.vv  vd, vs2, vs1, vm   funct6=0x26   vs2 unsigned
+//   vqwdotas.vv  vd, vs2, vs1, vm   funct6=0x27   vs2 signed
+// Computes  vd[0] += sum_{i=vstart..vl-1} (mask[i] ? vs2[i] * vs1[i] : 0)
+// modulo 2^32.  vs1, vs2 are EEW=8, EMUL=LMUL; vd is EEW=32, EMUL=1, accumulator in vd[0].
+// Other elements of vd are tail.
+//
+// TODO(Zvfbfa): The spec uses vtype.altfmt to select vs1 signedness
+// (0=unsigned, 1=signed).  vtype.altfmt is not yet in sail-riscv master;
+// it depends on the Zvfbfa extension, currently in draft PR:
+//   https://github.com/riscv/sail-riscv/pull/1581
+// This implementation pins vs1 to UNSIGNED, matching the altfmt=0 case.
+// When the Zvfbfa PR lands, extend the funct6 match block below to branch
+// on vtype.altfmt for vs1 signedness (two more arms).
+
+function clause currentlyEnabled(Ext_Zvqwdota8i) = hartSupports(Ext_Zvqwdota8i) & currentlyEnabled(Ext_Zve32x)
+
+union clause instruction = ZVQWDOTA8I : (zvqwdota8i_funct6, bits(1), vregidx, vregidx, vregidx)
+
+mapping encdec_zvqwdota8i_funct6 : zvqwdota8i_funct6 <-> bits(6) = {
+  VQWDOTAU_VV <-> 0b100110,
+  VQWDOTAS_VV <-> 0b100111
+}
+
+$[wavedrom "funct6 _ _ _ OPIVV _ OP-VE"]
+mapping clause encdec = ZVQWDOTA8I(funct6, vm, vs2, vs1, vd)
+  <-> encdec_zvqwdota8i_funct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1110111
+  when currentlyEnabled(Ext_Zvqwdota8i) & get_sew() == 8
+
+function clause execute ZVQWDOTA8I(funct6, vm, vs2, vs1, vd) = {
+  let SEW         = get_sew();
+  let LMUL_pow    = get_lmul_pow();
+  let num_elem_vs = get_num_elem(LMUL_pow, SEW);
+  let SEW_acc = 32;
+
+  // vstart==0 required ("nonzero vstart is reserved") and vtype validity
+  if illegal_reduction() | not(valid_reg_group(vs1, LMUL_pow)) | not(valid_reg_group(vs2, LMUL_pow))
+  then return Illegal_Instruction();
+
+  // "The destination vector register cannot overlap with the source vector register groups."
+  let vd_int      = unsigned(vregidx_bits(vd));
+  let vs2_int     = unsigned(vregidx_bits(vs2));
+  let vs1_int     = unsigned(vregidx_bits(vs1));
+  let src_group_size : int = if LMUL_pow > 0 then 2 ^ LMUL_pow else 1;
+  if (vd_int >= vs2_int & vd_int < vs2_int + src_group_size) |
+     (vd_int >= vs1_int & vd_int < vs1_int + src_group_size)
+  then return Illegal_Instruction();
+
+  if unsigned(vl) == 0 then return RETIRE_SUCCESS;
+
+  // Guaranteed by the encdec when-clause; needed to give the Sail typechecker
+  // a concrete bound for bits('m).
+  assert(SEW == 8);
+
+  let 'n = num_elem_vs;
+  let 'm = SEW;
+  let vm_val  : bits('n)             = read_vmask(num_elem_vs, vm, zvreg);
+  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
+
+  let mask : bits('n) = match init_masked_source(num_elem_vs, LMUL_pow, vm_val) {
+    Ok(v)   => v,
+    Err(()) => return Illegal_Instruction()
+  };
+
+  // vd[0] is the running 32-bit accumulator; sum modulo 2^32.
+  var sum : bits(32) = read_single_element(SEW_acc, 0, vd);
+
+  foreach (i from 0 to (num_elem_vs - 1)) {
+    if mask[i] == 0b1 then {
+      // TODO(Zvfbfa, https://github.com/riscv/sail-riscv/pull/1581):
+      // vs1 is pinned to unsigned (altfmt=0).  Once vtype.altfmt is available,
+      // branch on it here to also support altfmt=1 (vs1 signed).
+      let prod : bits(32) = match funct6 {
+        VQWDOTAU_VV => to_bits_unsafe(32, unsigned(vs2_val[i]) * unsigned(vs1_val[i])),
+        VQWDOTAS_VV => to_bits_unsafe(32, signed(vs2_val[i])   * unsigned(vs1_val[i]))
+      };
+      sum = sum + prod
+    }
+  };
+
+  write_single_element(SEW_acc, 0, vd, sum);
+  // vd[1..] are tail elements, currently left undisturbed (matches vredsum.vs convention).
+  // TODO: configuration support for agnostic tail behavior.
+  set_vstart(zeros());
+  RETIRE_SUCCESS
+}
+
+mapping zvqwdota8i_mnemonic : zvqwdota8i_funct6 <-> string = {
+  VQWDOTAU_VV <-> "vqwdotau.vv",
+  VQWDOTAS_VV <-> "vqwdotas.vv"
+}
+
+mapping clause assembly = ZVQWDOTA8I(funct6, vm, vs2, vs1, vd)
+  <-> zvqwdota8i_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)

--- a/model/extensions/Zvqwdota8i/zvqwdota8i_insts.sail
+++ b/model/extensions/Zvqwdota8i/zvqwdota8i_insts.sail
@@ -1,0 +1,97 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// Zvqwdota8i: Quad-widening 8-bit integer dot-product (unratified, v0.2).
+// Two instructions, both in major opcode 0x77 (OP-VE) with funct3=000:
+//   vqwdotau.vv  vd, vs2, vs1, vm   funct6=0x26   vs2 unsigned
+//   vqwdotas.vv  vd, vs2, vs1, vm   funct6=0x27   vs2 signed
+// Computes  vd[0] += sum_{i=vstart..vl-1} (mask[i] ? vs2[i] * vs1[i] : 0)
+// modulo 2^32.  vs1, vs2 are EEW=8, EMUL=LMUL; vd is EEW=32, EMUL=1, accumulator in vd[0].
+// Other elements of vd are tail.
+//
+// TODO(Zvfbfa): The spec uses vtype.altfmt to select vs1 signedness
+// (0=unsigned, 1=signed).  vtype.altfmt is not yet in sail-riscv master;
+// it depends on the Zvfbfa extension, currently in draft PR:
+//   https://github.com/riscv/sail-riscv/pull/1581
+// This implementation pins vs1 to UNSIGNED, matching the altfmt=0 case.
+// When the Zvfbfa PR lands, extend the funct6 match block below to branch
+// on vtype.altfmt for vs1 signedness (two more arms).
+
+function clause currentlyEnabled(Ext_Zvqwdota8i) = hartSupports(Ext_Zvqwdota8i) & currentlyEnabled(Ext_Zve32x)
+
+union clause instruction = ZVQWDOTA8I : (zvqwdota8i_funct6, bits(1), vregidx, vregidx, vregidx)
+
+mapping encdec_zvqwdota8i_funct6 : zvqwdota8i_funct6 <-> bits(6) = {
+  VQWDOTAU_VV <-> 0b100110,
+  VQWDOTAS_VV <-> 0b100111
+}
+
+$[wavedrom "funct6 _ _ _ OPIVV _ OP-VE"]
+mapping clause encdec = ZVQWDOTA8I(funct6, vm, vs2, vs1, vd)
+  <-> encdec_zvqwdota8i_funct6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1110111
+  when currentlyEnabled(Ext_Zvqwdota8i) & get_sew() == 8
+
+function clause execute ZVQWDOTA8I(funct6, vm, vs2, vs1, vd) = {
+  let SEW         = get_sew();
+  let LMUL_pow    = get_lmul_pow();
+  let num_elem_vs = get_num_elem(LMUL_pow, SEW);
+  let SEW_acc = 32;
+
+  // "The destination vector register cannot overlap with the source vector register groups."
+  if illegal_vstart(VSTART_MANDATORY, num_elem_vs, LMUL_pow) |
+     illegal_reduction() |
+     not(valid_disjoint_reg_groups(vs2, vd, LMUL_pow, 0)) |
+     not(valid_disjoint_reg_groups(vs1, vd, LMUL_pow, 0)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW))
+  then return Illegal_Instruction();
+
+  if unsigned(vl) == 0 then return RETIRE_SUCCESS;
+
+  // Guaranteed by the encdec when-clause; needed to give the Sail typechecker
+  // a concrete bound for bits('m).
+  assert(SEW == 8);
+
+  let 'n = num_elem_vs;
+  let 'm = SEW;
+  let vm_val  : bits('n)             = read_vmask(num_elem_vs, vm, zvreg);
+  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs1);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
+
+  let mask : bits('n) = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
+
+  // vd[0] is the running 32-bit accumulator; sum modulo 2^32.
+  var sum : bits(32) = read_single_element(SEW_acc, 0, vd);
+
+  foreach (i from 0 to (num_elem_vs - 1)) {
+    if mask[i] == 0b1 then {
+      // TODO(Zvfbfa, https://github.com/riscv/sail-riscv/pull/1581):
+      // vs1 is pinned to unsigned (altfmt=0).  Once vtype.altfmt is available,
+      // branch on it here to also support altfmt=1 (vs1 signed).
+      let prod : bits(32) = match funct6 {
+        VQWDOTAU_VV => to_bits_unsafe(32, unsigned(vs2_val[i]) * unsigned(vs1_val[i])),
+        VQWDOTAS_VV => to_bits_unsafe(32, signed(vs2_val[i])   * unsigned(vs1_val[i]))
+      };
+      sum = sum + prod
+    }
+  };
+
+  write_single_element(SEW_acc, 0, vd, sum);
+  // vd[1..] are tail elements, currently left undisturbed (matches vredsum.vs convention).
+  // TODO: configuration support for agnostic tail behavior.
+  set_vstart(zeros());
+  RETIRE_SUCCESS
+}
+
+mapping zvqwdota8i_mnemonic : zvqwdota8i_funct6 <-> string = {
+  VQWDOTAU_VV <-> "vqwdotau.vv",
+  VQWDOTAS_VV <-> "vqwdotas.vv"
+}
+
+mapping clause assembly = ZVQWDOTA8I(funct6, vm, vs2, vs1, vd)
+  <-> zvqwdota8i_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)

--- a/model/extensions/Zvqwdota8i/zvqwdota8i_types.sail
+++ b/model/extensions/Zvqwdota8i/zvqwdota8i_types.sail
@@ -1,0 +1,9 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+enum zvqwdota8i_funct6 = {VQWDOTAU_VV, VQWDOTAS_VV}

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -320,6 +320,19 @@ extensions {
     }
   }
 
+  Zvqwdota8i {
+    requires core
+
+    Zvqwdota8i_types {
+      before sys
+      files extensions/Zvqwdota8i/zvqwdota8i_types.sail
+    }
+    Zvqwdota8i_insts {
+      requires sys, V, Zvqwdota8i_types
+      files extensions/Zvqwdota8i/zvqwdota8i_insts.sail
+    }
+  }
+
   // Control and Status Register (CSR) Instructions
   Zicsr {
     requires core

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -327,6 +327,19 @@ extensions {
     }
   }
 
+  Zvqwdota8i {
+    requires core
+
+    Zvqwdota8i_types {
+      before sys
+      files extensions/Zvqwdota8i/zvqwdota8i_types.sail
+    }
+    Zvqwdota8i_insts {
+      requires sys, V, Zvqwdota8i_types
+      files extensions/Zvqwdota8i/zvqwdota8i_insts.sail
+    }
+  }
+
   // Control and Status Register (CSR) Instructions
   Zicsr {
     requires core

--- a/test/first_party/CMakeLists.txt
+++ b/test/first_party/CMakeLists.txt
@@ -106,6 +106,13 @@ add_first_party_test("test_pmp_access.c")
 add_first_party_test("test_phys_perms_on_failing_sc.S")
 add_first_party_test("test_wfi_wait.S")
 add_first_party_test("test_tlb_stale_pte_access_fault.S")
+add_first_party_test("test_zvqwdota8i.S")
+
+# Tests in this list are run with --enable-experimental-extensions because
+# they exercise unratified extensions.
+set(experimental_tests
+    "test_zvqwdota8i.S"
+)
 
 list(LENGTH tests tests_len)
 math(EXPR test_last "${tests_len} - 1")
@@ -174,8 +181,14 @@ foreach(idx RANGE 0 ${test_last} 4)
 
     add_custom_target(build_${arch}_${test_source} ALL DEPENDS ${elf} ${config} ${override_config})
 
+    set(extra_sim_flags)
+    list(FIND experimental_tests "${test_source}" _exp_idx)
+    if (_exp_idx GREATER -1)
+        set(extra_sim_flags --enable-experimental-extensions)
+    endif()
+
     add_test(
         NAME "first_party_${arch}_${test_source}"
-        COMMAND $<TARGET_FILE:sail_riscv_sim> --config ${config} --config-override ${override_config} ${elf}
+        COMMAND $<TARGET_FILE:sail_riscv_sim> --config ${config} --config-override ${override_config} ${extra_sim_flags} ${elf}
     )
 endforeach()

--- a/test/first_party/CMakeLists.txt
+++ b/test/first_party/CMakeLists.txt
@@ -125,6 +125,13 @@ add_first_party_test("test_wfi_wait.S")
 add_first_party_test("test_wfi_external_simple_interrupt_generator.S")
 add_first_party_test("test_vrgatherei16_reg_group.S")
 add_first_party_test("test_tlb_stale_pte_access_fault.S")
+add_first_party_test("test_zvqwdota8i.S")
+
+# Tests in this list are run with --enable-experimental-extensions because
+# they exercise unratified extensions.
+set(experimental_tests
+    "test_zvqwdota8i.S"
+)
 
 add_first_party_override_test("test_sew_elen_bound.S" "elen_32.json")
 add_first_party_override_test("test_satp_physaddr_bits.S" "satp_physaddr_bits.json")
@@ -196,8 +203,14 @@ foreach(idx RANGE 0 ${test_last} 4)
 
     add_custom_target(build_${arch}_${test_source} ALL DEPENDS ${elf} ${config} ${override_config})
 
+    set(extra_sim_flags)
+    list(FIND experimental_tests "${test_source}" _exp_idx)
+    if (_exp_idx GREATER -1)
+        set(extra_sim_flags --enable-experimental-extensions)
+    endif()
+
     add_test(
         NAME "first_party_${arch}_${test_source}"
-        COMMAND $<TARGET_FILE:sail_riscv_sim> --config ${config} --config-override ${override_config} ${elf}
+        COMMAND $<TARGET_FILE:sail_riscv_sim> --config ${config} --config-override ${override_config} ${extra_sim_flags} ${elf}
     )
 endforeach()

--- a/test/first_party/src/test_zvqwdota8i.S
+++ b/test/first_party/src/test_zvqwdota8i.S
@@ -1,0 +1,89 @@
+# Test for the unratified Zvqwdota8i extension (Phase 1 of ldot-bdot).
+# Spec: https://github.com/aswaterman/riscv-misc/blob/main/isa/ldot-bdot/ldot-bdot.adoc
+#
+# Two instructions, both in major opcode 0x77 (OP-VE), funct3=000:
+#   vqwdotau.vv  vd, vs2, vs1, vm    funct6=0x26   vs2 unsigned, vs1 unsigned (altfmt=0)
+#   vqwdotas.vv  vd, vs2, vs1, vm    funct6=0x27   vs2 signed,   vs1 unsigned (altfmt=0)
+#
+# Instructions are hand-encoded with .4byte because no upstream assembler knows
+# these mnemonics yet.
+#
+# Encoding for vd=v8, vs2=v4, vs1=v2, vm=1 (unmasked):
+#   bits  31..26 25 24..20 19..15 14..12 11..7 6..0
+#   field funct6 vm vs2    vs1    funct3 vd    opcode
+#   vqwdotau.vv: 100110 1 00100 00010 000 01000 1110111 = 0x9A410477
+#   vqwdotas.vv: 100111 1 00100 00010 000 01000 1110111 = 0x9E410477
+#
+# NOTE: This test exercises only the altfmt=0 case (vs1 unsigned) because
+# vtype.altfmt is not yet in sail-riscv master.  See the TODO in
+# model/extensions/Zvqwdota8i/zvqwdota8i_insts.sail and Zvfbfa PR:
+#   https://github.com/riscv/sail-riscv/pull/1581
+#
+# This test requires `--enable-experimental-extensions` on the simulator
+# command line.  CMakeLists.txt threads that flag in via experimental_tests.
+
+.global main
+main:
+    # Enable mstatus.VS (bits 10:9) = Initial (0b01) so vector ops are legal.
+    # crt0 only enables FS; VS stays Off without this.
+    li t0, (1 << 9)
+    csrs mstatus, t0
+
+    # vsetvli zero, t0=8, e8, m1, ta, ma
+    li t0, 8
+    vsetvli zero, t0, e8, m1, ta, ma
+
+    # vs1 = v2 = [1,2,3,4,5,6,7,8]  (unsigned)
+    la a0, src_vs1
+    vle8.v v2, (a0)
+
+    # ----- Test 1: vqwdotau.vv with all-unsigned operands -----
+    # vs2 = v4 = [1,2,3,4,5,6,7,8]
+    la a1, src_vs2_u
+    vle8.v v4, (a1)
+
+    # vd = v8 = 0
+    vmv.v.i v8, 0
+
+    # vqwdotau.vv v8, v4, v2
+    .4byte 0x9A410477
+
+    # Read vd[0] as a 32-bit scalar
+    vsetivli zero, 1, e32, m1, ta, ma
+    vmv.x.s t0, v8
+    li t1, 204                  # 1+4+9+16+25+36+49+64
+    bne t0, t1, fail
+
+    # ----- Test 2: vqwdotas.vv with signed vs2, unsigned vs1 -----
+    li t0, 8
+    vsetvli zero, t0, e8, m1, ta, ma
+    la a1, src_vs2_s
+    vle8.v v4, (a1)
+
+    vsetivli zero, 1, e32, m1, ta, ma
+    vmv.v.i v8, 0
+    li t0, 8
+    vsetvli zero, t0, e8, m1, ta, ma
+
+    # vqwdotas.vv v8, v4, v2
+    .4byte 0x9E410477
+
+    vsetivli zero, 1, e32, m1, ta, ma
+    vmv.x.s t0, v8
+    li t1, 36                   # -1+4-9+16-25+36-49+64
+    bne t0, t1, fail
+
+pass:
+    li a0, 0
+    ret
+
+fail:
+    li a0, 1
+    ret
+
+.section .rodata
+.align 4
+src_vs1:   .byte 1, 2, 3, 4, 5, 6, 7, 8
+src_vs2_u: .byte 1, 2, 3, 4, 5, 6, 7, 8
+# Signed: -1, 2, -3, 4, -5, 6, -7, 8
+src_vs2_s: .byte 0xff, 2, 0xfd, 4, 0xfb, 6, 0xf9, 8


### PR DESCRIPTION
Implement Phase 1 of the unratified Zvdota family of dot-product extensions, adding the two `Zvqwdota8i` instructions `vqwdotau.vv` and `vqwdotas.vv` (major opcode 0x77, funct3=000, funct6 0x26/0x27).

Spec: https://github.com/aswaterman/riscv-misc/blob/main/isa/ldot-bdot/ldot-bdot.adoc

The spec uses `vtype.altfmt` to select vs1 signedness, but `altfmt` is not yet in sail-riscv master — it depends on the Zvfbfa extension (#1581). This PR pins vs1 to unsigned (the spec's `altfmt=0` case) and leaves a `TODO(Zvfbfa)` marker for the follow-up.

Enabled via `--enable-experimental-extensions`. Includes a new first-party test covering both opcodes on rv32 and rv64.

---

### AI tool disclosure (per CONTRIBUTING.md)

This PR was produced with AI assistance (Anthropic's Claude). The work was human-directed: I selected the extension and scope (Phase 1 only, vs1 pinned to `altfmt=0`), chose the encoding-space approach (OP-VE at 0x77, funct3=000), identified Zvabd as the structural template, and diagnosed every build/runtime failure (Sail typecheck constraint propagation requiring an explicit `assert(SEW == 8)`, the missing `mstatus[VS]` enable that traps `vsetvli` as illegal, and the LLVM 18 `-march=…zfbfmin` quirk) against actual Docker builds — not hand-waved. The AI produced initial drafts of the Sail code, the assembly test, and the documentation under that direction; I reviewed every line before commit. All commits are DCO-signed off by me, and I accept authorial responsibility for the content.