### PR TITLE
add smwid extension.

### DIFF
--- a/c_emulator/riscv_callbacks_if.cpp
+++ b/c_emulator/riscv_callbacks_if.cpp
@@ -16,6 +16,7 @@ void callbacks_if::fetch_callback([[maybe_unused]] ModelImpl &model, [[maybe_unu
 void callbacks_if::mem_write_callback(
   [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] const char *type,
+  [[maybe_unused]] sbits wid,
   [[maybe_unused]] sbits paddr,
   [[maybe_unused]] uint64_t width,
   [[maybe_unused]] lbits value
@@ -25,6 +26,7 @@ void callbacks_if::mem_write_callback(
 void callbacks_if::mem_read_callback(
   [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] const char *type,
+  [[maybe_unused]] sbits wid,
   [[maybe_unused]] sbits paddr,
   [[maybe_unused]] uint64_t width,
   [[maybe_unused]] lbits value
@@ -33,6 +35,7 @@ void callbacks_if::mem_read_callback(
 
 void callbacks_if::mem_exception_callback(
   [[maybe_unused]] ModelImpl &model,
+  [[maybe_unused]] sbits wid,
   [[maybe_unused]] sbits paddr,
   [[maybe_unused]] uint64_t num_of_exception
 ) {

--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -15,11 +15,25 @@ public:
 
   virtual void fetch_callback(ModelImpl &model, sbits opcode);
 
-  virtual void mem_write_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value);
+  virtual void mem_write_callback(
+    ModelImpl &model,
+    const char *type,
+    sbits wid,
+    sbits paddr,
+    uint64_t width,
+    lbits value
+  );
 
-  virtual void mem_read_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value);
+  virtual void mem_read_callback(
+    ModelImpl &model,
+    const char *type,
+    sbits wid,
+    sbits paddr,
+    uint64_t width,
+    lbits value
+  );
 
-  virtual void mem_exception_callback(ModelImpl &model, sbits paddr, uint64_t num_of_exception);
+  virtual void mem_exception_callback(ModelImpl &model, sbits wid, sbits paddr, uint64_t num_of_exception);
 
   virtual void xreg_full_write_callback(ModelImpl &model, const_sail_string abi_name, sbits reg, sbits value);
 

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -29,33 +29,67 @@ log_callbacks::log_callbacks(
 // Implementations of default callbacks for trace printing.
 // The model assumes that these functions do not change the state of the model.
 
-void log_callbacks::mem_write_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) {
+static void print_memory_access(
+  FILE *trace_log,
+  ModelImpl &model,
+  const char *type,
+  sbits wid,
+  sbits paddr,
+  const char *direction,
+  lbits value
+) {
+  fprintf(
+    trace_log,
+    "mem[%s,wid=%" PRIu64 ",0x%0*" PRIX64 "] %s ",
+    type,
+    wid.bits,
+    static_cast<int>((model.physaddrbits_len() + 3) / 4),
+    paddr.bits,
+    direction
+  );
+  gmp_fprintf(trace_log, "0x%0*ZX\n", value.len / 4, *value.bits);
+}
+
+void log_callbacks::mem_write_callback(
+  ModelImpl &model,
+  const char *type,
+  sbits wid,
+  sbits paddr,
+  uint64_t width,
+  lbits value
+) {
   // This is just passed due to Sail type system requirements.
   (void)width;
   if (trace_log != nullptr && config_print_mem_access) {
-    fprintf(
-      trace_log,
-      "mem[%s,0x%0*" PRIX64 "] <- ",
-      type,
-      static_cast<int>((model.physaddrbits_len() + 3) / 4),
-      paddr.bits
-    );
-    gmp_fprintf(trace_log, "0x%0*ZX\n", value.len / 4, *value.bits);
+    print_memory_access(trace_log, model, type, wid, paddr, "<-", value);
   }
 }
 
-void log_callbacks::mem_read_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) {
+void log_callbacks::mem_read_callback(
+  ModelImpl &model,
+  const char *type,
+  sbits wid,
+  sbits paddr,
+  uint64_t width,
+  lbits value
+) {
   // This is just passed due to Sail type system requirements.
   (void)width;
   if (trace_log != nullptr && config_print_mem_access) {
+    print_memory_access(trace_log, model, type, wid, paddr, "->", value);
+  }
+}
+
+void log_callbacks::mem_exception_callback(ModelImpl &model, sbits wid, sbits paddr, uint64_t num_of_exception) {
+  if (trace_log != nullptr && config_print_mem_access) {
     fprintf(
       trace_log,
-      "mem[%s,0x%0*" PRIX64 "] -> ",
-      type,
+      "mem[wid=%" PRIu64 ",0x%0*" PRIX64 "] !! exception=%" PRIu64 "\n",
+      wid.bits,
       static_cast<int>((model.physaddrbits_len() + 3) / 4),
-      paddr.bits
+      paddr.bits,
+      num_of_exception
     );
-    gmp_fprintf(trace_log, "0x%0*ZX\n", value.len / 4, *value.bits);
   }
 }
 

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -19,13 +19,29 @@ public:
   );
 
   // callbacks_if
-  void mem_write_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
-  void mem_read_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
+  void mem_write_callback(
+    ModelImpl &model,
+    const char *type,
+    sbits wid,
+    sbits paddr,
+    uint64_t width,
+    lbits value
+  ) override;
+  void mem_read_callback(
+    ModelImpl &model,
+    const char *type,
+    sbits wid,
+    sbits paddr,
+    uint64_t width,
+    lbits value
+  ) override;
+  void mem_exception_callback(ModelImpl &model, sbits wid, sbits paddr, uint64_t num_of_exception) override;
   void xreg_full_write_callback(ModelImpl &model, const_sail_string abi_name, sbits reg, sbits value) override;
   void freg_write_callback(ModelImpl &model, unsigned reg, sbits value) override;
   void csr_full_write_callback(ModelImpl &model, const_sail_string csr_name, unsigned reg, sbits value) override;
   void csr_full_read_callback(ModelImpl &model, const_sail_string csr_name, unsigned reg, sbits value) override;
   void vreg_write_callback(ModelImpl &model, unsigned reg, lbits value) override;
+
   // Page table walk callback
   void ptw_start_callback(
     ModelImpl &model,

--- a/c_emulator/riscv_callbacks_rvfi.cpp
+++ b/c_emulator/riscv_callbacks_rvfi.cpp
@@ -7,11 +7,25 @@
 // Implementations of default callbacks for RVFI.
 // The model assumes that these functions do not change the state of the model.
 
-void rvfi_callbacks::mem_write_callback(ModelImpl &model, const char *, sbits paddr, uint64_t width, lbits value) {
+void rvfi_callbacks::mem_write_callback(
+  ModelImpl &model,
+  const char *,
+  sbits wid,
+  sbits paddr,
+  uint64_t width,
+  lbits value
+) {
   model.zrvfi_write(paddr, width, value);
 }
 
-void rvfi_callbacks::mem_read_callback(ModelImpl &model, const char *, sbits paddr, uint64_t width, lbits value) {
+void rvfi_callbacks::mem_read_callback(
+  ModelImpl &model,
+  const char *,
+  sbits wid,
+  sbits paddr,
+  uint64_t width,
+  lbits value
+) {
   sail_int len;
   CREATE(sail_int)(&len);
   CONVERT_OF(sail_int, mach_int)(&len, width);
@@ -19,7 +33,7 @@ void rvfi_callbacks::mem_read_callback(ModelImpl &model, const char *, sbits pad
   KILL(sail_int)(&len);
 }
 
-void rvfi_callbacks::mem_exception_callback(ModelImpl &model, sbits paddr, uint64_t) {
+void rvfi_callbacks::mem_exception_callback(ModelImpl &model, sbits wid, sbits paddr, uint64_t) {
   model.zrvfi_mem_exception(paddr);
 }
 

--- a/c_emulator/riscv_callbacks_rvfi.h
+++ b/c_emulator/riscv_callbacks_rvfi.h
@@ -6,9 +6,23 @@ class rvfi_callbacks : public callbacks_if {
 
 public:
   // callbacks_if
-  void mem_write_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
-  void mem_read_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
-  void mem_exception_callback(ModelImpl &model, sbits paddr, uint64_t num_of_exception) override;
+  void mem_write_callback(
+    ModelImpl &model,
+    const char *type,
+    sbits wid,
+    sbits paddr,
+    uint64_t width,
+    lbits value
+  ) override;
+  void mem_read_callback(
+    ModelImpl &model,
+    const char *type,
+    sbits wid,
+    sbits paddr,
+    uint64_t width,
+    lbits value
+  ) override;
+  void mem_exception_callback(ModelImpl &model, sbits wid, sbits paddr, uint64_t num_of_exception) override;
   void xreg_full_write_callback(ModelImpl &model, const_sail_string abi_name, sbits reg, sbits value) override;
   void trap_callback(ModelImpl &model, bool is_interrupt, fbits cause) override;
 };

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -53,25 +53,25 @@ unit ModelImpl::fetch_callback(sbits opcode) {
   return UNIT;
 }
 
-unit ModelImpl::mem_write_callback(const char *type, sbits paddr, uint64_t width, lbits value) {
+unit ModelImpl::mem_write_callback(const char *type, sbits wid, sbits paddr, uint64_t width, lbits value) {
   for (auto c : m_callbacks) {
-    c->mem_write_callback(*this, type, paddr, width, value);
+    c->mem_write_callback(*this, type, wid, paddr, width, value);
   }
   if (m_reservation_invalidate_on_same_hart_store && match_reservation(paddr)) {
     cancel_reservation(UNIT);
   };
   return UNIT;
 }
-unit ModelImpl::mem_read_callback(const char *type, sbits paddr, uint64_t width, lbits value) {
+unit ModelImpl::mem_read_callback(const char *type, sbits wid, sbits paddr, uint64_t width, lbits value) {
   for (auto c : m_callbacks) {
-    c->mem_read_callback(*this, type, paddr, width, value);
+    c->mem_read_callback(*this, type, wid, paddr, width, value);
   }
   return UNIT;
 }
 
-unit ModelImpl::mem_exception_callback(sbits paddr, uint64_t num_of_exception) {
+unit ModelImpl::mem_exception_callback(sbits wid, sbits paddr, uint64_t num_of_exception) {
   for (auto c : m_callbacks) {
-    c->mem_exception_callback(*this, paddr, num_of_exception);
+    c->mem_exception_callback(*this, wid, paddr, num_of_exception);
   }
   return UNIT;
 }

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -98,9 +98,9 @@ private:
   // These functions are called by the Sail code.
 
   unit fetch_callback(sbits opcode) override;
-  unit mem_write_callback(const char *type, sbits paddr, uint64_t width, lbits value) override;
-  unit mem_read_callback(const char *type, sbits paddr, uint64_t width, lbits value) override;
-  unit mem_exception_callback(sbits paddr, uint64_t num_of_exception) override;
+  unit mem_write_callback(const char *type, sbits wid, sbits paddr, uint64_t width, lbits value) override;
+  unit mem_read_callback(const char *type, sbits wid, sbits paddr, uint64_t width, lbits value) override;
+  unit mem_exception_callback(sbits wid, sbits paddr, uint64_t num_of_exception) override;
   unit xreg_full_write_callback(const_sail_string abi_name, sbits reg, sbits value) override;
   unit freg_write_callback(unsigned reg, sbits value) override;
   // `full` indicates that the name and index of the CSR are provided.

--- a/c_emulator/riscv_platform_if.cpp
+++ b/c_emulator/riscv_platform_if.cpp
@@ -14,6 +14,7 @@ unit PlatformInterface::fetch_callback([[maybe_unused]] sbits opcode) {
 
 unit PlatformInterface::mem_write_callback(
   [[maybe_unused]] const char *type,
+  [[maybe_unused]] sbits wid,
   [[maybe_unused]] sbits paddr,
   [[maybe_unused]] uint64_t width,
   [[maybe_unused]] lbits value
@@ -23,6 +24,7 @@ unit PlatformInterface::mem_write_callback(
 
 unit PlatformInterface::mem_read_callback(
   [[maybe_unused]] const char *type,
+  [[maybe_unused]] sbits wid,
   [[maybe_unused]] sbits paddr,
   [[maybe_unused]] uint64_t width,
   [[maybe_unused]] lbits value
@@ -31,6 +33,7 @@ unit PlatformInterface::mem_read_callback(
 }
 
 unit PlatformInterface::mem_exception_callback(
+  [[maybe_unused]] sbits wid,
   [[maybe_unused]] sbits paddr,
   [[maybe_unused]] uint64_t num_of_exception
 ) {

--- a/c_emulator/riscv_platform_if.h
+++ b/c_emulator/riscv_platform_if.h
@@ -28,11 +28,11 @@ class PlatformInterface {
 public:
   virtual unit fetch_callback(sbits opcode);
 
-  virtual unit mem_write_callback(const char *type, sbits paddr, uint64_t width, lbits value);
+  virtual unit mem_write_callback(const char *type, sbits wid, sbits paddr, uint64_t width, lbits value);
 
-  virtual unit mem_read_callback(const char *type, sbits paddr, uint64_t width, lbits value);
+  virtual unit mem_read_callback(const char *type, sbits wid, sbits paddr, uint64_t width, lbits value);
 
-  virtual unit mem_exception_callback(sbits paddr, uint64_t num_of_exception);
+  virtual unit mem_exception_callback(sbits wid, sbits paddr, uint64_t num_of_exception);
 
   virtual unit xreg_full_write_callback(const_sail_string abi_name, sbits reg, sbits value);
 

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -391,7 +391,91 @@
     // Note: it is also legal for these instructions to spuriously
     // retire successfully at any point, but there is currently no
     // configuration option for this behaviour.
-    "max_time_to_wait": 10
+    "max_time_to_wait": 10,
+    "worlds": {
+      "enabled": false,
+      "unauthorized_behavior": "Smwid_Fatal",
+      "regions": [
+        {
+          "base": {
+            "len": 64,
+            "value": "0x1000"
+          },
+          "size": {
+            "len": 64,
+            "value": "0x1000"
+          },
+          "read_wids": {
+            "len": 64,
+            "value": "0x1"
+          },
+          "write_wids": {
+            "len": 64,
+            "value": "0x0"
+          },
+          "execute_wids": {
+            "len": 64,
+            "value": "0x0"
+          },
+          "ptw_wids": {
+            "len": 64,
+            "value": "0x0"
+          }
+        },
+        {
+          "base": {
+            "len": 64,
+            "value": "0x2000000"
+          },
+          "size": {
+            "len": 64,
+            "value": "0x2000000"
+          },
+          "read_wids": {
+            "len": 64,
+            "value": "0x1"
+          },
+          "write_wids": {
+            "len": 64,
+            "value": "0x1"
+          },
+          "execute_wids": {
+            "len": 64,
+            "value": "0x0"
+          },
+          "ptw_wids": {
+            "len": 64,
+            "value": "0x0"
+          }
+        },
+        {
+          "base": {
+            "len": 64,
+            "value": "0x80000000"
+          },
+          "size": {
+            "len": 64,
+            "value": "0x80000000"
+          },
+          "read_wids": {
+            "len": 64,
+            "value": "0x1"
+          },
+          "write_wids": {
+            "len": 64,
+            "value": "0x1"
+          },
+          "execute_wids": {
+            "len": 64,
+            "value": "0x1"
+          },
+          "ptw_wids": {
+            "len": 64,
+            "value": "0x1"
+          }
+        }
+      ]
+    }
   },
   "extensions": {
     "M": {
@@ -740,6 +824,19 @@
     },
     "Smcntrpmf": {
       "supported": true
+    },
+    "Smwid": {
+      "supported": false,
+      "nworlds": 2,
+      "pmwid": {
+        "len": 64,
+        "value": "0x0"
+      },
+      "pmwidlist": {
+        "len": 64,
+        "value": "0x1"
+      },
+      "mwid_locked_on_reset": true
     },
     "Svbare": {
       "supported": true,

--- a/model/core/callbacks.sail
+++ b/model/core/callbacks.sail
@@ -13,13 +13,13 @@
 val fetch_callback = pure {cpp: "fetch_callback"} : forall 'n, 'n in {16, 32}. (bits('n)) -> unit
 function fetch_callback(_) = ()
 
-val mem_write_callback = pure {cpp: "mem_write_callback"} : forall 'n, 0 < 'n <= max_mem_access . (/* access type */ string, /* addr */ physaddrbits, /* width */ int('n), /* value */ bits(8 * 'n)) -> unit
+val mem_write_callback = pure {cpp: "mem_write_callback"} : forall 'n, 0 < 'n <= max_mem_access . (/* access type */ string, /* wid */ xlenbits, /* addr */ physaddrbits, /* width */ int('n), /* value */ bits(8 * 'n)) -> unit
 function mem_write_callback(_) = ()
 
-val mem_read_callback = pure {cpp: "mem_read_callback"} : forall 'n, 0 < 'n <= max_mem_access . (/* access type */ string, /* addr */ physaddrbits, /* width */ int('n), /* value */ bits(8 * 'n)) -> unit
+val mem_read_callback = pure {cpp: "mem_read_callback"} : forall 'n, 0 < 'n <= max_mem_access . (/* access type */ string, /* wid */ xlenbits, /* addr */ physaddrbits, /* width */ int('n), /* value */ bits(8 * 'n)) -> unit
 function mem_read_callback(_) = ()
 
-val mem_exception_callback = pure {cpp: "mem_exception_callback"} : (/* addr */ physaddrbits, /* exception code */ exc_code) -> unit
+val mem_exception_callback = pure {cpp: "mem_exception_callback"} : (/* wid */ xlenbits, /* addr */ physaddrbits, /* exception code */ exc_code) -> unit
 function mem_exception_callback(_) = ()
 
 /// Called at the end of every step when PC is advanced to the next

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -553,6 +553,11 @@ function clause currentlyEnabled(Ext_Smnpm) = hartSupports(Ext_Smnpm)
 enum clause extension = Ext_Smstateen
 mapping clause extensionName = Ext_Smstateen <-> "smstateen"
 function clause hartSupports(Ext_Smstateen) = config extensions.Stateen.Smstateen.supported
+// RISC-V world
+enum clause extension = Ext_Smwid
+mapping clause extensionName = Ext_Smwid <-> "smwid"
+function clause hartSupports(Ext_Smwid) = config extensions.Smwid.supported
+function clause currentlyEnabled(Ext_Smwid) = hartSupports(Ext_Smwid) & currentlyEnabled(Ext_Zicsr)
 
 // QoS identifiers
 enum clause extension = Ext_Ssqosid
@@ -628,6 +633,7 @@ function currentlyEnabled_measure(ext : extension) -> int =
     Ext_Zve32x => 1, // > Zvl32b
     Ext_Smstateen => 1, // > Zicsr
     Ext_Ssstateen => 1, // > Zicsr
+    Ext_Smwid => 1, // > Zicsr
 
     // Note: even though these match the default case, making them explicit to
     // annotate the chain of dependencies
@@ -833,4 +839,5 @@ let extensions_ordered_for_isa_string = [
   Ext_Smmpm,
   Ext_Smnpm,
   Ext_Smstateen,
+  Ext_Smwid,
 ]

--- a/model/core/phys_mem_interface.sail
+++ b/model/core/phys_mem_interface.sail
@@ -70,6 +70,13 @@ struct RISCV_strong_access = {
 // addresses regardless of the actual physical address width.
 function physaddrbits_zero_extend(xs : physaddrbits) -> bits(64) = zero_extend(xs)
 
+// The Sail concurrency v1 interface only exposes a single boolean tag. Smwid's
+// multi-bit WID therefore degrades here to whether the transaction originates
+// from world 0 or from any non-zero world. The full WID continues to flow
+// through the explicit emulator callbacks and MMIO plumbing.
+function memory_transaction_tag(wid : xlenbits) -> bool =
+  wid != zeros()
+
 instantiation sail_mem_write with
   'pa = physaddrbits,
   pa_bits = physaddrbits_zero_extend,
@@ -81,9 +88,9 @@ instantiation sail_mem_write with
   // aborts, so just use unit here too
   'abort = unit
 
-val write_ram : forall 'n, 0 < 'n <= max_mem_access. (write_kind, physaddr, int('n), bits(8 * 'n), mem_meta) -> bool
+val write_ram : forall 'n, 0 < 'n <= max_mem_access. (xlenbits, write_kind, physaddr, int('n), bits(8 * 'n), mem_meta) -> bool
 
-function write_ram(wk, Physaddr(addr), width, data, meta) = {
+function write_ram(wid, wk, Physaddr(addr), width, data, meta) = {
   let request : Mem_write_request('n, 64, physaddrbits, unit, RISCV_strong_access) = struct {
     access_kind = match wk {
       Write_plain => AK_explicit(struct { variety = AV_plain, strength = AS_normal }),
@@ -98,7 +105,9 @@ function write_ram(wk, Physaddr(addr), width, data, meta) = {
     translation = (),
     size = width,
     value = Some(data),
-    tag = None(),
+    // Sail concurrency v1 only exposes option(bool) here, so Smwid can only
+    // preserve whether the transaction is tagged with world 0 or a non-zero world.
+    tag = Some(memory_transaction_tag(wid)),
   };
   // Write out metadata only if the value write succeeds.
   // It is assumed for now that this write always succeeds;
@@ -121,8 +130,8 @@ function write_ram_ea(_wk, Physaddr(_addr), _width) = ()
 instantiation sail_mem_read with
   pa_bits = physaddrbits_zero_extend
 
-val read_ram : forall 'n, 0 < 'n <= max_mem_access.  (read_kind, physaddr, int('n), bool) -> (bits(8 * 'n), mem_meta)
-function read_ram(rk, Physaddr(addr), width, read_meta) = {
+val read_ram : forall 'n, 0 < 'n <= max_mem_access.  (xlenbits, read_kind, physaddr, int('n), bool) -> (bits(8 * 'n), mem_meta)
+function read_ram(wid, rk, Physaddr(addr), width, read_meta) = {
   let meta = if read_meta then __ReadRAM_Meta(addr, width) else default_meta;
   let request : Mem_read_request('n, 64, physaddrbits, unit, RISCV_strong_access) = struct {
     access_kind = match rk {
@@ -138,7 +147,8 @@ function read_ram(rk, Physaddr(addr), width, read_meta) = {
     pa = addr,
     translation = (),
     size = width,
-    tag = false,
+    // Sail concurrency v1 only exposes a single bool tag for reads.
+    tag = memory_transaction_tag(wid),
   };
   match sail_mem_read(request) {
     Ok((value, _)) => (value, meta),

--- a/model/extensions/Smwid/smwid.sail
+++ b/model/extensions/Smwid/smwid.sail
@@ -1,0 +1,200 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+let sys_smwid_nworlds : int = config extensions.Smwid.nworlds
+let sys_smwid_pmwid : xlenbits = trunc(config extensions.Smwid.pmwid : bits(64))
+let sys_smwid_pmwidlist : xlenbits = trunc(config extensions.Smwid.pmwidlist : bits(64))
+let sys_smwid_locked_on_reset : bool = config extensions.Smwid.mwid_locked_on_reset : bool
+
+enum SmwidUnauthorizedBehavior = {
+  Smwid_Access_Fault,
+  Smwid_Fatal,
+}
+
+struct SmwidWorldRegion = {
+  base         : bits(64),
+  size         : bits(64),
+  read_wids    : bits(64),
+  write_wids   : bits(64),
+  execute_wids : bits(64),
+  ptw_wids     : bits(64),
+}
+
+let smwid_worlds_enabled : bool = config platform.worlds.enabled : bool
+let smwid_unauthorized_behavior : SmwidUnauthorizedBehavior = config platform.worlds.unauthorized_behavior
+let smwid_world_regions : list(SmwidWorldRegion) = config platform.worlds.regions
+
+function smwid_lock_mask() -> xlenbits = zero_extend(0b1) << (xlen - 1)
+
+// The Smwid CSR uses ceil(log2(NWorlds)) bits for the WID field.
+// For NWorlds == 1 the hart is fixed to a single world, so the field is empty.
+function smwid_wid_width_for_nworlds(nworlds : int) -> int = {
+  assert(nworlds >= 1, "Smwid requires at least one world");
+
+  match nworlds {
+    n if n <= 1  => 0,
+    n if n <= 2  => 1,
+    n if n <= 4  => 2,
+    n if n <= 8  => 3,
+    n if n <= 16 => 4,
+    n if n <= 32 => 5,
+    n if n <= 64 => 6,
+    _            => 7,
+  }
+}
+
+let sys_smwid_wid_width : int = smwid_wid_width_for_nworlds(sys_smwid_nworlds)
+
+function smwid_wid_mask_for_width(width : int) -> xlenbits = {
+  if width == 0
+  then zeros()
+  else if width >= xlen
+  then ones()
+  else (zero_extend(0b1) << width) - 1
+}
+
+function smwid_wid_mask() -> xlenbits =
+  smwid_wid_mask_for_width(sys_smwid_wid_width)
+
+function smwid_extract_wid(value : xlenbits) -> xlenbits =
+  value & smwid_wid_mask()
+
+function smwid_extract_locked(value : xlenbits) -> bool =
+  value[xlen - 1] == bitone
+
+function smwid_compose_value(wid : xlenbits, locked : bool) -> xlenbits = {
+  let base = wid & smwid_wid_mask();
+  if locked
+  then base | smwid_lock_mask()
+  else base & ~(smwid_lock_mask())
+}
+
+function smwid_authorized(wid : xlenbits) -> bool = {
+  let idx = unsigned(wid);
+  idx < sys_smwid_nworlds & (sys_smwid_pmwidlist >> idx)[0] == bitone
+}
+
+function smwid_wid_in_mask(mask : bits(64), wid : xlenbits) -> bool = {
+  let idx = unsigned(wid);
+  idx < 64 & (mask >> idx)[0] == bitone
+}
+
+function matching_smwid_world_region_bits_range(regions : list(SmwidWorldRegion), base : bits(64), size : bits(64)) -> option(SmwidWorldRegion) = {
+  match regions {
+    [||] => None(),
+    region :: rest => {
+      if range_subset(base, size, region.base, region.size)
+      then Some(region)
+      else matching_smwid_world_region_bits_range(rest, base, size)
+    }
+  }
+}
+
+function matching_smwid_world_region forall 'n, 0 < 'n <= max_mem_access . (addr : physaddr, width : int('n)) -> option(SmwidWorldRegion) =
+  matching_smwid_world_region_bits_range(smwid_world_regions, zero_extend(bits_of(addr)), to_bits(width))
+
+function smwid_region_allows_access(region : SmwidWorldRegion, access : MemoryAccessType(mem_payload), wid : xlenbits) -> bool =
+  match access {
+    InstructionFetch()          => smwid_wid_in_mask(region.execute_wids, wid),
+    Load(Data)                  => smwid_wid_in_mask(region.read_wids, wid),
+    Load(Vector)                => smwid_wid_in_mask(region.read_wids, wid),
+    Store(Data)                 => smwid_wid_in_mask(region.write_wids, wid),
+    Store(Vector)               => smwid_wid_in_mask(region.write_wids, wid),
+    LoadReserved(Data)          => smwid_wid_in_mask(region.read_wids, wid) & smwid_wid_in_mask(region.write_wids, wid),
+    StoreConditional(Data)      => smwid_wid_in_mask(region.read_wids, wid) & smwid_wid_in_mask(region.write_wids, wid),
+    Atomic(_, Data, Data)       => smwid_wid_in_mask(region.read_wids, wid) & smwid_wid_in_mask(region.write_wids, wid),
+    Load(ShadowStack)           => smwid_wid_in_mask(region.read_wids, wid),
+    Store(ShadowStack)          => smwid_wid_in_mask(region.write_wids, wid),
+    Atomic(AMOSWAP, ShadowStack, ShadowStack) => smwid_wid_in_mask(region.read_wids, wid) & smwid_wid_in_mask(region.write_wids, wid),
+    Load(PageTableEntry)        => smwid_wid_in_mask(region.ptw_wids, wid),
+    Store(PageTableEntry)       => smwid_wid_in_mask(region.ptw_wids, wid),
+    CacheAccess(CB_zero())      => smwid_wid_in_mask(region.write_wids, wid),
+    CacheAccess(CB_manage(_))   => smwid_wid_in_mask(region.read_wids, wid) | smwid_wid_in_mask(region.write_wids, wid),
+    CacheAccess(CB_prefetch(p)) => match p {
+      PREFETCH_R => smwid_wid_in_mask(region.read_wids, wid),
+      PREFETCH_W => smwid_wid_in_mask(region.write_wids, wid),
+      PREFETCH_I => smwid_wid_in_mask(region.execute_wids, wid),
+    },
+    LoadReserved(p) => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
+    StoreConditional(p) => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),
+    Atomic(AMOSWAP, rp, wp) => internal_error(__FILE__, __LINE__, "Invalid payloads (" ^ mem_payload_name(rp) ^ ", " ^ mem_payload_name(wp) ^ ") for Atomic."),
+    Atomic(op, ShadowStack, ShadowStack) => internal_error(__FILE__, __LINE__, "Invalid op (" ^ amo_mnemonic(op) ^ ") for ShadowStack Atomic."),
+    Atomic(_, rp, wp) => internal_error(__FILE__, __LINE__, "Invalid payloads (" ^ mem_payload_name(rp) ^ ", " ^ mem_payload_name(wp) ^ ") for Atomic."),
+  }
+
+function smwid_unauthorized_access_result(access : MemoryAccessType(mem_payload), wid : xlenbits, paddr : physaddr) -> option(ExceptionType) =
+  match smwid_unauthorized_behavior {
+    Smwid_Access_Fault => Some(accessFaultFromAccessType(access)),
+    Smwid_Fatal => internal_error(__FILE__, __LINE__,
+                                  "Smwid blocked " ^ to_str(access)
+                                  ^ " for WID " ^ dec_str(unsigned(wid))
+                                  ^ " at physical address " ^ hex_bits_str(bits_of(paddr))),
+  }
+
+register mwid : xlenbits = zeros()
+
+function legalize_mwid(old : xlenbits, written : xlenbits) -> xlenbits = {
+  if smwid_extract_locked(old)
+  then old
+  else {
+    let new_wid = smwid_extract_wid(written);
+    let new_locked = smwid_extract_locked(written);
+    smwid_compose_value(new_wid, new_locked)
+  }
+}
+
+function reset_smwid() -> unit = {
+  mwid = smwid_compose_value(sys_smwid_pmwid, sys_smwid_locked_on_reset);
+  csr_write_callback("mwid", mwid);
+}
+
+function get_mwid_wid() -> xlenbits = smwid_extract_wid(mwid)
+
+// Without Smwid, transactions still carry the platform-defined default WID.
+// Once Smwid is enabled, the active WID comes from the mwid CSR instead.
+function current_world_id_for_access(_access : MemoryAccessType(mem_payload), _priv : Privilege) -> xlenbits =
+  if currentlyEnabled(Ext_Smwid)
+  then get_mwid_wid()
+  else smwid_extract_wid(sys_smwid_pmwid)
+
+function smwid_access_controls_enabled(smwid_enabled : bool, worlds_enabled : bool) -> bool =
+  smwid_enabled | worlds_enabled
+
+function smwid_access_check(access : MemoryAccessType(mem_payload), wid : xlenbits, paddr : physaddr, width : mem_access_width) -> option(ExceptionType) = {
+  let smwid_enabled = currentlyEnabled(Ext_Smwid);
+  if not(smwid_access_controls_enabled(smwid_enabled, smwid_worlds_enabled))
+  then return None();
+
+  if smwid_enabled & not(smwid_authorized(wid))
+  then return smwid_unauthorized_access_result(access, wid, paddr);
+
+  if not(smwid_worlds_enabled)
+  then return None();
+
+  match matching_smwid_world_region(paddr, width) {
+    None() => smwid_unauthorized_access_result(access, wid, paddr),
+    Some(region) =>
+      if smwid_region_allows_access(region, access, wid)
+      then None()
+      else smwid_unauthorized_access_result(access, wid, paddr),
+  }
+}
+
+// The Worlds draft has not assigned a final CSR address for mwid yet.
+// Use 0x7C0 as a branch-local provisional address until the draft is finalized.
+mapping clause csr_name_map = 0x7C0 <-> "mwid"
+
+function clause is_CSR_accessible(0x7C0, priv, _) = currentlyEnabled(Ext_Smwid) & priv == Machine
+
+function clause read_CSR(0x7C0) = mwid
+
+function clause write_CSR(0x7C0, value) = {
+  mwid = legalize_mwid(mwid, value);
+  csr_write_callback("mwid", mwid);
+  Ok(mwid)
+}

--- a/model/extensions/Zicbom/zicbom_insts.sail
+++ b/model/extensions/Zicbom/zicbom_insts.sail
@@ -89,7 +89,8 @@ private function process_clean_inval(rs1 : regidx, cbop : cbop_zicbom) -> Execut
         Ok(paddr, pbmt, _) => {
           // Check PMA and PMP access controls.
           let ep = effectivePrivilege(access, mstatus, cur_privilege);
-          match phys_access_check(access, pbmt, ep, paddr, cache_block_size, false) {
+          let wid = current_world_id_for_access(access, ep);
+          match phys_access_check(access, pbmt, ep, wid, paddr, cache_block_size, false) {
             Some(e) => memory_exception(vaddr_for_error, e),
             // If there is no error, the model has no caches so there's no
             // more action required.

--- a/model/extensions/Zicbop/zicbop_insts.sail
+++ b/model/extensions/Zicbop/zicbop_insts.sail
@@ -49,12 +49,13 @@ function clause execute ZICBOP(cbop, rs1, offset) = {
 
     Ext_DataAddr_OK(vaddr) => match translateAddr(vaddr, access) {
       Ok(paddr, pbmt, _) => {
-          // Check PMA and PMP access controls.
-          let ep = effectivePrivilege(access, mstatus, cur_privilege);
-          match phys_access_check(access, pbmt, ep, paddr, cache_block_size, false) {
-            Some(_e) => (), // No access to cache; no-op.
-            None()   => (), // The model has no caches so there's no action required.
-          }
+        // Check PMA and PMP access controls.
+        let ep = effectivePrivilege(access, mstatus, cur_privilege);
+        let wid = current_world_id_for_access(access, ep);
+        match phys_access_check(access, pbmt, ep, wid, paddr, cache_block_size, false) {
+          Some(_e) => (), // No access to cache; no-op.
+          None()   => (), // The model has no caches so there's no action required.
+        }
       },
       Err(_) => (), // No access to cache; no-op.
     }

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -516,6 +516,10 @@ private function check_misc_extension_dependencies() -> bool = {
     valid = false;
     print_endline("The Ssqosid extension is enabled but Zicsr is disabled: supporting Ssqosid requires Zicsr.");
   };
+  if (config extensions.Smwid.supported : bool) & not(config extensions.Zicsr.supported : bool) then {
+    valid = false;
+    print_endline("The Smwid extension is enabled but Zicsr is disabled: supporting Smwid requires Zicsr.");
+  };
   if (config extensions.Sscounterenw.supported : bool) & ((sys_writable_hpm_counters[31 .. 3] & sys_scounteren_writable_bits[31 .. 3]) != sys_writable_hpm_counters[31 .. 3]) then {
     valid = false;
     print_endline("The Sscounterenw extension is enabled but `scounteren` is not writable (via `base.scounteren_writable_bits`) for some supported HPM counters (specified in `base.writable_hpm_counters`).");
@@ -525,6 +529,57 @@ private function check_misc_extension_dependencies() -> bool = {
     print_endline("The Ssnpm, Smmpm and Smnpm extensions are not supported on RV32.");
   };
   valid
+}
+
+private function smwid_mask_sets_invalid_wids(mask : bits(64), nworlds : int) -> bool = {
+  assert(1 <= nworlds & nworlds <= 64);
+  if nworlds == 64 then false
+  else {
+    let high_mask : bits(64) = ~((zero_extend(0b1) << nworlds) - 1);
+    (mask & high_mask) != zeros()
+  }
+}
+
+private function smwid_region_sets_invalid_wids(region : SmwidWorldRegion, nworlds : int) -> bool =
+  smwid_mask_sets_invalid_wids(region.read_wids, nworlds)
+  | smwid_mask_sets_invalid_wids(region.write_wids, nworlds)
+  | smwid_mask_sets_invalid_wids(region.execute_wids, nworlds)
+  | smwid_mask_sets_invalid_wids(region.ptw_wids, nworlds)
+
+private function check_smwid_world_region(region : SmwidWorldRegion, nworlds : int) -> bool = {
+  var valid : bool = true;
+  if region.size == zeros() then {
+    valid = false;
+    print_endline("Smwid world regions must have non-zero size.");
+  };
+  if region.base + region.size <_u region.base then {
+    valid = false;
+    print_endline("Smwid world region starting at " ^ bits_str(region.base) ^
+                  " with size " ^ bits_str(region.size) ^
+                  " wraps around the physical address space.");
+  };
+  if smwid_region_sets_invalid_wids(region, nworlds) then {
+    valid = false;
+    print_endline("Smwid world-region masks set bits above nworlds - 1.");
+  };
+  valid
+}
+
+private function check_smwid_world_regions(regions : list(SmwidWorldRegion), prev_base : bits(64), prev_size : bits(64), nworlds : int) -> bool = {
+  match regions {
+    [||] => true,
+    region :: rest => {
+      var valid : bool = true;
+      if region.base <_u prev_base + prev_size then {
+        valid = false;
+        print_endline("Smwid world region starting at " ^ bits_str(region.base) ^
+                      " is not above the end of the previous region starting at " ^
+                      bits_str(prev_base) ^ " and ending at " ^ bits_str(prev_base + prev_size) ^ ".");
+      };
+      valid = valid & check_smwid_world_region(region, nworlds);
+      valid & check_smwid_world_regions(rest, region.base, region.size, nworlds)
+    }
+  }
 }
 
 private function check_extension_param_constraints() -> bool = {
@@ -548,6 +603,40 @@ private function check_extension_param_constraints() -> bool = {
     if misaligned_exception_is_access_fault((config memory.misaligned.exceptions : GlobalMisalignedExceptions).vector) then {
       valid = false;
       print_endline("The Zicclsm extension is enabled, but misaligned vector loads/stores raise access faults before address translation (as per `memory.misaligned.exceptions.vector`); Zicclsm requires no exceptions or only misaligned exceptions for such accesses.");
+    };
+  };
+  if (config extensions.Smwid.supported : bool) | (config platform.worlds.enabled : bool) then {
+    let nworlds = config extensions.Smwid.nworlds : int;
+    let pmwid_bits : xlenbits = trunc(config extensions.Smwid.pmwid : bits(64));
+    let pmwid = unsigned(pmwid_bits);
+    let nworlds_valid = (1 <= nworlds) & (nworlds <= xlen);
+
+    if not(nworlds_valid) then {
+      valid = false;
+      print_endline("Smwid nworlds must be in the range [1, XLEN].");
+    };
+    if nworlds_valid then {
+      if pmwid >= nworlds then {
+        valid = false;
+        print_endline("Smwid pmwid must be less than nworlds.");
+      };
+      if (config extensions.Smwid.supported : bool) then {
+        let pmwidlist : xlenbits = trunc(config extensions.Smwid.pmwidlist : bits(64));
+        if (pmwid < xlen) & ((pmwidlist >> pmwid)[0] == 0b0) then {
+          valid = false;
+          print_endline("Smwid pmwidlist must authorize pmwid.");
+        };
+        if nworlds < xlen then {
+          let high_mask : xlenbits = ~((zero_extend(0b1) << nworlds) - 1);
+          if (pmwidlist & high_mask) != zeros() then {
+            valid = false;
+            print_endline("Smwid pmwidlist sets bits above nworlds - 1.");
+          };
+        };
+      };
+      if (config platform.worlds.enabled : bool) then {
+        valid = valid & check_smwid_world_regions(config platform.worlds.regions, zeros(), zeros(), nworlds);
+      };
     };
   };
   valid

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -61,7 +61,7 @@ pmp {
 }
 
 sys {
-  requires prelude, core, exceptions, pmp, V_core, Smcntrpmf, Zicfilp_regs, A_types, Stateen, Zicbop_types, PM_utils
+  requires prelude, core, exceptions, pmp, V_core, Smcntrpmf, Smwid, Zicfilp_regs, A_types, Stateen, Zicbop_types, PM_utils
 
   files
     sys/sys_reservation.sail,
@@ -177,6 +177,13 @@ extensions {
 
     files
       extensions/H/hext_insts.sail
+  }
+
+  Smwid {
+    requires core, A_types, Zicbop_types
+
+    files
+      extensions/Smwid/smwid.sail
   }
 
   // Floating point (F and D extensions)
@@ -408,7 +415,7 @@ extensions {
       files extensions/Zicbom/zicbom_types.sail
     }
     Zicbom_insts {
-      requires core, sys, Zicbom_types
+      requires core, sys, Smwid, Zicbom_types
       files extensions/Zicbom/zicbom_insts.sail
     }
   }
@@ -421,7 +428,7 @@ extensions {
     Zicbop_insts {
       // PREFETCH.{I,R,W} instructions override ORI hints (rd=0)
       before I_insts
-      requires core, sys, Zicbop_types
+      requires core, sys, Smwid, Zicbop_types
       files extensions/Zicbop/zicbop_insts.sail
     }
   }
@@ -566,7 +573,7 @@ mops {
 postlude {
   after extensions, mops, core
 
-  requires prelude, core, sys, exceptions, Smcntrpmf, pmp, Zicfilp_regs, Zicfilp_insts
+  requires prelude, core, sys, exceptions, Smcntrpmf, Smwid, pmp, Zicfilp_regs, Zicfilp_insts
 
   files
     postlude/insts_end.sail,
@@ -584,7 +591,7 @@ postlude {
 
 unit_tests {
   after postlude
-  requires prelude, core, sys, exceptions, postlude
+  requires prelude, core, sys, exceptions, postlude, Smwid
 
   files
     unit_tests/test_mstatus.sail,

--- a/model/sys/mem.sail
+++ b/model/sys/mem.sail
@@ -190,17 +190,23 @@ function phys_access_check forall 'n, 0 < 'n <= max_mem_access . (
   access : MemoryAccessType(mem_payload),
   pbmt : page_based_mem_type,
   priv : Privilege,
+  wid : xlenbits,
   paddr : physaddr,
   width : int('n),
   res_or_con : bool,
 ) -> option(ExceptionType) = {
+  let smwidError : option(ExceptionType) = smwid_access_check(access, wid, paddr, width);
   let pmpError : option(ExceptionType) = pmpCheck(paddr, width, access, priv);
   let pmaError : option(ExceptionType) = pmaCheck(paddr, width, access, pbmt, res_or_con);
-  match (pmpError, pmaError) {
-    (None(), None())     => None(),
-    (Some(e), None())    => Some(e),
-    (None(), Some(e))    => Some(e),
-    (Some(e0), Some(e1)) => Some(highestPriorityAlignmentOrAccessFault(e0, e1)),
+  match smwidError {
+    Some(e) => Some(e),
+    None() =>
+      match (pmpError, pmaError) {
+        (None(), None())     => None(),
+        (Some(e), None())    => Some(e),
+        (None(), Some(e))    => Some(e),
+        (Some(e0), Some(e1)) => Some(highestPriorityAlignmentOrAccessFault(e0, e1)),
+      }
   }
 }
 
@@ -209,6 +215,7 @@ private function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (
   access : MemoryAccessType(mem_payload),
   pbmt : page_based_mem_type,
   priv : Privilege,
+  wid : xlenbits,
   paddr : physaddr,
   width : int('n),
   aq : bool,
@@ -216,14 +223,14 @@ private function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (
   res: bool,
   meta : bool,
 ) -> MemoryOpResult((bits(8 * 'n), mem_meta)) =
-  match phys_access_check(access, pbmt, priv, paddr, width, res) {
+  match phys_access_check(access, pbmt, priv, wid, paddr, width, res) {
     Some(e) => Err(e),
     None() => {
       if   within_mmio_readable(paddr, width)
-      then MemoryOpResult_add_meta(mmio_read(access, paddr, width), default_meta)
+      then MemoryOpResult_add_meta(mmio_read(access, wid, paddr, width), default_meta)
       else {
         let rk = read_kind_of_flags(aq, rl, res);
-        Ok(read_ram(rk, paddr, width, meta))
+        Ok(read_ram(wid, rk, paddr, width, meta))
       }
     }
   }
@@ -237,17 +244,18 @@ val mem_read_priv_meta : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType
 
 // The most generic memory read operation
 function mem_read_priv_meta (access, pbmt, priv, paddr, width, aq, rl, res, meta) = {
+  let wid = current_world_id_for_access(access, priv);
   let result : MemoryOpResult((bits(8 * 'n), mem_meta)) =
     if (aq | res) & not(is_aligned_addr(paddr, width))
     then Err(E_Load_Addr_Align())
     else match (aq, rl, res) {
       (false, true,  false) => throw(Error_not_implemented("load.rl")),
       (false, true,  true)  => throw(Error_not_implemented("lr.rl")),
-      (_, _, _)             => checked_mem_read(access, pbmt, priv, paddr, width, aq, rl, res, meta)
+      (_, _, _)             => checked_mem_read(access, pbmt, priv, wid, paddr, width, aq, rl, res, meta)
     };
   match result {
-    Ok(value, _) => mem_read_callback(to_str(access), bits_of(paddr), width, value),
-    Err(e) => mem_exception_callback(bits_of(paddr), exceptionType_bits(e)),
+    Ok(value, _) => mem_read_callback(to_str(access), wid, bits_of(paddr), width, value),
+    Err(e) => mem_exception_callback(wid, bits_of(paddr), exceptionType_bits(e)),
   };
   result
 }
@@ -271,6 +279,7 @@ function mem_write_ea (addr, width, aq, rl, con) =
 
 // dispatches to MMIO regions or physical memory regions depending on physical memory map
 function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
+  wid : xlenbits,
   paddr : physaddr,
   width : int('n),
   data: bits(8 * 'n),
@@ -282,14 +291,14 @@ function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
   rl : bool,
   con : bool,
 ) -> MemoryOpResult(bool) =
-  match phys_access_check(access, pbmt, priv, paddr, width, con) {
+  match phys_access_check(access, pbmt, priv, wid, paddr, width, con) {
     Some(e) => Err(e),
     None() => {
       if   within_mmio_writable(paddr, width)
-      then mmio_write(paddr, width, data)
+      then mmio_write(wid, paddr, width, data)
       else {
         let wk = write_kind_of_flags(aq, rl, con);
-        Ok(write_ram(wk, paddr, width, data, meta))
+        Ok(write_ram(wid, wk, paddr, width, data, meta))
       }
     }
   }
@@ -301,16 +310,16 @@ function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
 // data.
 val mem_write_value_priv_meta : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), MemoryAccessType(mem_payload), page_based_mem_type, Privilege, mem_meta, bool, bool, bool) -> MemoryOpResult(bool)
 function mem_write_value_priv_meta (paddr, width, value, access, pbmt, priv, meta, aq, rl, con) = {
-  if (rl | con) & not(is_aligned_addr(paddr, width))
-  then Err(E_SAMO_Addr_Align())
-  else {
-    let result = checked_mem_write(paddr, width, value, access, pbmt, priv, meta, aq, rl, con);
-    match result {
-      Ok(_) => mem_write_callback(to_str(access), bits_of(paddr), width, value),
-      Err(e) => mem_exception_callback(bits_of(paddr), exceptionType_bits(e)),
-    };
-    result
-  }
+  let wid = current_world_id_for_access(access, priv);
+  let result =
+    if (rl | con) & not(is_aligned_addr(paddr, width))
+    then Err(E_SAMO_Addr_Align())
+    else checked_mem_write(wid, paddr, width, value, access, pbmt, priv, meta, aq, rl, con);
+  match result {
+    Ok(_) => mem_write_callback(to_str(access), wid, bits_of(paddr), width, value),
+    Err(e) => mem_exception_callback(wid, bits_of(paddr), exceptionType_bits(e)),
+  };
+  result
 }
 
 // Memory write with explicit Privilege and MemoryAccessType, and implicit metadata

--- a/model/sys/platform.sail
+++ b/model/sys/platform.sail
@@ -81,58 +81,62 @@ let MTIMECMP_BASE_HI : physaddrbits = zero_extend(0x04004)
 let MTIME_BASE       : physaddrbits = zero_extend(0x0bff8)
 let MTIME_BASE_HI    : physaddrbits = zero_extend(0x0bffc)
 
-private val clint_load : forall 'n, 'n > 0. (MemoryAccessType(mem_payload), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
-function clint_load(access, Physaddr(addr), width) = {
+private function mmio_trace_wid_suffix(wid : xlenbits) -> string =
+  " [wid=" ^ dec_str(unsigned(wid)) ^ "]"
+
+private val clint_load : forall 'n, 'n > 0. (MemoryAccessType(mem_payload), xlenbits, physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
+function clint_load(access, wid, Physaddr(addr), width) = {
   let addr = addr - plat_clint_base;
+  let wid_suffix = mmio_trace_wid_suffix(wid);
   // FIXME: For now, only allow exact aligned access.
   if addr == MSIP_BASE & ('n == 8 | 'n == 4)
   then {
     if   get_config_print_clint()
-    then print_log("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mip[MSI]));
+    then print_log("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mip[MSI]) ^ wid_suffix);
     Ok(zero_extend(sizeof(8 * 'n), mip[MSI]))
   }
   else if addr == MTIMECMP_BASE & ('n == 4)
   then {
     if   get_config_print_clint()
-    then print_log("clint<4>[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtimecmp[31..0]));
+    then print_log("clint<4>[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtimecmp[31..0]) ^ wid_suffix);
     // FIXME: Redundant zero_extend currently required by Lem backend
     Ok(zero_extend(32, mtimecmp[31..0]))
   }
   else if addr == MTIMECMP_BASE & ('n == 8)
   then {
     if   get_config_print_clint()
-    then print_log("clint<8>[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtimecmp));
+    then print_log("clint<8>[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtimecmp) ^ wid_suffix);
     // FIXME: Redundant zero_extend currently required by Lem backend
     Ok(zero_extend(64, mtimecmp))
   }
   else if addr == MTIMECMP_BASE_HI & ('n == 4)
   then {
     if   get_config_print_clint()
-    then print_log("clint-hi<4>[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtimecmp[63..32]));
+    then print_log("clint-hi<4>[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtimecmp[63..32]) ^ wid_suffix);
     // FIXME: Redundant zero_extend currently required by Lem backend
     Ok(zero_extend(32, mtimecmp[63..32]))
   }
   else if addr == MTIME_BASE & ('n == 4)
   then {
     if   get_config_print_clint()
-    then print_log("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtime));
+    then print_log("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtime) ^ wid_suffix);
     Ok(zero_extend(32, mtime[31..0]))
   }
   else if addr == MTIME_BASE & ('n == 8)
   then {
     if   get_config_print_clint()
-    then print_log("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtime));
+    then print_log("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtime) ^ wid_suffix);
     Ok(zero_extend(64, mtime))
   }
   else if addr == MTIME_BASE_HI & ('n == 4)
   then {
     if   get_config_print_clint()
-    then print_log("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtime));
+    then print_log("clint[" ^ bits_str(addr) ^ "] -> " ^ bits_str(mtime) ^ wid_suffix);
     Ok(zero_extend(32, mtime[63..32]))
   }
   else {
     if   get_config_print_clint()
-    then print_log("clint[" ^ bits_str(addr) ^ "] -> <not-mapped>");
+    then print_log("clint[" ^ bits_str(addr) ^ "] -> <not-mapped>" ^ wid_suffix);
     Err(accessFaultFromAccessType(access))
   }
 }
@@ -150,54 +154,55 @@ private function clint_dispatch(mip_was_written : bool) -> unit = {
   };
 }
 
-private val clint_store: forall 'n, 'n > 0. (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
-function clint_store(Physaddr(addr), width, data) = {
+private val clint_store: forall 'n, 'n > 0. (xlenbits, physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
+function clint_store(wid, Physaddr(addr), width, data) = {
   let addr = addr - plat_clint_base;
+  let wid_suffix = mmio_trace_wid_suffix(wid);
   if addr == MSIP_BASE & ('n == 8 | 'n == 4) then {
     if   get_config_print_clint()
-    then print_log("clint[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mip.MSI <- " ^ bits_str(data[0..0]) ^ ")");
+    then print_log("clint[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mip.MSI <- " ^ bits_str(data[0..0]) ^ ")" ^ wid_suffix);
     mip[MSI] = [data[0]];
     clint_dispatch(true);
     Ok(true)
   } else if addr == MTIMECMP_BASE & 'n == 8 then {
     if   get_config_print_clint()
-    then print_log("clint<8>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtimecmp)");
+    then print_log("clint<8>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtimecmp)" ^ wid_suffix);
     mtimecmp = zero_extend(64, data); // FIXME: Redundant zero_extend currently required by Lem backend
     clint_dispatch(false);
     Ok(true)
   } else if addr == MTIMECMP_BASE & 'n == 4 then {
     if   get_config_print_clint()
-    then print_log("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtimecmp)");
+    then print_log("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtimecmp)" ^ wid_suffix);
     mtimecmp = vector_update_subrange(mtimecmp, 31, 0, zero_extend(32, data));  // FIXME: Redundant zero_extend currently required by Lem backend
     clint_dispatch(false);
     Ok(true)
   } else if addr == MTIMECMP_BASE_HI & 'n == 4 then {
     if   get_config_print_clint()
-    then print_log("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtimecmp)");
+    then print_log("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtimecmp)" ^ wid_suffix);
     mtimecmp = vector_update_subrange(mtimecmp, 63, 32, zero_extend(32, data)); // FIXME: Redundant zero_extend currently required by Lem backend
     clint_dispatch(false);
     Ok(true)
   } else if addr == MTIME_BASE & 'n == 8 then {
     if   get_config_print_clint()
-    then print_log("clint<8>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtime)");
+    then print_log("clint<8>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtime)" ^ wid_suffix);
     mtime = data;
     clint_dispatch(false);
     Ok(true)
   } else if addr == MTIME_BASE & 'n == 4 then {
     if   get_config_print_clint()
-    then print_log("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtime)");
+    then print_log("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtime)" ^ wid_suffix);
     mtime[31 .. 0] = data;
     clint_dispatch(false);
     Ok(true)
   } else if addr == MTIME_BASE_HI & 'n == 4 then {
     if   get_config_print_clint()
-    then print_log("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtime)");
+    then print_log("clint<4>[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (mtime)" ^ wid_suffix);
     mtime[63 .. 32] = data;
     clint_dispatch(false);
     Ok(true)
   } else {
     if   get_config_print_clint()
-    then print_log("clint[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (<unmapped>)");
+    then print_log("clint[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (<unmapped>)" ^ wid_suffix);
     Err(E_SAMO_Access_Fault())
   }
 }
@@ -258,10 +263,11 @@ private function reset_htif () -> unit = {
 // we'll assume here that physical memory model has correctly
 // dispatched the address.
 
-private val htif_load : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(mem_payload), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
-function htif_load(access, Physaddr(paddr), width) = {
+private val htif_load : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(mem_payload), xlenbits, physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
+function htif_load(access, wid, Physaddr(paddr), width) = {
+  let wid_suffix = mmio_trace_wid_suffix(wid);
   if   get_config_print_htif()
-  then print_log("htif[" ^ hex_bits_str(paddr) ^ "] -> " ^ bits_str(htif_tohost));
+  then print_log("htif[" ^ hex_bits_str(paddr) ^ "] -> " ^ bits_str(htif_tohost) ^ wid_suffix);
 
   let base : physaddrbits = match htif_tohost_base {
     Some(base) => base,
@@ -278,10 +284,11 @@ function htif_load(access, Physaddr(paddr), width) = {
   else    Err(accessFaultFromAccessType(access))
 }
 
-private val htif_store : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
-function htif_store(Physaddr(paddr), width, data) = {
+private val htif_store : forall 'n, 0 < 'n <= max_mem_access . (xlenbits, physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
+function htif_store(wid, Physaddr(paddr), width, data) = {
+  let wid_suffix = mmio_trace_wid_suffix(wid);
   if   get_config_print_htif()
-  then print_log("htif[" ^ hex_bits_str(paddr) ^ "] <- " ^ bits_str(data));
+  then print_log("htif[" ^ hex_bits_str(paddr) ^ "] <- " ^ bits_str(data) ^ wid_suffix);
 
   let base : physaddrbits = match htif_tohost_base {
     Some(base) => base,
@@ -352,20 +359,20 @@ function within_mmio_writable forall 'n, 0 < 'n <= max_mem_access . (addr : phys
   then false
   else within_clint(addr, width) | within_sig(addr, width) | (within_htif_writable(addr, width) & 'n <= 8)
 
-function mmio_read forall 'n, 0 < 'n <= max_mem_access . (access : MemoryAccessType(mem_payload), paddr : physaddr, width : int('n)) -> MemoryOpResult(bits(8 * 'n)) =
+function mmio_read forall 'n, 0 < 'n <= max_mem_access . (access : MemoryAccessType(mem_payload), wid : xlenbits, paddr : physaddr, width : int('n)) -> MemoryOpResult(bits(8 * 'n)) =
   if   within_clint(paddr, width)
-  then clint_load(access, paddr, width)
+  then clint_load(access, wid, paddr, width)
   else if within_sig(paddr, width)
   then sig_load(access, paddr, width)
   else if within_htif_readable(paddr, width)
-  then htif_load(access, paddr, width)
+  then htif_load(access, wid, paddr, width)
   else Err(accessFaultFromAccessType(access))
 
-function mmio_write forall 'n, 0 < 'n <= max_mem_access . (paddr : physaddr, width : int('n), data: bits(8 * 'n)) -> MemoryOpResult(bool) =
+function mmio_write forall 'n, 0 < 'n <= max_mem_access . (wid : xlenbits, paddr : physaddr, width : int('n), data: bits(8 * 'n)) -> MemoryOpResult(bool) =
   if   within_clint(paddr, width)
-  then clint_store(paddr, width, data)
+  then clint_store(wid, paddr, width, data)
   else if within_sig(paddr, width)
   then sig_store(paddr, width, data)
   else if within_htif_writable(paddr, width)
-  then htif_store(paddr, width, data)
+  then htif_store(wid, paddr, width, data)
   else Err(E_SAMO_Access_Fault())

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -375,6 +375,7 @@ function reset_sys() -> unit = {
   // "Writable PMP registers’ A and L fields are set to 0, unless the platform
   // mandates a different reset value for some PMP registers’ A and L fields."
   reset_pmp();
+  reset_smwid();
 
   // "The [s,u]seed bits must have a defined reset value. The system must
   // not allow them to be in an undefined state after a reset."

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -278,6 +278,7 @@ type TR_Result('paddr : Type, 'failure : Type) = result(('paddr, page_based_mem_
 private function translate_TLB_hit forall 'v, is_sv_mode('v) . (
   sv_width  : int('v),
   _asid     : asidbits,
+  _wid      : xlenbits,
   vpn       : vpn_bits('v),
   access    : MemoryAccessType(mem_payload),
   priv      : Privilege,
@@ -317,6 +318,7 @@ private function translate_TLB_hit forall 'v, is_sv_mode('v) . (
 private function translate_TLB_miss forall 'v, is_sv_mode('v) . (
   sv_width : int('v),
   asid     : asidbits,
+  wid      : xlenbits,
   base_ppn : ppn_bits('v),
   vpn      : vpn_bits('v),
   access   : MemoryAccessType(mem_payload),
@@ -340,13 +342,13 @@ private function translate_TLB_miss forall 'v, is_sv_mode('v) . (
       match update_and_write_pte(pteAddr, pte_size, pte, access) {
         Ok(Some(new_pte)) => {
           // Writeback the PTE (which has new A/D bits).
-          add_to_TLB(sv_width, asid, vpn, ppn, new_pte, pteAddr, level, global);
+          add_to_TLB(sv_width, asid, wid, vpn, ppn, new_pte, pteAddr, level, global);
           Ok(ppn, pbmt, ext_ptw)
         },
         Ok(None()) => {
           // There was no change in the PTE, but it still needs to be added
           // to the TLB due to the TLB miss.
-          add_to_TLB(sv_width, asid, vpn, ppn, pte, pteAddr, level, global);
+          add_to_TLB(sv_width, asid, wid, vpn, ppn, pte, pteAddr, level, global);
           Ok(ppn, pbmt, ext_ptw)
         },
         Err(e) => Err(e, ext_ptw),
@@ -367,6 +369,7 @@ mapping satp_mode_width : SATPMode <-> {32, 39, 48, 57} = {
 private function translate forall 'v, is_sv_mode('v) . (
   sv_width : int('v),
   asid     : asidbits,
+  wid      : xlenbits,
   base_ppn : ppn_bits('v),
   vpn      : vpn_bits('v),
   access   : MemoryAccessType(mem_payload),
@@ -377,10 +380,10 @@ private function translate forall 'v, is_sv_mode('v) . (
 ) -> TR_Result(ppn_bits('v), PTW_Error) = {
   // On first reading, assume lookup_TLB returns None(), since TLBs
   // are not part of RISC-V archticture spec (see TLB NOTE above)
-  match lookup_TLB(sv_width, asid, vpn) {
-    Some(index, ent) => translate_TLB_hit(sv_width, asid, vpn, access, priv,
+  match lookup_TLB(sv_width, asid, wid, vpn) {
+    Some(index, ent) => translate_TLB_hit(sv_width, asid, wid, vpn, access, priv,
                                           mxr, do_sum, ext_ptw, index, ent),
-    None()           => translate_TLB_miss(sv_width, asid, base_ppn, vpn, access, priv,
+    None()           => translate_TLB_miss(sv_width, asid, wid, base_ppn, vpn, access, priv,
                                            mxr, do_sum, ext_ptw),
   }
 }
@@ -437,12 +440,14 @@ function translateAddr(
     let mxr    = mstatus[MXR] == 0b1;
     let do_sum = mstatus[SUM] == 0b1;
     let asid   = satp_to_asid(satp_sxlen);
+    let wid    = current_world_id_for_access(access, effPriv);
 
     // Step 1 of VATP.
     let base_ppn = satp_to_ppn(satp_sxlen);
 
     let res = translate(sv_width,
                         zero_extend(asid),
+                        wid,
                         base_ppn,
                         svAddr[sv_width - 1 .. pagesize_bits],
                         access, effPriv, mxr, do_sum,

--- a/model/sys/vmem_tlb.sail
+++ b/model/sys/vmem_tlb.sail
@@ -24,6 +24,7 @@ let  tlb_ppn_bits = sizeof(tlb_ppn_bits)
 private struct TLB_Entry = {
   asid       : asidbits,           // address-space id
   global     : bool,               // global translation
+  wid        : xlenbits,           // World ID associated with the translation
   vpn        : bits(tlb_vpn_bits), // Virtual Page Number. SvXX - 12 bits.
   levelMask  : bits(tlb_vpn_bits), // Mask for superpages. The lowest (level * level_bits) bits are 1s.
   ppn        : bits(tlb_ppn_bits), // Physical Page Number, 22 (Sv32), or 44 (Sv39+) bits.
@@ -110,9 +111,10 @@ function write_TLB(index : tlb_index_range, entry : TLB_Entry) -> unit =
 private function match_TLB_Entry(
   ent  : TLB_Entry,
   asid : asidbits,
+  wid  : xlenbits,
   vpn  : bits(tlb_vpn_bits),
 ) -> bool =
-  (ent.global | (ent.asid == asid)) & (ent.vpn == (vpn & ~(ent.levelMask)))
+  (ent.global | (ent.asid == asid)) & (ent.wid == wid) & (ent.vpn == (vpn & ~(ent.levelMask)))
 
 private function flush_TLB_Entry(
   ent   : TLB_Entry,
@@ -137,13 +139,14 @@ private function flush_TLB_Entry(
 function lookup_TLB forall 'v, is_sv_mode('v) . (
   sv_width : int('v),
   asid     : asidbits,
+  wid      : xlenbits,
   vpn      : vpn_bits('v),
 ) -> option((tlb_index_range, TLB_Entry)) = {
   let index = tlb_hash('v, vpn);
   match tlb[index] {
     None() => None(),
     Some(entry) => {
-      if match_TLB_Entry(entry, asid, sign_extend(vpn)) then Some((index, entry)) else None()
+      if match_TLB_Entry(entry, asid, wid, sign_extend(vpn)) then Some((index, entry)) else None()
     },
   }
 }
@@ -152,6 +155,7 @@ function lookup_TLB forall 'v, is_sv_mode('v) . (
 function add_to_TLB forall 'v, is_sv_mode('v) . (
   sv_width : int('v),
   asid     : asidbits,
+  wid      : xlenbits,
   vpn      : vpn_bits('v),
   ppn      : ppn_bits('v),
   pte      : pte_bits('v),
@@ -171,6 +175,7 @@ function add_to_TLB forall 'v, is_sv_mode('v) . (
 
   let entry : TLB_Entry = struct{asid      = asid,
                                  global    = global,
+                                 wid       = wid,
                                  pte       = zero_extend(pte),
                                  pteAddr   = pteAddr,
                                  levelMask = zero_extend(levelMask),

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -203,7 +203,8 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
           // PMP region without write permissions raises a store
           // access-fault exception."
           let effPriv = effectivePrivilege(access, mstatus, cur_privilege);
-          match phys_access_check(access, pbmt, effPriv, paddr, bytes, true) {
+          let wid = current_world_id_for_access(access, effPriv);
+          match phys_access_check(access, pbmt, effPriv, wid, paddr, bytes, true) {
             Some(e) => return Err(memory_exception(Virtaddr(vaddr), e)),
             None()  => write_success = false,
           }


### PR DESCRIPTION
This PR adds support for the Smwid sub-extension defined in the RISC-V Worlds specification to sail-riscv.
Specification reference:
[worlds.adoc](https://raw.githubusercontent.com/riscv/riscv-worlds/main/src/worlds.adoc)