### PR TITLE
Access model exception as a string instead of printing it.

### DIFF
--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -418,10 +418,19 @@ std::string ModelImpl::generate_isa_string() {
   return isa;
 }
 
-void ModelImpl::print_current_exception() {
-  if (current_exception != nullptr) {
-    zprint_exception(*current_exception);
+std::optional<std::string> ModelImpl::string_of_current_exception() {
+  // `current_exception` is initialized to a non-NULL value in `model_init()`.
+  // So `have_exception` needs to be checked first to see if `current_exception` has
+  // a valid value.
+  if (!have_exception) {
+    return std::nullopt;
   }
+  sail_string str;
+  CREATE(sail_string)(&str);
+  zstring_of_exception(&str, *current_exception);
+  std::string exception_str(str);
+  KILL(sail_string)(&str);
+  return exception_str;
 }
 
 void ModelImpl::tick_clock() {

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -56,7 +56,8 @@ public:
   bool dtb_within_configured_pma_memory(uint64_t addr, uint64_t size);
   std::string generate_dts();
   std::string generate_isa_string();
-  void print_current_exception();
+  // returns std::nullopt if the model has not thrown an exception.
+  std::optional<std::string> string_of_current_exception();
 
   void tick_clock();
   bool try_step(int64_t step_no, bool exit_wait);

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -469,7 +469,7 @@ void finish(ModelImpl &model, const CLIOptions &opts, const elf_info &elf_info, 
     fprintf(stderr, "Performance:      %" PRIu64 " kIPS\n", exec_msecs == 0 ? 0 : run_info.total_insns / exec_msecs);
   }
   close_logs();
-  exit(EXIT_SUCCESS);
+  exit(model.had_exception() ? EXIT_FAILURE : EXIT_SUCCESS);
 }
 
 void flush_logs() {
@@ -519,8 +519,9 @@ void run_sail(
     { /* run a Sail step */
       is_waiting = model.try_step(step_no, wait_steps_remaining == 0);
 
-      if (model.had_exception()) {
-        model.print_current_exception();
+      std::optional<std::string> opt_str = model.string_of_current_exception();
+      if (opt_str.has_value()) {
+        fprintf(stdout, "%s\n", opt_str.value().c_str());
         break;
       }
       if (opts.config_print_instr) {

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -107,7 +107,7 @@ add_custom_command(
         --c-preserve config_is_valid
         --c-preserve dtb_within_configured_pma_memory
         --c-preserve generate_canonical_isa_string
-        --c-preserve print_exception
+        --c-preserve string_of_exception
         # Preserve RVFI functions.
         --c-preserve rvfi_set_instr_packet
         --c-preserve rvfi_get_cmd

--- a/model/prelude/errors.sail
+++ b/model/prelude/errors.sail
@@ -23,9 +23,9 @@ function internal_error(file, line, s) = throw Error_internal_error(file ^ ":" ^
 val reserved_behavior : forall ('a : Type). string -> 'a
 function reserved_behavior(message) = throw Error_reserved_behavior(message)
 
-function print_exception(e : exception) -> unit =
+function string_of_exception(e : exception) -> string =
   match e {
-    Error_not_implemented(s)   => print_endline("Not implemented error: " ^ s),
-    Error_internal_error(s)    => print_endline("Internal error: " ^ s),
-    Error_reserved_behavior(s) => print_endline("Fatal reserved behavior: " ^ s),
+    Error_not_implemented(s)   => "Not implemented error: " ^ s,
+    Error_internal_error(s)    => "Internal error: " ^ s,
+    Error_reserved_behavior(s) => "Fatal reserved behavior: " ^ s,
   }


### PR DESCRIPTION
This is a cleaner API and allows the external harness to control its output.

This also fixes a bug where `finish()` would exit with success even if an exception was raised.