### PR TITLE
Add an option to configure handling of attempts to set an unsupported `vtype`.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -410,6 +410,12 @@
       // should be left as 3 (or any other legal value).
       "vlen_exp": @CONFIG__V__VLEN_EXP@,
       "elen_exp": @CONFIG__V__ELEN_EXP@,
+      // This determines how to handle attempts by vsetvli, vsetivli,
+      // and vsetvl to set an unsupported or reserved vtype.
+      // "Vtype_SetVill" - set vtype.vill, set vl to zero, clear vstart, and write rd.
+      // "Vtype_Illegal" - treat it as an illegal instruction.
+      // "Vtype_Fatal"   - raise a Sail exception, stopping execution.
+      "illegal_vtype": "Vtype_SetVill",
       "vl_use_ceil": false,
       // The maximum index EEW for indexed vector addressing mode, as
       // a power of 2.  This must be at least 3 but must not exceed

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -412,10 +412,10 @@
       "elen_exp": @CONFIG__V__ELEN_EXP@,
       // This determines how to handle attempts by vsetvli, vsetivli,
       // and vsetvl to set an unsupported or reserved vtype.
-      // "Vtype_SetVill" - set vtype.vill, set vl to zero, clear vstart, and write rd.
-      // "Vtype_Illegal" - treat it as an illegal instruction.
-      // "Vtype_Fatal"   - raise a Sail exception, stopping execution.
-      "illegal_vtype": "Vtype_SetVill",
+      // "IllegalVtype_SetVill" - set vtype.vill, set vl to zero, clear vstart, and write rd.
+      // "IllegalVtype_Illegal" - treat it as an illegal instruction.
+      // "IllegalVtype_Fatal"   - raise a Sail exception, stopping execution.
+      "illegal_vtype": "IllegalVtype_SetVill",
       "vl_use_ceil": false,
       // The maximum index EEW for indexed vector addressing mode, as
       // a power of 2.  This must be at least 3 but must not exceed

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -34,6 +34,8 @@
     when `vstart` is non-zero. The default value of true introduces a backward-
     incompatible change compared to previous versions, but can be changed to
     preserve the earlier behaviour.
+  - The handling of attempts to set an unsupported or reserved `vtype`
+    can now be configured; see `extensions.V.illegal_vtype`.
 
 - Performance improvements:
   - https://github.com/riscv/sail-riscv/pull/1692 : Optional `ENABLE_LTO`

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -157,9 +157,16 @@ enum RV32ZdinxOddRegisterReservedBehavior = {
   Zdinx_Illegal,
 }
 
+enum IllegalVtypeReservedBehavior = {
+  Vtype_SetVill,
+  Vtype_Illegal,
+  Vtype_Fatal,
+}
+
 let amocas_odd_register_reserved_behavior : AmocasOddRegisterReservedBehavior = config base.reserved_behavior.amocas_odd_register
 let fcsr_rm_reserved_behavior : FcsrRmReservedBehavior = config base.reserved_behavior.fcsr_rm
 let pmp_write_only_reserved_behavior : PmpWriteOnlyReservedBehavior = config base.reserved_behavior.pmpcfg_write_only
 let xenvcfg_cbie_reserved_behavior : XenvcfgCbieReservedBehavior = config base.reserved_behavior.xenvcfg_cbie
 let xtvec_mode_reserved_behavior : XtvecModeReservedBehavior = config base.reserved_behavior.xtvec_mode
 let rv32zdinx_odd_register_reserved_behavior : RV32ZdinxOddRegisterReservedBehavior = config base.reserved_behavior.rv32zdinx_odd_register
+let illegal_vtype_reserved_behavior : IllegalVtypeReservedBehavior = config extensions.V.illegal_vtype

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -158,9 +158,9 @@ enum RV32ZdinxOddRegisterReservedBehavior = {
 }
 
 enum IllegalVtypeReservedBehavior = {
-  Vtype_SetVill,
-  Vtype_Illegal,
-  Vtype_Fatal,
+  IllegalVtype_SetVill,
+  IllegalVtype_Illegal,
+  IllegalVtype_Fatal,
 }
 
 let amocas_odd_register_reserved_behavior : AmocasOddRegisterReservedBehavior = config base.reserved_behavior.amocas_odd_register

--- a/model/extensions/V/vext_vset_insts.sail
+++ b/model/extensions/V/vext_vset_insts.sail
@@ -56,9 +56,7 @@ mapping vtype_assembly : (bits(3), bits(1), bits(1), bits(3), bits(3)) <-> strin
 }
 
 private function handle_illegal_vtype(rd : regidx) -> ExecutionResult = {
-  // Note: Implementations can set vill or trap with an illegal
-  // instruction if the vtype setting is not supported.
-  // NOTE: vstart should NOT be zeroed out and rd
+  // Note: vstart should NOT be zeroed out and rd
   //       should NOT be written if trapping.
   match illegal_vtype_reserved_behavior {
     IllegalVtype_Illegal => return Illegal_Instruction(),

--- a/model/extensions/V/vext_vset_insts.sail
+++ b/model/extensions/V/vext_vset_insts.sail
@@ -61,9 +61,9 @@ private function handle_illegal_vtype(rd : regidx) -> ExecutionResult = {
   // NOTE: vstart should NOT be zeroed out and rd
   //       should NOT be written if trapping.
   match illegal_vtype_reserved_behavior {
-    Vtype_Illegal => return Illegal_Instruction(),
-    Vtype_Fatal              => reserved_behavior("unsupported or reserved vtype"),
-    Vtype_SetVill            => (),
+    IllegalVtype_Illegal => return Illegal_Instruction(),
+    IllegalVtype_Fatal   => reserved_behavior("unsupported or reserved vtype"),
+    IllegalVtype_SetVill => (),
   };
 
   vtype.bits = 0b1 @ zeros(xlen - 1); // set vtype.vill
@@ -155,7 +155,7 @@ mapping clause encdec = VSETVLI(vtr, ma, ta, sew, lmul, rs1, rd)
 
 function clause execute VSETVLI(vtr, ma, ta, sew, lmul, rs1, rd) = {
   if vtr != zeros()
-  then { handle_illegal_vtype(rd); return RETIRE_SUCCESS };
+  then return handle_illegal_vtype(rd);
 
   let avl =
     if rs1 != zreg then X(rs1)
@@ -206,7 +206,7 @@ mapping clause encdec = VSETIVLI(0b0 @ vtr, ma, ta, sew, lmul, uimm, rd)
 
 function clause execute VSETIVLI(vtr, ma, ta, sew, lmul, uimm, rd) = {
   if vtr != zeros()
-  then { handle_illegal_vtype(rd); return RETIRE_SUCCESS };
+  then return handle_illegal_vtype(rd);
 
   let avl : xlenbits = zero_extend(uimm);
   execute_vsetvl_type(ma, ta, sew, lmul, avl, false, rd)

--- a/model/extensions/V/vext_vset_insts.sail
+++ b/model/extensions/V/vext_vset_insts.sail
@@ -55,12 +55,16 @@ mapping vtype_assembly : (bits(3), bits(1), bits(1), bits(3), bits(3)) <-> strin
   (vtr, ma, ta, sew, lmul) <-> hex_bits_11(vtr @ ma @ ta @ sew @ lmul)
 }
 
-private function handle_illegal_vtype(rd : regidx) -> unit = {
+private function handle_illegal_vtype(rd : regidx) -> ExecutionResult = {
   // Note: Implementations can set vill or trap with an illegal
   // instruction if the vtype setting is not supported.
-  // TODO: configuration support for both solutions.
   // NOTE: vstart should NOT be zeroed out and rd
   //       should NOT be written if trapping.
+  match illegal_vtype_reserved_behavior {
+    Vtype_Illegal => return Illegal_Instruction(),
+    Vtype_Fatal              => reserved_behavior("unsupported or reserved vtype"),
+    Vtype_SetVill            => (),
+  };
 
   vtype.bits = 0b1 @ zeros(xlen - 1); // set vtype.vill
   vl = zeros();
@@ -72,6 +76,7 @@ private function handle_illegal_vtype(rd : regidx) -> unit = {
   //  and write the new value of vl into rd."
   // So `rd` should be written even if the arguments were illegal or reserved.
   X(rd) = vl;
+  RETIRE_SUCCESS
 }
 
 let vl_use_ceil : bool = config extensions.V.vl_use_ceil
@@ -100,8 +105,7 @@ private function execute_vsetvl_type(
 ) -> ExecutionResult = {
   // Check new SEW and LMUL have legal encodings. There are some reserved values.
   if is_invalid_lmul_pow(lmul) | is_invalid_sew_pow(sew) then {
-    handle_illegal_vtype(rd);
-    return RETIRE_SUCCESS;
+    return handle_illegal_vtype(rd);
   };
 
   let LMUL_pow_new = signed(lmul);
@@ -116,8 +120,7 @@ private function execute_vsetvl_type(
   // Also some cases require that VLMAX doesn't change (i.e. LMUL/SEW is constant).
   if SEW_pow_new > (LMUL_pow_new + elen_exp) |
      (requires_fixed_vlmax & (lmul_sew_ratio != lmul_sew_ratio_new | not(valid_vtype()))) then {
-    handle_illegal_vtype(rd);
-    return RETIRE_SUCCESS;
+    return handle_illegal_vtype(rd);
   };
 
   let VLMAX = 2 ^ (LMUL_pow_new + vlen_exp - SEW_pow_new);
@@ -179,7 +182,7 @@ function clause execute VSETVL(rs2, rs1, rd) = {
   let vt = Mk_Vtype(X(rs2));
 
   if vt[vill] == 0b1 | vt[reserved] != zeros()
-  then { handle_illegal_vtype(rd); return RETIRE_SUCCESS };
+  then return handle_illegal_vtype(rd);
 
   let avl =
     if rs1 != zreg then X(rs1)


### PR DESCRIPTION
The configuration option determines how to handle attempts by `vsetvli`, `vsetivli`, and `vsetvl` to set an unsupported or reserved `vtype`.
- "IllegalVtype_SetVill" - set `vtype.vill`, set `vl` to zero, clear `vstart`, and write `rd`.
- "IllegalVtype_Illegal" - treat it as an illegal instruction.
- "IllegalVtype_Fatal" - raise a Sail exception, stopping execution.
