### PR TITLE
Remove the `trace_log` extern global from the `riscv_model` library.

### DIFF
--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -262,23 +262,23 @@ unit ModelImpl::print_string(const_sail_string prefix, const_sail_string msg) {
 }
 
 unit ModelImpl::print_log(const_sail_string s) {
-  fprintf(trace_log, "%s\n", s);
+  fprintf(m_trace_log, "%s\n", s);
   return UNIT;
 }
 
 unit ModelImpl::print_log_instr(const_sail_string s, uint64_t pc) {
   auto maybe_symbol = symbolize_address(m_symbols, pc);
   if (maybe_symbol.has_value()) {
-    fprintf(trace_log, "%-80s    %s+%" PRIu64 "\n", s, maybe_symbol->second.c_str(), pc - maybe_symbol->first);
+    fprintf(m_trace_log, "%-80s    %s+%" PRIu64 "\n", s, maybe_symbol->second.c_str(), pc - maybe_symbol->first);
   } else {
-    fprintf(trace_log, "%s\n", s);
+    fprintf(m_trace_log, "%s\n", s);
   }
   return UNIT;
 }
 
 unit ModelImpl::print_step(unit) {
   if (m_config_print_step) {
-    fprintf(trace_log, "\n");
+    fprintf(m_trace_log, "\n");
   }
   return UNIT;
 }
@@ -357,6 +357,11 @@ void ModelImpl::set_elf_symbols(std::map<uint64_t, std::string> symbols) {
 
 void ModelImpl::set_term_fd(int fd) {
   m_term_fd = fd;
+}
+
+void ModelImpl::set_trace_log(FILE *log) {
+  assert(log != nullptr);
+  m_trace_log = log;
 }
 
 void ModelImpl::init_platform_constants() {

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -10,8 +10,6 @@
 #include "sail.h"
 #include "sail_riscv_model.h"
 
-extern FILE *trace_log;
-
 // Model wrapped with an implementation of its platform callbacks.
 class ModelImpl final : public hart::Model {
 public:
@@ -43,6 +41,7 @@ public:
 
   void set_elf_symbols(std::map<uint64_t, std::string> symbols);
   void set_term_fd(int fd);
+  void set_trace_log(FILE *log);
 
   // initialization
 
@@ -162,4 +161,7 @@ private:
 
   // Randomly seeded PRNG.
   std::mt19937_64 m_gen64{seed()};
+
+  // Trace log file
+  FILE *m_trace_log = stdout;
 };

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -56,15 +56,15 @@ struct elf_info {
 
 struct run_info {
   std::optional<rvfi_handler> rvfi;
-  int term_fd = 1;
+  // Terminal output goes to stdout unless changed via the `--terminal-log` option.
+  int term_fd = STDOUT_FILENO;
   steady_clock::time_point init_start;
   steady_clock::time_point init_end;
   uint64_t total_insns = 0;
+  FILE *trace_log = stdout;
 };
 
 } // namespace
-
-FILE *trace_log = stdout;
 
 static void print_build_info() {
   std::cout << "Sail RISC-V release: " << version_info::release_version << std::endl;
@@ -438,19 +438,22 @@ void write_signature(const std::string &file, unsigned signature_granularity, co
   fclose(f);
 }
 
-void close_logs() {
+void close_logs(run_info &run_info) {
+  if (run_info.term_fd != STDOUT_FILENO) {
+    close(run_info.term_fd);
+  }
+  if (run_info.trace_log != stdout) {
+    fclose(run_info.trace_log);
+  }
 #ifdef SAILCOV
   if (sail_coverage_exit() != 0) {
     fprintf(stderr, "Could not write coverage information!\n");
     exit(EXIT_FAILURE);
   }
 #endif
-  if (trace_log != stdout) {
-    fclose(trace_log);
-  }
 }
 
-void finish(ModelImpl &model, const CLIOptions &opts, const elf_info &elf_info, const run_info &run_info) {
+void finish(ModelImpl &model, const CLIOptions &opts, const elf_info &elf_info, run_info &run_info) {
   // Don't write a signature if there was an internal Sail exception.
   if (!model.had_exception() && !opts.sig_file.empty()) {
     write_signature(opts.sig_file, opts.signature_granularity, elf_info);
@@ -468,14 +471,14 @@ void finish(ModelImpl &model, const CLIOptions &opts, const elf_info &elf_info, 
     fprintf(stderr, "Instructions:     %" PRIu64 "\n", run_info.total_insns);
     fprintf(stderr, "Performance:      %" PRIu64 " kIPS\n", exec_msecs == 0 ? 0 : run_info.total_insns / exec_msecs);
   }
-  close_logs();
+  close_logs(run_info);
   exit(model.had_exception() ? EXIT_FAILURE : EXIT_SUCCESS);
 }
 
-void flush_logs() {
+void flush_logs(run_info &run_info) {
   fflush(stderr);
   fflush(stdout);
-  fflush(trace_log);
+  fflush(run_info.trace_log);
 }
 
 void run_sail(
@@ -525,7 +528,7 @@ void run_sail(
         break;
       }
       if (opts.config_print_instr) {
-        flush_logs();
+        flush_logs(run_info);
       }
       if (run_info.rvfi) {
         run_info.rvfi->send_trace(opts.config_print_rvfi);
@@ -545,7 +548,7 @@ void run_sail(
 
     if (!is_waiting) {
       if (opts.config_print_step) {
-        fprintf(trace_log, "\n");
+        fprintf(run_info.trace_log, "\n");
       }
       step_no++;
       insn_cnt++;
@@ -603,8 +606,8 @@ void init_logs(const CLIOptions &opts, run_info &run_info) {
   }
 
   if (!opts.trace_log_path.empty()) {
-    trace_log = fopen(opts.trace_log_path.c_str(), "w+");
-    if (trace_log == nullptr) {
+    run_info.trace_log = fopen(opts.trace_log_path.c_str(), "w+");
+    if (run_info.trace_log == nullptr) {
       fprintf(stderr, "Cannot create trace log '%s': %s\n", opts.trace_log_path.c_str(), strerror(errno));
       exit(EXIT_FAILURE);
     }
@@ -765,6 +768,8 @@ InitResult preinit_model(
   }
 
   init_logs(opts, run_info);
+  model.set_term_fd(run_info.term_fd);
+  model.set_trace_log(run_info.trace_log);
 
   return InitResult::Continue;
 }
@@ -778,7 +783,6 @@ uint64_t init_model(CLIOptions &opts, ModelImpl &model, elf_info &elf_info, run_
     }
     model.register_callback(&rvfi_cbs);
   }
-  model.set_term_fd(run_info.term_fd);
 
   if (!opts.dtb_file.empty()) {
     fprintf(stderr, "using %s as DTB file.\n", opts.dtb_file.c_str());
@@ -820,7 +824,7 @@ void run_model(CLIOptions &opts, ModelImpl &model, uint64_t entry, const elf_inf
     opts.config_print_ptw,
     opts.config_print_tlb,
     opts.config_use_abi_names,
-    trace_log
+    run_info.trace_log
   );
   model.register_callback(&log_cbs);
 
@@ -866,8 +870,8 @@ int inner_main(int argc, char **argv) {
   run_model(opts, model, entry, elf_info, run_info);
 
   model.model_fini();
-  flush_logs();
-  close_logs();
+  flush_logs(run_info);
+  close_logs(run_info);
 
   return EXIT_SUCCESS;
 }

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -58,6 +58,7 @@ struct run_info {
   std::optional<rvfi_handler> rvfi;
   // Terminal output goes to stdout unless changed via the `--terminal-log` option.
   int term_fd = STDOUT_FILENO;
+  bool close_term_fd = false;
   steady_clock::time_point init_start;
   steady_clock::time_point init_end;
   uint64_t total_insns = 0;
@@ -439,7 +440,7 @@ void write_signature(const std::string &file, unsigned signature_granularity, co
 }
 
 void close_logs(run_info &run_info) {
-  if (run_info.term_fd != STDOUT_FILENO) {
+  if (run_info.close_term_fd) {
     close(run_info.term_fd);
   }
   if (run_info.trace_log != stdout) {
@@ -604,6 +605,7 @@ void init_logs(const CLIOptions &opts, run_info &run_info) {
     fprintf(stderr, "Cannot create terminal log '%s': %s\n", opts.term_log.c_str(), strerror(errno));
     exit(EXIT_FAILURE);
   }
+  run_info.close_term_fd = true;
 
   if (!opts.trace_log_path.empty()) {
     run_info.trace_log = fopen(opts.trace_log_path.c_str(), "w+");


### PR DESCRIPTION
This also now allows `riscv_model` to be compiled as a shared library if needed.

Make `trace_log` part of `run_info` in `riscv_sim` and close the terminal file-descriptor as well when closing logs.  Use a more explicit `STDOUT_FILENO` for `term_fd` instead of `1`, and use a flag to track whether it needs to be closed.