### PR TITLE
Make -DFIRST_PARTY_TESTS=ON work by default on macOS

### DIFF
--- a/test/first_party/CMakeLists.txt
+++ b/test/first_party/CMakeLists.txt
@@ -6,10 +6,22 @@
 # 1. Clang, which is sensibly designed to be able to cross-compile to any architecture it supports.
 #    Unfortunately it is possible to build it without RISC-V support, e.g. RHEL 8 does this, so we
 #    need to check that. You can download a binary from https://github.com/llvm/llvm-project/releases
+#    On macOS, /usr/bin/clang is in $PATH by default but does not support the RISC-V target, so we default to
+#    a version installed by homebrew if we can find it.
 # 2. GCC via riscv32-unknown-elf-gcc. Unlike Clang you have to specifically build GCC as a cross
 #    compiler. You can download a binary from https://github.com/riscv-collab/riscv-gnu-toolchain/releases
 # 3. GCC via riscv64-unknown-elf-gcc, but only if it has "multilib" support, so we'll try riscv32-... first.
-
+if (APPLE)
+    find_program(HOMEBREW brew)
+    execute_process(
+        COMMAND ${HOMEBREW} --prefix llvm
+        OUTPUT_VARIABLE HOMEBREW_LLVM_DIR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND_ERROR_IS_FATAL NONE
+    )
+    find_program(CLANG_BIN "clang" PATHS "${HOMEBREW_LLVM_DIR}/bin" NO_DEFAULT_PATH)
+endif()
+# On macOS, this call is a no-op if already found in HOMEBREW_LLVM_DIR
 find_program(CLANG_BIN "clang")
 find_program(GCC_BIN_RV32 "riscv32-unknown-elf-gcc")
 find_program(GCC_BIN_RV64 "riscv64-unknown-elf-gcc")
@@ -31,7 +43,7 @@ set(CROSS_COMPILER_COMMAND_RV64)
 if (CLANG_BIN)
     # Check it supports RISC-V.
     execute_process(
-        COMMAND clang -print-targets
+        COMMAND ${CLANG_BIN} -print-targets
         OUTPUT_VARIABLE clang_targets
         COMMAND_ERROR_IS_FATAL ANY
     )


### PR DESCRIPTION
On macOS the clang binary in $PATH (/usr/bin/clang) does not support
RISC-V ELF targets, so we default to the homebrew installation instead.
If it's not found via homebrew users still need to pass a path to
CLANG_BIN manually. Additionally, the check for RISC-V support was using
the default clang in $PATH instead of $CLANG_BIN, so it failed on macOS.