### PR TITLE
Fix some clang-tidy issues caused by recent commits.

### DIFF
--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -417,7 +417,7 @@ bool ModelImpl::dtb_within_configured_pma_memory(uint64_t addr, uint64_t size) {
 
 std::vector<MemoryRegion> ModelImpl::main_memory_regions() const {
   std::vector<MemoryRegion> regions;
-  for (auto region = zpma_regions; region != nullptr; region = region->tl) {
+  for (auto *region = zpma_regions; region != nullptr; region = region->tl) {
     if (region->hd.zattributes.zmem_type == hart::zMainMemory) {
       regions.push_back({region->hd.zbase, region->hd.zsizze});
     }

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -417,7 +417,7 @@ bool ModelImpl::dtb_within_configured_pma_memory(uint64_t addr, uint64_t size) {
 
 std::vector<MemoryRegion> ModelImpl::main_memory_regions() const {
   std::vector<MemoryRegion> regions;
-  for (auto *region = zpma_regions; region != nullptr; region = region->tl) {
+  for (const auto *region = zpma_regions; region != nullptr; region = region->tl) {
     if (region->hd.zattributes.zmem_type == hart::zMainMemory) {
       regions.push_back({region->hd.zbase, region->hd.zsizze});
     }

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -128,12 +128,12 @@ void write_memory_dump(const MemoryRegion &region, const std::string &prefix) {
   const std::string file = file_os.str();
 
   FILE *f = fopen(file.c_str(), "wb");
-  if (!f) {
+  if (f == nullptr) {
     fprintf(stderr, "Cannot create memory dump '%s': %s\n", file.c_str(), strerror(errno));
     return;
   }
 
-  constexpr size_t buffer_size = 64 * 1024;
+  constexpr size_t buffer_size = static_cast<size_t>(64 * 1024);
   std::vector<uint8_t> buffer(buffer_size);
   uint64_t offset = 0;
   while (offset < region.size) {

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -133,6 +133,9 @@ void write_memory_dump(const MemoryRegion &region, const std::string &prefix) {
     return;
   }
 
+  // TODO: In C++23 we can use a literal suffix: 64 * 1024ZU
+  // (upper-case due to the clang-tidy
+  // `readability-uppercase-literal-suffix` check).
   constexpr size_t buffer_size = static_cast<size_t>(64 * 1024);
   std::vector<uint8_t> buffer(buffer_size);
   uint64_t offset = 0;


### PR DESCRIPTION
Fixes a couple of `readability-qualified-auto`, `readability-implicit-bool-conversion` and `bugprone-implicit-widening-of-multiplication-result` warnings.