### PR TITLE
Fix an ordering of `mem_write_ea()` with respect to the read of the data source register for AMOs.

### DIFF
--- a/model/extensions/A/zaamo_insts.sail
+++ b/model/extensions/A/zaamo_insts.sail
@@ -94,11 +94,6 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
     Ok(addr, pbmt, _) => (addr, pbmt),
   };
 
-  // AMOCAS.D for RV32 and AMOCAS.Q for RV64 operate on a pair of
-  // registers. When the first register of a register pair is
-  // x0, then both halves of the pair read/write as zero.
-  let rs2_val : bits('width * 8) = if width <= xlen_bytes then trunc(X(rs2)) else trunc(X_pair(rs2));
-
   let loaded : bits('width * 8) = match mem_write_ea(addr, width, access, aq & rl, rl, true) {
     Err(e) => return memory_exception(vaddr, e),
     Ok(_)  => match mem_read(access, pbmt, addr, width, aq, aq & rl, true) {
@@ -106,6 +101,14 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
       Ok(loaded) => loaded,
     },
   };
+
+  // Sequence the read of `rs2` after the call to `mem_write_ea` with the effective address.
+  // See https://github.com/riscv/sail-riscv/issues/1761.
+
+  // AMOCAS.D for RV32 and AMOCAS.Q for RV64 operate on a pair of
+  // registers. When the first register of a register pair is
+  // x0, then both halves of the pair read/write as zero.
+  let rs2_val : bits('width * 8) = if width <= xlen_bytes then trunc(X(rs2)) else trunc(X_pair(rs2));
 
   let result : bits('width * 8) = match op {
     AMOSWAP => rs2_val,

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -319,6 +319,10 @@ function clause execute STORE(imm, rs2, rs1, width) = {
   // This is checked during decoding.
   assert(width <= xlen_bytes);
 
+  // FIXME: the read of `rs2` should not be done before the
+  // `mem_write_ea` of the effective address.
+  // See https://github.com/riscv/sail-riscv/issues/1761.
+
   let data = X(rs2)[width * 8 - 1 .. 0];
   match vmem_write(rs1, offset, width, data, Store(Data), false, false, false) {
     Ok(_) => RETIRE_SUCCESS,

--- a/model/extensions/cfi/zicfiss_insts.sail
+++ b/model/extensions/cfi/zicfiss_insts.sail
@@ -195,6 +195,9 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
   // release consistency semantics, using the aq and rl bits, to help
   // implement multiprocessor synchronization."
 
+ // Sequence the read of `rs2` after the call to `mem_write_ea` with the effective address.
+ // See https://github.com/riscv/sail-riscv/issues/1761.
+
   let 'width = width;
   let mem_val : bits('width * 8) = match mem_write_ea(paddr, width, access, aq & rl, rl, true) {
     Err(e) => return memory_exception(vaddr, e),


### PR DESCRIPTION
Fixing the ordering issue for `STORE` remains.  See #1761.