### PR TITLE
Guard against a reserved shamt encoding that aliased with `add.uw`.

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -16,6 +16,9 @@
     (e.g. Linux boot time reduced by up to ~50%). Off by default to keep
     incremental builds fast, enabled in CI and release builds.
 
+- Important issues addressed and bugs fixed:
+  - https://github.com/riscv/sail-riscv/issues/1711 : A reserved instruction encoding was decoded as `add.uw`.
+
 # Release notes for version 0.11
 
 - Updates to the [configuration file](../config/config.json.in):

--- a/model/extensions/B/zba_insts.sail
+++ b/model/extensions/B/zba_insts.sail
@@ -38,7 +38,7 @@ mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, 0b00)
 // sh#add.uw
 mapping clause encdec = ZBA_RTYPEUW(rs2, rs1, rd, shamt)
   <-> 0b0010000 @ encdec_reg(rs2) @ encdec_reg(rs1) @ shamt @ 0b0 @ encdec_reg(rd) @ 0b0111011
-  when currentlyEnabled(Ext_Zba) & xlen == 64
+  when currentlyEnabled(Ext_Zba) & xlen == 64 & shamt != 0b00
 
 mapping zba_rtypeuw_mnemonic : shamt_zba <-> string = {
   0b00 <-> "add.uw",


### PR DESCRIPTION
Fixes #1711.