### PR TITLE
Convert the model callback API to use `shared_ptr`.

### DIFF
--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -8,13 +8,13 @@
 #include "riscv_callbacks_if.h"
 #include "symbol_table.h"
 
-void ModelImpl::register_callback(callbacks_if *cb) {
+void ModelImpl::register_callback(std::shared_ptr<callbacks_if> cb) {
   if (std::find(m_callbacks.begin(), m_callbacks.end(), cb) == m_callbacks.end()) {
     m_callbacks.push_back(cb);
   }
 }
 
-void ModelImpl::remove_callback(callbacks_if *cb) {
+void ModelImpl::remove_callback(std::shared_ptr<callbacks_if> cb) {
   m_callbacks.erase(std::remove(m_callbacks.begin(), m_callbacks.end(), cb), m_callbacks.end());
 }
 

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <map>
+#include <memory>
 #include <optional>
 #include <random>
 #include <vector>
@@ -22,8 +23,8 @@ public:
 
   // callbacks
 
-  void register_callback(callbacks_if *cb);
-  void remove_callback(callbacks_if *cb);
+  void register_callback(std::shared_ptr<callbacks_if> cb);
+  void remove_callback(std::shared_ptr<callbacks_if> cb);
 
   void call_pre_step_callbacks(bool is_waiting);
   void call_post_step_callbacks(bool is_waiting);
@@ -170,8 +171,7 @@ private:
   std::map<uint64_t, std::string> m_symbols;
   int m_term_fd = 1;
 
-  // TODO: Probably better with std::shared_ptr<callbacks_if>.
-  std::vector<callbacks_if *> m_callbacks;
+  std::vector<std::shared_ptr<callbacks_if>> m_callbacks;
 
   uint64_t m_reservation = 0;
   uint64_t m_reservation_addr = 0;

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -20,12 +20,6 @@
 using std::chrono::duration_cast;
 using std::chrono::milliseconds;
 
-namespace {
-
-rvfi_callbacks rvfi_cbs;
-
-} // namespace
-
 static void print_build_info() {
   std::cout << "Sail RISC-V release: " << version_info::release_version() << std::endl;
   std::cout << "Sail RISC-V git: " << version_info::git_version() << std::endl;
@@ -228,7 +222,7 @@ void flush_logs(run_info &run_info) {
 void run_sail(
   ModelImpl &model,
   const CLIOptions &opts,
-  traploop_detector &loop_detector,
+  std::shared_ptr<traploop_detector> loop_detector,
   const elf_info &elf_info,
   run_info &run_info
 ) {
@@ -325,12 +319,12 @@ void run_sail(
       model.tick_clock();
     }
 
-    if (loop_detector.loop_detected()) {
+    if (loop_detector->loop_detected()) {
       fprintf(
         stdout,
         "FAILURE: possible trap loop detected with MEPC=0x%" PRIx64 " and SEPC=0x%" PRIx64 "\n",
-        loop_detector.mepc(),
-        loop_detector.sepc()
+        loop_detector->mepc(),
+        loop_detector->sepc()
       );
       exit(EXIT_FAILURE);
     }
@@ -520,7 +514,7 @@ uint64_t init_model(CLIOptions &opts, ModelImpl &model, elf_info &elf_info, run_
     if (!run_info.rvfi->setup_socket(opts.config_print_rvfi)) {
       return 1;
     }
-    model.register_callback(&rvfi_cbs);
+    model.register_callback(std::make_shared<rvfi_callbacks>());
   }
 
   if (!opts.dtb_file.empty()) {

--- a/c_emulator/riscv_sim.h
+++ b/c_emulator/riscv_sim.h
@@ -60,7 +60,7 @@ uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file
 void run_sail(
   ModelImpl &model,
   const CLIOptions &opts,
-  traploop_detector &loop_detector,
+  std::shared_ptr<traploop_detector> loop_detector,
   const elf_info &elf_info,
   run_info &run_info
 );

--- a/c_emulator/sail_riscv_sim.cpp
+++ b/c_emulator/sail_riscv_sim.cpp
@@ -7,12 +7,12 @@
 #include <iostream>
 
 void run_model(CLIOptions &opts, ModelImpl &model, uint64_t entry, const elf_info &elf_info, run_info &run_info) {
-  traploop_detector loop_detector;
+  auto loop_detector = std::make_shared<traploop_detector>();
   if (!opts.disable_trap_loop_detection) {
-    model.register_callback(&loop_detector);
+    model.register_callback(loop_detector);
   }
 
-  log_callbacks log_cbs(
+  auto log_cbs = std::make_shared<log_callbacks>(
     opts.config_print_gpr,
     opts.config_print_fpr,
     opts.config_print_vreg,
@@ -23,7 +23,7 @@ void run_model(CLIOptions &opts, ModelImpl &model, uint64_t entry, const elf_inf
     opts.config_use_abi_names,
     run_info.trace_log
   );
-  model.register_callback(&log_cbs);
+  model.register_callback(log_cbs);
 
   do {
     run_sail(model, opts, loop_detector, elf_info, run_info);
@@ -31,7 +31,7 @@ void run_model(CLIOptions &opts, ModelImpl &model, uint64_t entry, const elf_inf
     if (run_info.rvfi) {
       /* Reset for next test */
       model.reinit_sail();
-      loop_detector.reset();
+      loop_detector->reset();
     }
   } while (run_info.rvfi);
 }


### PR DESCRIPTION
This fixes a TODO and removes the `rvfi_cbs` global. It also addresses some warnings from a slightly strengthened `clang-tidy` config (not checked in yet since too many other warnings need fixing).