### PR TITLE
Avoid vrgatherei16 reading vs1 unnecessarily

### DIFF
--- a/model/extensions/V/vext_arith_insts.sail
+++ b/model/extensions/V/vext_arith_insts.sail
@@ -88,7 +88,7 @@ function clause execute VVTYPE(funct6, vm, vs2, vs1, vd) = {
   let 'm = SEW;
 
   let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vs1_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs1); // not used for VV_VRGATHEREI16.
+  let vs1_val : vector('n, bits('m)) = if funct6 == VV_VRGATHEREI16 then vector_init(zeros()) else read_vreg(num_elem, SEW, LMUL_pow, vs1);
   let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
   let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
 

--- a/test/first_party/CMakeLists.txt
+++ b/test/first_party/CMakeLists.txt
@@ -105,6 +105,7 @@ add_first_party_test("test_misaligned_vector_register_groups.S")
 add_first_party_test("test_pmp_access.c")
 add_first_party_test("test_phys_perms_on_failing_sc.S")
 add_first_party_test("test_wfi_wait.S")
+add_first_party_test("test_vrgatherei16_reg_group.S")
 add_first_party_test("test_tlb_stale_pte_access_fault.S")
 
 list(LENGTH tests tests_len)

--- a/test/first_party/src/test_vrgatherei16_reg_group.S
+++ b/test/first_party/src/test_vrgatherei16_reg_group.S
@@ -1,0 +1,51 @@
+#include "common/encoding.h"
+
+.global main
+main:
+    # Save return address in temporary register.
+    mv t6, ra
+
+    # Enable vector.
+    li t0, MSTATUS_VS
+    csrs mstatus, t0
+
+    # Set SEW=32, LMUL=8. With these settings, vrgatherei16.vv has
+    # vs1 (index) EMUL = (16/SEW)*LMUL = (16/32)*8 = 4.
+    # Register v4 is valid for EMUL=4 (4 % 4 == 0), but would be
+    # incorrectly rejected if checked against LMUL=8.
+    vsetivli zero, 2, e32, m8, ta, ma
+
+    # Set trap handler.
+    la t0, trap_handler
+    csrw mtvec, t0
+
+    # vrgatherei16.vv with vs1=v4.
+    # vs1 EMUL = 4, so v4 is a valid register group start.
+    # This instruction should NOT raise an illegal instruction exception.
+test_instruction:
+    vrgatherei16.vv v8, v24, v4
+
+    # If execution reaches here without a trap, the instruction is valid.
+    j pass
+
+.balign 4
+trap_handler:
+    # Any trap at the test instruction is a test failure.
+    la t2, fail
+
+    csrr t0, mepc
+    la t1, test_instruction
+    bne t0, t1, 1f
+
+    csrw mepc, t2
+1:
+    mret
+
+pass:
+    li a0, 0
+    mv ra, t6
+    ret
+fail:
+    li a0, 1
+    mv ra, t6
+    ret


### PR DESCRIPTION
Although the read value from `vs1` was unused, the read itself asserted the validity of the register group.   Bypass the read by using a dummy vector for the unused value.

This fixes #1782.