### PR TITLE
Add a specification version check for access to the `{ms}envcfg` CSRs.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -141,9 +141,13 @@
       "fs_legal_states": "ExtContext_FourState",
       "vs_legal_states": "ExtContext_FourState"
     },
-    // Set the ISA manual version to use. Isa_Latest is always the latest that
-    // the Sail model supports. Other values include Isa_20240411, Isa_20211203, etc.
-    // See isa_version.sail for the complete list and the behaviours it affects.
+    // Set the ISA manual version to use. `Isa_Latest` is always the latest that
+    // the Sail model supports.  The other supported values for this field are:
+    // - Isa_20191213         (for the version tagged Ratified-IMAFDQC)
+    // - Isa_Draft_20211102   (commit a432a8997892d0a103798c2e436d36ae66da7d34, which required reserved PTE bits to be zero)
+    // - Isa_20211203         (for the version tagged Priv-v1.12)
+    // - Isa_20240411
+    // See isa_version.sail for more details and the affected behaviours.
     "isa_version": "Isa_Latest"
   },
   "memory": {

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -1,6 +1,11 @@
 # Release notes for the next version
 
+- Updates to the [configuration file](../config/config.json.in):
+  - The version of the ISA specification for the model can be
+    specified; see `base.isa_version`.
+
 - Important issues addressed and bugs fixed:
+  - https://github.com/riscv/sail-riscv/issues/1753 : Access to `xenvcfg` CSRs need to be gated by the specification version
   - https://github.com/riscv/sail-riscv/issues/1750 : Non-segmented indexed loads were trapping on legal overlaps
   - https://github.com/riscv/sail-riscv/issues/1748 : Segment loads/stores whose register numbers increment past v31 were not treated as reserved.
   - https://github.com/riscv/sail-riscv/issues/1069 : `vssubu` did not set `vxsat`

--- a/model/core/isa_version.sail
+++ b/model/core/isa_version.sail
@@ -45,3 +45,7 @@ let isa_version : IsaVersion = config base.isa_version
 // in PTEs must be zero otherwise the PTE is invalid.
 // TODO: This is not used yet; this is an example that will be implemented in a future commit.
 let pte_reserved_bits_must_be_zero = isa_version >= Isa_Draft_20211102
+
+// The 20211203 version defined the `{m,s,h}envcfg` CSRs. These CSRs
+// are not available in earlier versions.
+let xenvcfg_csrs_are_defined = isa_version >= Isa_20211203

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -458,12 +458,12 @@ mapping clause csr_name_map = 0x30A  <-> "menvcfg"
 mapping clause csr_name_map = 0x31A  <-> "menvcfgh"
 mapping clause csr_name_map = 0x10A  <-> "senvcfg"
 
-function clause is_CSR_accessible(0x30A, _, _) = currentlyEnabled(Ext_U) // menvcfg
-function clause is_CSR_accessible(0x31A, _, _) = currentlyEnabled(Ext_U) & (xlen == 32) // menvcfgh
+function clause is_CSR_accessible(0x30A, _, _) = currentlyEnabled(Ext_U) & isa_version >= Isa_20211203 // menvcfg
+function clause is_CSR_accessible(0x31A, _, _) = currentlyEnabled(Ext_U) & (xlen == 32) & isa_version >= Isa_20211203 // menvcfgh
 
 // This should ideally also check `xstateen.ENVCFG`, but due to module
 // interdependency issues, that is handled by `stateen_allows_CSR_access`.
-function clause is_CSR_accessible(0x10A, _, _) = currentlyEnabled(Ext_S) // senvcfg
+function clause is_CSR_accessible(0x10A, _, _) = currentlyEnabled(Ext_S) & isa_version >= Isa_20211203 // senvcfg
 
 function clause read_CSR(0x30A) = menvcfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x31A if xlen == 32) = menvcfg.bits[63 .. 32]

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -458,12 +458,12 @@ mapping clause csr_name_map = 0x30A  <-> "menvcfg"
 mapping clause csr_name_map = 0x31A  <-> "menvcfgh"
 mapping clause csr_name_map = 0x10A  <-> "senvcfg"
 
-function clause is_CSR_accessible(0x30A, _, _) = currentlyEnabled(Ext_U) & isa_version >= Isa_20211203 // menvcfg
-function clause is_CSR_accessible(0x31A, _, _) = currentlyEnabled(Ext_U) & (xlen == 32) & isa_version >= Isa_20211203 // menvcfgh
+function clause is_CSR_accessible(0x30A, _, _) = currentlyEnabled(Ext_U) & xenvcfg_csrs_are_defined // menvcfg
+function clause is_CSR_accessible(0x31A, _, _) = currentlyEnabled(Ext_U) & (xlen == 32) & xenvcfg_csrs_are_defined // menvcfgh
 
 // This should ideally also check `xstateen.ENVCFG`, but due to module
 // interdependency issues, that is handled by `stateen_allows_CSR_access`.
-function clause is_CSR_accessible(0x10A, _, _) = currentlyEnabled(Ext_S) & isa_version >= Isa_20211203 // senvcfg
+function clause is_CSR_accessible(0x10A, _, _) = currentlyEnabled(Ext_S) & xenvcfg_csrs_are_defined // senvcfg
 
 function clause read_CSR(0x30A) = menvcfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x31A if xlen == 32) = menvcfg.bits[63 .. 32]


### PR DESCRIPTION
These CSRs were defined in version 20211203 of the privileged spec; use `base.isa_version` to gate access to them.

Fixes #1753.