### PR TITLE
Update to the latest (2026-05-29) test suite release.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -125,37 +125,37 @@ endif()
 option(ENABLE_RISCV_ARCH_TESTS "Enable riscv-arch-tests" OFF)
 
 function(filter_arch_tests test_elfs elfs_to_use_varname)
-  # These tests pass with a config matching the one used in
-  # `riscv-arch-test`, but which differs from the ones generated in
-  # our build.  They can be re-enabled once we support more granular
-  # test-specific configurations in CI.
-  list(FILTER test_elfs EXCLUDE REGEX ".*/InterruptsS-00\\.elf$")
-  list(FILTER test_elfs EXCLUDE REGEX ".*/InterruptsSm-00\\.elf$")
-  list(FILTER test_elfs EXCLUDE REGEX ".*/S-00\\.elf$")
-  list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictS-01\\.elf$")
-  list(FILTER test_elfs EXCLUDE REGEX ".*/UV-00\\.elf$")
+    # These tests pass with a config matching the one used in
+    # `riscv-arch-test`, but which differs from the ones generated in
+    # our build.  They can be re-enabled once we support more granular
+    # test-specific configurations in CI.
+    list(FILTER test_elfs EXCLUDE REGEX ".*/InterruptsS-00\\.elf$")
+    list(FILTER test_elfs EXCLUDE REGEX ".*/InterruptsSm-00\\.elf$")
+    list(FILTER test_elfs EXCLUDE REGEX ".*/S-00\\.elf$")
+    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictS-01\\.elf$")
+    list(FILTER test_elfs EXCLUDE REGEX ".*/UV-00\\.elf$")
 
-  # These tests fail because
-  # https://github.com/riscv/sail-riscv/pull/1690 strengthened illegal
-  # instruction checks for vector instructions (like vbrev8).
-  # Instructions that executed with the 0.11 release now raise illegal
-  # instruction exceptions with the current version.
-  list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-14\\.elf$")
+    # These tests fail because
+    # https://github.com/riscv/sail-riscv/pull/1690 strengthened illegal
+    # instruction checks for vector instructions (like vbrev8).
+    # Instructions that executed with the 0.11 release now raise illegal
+    # instruction exceptions with the current version.
+    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-14\\.elf$")
 
-  # These tests similarly fail because
-  # https://github.com/riscv/sail-riscv/pull/1698 strengthens checks
-  # for vector source register overlaps (like vwadd.vv).
-  list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-13\\.elf$")
+    # These tests similarly fail because
+    # https://github.com/riscv/sail-riscv/pull/1698 strengthens checks
+    # for vector source register overlaps (like vwadd.vv).
+    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-13\\.elf$")
 
-  # These RV64 tests fail because
-  # https://github.com/riscv/sail-riscv/pull/1712 fixed an incorrect
-  # decoding of add.uw, and now correctly treats that encoding as
-  # reserved and traps with an illegal instruction exception.
-  list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictS-06\\.elf$")
-  list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictSm-06\\.elf$")
-  list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictU-02\\.elf$")
+    # These RV64 tests fail because
+    # https://github.com/riscv/sail-riscv/pull/1712 fixed an incorrect
+    # decoding of add.uw, and now correctly treats that encoding as
+    # reserved and traps with an illegal instruction exception.
+    list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictS-06\\.elf$")
+    list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictSm-06\\.elf$")
+    list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictU-02\\.elf$")
 
-  set(${elfs_to_use_varname} "${test_elfs}" PARENT_SCOPE)
+    set(${elfs_to_use_varname} "${test_elfs}" PARENT_SCOPE)
 endfunction()
 
 if(ENABLE_RISCV_ARCH_TESTS)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake options for test downloads
 set(TEST_DOWNLOAD_URL "https://github.com/riscv-software-src/sail-riscv-tests/releases/download" CACHE STRING "Base URL to download precompiled riscv-tests and riscv-vector-tests from")
-set(TEST_DOWNLOAD_VERSION "2026-04-17" CACHE STRING "Version of precompiled tests to download")
+set(TEST_DOWNLOAD_VERSION "2026-05-29" CACHE STRING "Version of precompiled tests to download")
 
 # Function to download and extract test files
 function(download_riscv_tests DOWNLOAD_PATH TARBALL_NAME DOWNLOAD_URL)
@@ -124,6 +124,41 @@ endif()
 # Download and add RISC-V arch tests.
 option(ENABLE_RISCV_ARCH_TESTS "Enable riscv-arch-tests" OFF)
 
+function(filter_arch_tests test_elfs elfs_to_use)
+  # These tests pass with a config matching the one used in
+  # `riscv-arch-test`, but which differs from the ones generated in
+  # our build.  They can be re-enabled once we support more granular
+  # test-specific configurations in CI.
+  list(FILTER test_elfs EXCLUDE REGEX ".*/InterruptsS-00.elf$")
+  list(FILTER test_elfs EXCLUDE REGEX ".*/InterruptsSm-00.elf$")
+  list(FILTER test_elfs EXCLUDE REGEX ".*/S-00.elf$")
+  list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictS-01.elf$")
+  list(FILTER test_elfs EXCLUDE REGEX ".*/UV-00.elf$")
+
+  # These tests fail because
+  # https://github.com/riscv/sail-riscv/pull/1690 strengthened illegal
+  # instruction checks for vector instructions (like vbrev8).
+  # Instructions that executed with the 0.11 release now raise illegal
+  # instruction exceptions with the current version.
+  list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-14.elf$")
+
+  # These tests similarly fail because
+  # https://github.com/riscv/sail-riscv/pull/1698 strengthens checks
+  # for vector source register overlaps (like vwadd.vv).
+  list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-13.elf$")
+
+  # These RV64 tests fail because
+  # https://github.com/riscv/sail-riscv/pull/1712 fixed an incorrect
+  # decoding of add.uw, and now correctly treats that encoding as
+  # reserved and traps with an illegal instruction exception.
+  list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictS-06.elf$")
+  list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictSm-06.elf$")
+  list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictU-02.elf$")
+
+  set(elfs_to_use "${test_elfs}")
+  return(PROPAGATE elfs_to_use)
+endfunction()
+
 if(ENABLE_RISCV_ARCH_TESTS)
     set(TARBALL_NAME "riscv-arch-tests")
     set(DOWNLOAD_PATH "${CMAKE_CURRENT_BINARY_DIR}/${TEST_DOWNLOAD_VERSION}")
@@ -139,7 +174,11 @@ if(ENABLE_RISCV_ARCH_TESTS)
         file(GLOB_RECURSE elf_list CONFIGURE_DEPENDS LIST_DIRECTORIES false
            "${DOWNLOAD_PATH}/${TARBALL_NAME}/sail-rv${xlen}-max/*.elf"
         )
-        foreach(elf IN LISTS elf_list)
+
+        # Filter out tests that fail for a good reason.
+        filter_arch_tests("${elf_list}" elfs_to_use)
+
+        foreach(elf IN LISTS elfs_to_use)
             file(RELATIVE_PATH elf_name "${CMAKE_CURRENT_BINARY_DIR}" ${elf})
             add_test(
                 # `elf_name` includes xlen so we don't need to add any details.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -124,7 +124,7 @@ endif()
 # Download and add RISC-V arch tests.
 option(ENABLE_RISCV_ARCH_TESTS "Enable riscv-arch-tests" OFF)
 
-function(filter_arch_tests test_elfs elfs_to_use)
+function(filter_arch_tests test_elfs elfs_to_use_varname)
   # These tests pass with a config matching the one used in
   # `riscv-arch-test`, but which differs from the ones generated in
   # our build.  They can be re-enabled once we support more granular
@@ -155,8 +155,7 @@ function(filter_arch_tests test_elfs elfs_to_use)
   list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictSm-06\\.elf$")
   list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictU-02\\.elf$")
 
-  set(elfs_to_use "${test_elfs}")
-  return(PROPAGATE elfs_to_use)
+  set(${elfs_to_use_varname} "${test_elfs}" PARENT_SCOPE)
 endfunction()
 
 if(ENABLE_RISCV_ARCH_TESTS)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -129,31 +129,31 @@ function(filter_arch_tests test_elfs elfs_to_use)
   # `riscv-arch-test`, but which differs from the ones generated in
   # our build.  They can be re-enabled once we support more granular
   # test-specific configurations in CI.
-  list(FILTER test_elfs EXCLUDE REGEX ".*/InterruptsS-00.elf$")
-  list(FILTER test_elfs EXCLUDE REGEX ".*/InterruptsSm-00.elf$")
-  list(FILTER test_elfs EXCLUDE REGEX ".*/S-00.elf$")
-  list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictS-01.elf$")
-  list(FILTER test_elfs EXCLUDE REGEX ".*/UV-00.elf$")
+  list(FILTER test_elfs EXCLUDE REGEX ".*/InterruptsS-00\\.elf$")
+  list(FILTER test_elfs EXCLUDE REGEX ".*/InterruptsSm-00\\.elf$")
+  list(FILTER test_elfs EXCLUDE REGEX ".*/S-00\\.elf$")
+  list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictS-01\\.elf$")
+  list(FILTER test_elfs EXCLUDE REGEX ".*/UV-00\\.elf$")
 
   # These tests fail because
   # https://github.com/riscv/sail-riscv/pull/1690 strengthened illegal
   # instruction checks for vector instructions (like vbrev8).
   # Instructions that executed with the 0.11 release now raise illegal
   # instruction exceptions with the current version.
-  list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-14.elf$")
+  list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-14\\.elf$")
 
   # These tests similarly fail because
   # https://github.com/riscv/sail-riscv/pull/1698 strengthens checks
   # for vector source register overlaps (like vwadd.vv).
-  list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-13.elf$")
+  list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-13\\.elf$")
 
   # These RV64 tests fail because
   # https://github.com/riscv/sail-riscv/pull/1712 fixed an incorrect
   # decoding of add.uw, and now correctly treats that encoding as
   # reserved and traps with an illegal instruction exception.
-  list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictS-06.elf$")
-  list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictSm-06.elf$")
-  list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictU-02.elf$")
+  list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictS-06\\.elf$")
+  list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictSm-06\\.elf$")
+  list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictU-02\\.elf$")
 
   set(elfs_to_use "${test_elfs}")
   return(PROPAGATE elfs_to_use)


### PR DESCRIPTION
The main highlight of this release is the vector test suites that have been fixed to avoid generating instructions that were reserved due to source register groups that overlapped with different EEWs. See: chipsalliance/riscv-vector-tests#92 and chipsalliance/riscv-vector-tests#93

The riscv-tests and riscv-arch-test suites were also updated to their latest releases.

Built with:
riscv-software-src/sail-riscv-tests: 222fbdd
riscv-tests: 1eb47d946c55f55cab8653c224c2993acc0276bd 
riscv-vector-tests: f76bff121dce91b6b23e1d37be77a5e44af914c3 
riscv-arch-test: cedc9279fae6636b526d210ae47c0b5eb7654305 
Spike: 20feb9c2bf2a7deab964d8190b0cbd4b4131bec3
Toolchain release: 2026.03.13
Sail RISC-V release: 0.11
```
$ ./compare-releases.py -p releases/2026-04-17 -c releases/2026-05-29 
riscv-tests has 667 test files, with 12 added to and 0 removed from the previous release. 
riscv-arch-tests has 2080 test files, with 554 added to and 0 removed from the previous release. 
riscv-vector-tests-v128x32 has 1944 test files, with 0 added to and 0 removed from the previous release. 
riscv-vector-tests-v128x64 has 3042 test files, with 0 added to and 0 removed from the previous release. 
riscv-vector-tests-v256x32 has 1945 test files, with 0 added to and 0 removed from the previous release. 
riscv-vector-tests-v256x64 has 3043 test files, with 0 added to and 0 removed from the previous release. 
riscv-vector-tests-v512x32 has 1945 test files, with 0 added to and 0 removed from the previous release. 
riscv-vector-tests-v512x64 has 3043 test files, with 0 added to and 0 removed from the previous release.
```

Some tests in `riscv-arch-tests` fail for reasons documented in `test/CMakeLists.txt`; these have been excluded from test runs.