### PR TITLE
Change SOFTFLOAT_PRELUDE to a function

### DIFF
--- a/c_emulator/riscv_softfloat.cpp
+++ b/c_emulator/riscv_softfloat.cpp
@@ -11,14 +11,15 @@ uint_fast8_t uint8_of_rm(uint64_t rm) {
   return static_cast<uint_fast8_t>(rm);
 }
 
+void softfloat_init(uint64_t rm) {
+  softfloat_exceptionFlags = 0;
+  softfloat_roundingMode = uint8_of_rm(rm);
+}
+
 } // namespace
 
-#define SOFTFLOAT_PRELUDE(rm)                                                                                          \
-  softfloat_exceptionFlags = 0;                                                                                        \
-  softfloat_roundingMode = uint8_of_rm(rm)
-
 bv5_bv16 softfloat_f16add(uint64_t rm, uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t a, b, res;
   a.v = v1;
@@ -29,7 +30,7 @@ bv5_bv16 softfloat_f16add(uint64_t rm, uint64_t v1, uint64_t v2) {
 }
 
 bv5_bv16 softfloat_f16sub(uint64_t rm, uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t a, b, res;
   a.v = v1;
@@ -40,7 +41,7 @@ bv5_bv16 softfloat_f16sub(uint64_t rm, uint64_t v1, uint64_t v2) {
 }
 
 bv5_bv16 softfloat_f16mul(uint64_t rm, uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t a, b, res;
   a.v = v1;
@@ -51,7 +52,7 @@ bv5_bv16 softfloat_f16mul(uint64_t rm, uint64_t v1, uint64_t v2) {
 }
 
 bv5_bv16 softfloat_f16div(uint64_t rm, uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t a, b, res;
   a.v = v1;
@@ -62,7 +63,7 @@ bv5_bv16 softfloat_f16div(uint64_t rm, uint64_t v1, uint64_t v2) {
 }
 
 bv5_bv32 softfloat_f32add(uint64_t rm, uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t a, b, res;
   a.v = v1;
@@ -73,7 +74,7 @@ bv5_bv32 softfloat_f32add(uint64_t rm, uint64_t v1, uint64_t v2) {
 }
 
 bv5_bv32 softfloat_f32sub(uint64_t rm, uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t a, b, res;
   a.v = v1;
@@ -84,7 +85,7 @@ bv5_bv32 softfloat_f32sub(uint64_t rm, uint64_t v1, uint64_t v2) {
 }
 
 bv5_bv32 softfloat_f32mul(uint64_t rm, uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t a, b, res;
   a.v = v1;
@@ -95,7 +96,7 @@ bv5_bv32 softfloat_f32mul(uint64_t rm, uint64_t v1, uint64_t v2) {
 }
 
 bv5_bv32 softfloat_f32div(uint64_t rm, uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t a, b, res;
   a.v = v1;
@@ -106,7 +107,7 @@ bv5_bv32 softfloat_f32div(uint64_t rm, uint64_t v1, uint64_t v2) {
 }
 
 bv5_bv64 softfloat_f64add(uint64_t rm, uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t a, b, res;
   a.v = v1;
@@ -117,7 +118,7 @@ bv5_bv64 softfloat_f64add(uint64_t rm, uint64_t v1, uint64_t v2) {
 }
 
 bv5_bv64 softfloat_f64sub(uint64_t rm, uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t a, b, res;
   a.v = v1;
@@ -128,7 +129,7 @@ bv5_bv64 softfloat_f64sub(uint64_t rm, uint64_t v1, uint64_t v2) {
 }
 
 bv5_bv64 softfloat_f64mul(uint64_t rm, uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t a, b, res;
   a.v = v1;
@@ -139,7 +140,7 @@ bv5_bv64 softfloat_f64mul(uint64_t rm, uint64_t v1, uint64_t v2) {
 }
 
 bv5_bv64 softfloat_f64div(uint64_t rm, uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t a, b, res;
   a.v = v1;
@@ -150,7 +151,7 @@ bv5_bv64 softfloat_f64div(uint64_t rm, uint64_t v1, uint64_t v2) {
 }
 
 bv5_bv16 softfloat_f16muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t a, b, c, res;
   a.v = v1;
@@ -162,7 +163,7 @@ bv5_bv16 softfloat_f16muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3)
 }
 
 bv5_bv32 softfloat_f32muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t a, b, c, res;
   a.v = v1;
@@ -174,7 +175,7 @@ bv5_bv32 softfloat_f32muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3)
 }
 
 bv5_bv64 softfloat_f64muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t a, b, c, res;
   a.v = v1;
@@ -186,7 +187,7 @@ bv5_bv64 softfloat_f64muladd(uint64_t rm, uint64_t v1, uint64_t v2, uint64_t v3)
 }
 
 bv5_bv16 softfloat_f16sqrt(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t a, res;
   a.v = v;
@@ -196,7 +197,7 @@ bv5_bv16 softfloat_f16sqrt(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv32 softfloat_f32sqrt(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t a, res;
   a.v = v;
@@ -206,7 +207,7 @@ bv5_bv32 softfloat_f32sqrt(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv64 softfloat_f64sqrt(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t a, res;
   a.v = v;
@@ -219,7 +220,7 @@ bv5_bv64 softfloat_f64sqrt(uint64_t rm, uint64_t v) {
 // 'exact' conversion, which sets the Inexact exception flag if
 // needed.
 bv5_bv32 softfloat_f16toi32(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t a;
   float32_t res;
@@ -231,7 +232,7 @@ bv5_bv32 softfloat_f16toi32(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv32 softfloat_f16toui32(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t a;
   float32_t res;
@@ -243,7 +244,7 @@ bv5_bv32 softfloat_f16toui32(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv64 softfloat_f16toi64(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t a;
   float64_t res;
@@ -255,7 +256,7 @@ bv5_bv64 softfloat_f16toi64(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv64 softfloat_f16toui64(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t a;
   float64_t res;
@@ -267,7 +268,7 @@ bv5_bv64 softfloat_f16toui64(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv32 softfloat_f32toi32(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t a, res;
   uint_fast8_t rm8 = uint8_of_rm(rm);
@@ -278,7 +279,7 @@ bv5_bv32 softfloat_f32toi32(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv32 softfloat_f32toui32(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t a, res;
   uint_fast8_t rm8 = uint8_of_rm(rm);
@@ -289,7 +290,7 @@ bv5_bv32 softfloat_f32toui32(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv64 softfloat_f32toi64(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t a;
   float64_t res;
@@ -301,7 +302,7 @@ bv5_bv64 softfloat_f32toi64(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv64 softfloat_f32toui64(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t a;
   float64_t res;
@@ -313,7 +314,7 @@ bv5_bv64 softfloat_f32toui64(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv32 softfloat_f64toi32(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t a;
   float32_t res;
@@ -325,7 +326,7 @@ bv5_bv32 softfloat_f64toi32(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv32 softfloat_f64toui32(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t a;
   float32_t res;
@@ -337,7 +338,7 @@ bv5_bv32 softfloat_f64toui32(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv64 softfloat_f64toi64(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t a, res;
   uint_fast8_t rm8 = uint8_of_rm(rm);
@@ -348,7 +349,7 @@ bv5_bv64 softfloat_f64toi64(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv64 softfloat_f64toui64(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t a, res;
   uint_fast8_t rm8 = uint8_of_rm(rm);
@@ -359,7 +360,7 @@ bv5_bv64 softfloat_f64toui64(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv16 softfloat_i32tof16(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t res;
   res = i32_to_f16(static_cast<int32_t>(v));
@@ -368,7 +369,7 @@ bv5_bv16 softfloat_i32tof16(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv16 softfloat_ui32tof16(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t res;
   res = ui32_to_f16(static_cast<uint32_t>(v));
@@ -377,7 +378,7 @@ bv5_bv16 softfloat_ui32tof16(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv16 softfloat_i64tof16(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t res;
   res = i64_to_f16(static_cast<int64_t>(v));
@@ -386,7 +387,7 @@ bv5_bv16 softfloat_i64tof16(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv16 softfloat_ui64tof16(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t res;
   res = ui64_to_f16(v);
@@ -395,7 +396,7 @@ bv5_bv16 softfloat_ui64tof16(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv32 softfloat_i32tof32(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t res;
   res = i32_to_f32(static_cast<int32_t>(v));
@@ -404,7 +405,7 @@ bv5_bv32 softfloat_i32tof32(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv32 softfloat_ui32tof32(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t res;
   res = ui32_to_f32(static_cast<uint32_t>(v));
@@ -413,7 +414,7 @@ bv5_bv32 softfloat_ui32tof32(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv32 softfloat_i64tof32(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t res;
   res = i64_to_f32(static_cast<int64_t>(v));
@@ -422,7 +423,7 @@ bv5_bv32 softfloat_i64tof32(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv32 softfloat_ui64tof32(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t res;
   res = ui64_to_f32(v);
@@ -431,7 +432,7 @@ bv5_bv32 softfloat_ui64tof32(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv64 softfloat_i32tof64(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t res;
   res = i32_to_f64(static_cast<int32_t>(v));
@@ -440,7 +441,7 @@ bv5_bv64 softfloat_i32tof64(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv64 softfloat_ui32tof64(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t res;
   res = ui32_to_f64(static_cast<uint32_t>(v));
@@ -449,7 +450,7 @@ bv5_bv64 softfloat_ui32tof64(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv64 softfloat_i64tof64(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t res;
   res = i64_to_f64(static_cast<int64_t>(v));
@@ -458,7 +459,7 @@ bv5_bv64 softfloat_i64tof64(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv64 softfloat_ui64tof64(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t res;
   res = ui64_to_f64(v);
@@ -467,7 +468,7 @@ bv5_bv64 softfloat_ui64tof64(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv32 softfloat_f16tof32(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t a;
   float32_t res;
@@ -478,7 +479,7 @@ bv5_bv32 softfloat_f16tof32(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv64 softfloat_f16tof64(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t a;
   float64_t res;
@@ -489,7 +490,7 @@ bv5_bv64 softfloat_f16tof64(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv64 softfloat_f32tof64(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t a;
   float64_t res;
@@ -500,7 +501,7 @@ bv5_bv64 softfloat_f32tof64(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv16 softfloat_f32tof16(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t a;
   float16_t res;
@@ -511,7 +512,7 @@ bv5_bv16 softfloat_f32tof16(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv16 softfloat_f64tof16(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t a;
   float16_t res;
@@ -522,7 +523,7 @@ bv5_bv16 softfloat_f64tof16(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv32 softfloat_f64tof32(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t a;
   float32_t res;
@@ -533,7 +534,7 @@ bv5_bv32 softfloat_f64tof32(uint64_t rm, uint64_t v) {
 }
 
 bv5_bv16 softfloat_f32tobf16(uint64_t rm, uint64_t v) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t a;
   bfloat16_t res;
@@ -544,7 +545,7 @@ bv5_bv16 softfloat_f32tobf16(uint64_t rm, uint64_t v) {
 }
 
 bv5_bool softfloat_f16lt(uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(0);
+  softfloat_init(0);
 
   float16_t a, b;
   a.v = v1;
@@ -555,7 +556,7 @@ bv5_bool softfloat_f16lt(uint64_t v1, uint64_t v2) {
 }
 
 bv5_bool softfloat_f16lt_quiet(uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(0);
+  softfloat_init(0);
 
   float16_t a, b;
   a.v = v1;
@@ -566,7 +567,7 @@ bv5_bool softfloat_f16lt_quiet(uint64_t v1, uint64_t v2) {
 }
 
 bv5_bool softfloat_f16le(uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(0);
+  softfloat_init(0);
 
   float16_t a, b;
   a.v = v1;
@@ -577,7 +578,7 @@ bv5_bool softfloat_f16le(uint64_t v1, uint64_t v2) {
 }
 
 bv5_bool softfloat_f16le_quiet(uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(0);
+  softfloat_init(0);
 
   float16_t a, b;
   a.v = v1;
@@ -588,7 +589,7 @@ bv5_bool softfloat_f16le_quiet(uint64_t v1, uint64_t v2) {
 }
 
 bv5_bool softfloat_f16eq(uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(0);
+  softfloat_init(0);
 
   float16_t a, b;
   a.v = v1;
@@ -599,7 +600,7 @@ bv5_bool softfloat_f16eq(uint64_t v1, uint64_t v2) {
 }
 
 bv5_bool softfloat_f32lt(uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(0);
+  softfloat_init(0);
 
   float32_t a, b;
   a.v = v1;
@@ -610,7 +611,7 @@ bv5_bool softfloat_f32lt(uint64_t v1, uint64_t v2) {
 }
 
 bv5_bool softfloat_f32lt_quiet(uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(0);
+  softfloat_init(0);
 
   float32_t a, b;
   a.v = v1;
@@ -621,7 +622,7 @@ bv5_bool softfloat_f32lt_quiet(uint64_t v1, uint64_t v2) {
 }
 
 bv5_bool softfloat_f32le(uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(0);
+  softfloat_init(0);
 
   float32_t a, b;
   a.v = v1;
@@ -632,7 +633,7 @@ bv5_bool softfloat_f32le(uint64_t v1, uint64_t v2) {
 }
 
 bv5_bool softfloat_f32le_quiet(uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(0);
+  softfloat_init(0);
 
   float32_t a, b;
   a.v = v1;
@@ -643,7 +644,7 @@ bv5_bool softfloat_f32le_quiet(uint64_t v1, uint64_t v2) {
 }
 
 bv5_bool softfloat_f32eq(uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(0);
+  softfloat_init(0);
 
   float32_t a, b;
   a.v = v1;
@@ -654,7 +655,7 @@ bv5_bool softfloat_f32eq(uint64_t v1, uint64_t v2) {
 }
 
 bv5_bool softfloat_f64lt(uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(0);
+  softfloat_init(0);
 
   float64_t a, b;
   a.v = v1;
@@ -665,7 +666,7 @@ bv5_bool softfloat_f64lt(uint64_t v1, uint64_t v2) {
 }
 
 bv5_bool softfloat_f64lt_quiet(uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(0);
+  softfloat_init(0);
 
   float64_t a, b;
   a.v = v1;
@@ -676,7 +677,7 @@ bv5_bool softfloat_f64lt_quiet(uint64_t v1, uint64_t v2) {
 }
 
 bv5_bool softfloat_f64le(uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(0);
+  softfloat_init(0);
 
   float64_t a, b;
   a.v = v1;
@@ -687,7 +688,7 @@ bv5_bool softfloat_f64le(uint64_t v1, uint64_t v2) {
 }
 
 bv5_bool softfloat_f64le_quiet(uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(0);
+  softfloat_init(0);
 
   float64_t a, b;
   a.v = v1;
@@ -698,7 +699,7 @@ bv5_bool softfloat_f64le_quiet(uint64_t v1, uint64_t v2) {
 }
 
 bv5_bool softfloat_f64eq(uint64_t v1, uint64_t v2) {
-  SOFTFLOAT_PRELUDE(0);
+  softfloat_init(0);
 
   float64_t a, b;
   a.v = v1;
@@ -709,7 +710,7 @@ bv5_bool softfloat_f64eq(uint64_t v1, uint64_t v2) {
 }
 
 bv5_bv16 softfloat_f16roundToInt(uint64_t rm, uint64_t v, bool exact) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float16_t a, res;
   uint_fast8_t rm8 = uint8_of_rm(rm);
@@ -720,7 +721,7 @@ bv5_bv16 softfloat_f16roundToInt(uint64_t rm, uint64_t v, bool exact) {
 }
 
 bv5_bv32 softfloat_f32roundToInt(uint64_t rm, uint64_t v, bool exact) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float32_t a, res;
   uint_fast8_t rm8 = uint8_of_rm(rm);
@@ -731,7 +732,7 @@ bv5_bv32 softfloat_f32roundToInt(uint64_t rm, uint64_t v, bool exact) {
 }
 
 bv5_bv64 softfloat_f64roundToInt(uint64_t rm, uint64_t v, bool exact) {
-  SOFTFLOAT_PRELUDE(rm);
+  softfloat_init(rm);
 
   float64_t a, res;
   uint_fast8_t rm8 = uint8_of_rm(rm);


### PR DESCRIPTION
There was no reason for this to be a macro. A function is more readable and less error prone.