### PR TITLE
Print HTIF failure exit code in hex as well as decimal

### DIFF
--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -601,7 +601,7 @@ void run_sail(ModelImpl &model, const CLIOptions &opts, traploop_detector &loop_
       if (model.zhtif_exit_code == 0) {
         fprintf(stdout, "SUCCESS\n");
       } else {
-        fprintf(stdout, "FAILURE: %" PRIi64 "\n", model.zhtif_exit_code);
+        fprintf(stdout, "FAILURE: %" PRIi64 " (0x%08" PRIx64 ")\n", model.zhtif_exit_code, (uint64_t)model.zhtif_exit_code);
         exit(EXIT_FAILURE);
       }
     }

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -601,7 +601,7 @@ void run_sail(ModelImpl &model, const CLIOptions &opts, traploop_detector &loop_
       if (model.zhtif_exit_code == 0) {
         fprintf(stdout, "SUCCESS\n");
       } else {
-        fprintf(stdout, "FAILURE: %" PRIi64 " (0x%08" PRIx64 ")\n", model.zhtif_exit_code, (uint64_t)model.zhtif_exit_code);
+        fprintf(stdout, "FAILURE: %" PRIi64 " (0x%08" PRIx64 ")\n", model.zhtif_exit_code, model.zhtif_exit_code);
         exit(EXIT_FAILURE);
       }
     }

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -292,7 +292,7 @@ function loop () : unit -> unit = {
     if htif_done then {
       let exit_val = unsigned(htif_exit_code);
       if exit_val == 0 then print("SUCCESS")
-      else print_string("FAILURE: ", dec_str(exit_val) ^ " (0x" ^ hex_bits_str(htif_exit_code) ^ ")");
+      else print_endline("FAILURE: " ^ dec_str(exit_val) ^ " (" ^ bits_str(htif_exit_code) ^ ")");
     } else {
       // update time
       i = i + 1;

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -292,7 +292,7 @@ function loop () : unit -> unit = {
     if htif_done then {
       let exit_val = unsigned(htif_exit_code);
       if exit_val == 0 then print("SUCCESS")
-      else print_int("FAILURE: ", exit_val);
+      else print_string("FAILURE: ", dec_str(exit_val) ^ " (0x" ^ hex_bits_str(htif_exit_code) ^ ")");
     } else {
       // update time
       i = i + 1;


### PR DESCRIPTION
When a test exits via the HTIF tohost protocol with a non-zero exit code, the simulator prints "FAILURE: N". The decimal value is not immediately interpretable in ACT tests because tohost encodes the test number and result in specific bit fields.

Print the value in both decimal and hex:
  FAILURE: 100664112 (0x06000330)

Change both the C emulator (riscv_sim.cpp) and the Sail interpreter path (model/postlude/step.sail) so all frontends produce the same format. The Sail path uses dec_str() and hex_bits_str() which are already available in the prelude.