### PR TITLE
Support single-mode trap vector configurations for `mtvec` and `stvec`.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -48,21 +48,38 @@
       "len": 32,
       "value": "0xFFFF_FFFF"
     },
-    // The `{m,s}tvec.base_alignment` parameters control the alignment
+    // `mtvec.{direct,vectored}.supported` indicates whether the
+    // corresponding mode is supported for `mtvec`.  At least one mode
+    // should be supported.  If both modes are supported, the mode on
+    // reset is unspecified.
+    // The `mtvec.{direct,vectored}.base_alignment` parameters control the alignment
     // of the trap vector base for each mode.  The alignment is
     // specified as the power of 2 of the desired byte alignment, and
     // can range from a minimum of 2 upto a maximum of 24. If
     // unaligned values are written to these CSRs, the lowest bits
     // will be zeroed to respect the specified alignment.
     "mtvec": {
-      "base_alignment": {
-        "direct" : 2,
-        "vectored" : 2
+      "direct": {
+        "supported": true,
+        "base_alignment": 2
+      },
+      "vectored": {
+        "supported": true,
+        "base_alignment": 2
       }
     },
+    // Similar to `mtvec` above. If `S` mode is not supported, these
+    // values need to be present and legal but are ignored.
     "stvec": {
-      "base_alignment": {
-        "vectored" : 2
+      // The spec requires `base_alignment` for `stvec.direct` to be 2
+      // (i.e. 4-byte alignment), hence there is no configuration
+      // parameter for it.
+      "direct": {
+        "supported": true
+      },
+      "vectored": {
+        "supported": true,
+        "base_alignment": 2
       }
     },
     // These settings control whether the specified exceptions

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -10,8 +10,9 @@
     to false to match previous behavior.
   - The maximum supported index EEW for the indexed vector addressing
     mode can be specified; see `extensions.V.max_index_eew_exp`.
-  - The alignment constraints of the bases of the `mtvec` and `stvec`
-    CSRs can now be specified; see `base.{m,s}tvec.base_alignment`.
+  - The supported modes of `mtvec` and `stvec` and the alignment
+    constraints of their bases can now be specified; see `base.mtvec`
+    and `base.stvec`.
   - The `base.scounteren_writable_bits` option now does not ignore the
     lowest three bits, governing access to the `cycle`, `time` and
     `instret` CSRs from U-mode.

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -8,11 +8,20 @@
 
 // Platform-specific configuration parameters.
 
+// Trap vector mode.
+enum TrapVectorMode = {TV_Direct, TV_Vector, TV_Reserved}
+
+let plat_mtvec_direct_mode_supported : bool = config base.mtvec.direct.supported
+let plat_mtvec_vectored_mode_supported : bool = config base.mtvec.vectored.supported
+
+let plat_stvec_direct_mode_supported : bool = config base.stvec.direct.supported
+let plat_stvec_vectored_mode_supported : bool = config base.stvec.vectored.supported
+
 // Trap vector alignment.
 type tvec_alignment = range(2, 24)
-let plat_mtvec_base_alignment_direct_exp   : tvec_alignment = config base.mtvec.base_alignment.direct
-let plat_mtvec_base_alignment_vectored_exp : tvec_alignment = config base.mtvec.base_alignment.vectored
-let plat_stvec_base_alignment_vectored_exp : tvec_alignment = config base.stvec.base_alignment.vectored
+let plat_mtvec_direct_base_alignment_exp   : tvec_alignment = config base.mtvec.direct.base_alignment
+let plat_mtvec_vectored_base_alignment_exp : tvec_alignment = config base.mtvec.vectored.base_alignment
+let plat_stvec_vectored_base_alignment_exp : tvec_alignment = config base.stvec.vectored.base_alignment
 
 // Cache block size is 2^cache_block_size_exp. Max is `max_mem_access` (4096)
 // because this model performs `cbo.zero` with a single write, and the behaviour

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -9,8 +9,6 @@
 // Platform-specific configuration parameters.
 
 // Trap vector mode.
-enum TrapVectorMode = {TV_Direct, TV_Vector, TV_Reserved}
-
 let plat_mtvec_direct_mode_supported : bool = config base.mtvec.direct.supported
 let plat_mtvec_vectored_mode_supported : bool = config base.mtvec.vectored.supported
 

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -483,19 +483,26 @@ bitfield Mtvec : xlenbits = {
 register mtvec : Mtvec  // Trap Vector
 
 // PUBLIC: invoked from set_{ms}tvec() [exceptions/sys_exceptions.sail]
-function legalize_tvec(o : Mtvec, v : xlenbits, direct_alignment_exp : tvec_alignment, vectored_alignment_exp : tvec_alignment) -> Mtvec = {
+function legalize_tvec(
+  o : Mtvec,
+  v : xlenbits,
+  direct_supported : bool,
+  direct_alignment_exp : tvec_alignment,
+  vectored_supported : bool,
+  vectored_alignment_exp : tvec_alignment
+) -> Mtvec = {
   let v = Mk_Mtvec(v);
   // Legalize mode.
-  let v : Mtvec = match trapVectorMode_of_bits(v[Mode]) {
-    TV_Direct => v,
-    TV_Vector => v,
+  let v : Mtvec = match trapVectorMode(v[Mode]) {
+    TV_Direct => if direct_supported then v else [v with Mode = o[Mode]],
+    TV_Vector => if vectored_supported then v else [v with Mode = o[Mode]],
     _         => match xtvec_mode_reserved_behavior {
       Xtvec_Fatal => reserved_behavior("Tried to write a reserved value (" ^ dec_str(unsigned(v[Mode])) ^ ") to the MODE field of xtvec."),
       Xtvec_Ignore => [v with Mode = o[Mode]],
     },
   };
   // Legalize alignment.
-  let base_alignment : tvec_alignment = match trapVectorMode_of_bits(v[Mode]) {
+  let base_alignment : tvec_alignment = match trapVectorMode(v[Mode]) {
     TV_Direct   => direct_alignment_exp,
     TV_Vector   => vectored_alignment_exp,
     TV_Reserved => // This should never happen due to the check above.
@@ -520,7 +527,7 @@ function clause write_CSR(0x342, value) = { mcause.bits = value; Ok(mcause.bits)
 // Interpreting the trap-vector address
 function tvec_addr(m : Mtvec, c : Mcause) -> option(xlenbits) = {
   let base : xlenbits = m[Base] @ 0b00;
-  match (trapVectorMode_of_bits(m[Mode])) {
+  match trapVectorMode(m[Mode]) {
     TV_Direct => Some(base),
     TV_Vector => if   c[IsInterrupt] == 0b1
                  then Some(base + (zero_extend(c[Cause]) << 2))

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -337,6 +337,7 @@ overload to_str = {trapCause_to_str}
 // trap modes
 
 type tv_mode = bits(2)
+enum TrapVectorMode = {TV_Direct, TV_Vector, TV_Reserved}
 
 mapping trapVectorMode : tv_mode <-> TrapVectorMode = {
   0b00 <-> TV_Direct,

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -337,14 +337,13 @@ overload to_str = {trapCause_to_str}
 // trap modes
 
 type tv_mode = bits(2)
-enum TrapVectorMode = {TV_Direct, TV_Vector, TV_Reserved}
 
-function trapVectorMode_of_bits(m : tv_mode) -> TrapVectorMode =
-  match (m) {
-    0b00 => TV_Direct,
-    0b01 => TV_Vector,
-    _    => TV_Reserved
-  }
+mapping trapVectorMode : tv_mode <-> TrapVectorMode = {
+  0b00 <-> TV_Direct,
+  0b01 <-> TV_Vector,
+  0b10 <-> TV_Reserved,
+  0b11 <-> TV_Reserved,
+}
 
 // xRET types
 // (capitalized versions conflict with the instructions themselves)

--- a/model/exceptions/sys_exceptions.sail
+++ b/model/exceptions/sys_exceptions.sail
@@ -71,13 +71,38 @@ function get_stvec() -> xlenbits =
   stvec.bits
 
 function set_mtvec(value : xlenbits) -> xlenbits = {
-  mtvec = legalize_tvec(mtvec, value, plat_mtvec_base_alignment_direct_exp, plat_mtvec_base_alignment_vectored_exp);
+  mtvec = legalize_tvec(mtvec,
+                        value,
+                        plat_mtvec_direct_mode_supported,
+                        plat_mtvec_direct_base_alignment_exp,
+                        plat_mtvec_vectored_mode_supported,
+                        plat_mtvec_vectored_base_alignment_exp);
   mtvec.bits
 }
 
 function set_stvec(value : xlenbits) -> xlenbits = {
-  stvec = legalize_tvec(stvec, value, 2, plat_stvec_base_alignment_vectored_exp);
+  stvec = legalize_tvec(stvec,
+                        value,
+                        plat_stvec_direct_mode_supported,
+                        2,
+                        plat_stvec_vectored_mode_supported,
+                        plat_stvec_vectored_base_alignment_exp);
   stvec.bits
+}
+
+// Ensure that xtvec[Mode] contains a supported value on reset.
+// This would matter if these fields are read-only for the DUT.
+function reset_tvecs() -> unit = {
+  if plat_mtvec_direct_mode_supported then {
+    mtvec[Mode] = trapVectorMode(TV_Direct)
+  } else if plat_mtvec_vectored_mode_supported then {
+    mtvec[Mode] = trapVectorMode(TV_Vector)
+  };
+  if plat_stvec_direct_mode_supported then {
+    stvec[Mode] = trapVectorMode(TV_Direct)
+  } else if plat_stvec_vectored_mode_supported then {
+    stvec[Mode] = trapVectorMode(TV_Vector)
+  };
 }
 
 mapping clause csr_name_map = 0x105  <-> "stvec"

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -575,6 +575,7 @@ private function check_mmio_devices() -> bool = {
 
 function config_is_valid() -> bool = {
     check_privs()
+  & check_tvecs()
   & check_mmu_config()
   & check_mem_layout()
   & check_mmio_devices()

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -15,6 +15,22 @@ private function check_privs() -> bool = {
   true
 }
 
+private function check_tvecs() -> bool = {
+  var valid : bool = true;
+
+  if not(config base.mtvec.direct.supported : bool) & not(config base.mtvec.vectored.supported : bool) then {
+    valid = false;
+    print_endline("`mtvec` specifies neither `direct` or `vectored` is supported; one of the modes must be supported.");
+  };
+
+  if (config extensions.S.supported : bool) & not(config base.stvec.direct.supported : bool) & not(config base.stvec.vectored.supported : bool) then {
+    valid = false;
+    print_endline("`stvec` specifies neither `direct` or `vectored` is supported; one of the modes must be supported.");
+  };
+
+  valid
+}
+
 private function require_Sv32(ext_name : string) -> bool = {
   if not(config extensions.Sv32.supported : bool) then {
     print_endline("The " ^ ext_name ^ " extension is enabled but Sv32 is disabled: " ^ ext_name ^ " depends on Sv32 on RV32.");

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -342,6 +342,10 @@ function reset_sys() -> unit = {
   mstatus[MIE] = 0b0;
   mstatus[MPRV] = 0b0;
 
+  // Though {ms}tvec are unspecified on reset, their mode should hold
+  // a supported value when read.
+  reset_tvecs();
+
   // "If little-endian memory accesses are supported, the mstatus/mstatush field
   // MBE is reset to 0."
   // TODO: The handling of mstatush is a bit awkward currently, but the model


### PR DESCRIPTION
Also set `{ms}tvec` to a supported mode on reset.  This is needed to match DUTs that have a hard-wired single-mode.

Fixes #1729.