### PR TITLE
Add a config option for the maximum index EEW for the indexed vector addressing mode.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -379,9 +379,9 @@
       "vlen_exp": @CONFIG__V__VLEN_EXP@,
       "elen_exp": @CONFIG__V__ELEN_EXP@,
       "vl_use_ceil": false,
-      // The maximum index EEW for indexed vector addressing mode,
-      // as a power of 2.  This must not exceed the supported
-      // ELEN.
+      // The maximum index EEW for indexed vector addressing mode, as
+      // a power of 2.  This must be at least 3 but must not exceed
+      // the supported ELEN.
       "max_index_eew_exp": @CONFIG__V__ELEN_EXP@
     },
     "B": {

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -380,7 +380,7 @@
       "elen_exp": @CONFIG__V__ELEN_EXP@,
       "vl_use_ceil": false,
       // The maximum index EEW for indexed vector addressing mode,
-      // as a power of 2.  This needs to be less then the supported
+      // as a power of 2.  This must not exceed the supported
       // ELEN.
       "max_index_eew_exp": @CONFIG__V__ELEN_EXP@
     },

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -379,6 +379,9 @@
       "vlen_exp": @CONFIG__V__VLEN_EXP@,
       "elen_exp": @CONFIG__V__ELEN_EXP@,
       "vl_use_ceil": false,
+      // The maximum index EEW for indexed vector addressing mode,
+      // as a power of 2.  This needs to be less then the supported
+      // ELEN.
       "max_index_eew_exp": @CONFIG__V__ELEN_EXP@
     },
     "B": {

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -378,7 +378,8 @@
       // should be left as 3 (or any other legal value).
       "vlen_exp": @CONFIG__V__VLEN_EXP@,
       "elen_exp": @CONFIG__V__ELEN_EXP@,
-      "vl_use_ceil": false
+      "vl_use_ceil": false,
+      "max_index_eew_exp": @CONFIG__V__ELEN_EXP@
     },
     "B": {
       "supported": true

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -8,6 +8,8 @@
     by the same hart to the reservation set has been added; see
     `platform.reservation.invalidate_on_same_hart_store`. This defaults
     to false to match previous behavior.
+  - The maximum supported index EEW for the indexed vector addressing
+    mode can be specified; see `extensions.V.max_index_eew_exp`.
   - The alignment constraints of the bases of the `mtvec` and `stvec`
     CSRs can now be specified; see `base.{m,s}tvec.base_alignment`.
 

--- a/model/extensions/V/vext_control.sail
+++ b/model/extensions/V/vext_control.sail
@@ -25,6 +25,7 @@ function clause currentlyEnabled(Ext_V) = hartSupports(Ext_V) & (misa[V] == 0b1)
 function clause currentlyEnabled(Ext_Zvfh)    = hartSupports(Ext_Zvfh)     & currentlyEnabled(Ext_Zve32f) & currentlyEnabled(Ext_Zfhmin)
 function clause currentlyEnabled(Ext_Zvfhmin) = (hartSupports(Ext_Zvfhmin) & currentlyEnabled(Ext_Zve32f)) | currentlyEnabled(Ext_Zvfh)
 
+let max_index_eew_exp : int = config extensions.V.max_index_eew_exp
 // Get the total number of elements in a register group (not considering `vl`).
 // For fractional groups (negative LMUL_pow) we return the number of elements
 // in a single register. The fractional aspect is handled by `init_masked_result()`.

--- a/model/extensions/V/vext_control.sail
+++ b/model/extensions/V/vext_control.sail
@@ -25,7 +25,8 @@ function clause currentlyEnabled(Ext_V) = hartSupports(Ext_V) & (misa[V] == 0b1)
 function clause currentlyEnabled(Ext_Zvfh)    = hartSupports(Ext_Zvfh)     & currentlyEnabled(Ext_Zve32f) & currentlyEnabled(Ext_Zfhmin)
 function clause currentlyEnabled(Ext_Zvfhmin) = (hartSupports(Ext_Zvfhmin) & currentlyEnabled(Ext_Zve32f)) | currentlyEnabled(Ext_Zvfh)
 
-let max_index_eew_exp : int = config extensions.V.max_index_eew_exp
+let max_index_eew_exp : nat = config extensions.V.max_index_eew_exp
+
 // Get the total number of elements in a register group (not considering `vl`).
 // For fractional groups (negative LMUL_pow) we return the number of elements
 // in a single register. The fractional aspect is handled by `init_masked_result()`.

--- a/model/extensions/V/vext_mem_insts.sail
+++ b/model/extensions/V/vext_mem_insts.sail
@@ -361,8 +361,8 @@ union clause instruction = VLXSEGTYPE : (nfields, bits(1), vregidx, regidx, vlew
 
 mapping clause encdec = VLXSEGTYPE(nf, vm, vs2, rs1, width, vd, mop)
   <-> encdec_nfields(nf) @ 0b0 @ encdec_indexed_mop(mop) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
-  when (currentlyEnabled(Ext_Zve32x) & vlewidth_pow(width) <= 5)
-     | (currentlyEnabled(Ext_Zve64x) & vlewidth_pow(width) <= 6 & xlen == 64)
+  when (currentlyEnabled(Ext_Zve32x) & vlewidth_pow(width) <= max_index_eew_exp)
+     | (currentlyEnabled(Ext_Zve64x) & vlewidth_pow(width) <= max_index_eew_exp & xlen == 64)
 
 // `mop` selects between the ordered and unordered variants of these instructions.  This function currently
 // only implements the ordered variant, hence `mop` is ignored.
@@ -426,8 +426,8 @@ union clause instruction = VSXSEGTYPE : (nfields, bits(1), vregidx, regidx, vlew
 
 mapping clause encdec = VSXSEGTYPE(nf, vm, vs2, rs1, width, vs3, mop)
   <-> encdec_nfields(nf) @ 0b0 @ encdec_indexed_mop(mop) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
-  when (currentlyEnabled(Ext_Zve32x) & vlewidth_pow(width) <= 5)
-     | (currentlyEnabled(Ext_Zve64x) & vlewidth_pow(width) <= 6 & xlen == 64)
+  when (currentlyEnabled(Ext_Zve32x) & vlewidth_pow(width) <= max_index_eew_exp)
+     | (currentlyEnabled(Ext_Zve64x) & vlewidth_pow(width) <= max_index_eew_exp & xlen == 64)
 
 // `mop` selects between the ordered and unordered variants of these instructions.  This function currently
 // only implements the ordered variant, hence `mop` is ignored.

--- a/model/extensions/V/vext_mem_insts.sail
+++ b/model/extensions/V/vext_mem_insts.sail
@@ -426,7 +426,6 @@ union clause instruction = VSXSEGTYPE : (nfields, bits(1), vregidx, regidx, vlew
 mapping clause encdec = VSXSEGTYPE(nf, vm, vs2, rs1, width, vs3, mop)
   <-> encdec_nfields(nf) @ 0b0 @ encdec_indexed_mop(mop) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vs3) @ 0b0100111
   when (currentlyEnabled(Ext_Zve32x) & vlewidth_pow(width) <= max_index_eew_exp)
-     | (currentlyEnabled(Ext_Zve64x) & vlewidth_pow(width) <= max_index_eew_exp & xlen == 64)
 
 // `mop` selects between the ordered and unordered variants of these instructions.  This function currently
 // only implements the ordered variant, hence `mop` is ignored.

--- a/model/extensions/V/vext_mem_insts.sail
+++ b/model/extensions/V/vext_mem_insts.sail
@@ -361,8 +361,7 @@ union clause instruction = VLXSEGTYPE : (nfields, bits(1), vregidx, regidx, vlew
 
 mapping clause encdec = VLXSEGTYPE(nf, vm, vs2, rs1, width, vd, mop)
   <-> encdec_nfields(nf) @ 0b0 @ encdec_indexed_mop(mop) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ encdec_vlewidth(width) @ encdec_vreg(vd) @ 0b0000111
-  when (currentlyEnabled(Ext_Zve32x) & vlewidth_pow(width) <= max_index_eew_exp)
-     | (currentlyEnabled(Ext_Zve64x) & vlewidth_pow(width) <= max_index_eew_exp & xlen == 64)
+   when currentlyEnabled(Ext_Zve32x) & vlewidth_pow(width) <= max_index_eew_exp
 
 // `mop` selects between the ordered and unordered variants of these instructions.  This function currently
 // only implements the ordered variant, hence `mop` is ignored.

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -153,6 +153,11 @@ private function check_vext_config() -> bool = {
     valid = false;
     print_endline("Zve*x is enabled but ELEN is 2^" ^ dec_str(elen_exp) ^ ": ELEN must be >= 2^5");
   };
+  let max_index_eew = config extensions.V.max_index_eew_exp : nat;
+  if max_index_eew > elen_exp then {
+    valid = false;
+    print_endline("The maximum index EEW is 2^" ^ dec_str(max_index_eew) ^ " but ELEN is 2^" ^ dec_str(elen_exp) ^ ": the index EEW must be less than ELEN.");
+  };
   if vector_support_level >= Float_single & not(config extensions.F.supported : bool) then {
     valid = false;
     print_endline("Zve*f is enabled but F is disabled: supporting Zve*f requires F.");

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -153,10 +153,16 @@ private function check_vext_config() -> bool = {
     valid = false;
     print_endline("Zve*x is enabled but ELEN is 2^" ^ dec_str(elen_exp) ^ ": ELEN must be >= 2^5");
   };
+  // Ideally, this parameter should be
+  //   let max_index_eew_exp = config extensions.V.max_index_eew_exp : range(3, elen_exp)
+  // except that it runs into https://github.com/rems-project/sail/issues/1392
   let max_index_eew = config extensions.V.max_index_eew_exp : nat;
   if max_index_eew > elen_exp then {
     valid = false;
     print_endline("The maximum index EEW is 2^" ^ dec_str(max_index_eew) ^ " but ELEN is 2^" ^ dec_str(elen_exp) ^ ": the index EEW must not exceed ELEN.");
+  } else if max_index_eew < 3 then {
+    valid = false;
+    print_endline("The maximum index EEW is 2^" ^ dec_str(max_index_eew) ^ " but it should be at least 2^3.");
   };
   if vector_support_level >= Float_single & not(config extensions.F.supported : bool) then {
     valid = false;

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -156,7 +156,7 @@ private function check_vext_config() -> bool = {
   let max_index_eew = config extensions.V.max_index_eew_exp : nat;
   if max_index_eew > elen_exp then {
     valid = false;
-    print_endline("The maximum index EEW is 2^" ^ dec_str(max_index_eew) ^ " but ELEN is 2^" ^ dec_str(elen_exp) ^ ": the index EEW must be less than ELEN.");
+    print_endline("The maximum index EEW is 2^" ^ dec_str(max_index_eew) ^ " but ELEN is 2^" ^ dec_str(elen_exp) ^ ": the index EEW must not exceed ELEN.");
   };
   if vector_support_level >= Float_single & not(config extensions.F.supported : bool) then {
     valid = false;


### PR DESCRIPTION
This implements this bit of the spec:

> A profile may place an upper limit on the maximum supported index EEW (e.g., only up to XLEN) smaller than ELEN.

This fixes #1719. 