### PR TITLE
Move `V.illegal_vtype` under `V.reserved_behavior`

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -420,12 +420,14 @@
       // should be left as 3 (or any other legal value).
       "vlen_exp": @CONFIG__V__VLEN_EXP@,
       "elen_exp": @CONFIG__V__ELEN_EXP@,
-      // This determines how to handle attempts by vsetvli, vsetivli,
-      // and vsetvl to set an unsupported or reserved vtype.
-      // "IllegalVtype_SetVill" - set vtype.vill, set vl to zero, clear vstart, and write rd.
-      // "IllegalVtype_Illegal" - treat it as an illegal instruction.
-      // "IllegalVtype_Fatal"   - raise a Sail exception, stopping execution.
-      "illegal_vtype": "IllegalVtype_SetVill",
+      "reserved_behavior": {
+        // This determines how to handle attempts by vsetvli, vsetivli,
+        // and vsetvl to set an unsupported or reserved vtype.
+        // "IllegalVtype_SetVill" - set vtype.vill, set vl to zero, clear vstart, and write rd.
+        // "IllegalVtype_Illegal" - treat it as an illegal instruction.
+        // "IllegalVtype_Fatal"   - raise a Sail exception, stopping execution.
+        "illegal_vtype": "IllegalVtype_SetVill"
+      },
       "vl_use_ceil": false,
       // The maximum index EEW for indexed vector addressing mode, as
       // a power of 2.  This must be at least 3 but must not exceed

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -35,7 +35,7 @@
     incompatible change compared to previous versions, but can be changed to
     preserve the earlier behaviour.
   - The handling of attempts to set an unsupported or reserved `vtype`
-    can now be configured; see `extensions.V.illegal_vtype`.
+    can now be configured; see `extensions.V.reserved_behavior.illegal_vtype`.
   - The supported values for `mstatus.FS` and `mstatus.VS` can be
     configured; see `base.mstatus.fs_legal_values` and
     `base.mstatus.vs_legal_values`.

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -179,4 +179,4 @@ let pmp_write_only_reserved_behavior : PmpWriteOnlyReservedBehavior = config bas
 let xenvcfg_cbie_reserved_behavior : XenvcfgCbieReservedBehavior = config base.reserved_behavior.xenvcfg_cbie
 let xtvec_mode_reserved_behavior : XtvecModeReservedBehavior = config base.reserved_behavior.xtvec_mode
 let rv32zdinx_odd_register_reserved_behavior : RV32ZdinxOddRegisterReservedBehavior = config base.reserved_behavior.rv32zdinx_odd_register
-let illegal_vtype_reserved_behavior : IllegalVtypeReservedBehavior = config extensions.V.illegal_vtype
+let illegal_vtype_reserved_behavior : IllegalVtypeReservedBehavior = config extensions.V.reserved_behavior.illegal_vtype


### PR DESCRIPTION
This allows consolidating other parameters configuring reserved behavior for the vector extension under `extensions.V.reserved_behavior`.