### PR TITLE
Make WFI optionally available to user-mode.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -361,7 +361,10 @@
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
     "wfi_is_nop": false,
-    // WFI is optionally available to User mode.
+    // WFI is optionally available to User mode.  Note that even if
+    // `wfi_is_nop` is set to `true` above, it will still not be
+    // available to User mode unless `wfi_available_to_user_mode` is
+    // also `true`.
     "wfi_available_to_user_mode": false,
     // The maximum increment in the time CSR before a wait instruction
     // (e.g. WFI, WRS.NTO, WRS.STO) that is not a NOP expires its

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -361,6 +361,8 @@
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
     "wfi_is_nop": false,
+    // WFI is optionally available to User mode.
+    "wfi_available_to_user_mode": false,
     // The maximum increment in the time CSR before a wait instruction
     // (e.g. WFI, WRS.NTO, WRS.STO) that is not a NOP expires its
     // wait. It is not possible to wait indefinitely.

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -19,6 +19,9 @@
   - Writable bits of the `mcounteren` CSR can now be specified;
     see `base.mcounteren_writable_bits`. (This was previously controlled
     by `base.writable_hpm_counters`, which was incorrect.)
+  - The WFI instruction can be optionally made available to User mode;
+    see `platform.wfi_available_to_user_mode`. This is set to false
+    by default for backwards compatibility.
 
 - Performance improvements:
   - https://github.com/riscv/sail-riscv/pull/1692 : Optional `ENABLE_LTO`

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -98,6 +98,9 @@ let plat_sig_size : physaddrbits = zero_extend(0x20)
 
 let plat_insns_per_tick : nat1 = config platform.instructions_per_tick
 
+// Whether WFI is available to User mode.
+let plat_wfi_available_to_usermode : bool = config platform.wfi_available_to_user_mode
+
 // Maximum increment in the time CSR to wait for wait instructions.  This is not
 // used within the model but instead configures the external C++ harness.
 let max_wait_time : nat = config platform.max_time_to_wait

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -657,7 +657,7 @@ function clause execute WFI() =
     // mstatus[TW] is checked when the wait times out in
     // `run_hart_waiting()`.
     Supervisor        => Enter_Wait(WAIT_WFI),
-    User              => Illegal_Instruction(),
+    User              => if plat_wfi_available_to_usermode then Enter_Wait(WAIT_WFI) else Illegal_Instruction(),
     VirtualUser       => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
     VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
   }

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -55,9 +55,17 @@ private function run_hart_waiting(_step_no : nat, wr: WaitReason, instbits : ins
       // less-privileged mode, and it does not complete within an
       // implementation-specific, bounded time limit, the WFI
       // instruction causes an illegal-instruction exception."
-      if   (cur_privilege == Machine | mstatus[TW] == 0b0)
-      then Step_Execute(Retire_Success(), instbits)
-      else Step_Execute(Illegal_Instruction(), instbits)
+
+      // "When S-mode is implemented, then executing WFI in U-mode
+      // causes an illegal-instruction exception, regardless of the
+      // value of the TW bit, unless the instruction completes within
+      // an implementation-specific, bounded time limit."
+
+      let is_illegal = (cur_privilege != Machine & mstatus[TW] == 0b1) |
+          (cur_privilege == User & currentlyEnabled(Ext_S));
+      if is_illegal
+      then Step_Execute(Illegal_Instruction(), instbits)
+      else Step_Execute(Retire_Success(), instbits);
     },
     (WAIT_WRS_STO, _, true) => {
       if   get_config_print_instr()


### PR DESCRIPTION
According to the spec,

> WFI is available in all privileged modes, and optionally available to U-mode.

Add a configuration parameter for this case, and set it to false by default for backwards compatibility.

Fixes #1739.