### PR TITLE
Fixes to Vector Illegal Instruction Traps

### DIFF
--- a/model/extensions/V/vext_arith_insts.sail
+++ b/model/extensions/V/vext_arith_insts.sail
@@ -1925,7 +1925,7 @@ function clause execute VMVXS(vs2, rd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, 0) |
+  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, LMUL_pow) |
      illegal_vd_unmasked()
   then return Illegal_Instruction();
 
@@ -2453,7 +2453,7 @@ function clause execute VMVSX(rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, 0) |
+  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, LMUL_pow) |
      illegal_vd_unmasked()
   then return Illegal_Instruction();
 

--- a/model/extensions/V/vext_arith_insts.sail
+++ b/model/extensions/V/vext_arith_insts.sail
@@ -1922,10 +1922,13 @@ mapping clause encdec = VMVXS(vs2, rd)
 
 function clause execute VMVXS(vs2, rd) = {
   let SEW      = get_sew();
+  let num_elem = get_num_elem(0, SEW);
+  // Scalar move instructions disregard LMUL, but for the purposes of finding an illegal vstart,
+  // some implementations use LMUL for the bounds check, and this helps match those implementations.
   let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem_vstart = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, LMUL_pow) |
+  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem_vstart, LMUL_pow) |
      illegal_vd_unmasked()
   then return Illegal_Instruction();
 
@@ -2450,10 +2453,12 @@ mapping clause encdec = VMVSX(rs1, vd)
 
 function clause execute VMVSX(rs1, vd) = {
   let SEW      = get_sew();
+  let num_elem = get_num_elem(0, SEW);
+  // See above comment in VMVXS for why LMUL is used here
   let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem_vstart = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, LMUL_pow) |
+  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem_vstart, LMUL_pow) |
      illegal_vd_unmasked()
   then return Illegal_Instruction();
 
@@ -2480,7 +2485,7 @@ function clause execute VMVSX(rs1, vd) = {
     }
   };
 
-  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  write_vreg(num_elem, SEW, 0, vd, result);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }

--- a/model/extensions/V/vext_arith_insts.sail
+++ b/model/extensions/V/vext_arith_insts.sail
@@ -1922,7 +1922,8 @@ mapping clause encdec = VMVXS(vs2, rd)
 
 function clause execute VMVXS(vs2, rd) = {
   let SEW      = get_sew();
-  let num_elem = get_num_elem(0, SEW);
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, 0) |
      illegal_vd_unmasked()
@@ -2449,7 +2450,8 @@ mapping clause encdec = VMVSX(rs1, vd)
 
 function clause execute VMVSX(rs1, vd) = {
   let SEW      = get_sew();
-  let num_elem = get_num_elem(0, SEW);
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, 0) |
      illegal_vd_unmasked()
@@ -2478,7 +2480,7 @@ function clause execute VMVSX(rs1, vd) = {
     }
   };
 
-  write_vreg(num_elem, SEW, 0, vd, result);
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }

--- a/model/extensions/V/vext_fp_insts.sail
+++ b/model/extensions/V/vext_fp_insts.sail
@@ -896,7 +896,7 @@ function clause execute VFMVFS(vs2, rd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, 0) | illegal_fp_vd_unmasked(SEW, rm_3b) | SEW > flen
+  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, LMUL_pow) | illegal_fp_vd_unmasked(SEW, rm_3b) | SEW > flen
   then return Illegal_Instruction();
 
   assert(num_elem > 0 & SEW != 8);
@@ -1431,7 +1431,7 @@ function clause execute VFMVSF(rs1, vd) = {
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, 0) | illegal_fp_vd_unmasked(SEW, rm_3b) then return Illegal_Instruction();
+  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, LMUL_pow) | illegal_fp_vd_unmasked(SEW, rm_3b) then return Illegal_Instruction();
 
   assert(num_elem > 0 & SEW != 8);
 

--- a/model/extensions/V/vext_fp_insts.sail
+++ b/model/extensions/V/vext_fp_insts.sail
@@ -893,7 +893,8 @@ mapping clause encdec = VFMVFS(vs2, rd)
 function clause execute VFMVFS(vs2, rd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
-  let num_elem = get_num_elem(0, SEW);
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, 0) | illegal_fp_vd_unmasked(SEW, rm_3b) | SEW > flen
   then return Illegal_Instruction();
@@ -1427,7 +1428,8 @@ mapping clause encdec = VFMVSF(rs1, vd)
 function clause execute VFMVSF(rs1, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
-  let num_elem = get_num_elem(0, SEW);
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
 
   if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, 0) | illegal_fp_vd_unmasked(SEW, rm_3b) then return Illegal_Instruction();
 
@@ -1454,7 +1456,7 @@ function clause execute VFMVSF(rs1, vd) = {
     }
   };
 
-  write_vreg(num_elem, SEW, 0, vd, result);
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }

--- a/model/extensions/V/vext_fp_insts.sail
+++ b/model/extensions/V/vext_fp_insts.sail
@@ -893,10 +893,12 @@ mapping clause encdec = VFMVFS(vs2, rd)
 function clause execute VFMVFS(vs2, rd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
+  let num_elem = get_num_elem(0, SEW);
+  // See comment in VMVXS for the use of LMUL
   let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem_vstart = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, LMUL_pow) | illegal_fp_vd_unmasked(SEW, rm_3b) | SEW > flen
+  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem_vstart, LMUL_pow) | illegal_fp_vd_unmasked(SEW, rm_3b) | SEW > flen
   then return Illegal_Instruction();
 
   assert(num_elem > 0 & SEW != 8);
@@ -1428,10 +1430,12 @@ mapping clause encdec = VFMVSF(rs1, vd)
 function clause execute VFMVSF(rs1, vd) = {
   let rm_3b    = fcsr[FRM];
   let SEW      = get_sew();
+  let num_elem = get_num_elem(0, SEW);
+  // See VMVXS for LMUL usage here
   let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let num_elem_vstart = get_num_elem(LMUL_pow, SEW);
 
-  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem, LMUL_pow) | illegal_fp_vd_unmasked(SEW, rm_3b) then return Illegal_Instruction();
+  if illegal_vstart(VSTART_SCALAR_MOVE, num_elem_vstart, LMUL_pow) | illegal_fp_vd_unmasked(SEW, rm_3b) then return Illegal_Instruction();
 
   assert(num_elem > 0 & SEW != 8);
 
@@ -1456,7 +1460,7 @@ function clause execute VFMVSF(rs1, vd) = {
     }
   };
 
-  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  write_vreg(num_elem, SEW, 0, vd, result);
   set_vstart(zeros());
   RETIRE_SUCCESS
 }

--- a/model/extensions/V/vext_fp_red_insts.sail
+++ b/model/extensions/V/vext_fp_red_insts.sail
@@ -112,7 +112,6 @@ function clause execute RFWVVTYPE(_funct6, vm, vs2, vs1, vd) = {
 
   if illegal_vstart(VSTART_MANDATORY, num_elem_vs, LMUL_pow) |
      illegal_fp_widening_reduction(SEW, rm_3b, SEW_widen) |
-     not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_src_overlap(vs2, SEW, LMUL_pow, vs1, SEW_widen, 0)) |
      not(valid_vm_src_overlap(vm, vs1, SEW_widen)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))

--- a/model/extensions/V/vext_fp_red_insts.sail
+++ b/model/extensions/V/vext_fp_red_insts.sail
@@ -113,7 +113,8 @@ function clause execute RFWVVTYPE(_funct6, vm, vs2, vs1, vd) = {
   if illegal_vstart(VSTART_MANDATORY, num_elem_vs, LMUL_pow) |
      illegal_fp_widening_reduction(SEW, rm_3b, SEW_widen) |
      not(valid_reg_group(vs2, LMUL_pow)) |
-     not(valid_vm_src_overlap(vm, vs1, SEW)) |
+     not(valid_src_overlap(vs2, SEW, LMUL_pow, vs1, SEW_widen, 0)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW_widen)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 

--- a/model/extensions/V/vext_fp_red_insts.sail
+++ b/model/extensions/V/vext_fp_red_insts.sail
@@ -37,6 +37,7 @@ function clause execute RFVVTYPE(funct6, vm, vs2, vs1, vd) = {
   if illegal_vstart(VSTART_MANDATORY, num_elem_vs, LMUL_pow) |
      illegal_fp_reduction(SEW, rm_3b) |
      not(valid_reg_group(vs2, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 
@@ -112,6 +113,7 @@ function clause execute RFWVVTYPE(_funct6, vm, vs2, vs1, vd) = {
   if illegal_vstart(VSTART_MANDATORY, num_elem_vs, LMUL_pow) |
      illegal_fp_widening_reduction(SEW, rm_3b, SEW_widen) |
      not(valid_reg_group(vs2, LMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs1, SEW)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
 

--- a/model/extensions/V/vext_mem_insts.sail
+++ b/model/extensions/V/vext_mem_insts.sail
@@ -370,7 +370,7 @@ function clause execute VLXSEGTYPE(nf, vm, vs2, rs1, width, vd, _mop) = {
   let index_dst_overlap : bool =
     if nf == 1
     then not(valid_reg_overlap(vs2, vd, EMUL_index_pow, EMUL_data_pow))          // non-segment indexed load
-    else not(valid_disjoint_reg_groups(vs2, vd, EMUL_index_pow, EMUL_data_pow)); // segment indexed load
+    else not(valid_disjoint_reg_groups_segmented(vs2, vd, EMUL_index_pow, EMUL_data_pow, nf)); // segment indexed load
 
   if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_data_pow) |
      illegal_indexed_load(vd, vm, nf, 2 ^ EEW_index_pow, EMUL_index_pow, EMUL_data_pow) |

--- a/model/extensions/V/vext_mem_insts.sail
+++ b/model/extensions/V/vext_mem_insts.sail
@@ -194,7 +194,10 @@ function clause execute VSSEGTYPE(nf, vm, rs1, width, vs3) = {
   let num_elem = get_num_elem(EMUL_pow, EEW);
   assert(num_elem > 0);
 
-  if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_pow) | illegal_store(vs3, nf, EEW, EMUL_pow) | not(valid_reg_group(vs3, EMUL_pow))
+  if illegal_vstart(VSTART_LOAD_STORE, num_elem, EMUL_pow) |
+     illegal_store(vs3, nf, EEW, EMUL_pow) |
+     not(valid_reg_group(vs3, EMUL_pow)) |
+     not(valid_vm_src_overlap(vm, vs3, EEW))
   then return Illegal_Instruction();
 
   let EMUL_reg = 2 ^ max(EMUL_pow, 0);

--- a/model/extensions/V/vext_red_insts.sail
+++ b/model/extensions/V/vext_red_insts.sail
@@ -32,6 +32,7 @@ function clause execute RIVVTYPE(funct6, vm, vs2, vs1, vd) = {
 
   if illegal_vstart(VSTART_MANDATORY, num_elem_vs, LMUL_pow) |
      illegal_widening_reduction(SEW_widen) |
+     not(valid_src_overlap(vs2, SEW_widen, 0, vs1, SEW, LMUL_pow)) |
      not(valid_vm_src_overlap(vm, vs2, SEW)) |
      not(valid_vm_src_overlap(vm, vs1, SEW_widen))
   then return Illegal_Instruction();

--- a/model/extensions/V/vext_red_insts.sail
+++ b/model/extensions/V/vext_red_insts.sail
@@ -32,7 +32,8 @@ function clause execute RIVVTYPE(funct6, vm, vs2, vs1, vd) = {
 
   if illegal_vstart(VSTART_MANDATORY, num_elem_vs, LMUL_pow) |
      illegal_widening_reduction(SEW_widen) |
-     not(valid_src_overlap(vs2, SEW_widen, 0, vs1, SEW, LMUL_pow)) |
+     not(valid_reg_group(vs2, LMUL_pow)) |
+     not(valid_src_overlap(vs2, SEW, LMUL_pow, vs1, SEW_widen, 0)) |
      not(valid_vm_src_overlap(vm, vs2, SEW)) |
      not(valid_vm_src_overlap(vm, vs1, SEW_widen))
   then return Illegal_Instruction();

--- a/model/extensions/V/vext_red_insts.sail
+++ b/model/extensions/V/vext_red_insts.sail
@@ -32,7 +32,6 @@ function clause execute RIVVTYPE(funct6, vm, vs2, vs1, vd) = {
 
   if illegal_vstart(VSTART_MANDATORY, num_elem_vs, LMUL_pow) |
      illegal_widening_reduction(SEW_widen) |
-     not(valid_reg_group(vs2, LMUL_pow)) |
      not(valid_src_overlap(vs2, SEW, LMUL_pow, vs1, SEW_widen, 0)) |
      not(valid_vm_src_overlap(vm, vs2, SEW)) |
      not(valid_vm_src_overlap(vm, vs1, SEW_widen))

--- a/model/extensions/V/vext_utils_insts.sail
+++ b/model/extensions/V/vext_utils_insts.sail
@@ -142,6 +142,19 @@ function valid_disjoint_reg_groups(rs : vregidx, rd : vregidx, EMUL_pow_rs : int
   rs_int + rs_group <= rd_int | rd_int + rd_group <= rs_int
 }
 
+// Check for valid overlaps in segmented instructions that have an additional number of data fields
+function valid_disjoint_reg_groups_segmented(rs : vregidx, rd : vregidx, EMUL_pow_rs : int, EMUL_pow_rd : int, data_fields: int) -> bool = {
+  let rs_group = 2 ^ max(EMUL_pow_rs, 0);
+  let rd_group = 2 ^ max(EMUL_pow_rd, 0);
+  let rs_int = unsigned(vregidx_bits(rs));
+  let rd_int = unsigned(vregidx_bits(rd));
+
+  if rs_int % rs_group != 0 | rd_int % rd_group != 0
+  then return false;
+
+  rs_int + rs_group <= rd_int | rd_int + rd_group * data_fields <= rs_int
+}
+
 // Check for valid overlaps between source register groups: overlaps
 // are not allowed if the EEWs are different for the two groups; a
 // mask register is considered to have EEW of 1. This also checks if

--- a/model/extensions/V/vext_utils_insts.sail
+++ b/model/extensions/V/vext_utils_insts.sail
@@ -143,7 +143,7 @@ function valid_disjoint_reg_groups(rs : vregidx, rd : vregidx, EMUL_pow_rs : int
 }
 
 // Check for valid overlaps in segmented instructions that have an additional number of data fields
-function valid_disjoint_reg_groups_segmented(rs : vregidx, rd : vregidx, EMUL_pow_rs : int, EMUL_pow_rd : int, data_fields: int) -> bool = {
+function valid_disjoint_reg_groups_segmented(rs : vregidx, rd : vregidx, EMUL_pow_rs : int, EMUL_pow_rd : int, data_fields: nfields) -> bool = {
   let rs_group = 2 ^ max(EMUL_pow_rs, 0);
   let rd_group = 2 ^ max(EMUL_pow_rd, 0);
   let rs_int = unsigned(vregidx_bits(rs));


### PR DESCRIPTION
This PR adds a few fixes to the illegal instruction detection in the vector instructions:

1. This changes the number of elements that are being considered in the vstart check for scalar move instructions, to align it with the way that arithmetic instructions that permit nonzero vstart are handled. This allows sail to match the behavior that I have observed on other implementations that allow nonzero vstart for scalar moves.
2. This adds mask overlap checks for vs3 in VSSEG type instructions and to vs1 in floating point reductions. Both of these follow from the same rule in the spec: "A vector register cannot be used to provide source operands with more than one EEW for a single instruction. A mask register source is considered to have EEW=1 for this constraint. An encoding that would result in the same vector register being read with two or more different EEWs, including when the vector register appears at different positions within two or more vector register groups, is reserved," because mask registers are read at EEW=1.
3. Also following from that rule, this PR adds an overlap constraint to integer widening reductions because the scalar and vector registers are read at different EEWs. 
4. It expands the segmented indexed load overlap check to take the number of segments into account, so that all possible overlaps are checked.
