### PR TITLE
Add `clang-tidy` support to the C++ build and fix basic `bugprone` warnings.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,8 @@
+---
+Checks: >
+  -*,
+  bugprone*,
+  -bugprone-easily-swappable-parameters
+
+HeaderFilterRegex: ""
+...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - os: ubuntu-24.04-arm
             cmake_version: "4.1.2"
             first_party_tests: true
+            clang_tidy: true
           - os: macos-latest
             cmake_version: "3.20.0"
             first_party_tests: true
@@ -81,6 +82,7 @@ jobs:
             -DENABLE_RISCV_ARCH_TESTS=TRUE \
             -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE \
             -DENABLE_LTO=TRUE \
+            -DENABLE_CLANG_TIDY=${{ matrix.clang_tidy }} \
             $CLANG_FLAG
           ninja -C build all generated_sail_riscv_docs generated_smt_rv64d generated_smt_rv32d
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,12 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 # Generally it just simplifies everything for a negligible performance cost.
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
+# Enable clang-tidy.
+option(ENABLE_CLANG_TIDY "Enable clang-tidy linting." OFF)
+if (ENABLE_CLANG_TIDY)
+    find_program(CLANG_TIDY_PATH clang-tidy REQUIRED)
+endif()
+
 # Enable link-time optimization globally. This allows the linker to inline
 # Sail runtime helpers (eq_bits, add_bits_int, etc.) into the generated
 # model code, which is the dominant cost in the simulator hot path.

--- a/c_emulator/CMakeLists.txt
+++ b/c_emulator/CMakeLists.txt
@@ -49,6 +49,10 @@ add_library(riscv_model
     "${CMAKE_BINARY_DIR}/sail_riscv_model.h"
 )
 
+set_source_files_properties("${CMAKE_BINARY_DIR}/sail_riscv_model.cpp" "${CMAKE_BINARY_DIR}/sail_riscv_model.h"
+    PROPERTIES SKIP_LINTING ON
+)
+
 target_include_directories(riscv_model
     PUBLIC
         # So the generated C can find riscv_platform/prelude.h"
@@ -64,6 +68,12 @@ target_link_libraries(riscv_model
 )
 
 add_dependencies(riscv_model generated_sail_riscv_model generated_config_schema)
+
+if (ENABLE_CLANG_TIDY)
+    set_target_properties(riscv_model
+        PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_PATH}"
+    )
+endif()
 
 ## A binary that can load an ELF file into the model and run it.
 
@@ -100,6 +110,12 @@ add_dependencies(sail_riscv_sim generated_sail_riscv_model)
 target_link_libraries(sail_riscv_sim
     PRIVATE CLI11 riscv_model
 )
+
+if (ENABLE_CLANG_TIDY)
+    set_target_properties(sail_riscv_sim
+        PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_PATH}"
+    )
+endif()
 
 # After the emulator is built, use it to validate the generated config files.
 foreach (config_filename IN LISTS generated_config_filenames)

--- a/c_emulator/cli_options.cpp
+++ b/c_emulator/cli_options.cpp
@@ -148,7 +148,7 @@ CLIOptions parse_cli(int argc, char **argv) {
   );
 
   std::size_t column_width = 45;
-  app.get_formatter()->long_option_alignment_ratio(6.f / column_width);
+  app.get_formatter()->long_option_alignment_ratio(6.f / static_cast<float>(column_width));
   app.get_formatter()->column_width(column_width);
 
   if (argc == 1) {

--- a/c_emulator/riscv_callbacks_if.cpp
+++ b/c_emulator/riscv_callbacks_if.cpp
@@ -17,7 +17,7 @@ void callbacks_if::mem_write_callback(
   [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] const char *type,
   [[maybe_unused]] sbits paddr,
-  [[maybe_unused]] uint64_t width,
+  [[maybe_unused]] int64_t width,
   [[maybe_unused]] lbits value
 ) {
 }
@@ -26,7 +26,7 @@ void callbacks_if::mem_read_callback(
   [[maybe_unused]] ModelImpl &model,
   [[maybe_unused]] const char *type,
   [[maybe_unused]] sbits paddr,
-  [[maybe_unused]] uint64_t width,
+  [[maybe_unused]] int64_t width,
   [[maybe_unused]] lbits value
 ) {
 }

--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -15,9 +15,9 @@ public:
 
   virtual void fetch_callback(ModelImpl &model, sbits opcode);
 
-  virtual void mem_write_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value);
+  virtual void mem_write_callback(ModelImpl &model, const char *type, sbits paddr, int64_t width, lbits value);
 
-  virtual void mem_read_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value);
+  virtual void mem_read_callback(ModelImpl &model, const char *type, sbits paddr, int64_t width, lbits value);
 
   virtual void mem_exception_callback(ModelImpl &model, sbits paddr, uint64_t num_of_exception);
 

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -29,7 +29,7 @@ log_callbacks::log_callbacks(
 // Implementations of default callbacks for trace printing.
 // The model assumes that these functions do not change the state of the model.
 
-void log_callbacks::mem_write_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) {
+void log_callbacks::mem_write_callback(ModelImpl &model, const char *type, sbits paddr, int64_t width, lbits value) {
   // This is just passed due to Sail type system requirements.
   (void)width;
   if (trace_log != nullptr && config_print_mem_access) {
@@ -44,7 +44,7 @@ void log_callbacks::mem_write_callback(ModelImpl &model, const char *type, sbits
   }
 }
 
-void log_callbacks::mem_read_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) {
+void log_callbacks::mem_read_callback(ModelImpl &model, const char *type, sbits paddr, int64_t width, lbits value) {
   // This is just passed due to Sail type system requirements.
   (void)width;
   if (trace_log != nullptr && config_print_mem_access) {

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -19,8 +19,8 @@ public:
   );
 
   // callbacks_if
-  void mem_write_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
-  void mem_read_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
+  void mem_write_callback(ModelImpl &model, const char *type, sbits paddr, int64_t width, lbits value) override;
+  void mem_read_callback(ModelImpl &model, const char *type, sbits paddr, int64_t width, lbits value) override;
   void xreg_full_write_callback(ModelImpl &model, const_sail_string abi_name, sbits reg, sbits value) override;
   void freg_write_callback(ModelImpl &model, unsigned reg, sbits value) override;
   void csr_full_write_callback(ModelImpl &model, const_sail_string csr_name, unsigned reg, sbits value) override;

--- a/c_emulator/riscv_callbacks_rvfi.cpp
+++ b/c_emulator/riscv_callbacks_rvfi.cpp
@@ -7,11 +7,11 @@
 // Implementations of default callbacks for RVFI.
 // The model assumes that these functions do not change the state of the model.
 
-void rvfi_callbacks::mem_write_callback(ModelImpl &model, const char *, sbits paddr, uint64_t width, lbits value) {
+void rvfi_callbacks::mem_write_callback(ModelImpl &model, const char *, sbits paddr, int64_t width, lbits value) {
   model.zrvfi_write(paddr, width, value);
 }
 
-void rvfi_callbacks::mem_read_callback(ModelImpl &model, const char *, sbits paddr, uint64_t width, lbits value) {
+void rvfi_callbacks::mem_read_callback(ModelImpl &model, const char *, sbits paddr, int64_t width, lbits value) {
   sail_int len;
   CREATE(sail_int)(&len);
   CONVERT_OF(sail_int, mach_int)(&len, width);
@@ -24,7 +24,7 @@ void rvfi_callbacks::mem_exception_callback(ModelImpl &model, sbits paddr, uint6
 }
 
 void rvfi_callbacks::xreg_full_write_callback(ModelImpl &model, const_sail_string, sbits reg, sbits value) {
-  model.zrvfi_wX(reg.bits, value);
+  model.zrvfi_wX(static_cast<int64_t>(reg.bits), value);
 }
 
 void rvfi_callbacks::trap_callback(ModelImpl &model, bool is_interrupt, fbits cause) {

--- a/c_emulator/riscv_callbacks_rvfi.h
+++ b/c_emulator/riscv_callbacks_rvfi.h
@@ -6,8 +6,8 @@ class rvfi_callbacks : public callbacks_if {
 
 public:
   // callbacks_if
-  void mem_write_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
-  void mem_read_callback(ModelImpl &model, const char *type, sbits paddr, uint64_t width, lbits value) override;
+  void mem_write_callback(ModelImpl &model, const char *type, sbits paddr, int64_t width, lbits value) override;
+  void mem_read_callback(ModelImpl &model, const char *type, sbits paddr, int64_t width, lbits value) override;
   void mem_exception_callback(ModelImpl &model, sbits paddr, uint64_t num_of_exception) override;
   void xreg_full_write_callback(ModelImpl &model, const_sail_string abi_name, sbits reg, sbits value) override;
   void trap_callback(ModelImpl &model, bool is_interrupt, fbits cause) override;

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -53,7 +53,7 @@ unit ModelImpl::fetch_callback(sbits opcode) {
   return UNIT;
 }
 
-unit ModelImpl::mem_write_callback(const char *type, sbits paddr, uint64_t width, lbits value) {
+unit ModelImpl::mem_write_callback(const char *type, sbits paddr, int64_t width, lbits value) {
   for (auto c : m_callbacks) {
     c->mem_write_callback(*this, type, paddr, width, value);
   }
@@ -62,7 +62,7 @@ unit ModelImpl::mem_write_callback(const char *type, sbits paddr, uint64_t width
   };
   return UNIT;
 }
-unit ModelImpl::mem_read_callback(const char *type, sbits paddr, uint64_t width, lbits value) {
+unit ModelImpl::mem_read_callback(const char *type, sbits paddr, int64_t width, lbits value) {
   for (auto c : m_callbacks) {
     c->mem_read_callback(*this, type, paddr, width, value);
   }

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -98,8 +98,8 @@ private:
   // These functions are called by the Sail code.
 
   unit fetch_callback(sbits opcode) override;
-  unit mem_write_callback(const char *type, sbits paddr, uint64_t width, lbits value) override;
-  unit mem_read_callback(const char *type, sbits paddr, uint64_t width, lbits value) override;
+  unit mem_write_callback(const char *type, sbits paddr, int64_t width, lbits value) override;
+  unit mem_read_callback(const char *type, sbits paddr, int64_t width, lbits value) override;
   unit mem_exception_callback(sbits paddr, uint64_t num_of_exception) override;
   unit xreg_full_write_callback(const_sail_string abi_name, sbits reg, sbits value) override;
   unit freg_write_callback(unsigned reg, sbits value) override;

--- a/c_emulator/riscv_platform_if.cpp
+++ b/c_emulator/riscv_platform_if.cpp
@@ -15,7 +15,7 @@ unit PlatformInterface::fetch_callback([[maybe_unused]] sbits opcode) {
 unit PlatformInterface::mem_write_callback(
   [[maybe_unused]] const char *type,
   [[maybe_unused]] sbits paddr,
-  [[maybe_unused]] uint64_t width,
+  [[maybe_unused]] int64_t width,
   [[maybe_unused]] lbits value
 ) {
   return UNIT;
@@ -24,7 +24,7 @@ unit PlatformInterface::mem_write_callback(
 unit PlatformInterface::mem_read_callback(
   [[maybe_unused]] const char *type,
   [[maybe_unused]] sbits paddr,
-  [[maybe_unused]] uint64_t width,
+  [[maybe_unused]] int64_t width,
   [[maybe_unused]] lbits value
 ) {
   return UNIT;

--- a/c_emulator/riscv_platform_if.h
+++ b/c_emulator/riscv_platform_if.h
@@ -28,9 +28,9 @@ class PlatformInterface {
 public:
   virtual unit fetch_callback(sbits opcode);
 
-  virtual unit mem_write_callback(const char *type, sbits paddr, uint64_t width, lbits value);
+  virtual unit mem_write_callback(const char *type, sbits paddr, int64_t width, lbits value);
 
-  virtual unit mem_read_callback(const char *type, sbits paddr, uint64_t width, lbits value);
+  virtual unit mem_read_callback(const char *type, sbits paddr, int64_t width, lbits value);
 
   virtual unit mem_exception_callback(sbits paddr, uint64_t num_of_exception);
 

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -173,8 +173,8 @@ void write_signature(const std::string &file, unsigned signature_granularity, co
   /* write out words depending on signature granularity in signature area */
   for (uint64_t addr = elf_info.mem_sig_start; addr < elf_info.mem_sig_end; addr += signature_granularity) {
     /* most-significant byte first */
-    for (int i = static_cast<int>(signature_granularity) - 1; i >= 0; i--) {
-      uint8_t byte = (uint8_t)read_mem(addr + i);
+    for (unsigned i = signature_granularity; i > 0; --i) {
+      uint8_t byte = static_cast<uint8_t>(read_mem(addr + i - 1));
       fprintf(f, "%02x", byte);
     }
     fprintf(f, "\n");

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -27,10 +27,10 @@ rvfi_callbacks rvfi_cbs;
 } // namespace
 
 static void print_build_info() {
-  std::cout << "Sail RISC-V release: " << version_info::release_version << std::endl;
-  std::cout << "Sail RISC-V git: " << version_info::git_version << std::endl;
-  std::cout << "Sail: " << version_info::sail_version << std::endl;
-  std::cout << "C++ compiler: " << version_info::cxx_compiler_version << std::endl;
+  std::cout << "Sail RISC-V release: " << version_info::release_version() << std::endl;
+  std::cout << "Sail RISC-V git: " << version_info::git_version() << std::endl;
+  std::cout << "Sail: " << version_info::sail_version() << std::endl;
+  std::cout << "C++ compiler: " << version_info::cxx_compiler_version() << std::endl;
   std::cout << "CLI11: " << CLI11_VERSION << std::endl;
   std::cout << "ELFIO: " << ELFIO_VERSION << std::endl;
   std::cout << "JSONCONS: " << jsoncons::version() << std::endl;
@@ -173,7 +173,7 @@ void write_signature(const std::string &file, unsigned signature_granularity, co
   /* write out words depending on signature granularity in signature area */
   for (uint64_t addr = elf_info.mem_sig_start; addr < elf_info.mem_sig_end; addr += signature_granularity) {
     /* most-significant byte first */
-    for (int i = signature_granularity - 1; i >= 0; i--) {
+    for (int i = static_cast<int>(signature_granularity) - 1; i >= 0; i--) {
       uint8_t byte = (uint8_t)read_mem(addr + i);
       fprintf(f, "%02x", byte);
     }
@@ -343,8 +343,8 @@ void run_sail(
 
 void init_logs(const CLIOptions &opts, run_info &run_info) {
   if (!opts.term_log.empty()) {
-    if ((run_info.term_fd =
-           open(opts.term_log.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IRGRP | S_IROTH | S_IWUSR)) < 0) {
+    run_info.term_fd = open(opts.term_log.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IRGRP | S_IROTH | S_IWUSR);
+    if (run_info.term_fd < 0) {
       fprintf(stderr, "Cannot create terminal log '%s': %s\n", opts.term_log.c_str(), strerror(errno));
       exit(EXIT_FAILURE);
     }
@@ -371,7 +371,7 @@ void init_logs(const CLIOptions &opts, run_info &run_info) {
 // initialization.
 InitResult preinit_args(CLIOptions &opts, std::string &config_json_string) {
   if (opts.do_print_version) {
-    std::cout << version_info::release_version << std::endl;
+    std::cout << version_info::release_version() << std::endl;
     return InitResult::ExitSuccess;
   }
   if (opts.do_print_build_info) {

--- a/c_emulator/riscv_softfloat.cpp
+++ b/c_emulator/riscv_softfloat.cpp
@@ -358,7 +358,7 @@ bv5_bv16 softfloat_i32tof16(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t res;
-  res = i32_to_f16((int32_t)v);
+  res = i32_to_f16(static_cast<int32_t>(v));
 
   return {softfloat_exceptionFlags, res.v};
 }
@@ -367,7 +367,7 @@ bv5_bv16 softfloat_ui32tof16(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t res;
-  res = ui32_to_f16((uint32_t)v);
+  res = ui32_to_f16(static_cast<uint32_t>(v));
 
   return {softfloat_exceptionFlags, res.v};
 }
@@ -376,7 +376,7 @@ bv5_bv16 softfloat_i64tof16(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float16_t res;
-  res = i64_to_f16(v);
+  res = i64_to_f16(static_cast<int64_t>(v));
 
   return {softfloat_exceptionFlags, res.v};
 }
@@ -394,7 +394,7 @@ bv5_bv32 softfloat_i32tof32(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t res;
-  res = i32_to_f32((int32_t)v);
+  res = i32_to_f32(static_cast<int32_t>(v));
 
   return {softfloat_exceptionFlags, res.v};
 }
@@ -403,7 +403,7 @@ bv5_bv32 softfloat_ui32tof32(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t res;
-  res = ui32_to_f32((uint32_t)v);
+  res = ui32_to_f32(static_cast<uint32_t>(v));
 
   return {softfloat_exceptionFlags, res.v};
 }
@@ -412,7 +412,7 @@ bv5_bv32 softfloat_i64tof32(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float32_t res;
-  res = i64_to_f32(v);
+  res = i64_to_f32(static_cast<int64_t>(v));
 
   return {softfloat_exceptionFlags, res.v};
 }
@@ -430,7 +430,7 @@ bv5_bv64 softfloat_i32tof64(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t res;
-  res = i32_to_f64((int32_t)v);
+  res = i32_to_f64(static_cast<int32_t>(v));
 
   return {softfloat_exceptionFlags, res.v};
 }
@@ -439,7 +439,7 @@ bv5_bv64 softfloat_ui32tof64(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t res;
-  res = ui32_to_f64((uint32_t)v);
+  res = ui32_to_f64(static_cast<uint32_t>(v));
 
   return {softfloat_exceptionFlags, res.v};
 }
@@ -448,7 +448,7 @@ bv5_bv64 softfloat_i64tof64(uint64_t rm, uint64_t v) {
   SOFTFLOAT_PRELUDE(rm);
 
   float64_t res;
-  res = i64_to_f64(v);
+  res = i64_to_f64(static_cast<int64_t>(v));
 
   return {softfloat_exceptionFlags, res.v};
 }

--- a/c_emulator/rvfi_dii.cpp
+++ b/c_emulator/rvfi_dii.cpp
@@ -134,7 +134,7 @@ rvfi_prestep_t rvfi_handler::pre_step(bool config_print) {
   if (config_print) {
     fprintf(stderr, "Waiting for cmd packet... ");
   }
-  int res = read(dii_sock, &instr_bits, sizeof(instr_bits));
+  ssize_t res = read(dii_sock, &instr_bits, sizeof(instr_bits));
   if (config_print) {
     fprintf(stderr, "Read cmd packet: %016jx\n", (intmax_t)instr_bits);
     m_model.zprint_instr_packet(instr_bits);

--- a/c_emulator/sail_riscv_version.cpp.in
+++ b/c_emulator/sail_riscv_version.cpp.in
@@ -2,9 +2,25 @@
 
 namespace version_info {
 
-const std::string_view release_version = "@sail_riscv_release_version@";
-const std::string_view git_version = "@sail_riscv_git_version@";
-const std::string_view sail_version = "@sail_version@";
-const std::string_view cxx_compiler_version = "@CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@";
+static const char *c_release_version = "@sail_riscv_release_version@";
+static const char *c_git_version = "@sail_riscv_git_version@";
+static const char *c_sail_version = "@sail_version@";
+static const char *c_cxx_compiler_version = "@CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@";
+
+const std::string_view release_version() {
+  return std::string_view(c_release_version);
+}
+
+const std::string_view git_version() {
+  return std::string_view(c_git_version);
+}
+
+const std::string_view sail_version() {
+  return std::string_view(c_sail_version);
+}
+
+const std::string_view cxx_compiler_version() {
+  return std::string_view(c_cxx_compiler_version);
+}
 
 }

--- a/c_emulator/sail_riscv_version.cpp.in
+++ b/c_emulator/sail_riscv_version.cpp.in
@@ -2,25 +2,20 @@
 
 namespace version_info {
 
-static const char *c_release_version = "@sail_riscv_release_version@";
-static const char *c_git_version = "@sail_riscv_git_version@";
-static const char *c_sail_version = "@sail_version@";
-static const char *c_cxx_compiler_version = "@CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@";
-
 const std::string_view release_version() {
-  return std::string_view(c_release_version);
+  return "@sail_riscv_release_version@";
 }
 
 const std::string_view git_version() {
-  return std::string_view(c_git_version);
+  return "@sail_riscv_git_version@";
 }
 
 const std::string_view sail_version() {
-  return std::string_view(c_sail_version);
+  return "@sail_version@";
 }
 
 const std::string_view cxx_compiler_version() {
-  return std::string_view(c_cxx_compiler_version);
+  return "@CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@";
 }
 
 }

--- a/c_emulator/sail_riscv_version.cpp.in
+++ b/c_emulator/sail_riscv_version.cpp.in
@@ -2,19 +2,19 @@
 
 namespace version_info {
 
-const std::string_view release_version() {
+std::string_view release_version() {
   return "@sail_riscv_release_version@";
 }
 
-const std::string_view git_version() {
+std::string_view git_version() {
   return "@sail_riscv_git_version@";
 }
 
-const std::string_view sail_version() {
+std::string_view sail_version() {
   return "@sail_version@";
 }
 
-const std::string_view cxx_compiler_version() {
+std::string_view cxx_compiler_version() {
   return "@CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@";
 }
 

--- a/c_emulator/sail_riscv_version.h
+++ b/c_emulator/sail_riscv_version.h
@@ -4,9 +4,9 @@
 
 namespace version_info {
 
-extern const std::string_view release_version;
-extern const std::string_view git_version;
-extern const std::string_view sail_version;
-extern const std::string_view cxx_compiler_version;
+const std::string_view release_version();
+const std::string_view git_version();
+const std::string_view sail_version();
+const std::string_view cxx_compiler_version();
 
 }; // namespace version_info

--- a/c_emulator/sail_riscv_version.h
+++ b/c_emulator/sail_riscv_version.h
@@ -4,9 +4,9 @@
 
 namespace version_info {
 
-const std::string_view release_version();
-const std::string_view git_version();
-const std::string_view sail_version();
-const std::string_view cxx_compiler_version();
+std::string_view release_version();
+std::string_view git_version();
+std::string_view sail_version();
+std::string_view cxx_compiler_version();
 
 }; // namespace version_info

--- a/dependencies/CLI11/CMakeLists.txt
+++ b/dependencies/CLI11/CMakeLists.txt
@@ -12,5 +12,7 @@ FetchContent_Declare(cli11_hpp
 if(DOWNLOAD_CLI11)
   FetchContent_MakeAvailable(cli11_hpp)
   add_library(CLI11 INTERFACE)
-  target_include_directories(CLI11 INTERFACE "${cli11_hpp_SOURCE_DIR}")
+  target_include_directories(CLI11
+    SYSTEM INTERFACE
+    "${cli11_hpp_SOURCE_DIR}")
 endif()

--- a/dependencies/elfio/CMakeLists.txt
+++ b/dependencies/elfio/CMakeLists.txt
@@ -41,9 +41,13 @@ add_library(elfio::elfio ALIAS elfio)
 
 target_include_directories(
     elfio
-    INTERFACE
+    SYSTEM INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+set_source_files_properties(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    PROPERTIES SKIP_LINTING ON
+)
 
 # If this is the top level project, add in logic to install elfio
 if(IS_TOP_PROJECT)

--- a/dependencies/jsoncons/CMakeLists.txt
+++ b/dependencies/jsoncons/CMakeLists.txt
@@ -15,3 +15,7 @@ FetchContent_Declare(
 if (DOWNLOAD_JSONCONS)
     FetchContent_MakeAvailable(jsoncons)
 endif()
+
+set_target_properties(jsoncons
+    PROPERTIES SKIP_LINTING ON
+)

--- a/dependencies/softfloat/CMakeLists.txt
+++ b/dependencies/softfloat/CMakeLists.txt
@@ -59,8 +59,6 @@ target_compile_definitions(softfloat PRIVATE
 )
 
 set_source_files_properties(
-    DIRECTORY
-       "${CMAKE_CURRENT_SOURCE_DIR}"
-    PROPERTIES
-        SKIP_LINTING ON
+    DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    PROPERTIES SKIP_LINTING ON
 )

--- a/dependencies/softfloat/CMakeLists.txt
+++ b/dependencies/softfloat/CMakeLists.txt
@@ -35,7 +35,8 @@ add_library(softfloat
     ${riscv_source}
 )
 
-target_include_directories(softfloat PUBLIC
+target_include_directories(softfloat
+    SYSTEM PUBLIC
     "${source_dir}/build/Linux-x86_64-GCC"
     "${source_dir}/source/include"
     "${source_dir}/source/RISCV"
@@ -55,4 +56,11 @@ target_compile_definitions(softfloat PRIVATE
     SOFTFLOAT_FAST_DIV32TO16
     SOFTFLOAT_FAST_DIV64TO32
     SOFTFLOAT_FAST_INT64
+)
+
+set_source_files_properties(
+    DIRECTORY
+       "${CMAKE_CURRENT_SOURCE_DIR}"
+    PROPERTIES
+        SKIP_LINTING ON
 )

--- a/sail_runtime/CMakeLists.txt
+++ b/sail_runtime/CMakeLists.txt
@@ -15,7 +15,8 @@ add_library(sail_runtime
 )
 
 target_include_directories(sail_runtime
-    PUBLIC "${sail_dir}/lib"
+    SYSTEM PUBLIC
+    "${sail_dir}/lib"
 )
 target_compile_options(sail_runtime PRIVATE -Wno-extra -Wno-unused)
 target_link_libraries(sail_runtime PUBLIC GMP::GMP)


### PR DESCRIPTION
- A  CMake option adds `clang-tidy` checks to the build.   In order to get `clang-tidy` to skip analyzing dependencies, their headers are specified as `SYSTEM` includes, and linting is requested to be skipped for generated C++ files.

-  A minimal `clang-tidy`  configuration enables only `bugprone` checks.  The checks can be expanded gradually.

- This fixes several `clang-tidy` warnings, mostly related to integer conversions.

  Most of the diff fixes the `width` parameter in `mem_{read,write}_callback` to be an `int64_t` (Sail C API's `mach_int`) instead of `uint64_t`.

  There were some missing casts for conversions in the Softfloat API. Existing C-style casts were converted into `static_cast<>`.

  Statically allocated constant version strings were converted into C-style strings to fix a warning that the C++ string constructors can raise exceptions during static allocation (induced by their use to initialize `std::string_view`).  These are now accessed via functions instead of as constants.

  Other miscellaneous warnings were similarly fixed.

- `clang-tidy` is added to the CI for the latest versions of CMake/Ubuntu.

  It would be good to enable it on MacOS as well, since the tool gives slightly different warnings on that platform.  However, the `brew`-installed LLVM currently fails due to `an unsupported platform` warning that gets converted into an error due to `-DWARNINGS_AS_ERRORS=TRUE` and fails the CI build.