### PR TITLE
Handle reserved `vtype` bits in `vsetvli`/`vsetivli` instruction encodings.

### DIFF
--- a/model/extensions/V/vext_vset_insts.sail
+++ b/model/extensions/V/vext_vset_insts.sail
@@ -40,15 +40,6 @@ mapping ma_flag : string <-> bits(1) = {
   sep() ^ "mu" <-> 0b0,
 }
 
-mapping vtype_assembly : string <-> (bits(1), bits(1), bits(3), bits(3)) = {
-  // Mnemonics are preferable but there's no mnemonic for lmul=0b100.
-  sew_flag(sew) ^ maybe_lmul_flag(lmul) ^ ta_flag(ta) ^ ma_flag(ma) <-> (ma, ta, sew, lmul)
-    when sew[2] != 0b1 & lmul != 0b100,
-  // However that is still potentially a legal instruction so you can
-  // use an integer for the whole vtype in that case.
-  hex_bits_8(ma @ ta @ sew @ lmul)  <-> (ma, ta, sew, lmul),
-}
-
 // For vsetvli and vsetivli, we absorb a reserved vtype fragment
 // (`vtr`) to parameterize reserved behavior, but this fragment cannot
 // be represented in assembly, so a custom mapper is used for the
@@ -56,6 +47,15 @@ mapping vtype_assembly : string <-> (bits(1), bits(1), bits(3), bits(3)) = {
 val vtr_mnemonic : bits(3) <-> string
 function vtr_mnemonic_forwards(_vtr) = ""
 function vtr_mnemonic_forwards_matches(_vtr) = true
+
+mapping vtype_assembly : (bits(3), bits(1), bits(1), bits(3), bits(3)) <-> string = {
+  // Mnemonics are preferable but there's no mnemonic for lmul=0b100.
+  (vtr, ma, ta, sew, lmul) <-> sew_flag(sew) ^ maybe_lmul_flag(lmul) ^ ta_flag(ta) ^ ma_flag(ma) ^ vtr_mnemonic(vtr)
+    when sew[2] != 0b1 & lmul != 0b100 & vtr == 0b000,
+  // However that is still potentially a legal instruction so you can
+  // use an integer for the whole vtype in that case.
+  (vtr, ma, ta, sew, lmul) <-> hex_bits_11(vtr @ ma @ ta @ sew @ lmul)
+}
 
 private function handle_illegal_vtype(rd : regidx) -> unit = {
   // Note: Implementations can set vill or trap with an illegal
@@ -168,7 +168,7 @@ function clause execute VSETVLI(vtr, ma, ta, sew, lmul, rs1, rd) = {
 
 
 mapping clause assembly = VSETVLI(vtr, ma, ta, sew, lmul, rs1, rd)
-  <-> "vsetvli" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ vtype_assembly(ma, ta, sew, lmul) ^ vtr_mnemonic(vtr)
+  <-> "vsetvli" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ vtype_assembly(vtr, ma, ta, sew, lmul)
 
 // ********************************** vsetvl ************************************
 union clause instruction = VSETVL : (regidx, regidx, regidx)
@@ -212,4 +212,4 @@ function clause execute VSETIVLI(vtr, ma, ta, sew, lmul, uimm, rd) = {
 }
 
 mapping clause assembly = VSETIVLI(vtr, ma, ta, sew, lmul, uimm, rd)
-  <-> "vsetivli" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_5(uimm) ^ sep() ^ vtype_assembly(ma, ta, sew, lmul) ^ vtr_mnemonic(vtr)
+  <-> "vsetivli" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_5(uimm) ^ sep() ^ vtype_assembly(vtr, ma, ta, sew, lmul)

--- a/model/extensions/V/vext_vset_insts.sail
+++ b/model/extensions/V/vext_vset_insts.sail
@@ -49,6 +49,14 @@ mapping vtype_assembly : string <-> (bits(1), bits(1), bits(3), bits(3)) = {
   hex_bits_8(ma @ ta @ sew @ lmul)  <-> (ma, ta, sew, lmul),
 }
 
+// For vsetvli and vsetivli, we absorb a reserved vtype fragment
+// (`vtr`) to parameterize reserved behavior, but this fragment cannot
+// be represented in assembly, so a custom mapper is used for the
+// mnemonic.
+val vtr_mnemonic : bits(3) <-> string
+function vtr_mnemonic_forwards(_vtr) = ""
+function vtr_mnemonic_forwards_matches(_vtr) = true
+
 private function handle_illegal_vtype(rd : regidx) -> unit = {
   // Note: Implementations can set vill or trap with an illegal
   // instruction if the vtype setting is not supported.
@@ -138,13 +146,16 @@ private function execute_vsetvl_type(
 }
 
 // ********************************** vsetvli ***********************************
-union clause instruction = VSETVLI : (bits(1), bits(1), bits(3), bits(3), regidx, regidx)
+union clause instruction = VSETVLI : (bits(3), bits(1), bits(1), bits(3), bits(3), regidx, regidx)
 
-mapping clause encdec = VSETVLI(ma, ta, sew, lmul, rs1, rd)
-  <-> 0b0000 @ ma @ ta @ sew @ lmul @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b1010111
+mapping clause encdec = VSETVLI(vtr, ma, ta, sew, lmul, rs1, rd)
+  <-> 0b0 @ vtr @ ma @ ta @ sew @ lmul @ encdec_reg(rs1) @ 0b111 @ encdec_reg(rd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute VSETVLI(ma, ta, sew, lmul, rs1, rd) = {
+function clause execute VSETVLI(vtr, ma, ta, sew, lmul, rs1, rd) = {
+  if vtr != zeros()
+  then { handle_illegal_vtype(rd); return RETIRE_SUCCESS };
+
   let avl =
     if rs1 != zreg then X(rs1)
     else if rd != zreg then ones()
@@ -155,8 +166,9 @@ function clause execute VSETVLI(ma, ta, sew, lmul, rs1, rd) = {
   execute_vsetvl_type(ma, ta, sew, lmul, avl, requires_fixed_vlmax, rd)
 }
 
-mapping clause assembly = VSETVLI(ma, ta, sew, lmul, rs1, rd)
-  <-> "vsetvli" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ vtype_assembly(ma, ta, sew, lmul)
+
+mapping clause assembly = VSETVLI(vtr, ma, ta, sew, lmul, rs1, rd)
+  <-> "vsetvli" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ vtype_assembly(ma, ta, sew, lmul) ^ vtr_mnemonic(vtr)
 
 // ********************************** vsetvl ************************************
 union clause instruction = VSETVL : (regidx, regidx, regidx)
@@ -185,16 +197,19 @@ mapping clause assembly = VSETVL(rs2, rs1, rd)
   <-> "vsetvl" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
 // ********************************* vsetivli ***********************************
-union clause instruction = VSETIVLI : ( bits(1), bits(1), bits(3), bits(3), bits(5), regidx)
+union clause instruction = VSETIVLI : (bits(3), bits(1), bits(1), bits(3), bits(3), bits(5), regidx)
 
-mapping clause encdec = VSETIVLI(ma, ta, sew, lmul, uimm, rd)
-  <-> 0b1100 @ ma @ ta @ sew @ lmul @ uimm @ 0b111 @ encdec_reg(rd) @ 0b1010111
+mapping clause encdec = VSETIVLI(0b0 @ vtr, ma, ta, sew, lmul, uimm, rd)
+  <-> 0b11 @ vtr @ ma @ ta @ sew @ lmul @ uimm @ 0b111 @ encdec_reg(rd) @ 0b1010111
   when currentlyEnabled(Ext_Zve32x)
 
-function clause execute VSETIVLI(ma, ta, sew, lmul, uimm, rd) = {
+function clause execute VSETIVLI(vtr, ma, ta, sew, lmul, uimm, rd) = {
+  if vtr != zeros()
+  then { handle_illegal_vtype(rd); return RETIRE_SUCCESS };
+
   let avl : xlenbits = zero_extend(uimm);
   execute_vsetvl_type(ma, ta, sew, lmul, avl, false, rd)
 }
 
-mapping clause assembly = VSETIVLI(ma, ta, sew, lmul, uimm, rd)
-  <-> "vsetivli" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_5(uimm) ^ sep() ^ vtype_assembly(ma, ta, sew, lmul)
+mapping clause assembly = VSETIVLI(vtr, ma, ta, sew, lmul, uimm, rd)
+  <-> "vsetivli" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_5(uimm) ^ sep() ^ vtype_assembly(ma, ta, sew, lmul) ^ vtr_mnemonic(vtr)

--- a/model/extensions/V/vext_vset_insts.sail
+++ b/model/extensions/V/vext_vset_insts.sail
@@ -40,10 +40,8 @@ mapping ma_flag : string <-> bits(1) = {
   sep() ^ "mu" <-> 0b0,
 }
 
-// For vsetvli and vsetivli, we absorb a reserved vtype fragment
-// (`vtr`) to parameterize reserved behavior, but this fragment cannot
-// be represented in assembly, so a custom mapper is used for the
-// mnemonic.
+// For vsetvli and vsetivli, vtr = 0b000 is implicit in the assembly and
+// cannot be printed.
 val vtr_mnemonic : bits(3) <-> string
 function vtr_mnemonic_forwards(_vtr) = ""
 function vtr_mnemonic_forwards_matches(_vtr) = true


### PR DESCRIPTION
Though the bits may be reserved, it is more flexible to still decode the instructions in order to decide how to handle the reserved behavior.

This PR just sets the `vill` bit in `vtype`.  A subsequent PR will introduce the parameters to handle the reserved behavior.

Partially fixes #1699.