### PR TITLE
Add build rule for HOL4 theorem prover

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,6 @@ add_custom_target(csim DEPENDS sail_riscv_sim)
 add_custom_target(check DEPENDS generated_model_rv)
 
 # TODO: Add `interpret` target.
-# TODO: Add hol4 target.
 
 # Release packaging.
 include(cmake/packaging.cmake)

--- a/handwritten_support/Holmakefile.in
+++ b/handwritten_support/Holmakefile.in
@@ -1,6 +1,6 @@
 INCLUDES = $(LEM_DIR)/hol-lib $(SAIL_LIB_DIR)/hol
 
-SCRIPTS = riscv_extrasScript.sml  riscv_typesScript.sml  riscvScript.sml
+SCRIPTS = riscv_extrasScript.sml  @arch@_typesScript.sml  @arch@Script.sml
 
 THYS = $(patsubst %Script.sml,%Theory.uo,$(SCRIPTS))
 

--- a/handwritten_support/riscv_extras.lem
+++ b/handwritten_support/riscv_extras.lem
@@ -13,6 +13,7 @@ open import Sail2_values
 open import Sail2_operators_bitlists
 open import Sail2_concurrency_interface
 open import Sail2_monadic_combinators
+open import Sail2_undefined_concurrency_interface
 
 type bitvector = list Sail2_values.bitU
 
@@ -31,9 +32,7 @@ val plat_term_read : forall 'abort 'barrier 'cache_op 'fault 'pa 'tlb_op 'transl
 let plat_term_read () = return []
 declare ocaml target_rep function plat_term_read = `Platform.term_read`
 
-val plat_get_16_random_bits : forall 'abort 'barrier 'cache_op 'fault 'pa 'tlb_op 'translation_summary 'trans_start 'trans_end 'arch_ak 'rv 'e. Register_Value 'rv =>
-  unit -> monad 'abort 'barrier 'cache_op 'fault 'pa 'tlb_op 'translation_summary 'trans_start 'trans_end 'arch_ak 'rv bitvector 'e
-let plat_get_16_random_bits () = choose_bitvector "plat_get_16_random_bits" 16
+let plat_get_16_random_bits () = undefined_bitvector 16
 declare ocaml target_rep function plat_get_16_random_bits = `Platform.get_16_random_bits`
 
 let sys_enable_experimental_extensions () = false

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -565,4 +565,36 @@ foreach (xlen IN ITEMS 32 64)
             "${CMAKE_BINARY_DIR}/isabelle/${arch}/ROOT"
     )
     add_custom_target(generated_isabelle_${arch} DEPENDS "${CMAKE_BINARY_DIR}/isabelle/${arch}/${arch_thy}.thy")
+
+    ############# HOL4 #############
+
+    # Build HOL4 definitions from Lem
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/hol4/${arch}")
+    configure_file("${CMAKE_SOURCE_DIR}/handwritten_support/Holmakefile.in" "${CMAKE_BINARY_DIR}/hol4/${arch}/Holmakefile" @ONLY)
+    add_custom_command(
+        DEPENDS
+          "${arch}.lem"
+          "${arch}_types.lem"
+          "${CMAKE_SOURCE_DIR}/handwritten_support/riscv_extras.lem"
+          "${CMAKE_SOURCE_DIR}/handwritten_support/riscv_extras_fdext.lem"
+        VERBATIM
+        OUTPUT
+          "${CMAKE_BINARY_DIR}/hol4/${arch}/${arch}Script.thy"
+          "${CMAKE_BINARY_DIR}/hol4/${arch}/${arch}_typesScript.thy"
+          "${CMAKE_BINARY_DIR}/hol4/${arch}/riscv_extrasScript.thy"
+          "${CMAKE_BINARY_DIR}/hol4/${arch}/riscv_extras_fdextScript.thy"
+        COMMENT "Building HOL4 definitions from Lem definitions (${arch})"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND
+            lem
+            -wl ign
+            -hol
+            -outdir ${CMAKE_BINARY_DIR}/hol4/${arch}
+            -lib Sail=${sail_dir}/lib/hol
+            ${CMAKE_SOURCE_DIR}/handwritten_support/riscv_extras.lem
+            ${CMAKE_SOURCE_DIR}/handwritten_support/riscv_extras_fdext.lem
+            ${arch}_types.lem
+            ${arch}.lem
+    )
+    add_custom_target(generated_hol4_${arch} DEPENDS "${CMAKE_BINARY_DIR}/hol4/${arch}/${arch}Script.thy")
 endforeach()


### PR DESCRIPTION
This includes a small tweak to the handwritten Lem file to sidestep a an issue with the Sail library.

It requires the current development versions of Sail and Lem to build.