### PR TITLE
Fix incorrect ignore of the lowest three bits of `base.scounteren_writable_bits`.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -32,8 +32,8 @@
     // and `cycle`, `time` and `instret` registers, are read-only
     // zero. A set bit specifies that the corresponding bit of
     // `scounteren` is writable, otherwise the bit is read-only zero.
-    // If Sscounterenw is supported this must be a superset of
-    // `writable_hpm_counters`.
+    // If Sscounterenw is supported the top 29 bits must be a superset of
+    // the top 29 bits of `writable_hpm_counters`.
     "scounteren_writable_bits": {
       "len": 32,
       "value": "0xFFFF_FFFF"

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -27,11 +27,11 @@
       "len": 32,
       "value": "0xFFFF_FFFF"
     },
-    // The top 29 bits in this value control whether the
-    // corresponding bits of the `scounteren` CSR that control HPM
-    // counters are read-only zero. A set bit specifies that the
-    // corresponding bit of `scounteren` is writable, otherwise
-    // the bit is read-only zero.  The lowest 3 bits are ignored.
+    // The bits in this value control whether the corresponding bits
+    // of the `scounteren` CSR that control access to HPM counters,
+    // and `cycle`, `time` and `instret` registers, are read-only
+    // zero. A set bit specifies that the corresponding bit of
+    // `scounteren` is writable, otherwise the bit is read-only zero.
     // If Sscounterenw is supported this must be a superset of
     // `writable_hpm_counters`.
     "scounteren_writable_bits": {

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -10,6 +10,9 @@
     to false to match previous behavior.
   - The alignment constraints of the bases of the `mtvec` and `stvec`
     CSRs can now be specified; see `base.{m,s}tvec.base_alignment`.
+  - The `base.scounteren_writable_bits` option now does not ignore the
+    lowest three bits, governing access to the `cycle`, `time` and
+    `instret` CSRs from U-mode.
 
 - Performance improvements:
   - https://github.com/riscv/sail-riscv/pull/1692 : Optional `ENABLE_LTO`

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -580,7 +580,7 @@ bitfield Counteren : bits(32) = {
 
 function clause currentlyEnabled(Ext_Sscounterenw) = hartSupports(Ext_Sscounterenw) & currentlyEnabled(Ext_S)
 
-// Which bits of `scounteren` are writable. Bits [2 .. 0] are ignored.
+// Which bits of `scounteren` are writable.
 let sys_scounteren_writable_bits : bits(32) = config base.scounteren_writable_bits
 
 // scounteren

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -585,7 +585,7 @@ let sys_scounteren_writable_bits : bits(32) = config base.scounteren_writable_bi
 
 // scounteren
 private function legalize_scounteren(_c : Counteren, v : xlenbits) -> Counteren =
-  Mk_Counteren(v[31 .. 0] & (sys_scounteren_writable_bits[31 .. 3] @ 0b111))
+  Mk_Counteren(v[31 .. 0] & sys_scounteren_writable_bits)
 
 register scounteren : Counteren
 mapping clause csr_name_map = 0x106  <-> "scounteren"


### PR DESCRIPTION
According to the spec, all bits of `scounteren` are WARL:

> scounteren must be implemented. However, any of the bits may be read-only zero, indicating reads to the corresponding counter will cause an exception when executing in U-mode. Hence, they are effectively WARL fields.

Ignoring the lowest three bits of the parameter did not allow the corresponding bits of `scounteren` to be readonly-zero.