### PR TITLE
Adjust callback API to use `ModelImpl` instead of `hart::Model`.

### DIFF
--- a/c_emulator/riscv_callbacks_if.cpp
+++ b/c_emulator/riscv_callbacks_if.cpp
@@ -1,22 +1,20 @@
 #include "riscv_callbacks_if.h"
 
-#include "sail_riscv_model.h"
-
 // Default implementations that do nothing.
 
 // Callback invoked before each step
-void callbacks_if::pre_step_callback([[maybe_unused]] hart::Model &model, [[maybe_unused]] bool is_waiting) {
+void callbacks_if::pre_step_callback([[maybe_unused]] ModelImpl &model, [[maybe_unused]] bool is_waiting) {
 }
 
 // Callback invoked after each step
-void callbacks_if::post_step_callback([[maybe_unused]] hart::Model &model, [[maybe_unused]] bool is_waiting) {
+void callbacks_if::post_step_callback([[maybe_unused]] ModelImpl &model, [[maybe_unused]] bool is_waiting) {
 }
 
-void callbacks_if::fetch_callback([[maybe_unused]] hart::Model &model, [[maybe_unused]] sbits opcode) {
+void callbacks_if::fetch_callback([[maybe_unused]] ModelImpl &model, [[maybe_unused]] sbits opcode) {
 }
 
 void callbacks_if::mem_write_callback(
-  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] const char *type,
   [[maybe_unused]] sbits paddr,
   [[maybe_unused]] uint64_t width,
@@ -25,7 +23,7 @@ void callbacks_if::mem_write_callback(
 }
 
 void callbacks_if::mem_read_callback(
-  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] const char *type,
   [[maybe_unused]] sbits paddr,
   [[maybe_unused]] uint64_t width,
@@ -34,14 +32,14 @@ void callbacks_if::mem_read_callback(
 }
 
 void callbacks_if::mem_exception_callback(
-  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] sbits paddr,
   [[maybe_unused]] uint64_t num_of_exception
 ) {
 }
 
 void callbacks_if::xreg_full_write_callback(
-  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] const_sail_string abi_name,
   [[maybe_unused]] sbits reg,
   [[maybe_unused]] sbits value
@@ -49,14 +47,14 @@ void callbacks_if::xreg_full_write_callback(
 }
 
 void callbacks_if::freg_write_callback(
-  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] unsigned reg,
   [[maybe_unused]] sbits value
 ) {
 }
 
 void callbacks_if::csr_full_write_callback(
-  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] const_sail_string csr_name,
   [[maybe_unused]] unsigned reg,
   [[maybe_unused]] sbits value
@@ -64,7 +62,7 @@ void callbacks_if::csr_full_write_callback(
 }
 
 void callbacks_if::csr_full_read_callback(
-  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] const_sail_string csr_name,
   [[maybe_unused]] unsigned reg,
   [[maybe_unused]] sbits value
@@ -72,34 +70,34 @@ void callbacks_if::csr_full_read_callback(
 }
 
 void callbacks_if::vreg_write_callback(
-  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] unsigned reg,
   [[maybe_unused]] lbits value
 ) {
 }
 
-void callbacks_if::pc_write_callback([[maybe_unused]] hart::Model &model, [[maybe_unused]] sbits new_pc) {
+void callbacks_if::pc_write_callback([[maybe_unused]] ModelImpl &model, [[maybe_unused]] sbits new_pc) {
 }
 
-void callbacks_if::redirect_callback([[maybe_unused]] hart::Model &model, [[maybe_unused]] sbits new_pc) {
+void callbacks_if::redirect_callback([[maybe_unused]] ModelImpl &model, [[maybe_unused]] sbits new_pc) {
 }
 
 void callbacks_if::trap_callback(
-  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] bool is_interrupt,
   [[maybe_unused]] fbits cause
 ) {
 }
 
-void callbacks_if::xret_callback([[maybe_unused]] hart::Model &model, [[maybe_unused]] bool is_mret) {
+void callbacks_if::xret_callback([[maybe_unused]] ModelImpl &model, [[maybe_unused]] bool is_mret) {
 }
 
-void callbacks_if::instret_callback([[maybe_unused]] hart::Model &model) {
+void callbacks_if::instret_callback([[maybe_unused]] ModelImpl &model) {
 }
 
 // Page table walk callbacks
 void callbacks_if::ptw_start_callback(
-  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] uint64_t vpn,
   [[maybe_unused]] hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
   [[maybe_unused]] hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
@@ -107,7 +105,7 @@ void callbacks_if::ptw_start_callback(
 }
 
 void callbacks_if::ptw_step_callback(
-  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] int64_t level,
   [[maybe_unused]] sbits pte_addr,
   [[maybe_unused]] uint64_t pte
@@ -115,14 +113,14 @@ void callbacks_if::ptw_step_callback(
 }
 
 void callbacks_if::ptw_success_callback(
-  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] uint64_t final_ppn,
   [[maybe_unused]] int64_t level
 ) {
 }
 
 void callbacks_if::ptw_fail_callback(
-  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] hart::zPTW_Error error_type,
   [[maybe_unused]] int64_t level,
   [[maybe_unused]] sbits pte_addr
@@ -130,20 +128,20 @@ void callbacks_if::ptw_fail_callback(
 }
 
 void callbacks_if::tlb_add_callback(
-  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
   [[maybe_unused]] uint64_t index
 ) {
 }
 
-void callbacks_if::tlb_flush_begin_callback([[maybe_unused]] hart::Model &model) {
+void callbacks_if::tlb_flush_begin_callback([[maybe_unused]] ModelImpl &model) {
 }
 
-void callbacks_if::tlb_flush_callback([[maybe_unused]] hart::Model &model, [[maybe_unused]] uint64_t index) {
+void callbacks_if::tlb_flush_callback([[maybe_unused]] ModelImpl &model, [[maybe_unused]] uint64_t index) {
 }
 
 void callbacks_if::tlb_flush_end_callback(
-  [[maybe_unused]] hart::Model &model,
+  [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb
 ) {
 }

--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -1,10 +1,9 @@
 #pragma once
 
+#include "riscv_model_impl.h"
 #include "sail.h"
 
 namespace hart {
-
-class Model;
 
 struct zMemoryAccessTypezIEmem_payloadz5zK;
 struct ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9;
@@ -17,62 +16,62 @@ public:
   virtual ~callbacks_if() = default;
 
   // Callback invoked before each step
-  virtual void pre_step_callback(hart::Model &model, bool is_waiting);
+  virtual void pre_step_callback(ModelImpl &model, bool is_waiting);
 
   // Callback invoked after each step
-  virtual void post_step_callback(hart::Model &model, bool is_waiting);
+  virtual void post_step_callback(ModelImpl &model, bool is_waiting);
 
-  virtual void fetch_callback(hart::Model &model, sbits opcode);
+  virtual void fetch_callback(ModelImpl &model, sbits opcode);
 
-  virtual void mem_write_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value);
+  virtual void mem_write_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value);
 
-  virtual void mem_read_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value);
+  virtual void mem_read_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value);
 
-  virtual void mem_exception_callback(hart::Model &model, sbits paddr, uint64_t num_of_exception);
+  virtual void mem_exception_callback(ModelImpl &model, sbits paddr, uint64_t num_of_exception);
 
-  virtual void xreg_full_write_callback(hart::Model &model, const_sail_string abi_name, sbits reg, sbits value);
+  virtual void xreg_full_write_callback(ModelImpl &model, const_sail_string abi_name, sbits reg, sbits value);
 
-  virtual void freg_write_callback(hart::Model &model, unsigned reg, sbits value);
+  virtual void freg_write_callback(ModelImpl &model, unsigned reg, sbits value);
 
-  virtual void csr_full_write_callback(hart::Model &model, const_sail_string csr_name, unsigned reg, sbits value);
+  virtual void csr_full_write_callback(ModelImpl &model, const_sail_string csr_name, unsigned reg, sbits value);
 
-  virtual void csr_full_read_callback(hart::Model &model, const_sail_string csr_name, unsigned reg, sbits value);
+  virtual void csr_full_read_callback(ModelImpl &model, const_sail_string csr_name, unsigned reg, sbits value);
 
-  virtual void vreg_write_callback(hart::Model &model, unsigned reg, lbits value);
+  virtual void vreg_write_callback(ModelImpl &model, unsigned reg, lbits value);
 
-  virtual void pc_write_callback(hart::Model &model, sbits new_pc);
+  virtual void pc_write_callback(ModelImpl &model, sbits new_pc);
 
-  virtual void redirect_callback(hart::Model &model, sbits new_pc);
+  virtual void redirect_callback(ModelImpl &model, sbits new_pc);
 
-  virtual void trap_callback(hart::Model &model, bool is_interrupt, fbits cause);
+  virtual void trap_callback(ModelImpl &model, bool is_interrupt, fbits cause);
 
-  virtual void xret_callback(hart::Model &model, bool is_mret);
+  virtual void xret_callback(ModelImpl &model, bool is_mret);
 
-  virtual void instret_callback(hart::Model &model);
+  virtual void instret_callback(ModelImpl &model);
 
   // Page table walk callbacks
   virtual void ptw_start_callback(
-    hart::Model &model,
+    ModelImpl &model,
     uint64_t vpn,
     hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
     hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
   );
 
-  virtual void ptw_step_callback(hart::Model &model, int64_t level, sbits pte_addr, uint64_t pte);
+  virtual void ptw_step_callback(ModelImpl &model, int64_t level, sbits pte_addr, uint64_t pte);
 
-  virtual void ptw_success_callback(hart::Model &model, uint64_t final_ppn, int64_t level);
+  virtual void ptw_success_callback(ModelImpl &model, uint64_t final_ppn, int64_t level);
 
-  virtual void ptw_fail_callback(hart::Model &model, hart::zPTW_Error error_type, int64_t level, sbits pte_addr);
+  virtual void ptw_fail_callback(ModelImpl &model, hart::zPTW_Error error_type, int64_t level, sbits pte_addr);
 
   virtual void tlb_add_callback(
-    hart::Model &model,
+    ModelImpl &model,
     hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
     uint64_t index
   );
 
-  virtual void tlb_flush_begin_callback(hart::Model &model);
+  virtual void tlb_flush_begin_callback(ModelImpl &model);
 
-  virtual void tlb_flush_callback(hart::Model &model, uint64_t index);
+  virtual void tlb_flush_callback(ModelImpl &model, uint64_t index);
 
-  virtual void tlb_flush_end_callback(hart::Model &model, hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb);
+  virtual void tlb_flush_end_callback(ModelImpl &model, hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb);
 };

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -1,5 +1,5 @@
 #include "riscv_callbacks_log.h"
-#include "sail_riscv_model.h"
+#include "riscv_model_impl.h"
 #include <algorithm>
 #include <inttypes.h>
 #include <vector>
@@ -29,7 +29,7 @@ log_callbacks::log_callbacks(
 // Implementations of default callbacks for trace printing.
 // The model assumes that these functions do not change the state of the model.
 
-void log_callbacks::mem_write_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value) {
+void log_callbacks::mem_write_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) {
   // This is just passed due to Sail type system requirements.
   (void)width;
   if (trace_log != nullptr && config_print_mem_access) {
@@ -44,7 +44,7 @@ void log_callbacks::mem_write_callback(hart::Model &model, const char *type, sbi
   }
 }
 
-void log_callbacks::mem_read_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value) {
+void log_callbacks::mem_read_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) {
   // This is just passed due to Sail type system requirements.
   (void)width;
   if (trace_log != nullptr && config_print_mem_access) {
@@ -59,7 +59,7 @@ void log_callbacks::mem_read_callback(hart::Model &model, const char *type, sbit
   }
 }
 
-void log_callbacks::xreg_full_write_callback(hart::Model &, const_sail_string abi_name, sbits reg, sbits value) {
+void log_callbacks::xreg_full_write_callback(ModelImpl &, const_sail_string abi_name, sbits reg, sbits value) {
   if (trace_log != nullptr && config_print_gpr) {
     if (config_use_abi_names) {
       fprintf(trace_log, "%s <- 0x%0*" PRIX64 "\n", abi_name, static_cast<int>(value.len / 4), value.bits);
@@ -69,7 +69,7 @@ void log_callbacks::xreg_full_write_callback(hart::Model &, const_sail_string ab
   }
 }
 
-void log_callbacks::freg_write_callback(hart::Model &, unsigned reg, sbits value) {
+void log_callbacks::freg_write_callback(ModelImpl &, unsigned reg, sbits value) {
   // TODO: will only print bits; should we print in floating point format?
   if (trace_log != nullptr && config_print_fpr) {
     // TODO: Might need to change from PRIX64 to PRIX128 once the "Q"
@@ -78,7 +78,7 @@ void log_callbacks::freg_write_callback(hart::Model &, unsigned reg, sbits value
   }
 }
 
-void log_callbacks::csr_full_write_callback(hart::Model &, const_sail_string csr_name, unsigned reg, sbits value) {
+void log_callbacks::csr_full_write_callback(ModelImpl &, const_sail_string csr_name, unsigned reg, sbits value) {
   if (trace_log != nullptr && config_print_csr) {
     fprintf(
       trace_log,
@@ -91,7 +91,7 @@ void log_callbacks::csr_full_write_callback(hart::Model &, const_sail_string csr
   }
 }
 
-void log_callbacks::csr_full_read_callback(hart::Model &, const_sail_string csr_name, unsigned reg, sbits value) {
+void log_callbacks::csr_full_read_callback(ModelImpl &, const_sail_string csr_name, unsigned reg, sbits value) {
   if (trace_log != nullptr && config_print_csr) {
     fprintf(
       trace_log,
@@ -104,7 +104,7 @@ void log_callbacks::csr_full_read_callback(hart::Model &, const_sail_string csr_
   }
 }
 
-void log_callbacks::vreg_write_callback(hart::Model &, unsigned reg, lbits value) {
+void log_callbacks::vreg_write_callback(ModelImpl &, unsigned reg, lbits value) {
   if (trace_log != nullptr && config_print_vreg) {
     fprintf(trace_log, "v%d <- ", reg);
     gmp_fprintf(trace_log, "0x%0*ZX\n", value.len / 4, *value.bits);
@@ -113,7 +113,7 @@ void log_callbacks::vreg_write_callback(hart::Model &, unsigned reg, lbits value
 
 // Page table walk callback
 void log_callbacks::ptw_start_callback(
-  hart::Model &model,
+  ModelImpl &model,
   uint64_t vpn,
   hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
   hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
@@ -130,7 +130,7 @@ void log_callbacks::ptw_start_callback(
   }
 }
 
-void log_callbacks::ptw_step_callback(hart::Model & /*model*/, int64_t level, sbits pte_addr, uint64_t pte) {
+void log_callbacks::ptw_step_callback(ModelImpl & /*model*/, int64_t level, sbits pte_addr, uint64_t pte) {
   if (trace_log != nullptr && config_print_ptw) {
     fprintf(
       trace_log,
@@ -142,14 +142,14 @@ void log_callbacks::ptw_step_callback(hart::Model & /*model*/, int64_t level, sb
   }
 }
 
-void log_callbacks::ptw_success_callback(hart::Model & /*model*/, uint64_t final_ppn, int64_t level) {
+void log_callbacks::ptw_success_callback(ModelImpl & /*model*/, uint64_t final_ppn, int64_t level) {
   if (trace_log != nullptr && config_print_ptw) {
     fprintf(trace_log, "PTW: Success, final_ppn=0x%" PRIx64 ", level=%" PRId64 "\n", final_ppn, level);
   }
 }
 
 void log_callbacks::ptw_fail_callback(
-  hart::Model &model,
+  ModelImpl &model,
   struct hart::zPTW_Error error_type,
   int64_t level,
   sbits pte_addr
@@ -171,7 +171,7 @@ void log_callbacks::ptw_fail_callback(
 
 static void print_tlb(
   FILE *trace_log,
-  hart::Model &model,
+  ModelImpl &model,
   hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
   const std::vector<uint64_t> &indices,
   bool is_flush
@@ -232,7 +232,7 @@ static void print_tlb(
 }
 
 void log_callbacks::tlb_add_callback(
-  hart::Model &model,
+  ModelImpl &model,
   hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
   uint64_t index
 ) {
@@ -243,17 +243,17 @@ void log_callbacks::tlb_add_callback(
 
 std::vector<uint64_t> pending_flush_indices;
 
-void log_callbacks::tlb_flush_begin_callback(hart::Model &model) {
+void log_callbacks::tlb_flush_begin_callback(ModelImpl &model) {
   pending_flush_indices.clear();
 }
 
-void log_callbacks::tlb_flush_callback(hart::Model &model, uint64_t index) {
+void log_callbacks::tlb_flush_callback(ModelImpl &model, uint64_t index) {
   if (config_print_tlb) {
     pending_flush_indices.push_back(index);
   }
 }
 
-void log_callbacks::tlb_flush_end_callback(hart::Model &model, hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb) {
+void log_callbacks::tlb_flush_end_callback(ModelImpl &model, hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb) {
   if (trace_log != nullptr && config_print_tlb && !pending_flush_indices.empty()) {
     print_tlb(trace_log, model, tlb, pending_flush_indices, true);
   }

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -19,36 +19,31 @@ public:
   );
 
   // callbacks_if
-  void mem_write_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
-  void mem_read_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
-  void xreg_full_write_callback(hart::Model &model, const_sail_string abi_name, sbits reg, sbits value) override;
-  void freg_write_callback(hart::Model &model, unsigned reg, sbits value) override;
-  void csr_full_write_callback(hart::Model &model, const_sail_string csr_name, unsigned reg, sbits value) override;
-  void csr_full_read_callback(hart::Model &model, const_sail_string csr_name, unsigned reg, sbits value) override;
-  void vreg_write_callback(hart::Model &model, unsigned reg, lbits value) override;
+  void mem_write_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
+  void mem_read_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
+  void xreg_full_write_callback(ModelImpl &model, const_sail_string abi_name, sbits reg, sbits value) override;
+  void freg_write_callback(ModelImpl &model, unsigned reg, sbits value) override;
+  void csr_full_write_callback(ModelImpl &model, const_sail_string csr_name, unsigned reg, sbits value) override;
+  void csr_full_read_callback(ModelImpl &model, const_sail_string csr_name, unsigned reg, sbits value) override;
+  void vreg_write_callback(ModelImpl &model, unsigned reg, lbits value) override;
   // Page table walk callback
   void ptw_start_callback(
-    hart::Model &model,
+    ModelImpl &model,
     uint64_t vpn,
     hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
     hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
   ) override;
-  void ptw_step_callback(hart::Model &model, int64_t level, sbits pte_addr, uint64_t pte) override;
-  void ptw_success_callback(hart::Model &model, uint64_t final_ppn, int64_t level) override;
-  void ptw_fail_callback(
-    hart::Model &model,
-    struct hart::zPTW_Error error_type,
-    int64_t level,
-    sbits pte_addr
-  ) override;
+  void ptw_step_callback(ModelImpl &model, int64_t level, sbits pte_addr, uint64_t pte) override;
+  void ptw_success_callback(ModelImpl &model, uint64_t final_ppn, int64_t level) override;
+  void ptw_fail_callback(ModelImpl &model, struct hart::zPTW_Error error_type, int64_t level, sbits pte_addr) override;
   void tlb_add_callback(
-    hart::Model &model,
+    ModelImpl &model,
     hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
     uint64_t index
   ) override;
-  void tlb_flush_begin_callback(hart::Model &model) override;
-  void tlb_flush_callback(hart::Model &model, uint64_t index) override;
-  void tlb_flush_end_callback(hart::Model &model, hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb) override;
+  void tlb_flush_begin_callback(ModelImpl &model) override;
+  void tlb_flush_callback(ModelImpl &model, uint64_t index) override;
+  void tlb_flush_end_callback(ModelImpl &model, hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb) override;
 
 private:
   bool config_print_gpr;

--- a/c_emulator/riscv_callbacks_rvfi.cpp
+++ b/c_emulator/riscv_callbacks_rvfi.cpp
@@ -2,16 +2,16 @@
 #include <inttypes.h>
 #include <stdlib.h>
 
-#include "sail_riscv_model.h"
+#include "riscv_model_impl.h"
 
 // Implementations of default callbacks for RVFI.
 // The model assumes that these functions do not change the state of the model.
 
-void rvfi_callbacks::mem_write_callback(hart::Model &model, const char *, sbits paddr, uint64_t width, lbits value) {
+void rvfi_callbacks::mem_write_callback(ModelImpl &model, const char *, sbits paddr, uint64_t width, lbits value) {
   model.zrvfi_write(paddr, width, value);
 }
 
-void rvfi_callbacks::mem_read_callback(hart::Model &model, const char *, sbits paddr, uint64_t width, lbits value) {
+void rvfi_callbacks::mem_read_callback(ModelImpl &model, const char *, sbits paddr, uint64_t width, lbits value) {
   sail_int len;
   CREATE(sail_int)(&len);
   CONVERT_OF(sail_int, mach_int)(&len, width);
@@ -19,15 +19,15 @@ void rvfi_callbacks::mem_read_callback(hart::Model &model, const char *, sbits p
   KILL(sail_int)(&len);
 }
 
-void rvfi_callbacks::mem_exception_callback(hart::Model &model, sbits paddr, uint64_t) {
+void rvfi_callbacks::mem_exception_callback(ModelImpl &model, sbits paddr, uint64_t) {
   model.zrvfi_mem_exception(paddr);
 }
 
-void rvfi_callbacks::xreg_full_write_callback(hart::Model &model, const_sail_string, sbits reg, sbits value) {
+void rvfi_callbacks::xreg_full_write_callback(ModelImpl &model, const_sail_string, sbits reg, sbits value) {
   model.zrvfi_wX(reg.bits, value);
 }
 
-void rvfi_callbacks::trap_callback(hart::Model &model, bool is_interrupt, fbits cause) {
+void rvfi_callbacks::trap_callback(ModelImpl &model, bool is_interrupt, fbits cause) {
   (void)is_interrupt;
   (void)cause;
   model.zrvfi_trap(UNIT);

--- a/c_emulator/riscv_callbacks_rvfi.h
+++ b/c_emulator/riscv_callbacks_rvfi.h
@@ -6,9 +6,9 @@ class rvfi_callbacks : public callbacks_if {
 
 public:
   // callbacks_if
-  void mem_write_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
-  void mem_read_callback(hart::Model &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
-  void mem_exception_callback(hart::Model &model, sbits paddr, uint64_t num_of_exception) override;
-  void xreg_full_write_callback(hart::Model &model, const_sail_string abi_name, sbits reg, sbits value) override;
-  void trap_callback(hart::Model &model, bool is_interrupt, fbits cause) override;
+  void mem_write_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
+  void mem_read_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
+  void mem_exception_callback(ModelImpl &model, sbits paddr, uint64_t num_of_exception) override;
+  void xreg_full_write_callback(ModelImpl &model, const_sail_string abi_name, sbits reg, sbits value) override;
+  void trap_callback(ModelImpl &model, bool is_interrupt, fbits cause) override;
 };

--- a/c_emulator/rvfi_dii.cpp
+++ b/c_emulator/rvfi_dii.cpp
@@ -16,7 +16,7 @@
 #include "rvfi_dii.h"
 #include "sail.h"
 
-rvfi_handler::rvfi_handler(int port, hart::Model &model) : dii_port(port), m_model(model) {
+rvfi_handler::rvfi_handler(int port, ModelImpl &model) : dii_port(port), m_model(model) {
   fprintf(stderr, "using %d as RVFI port.\n", port);
 }
 

--- a/c_emulator/rvfi_dii.h
+++ b/c_emulator/rvfi_dii.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include "riscv_model_impl.h"
 #include "sail.h"
-#include "sail_riscv_model.h"
 
 enum rvfi_prestep_t {
   RVFI_prestep_continue,  // continue loop
@@ -14,7 +14,7 @@ using packet_reader_fn = void (hart::Model::*)(lbits *rop, unit);
 
 class rvfi_handler {
 public:
-  explicit rvfi_handler(int port, hart::Model &model);
+  explicit rvfi_handler(int port, ModelImpl &model);
 
   bool setup_socket(bool config_print);
   uint64_t get_entry();
@@ -28,5 +28,5 @@ private:
   int dii_port = -1;
   int dii_sock = -1;
 
-  hart::Model &m_model;
+  ModelImpl &m_model;
 };

--- a/c_emulator/traploop_detector.cpp
+++ b/c_emulator/traploop_detector.cpp
@@ -1,5 +1,4 @@
 #include "traploop_detector.h"
-#include "sail_riscv_model.h"
 #include <cstdlib>
 #include <inttypes.h>
 
@@ -14,7 +13,7 @@ void traploop_detector::reset() {
   nested_trap_count = 0;
 }
 
-void traploop_detector::trap_callback(hart::Model &model, bool, fbits) {
+void traploop_detector::trap_callback(ModelImpl &model, bool, fbits) {
   if (nested_trap_count == 0) {
     mepc_at_first_trap = model.zmepc.bits;
     sepc_at_first_trap = model.zsepc.bits;
@@ -23,11 +22,11 @@ void traploop_detector::trap_callback(hart::Model &model, bool, fbits) {
   instrets_since_last_trap = 0;
 }
 
-void traploop_detector::xret_callback(hart::Model &, bool) {
+void traploop_detector::xret_callback(ModelImpl &, bool) {
   reset();
 }
 
-void traploop_detector::instret_callback(hart::Model &) {
+void traploop_detector::instret_callback(ModelImpl &) {
   if (nested_trap_count != 0) {
     instrets_since_last_trap++;
     if (instrets_since_last_trap > instrets_to_reset_loop) {

--- a/c_emulator/traploop_detector.h
+++ b/c_emulator/traploop_detector.h
@@ -14,9 +14,9 @@ public:
   uint64_t sepc() const;
 
   // callbacks_if
-  void trap_callback(hart::Model &model, bool is_interrupt, fbits cause) override;
-  void xret_callback(hart::Model &model, bool is_mret) override;
-  void instret_callback(hart::Model &model) override;
+  void trap_callback(ModelImpl &model, bool is_interrupt, fbits cause) override;
+  void xret_callback(ModelImpl &model, bool is_mret) override;
+  void instret_callback(ModelImpl &model) override;
 
 private:
   uint64_t mepc_at_first_trap = 0;


### PR DESCRIPTION
This enables a subsequent refactor where the callbacks can avoid direct access of the internals of the Sail model and instead use appropriate wrappers in `ModelImpl`.