### PR TITLE
Support configuring legal values for `mstatus.{FS,VS}`.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -132,8 +132,14 @@
       "rv32zdinx_odd_register": "Zdinx_Illegal"
     },
     "mstatus": {
-      "mstatus_fs_legal_values": [0, 1, 2, 3],
-      "mstatus_vs_writable": false
+      // The legal values for the FS and VS fields in this CSR are
+      // specified by the two fields below.  Their values can be one
+      // of:
+      // - "ExtContext_FourState" allows all values {Off, Initial, Clean, Dirty}.
+      // - "ExtContext_TwoState" allows {Off, Dirty}.
+      // - "ExtContext_Off" allows only {Off}.  This makes the field read-only zero.
+      "fs_legal_states": "ExtContext_FourState",
+      "vs_legal_states": "ExtContext_FourState"
     }
   },
   "memory": {

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -136,7 +136,7 @@
       // specified by the two fields below.  Their values can be one
       // of:
       // - "ExtContext_FourState" allows all values {Off, Initial, Clean, Dirty}.
-      // - "ExtContext_TwoState" allows {Off, Dirty}.
+      // - "ExtContext_TwoState" allows {Off, Dirty}, and writes of Initial and Clean get written as Dirty.
       // - "ExtContext_Off" allows only {Off}.  This makes the field read-only zero.
       "fs_legal_states": "ExtContext_FourState",
       "vs_legal_states": "ExtContext_FourState"

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -130,6 +130,10 @@
       // "Zdinx_Fatal"  – raise a Sail exception, stopping execution.
       // "Zdinx_Illegal" – treat it as an illegal instruction.
       "rv32zdinx_odd_register": "Zdinx_Illegal"
+    },
+    "mstatus": {
+      "mstatus_fs_legal_values": [0, 1, 2, 3],
+      "mstatus_vs_writable": false
     }
   },
   "memory": {

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -36,6 +36,9 @@
     preserve the earlier behaviour.
   - The handling of attempts to set an unsupported or reserved `vtype`
     can now be configured; see `extensions.V.illegal_vtype`.
+  - The supported values for `mstatus.FS` and `mstatus.VS` can be
+    configured; see `base.mstatus.fs_legal_values` and
+    `base.mstatus.vs_legal_values`.
 
 - Performance improvements:
   - https://github.com/riscv/sail-riscv/pull/1692 : Optional `ENABLE_LTO`

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -86,6 +86,16 @@ struct GlobalMisalignedExceptions = {
 // The handling of misaligned accesses before address translation.
 let plat_misaligned_access : GlobalMisalignedExceptions = config memory.misaligned.exceptions
 
+// Legal values for FS and VS.  This is an enumeration to avoid lists.
+enum ExtContext = {
+  ExtContext_Off,        // The extension is always off.
+  ExtContext_TwoState,   // Legal values are Off and Dirty.
+  ExtContext_FourState,  // Legal values are Off, Initial, Clean and Dirty.
+}
+
+let plat_mstatus_legal_fs : ExtContext = config base.mstatus.fs_legal_states
+let plat_mstatus_legal_vs : ExtContext = config base.mstatus.vs_legal_states
+
 // Location of clock-interface, which should match with the spec in the DTB
 let plat_have_clint : bool = config platform.clint.supported
 let plat_clint_base : physaddrbits = to_bits_checked(config platform.clint.base : int)

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -87,14 +87,14 @@ struct GlobalMisalignedExceptions = {
 let plat_misaligned_access : GlobalMisalignedExceptions = config memory.misaligned.exceptions
 
 // Legal values for FS and VS.  This is an enumeration to avoid lists.
-enum ExtContext = {
+enum ExtContextPolicy = {
   ExtContext_Off,        // The extension is always off.
   ExtContext_TwoState,   // Legal values are Off and Dirty.
   ExtContext_FourState,  // Legal values are Off, Initial, Clean and Dirty.
 }
 
-let plat_mstatus_legal_fs : ExtContext = config base.mstatus.fs_legal_states
-let plat_mstatus_legal_vs : ExtContext = config base.mstatus.vs_legal_states
+let plat_mstatus_legal_fs : ExtContextPolicy = config base.mstatus.fs_legal_states
+let plat_mstatus_legal_vs : ExtContextPolicy = config base.mstatus.vs_legal_states
 
 // Location of clock-interface, which should match with the spec in the DTB
 let plat_have_clint : bool = config platform.clint.supported

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -91,6 +91,9 @@ let sys_enable_writable_fiom : bool = config base.writable_fiom
 // Which HPM counters are supported (as a bit mask). Bits [2 .. 0] are ignored.
 let sys_writable_hpm_counters : bits(32) = config base.writable_hpm_counters
 
+// The mstatus.FS legal values list.
+let mstatus_fs_legal_values : list(int) = config base.mstatus.mstatus_fs_legal_values
+
 // Supervisor timecmp
 function clause currentlyEnabled(Ext_Sstc) = hartSupports(Ext_Sstc)
 
@@ -149,6 +152,18 @@ function virtual_memory_supported() -> bool = {
 // This measure needs to be > currentlyEnabled_measure(Ext_Sv{32,39,48,57}),
 // currently all equal to 2, see currentlyEnabled_measure in extensions.sail
 termination_measure virtual_memory_supported(_) = 3
+
+function match_fs_legal_values(legal_values : list(int), v : int) -> bool = {
+  match legal_values {
+    [||] => false,
+    value :: rest => (value == v) | match_fs_legal_values(rest, v)
+  }
+}
+
+function is_vs_read_only() -> bool = {
+  let mstatus_vs_writable : bool = config base.mstatus.mstatus_vs_writable;
+  not(hartSupports(Ext_Zve32x)) | (not(hartSupports(Ext_S)) & not(hartSupports(Ext_V)) & mstatus_vs_writable)
+}
 
 //
 // Illegal values legalized to least privileged mode supported.
@@ -229,17 +244,16 @@ private function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
     MPRV = if currentlyEnabled(Ext_U) then v[MPRV] else 0b0,
     // We don't have any extension context yet.
     XS = extStatus_to_bits(Off),
-    // "If neither the F extension nor S-mode is implemented, then FS is read-only zero.
-    // If S-mode is implemented but the F extension is not, FS may optionally be read-only zero."
-    // TODO: This should be made a platform parameter for the latter case.
-    FS = if hartSupports(Ext_Zfinx) | (not(hartSupports(Ext_F)) & not(currentlyEnabled(Ext_S))) then 0b00 else v[FS],
+    // FS is WARL, and making FS writable can support the M-mode emulation of an FPU
+    // to support code running in S/U-modes.  Spike does this, and for now, we match it,
+    // but only if Zfinx isn't enabled.
+    FS = if not(hartSupports(Ext_Zfinx)) & match_fs_legal_values(mstatus_fs_legal_values, unsigned(v[FS])) then v[FS] else extStatus_to_bits(Off),
     MPP = if have_nominal_privLevel(v[MPP]) then v[MPP] else privLevel_to_bits(lowest_supported_privLevel()),
     SPP = if currentlyEnabled(Ext_S) then v[SPP] else 0b0,
     // If neither the v registers nor S-mode is implemented, then VS is
     // read-only zero. If S-mode is implemented but the v registers are not,
     // VS may optionally be read-only zero.
-    // TODO: This should be made a platform parameter for the latter case.
-    VS = if not(hartSupports(Ext_Zve32x)) then 0b00 else v[VS],
+    VS = if is_vs_read_only() then 0b00 else v[VS],
     MPIE = v[MPIE],
     SPIE = if currentlyEnabled(Ext_S) then v[SPIE] else 0b0,
     MIE = v[MIE],

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -91,9 +91,6 @@ let sys_enable_writable_fiom : bool = config base.writable_fiom
 // Which HPM counters are supported (as a bit mask). Bits [2 .. 0] are ignored.
 let sys_writable_hpm_counters : bits(32) = config base.writable_hpm_counters
 
-// The mstatus.FS legal values list.
-let mstatus_fs_legal_values : list(int) = config base.mstatus.mstatus_fs_legal_values
-
 // Supervisor timecmp
 function clause currentlyEnabled(Ext_Sstc) = hartSupports(Ext_Sstc)
 
@@ -152,18 +149,6 @@ function virtual_memory_supported() -> bool = {
 // This measure needs to be > currentlyEnabled_measure(Ext_Sv{32,39,48,57}),
 // currently all equal to 2, see currentlyEnabled_measure in extensions.sail
 termination_measure virtual_memory_supported(_) = 3
-
-function match_fs_legal_values(legal_values : list(int), v : int) -> bool = {
-  match legal_values {
-    [||] => false,
-    value :: rest => (value == v) | match_fs_legal_values(rest, v)
-  }
-}
-
-function is_vs_read_only() -> bool = {
-  let mstatus_vs_writable : bool = config base.mstatus.mstatus_vs_writable;
-  not(hartSupports(Ext_Zve32x)) | (not(hartSupports(Ext_S)) & not(hartSupports(Ext_V)) & mstatus_vs_writable)
-}
 
 //
 // Illegal values legalized to least privileged mode supported.
@@ -242,18 +227,15 @@ private function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
     MXR = if currentlyEnabled(Ext_S) then v[MXR] else 0b0,
     SUM = if virtual_memory_supported() then v[SUM] else 0b0,
     MPRV = if currentlyEnabled(Ext_U) then v[MPRV] else 0b0,
+
     // We don't have any extension context yet.
     XS = extStatus_to_bits(Off),
-    // FS is WARL, and making FS writable can support the M-mode emulation of an FPU
-    // to support code running in S/U-modes.  Spike does this, and for now, we match it,
-    // but only if Zfinx isn't enabled.
-    FS = if not(hartSupports(Ext_Zfinx)) & match_fs_legal_values(mstatus_fs_legal_values, unsigned(v[FS])) then v[FS] else extStatus_to_bits(Off),
+    // Validate FS and VS against their allowed set.
+    FS = if is_extStatus_valid(plat_mstatus_legal_fs, extStatus_bits(v[FS])) then v[FS] else o[FS],
+    VS = if is_extStatus_valid(plat_mstatus_legal_vs, extStatus_bits(v[VS])) then v[VS] else o[VS],
+
     MPP = if have_nominal_privLevel(v[MPP]) then v[MPP] else privLevel_to_bits(lowest_supported_privLevel()),
     SPP = if currentlyEnabled(Ext_S) then v[SPP] else 0b0,
-    // If neither the v registers nor S-mode is implemented, then VS is
-    // read-only zero. If S-mode is implemented but the v registers are not,
-    // VS may optionally be read-only zero.
-    VS = if is_vs_read_only() then 0b00 else v[VS],
     MPIE = v[MPIE],
     SPIE = if currentlyEnabled(Ext_S) then v[SPIE] else 0b0,
     MIE = v[MIE],

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -229,10 +229,10 @@ private function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
     MPRV = if currentlyEnabled(Ext_U) then v[MPRV] else 0b0,
 
     // We don't have any extension context yet.
-    XS = extStatus_to_bits(Off),
+    XS = extStatus_map(Off),
     // Validate FS and VS against their allowed set.
-    FS = if is_extStatus_valid(plat_mstatus_legal_fs, extStatus_bits(v[FS])) then v[FS] else o[FS],
-    VS = if is_extStatus_valid(plat_mstatus_legal_vs, extStatus_bits(v[VS])) then v[VS] else o[VS],
+    FS = legalize_extStatus(plat_mstatus_legal_fs, v[FS]),
+    VS = legalize_extStatus(plat_mstatus_legal_vs, v[VS]),
 
     MPP = if have_nominal_privLevel(v[MPP]) then v[MPP] else privLevel_to_bits(lowest_supported_privLevel()),
     SPP = if currentlyEnabled(Ext_S) then v[SPP] else 0b0,
@@ -243,9 +243,9 @@ private function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
   ];
 
   // Set dirty bit to OR of other status bits.
-  let dirty = extStatus_of_bits(o[FS]) == Dirty |
-              extStatus_of_bits(o[XS]) == Dirty |
-              extStatus_of_bits(o[VS]) == Dirty;
+  let dirty = extStatus_map(o[FS]) == Dirty |
+              extStatus_map(o[XS]) == Dirty |
+              extStatus_map(o[VS]) == Dirty;
 
   [o with SD = bool_to_bit(dirty)]
 }
@@ -714,8 +714,8 @@ private function lower_mstatus(m : Mstatus) -> Sstatus = {
 }
 
 private function lift_sstatus(m : Mstatus, s : Sstatus) -> Mstatus = {
-  let dirty = extStatus_of_bits(s[FS]) == Dirty | extStatus_of_bits(s[XS]) == Dirty |
-              extStatus_of_bits(s[VS]) == Dirty;
+  let dirty = extStatus_map(s[FS]) == Dirty | extStatus_map(s[XS]) == Dirty |
+              extStatus_map(s[VS]) == Dirty;
 
   [m with
     SD = bool_to_bit(dirty),

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -355,21 +355,29 @@ enum xRET_type = {mRET, sRET}
 type ext_status = bits(2)
 enum ExtStatus = {Off, Initial, Clean, Dirty}
 
-mapping extStatus_bits : ExtStatus <-> ext_status = {
+mapping extStatus_map : ExtStatus <-> ext_status = {
   Off     <-> 0b00,
   Initial <-> 0b01,
   Clean   <-> 0b10,
   Dirty   <-> 0b11
 }
 
-function extStatus_to_bits(e : ExtStatus) -> ext_status = extStatus_bits(e)
-function extStatus_of_bits(b : ext_status) -> ExtStatus = extStatus_bits(b)
-
-function is_extStatus_valid(ctx : ExtContext, status : ExtStatus) -> bool = {
+function legalize_extStatus(ctx : ExtContext, status : ext_status) -> ext_status = {
+  let status_enum = extStatus_map(status);
   match ctx {
-    ExtContext_Off       => status == Off,
-    ExtContext_TwoState  => status == Off | status == Dirty,
-    ExtContext_FourState => true,
+    ExtContext_Off       => extStatus_map(Off),
+
+    // This emulates the following implementation choice from the spec:
+    //
+    // "On other implementations, dirtiness might not be tracked at
+    // all, in which case the valid FS states are Off and Dirty, and
+    // an attempt to set FS to Initial or Clean causes it to be set to
+    // Dirty."
+    //
+    // and analogously for VS.
+    ExtContext_TwoState  => if status_enum == Off then status else extStatus_map(Dirty),
+
+    ExtContext_FourState => status,
   }
 }
 

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -362,8 +362,8 @@ mapping extStatus_map : ExtStatus <-> ext_status = {
   Dirty   <-> 0b11
 }
 
-function legalize_extStatus(ctx : ExtContext, status : ext_status) -> ext_status = {
-  match ctx {
+function legalize_extStatus(policy : ExtContextPolicy, status : ext_status) -> ext_status = {
+  match policy {
     ExtContext_Off       => extStatus_map(Off),
 
     // This emulates the following implementation choice from the spec:

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -365,6 +365,14 @@ mapping extStatus_bits : ExtStatus <-> ext_status = {
 function extStatus_to_bits(e : ExtStatus) -> ext_status = extStatus_bits(e)
 function extStatus_of_bits(b : ext_status) -> ExtStatus = extStatus_bits(b)
 
+function is_extStatus_valid(ctx : ExtContext, status : ExtStatus) -> bool = {
+  match ctx {
+    ExtContext_Off       => status == Off,
+    ExtContext_TwoState  => status == Off | status == Dirty,
+    ExtContext_FourState => true,
+  }
+}
+
 // supervisor-level address translation modes
 
 type satp_mode = bits(4)

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -363,7 +363,6 @@ mapping extStatus_map : ExtStatus <-> ext_status = {
 }
 
 function legalize_extStatus(ctx : ExtContext, status : ext_status) -> ext_status = {
-  let status_enum = extStatus_map(status);
   match ctx {
     ExtContext_Off       => extStatus_map(Off),
 
@@ -375,7 +374,7 @@ function legalize_extStatus(ctx : ExtContext, status : ext_status) -> ext_status
     // Dirty."
     //
     // and analogously for VS.
-    ExtContext_TwoState  => if status_enum == Off then status else extStatus_map(Dirty),
+    ExtContext_TwoState  => if extStatus_map(status) == Off then status else extStatus_map(Dirty),
 
     ExtContext_FourState => status,
   }

--- a/model/extensions/FD/fdext_regs.sail
+++ b/model/extensions/FD/fdext_regs.sail
@@ -109,7 +109,7 @@ register f31 : fregtype
 
 function dirty_fd_context() -> unit = {
   assert(hartSupports(Ext_F));
-  mstatus[FS] = extStatus_to_bits(Dirty);
+  mstatus[FS] = extStatus_map(Dirty);
   mstatus[SD] = 0b1;
   long_csr_write_callback("mstatus", "mstatush", mstatus.bits);
 }

--- a/model/extensions/V/vext_regs.sail
+++ b/model/extensions/V/vext_regs.sail
@@ -136,7 +136,7 @@ function rV (Vregno(r) : vregno) -> vlenbits = {
 
 function dirty_v_context() -> unit = {
   assert(hartSupports(Ext_Zve32x));
-  mstatus[VS] = extStatus_to_bits(Dirty);
+  mstatus[VS] = extStatus_map(Dirty);
   mstatus[SD] = 0b1;
   long_csr_write_callback("mstatus", "mstatush", mstatus.bits);
 }

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -567,34 +567,53 @@ private function check_stateen_config() -> bool = {
 private function check_mmio_devices() -> bool = {
   var valid : bool = true;
   if plat_sig_base[1 .. 0] != zeros() then {
-    print_endline("platform.simple_interrupt_generator.base is not 4-byte aligned.");
     valid = false;
+    print_endline("platform.simple_interrupt_generator.base is not 4-byte aligned.");
   };
   valid
 }
 
-private function check_fs_valid_values() -> bool = {
+private function check_mstatus_fields() -> bool = {
   var valid : bool = true;
-  if hartSupports(Ext_F) then {
-    if not(match_fs_legal_values(mstatus_fs_legal_values, 3)) then {
-      print_endline("F extension is enabled but mstatus.FS = 3 is not allowed");
+
+  let legal_fs : ExtContext = config base.mstatus.fs_legal_states;
+  if (config extensions.Zfinx.supported : bool) then {
+    if legal_fs != ExtContext_Off then {
       valid = false;
+      print_endline("The Zfinx extension is enabled but `base.mstatus.fs_legal_states` is not set to `ExtContext_Off`: `mstatus.FS` needs to be read-only zero (i.e. `base.mstatus.fs_legal_states` should be set to `ExtContext_Off`).")
     }
-  }
-  else if not(hartSupports(Ext_S)) then
-    match mstatus_fs_legal_values {
-      0 :: [||] => valid = true,
-      _ => {
-        print_endline("neither F nor S is enabled but mstatus.FS is not read-only zero");
-        valid = false;
-      }
-    };
+  } else if (config extensions.F.supported : bool) then {
+    if legal_fs == ExtContext_Off then {
+      valid = false;
+      print_endline("The F extension is enabled but `base.mstatus.fs_legal_states` is set to `ExtContext_Off`, which makes `mstatus.FS` read-only zero: it cannot be read-only zero.")
+    }
+  } else if not(config extensions.S.supported : bool) then {
+    if legal_fs != ExtContext_Off then {
+      valid = false;
+      print_endline("Both supervisor mode (S) and the F extension are not enabled, but `base.mstatus.fs_legal_states` is not set to `ExtContext_Off`; i.e. `mstatus.FS` is not read-only zero: it should be read-only zero.");
+    }
+  };
+
+  let legal_vs : ExtContext = config base.mstatus.vs_legal_states;
+  if vector_support_level >= Integer then {
+    if legal_vs == ExtContext_Off then {
+      valid = false;
+      print_endline("The vector registers are enabled but `base.mstatus.vs_legal_states` is set to `ExtContext_Off`, which makes `mstatus.VS` read-only zero: it cannot be read-only zero.");
+    }
+  } else if not(config extensions.S.supported : bool) then {
+    if legal_fs != ExtContext_Off then {
+      valid = false;
+      print_endline("Both supervisor mode (S) and the vector registers are not enabled, but `base.mstatus.vs_legal_states` is not set to `ExtContext_Off`; i.e. `mstatus.VS` is not read-only zero: it should be read-only zero.");
+    }
+  };
+
   valid
 }
 
 function config_is_valid() -> bool = {
     check_privs()
   & check_tvecs()
+  & check_mstatus_fields()
   & check_mmu_config()
   & check_mem_layout()
   & check_mmio_devices()
@@ -604,5 +623,4 @@ function config_is_valid() -> bool = {
   & check_misc_extension_dependencies()
   & check_extension_param_constraints()
   & check_stateen_config()
-  & check_fs_valid_values()
 }

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -576,7 +576,7 @@ private function check_mmio_devices() -> bool = {
 private function check_mstatus_fields() -> bool = {
   var valid : bool = true;
 
-  let legal_fs : ExtContext = config base.mstatus.fs_legal_states;
+  let legal_fs : ExtContextPolicy = config base.mstatus.fs_legal_states;
   if (config extensions.Zfinx.supported : bool) then {
     if legal_fs != ExtContext_Off then {
       valid = false;
@@ -594,7 +594,7 @@ private function check_mstatus_fields() -> bool = {
     }
   };
 
-  let legal_vs : ExtContext = config base.mstatus.vs_legal_states;
+  let legal_vs : ExtContextPolicy = config base.mstatus.vs_legal_states;
   if vector_support_level >= Integer then {
     if legal_vs == ExtContext_Off then {
       valid = false;

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -601,7 +601,7 @@ private function check_mstatus_fields() -> bool = {
       print_endline("The vector registers are enabled but `base.mstatus.vs_legal_states` is set to `ExtContext_Off`, which makes `mstatus.VS` read-only zero: it cannot be read-only zero.");
     }
   } else if not(config extensions.S.supported : bool) then {
-    if legal_fs != ExtContext_Off then {
+    if legal_vs != ExtContext_Off then {
       valid = false;
       print_endline("Both supervisor mode (S) and the vector registers are not enabled, but `base.mstatus.vs_legal_states` is not set to `ExtContext_Off`; i.e. `mstatus.VS` is not read-only zero: it should be read-only zero.");
     }

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -573,6 +573,25 @@ private function check_mmio_devices() -> bool = {
   valid
 }
 
+private function check_fs_valid_values() -> bool = {
+  var valid : bool = true;
+  if hartSupports(Ext_F) then {
+    if not(match_fs_legal_values(mstatus_fs_legal_values, 3)) then {
+      print_endline("F extension is enabled but mstatus.FS = 3 is not allowed");
+      valid = false;
+    }
+  }
+  else if not(hartSupports(Ext_S)) then
+    match mstatus_fs_legal_values {
+      0 :: [||] => valid = true,
+      _ => {
+        print_endline("neither F nor S is enabled but mstatus.FS is not read-only zero");
+        valid = false;
+      }
+    };
+  valid
+}
+
 function config_is_valid() -> bool = {
     check_privs()
   & check_tvecs()
@@ -585,4 +604,5 @@ function config_is_valid() -> bool = {
   & check_misc_extension_dependencies()
   & check_extension_param_constraints()
   & check_stateen_config()
+  & check_fs_valid_values()
 }


### PR DESCRIPTION
This uses an enum to support three likely configurations for these extension context states:

- `Off`: implying read-only zero (or the set `{Off}`)
- `TwoState`: containing `{Off, Dirty}`
- `FourState`: containing all the possible states `{Off, Initial, Clean, Dirty}`

since these seem the most likely implementation choices.

It handles the following clauses of the spec:

> If S-mode is implemented but the F extension is not, FS may optionally be read-only zero.

> If S-mode is implemented but the v registers are not, VS may optionally be read-only zero.

It also moves the supported extension validation checks to `validate_config` where it is done once, and then CSR value legalization is just done against the configured enum above.

This fixes #1722.