### PR TITLE
Test for configuration to raise access faults on misaligned access

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -223,7 +223,7 @@
       // 2^allowed_within_exp sized regions will be split into multiple
       // memory operations. 0 means all misaligned accesses will be split.
       // The maximum value is 12 (one page).
-      "allowed_within_exp": 0,
+      "allowed_within_exp": 12,
       // If the access gets split due to `allowed_within_exp` then the size
       // of the operations will be one byte if `byte_by_byte` is set, otherwise
       // they will be the maximum size possible based on the alignment. For
@@ -326,7 +326,7 @@
         },
         "size": {
           "len": 64,
-          "value": "0x80000000"
+          "value": "0x40000000"
         },
         "attributes": {
           "mem_type": "MainMemory",
@@ -343,6 +343,43 @@
             },
             "vector": {
               "None" : null
+            },
+            "amo": "AccessFault"
+          },
+          "atomic_support": "AMOCASQ",
+          "reservability": "RsrvEventual",
+          "supports_cbo_zero": true,
+          "supports_pte_read": true,
+          "supports_pte_write": true
+        },
+        "include_in_device_tree": true
+      },
+      // RAM that raises access faults on misaligned access.
+      // This is for testing/demo purposes.
+      {
+        "base": {
+          "len": 64,
+          "value": "0xF0000000"
+        },
+        "size": {
+          "len": 64,
+          "value": "0x10000000"
+        },
+        "attributes": {
+          "mem_type": "IOMemory",
+          "cacheable": true,
+          "coherent": true,
+          "executable": true,
+          "readable": true,
+          "writable": true,
+          "read_idempotent": true,
+          "write_idempotent": true,
+          "misaligned_exceptions": {
+            "load_store": {
+              "Some": "AccessFault"
+            },
+            "vector": {
+              "Some": "AccessFault"
             },
             "amo": "AccessFault"
           },

--- a/test/first_party/CMakeLists.txt
+++ b/test/first_party/CMakeLists.txt
@@ -124,6 +124,7 @@ add_first_party_test("test_phys_perms_on_failing_sc.S")
 add_first_party_test("test_wfi_wait.S")
 add_first_party_test("test_vrgatherei16_reg_group.S")
 add_first_party_test("test_tlb_stale_pte_access_fault.S")
+add_first_party_test("test_misaligned_access_fault.S")
 
 add_first_party_override_test("test_sew_elen_bound.S" "elen_32.json")
 

--- a/test/first_party/src/test_misaligned_access_fault.S
+++ b/test/first_party/src/test_misaligned_access_fault.S
@@ -1,0 +1,49 @@
+#include "common/encoding.h"
+
+# Test that misaligned accesses to RAM that is configured to raise access
+# faults on misaligned access actually does raise an access fault.
+
+# This must be in the correctly configured RAM region (see config.json.in).
+#define TEST_ADDRESS 0xF0000001
+
+.global main
+main:
+    # Save return address in temporary register we're not using.
+    mv t6, ra
+
+    la t0, trap_handler
+    csrw mtvec, t0
+
+    li t0, TEST_ADDRESS
+trapping_instruction:
+    lw t0, 0(t0)
+    # We should get a trap; if not it's a failure.
+    j fail
+
+.balign 4
+trap_handler:
+    # mepc should be `trapping_instruction`.
+    csrr t0, mepc
+    la t1, trapping_instruction
+    bne t0, t1, fail
+
+    # mtval should be the test address.
+    csrr t0, mtval
+    li t1, TEST_ADDRESS
+    bne t0, t1, fail
+
+    # mcause should be access fault.
+    csrr t0, mcause
+    li t1, CAUSE_LOAD_ACCESS
+    bne t0, t1, fail
+
+    j pass
+
+pass:
+    li a0, 0
+    mv ra, t6
+    ret
+fail:
+    li a0, 1
+    mv ra, t6
+    ret


### PR DESCRIPTION
This adds a first party test to check that it is possible to configure a memory region to raise an access fault on misaligned access. I added an extra memory region to the default config for this but it could also go in a test specific override (maybe better).

Also this changes the default `allowed_within_exp` to 12 which is way less surprising - otherwise *all* misaligned accesses are split into 1-byte accesses so you don't get any exception at all in this test.