### PR TITLE
Add --stop-at-pc CLI option

### DIFF
--- a/c_emulator/cli_options.cpp
+++ b/c_emulator/cli_options.cpp
@@ -56,6 +56,7 @@ CLIOptions parse_cli(int argc, char **argv) {
     ->check(CLI::Range(1, 65535))
     ->option_text("<int> (within [1 - 65535])");
   app.add_option("--inst-limit", opts.insn_limit, "Instruction limit")->option_text("<uint>");
+  app.add_option("--stop-at-pc", opts.stop_at_pc, "Stop execution when PC reaches address")->option_text("<address>");
 #ifdef SAILCOV
   app.add_option("--sailcov-file", opts.sailcov_file, "Sail coverage output file")->option_text("<file>");
 #endif

--- a/c_emulator/cli_options.h
+++ b/c_emulator/cli_options.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -26,6 +27,7 @@ struct CLIOptions {
   unsigned rvfi_dii_port = 0;
   std::vector<std::string> elfs;
   uint64_t insn_limit = 0;
+  std::optional<uint64_t> stop_at_pc;
 
   std::string sig_file = {};
   unsigned signature_granularity = DEFAULT_SIGNATURE_GRANULARITY;

--- a/c_emulator/riscv_callbacks_stop_at_pc.h
+++ b/c_emulator/riscv_callbacks_stop_at_pc.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdint>
+
+#include "riscv_callbacks_if.h"
+#include "sail.h"
+
+class stop_at_pc_callbacks : public callbacks_if {
+public:
+  explicit stop_at_pc_callbacks(uint64_t pc) : m_pc(pc) {
+  }
+
+  bool stop_requested() const {
+    return m_stop_requested;
+  }
+
+  void pc_write_callback(ModelImpl &, sbits new_pc) override {
+    if (new_pc.bits == m_pc) {
+      m_stop_requested = true;
+    }
+  }
+
+private:
+  uint64_t m_pc = 0;
+  bool m_stop_requested = false;
+};

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -7,6 +7,7 @@
 #include "jsoncons/config/version.hpp"
 #include "jsoncons/json.hpp"
 #include "riscv_callbacks_rvfi.h"
+#include "riscv_callbacks_stop_at_pc.h"
 #include "riscv_model_impl.h"
 #ifdef SAILCOV
 #include "sail_coverage.h"
@@ -229,6 +230,7 @@ void run_sail(
   ModelImpl &model,
   const CLIOptions &opts,
   std::shared_ptr<traploop_detector> loop_detector,
+  std::shared_ptr<stop_at_pc_callbacks> stop_at_pc,
   const elf_info &elf_info,
   run_info &run_info
 ) {
@@ -246,7 +248,8 @@ void run_sail(
 
   auto interval_start = steady_clock::now();
 
-  while (!model.htif_done() && (opts.insn_limit == 0 || run_info.total_insns < opts.insn_limit)) {
+  while (!model.htif_done() && !(stop_at_pc && stop_at_pc->stop_requested()) &&
+         (opts.insn_limit == 0 || run_info.total_insns < opts.insn_limit)) {
     if (run_info.rvfi.has_value()) {
       switch (run_info.rvfi->pre_step(opts.config_print_rvfi)) {
       case RVFI_prestep_continue:

--- a/c_emulator/riscv_sim.h
+++ b/c_emulator/riscv_sim.h
@@ -12,6 +12,7 @@ using std::chrono::steady_clock;
 
 struct CLIOptions;
 class traploop_detector;
+class stop_at_pc_callbacks;
 class ModelImpl;
 
 struct elf_info {
@@ -61,6 +62,7 @@ void run_sail(
   ModelImpl &model,
   const CLIOptions &opts,
   std::shared_ptr<traploop_detector> loop_detector,
+  std::shared_ptr<stop_at_pc_callbacks> stop_at_pc,
   const elf_info &elf_info,
   run_info &run_info
 );

--- a/c_emulator/sail_riscv_sim.cpp
+++ b/c_emulator/sail_riscv_sim.cpp
@@ -1,5 +1,6 @@
 #include "cli_options.h"
 #include "riscv_callbacks_log.h"
+#include "riscv_callbacks_stop_at_pc.h"
 #include "riscv_model_impl.h"
 #include "riscv_sim.h"
 #include "traploop_detector.h"
@@ -12,6 +13,11 @@ void run_model(CLIOptions &opts, ModelImpl &model, uint64_t, const elf_info &elf
   auto loop_detector = std::make_shared<traploop_detector>();
   if (!opts.disable_trap_loop_detection) {
     model.register_callback(loop_detector);
+  }
+  std::shared_ptr<stop_at_pc_callbacks> stop_at_pc;
+  if (opts.stop_at_pc.has_value()) {
+    stop_at_pc = std::make_shared<stop_at_pc_callbacks>(*opts.stop_at_pc);
+    model.register_callback(stop_at_pc);
   }
 
   auto log_cbs = std::make_shared<log_callbacks>(
@@ -28,7 +34,7 @@ void run_model(CLIOptions &opts, ModelImpl &model, uint64_t, const elf_info &elf
   model.register_callback(log_cbs);
 
   do {
-    run_sail(model, opts, loop_detector, elf_info, run_info);
+    run_sail(model, opts, loop_detector, stop_at_pc, elf_info, run_info);
     // `run_sail` only returns in the case of rvfi.
     if (run_info.rvfi) {
       /* Reset for next test */


### PR DESCRIPTION
Add `--stop-at-pc <addr>`. When specified, execution terminates as soon as the specified program counter is reached (similar to Spike's until pc debug command).

See #1779