### PR TITLE
Update jsoncons and CLI11 to newer versions.

### DIFF
--- a/dependencies/CLI11/CMakeLists.txt
+++ b/dependencies/CLI11/CMakeLists.txt
@@ -4,9 +4,9 @@ include(FetchContent)
 option(DOWNLOAD_CLI11 "Download CLI11" ON)
 
 FetchContent_Declare(cli11_hpp
-  URL "https://github.com/CLIUtils/CLI11/releases/download/v2.6.1/CLI11.hpp"
+  URL "https://github.com/CLIUtils/CLI11/releases/download/v2.6.2/CLI11.hpp"
   DOWNLOAD_NO_EXTRACT YES
-  URL_HASH SHA256=8bad421104bbac1d763be60e3f833768e72c2d9f6fa14a6d19162979ba97c2e9
+  URL_HASH SHA256=227a16fe5f9f8ada80c3c409492475536f597e7bd83a6c26eacc3c8c149a9295
 )
 
 if(DOWNLOAD_CLI11)

--- a/dependencies/jsoncons/CMakeLists.txt
+++ b/dependencies/jsoncons/CMakeLists.txt
@@ -8,8 +8,8 @@ set(JSONCONS_BUILD_TESTS OFF)
 
 FetchContent_Declare(
   jsoncons
-  URL https://github.com/danielaparker/jsoncons/archive/refs/tags/v1.4.3.tar.gz
-  URL_HASH SHA3_256=7AE49B206A2D271C4B1A122824FA76EFAAD91703F3124AC7A66A26D1EEA1D07E
+  URL https://github.com/danielaparker/jsoncons/archive/refs/tags/v1.8.1.tar.gz
+  URL_HASH SHA3_256=c1f7957049ce756005ce67917ce8b6f09c0cf56e630664edeb272365229baada
 )
 
 if (DOWNLOAD_JSONCONS)


### PR DESCRIPTION
The `jsonscons` update fixes a build failure with gcc 16.1.1 that looks like this:

```
FAILED: [code=1] c_emulator/CMakeFiles/sail_riscv_sim.dir/riscv_sim.cpp.o 
/usr/bin/c++  -I/home/mundkur/src/hw/sail-ol/sail-riscv/build/_deps/cli11_hpp-src -I/home/mundkur/src/hw/sail-ol/sail-riscv/c_emulator -I/home/mundkur/src/hw/sail-ol/sail-riscv/build -I/home/mundkur/src/hw/sail-ol/sail-riscv/build/c_emulator -I/home/mundkur/src/hw/sail-ol/sail-riscv/dependencies/elfio -I/home/mundkur/src/hw/sail-ol/sail-riscv/dependencies/softfloat/berkeley-softfloat-3/build/Linux-x86_64-GCC -I/home/mundkur/src/hw/sail-ol/sail-riscv/dependencies/softfloat/berkeley-softfloat-3/source/include -I/home/mundkur/src/hw/sail-ol/sail-riscv/dependencies/softfloat/berkeley-softfloat-3/source/RISCV -I/home/mundkur/src/hw/sail-ol/sail/lib -I/home/mundkur/src/hw/sail-ol/sail-riscv/build/_deps/jsoncons-src/include -I/home/mundkur/src/hw/sail-ol/sail-riscv/build/config -O2 -g -DNDEBUG -std=gnu++17 -fPIE -Wall -Wextra -Wno-sign-compare -UNDEBUG -Wno-unused-parameter -Wno-parentheses-equality -Werror -MD -MT c_emulator/CMakeFiles/sail_riscv_sim.dir/riscv_sim.cpp.o -MF c_emulator/CMakeFiles/sail_riscv_sim.dir/riscv_sim.cpp.o.d -o c_emulator/CMakeFiles/sail_riscv_sim.dir/riscv_sim.cpp.o -c /home/mundkur/src/hw/sail-ol/sail-riscv/c_emulator/riscv_sim.cpp
In file included from /home/mundkur/src/hw/sail-ol/sail-riscv/build/_deps/jsoncons-src/include/jsoncons/json_exception.hpp:18,
                 from /home/mundkur/src/hw/sail-ol/sail-riscv/build/_deps/jsoncons-src/include/jsoncons/conv_error.hpp:17,
                 from /home/mundkur/src/hw/sail-ol/sail-riscv/build/_deps/jsoncons-src/include/jsoncons/basic_json.hpp:31,
                 from /home/mundkur/src/hw/sail-ol/sail-riscv/build/_deps/jsoncons-src/include/jsoncons/json.hpp:10,
                 from /home/mundkur/src/hw/sail-ol/sail-riscv/c_emulator/config_utils.h:4,
                 from /home/mundkur/src/hw/sail-ol/sail-riscv/c_emulator/riscv_sim.cpp:4:
In function ‘typename std::enable_if<(jsoncons::ext_traits::is_char8<CharT>::value && jsoncons::ext_traits::is_char32<CodepointT>::value), jsoncons::unicode_traits::convert_result<CharT> >::type jsoncons::unicode_traits::to_codepoint(const CharT*, const CharT*, CodepointT&, conv_flags) [with CharT = char; CodepointT = unsigned int]’,
    inlined from ‘std::size_t jsoncons::detail::escape_string(const CharT*, std::size_t, bool, bool, Sink&) [with CharT = char; Sink = jsoncons::stream_sink<char>]’ at /home/mundkur/src/hw/sail-ol/sail-riscv/build/_deps/jsoncons-src/include/jsoncons/json_encoder.hpp:109:62:
/home/mundkur/src/hw/sail-ol/sail-riscv/build/_deps/jsoncons-src/include/jsoncons/utility/unicode_traits.hpp:431:52: error: array subscript 6 is above array bounds of ‘const uint32_t [6]’ {aka ‘const unsigned int [6]’} [-Werror=array-bounds=]
  431 |         ch -= offsets_from_utf8[extra_bytes_to_read];
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
/home/mundkur/src/hw/sail-ol/sail-riscv/build/_deps/jsoncons-src/include/jsoncons/utility/unicode_traits.hpp: In function ‘std::size_t jsoncons::detail::escape_string(const CharT*, std::size_t, bool, bool, Sink&) [with CharT = char; Sink = jsoncons::stream_sink<char>]’:
/home/mundkur/src/hw/sail-ol/sail-riscv/build/_deps/jsoncons-src/include/jsoncons/utility/unicode_traits.hpp:152:20: note: while referencing ‘jsoncons::unicode_traits::offsets_from_utf8’
  152 |     const uint32_t offsets_from_utf8[6] = { 0x00000000UL, 0x00003080UL, 0x000E2080UL,
      |                    ^~~~~~~~~~~~~~~~~

```

While here, CLI11 has also been updated to a newer version.