### PR TITLE
Correctly update vxsat in vssubu and add vxsat to trace when changed

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -3,6 +3,7 @@
 - Important issues addressed and bugs fixed:
   - https://github.com/riscv/sail-riscv/issues/1750 : Non-segmented indexed loads were trapping on legal overlaps
   - https://github.com/riscv/sail-riscv/issues/1748 : Segment loads/stores whose register numbers increment past v31 were not treated as reserved.
+  - https://github.com/riscv/sail-riscv/issues/1069 : `vssubu` did not set `vxsat`
 
 # Release notes for version 0.12
 

--- a/model/extensions/V/vext_arith_insts.sail
+++ b/model/extensions/V/vext_arith_insts.sail
@@ -112,7 +112,10 @@ function clause execute VVTYPE(funct6, vm, vs2, vs1, vd) = {
         VV_VSADDU        => unsigned_saturation('m, zero_extend('m + 1, vs2_val[i]) + zero_extend('m + 1, vs1_val[i])),
         VV_VSADD         => signed_saturation('m, sign_extend('m + 1, vs2_val[i]) + sign_extend('m + 1, vs1_val[i])),
         VV_VSSUBU        => {
-                              if unsigned(vs2_val[i]) < unsigned(vs1_val[i]) then zeros()
+                              if unsigned(vs2_val[i]) < unsigned(vs1_val[i]) then {
+                                write_vxsat(0b1);
+                                zeros()
+                              }
                               else unsigned_saturation('m, zero_extend('m + 1, vs2_val[i]) - zero_extend('m + 1, vs1_val[i]))
                             },
         VV_VSSUB         => signed_saturation('m, sign_extend('m + 1, vs2_val[i]) - sign_extend('m + 1, vs1_val[i])),
@@ -514,7 +517,10 @@ function clause execute VXTYPE(funct6, vm, vs2, rs1, vd) = {
         VX_VSADDU  => unsigned_saturation('m, zero_extend('m + 1, vs2_val[i]) + zero_extend('m + 1, rs1_val) ),
         VX_VSADD   => signed_saturation('m, sign_extend('m + 1, vs2_val[i]) + sign_extend('m + 1, rs1_val) ),
         VX_VSSUBU  => {
-                        if unsigned(vs2_val[i]) < unsigned(rs1_val) then zeros()
+                        if unsigned(vs2_val[i]) < unsigned(rs1_val) then {
+                          write_vxsat(0b1);
+                          zeros()
+                        }
                         else unsigned_saturation('m, zero_extend('m + 1, vs2_val[i]) - zero_extend('m + 1, rs1_val) )
                       },
         VX_VSSUB   => signed_saturation('m, sign_extend('m + 1, vs2_val[i]) - sign_extend('m + 1, rs1_val) ),

--- a/model/extensions/V/vext_regs.sail
+++ b/model/extensions/V/vext_regs.sail
@@ -346,6 +346,12 @@ private function write_vcsr(vxrm_val : bits(2), vxsat_val : bits(1)) -> unit = {
   dirty_v_context()
 }
 
+function write_vxsat(vxsat_val: bits(1)) -> unit = {
+  write_vcsr(vcsr[vxrm], vxsat_val);
+  csr_write_callback("vxsat", zero_extend(vcsr[vxsat]));
+  csr_write_callback("vcsr", zero_extend(vcsr.bits));
+}
+
 function clause write_CSR(0x008, value) = { set_vstart(value[15 .. 0]); Ok(vstart) }
 function clause write_CSR(0x009, value) = { write_vcsr (vcsr[vxrm], value[0 .. 0]); Ok(zero_extend(vcsr[vxsat])) }
 function clause write_CSR(0x00A, value) = { write_vcsr (value[1 .. 0], vcsr[vxsat]); Ok(zero_extend(vcsr[vxrm])) }

--- a/model/extensions/V/vext_regs.sail
+++ b/model/extensions/V/vext_regs.sail
@@ -347,9 +347,11 @@ private function write_vcsr(vxrm_val : bits(2), vxsat_val : bits(1)) -> unit = {
 }
 
 function write_vxsat(vxsat_val: bits(1)) -> unit = {
-  write_vcsr(vcsr[vxrm], vxsat_val);
-  csr_write_callback("vxsat", zero_extend(vcsr[vxsat]));
-  csr_write_callback("vcsr", zero_extend(vcsr.bits));
+  if vcsr[vxsat] != vxsat_val then {
+    write_vcsr(vcsr[vxrm], vxsat_val);
+    csr_write_callback("vxsat", zero_extend(vcsr[vxsat]));
+    csr_write_callback("vcsr", zero_extend(vcsr.bits));
+  }
 }
 
 function clause write_CSR(0x008, value) = { set_vstart(value[15 .. 0]); Ok(vstart) }

--- a/model/extensions/V/vext_regs.sail
+++ b/model/extensions/V/vext_regs.sail
@@ -348,10 +348,11 @@ private function write_vcsr(vxrm_val : bits(2), vxsat_val : bits(1)) -> unit = {
 
 function write_vxsat(vxsat_val: bits(1)) -> unit = {
   if vcsr[vxsat] != vxsat_val then {
-    write_vcsr(vcsr[vxrm], vxsat_val);
-    csr_write_callback("vxsat", zero_extend(vcsr[vxsat]));
-    csr_write_callback("vcsr", zero_extend(vcsr.bits));
-  }
+    vcsr[vxsat] = vxsat_val;
+    dirty_v_context();
+  };
+  csr_write_callback("vxsat", zero_extend(vcsr[vxsat]));
+  csr_write_callback("vcsr", zero_extend(vcsr.bits));
 }
 
 function clause write_CSR(0x008, value) = { set_vstart(value[15 .. 0]); Ok(vstart) }

--- a/model/extensions/V/vext_utils_insts.sail
+++ b/model/extensions/V/vext_utils_insts.sail
@@ -609,6 +609,7 @@ function unsigned_saturation(len, elem) = {
     write_vxsat(0b1);
     ones('m)
   } else {
+    write_vxsat(vcsr[vxsat]);
     elem['m - 1 .. 0]
   }
 }
@@ -623,6 +624,7 @@ function signed_saturation(len, elem) = {
     write_vxsat(0b1);
     0b1 @ zeros('m - 1)
   } else {
+    write_vxsat(vcsr[vxsat]);
     elem['m - 1 .. 0]
   };
 }

--- a/model/extensions/V/vext_utils_insts.sail
+++ b/model/extensions/V/vext_utils_insts.sail
@@ -609,7 +609,6 @@ function unsigned_saturation(len, elem) = {
     write_vxsat(0b1);
     ones('m)
   } else {
-    write_vxsat(vcsr[vxsat]);
     elem['m - 1 .. 0]
   }
 }
@@ -624,7 +623,6 @@ function signed_saturation(len, elem) = {
     write_vxsat(0b1);
     0b1 @ zeros('m - 1)
   } else {
-    write_vxsat(vcsr[vxsat]);
     elem['m - 1 .. 0]
   };
 }

--- a/model/extensions/V/vext_utils_insts.sail
+++ b/model/extensions/V/vext_utils_insts.sail
@@ -606,9 +606,10 @@ function get_fixed_rounding_incr(vec_elem, shift_amount) = {
 val unsigned_saturation : forall ('m 'n: Int), ('n >= 'm > 1). (int('m), bits('n)) -> bits('m)
 function unsigned_saturation(len, elem) = {
   if unsigned(elem) > unsigned(ones('m)) then {
-    vcsr[vxsat] = 0b1;
+    write_vxsat(0b1);
     ones('m)
   } else {
+    write_vxsat(vcsr[vxsat]);
     elem['m - 1 .. 0]
   }
 }
@@ -617,12 +618,13 @@ function unsigned_saturation(len, elem) = {
 val signed_saturation : forall ('m 'n: Int), ('n >= 'm > 1). (int('m), bits('n)) -> bits('m)
 function signed_saturation(len, elem) = {
   if signed(elem) > signed(0b0 @ ones('m - 1)) then {
-    vcsr[vxsat] = 0b1;
+    write_vxsat(0b1);
     0b0 @ ones('m - 1)
   } else if signed(elem) < signed(0b1 @ zeros('m - 1)) then {
-    vcsr[vxsat] = 0b1;
+    write_vxsat(0b1);
     0b1 @ zeros('m - 1)
   } else {
+    write_vxsat(vcsr[vxsat]);
     elem['m - 1 .. 0]
   };
 }


### PR DESCRIPTION
In vssubu, when the value in vs2 was greater than rs1 or the value in vs1, the previous behavior was to clamp the result to zero and return. The spec says: "If the result would overflow the destination, the result is replaced with the closest representable value, and the vxsat bit is set," so vxsat should have been set in these cases. This PR sets vxsat in these cases. Fixes #1069.

This PR also adds vxsat updates to the trace. Previously, the only updates to vxsat that were logged in the trace were updates in csr write instructions. The addition of vxsat to the trace is modeled after the way that fflags handled, in that every instruction that can update these csrs issues a write callback for both vcsr and vxsat. 