### PR TITLE
Bump Sail compiler release to 0.20.2.

### DIFF
--- a/.github/actions/sail-setup/action.yml
+++ b/.github/actions/sail-setup/action.yml
@@ -8,7 +8,7 @@ inputs:
   sail-version:
     description: 'Sail version to install (use "latest" to build from source)'
     required: false
-    default: "0.20.1"
+    default: "0.20.2"
   install-clang:
     description: "Install latest Clang"
     required: false
@@ -18,34 +18,34 @@ inputs:
 #
 #                          | RISC-V Model                 |sail-riscv-tests|first-party-tests|   Rocq    |    Lean        | Linux boot
 #--------------------------------------------------------------------------------------------------------------------------------------
-# ubuntu-22.04 (x86_64):   | Sail:  0.20.1 (binary)       |                |                 |           |                |
+# ubuntu-22.04 (x86_64):   | Sail:  default (binary)      |                |                 |           |                |
 #                          | CMake: 4.1.2 + 3.20.0        |       x        |       x         |           |                |
 #                          | Clang: latest (apt.llvm.org) |                |                 |           |                |
 #--------------------------------------------------------------------------------------------------------------------------------------
-# ubuntu-24.04-arm:        | Sail:  0.20.1 (binary)       |                |                 |           |                |
+# ubuntu-24.04-arm:        | Sail:  default (binary)      |                |                 |           |                |
 #                          | CMake: 4.1.2 + 3.20.0        |       x        |       x         |           |                |
 #                          | Clang: latest (apt.llvm.org) |                |                 |           |                |
 #--------------------------------------------------------------------------------------------------------------------------------------
-# macos-latest:            | Sail:  0.20.1 (opam)         |                |                 |           |                |
+# macos-latest:            | Sail:  default (opam)        |                |                 |           |                |
 #                          | CMake: 4.1.2 + 3.20.0        |       x        |       x         |           |                |
 #                          | Clang: brew versions         |                |                 |           |                |
 #--------------------------------------------------------------------------------------------------------------------------------------
-# ubuntu-latest:           | Sail:  0.20.1 (binary)       |                |                 |           | Sail: latest   |
+# ubuntu-latest:           | Sail:  default (binary)      |                |                 |           | Sail: latest   |
 #                          | CMake: (4.1.2)               |       x        |       x         |           | CMake: (4.1.2) |    x
 #                          | Clang: latest (apt.llvm.org) |                |                 |           | Clang: -       |
 #--------------------------------------------------------------------------------------------------------------------------------------
 # (Container builds)       |                              |                |                 |           |                |
 # ------------------       |                              |                |                 |           |                |
 #                          |                              |                |                 |           |                |
-# rockylinux:8.9           | Sail:  0.20.1                |                |                 |           |                |
+# rockylinux:8.9           | Sail:  default               |                |                 |           |                |
 # runner: ubuntu-latest    | CMake: 3.20.0                |       x        |                 |           |                |
 #                          | Clang: -                     |                |                 |           |                |
 #--------------------------------------------------------------------------------------------------------------------------------------
-# rockylinux:8.9           | Sail:  0.20.1                |                |                 |           |                |
+# rockylinux:8.9           | Sail:  default               |                |                 |           |                |
 # runner: ubuntu-24.04-arm | CMake: 3.20.0                |       x        |                 |           |                |
 #                          | Clang: -                     |                |                 |           |                |
 #--------------------------------------------------------------------------------------------------------------------------------------
-# rocq/rocq-prover:9.0.1   | Sail:  (0.20.1)              |                |                 |           |                |
+# rocq/rocq-prover:9.0.1   | Sail:  (default)             |                |                 |           |                |
 # runner: ubuntu-latest    | CMake: (4.1.2)               |                |                 | coq 9.0.1 |                |
 #                          | Clang: -                     |                |                 |           |                |
 
@@ -111,7 +111,7 @@ runs:
       shell: bash
       run: |
         sudo mkdir -p /usr/local
-        curl --location https://github.com/rems-project/sail/releases/download/${{ inputs.sail-version }}/sail-$(uname)-$(arch).tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
+        curl --location https://github.com/rems-project/sail/releases/download/${{ inputs.sail-version }}-binary/sail-$(uname)-$(arch).tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
 
     - name: Install Sail (macOS opam)
       if: runner.os == 'macOS' && steps.cache-opam-restore.outputs.cache-hit != 'true' && inputs.sail-version != 'latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
     container: ${{ matrix.container }}
 
     env:
-      SAIL_VERSION: "0.20.1"
+      SAIL_VERSION: "0.20.2"
       # This helps with reproducible builds by not embedding variable timestamps in files.
       # This is needed in particular for the Debian package's compressed changelog.
       # See the comments in `cmake/packaging.cmake`.

--- a/.github/workflows/rocq.yml
+++ b/.github/workflows/rocq.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OPAMROOT: /home/rocq/.opam
-      SAIL_VERSION: "0.20.1"
+      SAIL_VERSION: "0.20.2"
     container:
       image: rocq/rocq-prover:9.0.1
       # github requires root to access some resources from outside the container

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ project(sail-riscv
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-set(SAIL_REQUIRED_VER 0.20.1)
+set(SAIL_REQUIRED_VER 0.20.2)
 
 # Make users explicitly pick a build type so they don't get
 # surprised when the default gives a very slow emulator.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ ./build_simulator.sh
 
 will build the simulator at `build/c_emulator/sail_riscv_sim`.
 
-If you get an error message saying `sail: unknown option '--require-version'.` it's because your Sail compiler is too old. You need version 0.20.1 or later.
+If you get an error message saying `sail: unknown option '--require-version'.` it's because your Sail compiler is too old. You need version 0.20.2 or later.
 
 By default [`build_simulator.sh`](./build_simulator.sh) will download and build [libgmp](https://gmplib.org).
 To use a system installation of libgmp, run `env DOWNLOAD_GMP=FALSE ./build_simulator.sh` instead.

--- a/coq-sail-riscv.opam
+++ b/coq-sail-riscv.opam
@@ -17,18 +17,18 @@ install: [
   ["sh" "-c" "install build/rocq/* `coqc -where`/user-contrib/Riscv"]
 ]
 depends: [
-  "sail" {>= "0.20.1"}
-  "sail_c_backend" {>= "0.20.1"}
-  "sail_coq_backend" {>= "0.20.1"}
-  "sail_doc_backend" {>= "0.20.1"}
-  "sail_latex_backend" {>= "0.20.1"}
-  "sail_lean_backend" {>= "0.20.1"}
-  "sail_lem_backend" {>= "0.20.1"}
-  "sail_smt_backend" {>= "0.20.1"}
-  "sail_sv_backend" {>= "0.20.1"}
-  "sail_ocaml_backend" {>= "0.20.1"}
-  "sail_output" {>= "0.20.1"}
-  "coq-sail-stdpp" {>= "0.20.1"}
+  "sail" {>= "0.20.2"}
+  "sail_c_backend" {>= "0.20.2"}
+  "sail_coq_backend" {>= "0.20.2"}
+  "sail_doc_backend" {>= "0.20.2"}
+  "sail_latex_backend" {>= "0.20.2"}
+  "sail_lean_backend" {>= "0.20.2"}
+  "sail_lem_backend" {>= "0.20.2"}
+  "sail_smt_backend" {>= "0.20.2"}
+  "sail_sv_backend" {>= "0.20.2"}
+  "sail_ocaml_backend" {>= "0.20.2"}
+  "sail_output" {>= "0.20.2"}
+  "coq-sail-stdpp" {>= "0.20.2"}
   "conf-cmake"
 ]
 synopsis:

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -5,6 +5,9 @@
   - https://github.com/riscv/sail-riscv/issues/1748 : Segment loads/stores whose register numbers increment past v31 were not treated as reserved.
   - https://github.com/riscv/sail-riscv/issues/1069 : `vssubu` did not set `vxsat`
 
+- Other notes:
+  - The model now requires the Sail 0.20.2 compiler version.
+
 # Release notes for version 0.12
 
 The main highlights of this release are the addition of the pointer


### PR DESCRIPTION
This updates the download location for the binary releases.