### PR TITLE
Enable specification of delegatable trap and interrupt subsets for `medeleg` and `mideleg`.

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -13,6 +13,12 @@ foreach(CONFIG__BASE__XLEN IN ITEMS 32 64)
             set(CONFIG_XLEN_IS_64 "false")
             set(CONFIG_XLEN_IS_${CONFIG__BASE__XLEN} "true")
 
+            if (${CONFIG__BASE__XLEN} EQUAL 32)
+              set(CONFIG_MIDELEG_DELEGATABLE_BITS_VALUE "0xFFFF_FFFF")
+            else()
+              set(CONFIG_MIDELEG_DELEGATABLE_BITS_VALUE "0xFFFF_FFFF_FFFF_FFFF")
+            endif()
+
             set(CONFIG_ELEN_IS_32 "false")
             set(CONFIG_ELEN_IS_64 "false")
             set(CONFIG_ELEN_IS_${elen} "true")

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -82,6 +82,27 @@
         "base_alignment": 2
       }
     },
+    "medeleg": {
+      // A bit set to 1 in this value specifies that the corresponding
+      // bit of `medeleg` can be set to 1. It represents the subset of
+      // delegatable traps of the implementation. Bits for traps that
+      // cannot be delegated as per the specification will be ignored.
+      "delegatable_bits": {
+        "len": 64,
+        "value": "0xFFFF_FFFF_FFFF_FFFF"
+      }
+    },
+    "mideleg": {
+      // A bit set to 1 in this value specifies that the corresponding
+      // bit of `mideleg` can be set to 1. It represents the subset of
+      // delegatable interrupts of the implementation. Bits for
+      // interrupts that cannot be delegated as per the specification
+      // will be ignored.
+      "delegatable_bits": {
+        "len": "xlen",
+        "value": "@CONFIG_MIDELEG_DELEGATABLE_BITS_VALUE@"
+      }
+    },
     // These settings control whether the specified exceptions
     // cause information to be written into the appropriate
     // `xtval` registers.

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -3,6 +3,8 @@
 - Updates to the [configuration file](../config/config.json.in):
   - The version of the ISA specification for the model can be
     specified; see `base.isa_version`.
+  - Delegatable subsets of `medeleg` and `mideleg` can be specified;
+    see `base.medeleg.delegatable_bits` and `base.mideleg.delegatable_bits`.
 
 - Important issues addressed and bugs fixed:
   - https://github.com/riscv/sail-riscv/issues/1753 : Access to `xenvcfg` CSRs need to be gated by the specification version

--- a/model/core/interrupt_regs.sail
+++ b/model/core/interrupt_regs.sail
@@ -54,10 +54,8 @@ private function legalize_mie(o : Minterrupts, v : xlenbits) -> Minterrupts = {
 }
 
 private function legalize_mideleg(o : Minterrupts, v : xlenbits) -> Minterrupts = {
+  let v = Mk_Minterrupts(v & plat_mideleg_delegatable_bits);
   // M-mode interrupt delegation bits "should" be hardwired to 0.
-  // TODO: Configuration options specifying whether M-mode interrupts
-  // can be delegated.
-  let v = Mk_Minterrupts(v);
   [o with
     LCOFI = if currentlyEnabled(Ext_Sscofpmf) then v[LCOFI] else 0b0,
     MEI   = 0b0,
@@ -88,7 +86,7 @@ bitfield Medeleg : bits(64) = {
 
 private function legalize_medeleg(_o : Medeleg, v : bits(64)) -> Medeleg = {
   // M-EnvCalls delegation is not supported
-  [Mk_Medeleg(v) with MEnvCall = 0b0]
+  [Mk_Medeleg(v & plat_medeleg_delegatable_bits) with MEnvCall = 0b0]
 }
 
 // Note that mip's MEIP and SEIP had special handling. MEIP is always

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -21,6 +21,10 @@ let plat_mtvec_direct_base_alignment_exp   : tvec_alignment = config base.mtvec.
 let plat_mtvec_vectored_base_alignment_exp : tvec_alignment = config base.mtvec.vectored.base_alignment
 let plat_stvec_vectored_base_alignment_exp : tvec_alignment = config base.stvec.vectored.base_alignment
 
+// Delegatable bits of `medeleg` and `mideleg`.
+let plat_medeleg_delegatable_bits : bits(64) = config base.medeleg.delegatable_bits
+let plat_mideleg_delegatable_bits : xlenbits = config base.mideleg.delegatable_bits
+
 // Cache block size is 2^cache_block_size_exp. Max is `max_mem_access` (4096)
 // because this model performs `cbo.zero` with a single write, and the behaviour
 // with cache blocks larger than a page is not clearly defined.


### PR DESCRIPTION
An implementation can choose to subset the delegatable traps and interrupts.  This adds config options to specify the corresponding bits of `medeleg` and `mideleg`.

Fixes #1781.