### PR TITLE
Fix typo in ci workflow: `first_party_steps` -> `first_party_tests`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,20 +13,20 @@ jobs:
             first_party_tests: true
           - os: ubuntu-22.04
             cmake_version: "4.1.2"
-            first_party_steps: true
+            first_party_tests: true
             run_all_steps: true
           - os: ubuntu-24.04-arm
             cmake_version: "3.20.0"
             first_party_tests: true
           - os: ubuntu-24.04-arm
             cmake_version: "4.1.2"
-            first_party_steps: true
+            first_party_tests: true
           - os: macos-latest
             cmake_version: "3.20.0"
             first_party_tests: true
           - os: macos-latest
             cmake_version: "4.1.2"
-            first_party_steps: true
+            first_party_tests: true
           - os: ubuntu-latest
             container: rockylinux:8.9.20231119
             cmake_version: "3.20.0"


### PR DESCRIPTION
This meant that first party tests were running on fewer platforms than expected.
(I had unfortunately introduced the typo in 57d701a4b)