### PR TITLE
More clang-tidy cleanup.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,13 @@
 Checks: >
   -*,
   bugprone*,
-  -bugprone-easily-swappable-parameters
+  -bugprone-easily-swappable-parameters,
+  clang-diagnostic-*,
+  misc-*,
+  -misc-include-cleaner,
+  -misc-const-correctness,
+  -misc-no-recursion,
+  -misc-use-anonymous-namespace
 
 HeaderFilterRegex: ""
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,8 +7,7 @@ Checks: >
   misc-*,
   -misc-include-cleaner,
   -misc-const-correctness,
-  -misc-no-recursion,
-  -misc-use-anonymous-namespace
+  -misc-no-recursion
 
 HeaderFilterRegex: ""
 ...

--- a/c_emulator/config_utils.cpp
+++ b/c_emulator/config_utils.cpp
@@ -12,6 +12,8 @@
 #include "sail_config.h"
 #include "sail_riscv_model.h"
 
+namespace {
+
 std::string keypath_to_str(const std::vector<const char *> &keypath) {
   std::string s;
   if (keypath.empty()) {
@@ -24,6 +26,8 @@ std::string keypath_to_str(const std::vector<const char *> &keypath) {
   s.pop_back();
   return s;
 }
+
+} // namespace
 
 uint64_t get_config_uint64(const std::vector<const char *> &keypath) {
   sail_config_json json = sail_config_get(keypath.size(), keypath.data());

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -115,8 +115,8 @@ void log_callbacks::vreg_write_callback(ModelImpl &, unsigned reg, lbits value) 
 void log_callbacks::ptw_start_callback(
   ModelImpl &model,
   uint64_t vpn,
-  hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
-  hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+  ModelImpl::MemoryAccessType access_type,
+  ModelImpl::Privilege privilege
 ) {
   if (trace_log != nullptr && config_print_ptw) {
     fprintf(
@@ -149,7 +149,7 @@ void log_callbacks::ptw_success_callback(ModelImpl & /*model*/, uint64_t final_p
 
 void log_callbacks::ptw_fail_callback(
   ModelImpl &model,
-  struct hart::zPTW_Error error_type,
+  ModelImpl::PTW_Error error_type,
   int64_t level,
   sbits pte_addr
 ) {
@@ -164,10 +164,15 @@ void log_callbacks::ptw_fail_callback(
   }
 }
 
-static void print_tlb(
+namespace {
+
+// TODO: make this a class member and avoid a global.
+std::vector<uint64_t> pending_flush_indices;
+
+void print_tlb(
   FILE *trace_log,
-  ModelImpl &model,
-  hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
+  ModelImpl &,
+  ModelImpl::TLB_Entry tlb,
   const std::vector<uint64_t> &indices,
   bool is_flush
 ) {
@@ -226,29 +231,25 @@ static void print_tlb(
   );
 }
 
-void log_callbacks::tlb_add_callback(
-  ModelImpl &model,
-  hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
-  uint64_t index
-) {
+} // namespace
+
+void log_callbacks::tlb_add_callback(ModelImpl &model, ModelImpl::TLB_Entry tlb, uint64_t index) {
   if (trace_log != nullptr && config_print_tlb) {
     print_tlb(trace_log, model, tlb, {index}, false);
   }
 }
 
-std::vector<uint64_t> pending_flush_indices;
-
-void log_callbacks::tlb_flush_begin_callback(ModelImpl &model) {
+void log_callbacks::tlb_flush_begin_callback(ModelImpl &) {
   pending_flush_indices.clear();
 }
 
-void log_callbacks::tlb_flush_callback(ModelImpl &model, uint64_t index) {
+void log_callbacks::tlb_flush_callback(ModelImpl &, uint64_t index) {
   if (config_print_tlb) {
     pending_flush_indices.push_back(index);
   }
 }
 
-void log_callbacks::tlb_flush_end_callback(ModelImpl &model, hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb) {
+void log_callbacks::tlb_flush_end_callback(ModelImpl &model, ModelImpl::TLB_Entry tlb) {
   if (trace_log != nullptr && config_print_tlb && !pending_flush_indices.empty()) {
     print_tlb(trace_log, model, tlb, pending_flush_indices, true);
   }

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -30,20 +30,16 @@ public:
   void ptw_start_callback(
     ModelImpl &model,
     uint64_t vpn,
-    hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
-    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+    ModelImpl::MemoryAccessType access_type,
+    ModelImpl::Privilege privilege
   ) override;
   void ptw_step_callback(ModelImpl &model, int64_t level, sbits pte_addr, uint64_t pte) override;
   void ptw_success_callback(ModelImpl &model, uint64_t final_ppn, int64_t level) override;
-  void ptw_fail_callback(ModelImpl &model, struct hart::zPTW_Error error_type, int64_t level, sbits pte_addr) override;
-  void tlb_add_callback(
-    ModelImpl &model,
-    hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
-    uint64_t index
-  ) override;
+  void ptw_fail_callback(ModelImpl &model, ModelImpl::PTW_Error error_type, int64_t level, sbits pte_addr) override;
+  void tlb_add_callback(ModelImpl &model, ModelImpl::TLB_Entry tlb, uint64_t index) override;
   void tlb_flush_begin_callback(ModelImpl &model) override;
   void tlb_flush_callback(ModelImpl &model, uint64_t index) override;
-  void tlb_flush_end_callback(ModelImpl &model, hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb) override;
+  void tlb_flush_end_callback(ModelImpl &model, ModelImpl::TLB_Entry tlb) override;
 
 private:
   bool config_print_gpr;

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -20,7 +20,11 @@
 using std::chrono::duration_cast;
 using std::chrono::milliseconds;
 
-static void print_build_info() {
+// Internal utilities.
+
+namespace {
+
+void print_build_info() {
   std::cout << "Sail RISC-V release: " << version_info::release_version() << std::endl;
   std::cout << "Sail RISC-V git: " << version_info::git_version() << std::endl;
   std::cout << "Sail: " << version_info::sail_version() << std::endl;
@@ -30,7 +34,7 @@ static void print_build_info() {
   std::cout << "JSONCONS: " << jsoncons::version() << std::endl;
 }
 
-static jsoncons::json parse_json_or_exit(const std::string &json_text, const std::string &source_desc) {
+jsoncons::json parse_json_or_exit(const std::string &json_text, const std::string &source_desc) {
   try {
     return jsoncons::json::parse(json_text);
   } catch (const jsoncons::json_exception &e) {
@@ -54,6 +58,66 @@ void deep_merge_json(jsoncons::json &base, const jsoncons::json &json_override) 
     }
   }
 }
+
+void write_dtb_to_rom(ModelImpl &model, const std::vector<uint8_t> &dtb) {
+  uint64_t addr = get_config_uint64({"memory", "dtb_address"});
+  uint64_t size = static_cast<uint64_t>(dtb.size());
+
+  // Overflow check for addr + size - 1
+  uint64_t end = addr + size - 1;
+  if (end < addr) {
+    fprintf(stderr, "DTB address/size overflow: addr=0x%0" PRIx64 ", size=0x%0" PRIx64 "\n", addr, size);
+    exit(EXIT_FAILURE);
+  }
+
+  // Validate DTB range against configured PMA memory regions.
+  if (!model.dtb_within_configured_pma_memory(addr, size)) {
+    fprintf(
+      stderr,
+      "DTB does not fit in any configured PMA memory region: "
+      "addr=0x%0" PRIx64 ", size=0x%0" PRIx64 " (end=0x%0" PRIx64 ")\n"
+      "Hint: adjust memory.dtb_address or memory.regions in the config.\n",
+      addr,
+      size,
+      end
+    );
+    exit(EXIT_FAILURE);
+  }
+
+  for (uint8_t d : dtb) {
+    write_mem(addr++, d);
+  }
+}
+
+void write_signature(const std::string &file, unsigned signature_granularity, const elf_info &elf_info) {
+  if (elf_info.mem_sig_start >= elf_info.mem_sig_end) {
+    fprintf(
+      stderr,
+      "Invalid signature region [0x%0" PRIx64 ",0x%0" PRIx64 "] to %s.\n",
+      elf_info.mem_sig_start,
+      elf_info.mem_sig_end,
+      file.c_str()
+    );
+    return;
+  }
+  FILE *f = fopen(file.c_str(), "w");
+  if (!f) {
+    fprintf(stderr, "Cannot open file '%s': %s\n", file.c_str(), strerror(errno));
+    return;
+  }
+  /* write out words depending on signature granularity in signature area */
+  for (uint64_t addr = elf_info.mem_sig_start; addr < elf_info.mem_sig_end; addr += signature_granularity) {
+    /* most-significant byte first */
+    for (unsigned i = signature_granularity; i > 0; --i) {
+      uint8_t byte = static_cast<uint8_t>(read_mem(addr + i - 1));
+      fprintf(f, "%02x", byte);
+    }
+    fprintf(f, "\n");
+  }
+  fclose(f);
+}
+
+} // namespace
 
 uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file, elf_info &elf_info) {
   ELF elf = ELF::open(filename);
@@ -116,64 +180,6 @@ uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file
   }
 
   return elf.entry();
-}
-
-void write_dtb_to_rom(ModelImpl &model, const std::vector<uint8_t> &dtb) {
-  uint64_t addr = get_config_uint64({"memory", "dtb_address"});
-  uint64_t size = static_cast<uint64_t>(dtb.size());
-
-  // Overflow check for addr + size - 1
-  uint64_t end = addr + size - 1;
-  if (end < addr) {
-    fprintf(stderr, "DTB address/size overflow: addr=0x%0" PRIx64 ", size=0x%0" PRIx64 "\n", addr, size);
-    exit(EXIT_FAILURE);
-  }
-
-  // Validate DTB range against configured PMA memory regions.
-  if (!model.dtb_within_configured_pma_memory(addr, size)) {
-    fprintf(
-      stderr,
-      "DTB does not fit in any configured PMA memory region: "
-      "addr=0x%0" PRIx64 ", size=0x%0" PRIx64 " (end=0x%0" PRIx64 ")\n"
-      "Hint: adjust memory.dtb_address or memory.regions in the config.\n",
-      addr,
-      size,
-      end
-    );
-    exit(EXIT_FAILURE);
-  }
-
-  for (uint8_t d : dtb) {
-    write_mem(addr++, d);
-  }
-}
-
-void write_signature(const std::string &file, unsigned signature_granularity, const elf_info &elf_info) {
-  if (elf_info.mem_sig_start >= elf_info.mem_sig_end) {
-    fprintf(
-      stderr,
-      "Invalid signature region [0x%0" PRIx64 ",0x%0" PRIx64 "] to %s.\n",
-      elf_info.mem_sig_start,
-      elf_info.mem_sig_end,
-      file.c_str()
-    );
-    return;
-  }
-  FILE *f = fopen(file.c_str(), "w");
-  if (!f) {
-    fprintf(stderr, "Cannot open file '%s': %s\n", file.c_str(), strerror(errno));
-    return;
-  }
-  /* write out words depending on signature granularity in signature area */
-  for (uint64_t addr = elf_info.mem_sig_start; addr < elf_info.mem_sig_end; addr += signature_granularity) {
-    /* most-significant byte first */
-    for (unsigned i = signature_granularity; i > 0; --i) {
-      uint8_t byte = static_cast<uint8_t>(read_mem(addr + i - 1));
-      fprintf(f, "%02x", byte);
-    }
-    fprintf(f, "\n");
-  }
-  fclose(f);
 }
 
 void close_logs(run_info &run_info) {

--- a/c_emulator/riscv_softfloat.cpp
+++ b/c_emulator/riscv_softfloat.cpp
@@ -5,9 +5,13 @@ extern "C" {
 #include "softfloat.h"
 }
 
-static uint_fast8_t uint8_of_rm(uint64_t rm) {
+namespace {
+
+uint_fast8_t uint8_of_rm(uint64_t rm) {
   return static_cast<uint_fast8_t>(rm);
 }
+
+} // namespace
 
 #define SOFTFLOAT_PRELUDE(rm)                                                                                          \
   softfloat_exceptionFlags = 0;                                                                                        \

--- a/c_emulator/sail_riscv_sim.cpp
+++ b/c_emulator/sail_riscv_sim.cpp
@@ -6,7 +6,9 @@
 
 #include <iostream>
 
-void run_model(CLIOptions &opts, ModelImpl &model, uint64_t entry, const elf_info &elf_info, run_info &run_info) {
+namespace {
+
+void run_model(CLIOptions &opts, ModelImpl &model, uint64_t, const elf_info &elf_info, run_info &run_info) {
   auto loop_detector = std::make_shared<traploop_detector>();
   if (!opts.disable_trap_loop_detection) {
     model.register_callback(loop_detector);
@@ -72,6 +74,8 @@ int inner_main(int argc, char **argv) {
 
   return EXIT_SUCCESS;
 }
+
+} // namespace
 
 int main(int argc, char **argv) {
   // Catch all exceptions and print them a bit more nicely than the default.


### PR DESCRIPTION
Add most of the `misc-*` checks.

This moves local functions into anonymous namespaces (due to `misc-internal-linkage` and `misc-use-anonymous-namespace`) and removes unused parameters (due to `misc-unused-parameters`).

`misc-no-recursion` is disabled as `riscv_sim.cpp:deep_merge_json()` is self-recursive.

`misc-include-cleaner` and `misc-const-correctness` are disabled for now since they require more cleanup (of perhaps questionable value).

This also fixes some missed cases of removing z-encoded type names.