### PR TITLE
Refactor the callback API to avoid z-encoded internal model types.

### DIFF
--- a/c_emulator/riscv_callbacks_if.cpp
+++ b/c_emulator/riscv_callbacks_if.cpp
@@ -99,8 +99,8 @@ void callbacks_if::instret_callback([[maybe_unused]] ModelImpl &model) {
 void callbacks_if::ptw_start_callback(
   [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] uint64_t vpn,
-  [[maybe_unused]] hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
-  [[maybe_unused]] hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+  [[maybe_unused]] ModelImpl::MemoryAccessType access_type,
+  [[maybe_unused]] ModelImpl::Privilege privilege
 ) {
 }
 
@@ -121,7 +121,7 @@ void callbacks_if::ptw_success_callback(
 
 void callbacks_if::ptw_fail_callback(
   [[maybe_unused]] ModelImpl &model,
-  [[maybe_unused]] hart::zPTW_Error error_type,
+  [[maybe_unused]] ModelImpl::PTW_Error error_type,
   [[maybe_unused]] int64_t level,
   [[maybe_unused]] sbits pte_addr
 ) {
@@ -129,7 +129,7 @@ void callbacks_if::ptw_fail_callback(
 
 void callbacks_if::tlb_add_callback(
   [[maybe_unused]] ModelImpl &model,
-  [[maybe_unused]] hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
+  [[maybe_unused]] ModelImpl::TLB_Entry tlb,
   [[maybe_unused]] uint64_t index
 ) {
 }
@@ -142,6 +142,6 @@ void callbacks_if::tlb_flush_callback([[maybe_unused]] ModelImpl &model, [[maybe
 
 void callbacks_if::tlb_flush_end_callback(
   [[maybe_unused]] ModelImpl &model,
-  [[maybe_unused]] hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb
+  [[maybe_unused]] ModelImpl::TLB_Entry tlb
 ) {
 }

--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -3,14 +3,6 @@
 #include "riscv_model_impl.h"
 #include "sail.h"
 
-namespace hart {
-
-struct zMemoryAccessTypezIEmem_payloadz5zK;
-struct ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9;
-struct zPTW_Error;
-struct zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9;
-} // namespace hart
-
 class callbacks_if {
 public:
   virtual ~callbacks_if() = default;
@@ -53,25 +45,21 @@ public:
   virtual void ptw_start_callback(
     ModelImpl &model,
     uint64_t vpn,
-    hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
-    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+    ModelImpl::MemoryAccessType access_type,
+    ModelImpl::Privilege privilege
   );
 
   virtual void ptw_step_callback(ModelImpl &model, int64_t level, sbits pte_addr, uint64_t pte);
 
   virtual void ptw_success_callback(ModelImpl &model, uint64_t final_ppn, int64_t level);
 
-  virtual void ptw_fail_callback(ModelImpl &model, hart::zPTW_Error error_type, int64_t level, sbits pte_addr);
+  virtual void ptw_fail_callback(ModelImpl &model, ModelImpl::PTW_Error error_type, int64_t level, sbits pte_addr);
 
-  virtual void tlb_add_callback(
-    ModelImpl &model,
-    hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
-    uint64_t index
-  );
+  virtual void tlb_add_callback(ModelImpl &model, ModelImpl::TLB_Entry tlb, uint64_t index);
 
   virtual void tlb_flush_begin_callback(ModelImpl &model);
 
   virtual void tlb_flush_callback(ModelImpl &model, uint64_t index);
 
-  virtual void tlb_flush_end_callback(ModelImpl &model, hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb);
+  virtual void tlb_flush_end_callback(ModelImpl &model, ModelImpl::TLB_Entry tlb);
 };

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -37,7 +37,7 @@ void log_callbacks::mem_write_callback(ModelImpl &model, const char *type, sbits
       trace_log,
       "mem[%s,0x%0*" PRIX64 "] <- ",
       type,
-      static_cast<int>((model.zphysaddrbits_len + 3) / 4),
+      static_cast<int>((model.physaddrbits_len() + 3) / 4),
       paddr.bits
     );
     gmp_fprintf(trace_log, "0x%0*ZX\n", value.len / 4, *value.bits);
@@ -52,7 +52,7 @@ void log_callbacks::mem_read_callback(ModelImpl &model, const char *type, sbits 
       trace_log,
       "mem[%s,0x%0*" PRIX64 "] -> ",
       type,
-      static_cast<int>((model.zphysaddrbits_len + 3) / 4),
+      static_cast<int>((model.physaddrbits_len() + 3) / 4),
       paddr.bits
     );
     gmp_fprintf(trace_log, "0x%0*ZX\n", value.len / 4, *value.bits);
@@ -119,14 +119,13 @@ void log_callbacks::ptw_start_callback(
   hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
 ) {
   if (trace_log != nullptr && config_print_ptw) {
-    sail_string str_ac, str_pr;
-    CREATE(sail_string)(&str_ac);
-    CREATE(sail_string)(&str_pr);
-    model.zaccessType_to_str(&str_ac, access_type);
-    model.zprivLevel_to_str(&str_pr, privilege.ztup0);
-    fprintf(trace_log, "PTW: Start, vpn=0x%" PRIx64 ", access_type=%s, privilege=%s\n", vpn, str_ac, str_pr);
-    KILL(sail_string)(&str_ac);
-    KILL(sail_string)(&str_pr);
+    fprintf(
+      trace_log,
+      "PTW: Start, vpn=0x%" PRIx64 ", access_type=%s, privilege=%s\n",
+      vpn,
+      model.memory_access_type_to_string(access_type).c_str(),
+      model.privilege_to_string(privilege).c_str()
+    );
   }
 }
 
@@ -155,17 +154,13 @@ void log_callbacks::ptw_fail_callback(
   sbits pte_addr
 ) {
   if (trace_log != nullptr && config_print_ptw) {
-    sail_string str_et;
-    CREATE(sail_string)(&str_et);
-    model.zptw_error_to_str(&str_et, error_type);
     fprintf(
       trace_log,
       "PTW: failed, error=%s, level=%" PRId64 ", pte_addr=0x%" PRIX64 "\n",
-      str_et,
+      model.ptw_error_to_string(error_type).c_str(),
       level,
       pte_addr.bits
     );
-    KILL(sail_string)(&str_et);
   }
 }
 

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -146,11 +146,7 @@ unit ModelImpl::instret_callback(unit) {
   return UNIT;
 }
 
-unit ModelImpl::ptw_start_callback(
-  uint64_t vpn,
-  hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
-  hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
-) {
+unit ModelImpl::ptw_start_callback(uint64_t vpn, MemoryAccessType access_type, Privilege privilege) {
   for (auto c : m_callbacks) {
     c->ptw_start_callback(*this, vpn, access_type, privilege);
   }
@@ -171,14 +167,14 @@ unit ModelImpl::ptw_success_callback(uint64_t final_ppn, int64_t level) {
   return UNIT;
 }
 
-unit ModelImpl::ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sbits pte_addr) {
+unit ModelImpl::ptw_fail_callback(PTW_Error error_type, int64_t level, sbits pte_addr) {
   for (auto c : m_callbacks) {
     c->ptw_fail_callback(*this, error_type, level, pte_addr);
   }
   return UNIT;
 }
 
-unit ModelImpl::tlb_add_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, uint64_t index) {
+unit ModelImpl::tlb_add_callback(TLB_Entry tlb, uint64_t index) {
   for (auto c : m_callbacks) {
     c->tlb_add_callback(*this, tlb, index);
   }
@@ -199,7 +195,7 @@ unit ModelImpl::tlb_flush_callback(uint64_t index) {
   return UNIT;
 }
 
-unit ModelImpl::tlb_flush_end_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb) {
+unit ModelImpl::tlb_flush_end_callback(TLB_Entry tlb) {
   for (auto c : m_callbacks) {
     c->tlb_flush_end_callback(*this, tlb);
   }
@@ -399,6 +395,14 @@ void ModelImpl::reinit_sail(
   init_sail(elf_entry, config_file, htif_tohost_address);
 }
 
+void ModelImpl::model_init() {
+  hart::Model::model_init();
+}
+
+void ModelImpl::model_fini() {
+  hart::Model::model_fini();
+}
+
 bool ModelImpl::config_is_valid() {
   return zconfig_is_valid(UNIT);
 }
@@ -438,6 +442,33 @@ std::optional<std::string> ModelImpl::string_of_current_exception() {
   return exception_str;
 }
 
+std::string ModelImpl::memory_access_type_to_string(MemoryAccessType access_type) {
+  sail_string sstr;
+  CREATE(sail_string)(&sstr);
+  zaccessType_to_str(&sstr, access_type);
+  std::string str(sstr);
+  KILL(sail_string)(&sstr);
+  return str;
+}
+
+std::string ModelImpl::privilege_to_string(Privilege privilege) {
+  sail_string sstr;
+  CREATE(sail_string)(&sstr);
+  zprivLevel_to_str(&sstr, privilege.ztup0);
+  std::string str(sstr);
+  KILL(sail_string)(&sstr);
+  return str;
+}
+
+std::string ModelImpl::ptw_error_to_string(PTW_Error error_type) {
+  sail_string sstr;
+  CREATE(sail_string)(&sstr);
+  zptw_error_to_str(&sstr, error_type);
+  std::string str(sstr);
+  KILL(sail_string)(&sstr);
+  return str;
+}
+
 void ModelImpl::tick_clock() {
   ztick_clock(UNIT);
 }
@@ -453,6 +484,18 @@ bool ModelImpl::try_step(int64_t step_no, bool exit_wait) {
 
 int64_t ModelImpl::xlen() const {
   return zxlen;
+}
+
+int64_t ModelImpl::physaddrbits_len() const {
+  return zphysaddrbits_len;
+}
+
+uint64_t ModelImpl::mepc() const {
+  return zmepc.bits;
+}
+
+uint64_t ModelImpl::sepc() const {
+  return zsepc.bits;
 }
 
 uint64_t ModelImpl::htif_exit_code() const {

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -11,8 +11,15 @@
 #include "sail_riscv_model.h"
 
 // Model wrapped with an implementation of its platform callbacks.
-class ModelImpl final : public hart::Model {
+class ModelImpl final : private hart::Model {
 public:
+  // types
+
+  using Privilege = hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9;
+  using MemoryAccessType = hart::zMemoryAccessTypezIEmem_payloadz5zK;
+  using PTW_Error = hart::zPTW_Error;
+  using TLB_Entry = hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9;
+
   // callbacks
 
   void register_callback(callbacks_if *cb);
@@ -48,23 +55,41 @@ public:
   void init_platform_constants();
   void init_sail(uint64_t entry, const char *config_file, const std::optional<uint64_t> &htif_tohost_address);
   void reinit_sail(uint64_t entry, const char *config_file, const std::optional<uint64_t> &htif_tohost_address);
+  void model_init();
+  void model_fini();
 
-  // access to model state
+  // string conversions
+
+  std::string memory_access_type_to_string(MemoryAccessType access_type);
+  std::string privilege_to_string(Privilege privilege);
+  std::string ptw_error_to_string(PTW_Error error_type);
+
+  // access to model configuration
 
   bool config_is_valid();
   bool dtb_within_configured_pma_memory(uint64_t addr, uint64_t size);
   std::string generate_dts();
   std::string generate_isa_string();
-  // returns std::nullopt if the model has not thrown an exception.
-  std::optional<std::string> string_of_current_exception();
+
+  // access to model state
 
   void tick_clock();
   bool try_step(int64_t step_no, bool exit_wait);
 
   int64_t xlen() const;
+  int64_t physaddrbits_len() const;
+  uint64_t mepc() const;
+  uint64_t sepc() const;
   uint64_t htif_exit_code() const;
   bool htif_done() const;
   bool had_exception() const;
+  // returns std::nullopt if the model has not thrown an exception.
+  std::optional<std::string> string_of_current_exception();
+
+  // RVFI support
+
+  friend class rvfi_handler;
+  friend class rvfi_callbacks;
 
 private:
   // These functions are called by the Sail code.
@@ -88,18 +113,14 @@ private:
   unit instret_callback(unit) override;
 
   // Page table walk callbacks
-  unit ptw_start_callback(
-    uint64_t vpn,
-    hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
-    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
-  ) override;
+  unit ptw_start_callback(uint64_t vpn, MemoryAccessType access_type, Privilege privilege) override;
   unit ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte) override;
   unit ptw_success_callback(uint64_t final_ppn, int64_t level) override;
-  unit ptw_fail_callback(hart::zPTW_Error error_type, int64_t level, sbits pte_addr) override;
-  unit tlb_add_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb, uint64_t index) override;
+  unit ptw_fail_callback(PTW_Error error_type, int64_t level, sbits pte_addr) override;
+  unit tlb_add_callback(TLB_Entry tlb, uint64_t index) override;
   unit tlb_flush_begin_callback(unit) override;
   unit tlb_flush_callback(uint64_t index) override;
-  unit tlb_flush_end_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb) override;
+  unit tlb_flush_end_callback(TLB_Entry tlb) override;
   // Provides entropy for the scalar cryptography extension.
   mach_bits plat_get_16_random_bits(unit) override;
 

--- a/c_emulator/traploop_detector.cpp
+++ b/c_emulator/traploop_detector.cpp
@@ -15,8 +15,8 @@ void traploop_detector::reset() {
 
 void traploop_detector::trap_callback(ModelImpl &model, bool, fbits) {
   if (nested_trap_count == 0) {
-    mepc_at_first_trap = model.zmepc.bits;
-    sepc_at_first_trap = model.zsepc.bits;
+    mepc_at_first_trap = model.mepc();
+    sepc_at_first_trap = model.sepc();
   }
   nested_trap_count++;
   instrets_since_last_trap = 0;


### PR DESCRIPTION
This builds on the previous refactors of #1720 and #1724. The callbacks now access model internals via `ModelImpl`. This allows `hart::Model` to be a private inheritance of `ModelImpl`.  Callbacks are still exposed to basic Sail C types (i.e. `{lsf}bits`).

Unfortunately, RVFI requires more complex access and for now its implementation classes are made friends of `ModelImpl`.