### PR TITLE
Don't close stdout when no terminal log is set

### DIFF
--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -599,15 +599,14 @@ void run_sail(
 }
 
 void init_logs(const CLIOptions &opts, run_info &run_info) {
-  if (!opts.term_log.empty() &&
-      (run_info.term_fd =
-         open(opts.term_log.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IRGRP | S_IROTH | S_IWUSR)) < 0) {
-    fprintf(stderr, "Cannot create terminal log '%s': %s\n", opts.term_log.c_str(), strerror(errno));
-    exit(EXIT_FAILURE);
+  if (!opts.term_log.empty()) {
+    if ((run_info.term_fd =
+           open(opts.term_log.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IRGRP | S_IROTH | S_IWUSR)) < 0) {
+      fprintf(stderr, "Cannot create terminal log '%s': %s\n", opts.term_log.c_str(), strerror(errno));
+      exit(EXIT_FAILURE);
+    }
+    run_info.close_term_fd = true;
   }
-  // Don't close term_fd unless we opened a file for it, otherwise it's still
-  // stdout, and closing stdout drops buffered output when stdout isn't a terminal.
-  run_info.close_term_fd = !opts.term_log.empty();
 
   if (!opts.trace_log_path.empty()) {
     run_info.trace_log = fopen(opts.trace_log_path.c_str(), "w+");

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -605,7 +605,9 @@ void init_logs(const CLIOptions &opts, run_info &run_info) {
     fprintf(stderr, "Cannot create terminal log '%s': %s\n", opts.term_log.c_str(), strerror(errno));
     exit(EXIT_FAILURE);
   }
-  run_info.close_term_fd = true;
+  // Don't close term_fd unless we opened a file for it, otherwise it's still
+  // stdout, and closing stdout drops buffered output when stdout isn't a terminal.
+  run_info.close_term_fd = !opts.term_log.empty();
 
   if (!opts.trace_log_path.empty()) {
     run_info.trace_log = fopen(opts.trace_log_path.c_str(), "w+");


### PR DESCRIPTION
`term_fd` defaults to `stdout` and is only changed when `--terminal-log` is passed, but `close_term_fd` was set to true unconditionally. So with no terminal log, cleanup closed `stdout` before `exit()` flushed it.

This was harmless on a terminal, but with a file/pipe the buffered output was dropped at exit which can break workflows that capture output and grep it for a result.

Only close `term_fd` when a log file was actually opened.