### PR TITLE
Add a `--dump-memory` CLI option.

### DIFF
--- a/c_emulator/cli_options.cpp
+++ b/c_emulator/cli_options.cpp
@@ -15,6 +15,13 @@ CLIOptions parse_cli(int argc, char **argv) {
   app.add_flag("--validate-config", opts.do_validate_config, "Exit after config validation (it is always validated)");
   app.add_flag("--print-device-tree", opts.do_print_dts, "Print device tree");
   app.add_flag("--print-isa-string", opts.do_print_isa, "Print ISA string");
+  app
+    .add_option(
+      "--dump-memory",
+      opts.dump_memory_prefix,
+      "Dump MainMemory regions at end of simulation using the given prefix"
+    )
+    ->option_text("<prefix>");
   app.add_flag(
     "--enable-experimental-extensions",
     opts.config_enable_experimental_extensions,

--- a/c_emulator/cli_options.h
+++ b/c_emulator/cli_options.h
@@ -15,6 +15,7 @@ struct CLIOptions {
   bool do_print_dts = false;
   bool do_validate_config = false;
   bool do_print_isa = false;
+  std::string dump_memory_prefix = {};
 
   bool use_rv32_default = false;
   bool disable_trap_loop_detection = false;

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -415,6 +415,16 @@ bool ModelImpl::dtb_within_configured_pma_memory(uint64_t addr, uint64_t size) {
   return zdtb_within_configured_pma_memory(addr, size);
 }
 
+std::vector<MemoryRegion> ModelImpl::main_memory_regions() const {
+  std::vector<MemoryRegion> regions;
+  for (auto region = zpma_regions; region != nullptr; region = region->tl) {
+    if (region->hd.zattributes.zmem_type == hart::zMainMemory) {
+      regions.push_back({region->hd.zbase, region->hd.zsizze});
+    }
+  }
+  return regions;
+}
+
 std::string ModelImpl::generate_dts() {
   char *c_dts = nullptr;
   zgenerate_dts(&c_dts, UNIT);

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -11,6 +11,11 @@
 #include "sail.h"
 #include "sail_riscv_model.h"
 
+struct MemoryRegion {
+  uint64_t base = 0;
+  uint64_t size = 0;
+};
+
 // Model wrapped with an implementation of its platform callbacks.
 class ModelImpl final : private hart::Model {
 public:
@@ -69,6 +74,7 @@ public:
 
   bool config_is_valid();
   bool dtb_within_configured_pma_memory(uint64_t addr, uint64_t size);
+  std::vector<MemoryRegion> main_memory_regions() const;
   std::string generate_dts();
   std::string generate_isa_string();
 

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -15,7 +15,11 @@
 #include "symbol_table.h"
 #include "traploop_detector.h"
 
+#include <algorithm>
+#include <cerrno>
+#include <cstring>
 #include <fcntl.h>
+#include <sstream>
 
 using std::chrono::duration_cast;
 using std::chrono::milliseconds;
@@ -117,6 +121,41 @@ void write_signature(const std::string &file, unsigned signature_granularity, co
   fclose(f);
 }
 
+void write_memory_dump(const MemoryRegion &region, const std::string &prefix) {
+  std::ostringstream file_os;
+  file_os << prefix << ".0x" << std::hex << region.base << ".bin";
+  const std::string file = file_os.str();
+
+  FILE *f = fopen(file.c_str(), "wb");
+  if (!f) {
+    fprintf(stderr, "Cannot create memory dump '%s': %s\n", file.c_str(), strerror(errno));
+    return;
+  }
+
+  constexpr size_t buffer_size = 64 * 1024;
+  std::vector<uint8_t> buffer(buffer_size);
+  uint64_t offset = 0;
+  while (offset < region.size) {
+    size_t chunk = static_cast<size_t>(std::min<uint64_t>(buffer.size(), region.size - offset));
+    for (size_t i = 0; i < chunk; ++i) {
+      buffer[i] = static_cast<uint8_t>(read_mem(region.base + offset + i));
+    }
+    if (fwrite(buffer.data(), 1, chunk, f) != chunk) {
+      fprintf(stderr, "Could not write memory dump '%s': %s\n", file.c_str(), strerror(errno));
+      break;
+    }
+    offset += chunk;
+  }
+
+  fclose(f);
+}
+
+void write_memory_dumps(const std::vector<MemoryRegion> &regions, const std::string &prefix) {
+  for (const auto &region : regions) {
+    write_memory_dump(region, prefix);
+  }
+}
+
 } // namespace
 
 uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file, elf_info &elf_info) {
@@ -201,6 +240,9 @@ void finish(ModelImpl &model, const CLIOptions &opts, const elf_info &elf_info, 
   // Don't write a signature if there was an internal Sail exception.
   if (!model.had_exception() && !opts.sig_file.empty()) {
     write_signature(opts.sig_file, opts.signature_granularity, elf_info);
+  }
+  if (!opts.dump_memory_prefix.empty()) {
+    write_memory_dumps(model.main_memory_regions(), opts.dump_memory_prefix);
   }
 
   // `model_fini()` exits with failure if there was a Sail exception.
@@ -401,6 +443,9 @@ InitResult preinit_args(CLIOptions &opts, std::string &config_json_string) {
   }
   if (!opts.trace_log_path.empty()) {
     fprintf(stderr, "using %s for trace output.\n", opts.trace_log_path.c_str());
+  }
+  if (!opts.dump_memory_prefix.empty()) {
+    fprintf(stderr, "will dump main memory on completion using prefix '%s'.\n", opts.dump_memory_prefix.c_str());
   }
 
   if (!opts.config_file.empty()) {


### PR DESCRIPTION
When set, raw memory dump files are written for each MainMemory region after execution ends (similar to Spike's `mem.0x<base>.bin`).

This accompanies the `--stop-at-pc` CLI option; these two options will help the integration of the tests from the RVVTS test framework.

The [RVVTS Framework](https://github.com/ics-jku/RVVTS) is a modular, open-source framework designed for comprehensive testing of RISC-V Vector (RVV) implementations.  This will allow RVV comparisons between the Spike and Sail-RISCV versions. In the medium term, this will also make the automated use of RVVTS in a Sail-RISCV CI workflow possible.