### PR TITLE
Update to C++23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ project(sail-riscv
   HOMEPAGE_URL "https://github.com/riscv/sail-riscv"
 )
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(SAIL_REQUIRED_VER 0.20.1)
 

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <iostream>
 #include <optional>
+#include <print>
 #include <stdexcept>
 #include <stdio.h>
 #include <stdlib.h>
@@ -305,7 +306,7 @@ static CLIOptions parse_cli(int argc, char **argv) {
   app.get_formatter()->column_width(column_width);
 
   if (argc == 1) {
-    fprintf(stdout, "%s\n", app.help().c_str());
+    std::print("{}\n", app.help());
     exit(EXIT_FAILURE);
   }
 


### PR DESCRIPTION
Update the required C++ version to C++23. This brings a lot of improvements, notably a much nicer string formatting/printing library, and `std::expected` (like `Result` in Rust/Sail/etc.).

We're not sure if this recent (by C++ timescales) requirement will be an issue for users, so this commit introduces it in the most minimal way possible, so that it can easily be reverted. If nobody complains after, e.g. 6 months, then we can start converting the code to use C++23 features in anger.

I suspect it *won't* be an issue because:

1. Compilers have got a lot better at keeping up with the standard recently. C++23 was mostly supported by GCC/Clang in 2023.
2. We statically link the standard C++ library in the binary releases, so this shouldn't add a new dependency for users of that.
3. Most hardware people seem to run RHEL 8 or similar, which makes it really easy to install newer compilers: `sudo dnf install gcc-toolset-15`.