### PR TITLE
Add support for VLEN=64 in config generation and vector tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
             -DFIRST_PARTY_TESTS=${{ matrix.first_party_tests }} \
             -DENABLE_RISCV_TESTS=TRUE \
             -DENABLE_RISCV_ARCH_TESTS=TRUE \
+            -DENABLE_RISCV_VECTOR_TESTS_V64_E64=TRUE \
             -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE \
             -DENABLE_LTO=TRUE \
             $CLANG_FLAG

--- a/.github/workflows/run-full-tests.yml
+++ b/.github/workflows/run-full-tests.yml
@@ -23,11 +23,12 @@ jobs:
           [
             RISCV_TESTS,
             RISCV_ARCH_TESTS,
+            RISCV_VECTOR_TESTS_V64_E32,
+            RISCV_VECTOR_TESTS_V64_E64,
             RISCV_VECTOR_TESTS_V128_E32,
             RISCV_VECTOR_TESTS_V128_E64,
             RISCV_VECTOR_TESTS_V256_E32,
             RISCV_VECTOR_TESTS_V256_E64,
-            RISCV_VECTOR_TESTS_V512_E32,
             RISCV_VECTOR_TESTS_V512_E64,
           ]
     steps:

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -3,7 +3,7 @@ set(generated_config_filenames)
 # Create a variety of configuration files for different XLEN/ELEN/VLENs.
 foreach(CONFIG__BASE__XLEN IN ITEMS 32 64)
     foreach(CONFIG__V__ELEN_EXP RANGE 5 6)
-        foreach(CONFIG__V__VLEN_EXP RANGE 7 9)
+        foreach(CONFIG__V__VLEN_EXP RANGE 6 9)
             math(EXPR vlen "1 << ${CONFIG__V__VLEN_EXP}")
             math(EXPR elen "1 << ${CONFIG__V__ELEN_EXP}")
 
@@ -19,8 +19,12 @@ foreach(CONFIG__BASE__XLEN IN ITEMS 32 64)
 
             if(CONFIG_ELEN_IS_32 STREQUAL true)
               set(CONFIG__V__SUPPORT "Float_single")
-            elseif(CONFIG_ELEN_IS_64 STREQUAL true)
+            # Check if we can enable the full V extension.
+            elseif((CONFIG_ELEN_IS_64 STREQUAL true) AND (vlen GREATER 64))
               set(CONFIG__V__SUPPORT "Full")
+            # Otherwise fallback to Float_double for ELEN=64.
+            elseif(CONFIG_ELEN_IS_64 STREQUAL true)
+              set(CONFIG__V__SUPPORT "Float_double")
             endif()
 
             configure_file(config.json.in ${CMAKE_CURRENT_BINARY_DIR}/${config_filename})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,7 +84,7 @@ endfunction()
 # supported by the RISC-V Vector Test suite.
 foreach(vlen IN ITEMS 64 128 256 512)
     foreach(elen IN ITEMS 32 64)
-        if((${vlen} STREQUAL 512) AND (${elen} STREQUAL 32))
+        if((${vlen} EQUAL 512) AND (${elen} EQUAL 32))
             # The test suite for this combination is not built due to
             # its long execution time.
             continue()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,7 +84,7 @@ endfunction()
 # supported by the RISC-V Vector Test suite.
 foreach(vlen IN ITEMS 64 128 256 512)
     foreach(elen IN ITEMS 32 64)
-        if(("$vlen" STREQUAL "512") AND ("$elen" STREQUAL "32"))
+        if(("${vlen}" STREQUAL "512") AND ("${elen}" STREQUAL "32"))
             # The test suite for this combination is not built due to
             # its long execution time.
             continue()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake options for test downloads
 set(TEST_DOWNLOAD_URL "https://github.com/riscv-software-src/sail-riscv-tests/releases/download" CACHE STRING "Base URL to download precompiled riscv-tests and riscv-vector-tests from")
-set(TEST_DOWNLOAD_VERSION "2026-05-29" CACHE STRING "Version of precompiled tests to download")
+set(TEST_DOWNLOAD_VERSION "2026-06-10" CACHE STRING "Version of precompiled tests to download")
 
 # Function to download and extract test files
 function(download_riscv_tests DOWNLOAD_PATH TARBALL_NAME DOWNLOAD_URL)
@@ -82,8 +82,13 @@ endfunction()
 # Download and add RVV tests.
 # NOTE: Setting XLEN independently of ELEN is not
 # supported by the RISC-V Vector Test suite.
-foreach(vlen IN ITEMS 128 256 512)
+foreach(vlen IN ITEMS 64 128 256 512)
     foreach(elen IN ITEMS 32 64)
+        if(("$vlen" STREQUAL "512") AND ("$elen" STREQUAL "32"))
+            # The test suite for this combination is not built due to
+            # its long execution time.
+            continue()
+        endif()
         setup_vector_test("${vlen}" "${elen}")
     endforeach()
 endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,7 +84,7 @@ endfunction()
 # supported by the RISC-V Vector Test suite.
 foreach(vlen IN ITEMS 64 128 256 512)
     foreach(elen IN ITEMS 32 64)
-        if(("${vlen}" STREQUAL "512") AND ("${elen}" STREQUAL "32"))
+        if((${vlen} STREQUAL 512) AND (${elen} STREQUAL 32))
             # The test suite for this combination is not built due to
             # its long execution time.
             continue()


### PR DESCRIPTION
VLEN=64 is not included under the full V extension and so provides an additional test point.

Remove testing of the VLEN=512/ELEN=32 combination since the test suite for this combination takes around 6 hours to generate which often exceeds the maximum Github CI execution time limit (6 hours).

The VLEN=64 suites are in the latest `sail-riscv-tests` release:
```
$ ./compare-releases.py -p releases/2026-05-29 -c releases/2026-06-10
riscv-tests has 667 test files, with 0 added to and 0 removed from the previous release.
riscv-arch-tests has 2080 test files, with 0 added to and 0 removed from the previous release.
riscv-vector-tests-v64x32 with 1941 test files was added.
riscv-vector-tests-v64x64 with 3025 test files was added.
riscv-vector-tests-v128x32 has 1944 test files, with 0 added to and 0 removed from the previous release.
riscv-vector-tests-v128x64 has 3042 test files, with 0 added to and 0 removed from the previous release.
riscv-vector-tests-v256x32 has 1945 test files, with 0 added to and 0 removed from the previous release.
riscv-vector-tests-v256x64 has 3043 test files, with 0 added to and 0 removed from the previous release.
riscv-vector-tests-v512x32 with 1945 test files was removed.
riscv-vector-tests-v512x64 has 3043 test files, with 0 added to and 0 removed from the previous release.
```