### PR TITLE
Simplify the `reinit_sail()` API.

### DIFF
--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -375,24 +375,28 @@ void ModelImpl::init_sail(
   const char *config_file,
   const std::optional<uint64_t> &htif_tohost_address
 ) {
+  m_elf_entry = elf_entry;
+  m_config_file = config_file != nullptr ? config_file : "";
+  m_htif_tohost_address = htif_tohost_address;
+
+  init_sail_impl();
+}
+
+void ModelImpl::init_sail_impl() {
   // zset_pc_reset_address must be called before zinit_model
   // because reset happens inside init_model().
-  zset_pc_reset_address(elf_entry);
-  if (htif_tohost_address.has_value()) {
-    zenable_htif(*htif_tohost_address);
+  zset_pc_reset_address(m_elf_entry);
+  if (m_htif_tohost_address.has_value()) {
+    zenable_htif(m_htif_tohost_address.value());
   }
-  zinit_model(config_file != nullptr ? config_file : "");
+  zinit_model(m_config_file.c_str());
   zinit_boot_requirements(UNIT);
 }
 
-void ModelImpl::reinit_sail(
-  uint64_t elf_entry,
-  const char *config_file,
-  const std::optional<uint64_t> &htif_tohost_address
-) {
+void ModelImpl::reinit_sail() {
   model_fini();
   model_init();
-  init_sail(elf_entry, config_file, htif_tohost_address);
+  init_sail_impl();
 }
 
 void ModelImpl::model_init() {

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -54,7 +54,7 @@ public:
 
   void init_platform_constants();
   void init_sail(uint64_t entry, const char *config_file, const std::optional<uint64_t> &htif_tohost_address);
-  void reinit_sail(uint64_t entry, const char *config_file, const std::optional<uint64_t> &htif_tohost_address);
+  void reinit_sail();
   void model_init();
   void model_fini();
 
@@ -92,6 +92,9 @@ public:
   friend class rvfi_callbacks;
 
 private:
+  // Internal functions.
+  void init_sail_impl();
+
   // These functions are called by the Sail code.
 
   unit fetch_callback(sbits opcode) override;
@@ -158,6 +161,11 @@ private:
   bool m_config_use_abi_names = false;
 
   bool m_config_print_step = false;
+
+  // Initialization.
+  uint64_t m_elf_entry = 0;
+  std::string m_config_file = {};
+  std::optional<uint64_t> m_htif_tohost_address = {};
 
   std::map<uint64_t, std::string> m_symbols;
   int m_term_fd = 1;

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -835,7 +835,7 @@ void run_model(CLIOptions &opts, ModelImpl &model, uint64_t entry, const elf_inf
     // `run_sail` only returns in the case of rvfi.
     if (run_info.rvfi) {
       /* Reset for next test */
-      model.reinit_sail(entry, opts.config_file.c_str(), elf_info.htif_tohost_address);
+      model.reinit_sail();
       loop_detector.reset();
     }
   } while (run_info.rvfi);


### PR DESCRIPTION
`reinit_sail()` should not have to provide again the same parameters that were already provided in `init_sail()`.  This allows an initialized model to be reinitialized without having to know the initialization parameters.