### PR TITLE
Add a `base.mcounteren_writable_bits` configuration.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -38,6 +38,16 @@
       "len": 32,
       "value": "0xFFFF_FFFF"
     },
+    // The bits in this value control whether the corresponding bits
+    // of the `mcounteren` CSR that control access to HPM counters,
+    // and `cycle`, `time` and `instret` registers at lower privilege
+    // modes, are read-only zero. A set bit specifies that the
+    // corresponding bit of `mcounteren` is writable, otherwise the
+    // bit is read-only zero.
+    "mcounteren_writable_bits": {
+      "len": 32,
+      "value": "0xFFFF_FFFF"
+    },
     // The `{m,s}tvec.base_alignment` parameters control the alignment
     // of the trap vector base for each mode.  The alignment is
     // specified as the power of 2 of the desired byte alignment, and

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -13,6 +13,9 @@
   - The `base.scounteren_writable_bits` option now does not ignore the
     lowest three bits, governing access to the `cycle`, `time` and
     `instret` CSRs from U-mode.
+  - Writable bits of the `mcounteren` CSR can now be specified;
+    see `base.mcounteren_writable_bits`. (This was previously controlled
+    by `base.writable_hpm_counters`, which was incorrect.)
 
 - Performance improvements:
   - https://github.com/riscv/sail-riscv/pull/1692 : Optional `ENABLE_LTO`

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -593,10 +593,12 @@ function clause is_CSR_accessible(0x106, _, _) = currentlyEnabled(Ext_S) // scou
 function clause read_CSR(0x106) = zero_extend(scounteren.bits)
 function clause write_CSR(0x106, value) = { scounteren = legalize_scounteren(scounteren, value); Ok(zero_extend(scounteren.bits)) }
 
+// Which bits of `mcounteren` are writable.
+let sys_mcounteren_writable_bits : bits(32) = config base.mcounteren_writable_bits
+
 // mcounteren
 function legalize_mcounteren(_c : Counteren, v : xlenbits) -> Counteren = {
-  let supported_counters = sys_writable_hpm_counters[31 .. 3] @ 0b111;
-  Mk_Counteren(v[31 .. 0] & supported_counters)
+  Mk_Counteren(v[31 .. 0] & sys_mcounteren_writable_bits)
 }
 
 register mcounteren : Counteren


### PR DESCRIPTION
The legalization of `mcounteren` was controlled by `base.writable_hpm_counters`; however, whether hpm counters are read-only zero as specified by `writable_hpm_counters` is independent of whether bits in `mcounteren` can enable access to those counters.

`base.mcounteren_writable_bits` deconflates the two concerns, and is the `mcounteren` counterpart of the existing `base.scounteren_writable_bits`.

Also, like `scounteren`, all bits of `mcounteren` are WARL:

> In harts with U-mode, the mcounteren must be implemented, but all fields are WARL and may be read-only zero

This is unlike `writable_hpm_counters`, which ignores its lowest three bits.