### PR TITLE
Fix Traps on Legal Overlaps for Non-Segmented Loads

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -1,5 +1,10 @@
 # Release notes for the next version
 
+- Important issues addressed and bugs fixed:
+  - https://github.com/riscv/sail-riscv/issues/1750 : Non-segmented indexed loads were trapping on legal overlaps
+
+# Release notes for version 0.12
+
 The main highlights of this release are the addition of the pointer
 masking extensions, improved performance, more configuration
 parameters and stricter handling of register constraints in the vector

--- a/model/extensions/V/vext_mem_insts.sail
+++ b/model/extensions/V/vext_mem_insts.sail
@@ -371,7 +371,6 @@ function clause execute VLXSEGTYPE(nf, vm, vs2, rs1, width, vd, _mop) = {
 
   if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_data_pow) |
      illegal_indexed_load(vd, vm, nf, 2 ^ EEW_index_pow, EMUL_index_pow, EMUL_data_pow) |
-     not(valid_disjoint_reg_groups(vs2, vd, EMUL_index_pow, EMUL_data_pow)) |
      index_dst_overlap |
      not(valid_vm_src_overlap(vm, vs2, EEW_index))
   then return Illegal_Instruction();


### PR DESCRIPTION
The changes in the 0.12 release brought in checks that were too restrictive for the non-segmented indexed loads. This removes a check for `not(valid_disjoint_reg_groups(vs2, vd, EMUL_index_pow, EMUL_data_pow))` that ran in all cases, instead of just in the segmented case. This case is still in the `indexed_dst_overlap` variable, so it is still checked in the cases where it matters. 

Fixes #1750.