### PR TITLE
Clean up vector mask instructions

### DIFF
--- a/model/extensions/V/vext_mask_insts.sail
+++ b/model/extensions/V/vext_mask_insts.sail
@@ -32,7 +32,6 @@ mapping clause encdec = MMTYPE(funct6, vs2, vs1, vd)
 
 function clause execute MMTYPE(funct6, vs2, vs1, vd) = {
   let SEW      = get_sew();
-  let LMUL_pow = get_lmul_pow();
   let num_elem = vlen;
 
   if illegal_vd_unmasked() then return Illegal_Instruction();
@@ -93,29 +92,21 @@ mapping clause encdec = VCPOP_M(vm, vs2, rd)
      | (currentlyEnabled(Ext_Zve64x) & get_sew() <= 64)
 
 function clause execute VCPOP_M(vm, vs2, rd) = {
-  let SEW      = get_sew();
-  let LMUL_pow = get_lmul_pow();
   let num_elem = vlen;
 
   if illegal_vd_unmasked() | not(assert_vstart(0)) then return Illegal_Instruction();
 
   let 'n = num_elem;
-  let 'm = SEW;
 
   let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
 
-  let (_, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val) {
+  let mask : bits('n) = match init_masked_source(num_elem, 0, vm_val) {
     Ok(v)   => v,
     Err(()) => return Illegal_Instruction()
   };
 
-  var count : nat = 0;
-  foreach (i from 0 to (num_elem - 1)) {
-    if (mask & vs2_val)[i] == 0b1 then count = count + 1;
-  };
-
-  X(rd) = to_bits_unsafe(xlen, count);
+  X(rd) = to_bits_unsafe(xlen, count_ones(mask & vs2_val));
   set_vstart(zeros());
   RETIRE_SUCCESS
 }
@@ -132,29 +123,22 @@ mapping clause encdec = VFIRST_M(vm, vs2, rd)
      | (currentlyEnabled(Ext_Zve64x) & get_sew() <= 64)
 
 function clause execute VFIRST_M(vm, vs2, rd) = {
-  let SEW      = get_sew();
-  let LMUL_pow = get_lmul_pow();
   let num_elem = vlen;
 
   if illegal_vd_unmasked() | not(assert_vstart(0)) then return Illegal_Instruction();
 
   let 'n = num_elem;
-  let 'm = SEW;
 
   let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
 
-  let (_, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, 0, vs2_val, vm_val) {
+  let mask : bits('n) = match init_masked_source(num_elem, 0, vm_val) {
     Ok(v)   => v,
     Err(()) => return Illegal_Instruction()
   };
 
-  var index : int = -1;
-  foreach (i from 0 to (num_elem - 1)) {
-    if index == -1 then {
-      if (mask & vs2_val)[i] == 0b1 then index = i;
-    };
-  };
+  let active = mask & vs2_val;
+  let index = if active == zeros() then -1 else count_trailing_zeros(active);
 
   X(rd) = to_bits_unsafe(xlen, index);
   set_vstart(zeros());
@@ -174,7 +158,6 @@ mapping clause encdec = VMSBF_M(vm, vs2, vd)
 
 function clause execute VMSBF_M(vm, vs2, vd) = {
   let SEW      = get_sew();
-  let LMUL_pow = get_lmul_pow();
   let num_elem = vlen;
 
   if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
@@ -219,7 +202,6 @@ mapping clause encdec = VMSIF_M(vm, vs2, vd)
 
 function clause execute VMSIF_M(vm, vs2, vd) = {
   let SEW      = get_sew();
-  let LMUL_pow = get_lmul_pow();
   let num_elem = vlen;
 
   if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2
@@ -264,7 +246,6 @@ mapping clause encdec = VMSOF_M(vm, vs2, vd)
 
 function clause execute VMSOF_M(vm, vs2, vd) = {
   let SEW      = get_sew();
-  let LMUL_pow = get_lmul_pow();
   let num_elem = vlen;
 
   if illegal_normal(vd, vm) | not(assert_vstart(0)) | vd == vs2

--- a/model/extensions/V/vext_mask_insts.sail
+++ b/model/extensions/V/vext_mask_insts.sail
@@ -106,7 +106,7 @@ function clause execute VCPOP_M(vm, vs2, rd) = {
     Err(()) => return Illegal_Instruction()
   };
 
-  X(rd) = to_bits_unsafe(xlen, count_ones(mask & vs2_val));
+  X(rd) = to_bits(xlen, count_ones(mask & vs2_val));
   set_vstart(zeros());
   RETIRE_SUCCESS
 }
@@ -138,9 +138,8 @@ function clause execute VFIRST_M(vm, vs2, rd) = {
   };
 
   let active = mask & vs2_val;
-  let index = if active == zeros() then -1 else count_trailing_zeros(active);
 
-  X(rd) = to_bits_unsafe(xlen, index);
+  X(rd) = if active == zeros() then ones() else to_bits(count_trailing_zeros(active));
   set_vstart(zeros());
   RETIRE_SUCCESS
 }


### PR DESCRIPTION
* Use init_masked_source for vcpop.m and vfirst.m since they write to a scalar rd and not a vector destination.
* Replace loops in vcpop.m and vfirst.m with count_ones and count_trailing_zeros.
* Remove unused SEW/LMUL_pow variables.