### PR TITLE
Enable some `readability` checks in `clang-tidy`.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,14 @@ Checks: >
   misc-*,
   -misc-include-cleaner,
   -misc-const-correctness,
-  -misc-no-recursion
+  -misc-no-recursion,
+  readability-*,
+  -readability-identifier-length,
+  -readability-isolate-declaration,
+  -readability-named-parameter,
+  -readability-avoid-nested-conditional-operator,
+  -readability-magic-numbers,
+  -readability-function-cognitive-complexity
 
 HeaderFilterRegex: ""
 ...

--- a/c_emulator/cli_options.cpp
+++ b/c_emulator/cli_options.cpp
@@ -148,7 +148,7 @@ CLIOptions parse_cli(int argc, char **argv) {
   );
 
   std::size_t column_width = 45;
-  app.get_formatter()->long_option_alignment_ratio(6.f / static_cast<float>(column_width));
+  app.get_formatter()->long_option_alignment_ratio(6.F / static_cast<float>(column_width));
   app.get_formatter()->column_width(column_width);
 
   if (argc == 1) {

--- a/c_emulator/config_utils.cpp
+++ b/c_emulator/config_utils.cpp
@@ -19,7 +19,7 @@ std::string keypath_to_str(const std::vector<const char *> &keypath) {
   if (keypath.empty()) {
     return s;
   }
-  for (auto part : keypath) {
+  for (const auto *part : keypath) {
     s += part;
     s += ".";
   }

--- a/c_emulator/riscv_platform_if.cpp
+++ b/c_emulator/riscv_platform_if.cpp
@@ -117,7 +117,7 @@ unit PlatformInterface::ptw_fail_callback(
 
 unit PlatformInterface::tlb_add_callback(
   [[maybe_unused]] hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb,
-  [[maybe_unused]] uint64_t level
+  [[maybe_unused]] uint64_t index
 ) {
   return UNIT;
 }
@@ -126,7 +126,7 @@ unit PlatformInterface::tlb_flush_begin_callback(unit) {
   return UNIT;
 }
 
-unit PlatformInterface::tlb_flush_callback([[maybe_unused]] uint64_t level) {
+unit PlatformInterface::tlb_flush_callback([[maybe_unused]] uint64_t index) {
   return UNIT;
 }
 

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -101,7 +101,7 @@ void write_signature(const std::string &file, unsigned signature_granularity, co
     return;
   }
   FILE *f = fopen(file.c_str(), "w");
-  if (!f) {
+  if (f == nullptr) {
     fprintf(stderr, "Cannot open file '%s': %s\n", file.c_str(), strerror(errno));
     return;
   }
@@ -528,7 +528,7 @@ uint64_t init_model(CLIOptions &opts, ModelImpl &model, elf_info &elf_info, run_
     write_dtb_to_rom(model, read_file(opts.dtb_file));
   }
 
-  uint64_t entry = run_info.rvfi.has_value() ? run_info.rvfi->get_entry()
+  uint64_t entry = run_info.rvfi.has_value() ? rvfi_handler::get_entry()
                                              : load_sail(model, opts.elfs[0], /*main_file=*/true, elf_info);
 
   fprintf(stdout, "Entry point: 0x%" PRIx64 "\n", entry);

--- a/c_emulator/rvfi_dii.cpp
+++ b/c_emulator/rvfi_dii.cpp
@@ -67,9 +67,14 @@ bool rvfi_handler::setup_socket(bool config_print) {
     return false;
   }
   if (config_print) {
-    fprintf(stderr, "RVFI socket fd flags=%d, nonblocking=%d\n", fd_flags, (fd_flags & O_NONBLOCK) != 0);
+    fprintf(
+      stderr,
+      "RVFI socket fd flags=%d, nonblocking=%s\n",
+      fd_flags,
+      ((fd_flags & O_NONBLOCK) != 0) ? "true" : "false"
+    );
   }
-  if (fd_flags & O_NONBLOCK) {
+  if ((fd_flags & O_NONBLOCK) != 0) {
     fprintf(stderr, "Socket was non-blocking, this will not work!\n");
     return false;
   }
@@ -173,11 +178,10 @@ rvfi_prestep_t rvfi_handler::pre_step(bool config_print) {
       }
       get_and_send_packet(&hart::Model::zrvfi_get_v2_support_packet, config_print);
       return RVFI_prestep_continue;
-    } else {
-      m_model.zrvfi_halt_exec_packet(UNIT);
-      send_trace(trace_version);
-      return RVFI_prestep_end_trace;
     }
+    m_model.zrvfi_halt_exec_packet(UNIT);
+    send_trace(trace_version != 0);
+    return RVFI_prestep_end_trace;
   }
   case 1: /* Instruction */
     break;

--- a/c_emulator/rvfi_dii.h
+++ b/c_emulator/rvfi_dii.h
@@ -17,7 +17,7 @@ public:
   explicit rvfi_handler(int port, ModelImpl &model);
 
   bool setup_socket(bool config_print);
-  uint64_t get_entry();
+  static uint64_t get_entry();
   void send_trace(bool config_print);
   rvfi_prestep_t pre_step(bool config_print);
 


### PR DESCRIPTION
Other than some minor cleanup, this interestingly found a mismatch in a parameter name for `tlb_add_callback` and `tlb_flush_callback`, which used `index` in `riscv_platform_if.h` (correctly) and `level` in `riscv_platform_if.cpp` (incorrectly).  This was caught by `readability-inconsistent-declaration-parameter-name`.

`rvfi_handler::gen_entry` which returns a constant was made `static` to satisfy `readability-convert-member-functions-to-static`.

`6.f` was made `6.F` due to `readability-uppercase-literal-suffix`.

One `else` block was removed to satisfy `readability-else-after-return`.

One `auto` was changed to `auto const *` to satisfy `readability-qualified-auto`.

Other fixes were due to `readability-implicit-bool-conversion`.

`readability-identifier-length`, `readability-magic-numbers`,  `readability-isolate-declaration` and `readability-named-parameter` were silenced since they each raise too many warnings.

`readability-avoid-nested-conditional-operator` was disabled since it complains over nested use of `?` e.g

```
const char *annotation = is_entry_selected ? (is_flush ? "  <- flushed" : "  <- added") : "";
```

Satisfying `readability-function-cognitive-complexity` will require refactoring `riscv_sim::run_sail()`.
