### PR TITLE
Enforce more fault consistency between `mem_write_ea` and `mem_write_value`.

### DIFF
--- a/model/extensions/A/zaamo_insts.sail
+++ b/model/extensions/A/zaamo_insts.sail
@@ -94,7 +94,7 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
     Ok(addr, pbmt, _) => (addr, pbmt),
   };
 
-  let loaded : bits('width * 8) = match mem_write_ea(addr, width, access, aq & rl, rl, true) {
+  let loaded : bits('width * 8) = match mem_write_ea(addr, width, access, pbmt, aq & rl, rl, true) {
     Err(e) => return memory_exception(vaddr, e),
     Ok(_)  => match mem_read(access, pbmt, addr, width, aq, aq & rl, true) {
       Err(e)     => return memory_exception(vaddr, e),

--- a/model/extensions/Zicboz/zicboz_insts.sail
+++ b/model/extensions/Zicboz/zicboz_insts.sail
@@ -51,7 +51,7 @@ function clause execute ZICBOZ(rs1) = {
         // equal to rs1, but pointer masking can change that.
         Err(e, _) => memory_exception(vaddr - negative_offset, e),
         Ok(paddr, pbmt, _) => {
-          match mem_write_ea(paddr, cache_block_size, access, false, false, false) {
+          match mem_write_ea(paddr, cache_block_size, access, pbmt, false, false, false) {
             Err(e) => memory_exception(vaddr - negative_offset, e),
             Ok(_)  => {
               match mem_write_value(paddr, cache_block_size, zeros(), access, pbmt, false, false, false) {

--- a/model/extensions/cfi/zicfiss_insts.sail
+++ b/model/extensions/cfi/zicfiss_insts.sail
@@ -199,7 +199,7 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
  // See https://github.com/riscv/sail-riscv/issues/1761.
 
   let 'width = width;
-  let mem_val : bits('width * 8) = match mem_write_ea(paddr, width, access, aq & rl, rl, true) {
+  let mem_val : bits('width * 8) = match mem_write_ea(paddr, width, access, pbmt, aq & rl, rl, true) {
     Err(e) => return memory_exception(vaddr, e),
     Ok(_)  => match mem_read(access, pbmt, paddr, width, aq, aq & rl, true) {
       Err(e) => return memory_exception(vaddr, e),

--- a/model/sys/mem.sail
+++ b/model/sys/mem.sail
@@ -253,11 +253,29 @@ function mem_read_priv (access, pbmt, priv, paddr, width, aq, rl, res) =
 function mem_read (access, pbmt, paddr, width, aq, rel, res) =
   mem_read_priv(access, pbmt, effectivePrivilege(access, mstatus, cur_privilege), paddr, width, aq, rel, res)
 
-val mem_write_ea : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), MemoryAccessType(mem_payload), bool, bool, bool) -> MemoryOpResult(unit)
-function mem_write_ea(addr, width, _access, aq, rl, con) =
-  if (rl | con) & not(is_aligned_addr(addr, width))
-  then Err(E_SAMO_Addr_Align())
-  else Ok(write_ram_ea(write_kind_of_flags(aq, rl, con), addr, width))
+// This function is always called before `mem_write_value`, i.e. it is not used before `mem_write_value_priv`.
+// It hence operates at effective privilege.
+val mem_write_ea : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), MemoryAccessType(mem_payload), page_based_mem_type, bool, bool, bool) -> MemoryOpResult(unit)
+function mem_write_ea(addr, width, access, pbmt, aq, rl, con) = {
+  let priv = effectivePrivilege(access, mstatus, cur_privilege);
+
+  // This function should only succeed when `mem_write_value` would
+  // succeed, and fail when `mem_write_value` would fail. This means
+  // it should at least perform the same PMP/PMA checks. However,
+  // there is a corner case that is not handled here: writes to MMIO
+  // regions, where the failure of those writes can only be determined
+  // currently by actually trying to perform those writes. In such
+  // cases, `mem_write_ea` could still succeed when the
+  // `mem_write_value` would fail. Since `mem_write_ea` is used only
+  // for the concurrency model, this will be an issue when that model
+  // is extended for MMIO, but until then, this should suffice for
+  // concurrency of RAM accesses.
+
+  match phys_access_check(access, pbmt, priv, addr, width, con) {
+    None()  => Ok(write_ram_ea(write_kind_of_flags(aq, rl, con), addr, width)),
+    Some(e) => Err(e)
+  }
+}
 
 // dispatches to MMIO regions or physical memory regions depending on physical memory map
 function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -150,7 +150,7 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
             Some(e) => return Err(memory_exception(Virtaddr(vaddr), e)),
             None()  => write_success = false,
           }
-        } else match mem_write_ea(paddr, bytes, access, aq, rl, res) {
+        } else match mem_write_ea(paddr, bytes, access, pbmt, aq, rl, res) {
           Err(e) => return Err(memory_exception(Virtaddr(vaddr), e)),
 
           Ok(()) => {


### PR DESCRIPTION
There is still a corner case for MMIO, which may need revisiting when the concurrency model is extended to MMIO regions.

This fixes one of the issues mentioned in #1761.