### PR TITLE
Lean: update the handwritten support to new Sail

### DIFF
--- a/handwritten_support/RiscvExtras.lean
+++ b/handwritten_support/RiscvExtras.lean
@@ -11,6 +11,7 @@ import THE_MODULE_NAME.Defs
 
 open Sail
 open ConcurrencyInterfaceV1
+open THE_MODULE_NAME.Defs
 
 def print_bits (_ : String) (_ : BitVec n) : Unit := ()
 def print_string (_ : String) (_ : String) : Unit := ()

--- a/handwritten_support/RiscvExtrasExecutable.lean
+++ b/handwritten_support/RiscvExtrasExecutable.lean
@@ -11,6 +11,7 @@ import THE_MODULE_NAME.Defs
 
 open Sail
 open ConcurrencyInterfaceV1
+open THE_MODULE_NAME.Defs
 
 def print_bits (_ : String) (_ : BitVec n) : Unit := ()
 def print_string (_ : String) (_ : String) : Unit := ()


### PR DESCRIPTION
The namespaces of the generated Lean changed, so the handwritten files need to open the right namespaces.