### PR TITLE
Enforce stricter vstart bounds checking

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -426,7 +426,12 @@
         // "IllegalVtype_SetVill" - set vtype.vill, set vl to zero, clear vstart, and write rd.
         // "IllegalVtype_Illegal" - treat it as an illegal instruction.
         // "IllegalVtype_Fatal"   - raise a Sail exception, stopping execution.
-        "illegal_vtype": "IllegalVtype_SetVill"
+        "illegal_vtype": "IllegalVtype_SetVill",
+        // This determines how to handle an out-of-bounds vstart (vstart >= VLMAX), which the
+        // vector spec marks reserved and recommends, but does not require, trapping.
+        // "Vstart_Illegal" - raise an illegal instruction exception.
+        // "Vstart_Ignore"  - treat as a no-op, the instruction writes nothing.
+        "vstart_out_of_bounds": "Vstart_Illegal"
       },
       "vl_use_ceil": false,
       // The maximum index EEW for indexed vector addressing mode, as

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -34,6 +34,15 @@
     when `vstart` is non-zero. The default value of true introduces a backward-
     incompatible change compared to previous versions, but can be changed to
     preserve the earlier behaviour.
+  - New option `extensions.V.reserved_behavior.vstart_out_of_bounds`
+    (default `Vstart_Illegal`) controls how an out-of-bounds `vstart`
+    (one greater than the largest element index for the current `vtype`,
+    `vstart` >= VLMAX) is handled. This applies to all vector
+    instructions, including the vector crypto extensions. `Vstart_Illegal`
+    raises an illegal instruction exception, `Vstart_Ignore` treats the
+    instruction as a no-op that writes no elements. The model now enforces
+    this bound by default, correctly accounting for fractional LMUL, which
+    introduces a backward-incompatible change compared to previous versions.
   - The handling of attempts to set an unsupported or reserved `vtype`
     can now be configured; see `extensions.V.reserved_behavior.illegal_vtype`.
   - The supported values for `mstatus.FS` and `mstatus.VS` can be

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -36,8 +36,8 @@
     preserve the earlier behaviour.
   - New option `extensions.V.reserved_behavior.vstart_out_of_bounds`
     (default `Vstart_Illegal`) controls how an out-of-bounds `vstart`
-    (one greater than the largest element index for the current `vtype`,
-    `vstart` >= VLMAX) is handled. This applies to all vector
+    (`vstart` >= VLMAX, i.e. one greater than the largest element index
+    for the current `vtype`) is handled. This applies to all vector
     instructions, including the vector crypto extensions. `Vstart_Illegal`
     raises an illegal instruction exception, `Vstart_Ignore` treats the
     instruction as a no-op that writes no elements. The model now enforces

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -173,6 +173,11 @@ enum IllegalVtypeReservedBehavior = {
   IllegalVtype_Fatal,
 }
 
+enum VstartReservedBehavior = {
+  Vstart_Illegal,
+  Vstart_Ignore,
+}
+
 let amocas_odd_register_reserved_behavior : AmocasOddRegisterReservedBehavior = config base.reserved_behavior.amocas_odd_register
 let fcsr_rm_reserved_behavior : FcsrRmReservedBehavior = config base.reserved_behavior.fcsr_rm
 let pmp_write_only_reserved_behavior : PmpWriteOnlyReservedBehavior = config base.reserved_behavior.pmpcfg_write_only
@@ -180,3 +185,4 @@ let xenvcfg_cbie_reserved_behavior : XenvcfgCbieReservedBehavior = config base.r
 let xtvec_mode_reserved_behavior : XtvecModeReservedBehavior = config base.reserved_behavior.xtvec_mode
 let rv32zdinx_odd_register_reserved_behavior : RV32ZdinxOddRegisterReservedBehavior = config base.reserved_behavior.rv32zdinx_odd_register
 let illegal_vtype_reserved_behavior : IllegalVtypeReservedBehavior = config extensions.V.reserved_behavior.illegal_vtype
+let vstart_reserved_behavior : VstartReservedBehavior = config extensions.V.reserved_behavior.vstart_out_of_bounds

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -173,7 +173,7 @@ enum IllegalVtypeReservedBehavior = {
   IllegalVtype_Fatal,
 }
 
-enum VstartReservedBehavior = {
+enum OOBVstartReservedBehavior = {
   Vstart_Illegal,
   Vstart_Ignore,
 }
@@ -185,4 +185,4 @@ let xenvcfg_cbie_reserved_behavior : XenvcfgCbieReservedBehavior = config base.r
 let xtvec_mode_reserved_behavior : XtvecModeReservedBehavior = config base.reserved_behavior.xtvec_mode
 let rv32zdinx_odd_register_reserved_behavior : RV32ZdinxOddRegisterReservedBehavior = config base.reserved_behavior.rv32zdinx_odd_register
 let illegal_vtype_reserved_behavior : IllegalVtypeReservedBehavior = config extensions.V.reserved_behavior.illegal_vtype
-let vstart_reserved_behavior : VstartReservedBehavior = config extensions.V.reserved_behavior.vstart_out_of_bounds
+let vstart_reserved_behavior : OOBVstartReservedBehavior = config extensions.V.reserved_behavior.vstart_out_of_bounds

--- a/model/extensions/V/vext_arith_insts.sail
+++ b/model/extensions/V/vext_arith_insts.sail
@@ -75,7 +75,7 @@ function clause execute VVTYPE(funct6, vm, vs2, vs1, vd) = {
                                then not(valid_src_overlap(vs1, 16, vs1_emul_pow, vs2, SEW, LMUL_pow))
                                else false;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_overlap(vs1, vd, vs1_emul_pow, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
@@ -98,10 +98,7 @@ function clause execute VVTYPE(funct6, vm, vs2, vs1, vd) = {
                                                     then read_vreg(num_elem, 16, vs1_emul_pow, vs1)
                                                     else vector_init(zeros());
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -225,7 +222,7 @@ function clause execute NVSTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
      not(valid_src_overlap(vs2, SEW_widen, LMUL_pow_widen, vs1, SEW, LMUL_pow)) |
@@ -245,10 +242,7 @@ function clause execute NVSTYPE(funct6, vm, vs2, vs1, vd) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -303,7 +297,7 @@ function clause execute NVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
      not(valid_src_overlap(vs2, SEW_widen, LMUL_pow_widen, vs1, SEW, LMUL_pow)) |
@@ -323,10 +317,7 @@ function clause execute NVTYPE(funct6, vm, vs2, vs1, vd) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -369,17 +360,14 @@ mapping clause encdec = MASKTYPEV (vs2, vs1,  vd)
      | (currentlyEnabled(Ext_Zve64x) & get_sew() <= 64)
 
 function clause execute MASKTYPEV(vs2, vs1, vd) = {
-  let start_element : nat = match get_start_element() {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let start_element = get_start_element();
   let end_element   = get_end_element();
   let SEW           = get_sew();
   let LMUL_pow      = get_lmul_pow();
   let num_elem      = get_num_elem(LMUL_pow, SEW); // max(VLMAX,VLEN/SEW))
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); // VLMAX
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_vd_masked(vd)  |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
@@ -433,7 +421,7 @@ function clause execute MOVETYPEV(vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_vd_unmasked()  |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow))
@@ -445,10 +433,7 @@ function clause execute MOVETYPEV(vs1, vd) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, ones()) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, ones());
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -499,7 +484,7 @@ function clause execute VXTYPE(funct6, vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -514,10 +499,7 @@ function clause execute VXTYPE(funct6, vm, vs2, rs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -627,7 +609,7 @@ function clause execute NXSTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs2, SEW_widen))
@@ -645,10 +627,7 @@ function clause execute NXSTYPE(funct6, vm, vs2, rs1, vd) = {
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -703,7 +682,7 @@ function clause execute NXTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs2, SEW_widen))
@@ -721,10 +700,7 @@ function clause execute NXTYPE(funct6, vm, vs2, rs1, vd) = {
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -788,7 +764,7 @@ function clause execute VXSG(funct6, vm, vs2, rs1, vd) = {
     VX_VRGATHER   => vd == vs2,
   };
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -804,10 +780,7 @@ function clause execute VXSG(funct6, vm, vs2, rs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -855,18 +828,14 @@ mapping clause encdec = MASKTYPEX(vs2, rs1, vd)
      | (currentlyEnabled(Ext_Zve64x) & get_sew() <= 64)
 
 function clause execute MASKTYPEX(vs2, rs1, vd) = {
-  let start_element : nat = match get_start_element() {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
-
+  let start_element = get_start_element();
   let end_element   = get_end_element();
   let SEW           = get_sew();
   let LMUL_pow      = get_lmul_pow();
   let num_elem      = get_num_elem(LMUL_pow, SEW); // max(VLMAX,VLEN/SEW))
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); // VLMAX
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_vd_masked(vd)  |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -918,7 +887,7 @@ function clause execute MOVETYPEX(rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) | illegal_vd_unmasked() | not(valid_reg_group(vd, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) | illegal_vd_unmasked() | not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -927,10 +896,7 @@ function clause execute MOVETYPEX(rs1, vd) = {
   let rs1_val : bits('m)             = get_scalar(rs1, 'm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, ones()) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, ones());
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -973,7 +939,7 @@ function clause execute VITYPE(funct6, vm, vs2, simm, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -988,10 +954,7 @@ function clause execute VITYPE(funct6, vm, vs2, simm, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1077,7 +1040,7 @@ function clause execute NISTYPE(funct6, vm, vs2, uimm, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs2, SEW_widen))
@@ -1095,10 +1058,7 @@ function clause execute NISTYPE(funct6, vm, vs2, uimm, vd) = {
   let imm_val : bits('m)             = zero_extend(uimm);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1153,7 +1113,7 @@ function clause execute NITYPE(funct6, vm, vs2, uimm, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs2, SEW_widen))
@@ -1171,10 +1131,7 @@ function clause execute NITYPE(funct6, vm, vs2, uimm, vd) = {
   let imm_val : bits('m)             = zero_extend(uimm);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1237,7 +1194,7 @@ function clause execute VISG(funct6, vm, vs2, simm, vd) = {
     VI_VSLIDEDOWN => false,
     VI_VRGATHER   => vd == vs2,
   };
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -1253,10 +1210,7 @@ function clause execute VISG(funct6, vm, vs2, simm, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1304,18 +1258,14 @@ mapping clause encdec = MASKTYPEI(vs2, simm, vd)
      | (currentlyEnabled(Ext_Zve64x) & get_sew() <= 64)
 
 function clause execute MASKTYPEI(vs2, simm, vd) = {
-  let start_element : nat = match get_start_element() {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
-
+  let start_element = get_start_element();
   let end_element   = get_end_element();
   let SEW           = get_sew();
   let LMUL_pow      = get_lmul_pow();
   let num_elem      = get_num_elem(LMUL_pow, SEW); // max(VLMAX,VLEN/SEW))
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); // VLMAX
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_vd_masked(vd)  |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -1367,7 +1317,7 @@ function clause execute MOVETYPEI(vd, simm) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) | illegal_vd_unmasked() | not(valid_reg_group(vd, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) | illegal_vd_unmasked() | not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -1376,10 +1326,7 @@ function clause execute MOVETYPEI(vd, simm) = {
   let imm_val : bits('m)             = sign_extend(simm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, ones()) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, ones());
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1416,12 +1363,9 @@ mapping clause encdec = VMVRTYPE(vs2, nreg, vd)
      | (currentlyEnabled(Ext_Zve64x) & get_sew() <= 64)
 
 function clause execute VMVRTYPE(vs2, nreg, vd) = {
-  let start_element : nat = match get_start_element() {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
-  let SEW     = get_sew();
-  let EMUL    = nreg;
+  let start_element = get_start_element();
+  let SEW           = get_sew();
+  let EMUL          = nreg;
 
   let EMUL_pow : range(0, 3) = match EMUL {
     1 => 0,
@@ -1429,14 +1373,14 @@ function clause execute VMVRTYPE(vs2, nreg, vd) = {
     4 => 2,
     8 => 3,
   };
+  let num_elem = get_num_elem(EMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, EMUL_pow) |
      illegal_vd_unmasked()  |
      not(valid_reg_group(vs2, EMUL_pow)) |
      not(valid_reg_group(vd, EMUL_pow))
   then return Illegal_Instruction();
 
-  let num_elem = get_num_elem(EMUL_pow, SEW);
   let 'n = num_elem;
   let 'm = SEW;
 
@@ -1492,7 +1436,7 @@ function clause execute MVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
@@ -1509,10 +1453,7 @@ function clause execute MVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1620,7 +1561,7 @@ function clause execute MVVMATYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
@@ -1637,10 +1578,7 @@ function clause execute MVVMATYPE(funct6, vm, vs2, vs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1694,7 +1632,7 @@ function clause execute WVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
@@ -1714,10 +1652,7 @@ function clause execute WVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1775,7 +1710,7 @@ function clause execute WVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_src_overlap(vs2, SEW_widen, LMUL_pow_widen, vs1, SEW, LMUL_pow)) |
@@ -1795,10 +1730,7 @@ function clause execute WVTYPE(funct6, vm, vs2, vs1, vd) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1850,7 +1782,7 @@ function clause execute WMVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
@@ -1870,10 +1802,7 @@ function clause execute WMVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1934,7 +1863,7 @@ function clause execute VEXTTYPE(funct6, vm, vs2, vd) = {
   let LMUL_pow_div = LMUL_pow - SEW_frac_pow;
   let SEW_div = SEW / (2 ^ SEW_frac_pow);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_div, LMUL_pow_div) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow_div, LMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs2, SEW_div))
@@ -1950,10 +1879,7 @@ function clause execute VEXTTYPE(funct6, vm, vs2, vd) = {
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_div, LMUL_pow_div, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1998,7 +1924,7 @@ function clause execute VMVXS(vs2, rd) = {
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
-  if illegal_vstart(VSTART_SCALAR_MOVE) |
+  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, 0) |
      illegal_vd_unmasked()
   then return Illegal_Instruction();
 
@@ -2028,16 +1954,13 @@ mapping clause encdec = MVVCOMPRESS(vs2, vs1, vd)
      | (currentlyEnabled(Ext_Zve64x) & get_sew() <= 64)
 
 function clause execute MVVCOMPRESS(vs2, vs1, vd) = {
-  let start_element : nat = match get_start_element() {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
-  let end_element = get_end_element();
-  let SEW         = get_sew();
-  let LMUL_pow    = get_lmul_pow();
-  let num_elem    = get_num_elem(LMUL_pow, SEW);
+  let start_element = get_start_element();
+  let end_element   = get_end_element();
+  let SEW           = get_sew();
+  let LMUL_pow      = get_lmul_pow();
+  let num_elem      = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_MANDATORY) |
+  if illegal_vstart(VSTART_MANDATORY, num_elem, LMUL_pow) |
      illegal_vd_unmasked() |
      not(valid_disjoint_reg_groups(vs1, vd, 0, LMUL_pow)) |
      vs2 == vd |
@@ -2119,7 +2042,7 @@ function clause execute MVXTYPE(funct6, vm, vs2, rs1, vd) = {
   // register group does not overlap the source vector register
   // group. Otherwise, the instruction encoding is reserved."
   let src_dst_overlap = funct6 == MVX_VSLIDE1UP & vs2 == vd;
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -2135,10 +2058,7 @@ function clause execute MVXTYPE(funct6, vm, vs2, rs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -2254,7 +2174,7 @@ function clause execute MVXMATYPE(funct6, vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -2269,10 +2189,7 @@ function clause execute MVXMATYPE(funct6, vm, vs2, rs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -2327,7 +2244,7 @@ function clause execute WVXTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
@@ -2345,10 +2262,7 @@ function clause execute WVXTYPE(funct6, vm, vs2, rs1, vd) = {
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -2406,7 +2320,7 @@ function clause execute WXTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_group(vs2, LMUL_pow_widen)) |
      not(valid_reg_group(vd, LMUL_pow_widen)) |
@@ -2425,10 +2339,7 @@ function clause execute WXTYPE(funct6, vm, vs2, rs1, vd) = {
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -2481,7 +2392,7 @@ function clause execute WMVXTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
@@ -2499,10 +2410,7 @@ function clause execute WMVXTYPE(funct6, vm, vs2, rs1, vd) = {
   let rs1_val : bits('m)             = get_scalar(rs1, SEW);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -2543,7 +2451,7 @@ function clause execute VMVSX(rs1, vd) = {
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
-  if illegal_vstart(VSTART_SCALAR_MOVE) |
+  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, 0) |
      illegal_vd_unmasked()
   then return Illegal_Instruction();
 
@@ -2555,10 +2463,7 @@ function clause execute VMVSX(rs1, vd) = {
   let rs1_val : bits('m)             = get_scalar(rs1, 'm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, 0, vd_val, ones()) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, 0, vd_val, ones());
   var result = initial_result;
 
   // one body element

--- a/model/extensions/V/vext_fp_insts.sail
+++ b/model/extensions/V/vext_fp_insts.sail
@@ -39,7 +39,7 @@ function clause execute FVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
@@ -58,10 +58,7 @@ function clause execute FVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -127,7 +124,7 @@ function clause execute FVVMATYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
@@ -146,10 +143,7 @@ function clause execute FVVMATYPE(funct6, vm, vs2, vs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -209,7 +203,7 @@ function clause execute FWVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
@@ -229,10 +223,7 @@ function clause execute FWVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -284,7 +275,7 @@ function clause execute FWVVMATYPE(funct6, vm, vs1, vs2, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
@@ -304,10 +295,7 @@ function clause execute FWVVMATYPE(funct6, vm, vs1, vs2, vd) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -358,7 +346,7 @@ function clause execute FWVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_src_overlap(vs2, SEW_widen, LMUL_pow_widen, vs1, SEW, LMUL_pow)) |
@@ -378,10 +366,7 @@ function clause execute FWVTYPE(funct6, vm, vs2, vs1, vd) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -430,7 +415,7 @@ function clause execute VFUNARY0(vm, vs2, vfunary0, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -446,10 +431,7 @@ function clause execute VFUNARY0(vm, vs2, vfunary0, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -556,7 +538,7 @@ function clause execute VFWUNARY0(vm, vs2, vfwunary0, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
@@ -573,10 +555,7 @@ function clause execute VFWUNARY0(vm, vs2, vfwunary0, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -694,7 +673,7 @@ function clause execute VFNUNARY0(vm, vs2, vfnunary0, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs2, SEW_widen))
@@ -710,10 +689,7 @@ function clause execute VFNUNARY0(vm, vs2, vfnunary0, vd) = {
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -836,7 +812,7 @@ function clause execute VFUNARY1(vm, vs2, vfunary1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -852,10 +828,7 @@ function clause execute VFUNARY1(vm, vs2, vfunary1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -922,7 +895,7 @@ function clause execute VFMVFS(vs2, rd) = {
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
-  if illegal_vstart(VSTART_SCALAR_MOVE) | illegal_fp_vd_unmasked(SEW, rm_3b) | SEW > flen
+  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, 0) | illegal_fp_vd_unmasked(SEW, rm_3b) | SEW > flen
   then return Illegal_Instruction();
 
   assert(num_elem > 0 & SEW != 8);
@@ -980,7 +953,7 @@ function clause execute FVFTYPE(funct6, vm, vs2, rs1, vd) = {
   // group. Otherwise, the instruction encoding is reserved."
   let src_dst_overlap = funct6 == VF_VSLIDE1UP & vs2 == vd;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -998,10 +971,7 @@ function clause execute FVFTYPE(funct6, vm, vs2, rs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1081,7 +1051,7 @@ function clause execute FVFMATYPE(funct6, vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_normal(vd, vm, SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -1098,10 +1068,7 @@ function clause execute FVFMATYPE(funct6, vm, vs2, rs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1161,7 +1128,7 @@ function clause execute FWVFTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
@@ -1179,10 +1146,7 @@ function clause execute FWVFTYPE(funct6, vm, vs2, rs1, vd) = {
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1234,7 +1198,7 @@ function clause execute FWVFMATYPE(funct6, vm, rs1, vs2, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
@@ -1252,10 +1216,7 @@ function clause execute FWVFMATYPE(funct6, vm, rs1, vs2, vd) = {
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1306,7 +1267,7 @@ function clause execute FWFTYPE(funct6, vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_group(vs2, LMUL_pow_widen)) |
      not(valid_reg_group(vd, LMUL_pow_widen)) |
@@ -1325,10 +1286,7 @@ function clause execute FWFTYPE(funct6, vm, vs2, rs1, vd) = {
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1365,17 +1323,14 @@ mapping clause encdec = VFMERGE(vs2, rs1, vd)
 
 function clause execute VFMERGE(vs2, rs1, vd) = {
   let rm_3b         = fcsr[FRM];
-  let start_element : nat = match get_start_element() {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let start_element = get_start_element();
   let end_element   = get_end_element();
   let SEW           = get_sew();
   let LMUL_pow      = get_lmul_pow();
   let num_elem      = get_num_elem(LMUL_pow, SEW); // max(VLMAX,VLEN/SEW))
   let real_num_elem = if LMUL_pow >= 0 then num_elem else num_elem / (0 - LMUL_pow); // VLMAX
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_vd_masked(vd, SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -1432,7 +1387,7 @@ function clause execute VFMV(rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_vd_unmasked(SEW, rm_3b) |
      not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
@@ -1445,10 +1400,7 @@ function clause execute VFMV(rs1, vd) = {
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, ones()) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, ones());
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -1477,7 +1429,7 @@ function clause execute VFMVSF(rs1, vd) = {
   let SEW      = get_sew();
   let num_elem = get_num_elem(0, SEW);
 
-  if illegal_vstart(VSTART_SCALAR_MOVE) | illegal_fp_vd_unmasked(SEW, rm_3b) then return Illegal_Instruction();
+  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, 0) | illegal_fp_vd_unmasked(SEW, rm_3b) then return Illegal_Instruction();
 
   assert(num_elem > 0 & SEW != 8);
 
@@ -1487,10 +1439,7 @@ function clause execute VFMVSF(rs1, vd) = {
   let rs1_val : bits('m)             = get_scalar_fp(rs1, 'm);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, 0, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, 0, vd_val, ones()) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, 0, vd_val, ones());
   var result = initial_result;
 
   // one body element

--- a/model/extensions/V/vext_fp_red_insts.sail
+++ b/model/extensions/V/vext_fp_red_insts.sail
@@ -34,7 +34,7 @@ function clause execute RFVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let rm_3b       = fcsr[FRM];
   let num_elem_vd = get_num_elem(0, SEW); // vd regardless of LMUL setting
 
-  if illegal_vstart(VSTART_MANDATORY) |
+  if illegal_vstart(VSTART_MANDATORY, num_elem_vs, LMUL_pow) |
      illegal_fp_reduction(SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
@@ -52,10 +52,7 @@ function clause execute RFVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let vd_val  : vector('d, bits('m)) = read_vreg(num_elem_vd, SEW, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
 
-  let mask : bits('n) = match init_masked_source(num_elem_vs, LMUL_pow, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let mask : bits('n) = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
 
   var sum : bits('m) = read_single_element(SEW, 0, vs1); // vs1 regardless of LMUL setting
   foreach (i from 0 to (num_elem_vs - 1)) {
@@ -112,7 +109,7 @@ function clause execute RFWVVTYPE(_funct6, vm, vs2, vs1, vd) = {
   let rm_3b       = fcsr[FRM];
   let SEW_widen   = SEW * 2;
 
-  if illegal_vstart(VSTART_MANDATORY) |
+  if illegal_vstart(VSTART_MANDATORY, num_elem_vs, LMUL_pow) |
      illegal_fp_widening_reduction(SEW, rm_3b, SEW_widen) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
@@ -133,10 +130,7 @@ function clause execute RFWVVTYPE(_funct6, vm, vs2, vs1, vd) = {
   let vd_val  : vector('d, bits('o)) = read_vreg(num_elem_vd, SEW_widen, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
 
-  let mask : bits('n) = match init_masked_source(num_elem_vs, LMUL_pow, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let mask : bits('n) = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
 
   var sum : bits('o) = read_single_element(SEW_widen, 0, vs1); // vs1 regardless of LMUL setting
   foreach (i from 0 to (num_elem_vs - 1)) {

--- a/model/extensions/V/vext_fp_vm_insts.sail
+++ b/model/extensions/V/vext_fp_vm_insts.sail
@@ -34,7 +34,7 @@ function clause execute FVVMTYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_vd_unmasked(SEW, rm_3b) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
@@ -52,10 +52,7 @@ function clause execute FVVMTYPE(funct6, vm, vs2, vs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)             = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (bits('n), bits('n)) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -110,7 +107,7 @@ function clause execute FVFMTYPE(funct6, vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_vd_unmasked(SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
@@ -126,10 +123,7 @@ function clause execute FVFMTYPE(funct6, vm, vs2, rs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)             = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (bits('n), bits('n)) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {

--- a/model/extensions/V/vext_mask_insts.sail
+++ b/model/extensions/V/vext_mask_insts.sail
@@ -34,7 +34,7 @@ function clause execute MMTYPE(funct6, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let num_elem = vlen;
 
-  if illegal_vd_unmasked() | illegal_vstart(VSTART_ARITH) then return Illegal_Instruction();
+  if illegal_vd_unmasked() | illegal_vstart(VSTART_ARITH, num_elem, 0) then return Illegal_Instruction();
 
   let 'n = num_elem;
   let 'm = SEW;
@@ -43,10 +43,7 @@ function clause execute MMTYPE(funct6, vs2, vs1, vd) = {
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, 0, vd_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (bits('n), bits('n)) = init_masked_result_carry(num_elem, SEW, 0, vd_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -94,17 +91,14 @@ mapping clause encdec = VCPOP_M(vm, vs2, rd)
 function clause execute VCPOP_M(vm, vs2, rd) = {
   let num_elem = vlen;
 
-  if illegal_vd_unmasked() | illegal_vstart(VSTART_MANDATORY) then return Illegal_Instruction();
+  if illegal_vd_unmasked() | illegal_vstart(VSTART_MANDATORY, num_elem, 0) then return Illegal_Instruction();
 
   let 'n = num_elem;
 
   let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
 
-  let mask : bits('n) = match init_masked_source(num_elem, 0, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let mask : bits('n) = init_masked_source(num_elem, 0, vm_val);
 
   X(rd) = to_bits(xlen, count_ones(mask & vs2_val));
   set_vstart(zeros());
@@ -125,17 +119,14 @@ mapping clause encdec = VFIRST_M(vm, vs2, rd)
 function clause execute VFIRST_M(vm, vs2, rd) = {
   let num_elem = vlen;
 
-  if illegal_vd_unmasked() | illegal_vstart(VSTART_MANDATORY) then return Illegal_Instruction();
+  if illegal_vd_unmasked() | illegal_vstart(VSTART_MANDATORY, num_elem, 0) then return Illegal_Instruction();
 
   let 'n = num_elem;
 
   let vm_val  : bits('n) = read_vmask(num_elem, vm, zvreg);
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
 
-  let mask : bits('n) = match init_masked_source(num_elem, 0, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let mask : bits('n) = init_masked_source(num_elem, 0, vm_val);
 
   let active = mask & vs2_val;
 
@@ -159,7 +150,7 @@ function clause execute VMSBF_M(vm, vs2, vd) = {
   let SEW      = get_sew();
   let num_elem = vlen;
 
-  if illegal_vstart(VSTART_MANDATORY) | illegal_normal(vd, vm) | vd == vs2
+  if illegal_vstart(VSTART_MANDATORY, num_elem, 0) | illegal_normal(vd, vm) | vd == vs2
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -169,10 +160,7 @@ function clause execute VMSBF_M(vm, vs2, vd) = {
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (bits('n), bits('n)) = init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val);
   var result = initial_result;
 
   var found_elem : bool = false;
@@ -203,7 +191,7 @@ function clause execute VMSIF_M(vm, vs2, vd) = {
   let SEW      = get_sew();
   let num_elem = vlen;
 
-  if illegal_vstart(VSTART_MANDATORY) | illegal_normal(vd, vm) | vd == vs2
+  if illegal_vstart(VSTART_MANDATORY, num_elem, 0) | illegal_normal(vd, vm) | vd == vs2
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -213,10 +201,7 @@ function clause execute VMSIF_M(vm, vs2, vd) = {
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (bits('n), bits('n)) = init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val);
   var result = initial_result;
 
   var found_elem : bool = false;
@@ -247,7 +232,7 @@ function clause execute VMSOF_M(vm, vs2, vd) = {
   let SEW      = get_sew();
   let num_elem = vlen;
 
-  if illegal_vstart(VSTART_MANDATORY) | illegal_normal(vd, vm) | vd == vs2
+  if illegal_vstart(VSTART_MANDATORY, num_elem, 0) | illegal_normal(vd, vm) | vd == vs2
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -257,10 +242,7 @@ function clause execute VMSOF_M(vm, vs2, vd) = {
   let vs2_val : bits('n) = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : bits('n) = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (bits('n), bits('n)) = init_masked_result_cmp(num_elem, SEW, 0, vd_val, vm_val);
   var result = initial_result;
 
   var found_elem : bool = false;
@@ -296,7 +278,7 @@ function clause execute VIOTA_M(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_MANDATORY) |
+  if illegal_vstart(VSTART_MANDATORY, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vd, LMUL_pow)) |
      vd == vs2
@@ -309,10 +291,7 @@ function clause execute VIOTA_M(vm, vs2, vd) = {
   let vs2_val : bits('n)             = read_vmask(num_elem, 0b0, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   var sum : int = 0;
@@ -344,7 +323,7 @@ function clause execute VID_V(vm, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) | illegal_normal(vd, vm) | not(valid_reg_group(vd, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) | illegal_normal(vd, vm) | not(valid_reg_group(vd, LMUL_pow))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -353,10 +332,7 @@ function clause execute VID_V(vm, vd) = {
   let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)    => v,
-    Err(())  => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {

--- a/model/extensions/V/vext_mem_insts.sail
+++ b/model/extensions/V/vext_mem_insts.sail
@@ -60,11 +60,11 @@ function clause execute VLSEGTYPE(nf, vm, rs1, width, vd) = {
 
   assert(-3 <= EMUL_pow & EMUL_pow <= 3);
 
-  if illegal_vstart(VSTART_LOAD_STORE) | illegal_load(vd, vm, nf, EEW, EMUL_pow) | not(valid_reg_group(vd, EMUL_pow))
-  then return Illegal_Instruction();
-
   let num_elem = get_num_elem(EMUL_pow, EEW); // # of element of each register group
   assert(num_elem > 0);
+
+  if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_pow) | illegal_load(vd, vm, nf, EEW, EMUL_pow) | not(valid_reg_group(vd, EMUL_pow))
+  then return Illegal_Instruction();
 
   let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
@@ -72,10 +72,7 @@ function clause execute VLSEGTYPE(nf, vm, rs1, width, vd) = {
 
   let 'm = nf * load_width_bytes * 8;
   let 'n = num_elem;
-  let (result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, 'm, EMUL_pow, vd_seg, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, 'm, EMUL_pow, vd_seg, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == 0b1 then { // active segments
@@ -120,11 +117,11 @@ function clause execute VLSEGFFTYPE(nf, vm, rs1, width, vd) = {
 
   assert(-3 <= EMUL_pow & EMUL_pow <= 3);
 
-  if illegal_vstart(VSTART_LOAD_STORE) | illegal_load(vd, vm, nf, EEW, EMUL_pow) | not(valid_reg_group(vd, EMUL_pow))
-  then return Illegal_Instruction();
-
   let num_elem = get_num_elem(EMUL_pow, EEW);
   assert(num_elem > 0);
+
+  if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_pow) | illegal_load(vd, vm, nf, EEW, EMUL_pow) | not(valid_reg_group(vd, EMUL_pow))
+  then return Illegal_Instruction();
 
   let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
@@ -133,10 +130,7 @@ function clause execute VLSEGFFTYPE(nf, vm, rs1, width, vd) = {
 
   let 'm = nf * load_width_bytes * 8;
   let 'n = num_elem;
-  let (result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val);
 
   var trimmed : bool = false;
   foreach (i from 0 to (num_elem - 1)) {
@@ -197,21 +191,18 @@ function clause execute VSSEGTYPE(nf, vm, rs1, width, vs3) = {
 
   assert(-3 <= EMUL_pow & EMUL_pow <= 3);
 
-  if illegal_vstart(VSTART_LOAD_STORE) | illegal_store(nf, EEW, EMUL_pow) | not(valid_reg_group(vs3, EMUL_pow))
-  then return Illegal_Instruction();
-
   let num_elem = get_num_elem(EMUL_pow, EEW);
   assert(num_elem > 0);
+
+  if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_pow) | illegal_store(nf, EEW, EMUL_pow) | not(valid_reg_group(vs3, EMUL_pow))
+  then return Illegal_Instruction();
 
   let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vs3_seg = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
 
   let 'n = num_elem;
-  let mask : bits('n) = match init_masked_source(num_elem, EMUL_pow, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let mask : bits('n) = init_masked_source(num_elem, EMUL_pow, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == 0b1 then { // active segments
@@ -254,11 +245,11 @@ function clause execute VLSSEGTYPE(nf, vm, rs2, rs1, width, vd) = {
 
   assert(-3 <= EMUL_pow & EMUL_pow <= 3);
 
-  if illegal_vstart(VSTART_LOAD_STORE) | illegal_load(vd, vm, nf, EEW, EMUL_pow) | not(valid_reg_group(vd, EMUL_pow))
-  then return Illegal_Instruction();
-
   let num_elem = get_num_elem(EMUL_pow, EEW);
   assert(num_elem > 0);
+
+  if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_pow) | illegal_load(vd, vm, nf, EEW, EMUL_pow) | not(valid_reg_group(vd, EMUL_pow))
+  then return Illegal_Instruction();
 
   let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let vm_val  = read_vmask(num_elem, vm, zvreg);
@@ -267,10 +258,7 @@ function clause execute VLSSEGTYPE(nf, vm, rs2, rs1, width, vd) = {
 
   let 'm = nf * load_width_bytes * 8;
   let 'n = num_elem;
-  let (result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, nf * load_width_bytes * 8, EMUL_pow, vd_seg, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == 0b1 then { // active segments
@@ -315,14 +303,14 @@ function clause execute VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3) = {
 
   assert(-3 <= EMUL_pow & EMUL_pow <= 3);
 
-  if illegal_vstart(VSTART_LOAD_STORE) |
+  let num_elem = get_num_elem(EMUL_pow, EEW);
+  assert(num_elem > 0);
+
+  if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_pow) |
      illegal_store(nf, EEW, EMUL_pow) |
      not(valid_reg_group(vs3, EMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs3, EEW))
   then return Illegal_Instruction();
-
-  let num_elem = get_num_elem(EMUL_pow, EEW);
-  assert(num_elem > 0);
 
   let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
@@ -330,10 +318,7 @@ function clause execute VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3) = {
   let rs2_val = unsigned(get_scalar(rs2, xlen));
 
   let 'n = num_elem;
-  let mask : bits('n) = match init_masked_source(num_elem, EMUL_pow, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let mask : bits('n) = init_masked_source(num_elem, EMUL_pow, vm_val);
 
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == 0b1 then { // active segments
@@ -376,21 +361,20 @@ function clause execute VLXSEGTYPE(nf, vm, vs2, rs1, width, vd, _mop) = {
   let EEW_data_bytes = get_sew_bytes();
   let EMUL_data_pow = get_lmul_pow();
   let EMUL_index_pow = EEW_index_pow - EEW_data_pow + EMUL_data_pow;
+  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8);
+  assert(num_elem > 0);
 
   let index_dst_overlap : bool =
     if nf == 1
     then not(valid_reg_overlap(vs2, vd, EMUL_index_pow, EMUL_data_pow))          // non-segment indexed load
     else not(valid_disjoint_reg_groups(vs2, vd, EMUL_index_pow, EMUL_data_pow)); // segment indexed load
 
-  if illegal_vstart(VSTART_LOAD_STORE) |
+  if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_data_pow) |
      illegal_indexed_load(vd, vm, nf, 2 ^ EEW_index_pow, EMUL_index_pow, EMUL_data_pow) |
      not(valid_disjoint_reg_groups(vs2, vd, EMUL_index_pow, EMUL_data_pow)) |
      index_dst_overlap |
      not(valid_vm_src_overlap(vm, vs2, EEW_index))
   then return Illegal_Instruction();
-
-  let num_elem = get_num_elem(EMUL_data_pow, EEW_data_bytes * 8);
-  assert(num_elem > 0);
 
   let EMUL_data_reg = if EMUL_data_pow <= 0 then 1 else 2 ^ EMUL_data_pow;
   let vm_val = read_vmask(num_elem, vm, zvreg);
@@ -400,10 +384,7 @@ function clause execute VLXSEGTYPE(nf, vm, vs2, rs1, width, vd, _mop) = {
   let 'm = nf * EEW_data_bytes * 8;
   let 'n = num_elem;
   let (result, mask) : (vector('n, bits('m)), bits('n)) =
-    match init_masked_result(num_elem, nf * EEW_data_bytes * 8, EMUL_data_pow, vd_seg, vm_val) {
-      Ok(v)   => v,
-      Err(()) => return Illegal_Instruction()
-    };
+    init_masked_result(num_elem, nf * EEW_data_bytes * 8, EMUL_data_pow, vd_seg, vm_val);
 
   // As mentioned above, currently mop = 1 (unordered) or 3 (ordered) do the same operations.
   foreach (i from 0 to (num_elem - 1)) {
@@ -454,7 +435,7 @@ function clause execute VSXSEGTYPE(nf, vm, vs2, rs1, width, vs3, _mop) = {
 
   assert(num_elem > 0);
 
-  if illegal_vstart(VSTART_LOAD_STORE) |
+  if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_data_pow) |
      illegal_indexed_store(nf, 2 ^ EEW_index_pow, EMUL_index_pow, EMUL_data_pow) |
      not(valid_src_overlap(vs2, EEW_index, EMUL_index_pow, vs3, EEW_data, EMUL_data_pow)) |
      not(valid_vm_src_overlap(vm, vs2, EEW_index)) |
@@ -467,10 +448,7 @@ function clause execute VSXSEGTYPE(nf, vm, vs2, rs1, width, vs3, _mop) = {
   let vs2_val = read_vreg(num_elem, EEW_index_bytes * 8, EMUL_index_pow, vs2);
 
   let 'n = num_elem;
-  let mask : bits('n) = match init_masked_source(num_elem, EMUL_data_pow, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let mask : bits('n) = init_masked_source(num_elem, EMUL_data_pow, vm_val);
 
   // As mentioned above, currently mop = 1 (unordered) or 3 (ordered) do the same operations.
   foreach (i from 0 to (num_elem - 1)) {
@@ -505,19 +483,19 @@ mapping clause encdec = VLRETYPE(nf, rs1, width, vd)
      | (currentlyEnabled(Ext_Zve64x) & vlewidth_pow(width) <= 6)
 
 function clause execute VLRETYPE(nf, rs1, width, vd) = {
-  if illegal_vstart(VSTART_LOAD_STORE) | not(valid_whole_register(vd, nf)) then return Illegal_Instruction();
-
   let EEW_pow = vlewidth_pow(width);
   let load_width_bytes = 2 ^ (EEW_pow - 3);
   let EEW = 2 ^ EEW_pow;
   let elem_per_reg = vlen / EEW;
   assert(elem_per_reg >= 0);
 
-  let start_element : nat = match get_start_element() {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
-  if start_element >= nf * elem_per_reg then return RETIRE_SUCCESS; // no elements are written if vstart >= evl
+  if illegal_vstart(VSTART_LOAD_STORE, nf * elem_per_reg, 0) | not(valid_whole_register(vd, nf)) then return Illegal_Instruction();
+
+  let start_element = get_start_element();
+  // NOTE: Non-trapping path, vstart >= evl writes no elements. Currently
+  // unreachable because illegal_vstart above always traps on out-of-bounds
+  // vstart, but kept so this stays correct if that trap is ever made optional.
+  if start_element >= nf * elem_per_reg then return RETIRE_SUCCESS;
   let elem_to_align : int = start_element % elem_per_reg;
   var cur_field : int = start_element / elem_per_reg;
   var cur_elem  : int = start_element;
@@ -562,18 +540,18 @@ mapping clause encdec = VSRETYPE(nf, rs1, vs3)
   when currentlyEnabled(Ext_Zve32x)
 
 function clause execute VSRETYPE(nf, rs1, vs3) = {
-  if illegal_vstart(VSTART_LOAD_STORE) | not(valid_whole_register(vs3, nf)) then return Illegal_Instruction();
-
   let load_width_bytes = 1;
   let EEW = 8;
   let elem_per_reg = vlen / EEW;
   assert(elem_per_reg >= 0);
 
-  let start_element : nat = match get_start_element() {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
-  if start_element >= nf * elem_per_reg then return RETIRE_SUCCESS; // no elements are written if vstart >= evl
+  if illegal_vstart(VSTART_LOAD_STORE, nf * elem_per_reg, 0) | not(valid_whole_register(vs3, nf)) then return Illegal_Instruction();
+
+  let start_element = get_start_element();
+  // NOTE: Non-trapping path, vstart >= evl writes no elements. Currently
+  // unreachable because illegal_vstart above always traps on out-of-bounds
+  // vstart, but kept so this stays correct if that trap is ever made optional.
+  if start_element >= nf * elem_per_reg then return RETIRE_SUCCESS;
   let elem_to_align : int = start_element % elem_per_reg;
   var cur_field : int = start_element / elem_per_reg;
   var cur_elem  : int = start_element;
@@ -634,13 +612,10 @@ function clause execute VMTYPE(rs1, vd_or_vs3, op) = {
   let evl : int = if vl_val % 8 == 0 then vl_val / 8 else vl_val / 8 + 1; // the effective vector length is evl=ceil(vl/8)
   let num_elem = get_num_elem(EMUL_pow, EEW);
 
-  if illegal_vstart(VSTART_LOAD_STORE) | illegal_vd_unmasked() then return Illegal_Instruction();
+  if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_pow) | illegal_vd_unmasked() then return Illegal_Instruction();
 
   assert(evl >= 0);
-  let start_element : nat = match get_start_element() {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let start_element = get_start_element();
   let 'n = num_elem;
   let vd_or_vs3_val : vector('n, bits(8)) = read_vreg(num_elem, 8, 0, vd_or_vs3);
 

--- a/model/extensions/V/vext_red_insts.sail
+++ b/model/extensions/V/vext_red_insts.sail
@@ -28,8 +28,9 @@ function clause execute RIVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let SEW_widen = SEW * 2;
+  let num_elem_vs = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_MANDATORY) |
+  if illegal_vstart(VSTART_MANDATORY, num_elem_vs, LMUL_pow) |
      illegal_widening_reduction(SEW_widen) |
      not(valid_vm_src_overlap(vm, vs2, SEW)) |
      not(valid_vm_src_overlap(vm, vs1, SEW_widen))
@@ -37,7 +38,6 @@ function clause execute RIVVTYPE(funct6, vm, vs2, vs1, vd) = {
 
   assert(SEW_widen <= 64);
 
-  let num_elem_vs = get_num_elem(LMUL_pow, SEW);
   let num_elem_vd = get_num_elem(0, SEW_widen); // vd regardless of LMUL setting
 
   if unsigned(vl) == 0 then return RETIRE_SUCCESS; // if vl=0, no operation is performed
@@ -51,10 +51,7 @@ function clause execute RIVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let vd_val  : vector('d, bits('o)) = read_vreg(num_elem_vd, SEW_widen, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
 
-  let mask : bits('n) = match init_masked_source(num_elem_vs, LMUL_pow, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let mask : bits('n) = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
 
   var sum : bits('o) = read_single_element(SEW_widen, 0, vs1); // vs1 regardless of LMUL setting
   foreach (i from 0 to (num_elem_vs - 1)) {
@@ -107,7 +104,7 @@ function clause execute RMVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let num_elem_vs = get_num_elem(LMUL_pow, SEW);
   let num_elem_vd = get_num_elem(0, SEW); // vd regardless of LMUL setting
 
-  if illegal_vstart(VSTART_MANDATORY) |
+  if illegal_vstart(VSTART_MANDATORY, num_elem_vs, LMUL_pow) |
      illegal_reduction() |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs2, SEW)) |
@@ -124,10 +121,7 @@ function clause execute RMVVTYPE(funct6, vm, vs2, vs1, vd) = {
   let vd_val  : vector('d, bits('m)) = read_vreg(num_elem_vd, SEW, 0, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem_vs, SEW, LMUL_pow, vs2);
 
-  let mask : bits('n) = match init_masked_source(num_elem_vs, LMUL_pow, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let mask : bits('n) = init_masked_source(num_elem_vs, LMUL_pow, vm_val);
 
   var sum : bits('m) = read_single_element(SEW, 0, vs1); // vs1 regardless of LMUL setting
   foreach (i from 0 to (num_elem_vs - 1)) {

--- a/model/extensions/V/vext_utils_insts.sail
+++ b/model/extensions/V/vext_utils_insts.sail
@@ -16,11 +16,6 @@ mapping maybe_vmask : string <-> bits(1) = {
   sep() ^ "v0.t"  <-> 0b0
 }
 
-// Check for vstart value
-function assert_vstart(i : int) -> bool = {
-  unsigned(vstart) == i
-}
-
 let vstart_arith_zero_required : bool = config extensions.V.vstart.zero_required.arith
 let vstart_scalar_move_zero_required : bool = config extensions.V.vstart.zero_required.scalar_move
 
@@ -34,8 +29,9 @@ let vstart_scalar_move_zero_required : bool = config extensions.V.vstart.zero_re
 //
 // VSTART_LOAD_STORE  - Memory instructions (loads, stores, segment, indexed,
 //                  fault-only-first, whole-register, and mask load/store).
-//                  These always allow any vstart value since vstart is
-//                  required for trap resumption. Never traps.
+//                  Any in-bounds vstart is allowed since vstart is required
+//                  for trap resumption; only an out-of-bounds vstart (greater
+//                  than the largest element index) traps. Not configurable.
 //
 // VSTART_SCALAR_MOVE - Scalar move instructions (vmv.x.s, vmv.s.x, vfmv.f.s,
 //                  vfmv.s.f). Both trapping and not trapping on a non-zero
@@ -47,12 +43,28 @@ let vstart_scalar_move_zero_required : bool = config extensions.V.vstart.zero_re
 //                  all reductions, vcompress, vcpop.m, vfirst.m,
 //                  vmsbf/sif/sof.m, and viota.m. Always traps, not
 //                  configurable.
-function illegal_vstart(cls : vstart_class) -> bool = {
+//
+// num_elem is what get_num_elem returned, and EMUL_pow is the EMUL used
+// to compute it. A vstart past the largest element index (VLMAX - 1) is
+// reserved. We need EMUL_pow to work out VLMAX when LMUL is fractional.
+function illegal_vstart(cls : vstart_class, num_elem : nat, EMUL_pow : int) -> bool = {
+  let vs = unsigned(vstart);
+  // For fractional LMUL, get_num_elem returns a whole register of elements,
+  // which is bigger than VLMAX, so divide to get VLMAX. When EMUL_pow >= 0,
+  // num_elem already equals VLMAX and we use it as-is.
+  let VLMAX = if EMUL_pow >= 0 then num_elem else num_elem / (2 ^ (0 - EMUL_pow));
+  // An out-of-bounds vstart (>= VLMAX) is reserved. The spec recommends but
+  // does not require trapping, whether it traps is configurable.
+  let out_of_bounds : bool = match vstart_reserved_behavior {
+    Vstart_Illegal => vs >= VLMAX,
+    Vstart_Ignore  => false,
+  };
   match cls {
-    VSTART_ARITH       => vstart_arith_zero_required & not(assert_vstart(0)),
-    VSTART_LOAD_STORE  => false,
-    VSTART_SCALAR_MOVE => vstart_scalar_move_zero_required & not(assert_vstart(0)),
-    VSTART_MANDATORY   => not(assert_vstart(0))
+    // Out-of-bounds vstart traps per config, in-bounds non-zero traps per config.
+    VSTART_ARITH       => out_of_bounds | (vstart_arith_zero_required & vs != 0),
+    VSTART_LOAD_STORE  => out_of_bounds,
+    VSTART_SCALAR_MOVE => out_of_bounds | (vstart_scalar_move_zero_required & vs != 0),
+    VSTART_MANDATORY   => vs != 0
   }
 }
 
@@ -343,19 +355,10 @@ function write_velem_quad_vec(vd, SEW, input, i) = {
     write_single_element(SEW, 4 * i + j, vd, input[j]);
 }
 
-// Get the starting element index from csr vtype
-function get_start_element() -> result(nat, unit) = {
-  let start_element = unsigned(vstart);
-  let SEW_pow = get_sew_pow();
-  // The use of vstart values greater than the largest element
-  // index for the current SEW setting is reserved.
-  //
-  // TODO: the bound here might be incorrect.
-  // See https://github.com/riscv/sail-riscv/pull/755#discussion_r2035095825
-  if start_element > (2 ^ (3 + vlen_exp - SEW_pow) - 1)
-  then Err(())
-  else Ok(start_element)
-}
+// Get the starting element index from the vstart csr. The validity of
+// vstart is checked by illegal_vstart at the start of each instruction,
+// so this just returns the value.
+function get_start_element() -> nat = unsigned(vstart)
 
 // Get the ending element index from csr vl
 function get_end_element() -> int = unsigned(vl) - 1
@@ -367,12 +370,9 @@ function get_end_element() -> int = unsigned(vl) - 1
 //   vector1 is the result vector with values applied to masked elements
 //   vector2 is a "mask" vector that is true for an element if the corresponding element
 //     in the result vector should be updated by the calling instruction
-val init_masked_result : forall 'n 'm 'p, 'n >= 0 . (int('n), int('m), int('p), vector('n, bits('m)), bits('n)) -> result((vector('n, bits('m)), bits('n)), unit)
+val init_masked_result : forall 'n 'm 'p, 'n >= 0 . (int('n), int('m), int('p), vector('n, bits('m)), bits('n)) -> (vector('n, bits('m)), bits('n))
 function init_masked_result(num_elem, _EEW, LMUL_pow, vd_val, vm_val) = {
-  let start_element : nat = match get_start_element() {
-    Ok(v)   => v,
-    Err(()) => return Err(())
-  };
+  let start_element = get_start_element();
   let end_element   = get_end_element();
   let tail_ag : agtype = get_vtype_vta();
   let mask_ag : agtype = get_vtype_vma();
@@ -415,19 +415,16 @@ function init_masked_result(num_elem, _EEW, LMUL_pow, vd_val, vm_val) = {
     }
   };
 
-  Ok((result, mask))
+  (result, mask)
 }
 
 // For instructions like vector reduction and vector store,
 // masks on prestart, inactive and tail elements only affect the validation of source register elements
 // (vs3 for store and vs2 for reduction). There's no destination register to be masked.
 // In these cases, this function can be called to simply get the mask vector for vs (without the prepared vd result vector).
-val init_masked_source : forall 'n 'p, 'n > 0. (int('n), int('p), bits('n)) -> result(bits('n), unit)
+val init_masked_source : forall 'n 'p, 'n > 0. (int('n), int('p), bits('n)) -> bits('n)
 function init_masked_source(num_elem, LMUL_pow, vm_val) = {
-  let start_element : nat = match get_start_element() {
-    Ok(v)   => v,
-    Err(()) => return Err(())
-  };
+  let start_element = get_start_element();
   let end_element   = get_end_element();
   var mask : bits('n) = undefined;
 
@@ -454,17 +451,14 @@ function init_masked_source(num_elem, LMUL_pow, vm_val) = {
     }
   };
 
-  Ok(mask)
+  mask
 }
 
 // Mask handling for carry functions that use masks as input/output
 // Only prestart and tail elements are masked in a mask value
-val init_masked_result_carry : forall 'n, 'n >= 0 . (int('n), sew_bitsize, int, bits('n)) -> result((bits('n), bits('n)), unit)
+val init_masked_result_carry : forall 'n, 'n >= 0 . (int('n), sew_bitsize, int, bits('n)) -> (bits('n), bits('n))
 function init_masked_result_carry(num_elem, _EEW, LMUL_pow, vd_val) = {
-  let start_element : nat = match get_start_element() {
-    Ok(v)   => v,
-    Err(()) => return Err(())
-  };
+  let start_element = get_start_element();
   let end_element   = get_end_element();
   var mask : bits('n) = undefined;
   var result : bits('n) = undefined;
@@ -494,16 +488,13 @@ function init_masked_result_carry(num_elem, _EEW, LMUL_pow, vd_val) = {
     }
   };
 
-  Ok(result, mask)
+  (result, mask)
 }
 
 // Mask handling for cmp functions that use masks as output
-val init_masked_result_cmp : forall 'n, 'n >= 0 . (int('n), sew_bitsize, int, bits('n), bits('n)) -> result((bits('n), bits('n)), unit)
+val init_masked_result_cmp : forall 'n, 'n >= 0 . (int('n), sew_bitsize, int, bits('n), bits('n)) -> (bits('n), bits('n))
 function init_masked_result_cmp(num_elem, _EEW, LMUL_pow, vd_val, vm_val) = {
-  let start_element : nat = match get_start_element() {
-    Ok(v)   => v,
-    Err(()) => return Err(())
-  };
+  let start_element = get_start_element();
   let end_element   = get_end_element();
   let mask_ag : agtype = get_vtype_vma();
   var mask : bits('n) = undefined;
@@ -541,7 +532,7 @@ function init_masked_result_cmp(num_elem, _EEW, LMUL_pow, vd_val, vm_val) = {
     }
   };
 
-  Ok(result, mask)
+  (result, mask)
 }
 
 // For vector load/store segment instructions:

--- a/model/extensions/V/vext_vm_insts.sail
+++ b/model/extensions/V/vext_vm_insts.sail
@@ -32,7 +32,7 @@ function clause execute VVMTYPE(funct6, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_vd_unmasked()  |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
@@ -48,10 +48,7 @@ function clause execute VVMTYPE(funct6, vs2, vs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)             = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (bits('n), bits('n)) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -98,7 +95,7 @@ function clause execute VVMCTYPE(funct6, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_vd_unmasked()  |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow))
@@ -111,10 +108,7 @@ function clause execute VVMCTYPE(funct6, vs2, vs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)             = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (bits('n), bits('n)) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -161,7 +155,7 @@ function clause execute VVMSTYPE(funct6, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_vd_masked(vd)  |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
@@ -181,10 +175,7 @@ function clause execute VVMSTYPE(funct6, vs2, vs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -232,7 +223,7 @@ function clause execute VVCMPTYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_vd_unmasked()  |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
@@ -248,10 +239,7 @@ function clause execute VVCMPTYPE(funct6, vm, vs2, vs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)             = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (bits('n), bits('n)) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -306,7 +294,7 @@ function clause execute VXMTYPE(funct6, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_vd_unmasked() |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_vm_src_overlap(0b0, vs2, SEW))
@@ -320,10 +308,7 @@ function clause execute VXMTYPE(funct6, vs2, rs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)             = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (bits('n), bits('n)) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -370,7 +355,7 @@ function clause execute VXMCTYPE(funct6, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) | illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) | illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -380,10 +365,7 @@ function clause execute VXMCTYPE(funct6, vs2, rs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)             = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (bits('n), bits('n)) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -430,7 +412,7 @@ function clause execute VXMSTYPE(funct6, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_vd_masked(vd)  |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -448,10 +430,7 @@ function clause execute VXMSTYPE(funct6, vs2, rs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -501,7 +480,7 @@ function clause execute VXCMPTYPE(funct6, vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_vd_unmasked() |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
@@ -515,10 +494,7 @@ function clause execute VXCMPTYPE(funct6, vm, vs2, rs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)             = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (bits('n), bits('n)) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -576,7 +552,7 @@ function clause execute VIMTYPE(funct6, vs2, simm, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_vd_unmasked() |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_vm_src_overlap(0b0, vs2, SEW))
@@ -590,10 +566,7 @@ function clause execute VIMTYPE(funct6, vs2, simm, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)             = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (bits('n), bits('n)) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -637,7 +610,7 @@ function clause execute VIMCTYPE(funct6, vs2, simm, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) | illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) | illegal_vd_unmasked() | not(valid_reg_group(vs2, LMUL_pow))
   then return Illegal_Instruction();
 
   let 'n = num_elem;
@@ -647,10 +620,7 @@ function clause execute VIMCTYPE(funct6, vs2, simm, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)             = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (bits('n), bits('n)) = init_masked_result_carry(num_elem, SEW, LMUL_pow, vd_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -694,7 +664,7 @@ function clause execute VIMSTYPE(funct6, vs2, simm, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_vd_masked(vd)  |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -712,10 +682,7 @@ function clause execute VIMSTYPE(funct6, vs2, simm, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vec_trues);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -761,7 +728,7 @@ function clause execute VICMPTYPE(funct6, vm, vs2, simm, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_vd_unmasked() |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
@@ -775,10 +742,7 @@ function clause execute VICMPTYPE(funct6, vm, vs2, simm, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : bits('n)             = read_vmask(num_elem, 0b0, vd);
 
-  let (initial_result, mask) : (bits('n), bits('n)) = match init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (bits('n), bits('n)) = init_masked_result_cmp(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {

--- a/model/extensions/Zvabd/zvabd_insts.sail
+++ b/model/extensions/Zvabd/zvabd_insts.sail
@@ -27,7 +27,7 @@ function clause execute VABS_V(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
@@ -39,10 +39,7 @@ function clause execute VABS_V(vm, vs2, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -75,7 +72,7 @@ function clause execute ZVABDTYPE(funct6, vm, vs2, vs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_vm_src_overlap(vm, vs1, SEW)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
@@ -89,10 +86,7 @@ function clause execute ZVABDTYPE(funct6, vm, vs2, vs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -136,7 +130,7 @@ function clause execute ZVWABDATYPE(funct6, vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
@@ -156,10 +150,7 @@ function clause execute ZVWABDATYPE(funct6, vm, vs2, vs1, vd) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {

--- a/model/extensions/bfloat16/zvfbfmin_insts.sail
+++ b/model/extensions/bfloat16/zvfbfmin_insts.sail
@@ -24,7 +24,7 @@ function clause execute (VFNCVTBF16_F_F_W(vm, vs2, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow_widen, LMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs2, SEW_widen))
@@ -41,10 +41,7 @@ function clause execute (VFNCVTBF16_F_F_W(vm, vs2, vd)) = {
   let vs2_val : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -79,7 +76,7 @@ function clause execute (VFWCVTBF16_F_F_V(vm, vs2, vd)) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
@@ -96,10 +93,7 @@ function clause execute (VFWCVTBF16_F_F_V(vm, vs2, vd)) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {

--- a/model/extensions/bfloat16/zvfbfwma_insts.sail
+++ b/model/extensions/bfloat16/zvfbfwma_insts.sail
@@ -24,7 +24,7 @@ function clause execute VFWMACCBF16_VV(vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
@@ -44,10 +44,7 @@ function clause execute VFWMACCBF16_VV(vm, vs2, vs1, vd) = {
   let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -82,7 +79,7 @@ function clause execute VFWMACCBF16_VF(vm, vs2, rs1, vd) = {
 
   assert(LMUL_pow_widen <= 3);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_fp_variable_width(vd, vm, SEW, rm_3b, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
@@ -98,10 +95,7 @@ function clause execute VFWMACCBF16_VF(vm, vs2, rs1, vd) = {
   let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   let rs1_val = bf16_to_f32_set_flags(F_BF16(rs1));

--- a/model/extensions/vector_crypto/zvbb_insts.sail
+++ b/model/extensions/vector_crypto/zvbb_insts.sail
@@ -24,7 +24,7 @@ function clause execute VANDN_VV(vm, vs1, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
@@ -41,10 +41,7 @@ function clause execute VANDN_VV(vm, vs1, vs2, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -71,7 +68,7 @@ function clause execute VANDN_VX(vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -86,10 +83,7 @@ function clause execute VANDN_VX(vm, vs2, rs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem- 1)) {
@@ -116,7 +110,7 @@ function clause execute VBREV_V(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -130,10 +124,7 @@ function clause execute VBREV_V(vm, vs2, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -164,7 +155,7 @@ function clause execute VBREV8_V(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -178,10 +169,7 @@ function clause execute VBREV8_V(vm, vs2, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -209,7 +197,7 @@ function clause execute VREV8_V(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -223,10 +211,7 @@ function clause execute VREV8_V(vm, vs2, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -254,7 +239,7 @@ function clause execute VCLZ_V(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -268,10 +253,7 @@ function clause execute VCLZ_V(vm, vs2, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -300,7 +282,7 @@ function clause execute VCTZ_V(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -314,10 +296,7 @@ function clause execute VCTZ_V(vm, vs2, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -346,7 +325,7 @@ function clause execute VCPOP_V(vm, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -360,10 +339,7 @@ function clause execute VCPOP_V(vm, vs2, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -396,7 +372,7 @@ function clause execute VROL_VV(vm, vs1, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
@@ -413,10 +389,7 @@ function clause execute VROL_VV(vm, vs1, vs2, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -444,7 +417,7 @@ function clause execute VROL_VX(vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -459,10 +432,7 @@ function clause execute VROL_VX(vm, vs2, rs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -490,7 +460,7 @@ function clause execute VROR_VV(vm, vs1, vs2, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
@@ -507,10 +477,7 @@ function clause execute VROR_VV(vm, vs1, vs2, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -538,7 +505,7 @@ function clause execute VROR_VX(vm, vs2, rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -553,10 +520,7 @@ function clause execute VROR_VX(vm, vs2, rs1, vd) = {
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -584,7 +548,7 @@ function clause execute VROR_VI(vm, vs2, uimm, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
@@ -599,10 +563,7 @@ function clause execute VROR_VI(vm, vs2, uimm, vd) = {
   let vs2_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val   : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -631,7 +592,7 @@ function clause execute VWSLL_VV(vm, vs2, vs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
@@ -652,10 +613,7 @@ function clause execute VWSLL_VV(vm, vs2, vs1, vd) = {
   let vd_val      : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
 
   let SEW_widen_bits = to_bits_unsafe(SEW_widen, 'o);
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -687,7 +645,7 @@ function clause execute VWSLL_VX(vm, vs2, rs1, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
@@ -706,10 +664,7 @@ function clause execute VWSLL_VX(vm, vs2, rs1, vd) = {
   let vd_val      : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
 
   let SEW_widen_bits = to_bits_unsafe(SEW_widen, 'o);
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {
@@ -740,7 +695,7 @@ function clause execute VWSLL_VI(vm, vs2, uimm, vd) = {
   let SEW_widen      = SEW * 2;
   let LMUL_pow_widen = LMUL_pow + 1;
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
@@ -759,10 +714,7 @@ function clause execute VWSLL_VI(vm, vs2, uimm, vd) = {
   let vd_val      : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
 
   let SEW_widen_bits = to_bits_unsafe(SEW_widen, 'o);
-  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = match init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to (num_elem - 1)) {

--- a/model/extensions/vector_crypto/zvbc_insts.sail
+++ b/model/extensions/vector_crypto/zvbc_insts.sail
@@ -21,8 +21,9 @@ mapping clause assembly = VCLMUL_VV (vm, vs2, vs1, vd)
 function clause execute VCLMUL_VV(vm, vs2, vs1, vd) = {
   let SEW       = get_sew();
   let LMUL_pow  = get_lmul_pow();
+  let num_elem  = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
@@ -31,7 +32,7 @@ function clause execute VCLMUL_VV(vm, vs2, vs1, vd) = {
      not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
-  let 'n = get_num_elem(LMUL_pow, SEW);
+  let 'n = num_elem;
   let 'm = SEW;
 
   let vm_val  : bits('n) = read_vmask('n, vm, zvreg);
@@ -39,10 +40,7 @@ function clause execute VCLMUL_VV(vm, vs2, vs1, vd) = {
   let vs1_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to ('n - 1)) {
@@ -69,15 +67,16 @@ mapping clause assembly = VCLMUL_VX (vm, vs2, rs1, vd)
 function clause execute VCLMUL_VX(vm, vs2, rs1, vd) = {
   let SEW       = get_sew();
   let LMUL_pow  = get_lmul_pow();
+  let num_elem  = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
-  let 'n = get_num_elem(LMUL_pow, SEW);
+  let 'n = num_elem;
   let 'm = SEW;
 
   let vm_val  : bits('n) = read_vmask('n, vm, zvreg);
@@ -85,10 +84,7 @@ function clause execute VCLMUL_VX(vm, vs2, rs1, vd) = {
   let vd_val  : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to ('n - 1)) {
@@ -115,8 +111,9 @@ mapping clause assembly = VCLMULH_VV (vm, vs2, vs1, vd)
 function clause execute VCLMULH_VV(vm, vs2, vs1, vd) = {
   let SEW       = get_sew();
   let LMUL_pow  = get_lmul_pow();
+  let num_elem  = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs1, LMUL_pow)) |
      not(valid_reg_group(vs2, LMUL_pow)) |
@@ -125,7 +122,7 @@ function clause execute VCLMULH_VV(vm, vs2, vs1, vd) = {
      not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
-  let 'n = get_num_elem(LMUL_pow, SEW);
+  let 'n = num_elem;
   let 'm = SEW;
 
   let vm_val  : bits('n) = read_vmask('n, vm, zvreg);
@@ -133,10 +130,7 @@ function clause execute VCLMULH_VV(vm, vs2, vs1, vd) = {
   let vs1_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to ('n - 1)) {
@@ -163,15 +157,16 @@ mapping clause assembly = VCLMULH_VX (vm, vs2, rs1, vd)
 function clause execute VCLMULH_VX(vm, vs2, rs1, vd) = {
   let SEW       = get_sew();
   let LMUL_pow  = get_lmul_pow();
+  let num_elem  = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_ARITH) |
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
      illegal_normal(vd, vm) |
      not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_reg_group(vd, LMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
-  let 'n = get_num_elem(LMUL_pow, SEW);
+  let 'n = num_elem;
   let 'm = SEW;
 
   let vm_val  : bits('n) = read_vmask('n, vm, zvreg);
@@ -179,10 +174,7 @@ function clause execute VCLMULH_VX(vm, vs2, rs1, vd) = {
   let vd_val  : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vd);
   let vs2_val : vector('n, bits('m)) = read_vreg('n, SEW, LMUL_pow, vs2);
 
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = match init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val) {
-    Ok(v)   => v,
-    Err(()) => return Illegal_Instruction()
-  };
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result('n, SEW, LMUL_pow, vd_val, vm_val);
   var result = initial_result;
 
   foreach (i from 0 to ('n - 1)) {

--- a/model/extensions/vector_crypto/zvk_utils.sail
+++ b/model/extensions/vector_crypto/zvk_utils.sail
@@ -15,8 +15,14 @@ function zvk_valid_reg_overlap(rs : vregidx, rd : vregidx, emul_pow : int) -> bo
 
 function zvk_check_encdec(EGW : nat, EGS : nat1) -> bool = {
   let LMUL_pow = get_lmul_pow();
-  let LMUL_times_VLEN = if LMUL_pow < 0 then vlen / (2 ^ abs_int(LMUL_pow)) else (2 ^ LMUL_pow) * vlen in
-  (unsigned(vl) % EGS == 0) & (unsigned(vstart) % EGS == 0) & LMUL_times_VLEN >= EGW
+  let LMUL_times_VLEN = if LMUL_pow < 0 then vlen / (2 ^ abs_int(LMUL_pow)) else (2 ^ LMUL_pow) * vlen;
+  let VLMAX = LMUL_times_VLEN / get_sew();
+  // An out-of-bounds vstart (>= VLMAX) is reserved, whether it traps is configurable.
+  let vstart_in_bounds : bool = match vstart_reserved_behavior {
+    Vstart_Illegal => unsigned(vstart) < VLMAX,
+    Vstart_Ignore  => true,
+  };
+  (unsigned(vl) % EGS == 0) & (unsigned(vstart) % EGS == 0) & LMUL_times_VLEN >= EGW & vstart_in_bounds
 }
 
 // Utility functions for Zvknh[ab]


### PR DESCRIPTION
The specification states that a `vstart` greater than the last valid element index is reserved. Vector instructions now can raise an illegal instruction in this case.

To support this, `illegal_vstart` requires the number of elements the instruction operates on. `get_num_elem` cannot be used directly as the bound, because for fractional LMUL (less than 1) it returns a value larger than the real limit. The `EMUL` is therefore passed as well and used to derive the correct bound. For `LMUL` of 1 or greater the value is already correct and behavior is unchanged.

The element-group crypto instructions (Zvkned, Zvknha/b, Zvksed, Zvksh, Zvkg) perform this check in their shared decode predicate (`zvk_check_encdec`) rather than in `illegal_vstart`. They continue to permit a non-zero `vstart` provided it is aligned to an element group.

The specification recommends but does not require trapping, so the behavior is configurable via the new option
`extensions.V.reserved_behavior.vstart_out_of_bounds`. The default `Vstart_Illegal` raises an illegal instruction exception, while `Vstart_Ignore` lets the instruction run as a no-op that writes no elements.

Follow up PR for https://github.com/riscv/sail-riscv/pull/1732 and fixes https://github.com/riscv/sail-riscv/issues/1104.