### PR TITLE
Reduce globals in the simulator in favor of struct parameters.

### DIFF
--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -357,7 +357,7 @@ void ModelImpl::set_config_print_step(bool on) {
   m_config_print_step = on;
 }
 
-void ModelImpl::set_elf_symbols(std::map<uint64_t, std::string> &&symbols) {
+void ModelImpl::set_elf_symbols(std::map<uint64_t, std::string> symbols) {
   m_symbols = std::move(symbols);
 }
 

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -8,13 +8,6 @@
 #include "riscv_callbacks_if.h"
 #include "symbol_table.h"
 
-int term_fd = 1; // set during startup
-void plat_term_write_impl(char c) {
-  if (write(term_fd, &c, sizeof(c)) < 0) {
-    fprintf(stderr, "Unable to write to terminal!\n");
-  }
-}
-
 void ModelImpl::register_callback(callbacks_if *cb) {
   if (std::find(m_callbacks.begin(), m_callbacks.end(), cb) == m_callbacks.end()) {
     m_callbacks.push_back(cb);
@@ -258,7 +251,10 @@ bool ModelImpl::valid_reservation(unit) {
 }
 
 unit ModelImpl::plat_term_write(mach_bits s) {
-  plat_term_write_impl(static_cast<char>(s));
+  char c = static_cast<char>(s);
+  if (write(m_term_fd, &c, sizeof(c)) < 0) {
+    fprintf(stderr, "Unable to write to terminal!\n");
+  }
   return UNIT;
 }
 
@@ -363,6 +359,10 @@ void ModelImpl::set_config_print_step(bool on) {
 
 void ModelImpl::set_elf_symbols(std::map<uint64_t, std::string> &&symbols) {
   m_symbols = std::move(symbols);
+}
+
+void ModelImpl::set_term_fd(int fd) {
+  m_term_fd = fd;
 }
 
 void ModelImpl::init_platform_constants() {

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -277,7 +277,7 @@ unit ModelImpl::print_log(const_sail_string s) {
 }
 
 unit ModelImpl::print_log_instr(const_sail_string s, uint64_t pc) {
-  auto maybe_symbol = symbolize_address(g_symbols, pc);
+  auto maybe_symbol = symbolize_address(m_symbols, pc);
   if (maybe_symbol.has_value()) {
     fprintf(trace_log, "%-80s    %s+%" PRIu64 "\n", s, maybe_symbol->second.c_str(), pc - maybe_symbol->first);
   } else {
@@ -359,6 +359,10 @@ void ModelImpl::set_config_use_abi_names(bool on) {
 
 void ModelImpl::set_config_print_step(bool on) {
   m_config_print_step = on;
+}
+
+void ModelImpl::set_elf_symbols(std::map<uint64_t, std::string> &&symbols) {
+  m_symbols = std::move(symbols);
 }
 
 void ModelImpl::init_platform_constants() {

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -11,8 +11,6 @@
 #include "sail_riscv_model.h"
 
 extern FILE *trace_log;
-extern int term_fd;
-void plat_term_write_impl(char c);
 
 // Model wrapped with an implementation of its platform callbacks.
 class ModelImpl final : public hart::Model {
@@ -40,6 +38,7 @@ public:
   void set_config_use_abi_names(bool on);
 
   void set_elf_symbols(std::map<uint64_t, std::string> &&g_symbols);
+  void set_term_fd(int fd);
 
   // initialization
   void init_platform_constants();
@@ -121,6 +120,7 @@ private:
   bool m_config_print_step = false;
 
   std::map<uint64_t, std::string> m_symbols;
+  int m_term_fd = 1;
 
   // TODO: Probably better with std::shared_ptr<callbacks_if>.
   std::vector<callbacks_if *> m_callbacks;

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -37,7 +37,7 @@ public:
   void set_config_rvfi(bool on);
   void set_config_use_abi_names(bool on);
 
-  void set_elf_symbols(std::map<uint64_t, std::string> &&g_symbols);
+  void set_elf_symbols(std::map<uint64_t, std::string> g_symbols);
   void set_term_fd(int fd);
 
   // initialization

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -37,7 +37,7 @@ public:
   void set_config_rvfi(bool on);
   void set_config_use_abi_names(bool on);
 
-  void set_elf_symbols(std::map<uint64_t, std::string> g_symbols);
+  void set_elf_symbols(std::map<uint64_t, std::string> symbols);
   void set_term_fd(int fd);
 
   // initialization

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <map>
 #include <optional>
 #include <random>
 #include <vector>
@@ -33,10 +34,12 @@ public:
   void set_config_print_interrupt(bool on);
   void set_config_print_htif(bool on);
   void set_config_print_pma(bool on);
+  void set_config_print_step(bool on);
+
   void set_config_rvfi(bool on);
   void set_config_use_abi_names(bool on);
 
-  void set_config_print_step(bool on);
+  void set_elf_symbols(std::map<uint64_t, std::string> &&g_symbols);
 
   // initialization
   void init_platform_constants();
@@ -116,6 +119,8 @@ private:
   bool m_config_use_abi_names = false;
 
   bool m_config_print_step = false;
+
+  std::map<uint64_t, std::string> m_symbols;
 
   // TODO: Probably better with std::shared_ptr<callbacks_if>.
   std::vector<callbacks_if *> m_callbacks;

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -56,6 +56,7 @@ struct elf_info {
 
 struct run_info {
   std::optional<rvfi_handler> rvfi;
+  int term_fd = 1;
   steady_clock::time_point init_start;
   steady_clock::time_point init_end;
   uint64_t total_insns = 0;
@@ -609,10 +610,10 @@ void run_sail(
   finish(model, opts, elf_info, run_info);
 }
 
-void init_logs(const CLIOptions &opts) {
+void init_logs(const CLIOptions &opts, run_info &run_info) {
   if (!opts.term_log.empty() &&
-      (term_fd = open(opts.term_log.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IRGRP | S_IROTH | S_IWUSR)) <
-        0) {
+      (run_info.term_fd =
+         open(opts.term_log.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IRGRP | S_IROTH | S_IWUSR)) < 0) {
     fprintf(stderr, "Cannot create terminal log '%s': %s\n", opts.term_log.c_str(), strerror(errno));
     exit(EXIT_FAILURE);
   }
@@ -779,7 +780,7 @@ InitResult preinit_model(
     return InitResult::ExitFailure;
   }
 
-  init_logs(opts);
+  init_logs(opts, run_info);
 
   return InitResult::Continue;
 }
@@ -793,6 +794,7 @@ uint64_t init_model(CLIOptions &opts, ModelImpl &model, elf_info &elf_info, run_
     }
     model.register_callback(&rvfi_cbs);
   }
+  model.set_term_fd(run_info.term_fd);
 
   if (!opts.dtb_file.empty()) {
     fprintf(stderr, "using %s as DTB file.\n", opts.dtb_file.c_str());
@@ -811,8 +813,8 @@ uint64_t init_model(CLIOptions &opts, ModelImpl &model, elf_info &elf_info, run_
     (void)load_sail(model, *it, /*main_file=*/false, elf_info);
   }
 
-  model.init_sail(entry, opts.config_file.c_str(), elf_info.htif_tohost_address);
   model.set_elf_symbols(std::move(elf_info.symbols));
+  model.init_sail(entry, opts.config_file.c_str(), elf_info.htif_tohost_address);
 
   run_info.init_end = steady_clock::now();
 

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -495,7 +495,7 @@ void run_sail(
   ModelImpl &model,
   const CLIOptions &opts,
   traploop_detector &loop_detector,
-  elf_info &elf_info,
+  const elf_info &elf_info,
   run_info &run_info
 ) {
   bool is_waiting = false;
@@ -821,7 +821,7 @@ uint64_t init_model(CLIOptions &opts, ModelImpl &model, elf_info &elf_info, run_
   return entry;
 }
 
-void run_model(CLIOptions &opts, ModelImpl &model, uint64_t entry, elf_info &elf_info, run_info &run_info) {
+void run_model(CLIOptions &opts, ModelImpl &model, uint64_t entry, const elf_info &elf_info, run_info &run_info) {
   traploop_detector loop_detector;
   if (!opts.disable_trap_loop_detection) {
     model.register_callback(&loop_detector);

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -44,20 +44,22 @@ using std::chrono::steady_clock;
 
 namespace {
 
-std::optional<rvfi_handler> rvfi;
-
-// The address of the HTIF tohost port, if it is enabled.
-std::optional<uint64_t> htif_tohost_address;
-
 rvfi_callbacks rvfi_cbs;
 
-uint64_t mem_sig_start = 0;
-uint64_t mem_sig_end = 0;
+struct elf_info {
+  // The address of the HTIF tohost port, if it is enabled.
+  std::optional<uint64_t> htif_tohost_address;
+  uint64_t mem_sig_start = 0;
+  uint64_t mem_sig_end = 0;
+  std::map<uint64_t, std::string> symbols;
+};
 
-steady_clock::time_point init_start;
-steady_clock::time_point init_end;
-
-uint64_t total_insns = 0;
+struct run_info {
+  std::optional<rvfi_handler> rvfi;
+  steady_clock::time_point init_start;
+  steady_clock::time_point init_end;
+  uint64_t total_insns = 0;
+};
 
 } // namespace
 
@@ -326,7 +328,7 @@ static CLIOptions parse_cli(int argc, char **argv) {
   return opts;
 }
 
-uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file) {
+uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file, elf_info &elf_info) {
   ELF elf = ELF::open(filename);
 
   switch (elf.architecture()) {
@@ -360,7 +362,7 @@ uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file
   // If multiple symbols from different ELF files have the same value the first
   // one wins.
   const auto reversed_symbols = reverse_symbol_table(symbols);
-  g_symbols.insert(reversed_symbols.begin(), reversed_symbols.end());
+  elf_info.symbols.insert(reversed_symbols.begin(), reversed_symbols.end());
 
   if (main_file) {
     // Only scan for test-signature/htif symbols in the main ELF file.
@@ -368,21 +370,21 @@ uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file
     const auto &tohost = symbols.find("tohost");
     if (tohost == symbols.end()) {
       fprintf(stderr, "Unable to locate tohost symbol; disabling HTIF.\n");
-      htif_tohost_address = std::nullopt;
+      elf_info.htif_tohost_address = std::nullopt;
     } else {
-      htif_tohost_address = tohost->second;
-      fprintf(stdout, "HTIF located at 0x%0" PRIx64 "\n", *htif_tohost_address);
+      elf_info.htif_tohost_address = tohost->second;
+      fprintf(stdout, "HTIF located at 0x%0" PRIx64 "\n", *elf_info.htif_tohost_address);
     }
     // Locate test-signature locations if any.
     const auto &begin_sig = symbols.find("begin_signature");
     if (begin_sig != symbols.end()) {
       fprintf(stdout, "begin_signature: 0x%0" PRIx64 "\n", begin_sig->second);
-      mem_sig_start = begin_sig->second;
+      elf_info.mem_sig_start = begin_sig->second;
     }
     const auto &end_sig = symbols.find("end_signature");
     if (end_sig != symbols.end()) {
       fprintf(stdout, "end_signature: 0x%0" PRIx64 "\n", end_sig->second);
-      mem_sig_end = end_sig->second;
+      elf_info.mem_sig_end = end_sig->second;
     }
   }
 
@@ -419,13 +421,13 @@ void write_dtb_to_rom(ModelImpl &model, const std::vector<uint8_t> &dtb) {
   }
 }
 
-void write_signature(const std::string &file, unsigned signature_granularity) {
-  if (mem_sig_start >= mem_sig_end) {
+void write_signature(const std::string &file, unsigned signature_granularity, const elf_info &elf_info) {
+  if (elf_info.mem_sig_start >= elf_info.mem_sig_end) {
     fprintf(
       stderr,
       "Invalid signature region [0x%0" PRIx64 ",0x%0" PRIx64 "] to %s.\n",
-      mem_sig_start,
-      mem_sig_end,
+      elf_info.mem_sig_start,
+      elf_info.mem_sig_end,
       file.c_str()
     );
     return;
@@ -436,7 +438,7 @@ void write_signature(const std::string &file, unsigned signature_granularity) {
     return;
   }
   /* write out words depending on signature granularity in signature area */
-  for (uint64_t addr = mem_sig_start; addr < mem_sig_end; addr += signature_granularity) {
+  for (uint64_t addr = elf_info.mem_sig_start; addr < elf_info.mem_sig_end; addr += signature_granularity) {
     /* most-significant byte first */
     for (int i = signature_granularity - 1; i >= 0; i--) {
       uint8_t byte = (uint8_t)read_mem(addr + i);
@@ -459,10 +461,10 @@ void close_logs() {
   }
 }
 
-void finish(ModelImpl &model, const CLIOptions &opts) {
+void finish(ModelImpl &model, const CLIOptions &opts, const elf_info &elf_info, const run_info &run_info) {
   // Don't write a signature if there was an internal Sail exception.
   if (!model.have_exception && !opts.sig_file.empty()) {
-    write_signature(opts.sig_file, opts.signature_granularity);
+    write_signature(opts.sig_file, opts.signature_granularity, elf_info);
   }
 
   // `model_fini()` exits with failure if there was a Sail exception.
@@ -470,12 +472,12 @@ void finish(ModelImpl &model, const CLIOptions &opts) {
 
   if (opts.do_show_times) {
     auto run_end = steady_clock::now();
-    uint64_t init_msecs = duration_cast<milliseconds>(init_end - init_start).count();
-    uint64_t exec_msecs = duration_cast<milliseconds>(run_end - init_end).count();
-    uint64_t kips = total_insns / exec_msecs;
+    uint64_t init_msecs = duration_cast<milliseconds>(run_info.init_end - run_info.init_start).count();
+    uint64_t exec_msecs = duration_cast<milliseconds>(run_end - run_info.init_end).count();
+    uint64_t kips = run_info.total_insns / exec_msecs;
     fprintf(stderr, "Initialization:   %" PRIu64 " ms\n", init_msecs);
     fprintf(stderr, "Execution:        %" PRIu64 " ms\n", exec_msecs);
-    fprintf(stderr, "Instructions:     %" PRIu64 "\n", total_insns);
+    fprintf(stderr, "Instructions:     %" PRIu64 "\n", run_info.total_insns);
     fprintf(stderr, "Performance:      %" PRIu64 " kIPS\n", kips);
   }
   close_logs();
@@ -488,7 +490,13 @@ void flush_logs() {
   fflush(trace_log);
 }
 
-void run_sail(ModelImpl &model, const CLIOptions &opts, traploop_detector &loop_detector) {
+void run_sail(
+  ModelImpl &model,
+  const CLIOptions &opts,
+  traploop_detector &loop_detector,
+  elf_info &elf_info,
+  run_info &run_info
+) {
   bool is_waiting = false;
   // The emulator tick increments time by 1 at every step, so the number
   // of steps to wait is equal to the needed increment in the time CSR.
@@ -503,13 +511,13 @@ void run_sail(ModelImpl &model, const CLIOptions &opts, traploop_detector &loop_
 
   auto interval_start = steady_clock::now();
 
-  while (!model.zhtif_done && (opts.insn_limit == 0 || total_insns < opts.insn_limit)) {
-    if (rvfi.has_value()) {
-      switch (rvfi->pre_step(opts.config_print_rvfi)) {
+  while (!model.zhtif_done && (opts.insn_limit == 0 || run_info.total_insns < opts.insn_limit)) {
+    if (run_info.rvfi.has_value()) {
+      switch (run_info.rvfi->pre_step(opts.config_print_rvfi)) {
       case RVFI_prestep_continue:
         continue;
       case RVFI_prestep_eof:
-        rvfi = std::nullopt;
+        run_info.rvfi = std::nullopt;
         return;
       case RVFI_prestep_end_trace:
         return;
@@ -534,8 +542,8 @@ void run_sail(ModelImpl &model, const CLIOptions &opts, traploop_detector &loop_
       if (opts.config_print_instr) {
         flush_logs();
       }
-      if (rvfi) {
-        rvfi->send_trace(opts.config_print_rvfi);
+      if (run_info.rvfi) {
+        run_info.rvfi->send_trace(opts.config_print_rvfi);
       }
       if (is_waiting) {
         if (wait_steps_remaining == 0) {
@@ -556,10 +564,10 @@ void run_sail(ModelImpl &model, const CLIOptions &opts, traploop_detector &loop_
       }
       step_no++;
       insn_cnt++;
-      total_insns++;
+      run_info.total_insns++;
     }
 
-    if (opts.do_show_times && (total_insns & 0xfffff) == 0) {
+    if (opts.do_show_times && (run_info.total_insns & 0xfffff) == 0) {
       const auto now = steady_clock::now();
       const auto interval = now - interval_start;
       interval_start = now;
@@ -598,7 +606,7 @@ void run_sail(ModelImpl &model, const CLIOptions &opts, traploop_detector &loop_
 
   // This is reached if there is a Sail exception, HTIF has indicated
   // successful completion, or the instruction limit has been reached.
-  finish(model, opts);
+  finish(model, opts, elf_info, run_info);
 }
 
 void init_logs(const CLIOptions &opts) {
@@ -704,9 +712,14 @@ InitResult preinit_args(CLIOptions &opts, std::string &config_json_string) {
 // Configures the model, validates the configuration, processes
 // options requiring a configured model and returns whether to continue with
 // model simulation.
-InitResult preinit_model(CLIOptions &opts, ModelImpl &model, const std::string &config_json_string) {
+InitResult preinit_model(
+  CLIOptions &opts,
+  ModelImpl &model,
+  const std::string &config_json_string,
+  run_info &run_info
+) {
   if (opts.rvfi_dii_port != 0) {
-    rvfi.emplace(opts.rvfi_dii_port, model);
+    run_info.rvfi.emplace(opts.rvfi_dii_port, model);
   }
 
   if (opts.config_enable_experimental_extensions) {
@@ -722,7 +735,7 @@ InitResult preinit_model(CLIOptions &opts, ModelImpl &model, const std::string &
   model.set_config_print_interrupt(opts.config_print_interrupt);
   model.set_config_print_htif(opts.config_print_htif);
   model.set_config_print_pma(opts.config_print_pma);
-  model.set_config_rvfi(rvfi.has_value());
+  model.set_config_rvfi(run_info.rvfi.has_value());
   model.set_config_use_abi_names(opts.config_use_abi_names);
 
   model.set_config_print_step(opts.config_print_step);
@@ -761,7 +774,7 @@ InitResult preinit_model(CLIOptions &opts, ModelImpl &model, const std::string &
   }
 
   // If we get here, we need to have ELF files to run (except in RVFI mode).
-  if (opts.elfs.empty() && !rvfi.has_value()) {
+  if (opts.elfs.empty() && !run_info.rvfi.has_value()) {
     fprintf(stderr, "No elf file provided.\n");
     return InitResult::ExitFailure;
   }
@@ -771,11 +784,11 @@ InitResult preinit_model(CLIOptions &opts, ModelImpl &model, const std::string &
   return InitResult::Continue;
 }
 
-uint64_t init_model(CLIOptions &opts, ModelImpl &model) {
-  init_start = steady_clock::now();
+uint64_t init_model(CLIOptions &opts, ModelImpl &model, elf_info &elf_info, run_info &run_info) {
+  run_info.init_start = steady_clock::now();
 
-  if (rvfi.has_value()) {
-    if (!rvfi->setup_socket(opts.config_print_rvfi)) {
+  if (run_info.rvfi.has_value()) {
+    if (!run_info.rvfi->setup_socket(opts.config_print_rvfi)) {
       return 1;
     }
     model.register_callback(&rvfi_cbs);
@@ -786,25 +799,27 @@ uint64_t init_model(CLIOptions &opts, ModelImpl &model) {
     write_dtb_to_rom(model, read_file(opts.dtb_file));
   }
 
-  uint64_t entry = rvfi.has_value() ? rvfi->get_entry() : load_sail(model, opts.elfs[0], /*main_file=*/true);
+  uint64_t entry = run_info.rvfi.has_value() ? run_info.rvfi->get_entry()
+                                             : load_sail(model, opts.elfs[0], /*main_file=*/true, elf_info);
 
   fprintf(stdout, "Entry point: 0x%" PRIx64 "\n", entry);
 
   // Load any additional ELF files into memory. If RVFI was NOT used skip
   // the first one because it was loaded above.
-  for (auto it = opts.elfs.cbegin() + (rvfi.has_value() ? 0 : 1); it != opts.elfs.cend(); it++) {
+  for (auto it = opts.elfs.cbegin() + (run_info.rvfi.has_value() ? 0 : 1); it != opts.elfs.cend(); it++) {
     fprintf(stdout, "Loading additional ELF file %s.\n", it->c_str());
-    (void)load_sail(model, *it, /*main_file=*/false);
+    (void)load_sail(model, *it, /*main_file=*/false, elf_info);
   }
 
-  model.init_sail(entry, opts.config_file.c_str(), htif_tohost_address);
+  model.init_sail(entry, opts.config_file.c_str(), elf_info.htif_tohost_address);
+  model.set_elf_symbols(std::move(elf_info.symbols));
 
-  init_end = steady_clock::now();
+  run_info.init_end = steady_clock::now();
 
   return entry;
 }
 
-void run_model(CLIOptions &opts, ModelImpl &model, uint64_t entry) {
+void run_model(CLIOptions &opts, ModelImpl &model, uint64_t entry, elf_info &elf_info, run_info &run_info) {
   traploop_detector loop_detector;
   if (!opts.disable_trap_loop_detection) {
     model.register_callback(&loop_detector);
@@ -824,14 +839,14 @@ void run_model(CLIOptions &opts, ModelImpl &model, uint64_t entry) {
   model.register_callback(&log_cbs);
 
   do {
-    run_sail(model, opts, loop_detector);
+    run_sail(model, opts, loop_detector, elf_info, run_info);
     // `run_sail` only returns in the case of rvfi.
-    if (rvfi) {
+    if (run_info.rvfi) {
       /* Reset for next test */
-      model.reinit_sail(entry, opts.config_file.c_str(), htif_tohost_address);
+      model.reinit_sail(entry, opts.config_file.c_str(), elf_info.htif_tohost_address);
       loop_detector.reset();
     }
-  } while (rvfi);
+  } while (run_info.rvfi);
 }
 
 int inner_main(int argc, char **argv) {
@@ -849,7 +864,8 @@ int inner_main(int argc, char **argv) {
   }
 
   ModelImpl model;
-  switch (preinit_model(opts, model, config_json_string)) {
+  run_info run_info;
+  switch (preinit_model(opts, model, config_json_string, run_info)) {
   case InitResult::ExitSuccess:
     return EXIT_SUCCESS;
   case InitResult::ExitFailure:
@@ -858,9 +874,10 @@ int inner_main(int argc, char **argv) {
     break;
   }
 
-  uint64_t entry = init_model(opts, model);
+  elf_info elf_info;
+  uint64_t entry = init_model(opts, model, elf_info, run_info);
 
-  run_model(opts, model, entry);
+  run_model(opts, model, entry, elf_info, run_info);
 
   model.model_fini();
   flush_logs();

--- a/c_emulator/symbol_table.cpp
+++ b/c_emulator/symbol_table.cpp
@@ -25,5 +25,3 @@ std::optional<std::pair<uint64_t, const std::string &>> symbolize_address(
   --it;
   return *it;
 }
-
-std::map<uint64_t, std::string> g_symbols;

--- a/c_emulator/symbol_table.h
+++ b/c_emulator/symbol_table.h
@@ -15,7 +15,3 @@ std::optional<std::pair<uint64_t, const std::string &>> symbolize_address(
   const std::map<uint64_t, std::string> &symbols,
   uint64_t address
 );
-
-// Global symbol table.
-// TODO: Don't use globals.
-extern std::map<uint64_t, std::string> g_symbols;


### PR DESCRIPTION
`trace_log` and `rvfi_cbs` are left as global for now to be handled later.
