### PR TITLE
Fix a misnamed `using` definition.

### DIFF
--- a/c_emulator/riscv_callbacks_if.cpp
+++ b/c_emulator/riscv_callbacks_if.cpp
@@ -129,7 +129,7 @@ void callbacks_if::ptw_fail_callback(
 
 void callbacks_if::tlb_add_callback(
   [[maybe_unused]] ModelImpl &model,
-  [[maybe_unused]] ModelImpl::TLB_Entry tlb,
+  [[maybe_unused]] ModelImpl::TLB tlb,
   [[maybe_unused]] uint64_t index
 ) {
 }
@@ -140,8 +140,5 @@ void callbacks_if::tlb_flush_begin_callback([[maybe_unused]] ModelImpl &model) {
 void callbacks_if::tlb_flush_callback([[maybe_unused]] ModelImpl &model, [[maybe_unused]] uint64_t index) {
 }
 
-void callbacks_if::tlb_flush_end_callback(
-  [[maybe_unused]] ModelImpl &model,
-  [[maybe_unused]] ModelImpl::TLB_Entry tlb
-) {
+void callbacks_if::tlb_flush_end_callback([[maybe_unused]] ModelImpl &model, [[maybe_unused]] ModelImpl::TLB tlb) {
 }

--- a/c_emulator/riscv_callbacks_if.h
+++ b/c_emulator/riscv_callbacks_if.h
@@ -55,11 +55,11 @@ public:
 
   virtual void ptw_fail_callback(ModelImpl &model, ModelImpl::PTW_Error error_type, int64_t level, sbits pte_addr);
 
-  virtual void tlb_add_callback(ModelImpl &model, ModelImpl::TLB_Entry tlb, uint64_t index);
+  virtual void tlb_add_callback(ModelImpl &model, ModelImpl::TLB tlb, uint64_t index);
 
   virtual void tlb_flush_begin_callback(ModelImpl &model);
 
   virtual void tlb_flush_callback(ModelImpl &model, uint64_t index);
 
-  virtual void tlb_flush_end_callback(ModelImpl &model, ModelImpl::TLB_Entry tlb);
+  virtual void tlb_flush_end_callback(ModelImpl &model, ModelImpl::TLB tlb);
 };

--- a/c_emulator/riscv_callbacks_log.cpp
+++ b/c_emulator/riscv_callbacks_log.cpp
@@ -169,13 +169,7 @@ namespace {
 // TODO: make this a class member and avoid a global.
 std::vector<uint64_t> pending_flush_indices;
 
-void print_tlb(
-  FILE *trace_log,
-  ModelImpl &,
-  ModelImpl::TLB_Entry tlb,
-  const std::vector<uint64_t> &indices,
-  bool is_flush
-) {
+void print_tlb(FILE *trace_log, ModelImpl &, ModelImpl::TLB tlb, const std::vector<uint64_t> &indices, bool is_flush) {
   fprintf(
     trace_log,
     "TLB %s [ len=%zu ]\n"
@@ -233,7 +227,7 @@ void print_tlb(
 
 } // namespace
 
-void log_callbacks::tlb_add_callback(ModelImpl &model, ModelImpl::TLB_Entry tlb, uint64_t index) {
+void log_callbacks::tlb_add_callback(ModelImpl &model, ModelImpl::TLB tlb, uint64_t index) {
   if (trace_log != nullptr && config_print_tlb) {
     print_tlb(trace_log, model, tlb, {index}, false);
   }
@@ -249,7 +243,7 @@ void log_callbacks::tlb_flush_callback(ModelImpl &, uint64_t index) {
   }
 }
 
-void log_callbacks::tlb_flush_end_callback(ModelImpl &model, ModelImpl::TLB_Entry tlb) {
+void log_callbacks::tlb_flush_end_callback(ModelImpl &model, ModelImpl::TLB tlb) {
   if (trace_log != nullptr && config_print_tlb && !pending_flush_indices.empty()) {
     print_tlb(trace_log, model, tlb, pending_flush_indices, true);
   }

--- a/c_emulator/riscv_callbacks_log.h
+++ b/c_emulator/riscv_callbacks_log.h
@@ -36,10 +36,10 @@ public:
   void ptw_step_callback(ModelImpl &model, int64_t level, sbits pte_addr, uint64_t pte) override;
   void ptw_success_callback(ModelImpl &model, uint64_t final_ppn, int64_t level) override;
   void ptw_fail_callback(ModelImpl &model, ModelImpl::PTW_Error error_type, int64_t level, sbits pte_addr) override;
-  void tlb_add_callback(ModelImpl &model, ModelImpl::TLB_Entry tlb, uint64_t index) override;
+  void tlb_add_callback(ModelImpl &model, ModelImpl::TLB tlb, uint64_t index) override;
   void tlb_flush_begin_callback(ModelImpl &model) override;
   void tlb_flush_callback(ModelImpl &model, uint64_t index) override;
-  void tlb_flush_end_callback(ModelImpl &model, ModelImpl::TLB_Entry tlb) override;
+  void tlb_flush_end_callback(ModelImpl &model, ModelImpl::TLB tlb) override;
 
 private:
   bool config_print_gpr;

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -174,7 +174,7 @@ unit ModelImpl::ptw_fail_callback(PTW_Error error_type, int64_t level, sbits pte
   return UNIT;
 }
 
-unit ModelImpl::tlb_add_callback(TLB_Entry tlb, uint64_t index) {
+unit ModelImpl::tlb_add_callback(TLB tlb, uint64_t index) {
   for (auto c : m_callbacks) {
     c->tlb_add_callback(*this, tlb, index);
   }
@@ -195,7 +195,7 @@ unit ModelImpl::tlb_flush_callback(uint64_t index) {
   return UNIT;
 }
 
-unit ModelImpl::tlb_flush_end_callback(TLB_Entry tlb) {
+unit ModelImpl::tlb_flush_end_callback(TLB tlb) {
   for (auto c : m_callbacks) {
     c->tlb_flush_end_callback(*this, tlb);
   }

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -24,7 +24,7 @@ public:
   using Privilege = hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9;
   using MemoryAccessType = hart::zMemoryAccessTypezIEmem_payloadz5zK;
   using PTW_Error = hart::zPTW_Error;
-  using TLB_Entry = hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9;
+  using TLB = hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9;
 
   // callbacks
 
@@ -127,10 +127,10 @@ private:
   unit ptw_step_callback(int64_t level, sbits pte_addr, uint64_t pte) override;
   unit ptw_success_callback(uint64_t final_ppn, int64_t level) override;
   unit ptw_fail_callback(PTW_Error error_type, int64_t level, sbits pte_addr) override;
-  unit tlb_add_callback(TLB_Entry tlb, uint64_t index) override;
+  unit tlb_add_callback(TLB tlb, uint64_t index) override;
   unit tlb_flush_begin_callback(unit) override;
   unit tlb_flush_callback(uint64_t index) override;
-  unit tlb_flush_end_callback(TLB_Entry tlb) override;
+  unit tlb_flush_end_callback(TLB tlb) override;
   // Provides entropy for the scalar cryptography extension.
   mach_bits plat_get_16_random_bits(unit) override;
 


### PR DESCRIPTION
The argument to the TLB modification callbacks is the full vector of `TLB_Entry`s, not just one entry. This unfortunate naming was introduced in #1731.