### PR TITLE
Fix a hack to work around an inability to forward declare the `Privilege` enum.

### DIFF
--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -458,7 +458,7 @@ std::string ModelImpl::memory_access_type_to_string(MemoryAccessType access_type
 std::string ModelImpl::privilege_to_string(Privilege privilege) {
   sail_string sstr;
   CREATE(sail_string)(&sstr);
-  zprivLevel_to_str(&sstr, privilege.ztup0);
+  zprivLevel_to_str(&sstr, privilege);
   std::string str(sstr);
   KILL(sail_string)(&sstr);
   return str;

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -16,7 +16,7 @@ class ModelImpl final : private hart::Model {
 public:
   // types
 
-  using Privilege = hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9;
+  using Privilege = hart::zPrivilege;
   using MemoryAccessType = hart::zMemoryAccessTypezIEmem_payloadz5zK;
   using PTW_Error = hart::zPTW_Error;
   using TLB_Entry = hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9;

--- a/c_emulator/riscv_platform_if.cpp
+++ b/c_emulator/riscv_platform_if.cpp
@@ -92,7 +92,7 @@ unit PlatformInterface::instret_callback(unit) {
 unit PlatformInterface::ptw_start_callback(
   [[maybe_unused]] uint64_t vpn,
   [[maybe_unused]] hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
-  [[maybe_unused]] hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+  [[maybe_unused]] hart::zPrivilege privilege
 ) {
   return UNIT;
 }

--- a/c_emulator/riscv_platform_if.h
+++ b/c_emulator/riscv_platform_if.h
@@ -9,10 +9,9 @@ namespace hart {
 class Model;
 
 struct zMemoryAccessTypezIEmem_payloadz5zK;
-struct ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9;
+enum zPrivilege : int;
 struct zPTW_Error;
 struct zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9;
-
 } // namespace hart
 
 // The Model class derives from this one so when Sail calls C callback
@@ -56,7 +55,7 @@ public:
   virtual unit ptw_start_callback(
     uint64_t vpn,
     hart::zMemoryAccessTypezIEmem_payloadz5zK access_type,
-    hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege
+    hart::zPrivilege privilege
   );
   virtual unit ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte);
   virtual unit ptw_success_callback(uint64_t final_ppn, int64_t level);

--- a/model/sys/callbacks.sail
+++ b/model/sys/callbacks.sail
@@ -14,7 +14,7 @@
 // the types (hart::zPrivilege etc.) in a separate header to hart::Model.
 // See https://github.com/rems-project/sail/issues/1560
 
-val ptw_start_callback = pure {cpp: "ptw_start_callback"} : (/* vpn */ bits(64), /* access type */ MemoryAccessType(mem_payload), /* privilege */ (Privilege, unit)) -> unit
+val ptw_start_callback = pure {cpp: "ptw_start_callback"} : (/* vpn */ bits(64), /* access type */ MemoryAccessType(mem_payload), /* privilege */ Privilege) -> unit
 function ptw_start_callback(_) = ()
 
 val ptw_step_callback = pure {cpp: "ptw_step_callback"} : (/* level */ range(0, 4), /* pte_addr */ physaddrbits, /* pte */ bits(64)) -> unit

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -110,7 +110,7 @@ function pt_walk(
   global,
   ext_ptw,
 ) = {
-  ptw_start_callback(zero_extend(vpn), access, (priv, ()));
+  ptw_start_callback(zero_extend(vpn), access, priv);
 
   // Extract the PPN component for this level; 10 bits on Sv32, otherwise 9.
   let 'vpn_i_size = if 'v == 32 then 10 else 9;


### PR DESCRIPTION
This requires the Sail compiler to output the enum storage type.