### PR TITLE
Add some `cppcoreguidelines` checks for `clang-tidy`.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,18 @@ Checks: >
   -readability-named-parameter,
   -readability-avoid-nested-conditional-operator,
   -readability-magic-numbers,
-  -readability-function-cognitive-complexity
+  -readability-function-cognitive-complexity,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-avoid-do-while,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-cstyle-cast,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-type-union-access,
+  -cppcoreguidelines-pro-type-vararg
 
 HeaderFilterRegex: ""
 ...

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -166,9 +166,6 @@ void log_callbacks::ptw_fail_callback(
 
 namespace {
 
-// TODO: make this a class member and avoid a global.
-std::vector<uint64_t> pending_flush_indices;
-
 void print_tlb(FILE *trace_log, ModelImpl &, ModelImpl::TLB tlb, const std::vector<uint64_t> &indices, bool is_flush) {
   fprintf(
     trace_log,

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -51,5 +51,5 @@ private:
   bool config_print_ptw;
   bool config_print_tlb;
   FILE *trace_log;
-  std::vector<uint64_t> pending_flush_indices{};
+  std::vector<uint64_t> pending_flush_indices;
 };

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -51,4 +51,5 @@ private:
   bool config_print_ptw;
   bool config_print_tlb;
   FILE *trace_log;
+  std::vector<uint64_t> pending_flush_indices{};
 };

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -448,7 +448,7 @@ std::optional<std::string> ModelImpl::string_of_current_exception() {
   if (!have_exception) {
     return std::nullopt;
   }
-  sail_string str{};
+  sail_string str = nullptr;
   CREATE(sail_string)(&str);
   zstring_of_exception(&str, *current_exception);
   std::string exception_str(str);
@@ -457,7 +457,7 @@ std::optional<std::string> ModelImpl::string_of_current_exception() {
 }
 
 std::string ModelImpl::memory_access_type_to_string(MemoryAccessType access_type) {
-  sail_string sstr{};
+  sail_string sstr = nullptr;
   CREATE(sail_string)(&sstr);
   zaccessType_to_str(&sstr, access_type);
   std::string str(sstr);
@@ -466,7 +466,7 @@ std::string ModelImpl::memory_access_type_to_string(MemoryAccessType access_type
 }
 
 std::string ModelImpl::privilege_to_string(Privilege privilege) {
-  sail_string sstr{};
+  sail_string sstr = nullptr;
   CREATE(sail_string)(&sstr);
   zprivLevel_to_str(&sstr, privilege.ztup0);
   std::string str(sstr);
@@ -475,7 +475,7 @@ std::string ModelImpl::privilege_to_string(Privilege privilege) {
 }
 
 std::string ModelImpl::ptw_error_to_string(PTW_Error error_type) {
-  sail_string sstr{};
+  sail_string sstr = nullptr;
   CREATE(sail_string)(&sstr);
   zptw_error_to_str(&sstr, error_type);
   std::string str(sstr);

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -448,7 +448,7 @@ std::optional<std::string> ModelImpl::string_of_current_exception() {
   if (!have_exception) {
     return std::nullopt;
   }
-  sail_string str;
+  sail_string str{};
   CREATE(sail_string)(&str);
   zstring_of_exception(&str, *current_exception);
   std::string exception_str(str);
@@ -457,7 +457,7 @@ std::optional<std::string> ModelImpl::string_of_current_exception() {
 }
 
 std::string ModelImpl::memory_access_type_to_string(MemoryAccessType access_type) {
-  sail_string sstr;
+  sail_string sstr{};
   CREATE(sail_string)(&sstr);
   zaccessType_to_str(&sstr, access_type);
   std::string str(sstr);
@@ -466,7 +466,7 @@ std::string ModelImpl::memory_access_type_to_string(MemoryAccessType access_type
 }
 
 std::string ModelImpl::privilege_to_string(Privilege privilege) {
-  sail_string sstr;
+  sail_string sstr{};
   CREATE(sail_string)(&sstr);
   zprivLevel_to_str(&sstr, privilege.ztup0);
   std::string str(sstr);
@@ -475,7 +475,7 @@ std::string ModelImpl::privilege_to_string(Privilege privilege) {
 }
 
 std::string ModelImpl::ptw_error_to_string(PTW_Error error_type) {
-  sail_string sstr;
+  sail_string sstr{};
   CREATE(sail_string)(&sstr);
   zptw_error_to_str(&sstr, error_type);
   std::string str(sstr);

--- a/c_emulator/rvfi_dii.cpp
+++ b/c_emulator/rvfi_dii.cpp
@@ -1,4 +1,5 @@
 #include <arpa/inet.h>
+#include <array>
 #include <errno.h>
 #include <fcntl.h>
 #include <netinet/ip.h>
@@ -36,7 +37,7 @@ bool rvfi_handler::setup_socket(bool config_print) {
     fprintf(stderr, "Unable to set reuseaddr on socket: %s\n", strerror(errno));
     return false;
   }
-  struct sockaddr_in addr;
+  struct sockaddr_in addr{};
   addr.sin_family = AF_INET;
   addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
   addr.sin_port = htons(dii_port);
@@ -135,7 +136,7 @@ void rvfi_handler::send_trace(bool config_print) {
 }
 
 rvfi_prestep_t rvfi_handler::pre_step(bool config_print) {
-  mach_bits instr_bits;
+  mach_bits instr_bits{};
   if (config_print) {
     fprintf(stderr, "Waiting for cmd packet... ");
   }
@@ -201,7 +202,7 @@ rvfi_prestep_t rvfi_handler::pre_step(bool config_print) {
     // From now on send traces in the requested format
     trace_version = insn;
     struct {
-      char msg[8];
+      std::array<char, 8> msg;
       uint64_t version;
     } version_response = {{'v', 'e', 'r', 's', 'i', 'o', 'n', '='}, trace_version};
     if (write(dii_sock, &version_response, sizeof(version_response)) != sizeof(version_response)) {


### PR DESCRIPTION
This adds another set of general clang-tidy checks.  Useful ones among those disabled could be enabled one-by-one with appropriate fixes in subsequent PRs.

It fixes the `init-variables` and `avoid-c-arrays` checks.

`avoid-magic-numbers` causes too many warnings currently.
`avoid-do-while` requires refactoring the small `do-while` loop in `sail_riscv_sim.cpp::run_model()`; probably not worth it.
`owning-memory` is disabled since it suggests the use of `gsl` (guidelines-support-library).
`bounds-avoid-unchecked-container-access` could be enabled in a later PR.
`bounds-array-to-pointer-decay` is triggered by accesses to `gmplib`'s `mpz_t` integers in `lbits` when using `gmp_fprintf`.
`bounds-pointer-arithmetic` is triggered when accessing an element in the Sail vector of TLB entries through the vector's `data` pointer.
`type-cstyle-cast` is disabled due to `struct sockaddr` usage for the socket in RVFI.
`type-reinterpret-cast` is disabled due to its use when writing bytes to memory from the ELF loader.
`type-union-access` is disabled since `option(TLB_Entry)` in the TLB callbacks is a union.
`type-vararg` is disabled due to the use of `fprintf`.


