### PR TITLE
Reject vector segment loads/stores that increment past v31

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -2,6 +2,7 @@
 
 - Important issues addressed and bugs fixed:
   - https://github.com/riscv/sail-riscv/issues/1750 : Non-segmented indexed loads were trapping on legal overlaps
+  - https://github.com/riscv/sail-riscv/issues/1748 : Segment loads/stores whose register numbers increment past v31 were not treated as reserved.
 
 # Release notes for version 0.12
 

--- a/model/extensions/V/vext_mem_insts.sail
+++ b/model/extensions/V/vext_mem_insts.sail
@@ -66,7 +66,7 @@ function clause execute VLSEGTYPE(nf, vm, rs1, width, vd) = {
   if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_pow) | illegal_load(vd, vm, nf, EEW, EMUL_pow) | not(valid_reg_group(vd, EMUL_pow))
   then return Illegal_Instruction();
 
-  let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
+  let EMUL_reg = 2 ^ max(EMUL_pow, 0);
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vd_seg = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
 
@@ -123,7 +123,7 @@ function clause execute VLSEGFFTYPE(nf, vm, rs1, width, vd) = {
   if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_pow) | illegal_load(vd, vm, nf, EEW, EMUL_pow) | not(valid_reg_group(vd, EMUL_pow))
   then return Illegal_Instruction();
 
-  let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
+  let EMUL_reg = 2 ^ max(EMUL_pow, 0);
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vd_seg = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
   let tail_ag = get_vtype_vta();
@@ -194,10 +194,10 @@ function clause execute VSSEGTYPE(nf, vm, rs1, width, vs3) = {
   let num_elem = get_num_elem(EMUL_pow, EEW);
   assert(num_elem > 0);
 
-  if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_pow) | illegal_store(nf, EEW, EMUL_pow) | not(valid_reg_group(vs3, EMUL_pow))
+  if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_pow) | illegal_store(vs3, nf, EEW, EMUL_pow) | not(valid_reg_group(vs3, EMUL_pow))
   then return Illegal_Instruction();
 
-  let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
+  let EMUL_reg = 2 ^ max(EMUL_pow, 0);
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vs3_seg = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
 
@@ -251,7 +251,7 @@ function clause execute VLSSEGTYPE(nf, vm, rs2, rs1, width, vd) = {
   if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_pow) | illegal_load(vd, vm, nf, EEW, EMUL_pow) | not(valid_reg_group(vd, EMUL_pow))
   then return Illegal_Instruction();
 
-  let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
+  let EMUL_reg = 2 ^ max(EMUL_pow, 0);
   let vm_val  = read_vmask(num_elem, vm, zvreg);
   let vd_seg  = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vd);
   let rs2_val = unsigned(get_scalar(rs2, xlen));
@@ -307,12 +307,12 @@ function clause execute VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3) = {
   assert(num_elem > 0);
 
   if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_pow) |
-     illegal_store(nf, EEW, EMUL_pow) |
+     illegal_store(vs3, nf, EEW, EMUL_pow) |
      not(valid_reg_group(vs3, EMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs3, EEW))
   then return Illegal_Instruction();
 
-  let EMUL_reg = if EMUL_pow <= 0 then 1 else 2 ^ EMUL_pow;
+  let EMUL_reg = 2 ^ max(EMUL_pow, 0);
   let vm_val = read_vmask(num_elem, vm, zvreg);
   let vs3_seg = read_vreg_seg(num_elem, load_width_bytes * 8, EMUL_pow, nf, vs3);
   let rs2_val = unsigned(get_scalar(rs2, xlen));
@@ -435,7 +435,7 @@ function clause execute VSXSEGTYPE(nf, vm, vs2, rs1, width, vs3, _mop) = {
   assert(num_elem > 0);
 
   if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_data_pow) |
-     illegal_indexed_store(nf, 2 ^ EEW_index_pow, EMUL_index_pow, EMUL_data_pow) |
+     illegal_indexed_store(vs3, nf, 2 ^ EEW_index_pow, EMUL_index_pow, EMUL_data_pow) |
      not(valid_src_overlap(vs2, EEW_index, EMUL_index_pow, vs3, EEW_data, EMUL_data_pow)) |
      not(valid_vm_src_overlap(vm, vs2, EEW_index)) |
      not(valid_vm_src_overlap(vm, vs3, EEW_data))

--- a/model/extensions/V/vext_utils_insts.sail
+++ b/model/extensions/V/vext_utils_insts.sail
@@ -180,6 +180,14 @@ function valid_segment(nf : nfields, EMUL_pow : int) -> bool = {
   else nf * 2 ^ EMUL_pow <= 8
 }
 
+// A segment load/store uses NFIELDS register groups of ceil(EMUL) registers
+// each, starting at reg. If those would run past v31 the encoding is
+// reserved, so check the last register stays in range.
+function valid_segment_no_overflow(reg : vregidx, nf : nfields, EMUL_pow : int) -> bool = {
+  let EMUL_reg = 2 ^ max(EMUL_pow, 0);
+  unsigned(vregidx_bits(reg)) + nf * EMUL_reg <= 32
+}
+
 /// "VSMUL.VX and VSMUL.VV are not included in EEW=64 in Zve64*."
 function valid_wide_vvtype(vvtype : vvfunct6) -> bool =
   match vvtype {
@@ -285,24 +293,28 @@ function illegal_widening_reduction(EEW : nat) -> bool = {
 // g. Non-indexed load instruction check
 function illegal_load(vd : vregidx, vm : bits(1), nf : nfields, EEW : nat, EMUL_pow : int) -> bool = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm)) |
-  not(valid_eew_emul(EEW, EMUL_pow)) | not(valid_segment(nf, EMUL_pow))
+  not(valid_eew_emul(EEW, EMUL_pow)) | not(valid_segment(nf, EMUL_pow)) |
+  not(valid_segment_no_overflow(vd, nf, EMUL_pow))
 }
 
 // h. Non-indexed store instruction check (with vs3 rather than vd)
-function illegal_store(nf : nfields, EEW : nat, EMUL_pow : int) -> bool = {
-  not(valid_vtype()) | not(valid_eew_emul(EEW, EMUL_pow)) | not(valid_segment(nf, EMUL_pow))
+function illegal_store(vs3 : vregidx, nf : nfields, EEW : nat, EMUL_pow : int) -> bool = {
+  not(valid_vtype()) | not(valid_eew_emul(EEW, EMUL_pow)) | not(valid_segment(nf, EMUL_pow)) |
+  not(valid_segment_no_overflow(vs3, nf, EMUL_pow))
 }
 
 // i. Indexed load instruction check
 function illegal_indexed_load(vd : vregidx, vm : bits(1), nf : nfields, EEW_index : nat, EMUL_pow_index : int, EMUL_pow_data : int) -> bool = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm)) |
-  not(valid_eew_emul(EEW_index, EMUL_pow_index)) | not(valid_segment(nf, EMUL_pow_data))
+  not(valid_eew_emul(EEW_index, EMUL_pow_index)) | not(valid_segment(nf, EMUL_pow_data)) |
+  not(valid_segment_no_overflow(vd, nf, EMUL_pow_data))
 }
 
 // j. Indexed store instruction check (with vs3 rather than vd)
-function illegal_indexed_store(nf : nfields, EEW_index : nat, EMUL_pow_index : int, EMUL_pow_data : int) -> bool = {
+function illegal_indexed_store(vs3 : vregidx, nf : nfields, EEW_index : nat, EMUL_pow_index : int, EMUL_pow_data : int) -> bool = {
   not(valid_vtype()) | not(valid_eew_emul(EEW_index, EMUL_pow_index)) |
-  not(valid_segment(nf, EMUL_pow_data))
+  not(valid_segment(nf, EMUL_pow_data)) |
+  not(valid_segment_no_overflow(vs3, nf, EMUL_pow_data))
 }
 
 // Scalar register shaping

--- a/model/extensions/V/vext_utils_insts.sail
+++ b/model/extensions/V/vext_utils_insts.sail
@@ -175,7 +175,7 @@ function valid_vm_src_overlap(vm : bits(1), rs : vregidx, EEW_rs : nat) -> bool 
 // Check for valid register grouping in vector segment load/store instructions:
 // The EMUL of load vd or store vs3 times the number of fields per segment
 // must not be larger than 8. (EMUL * NFIELDS <= 8)
-function valid_segment(nf : nfields, EMUL_pow : int) -> bool = {
+function valid_segment_group_size(nf : nfields, EMUL_pow : int) -> bool = {
   if EMUL_pow < 0 then nf / (2 ^ (0 - EMUL_pow)) <= 8
   else nf * 2 ^ EMUL_pow <= 8
 }
@@ -183,7 +183,7 @@ function valid_segment(nf : nfields, EMUL_pow : int) -> bool = {
 // A segment load/store uses NFIELDS register groups of ceil(EMUL) registers
 // each, starting at reg. If those would run past v31 the encoding is
 // reserved, so check the last register stays in range.
-function valid_segment_no_overflow(reg : vregidx, nf : nfields, EMUL_pow : int) -> bool = {
+function valid_segment_group_without_overflow(reg : vregidx, nf : nfields, EMUL_pow : int) -> bool = {
   let EMUL_reg = 2 ^ max(EMUL_pow, 0);
   unsigned(vregidx_bits(reg)) + nf * EMUL_reg <= 32
 }
@@ -293,28 +293,28 @@ function illegal_widening_reduction(EEW : nat) -> bool = {
 // g. Non-indexed load instruction check
 function illegal_load(vd : vregidx, vm : bits(1), nf : nfields, EEW : nat, EMUL_pow : int) -> bool = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm)) |
-  not(valid_eew_emul(EEW, EMUL_pow)) | not(valid_segment(nf, EMUL_pow)) |
-  not(valid_segment_no_overflow(vd, nf, EMUL_pow))
+  not(valid_eew_emul(EEW, EMUL_pow)) | not(valid_segment_group_size(nf, EMUL_pow)) |
+  not(valid_segment_group_without_overflow(vd, nf, EMUL_pow))
 }
 
 // h. Non-indexed store instruction check (with vs3 rather than vd)
 function illegal_store(vs3 : vregidx, nf : nfields, EEW : nat, EMUL_pow : int) -> bool = {
-  not(valid_vtype()) | not(valid_eew_emul(EEW, EMUL_pow)) | not(valid_segment(nf, EMUL_pow)) |
-  not(valid_segment_no_overflow(vs3, nf, EMUL_pow))
+  not(valid_vtype()) | not(valid_eew_emul(EEW, EMUL_pow)) | not(valid_segment_group_size(nf, EMUL_pow)) |
+  not(valid_segment_group_without_overflow(vs3, nf, EMUL_pow))
 }
 
 // i. Indexed load instruction check
 function illegal_indexed_load(vd : vregidx, vm : bits(1), nf : nfields, EEW_index : nat, EMUL_pow_index : int, EMUL_pow_data : int) -> bool = {
   not(valid_vtype()) | not(valid_rd_mask(vd, vm)) |
-  not(valid_eew_emul(EEW_index, EMUL_pow_index)) | not(valid_segment(nf, EMUL_pow_data)) |
-  not(valid_segment_no_overflow(vd, nf, EMUL_pow_data))
+  not(valid_eew_emul(EEW_index, EMUL_pow_index)) | not(valid_segment_group_size(nf, EMUL_pow_data)) |
+  not(valid_segment_group_without_overflow(vd, nf, EMUL_pow_data))
 }
 
 // j. Indexed store instruction check (with vs3 rather than vd)
 function illegal_indexed_store(vs3 : vregidx, nf : nfields, EEW_index : nat, EMUL_pow_index : int, EMUL_pow_data : int) -> bool = {
   not(valid_vtype()) | not(valid_eew_emul(EEW_index, EMUL_pow_index)) |
-  not(valid_segment(nf, EMUL_pow_data)) |
-  not(valid_segment_no_overflow(vs3, nf, EMUL_pow_data))
+  not(valid_segment_group_size(nf, EMUL_pow_data)) |
+  not(valid_segment_group_without_overflow(vs3, nf, EMUL_pow_data))
 }
 
 // Scalar register shaping


### PR DESCRIPTION
Segment load/stores encodings whose register numbers increment past v31 are reserved, but the model silently wrapped around the register file instead of trapping. This adds `valid_segment_no_overflow()` to the (indexed) load and store illegal check functions, so that these raise an illegal instruction exception.

Fixes #1748