### PR TITLE
Add configuration option to control when mstatus[FD] is dirtied

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -426,7 +426,17 @@
       "supported": true
     },
     "F": {
-      "supported": true
+      "supported": true,
+      // When to set mstatus[FS] and mstatus[SD] to 1, as a result of fflags
+      // being set. There are three options:
+      //
+      // - Fflags_Dirty_Precise: Only set FS/SD when absolutely required, because
+      //                         fflags has actually changed value.
+      // - Fflags_Dirty_Flag: Set FS/SD when the instruction sets a flag, even
+      //                      if that flag is already set.
+      // - Fflags_Dirty_Instruction: Set FS/SD when we execute an instruction that
+      //                             might set a flag, even if it actually doesn't.
+      "fflags_dirty_policy": "Fflags_Dirty_Precise"
     },
     "D": {
       "supported": true

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -5,6 +5,8 @@
     specified; see `base.isa_version`.
   - Delegatable subsets of `medeleg` and `mideleg` can be specified;
     see `base.medeleg.delegatable_bits` and `base.mideleg.delegatable_bits`.
+  - Add the `extensions.F.fflags_dirty_policy` option to configure exactly
+    when mstatus[FS/SD] is set by floating point instructions.
 
 - Important issues addressed and bugs fixed:
   - https://github.com/riscv/sail-riscv/issues/1794 : `vtype.vill` was not set when SEW was configured to exceed ELEN

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -190,3 +190,14 @@ let xtvec_mode_reserved_behavior : XtvecModeReservedBehavior = config base.reser
 let rv32zdinx_odd_register_reserved_behavior : RV32ZdinxOddRegisterReservedBehavior = config base.reserved_behavior.rv32zdinx_odd_register
 let illegal_vtype_reserved_behavior : IllegalVtypeReservedBehavior = config extensions.V.reserved_behavior.illegal_vtype
 let vstart_reserved_behavior : OOBVstartReservedBehavior = config extensions.V.reserved_behavior.vstart_out_of_bounds
+
+enum FflagsDirtyPolicy = {
+  // Only set dirty bits when required (fflags value changes).
+  Fflags_Dirty_Precise,
+  // Set dirty bits when an instruction would set a new fflag (even if it was already set).
+  Fflags_Dirty_Flag,
+  // Set dirty bits when an instruction is executed that *could* set an fflag.
+  Fflags_Dirty_Instruction,
+}
+
+let fflags_dirty_policy : FflagsDirtyPolicy = config extensions.F.fflags_dirty_policy

--- a/model/extensions/FD/fdext_regs.sail
+++ b/model/extensions/FD/fdext_regs.sail
@@ -438,12 +438,19 @@ function write_fcsr(frm : bits(3), fflags : bits(5)) -> unit = {
 
 // OR flags into the fflags register.
 function accrue_fflags(flags : bits(5)) -> unit = {
-  let f = fcsr[FFLAGS] | flags;
-  if  fcsr[FFLAGS] != f
-  then {
-    fcsr[FFLAGS] = f;
-    dirty_fd_context_if_present();
+  let new_fflags = fcsr[FFLAGS] | flags;
+  let fflags_changed = fcsr[FFLAGS] != new_fflags;
+
+  let set_dirty : bool = match fflags_dirty_policy {
+    Fflags_Dirty_Precise => fflags_changed,
+    Fflags_Dirty_Flag => flags != zeros(),
+    Fflags_Dirty_Instruction => true,
   };
+
+  fcsr[FFLAGS] = new_fflags;
+
+  if set_dirty then dirty_fd_context_if_present();
+
   csr_write_callback("fflags", zero_extend(fcsr[FFLAGS]));
   csr_write_callback("fcsr", zero_extend(fcsr.bits));
 }


### PR DESCRIPTION
Currently the model sets the FD (Float Dirty) bit only when absolutely required, but real implementations have a couple of other realistic options. This adds a configuration option that allows selecting them.

Note that the set of legal behaviours for dirty bits is in general unbounded. It would technically be legal to hard-code it to 1. But these are the most likely behaviours in actual hardware because they remove dependencies of setting FD, which makes things faster/easier on pipelined/OoO designs:

* Fflags_Dirty_Flag removes dependency on the value of `fflags`.
* Fflags_Dirty_Instruction removes dependency on execution of the instruction.

Fixes #1798