### PR TITLE
Add the `aq` and `rl` flags for LR/SC and AMOs to the access type.

### DIFF
--- a/model/core/mem_type_utils.sail
+++ b/model/core/mem_type_utils.sail
@@ -12,12 +12,12 @@ function accessFaultFromAccessType(access : MemoryAccessType(mem_payload)) -> Ex
     Load(Data)                          => E_Load_Access_Fault(),
     Load(Vector)                        => E_Load_Access_Fault(),
     Load(PageTableEntry)                => E_Load_Access_Fault(),
-    LoadReserved(Data)                  => E_Load_Access_Fault(),
+    LoadReserved(_, _, Data)            => E_Load_Access_Fault(),
     Store(Data)                         => E_SAMO_Access_Fault(),
     Store(Vector)                       => E_SAMO_Access_Fault(),
     Store(PageTableEntry)               => E_SAMO_Access_Fault(),
-    StoreConditional(Data)              => E_SAMO_Access_Fault(),
-    Atomic(_, Data, Data)               => E_SAMO_Access_Fault(),
+    StoreConditional(_, _, Data)        => E_SAMO_Access_Fault(),
+    Atomic(_, _, _, Data, Data)         => E_SAMO_Access_Fault(),
 
     // "For shadow stack instructions, the reported instruction type
     // is always as though it were a store or AMO, even for instructions
@@ -25,11 +25,12 @@ function accessFaultFromAccessType(access : MemoryAccessType(mem_payload)) -> Ex
     // write to it."
     Load(ShadowStack)                   => E_SAMO_Access_Fault(),
     Store(ShadowStack)                  => E_SAMO_Access_Fault(),
-    Atomic(_, ShadowStack, ShadowStack) => E_SAMO_Access_Fault(),
 
-    LoadReserved(p)                     => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
-    StoreConditional(p)                 => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),
-    Atomic(_, rp, wp)                   => internal_error(__FILE__, __LINE__, "Invalid payloads (" ^ mem_payload_name(rp) ^ ", " ^ mem_payload_str(wp) ^ ") for Atomic."),
+    Atomic(_, _, _, ShadowStack, ShadowStack) => E_SAMO_Access_Fault(),
+
+    LoadReserved(_, _, p)               => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
+    StoreConditional(_, _, p)           => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),
+    Atomic(_, _, _, rp, wp)             => internal_error(__FILE__, __LINE__, "Invalid payloads (" ^ mem_payload_name(rp) ^ ", " ^ mem_payload_str(wp) ^ ") for Atomic."),
 
     // Cache-block management (CB_manage) and zero (CB_zero)
     // instructions raise store faults.
@@ -52,12 +53,12 @@ function alignmentFaultFromAccessType(access : MemoryAccessType(mem_payload)) ->
     Load(Data)                          => E_Load_Addr_Align(),
     Load(Vector)                        => E_Load_Addr_Align(),
     Load(PageTableEntry)                => E_Load_Addr_Align(),
-    LoadReserved(Data)                  => E_Load_Addr_Align(),
+    LoadReserved(_, _, Data)            => E_Load_Addr_Align(),
     Store(Data)                         => E_SAMO_Addr_Align(),
     Store(Vector)                       => E_SAMO_Addr_Align(),
     Store(PageTableEntry)               => E_SAMO_Addr_Align(),
-    StoreConditional(Data)              => E_SAMO_Addr_Align(),
-    Atomic(_, Data, Data)               => E_SAMO_Addr_Align(),
+    StoreConditional(_, _, Data)        => E_SAMO_Addr_Align(),
+    Atomic(_, _, _, Data, Data)         => E_SAMO_Addr_Align(),
 
     // "For shadow stack instructions, the reported instruction type
     // is always as though it were a store or AMO, even for instructions
@@ -65,11 +66,12 @@ function alignmentFaultFromAccessType(access : MemoryAccessType(mem_payload)) ->
     // write to it."
     Load(ShadowStack)                   => E_SAMO_Addr_Align(),
     Store(ShadowStack)                  => E_SAMO_Addr_Align(),
-    Atomic(_, ShadowStack, ShadowStack) => E_SAMO_Addr_Align(),
 
-    LoadReserved(p)                     => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
-    StoreConditional(p)                 => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),
-    Atomic(_, rp, wp)                   => internal_error(__FILE__, __LINE__, "Invalid payloads (" ^ mem_payload_name(rp) ^ ", " ^ mem_payload_str(wp) ^ ") for Atomic."),
+    Atomic(_, _, _, ShadowStack, ShadowStack) => E_SAMO_Addr_Align(),
+
+    LoadReserved(_, _, p)               => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
+    StoreConditional(_, _, p)           => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),
+    Atomic(_, _, _, rp, wp)             => internal_error(__FILE__, __LINE__, "Invalid payloads (" ^ mem_payload_name(rp) ^ ", " ^ mem_payload_str(wp) ^ ") for Atomic."),
 
     // Cache-block management (CB_manage) and zero (CB_zero)
     // instructions raise store faults.

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -104,12 +104,14 @@ union cacheop = {
   CB_prefetch : cbop_zicbop,
 }
 
+// The two bool parameters are the `aq` and `rl` instruction
+// annotations respectively.
 union MemoryAccessType ('a : Type) = {
   Load             : 'a,
   Store            : 'a,
-  LoadReserved     : 'a,
-  StoreConditional : 'a,
-  Atomic           : (amoop, 'a, 'a),
+  LoadReserved     : (bool, bool, 'a),
+  StoreConditional : (bool, bool, 'a),
+  Atomic           : (amoop, bool, bool, 'a, 'a),
   InstructionFetch : unit,
   CacheAccess      : cacheop
 }

--- a/model/core/vmem_types.sail
+++ b/model/core/vmem_types.sail
@@ -54,13 +54,13 @@ mapping mem_payload_str : mem_payload <-> string = {
 
 function accessType_to_str(access : MemoryAccessType(mem_payload)) -> string =
   match access {
-    Load(p)             => "R" ^ mem_payload_str(p),
-    LoadReserved(p)     => "R" ^ mem_payload_str(p),
-    Store(p)            => "W" ^ mem_payload_str(p),
-    StoreConditional(p) => "W" ^ mem_payload_str(p),
-    Atomic(_, lp, sp)   => "R" ^ mem_payload_str(lp) ^ "W" ^ mem_payload_str(sp),
-    InstructionFetch()  => "X",
-    CacheAccess(_)      => "C",
+    Load(p)                   => "R" ^ mem_payload_str(p),
+    LoadReserved(_, _, p)     => "R" ^ mem_payload_str(p),
+    Store(p)                  => "W" ^ mem_payload_str(p),
+    StoreConditional(_, _, p) => "W" ^ mem_payload_str(p),
+    Atomic(_, _, _, lp, sp)   => "R" ^ mem_payload_str(lp) ^ "W" ^ mem_payload_str(sp),
+    InstructionFetch()        => "X",
+    CacheAccess(_)            => "C",
   }
 
 overload to_str = {accessType_to_str}
@@ -69,23 +69,24 @@ function is_shadow_stack_access(access : MemoryAccessType(mem_payload)) -> bool 
   match access {
     Load(ShadowStack)                   => true,
     Store(ShadowStack)                  => true,
-    Atomic(_, ShadowStack, ShadowStack) => true,
+
+    Atomic(_, _, _, ShadowStack, ShadowStack) => true,
 
     InstructionFetch()                  => false,
     Load(Data)                          => false,
     Load(Vector)                        => false,
     Load(PageTableEntry)                => false,
-    LoadReserved(Data)                  => false,
+    LoadReserved(_, _, Data)            => false,
     Store(Data)                         => false,
     Store(Vector)                       => false,
     Store(PageTableEntry)               => false,
-    StoreConditional(Data)              => false,
-    Atomic(_, Data, Data)               => false,
+    StoreConditional(_, _, Data)        => false,
+    Atomic(_, _, _, Data, Data)         => false,
     CacheAccess(_)                      => false,
 
-    LoadReserved(p)                     => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
-    StoreConditional(p)                 => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),
-    Atomic(_, rp, wp)                   => internal_error(__FILE__, __LINE__, "Invalid payloads (" ^ mem_payload_name(rp) ^ ", " ^ mem_payload_name(wp) ^ ") for Atomic."),
+    LoadReserved(_, _, p)               => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
+    StoreConditional(_, _, p)           => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),
+    Atomic(_, _, _, rp, wp)             => internal_error(__FILE__, __LINE__, "Invalid payloads (" ^ mem_payload_name(rp) ^ ", " ^ mem_payload_name(wp) ^ ") for Atomic."),
   }
 
 function is_amo_access(access : MemoryAccessType(mem_payload)) -> bool =
@@ -96,8 +97,8 @@ function is_amo_access(access : MemoryAccessType(mem_payload)) -> bool =
 
 function is_shadow_stack_amo(access : MemoryAccessType(mem_payload)) -> bool =
   match access {
-    Atomic(_, ShadowStack, ShadowStack) => true,
-    _                                   => false,
+    Atomic(_, _, _, ShadowStack, ShadowStack) => true,
+    _                                         => false,
   }
 
 function is_vector_access(access : MemoryAccessType(mem_payload)) -> bool =

--- a/model/extensions/A/zaamo_insts.sail
+++ b/model/extensions/A/zaamo_insts.sail
@@ -72,7 +72,7 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
   // This is checked during decoding.
   assert(width <= xlen_bytes * 2);
 
-  let access = Atomic(op, Data, Data);
+  let access = Atomic(op, aq, rl, Data, Data);
 
   // Get the address, X(rs1) (no offset).
   // Some extensions perform additional checks on address validity.
@@ -99,7 +99,7 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
   // x0, then both halves of the pair read/write as zero.
   let rs2_val : bits('width * 8) = if width <= xlen_bytes then trunc(X(rs2)) else trunc(X_pair(rs2));
 
-  let loaded : bits('width * 8) = match mem_write_ea(addr, width, aq & rl, rl, true) {
+  let loaded : bits('width * 8) = match mem_write_ea(addr, width, access, aq & rl, rl, true) {
     Err(e) => return memory_exception(vaddr, e),
     Ok(_)  => match mem_read(access, pbmt, addr, width, aq, aq & rl, true) {
       Err(e)     => return memory_exception(vaddr, e),

--- a/model/extensions/A/zalrsc_insts.sail
+++ b/model/extensions/A/zalrsc_insts.sail
@@ -42,7 +42,7 @@ function clause execute LOADRES(aq, rl, rs1, width, rd) = {
   // This is checked during decoding.
   assert(width <= xlen_bytes);
 
-  match vmem_read(rs1, zeros(), width, LoadReserved(Data), aq, aq & rl, true) {
+  match vmem_read(rs1, zeros(), width, LoadReserved(aq, rl, Data), aq, aq & rl, true) {
     Ok(data) => {
       X(rd) = sign_extend(data);
       RETIRE_SUCCESS
@@ -70,7 +70,7 @@ function clause execute STORECON(aq, rl, rs2, rs1, width, rd) = {
   // normal non-rmem case
   // RMEM: SC is allowed to succeed (but might fail later)
   let data = X(rs2)[width * 8 - 1 .. 0];
-  match vmem_write(rs1, zeros(), width, data, StoreConditional(Data), aq & rl, rl, true) {
+  match vmem_write(rs1, zeros(), width, data, StoreConditional(aq, rl, Data), aq & rl, rl, true) {
     Ok(b) => {
       X(rd) = zero_extend(bool_bit(~(b)));
       cancel_reservation();

--- a/model/extensions/Zicboz/zicboz_insts.sail
+++ b/model/extensions/Zicboz/zicboz_insts.sail
@@ -51,7 +51,7 @@ function clause execute ZICBOZ(rs1) = {
         // equal to rs1, but pointer masking can change that.
         Err(e, _) => memory_exception(vaddr - negative_offset, e),
         Ok(paddr, pbmt, _) => {
-          match mem_write_ea(paddr, cache_block_size, false, false, false) {
+          match mem_write_ea(paddr, cache_block_size, access, false, false, false) {
             Err(e) => memory_exception(vaddr - negative_offset, e),
             Ok(_)  => {
               match mem_write_value(paddr, cache_block_size, zeros(), access, pbmt, false, false, false) {

--- a/model/extensions/cfi/zicfiss_insts.sail
+++ b/model/extensions/cfi/zicfiss_insts.sail
@@ -168,7 +168,7 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
                          then return Virtual_Instruction(),
   };
 
-  let access = Atomic(AMOSWAP, ShadowStack, ShadowStack);
+  let access = Atomic(AMOSWAP, aq, rl, ShadowStack, ShadowStack);
 
   let vaddr : virtaddr = match get_transformed_data_addr(rs1, zeros(), access, width) {
     Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
@@ -196,7 +196,7 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
   // implement multiprocessor synchronization."
 
   let 'width = width;
-  let mem_val : bits('width * 8) = match mem_write_ea(paddr, width, aq & rl, rl, true) {
+  let mem_val : bits('width * 8) = match mem_write_ea(paddr, width, access, aq & rl, rl, true) {
     Err(e) => return memory_exception(vaddr, e),
     Ok(_)  => match mem_read(access, pbmt, paddr, width, aq, aq & rl, true) {
       Err(e) => return memory_exception(vaddr, e),

--- a/model/pmp/pmp_control.sail
+++ b/model/pmp/pmp_control.sail
@@ -14,12 +14,12 @@ private function pmpCheckRWX(ent : Pmpcfg_ent, access : MemoryAccessType(mem_pay
     Load(Data)                    => ent[R] == 0b1,
     Load(Vector)                  => ent[R] == 0b1,
     Load(PageTableEntry)          => ent[R] == 0b1,
-    LoadReserved(Data)            => ent[R] == 0b1,
+    LoadReserved(_, _, Data)      => ent[R] == 0b1,
     Store(Data)                   => ent[W] == 0b1,
     Store(Vector)                 => ent[W] == 0b1,
     Store(PageTableEntry)         => ent[W] == 0b1,
-    StoreConditional(Data)        => ent[W] == 0b1,
-    Atomic(_, Data, Data)         => ent[R] == 0b1 & ent[W] == 0b1,
+    StoreConditional(_, _, Data)  => ent[W] == 0b1,
+    Atomic(_, _, _, Data, Data)   => ent[R] == 0b1 & ent[W] == 0b1,
     InstructionFetch()            => ent[X] == 0b1,
 
     // "The PMP checks are extended to require read-write permission
@@ -27,11 +27,11 @@ private function pmpCheckRWX(ent : Pmpcfg_ent, access : MemoryAccessType(mem_pay
     Load(ShadowStack)             => ent[R] == 0b1 & ent[W] == 0b1,
     Store(ShadowStack)            => ent[R] == 0b1 & ent[W] == 0b1,
 
-    Atomic(_, ShadowStack, ShadowStack) => ent[R] == 0b1 & ent[W] == 0b1,
+    Atomic(_, _, _, ShadowStack, ShadowStack) => ent[R] == 0b1 & ent[W] == 0b1,
 
-    LoadReserved(p)               => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
-    StoreConditional(p)           => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),
-    Atomic(_, rp, wp)             => internal_error(__FILE__, __LINE__, "Invalid payloads (" ^ mem_payload_name(rp) ^ ", " ^ mem_payload_str(wp) ^ ") for Atomic."),
+    LoadReserved(_, _, p)         => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
+    StoreConditional(_, _, p)     => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),
+    Atomic(_, _, _, rp, wp)       => internal_error(__FILE__, __LINE__, "Invalid payloads (" ^ mem_payload_name(rp) ^ ", " ^ mem_payload_str(wp) ^ ") for Atomic."),
 
     // TODO: "If neither a load instruction nor store instruction is
     // permitted to access the physical addresses, but an instruction

--- a/model/sys/mem.sail
+++ b/model/sys/mem.sail
@@ -106,17 +106,18 @@ private function pmaCheck forall 'n, 0 < 'n <= max_mem_access .
             Store(Data)            => {assert(not(res_or_con)); attributes.writable},
             Store(Vector)          => {assert(not(res_or_con)); attributes.writable},
             Store(PageTableEntry)  => {assert(not(res_or_con)); attributes.supports_pte_write},
+
             // For LR/SC, we currently don't differentiate between the presence (RsrvEventual)
             // or absence (RsrvNonEventual) of an eventual success guarantee.
-            LoadReserved(Data)     => {assert(res_or_con); attributes.readable & attributes.reservability != RsrvNone},
-            StoreConditional(Data) => {assert(res_or_con); attributes.writable & attributes.reservability != RsrvNone},
-            Atomic(op, Data, Data)  => {assert(res_or_con); attributes.readable & attributes.writable & pma_allows_atomic_op(attributes.atomic_support, op, width)},
+            LoadReserved(_, _, Data)      => {assert(res_or_con); attributes.readable & attributes.reservability != RsrvNone},
+            StoreConditional(_, _, Data)  => {assert(res_or_con); attributes.writable & attributes.reservability != RsrvNone},
+            Atomic(op, _, _, Data, Data)  => {assert(res_or_con); attributes.readable & attributes.writable & pma_allows_atomic_op(attributes.atomic_support, op, width)},
 
             // "The PMA checks are extended to require memory referenced by shadow stack instructions
             // to be idempotent."
             Load(ShadowStack)      => {assert(not(res_or_con)); attributes.readable & attributes.read_idempotent},
             Store(ShadowStack)     => {assert(not(res_or_con)); attributes.writable & attributes.write_idempotent},
-            Atomic(AMOSWAP, ShadowStack, ShadowStack) => {assert(res_or_con); attributes.readable & attributes.writable & attributes.read_idempotent & attributes.write_idempotent & pma_allows_atomic_op(attributes.atomic_support, AMOSWAP, width)},
+            Atomic(AMOSWAP, _, _, ShadowStack, ShadowStack) => {assert(res_or_con); attributes.readable & attributes.writable & attributes.read_idempotent & attributes.write_idempotent & pma_allows_atomic_op(attributes.atomic_support, AMOSWAP, width)},
 
             // TODO for the CMO extensions: "The PMAs shall be the
             // same for all physical addresses in the cache block, and
@@ -153,11 +154,11 @@ private function pmaCheck forall 'n, 0 < 'n <= max_mem_access .
               PREFETCH_I => attributes.executable,
             },
 
-            LoadReserved(p)                => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
-            StoreConditional(p)            => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),
+            LoadReserved(_, _, p)          => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
+            StoreConditional(_, _, p)      => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),
 
-            Atomic(op, ShadowStack, ShadowStack) => internal_error(__FILE__, __LINE__, "Invalid op (" ^ amo_mnemonic(op) ^ ") for ShadowStack Atomic."),
-            Atomic(_, rp, wp)                    => internal_error(__FILE__, __LINE__, "Invalid payloads (" ^ mem_payload_name(rp) ^ ", " ^ mem_payload_name(wp) ^ ") for Atomic."),
+            Atomic(op, _, _, ShadowStack, ShadowStack) => internal_error(__FILE__, __LINE__, "Invalid op (" ^ amo_mnemonic(op) ^ ") for ShadowStack Atomic."),
+            Atomic(_, _, _, rp, wp)                    => internal_error(__FILE__, __LINE__, "Invalid payloads (" ^ mem_payload_name(rp) ^ ", " ^ mem_payload_name(wp) ^ ") for Atomic."),
           };
 
           if get_config_print_pma() & not(canAccess)
@@ -263,8 +264,8 @@ function mem_read_priv (access, pbmt, priv, paddr, width, aq, rl, res) =
 function mem_read (access, pbmt, paddr, width, aq, rel, res) =
   mem_read_priv(access, pbmt, effectivePrivilege(access, mstatus, cur_privilege), paddr, width, aq, rel, res)
 
-val mem_write_ea : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bool, bool, bool) -> MemoryOpResult(unit)
-function mem_write_ea (addr, width, aq, rl, con) =
+val mem_write_ea : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), MemoryAccessType(mem_payload), bool, bool, bool) -> MemoryOpResult(unit)
+function mem_write_ea(addr, width, _access, aq, rl, con) =
   if (rl | con) & not(is_aligned_addr(addr, width))
   then Err(E_SAMO_Addr_Align())
   else Ok(write_ram_ea(write_kind_of_flags(aq, rl, con), addr, width))

--- a/model/sys/pma.sail
+++ b/model/sys/pma.sail
@@ -147,13 +147,13 @@ function pma_misaligned_exception(pma : PMA, access : MemoryAccessType(mem_paylo
     Store(ShadowStack)     => exceptions.load_store,
     Load(Vector)           => exceptions.vector,
     Store(Vector)          => exceptions.vector,
-    Atomic(_, _, _)        => Some(exceptions.amo),
+    Atomic(_)              => Some(exceptions.amo),
 
     // These access types should not be misaligned at the PMA level.
-    InstructionFetch()     => internal_error(__FILE__, __LINE__, "PMA: Invalid misaligned instruction fetch."),
-    LoadReserved(p)        => internal_error(__FILE__, __LINE__, "PMA: Invalid misaligned load-reserved (" ^ mem_payload_name(p) ^ ")."),
-    StoreConditional(p)    => internal_error(__FILE__, __LINE__, "PMA: Invalid misaligned store-conditional (" ^ mem_payload_name(p) ^ ")."),
-    CacheAccess(_)         => internal_error(__FILE__, __LINE__, "PMA: Invalid misaligned cache-access."),
+    InstructionFetch()        => internal_error(__FILE__, __LINE__, "PMA: Invalid misaligned instruction fetch."),
+    LoadReserved(_, _, p)     => internal_error(__FILE__, __LINE__, "PMA: Invalid misaligned load-reserved (" ^ mem_payload_name(p) ^ ")."),
+    StoreConditional(_, _, p) => internal_error(__FILE__, __LINE__, "PMA: Invalid misaligned store-conditional (" ^ mem_payload_name(p) ^ ")."),
+    CacheAccess(_)            => internal_error(__FILE__, __LINE__, "PMA: Invalid misaligned cache-access."),
   }
 }
 

--- a/model/sys/vmem_pte.sail
+++ b/model/sys/vmem_pte.sail
@@ -169,28 +169,28 @@ private function check_PTE_permission(
       Store(PageTableEntry) => false,
       // "the shadow stack is readable by all instructions that only load from
       // memory."
-      Load(Data)         => true,
-      Load(Vector)       => true,
-      Load(ShadowStack)  => true,
-      LoadReserved(Data) => true,
+      Load(Data)               => true,
+      Load(Vector)             => true,
+      Load(ShadowStack)        => true,
+      LoadReserved(_, _, Data) => true,
 
       // "Memory mapped as an SS page cannot be written to by instructions other
       // than SSAMOSWAP.W/D, SSPUSH, and C.SSPUSH."
-      Store(Data)                         => false,
-      Store(Vector)                       => false,
-      StoreConditional(Data)              => false,
-      Atomic(_, Data, Data)               => false,
-      Store(ShadowStack)                  => true,
-      Atomic(_, ShadowStack, ShadowStack) => true,
+      Store(Data)                               => false,
+      Store(Vector)                             => false,
+      StoreConditional(_, _, Data)              => false,
+      Atomic(_, _, _, Data, Data)               => false,
+      Store(ShadowStack)                        => true,
+      Atomic(_, _, _, ShadowStack, ShadowStack) => true,
 
       // "Access to a SS page using cache-block operation (CBO.*) instructions
       // is not permitted. Such accesses will raise a store/AMO access-fault
       // exception."
       CacheAccess(_) => false,
 
-      LoadReserved(p)                => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
-      StoreConditional(p)            => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),
-      Atomic(_, rp, wp)              => internal_error(__FILE__, __LINE__, "Invalid payloads (" ^ mem_payload_name(rp) ^ ", " ^ mem_payload_name(wp) ^ ") for Atomic."),
+      LoadReserved(_, _, p)          => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
+      StoreConditional(_, _, p)      => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),
+      Atomic(_, _, _, rp, wp)        => internal_error(__FILE__, __LINE__, "Invalid payloads (" ^ mem_payload_name(rp) ^ ", " ^ mem_payload_name(wp) ^ ") for Atomic."),
 
     };
     if not(shadow_stack_ok) then return PTE_Check_Failure((), PTE_No_Access());
@@ -213,7 +213,7 @@ private function check_PTE_permission(
     LoadReserved(_)             => pte_R,
     Store(_)                    => pte_W,
     StoreConditional(_)         => pte_W,
-    Atomic(_, _, _)             => pte_W & pte_R,
+    Atomic(_)                   => pte_W & pte_R,
     InstructionFetch(_)         => pte_X,
     CacheAccess(CB_zero())      => pte_W,
     CacheAccess(CB_prefetch(p)) => match p {
@@ -265,7 +265,7 @@ private function update_PTE_Bits forall 'pte_size, 'pte_size in {32, 64} . (
                              // _not_ update the D bit if the SC fails for
                              // whatever reason.
                              StoreConditional(_)         => true,
-                             Atomic(_, _, _)             => true,
+                             Atomic(_)                   => true,
                              // "As implied by omission, a cache-block
                              // management instruction does not check the dirty
                              // bit and neither raises an exception nor sets the

--- a/model/sys/vmem_ptw.sail
+++ b/model/sys/vmem_ptw.sail
@@ -53,9 +53,9 @@ function translationException(access : MemoryAccessType(mem_payload),
                               err : PTW_Error)
                              -> ExceptionType = {
   match (access, err) {
-    (_, PTW_Ext_Error(e))                        => E_Extension(ext_translate_exception(e)),
-    (Atomic(_, Data, Data), PTW_No_Access())     => E_SAMO_Access_Fault(),
-    (Atomic(_, Data, Data), _)                   => E_SAMO_Page_Fault(),
+    (_, PTW_Ext_Error(e))                          => E_Extension(ext_translate_exception(e)),
+    (Atomic(_, _, _, Data, Data), PTW_No_Access()) => E_SAMO_Access_Fault(),
+    (Atomic(_, _, _, Data, Data), _)               => E_SAMO_Page_Fault(),
 
     (Load(Data), PTW_No_Access())                => E_Load_Access_Fault(),
     (Load(Data), _)                              => E_Load_Page_Fault(),
@@ -63,8 +63,8 @@ function translationException(access : MemoryAccessType(mem_payload),
     (Load(Vector), _)                            => E_Load_Page_Fault(),
     (Load(PageTableEntry), PTW_No_Access())      => E_Load_Access_Fault(),
     (Load(PageTableEntry), _)                    => E_Load_Page_Fault(),
-    (LoadReserved(Data), PTW_No_Access())        => E_Load_Access_Fault(),
-    (LoadReserved(Data), _)                      => E_Load_Page_Fault(),
+    (LoadReserved(_, _, Data), PTW_No_Access())  => E_Load_Access_Fault(),
+    (LoadReserved(_, _, Data), _)                => E_Load_Page_Fault(),
 
     (Store(Data), PTW_No_Access())               => E_SAMO_Access_Fault(),
     (Store(Data), _)                             => E_SAMO_Page_Fault(),
@@ -72,15 +72,16 @@ function translationException(access : MemoryAccessType(mem_payload),
     (Store(Vector), _)                           => E_SAMO_Page_Fault(),
     (Store(PageTableEntry), PTW_No_Access())     => E_SAMO_Access_Fault(),
     (Store(PageTableEntry), _)                   => E_SAMO_Page_Fault(),
-    (StoreConditional(Data), PTW_No_Access())    => E_SAMO_Access_Fault(),
-    (StoreConditional(Data), _)                  => E_SAMO_Page_Fault(),
+
+    (StoreConditional(_, _, Data), PTW_No_Access()) => E_SAMO_Access_Fault(),
+    (StoreConditional(_, _, Data), _)               => E_SAMO_Page_Fault(),
 
     // "For shadow stack instructions, the reported instruction type is
     // always as though it were a store or AMO, even for instructions
     // SSPOPCHK and C.SSPOPCHK that only read from memory and do not
     // write to it."
-    (Atomic(_, ShadowStack, ShadowStack), PTW_No_Access()) => E_SAMO_Access_Fault(),
-    (Atomic(_, ShadowStack, ShadowStack), _)               => E_SAMO_Page_Fault(),
+    (Atomic(_, _, _, ShadowStack, ShadowStack), PTW_No_Access()) => E_SAMO_Access_Fault(),
+    (Atomic(_, _, _, ShadowStack, ShadowStack), _)               => E_SAMO_Page_Fault(),
 
     (Load(ShadowStack), PTW_No_Access())         => E_SAMO_Access_Fault(),
     (Load(ShadowStack), _)                       => E_SAMO_Page_Fault(),
@@ -110,8 +111,8 @@ function translationException(access : MemoryAccessType(mem_payload),
       PREFETCH_I => E_Fetch_Page_Fault(),
     },
 
-    (LoadReserved(p), _)                => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
-    (StoreConditional(p), _)            => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),
-    (Atomic(_, rp, wp), _)              => internal_error(__FILE__, __LINE__, "Invalid payloads (" ^ mem_payload_name(rp) ^ ", " ^ mem_payload_name(wp) ^ ") for Atomic."),
+    (LoadReserved(_, _, p), _)          => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
+    (StoreConditional(_, _, p), _)      => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),
+    (Atomic(_, _, _, rp, wp), _)        => internal_error(__FILE__, __LINE__, "Invalid payloads (" ^ mem_payload_name(rp) ^ ", " ^ mem_payload_name(wp) ^ ") for Atomic."),
   }
 }

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -207,7 +207,7 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
             Some(e) => return Err(memory_exception(Virtaddr(vaddr), e)),
             None()  => write_success = false,
           }
-        } else match mem_write_ea(paddr, bytes, aq, rl, res) {
+        } else match mem_write_ea(paddr, bytes, access, aq, rl, res) {
           Err(e) => return Err(memory_exception(Virtaddr(vaddr), e)),
 
           Ok(()) => {


### PR DESCRIPTION
This merely adds the flags but does not use them.  A subsequent PR will use these flags where needed instead of the three bool arguments in the memory access functions.

The access type is also made an argument for `mem_write_ea` which only looked at the `aq`/`rl` flags; having the full access type will make it possible for `mem_write_ea` and `mem_write` to enforce the same PMP/PMA checks on the access (see #1761).