### PR TITLE
Improve handling of the delegatable bits configuration for `medeleg` and `mideleg`.

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -14,9 +14,9 @@ foreach(CONFIG__BASE__XLEN IN ITEMS 32 64)
             set(CONFIG_XLEN_IS_${CONFIG__BASE__XLEN} "true")
 
             if (${CONFIG__BASE__XLEN} EQUAL 32)
-              set(CONFIG_MIDELEG_DELEGATABLE_BITS_VALUE "0xFFFF_FFFF")
+              set(CONFIG_MIDELEG_DELEGATABLE_BITS_VALUE "0x0000_2222")
             else()
-              set(CONFIG_MIDELEG_DELEGATABLE_BITS_VALUE "0xFFFF_FFFF_FFFF_FFFF")
+              set(CONFIG_MIDELEG_DELEGATABLE_BITS_VALUE "0x0000_0000_0000_2222")
             endif()
 
             set(CONFIG_ELEN_IS_32 "false")

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -87,8 +87,9 @@
       // bit of `medeleg` can be set to 1. It represents the subset of
       // delegatable traps of the implementation. Bits should not be
       // set for traps that cannot be delegated as per the
-      // specification, and for reserved traps. This value is ignored
-      // when the `medeleg` CSR does not exist.
+      // specification, and delegation of reserved traps is not
+      // supported.  This value is ignored when the `medeleg` CSR does
+      // not exist.
       "delegatable_bits": {
         "len": 64,
         "value": "0x0000_0000_000c_b3FF"
@@ -99,9 +100,10 @@
       // bit of `mideleg` can be set to 1. It represents the subset of
       // delegatable interrupts of the implementation. Bits should not
       // be set for interrupts that cannot be delegated as per the
-      // specification, and for reserved interrupts. Bits set for
-      // interrupts designated for platform use are ignored. This
-      // value is ignored when the `mideleg` CSR does not exist.
+      // specification, and delegation of reserved interrupts is not
+      // supported. Bits set for interrupts designated for platform
+      // use are ignored. This value is ignored when the `mideleg` CSR
+      // does not exist.
       "delegatable_bits": {
         "len": "xlen",
         "value": "@CONFIG_MIDELEG_DELEGATABLE_BITS_VALUE@"

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -87,8 +87,8 @@
       // bit of `medeleg` can be set to 1. It represents the subset of
       // delegatable traps of the implementation. Bits should not be
       // set for traps that cannot be delegated as per the
-      // specification, and for reserved and custom traps. This value
-      // is ignored when the `medeleg` CSR does not exist.
+      // specification, and for reserved traps. This value is ignored
+      // when the `medeleg` CSR does not exist.
       "delegatable_bits": {
         "len": 64,
         "value": "0x0000_0000_000c_b3FF"

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -85,19 +85,23 @@
     "medeleg": {
       // A bit set to 1 in this value specifies that the corresponding
       // bit of `medeleg` can be set to 1. It represents the subset of
-      // delegatable traps of the implementation. Bits for traps that
-      // cannot be delegated as per the specification will be ignored.
+      // delegatable traps of the implementation. Bits should not be
+      // set for traps that cannot be delegated as per the
+      // specification, and for reserved and custom traps. This value
+      // is ignored when the `medeleg` CSR does not exist.
       "delegatable_bits": {
         "len": 64,
-        "value": "0xFFFF_FFFF_FFFF_FFFF"
+        "value": "0x0000_0000_000c_b3FF"
       }
     },
     "mideleg": {
       // A bit set to 1 in this value specifies that the corresponding
       // bit of `mideleg` can be set to 1. It represents the subset of
-      // delegatable interrupts of the implementation. Bits for
-      // interrupts that cannot be delegated as per the specification
-      // will be ignored.
+      // delegatable interrupts of the implementation. Bits should not
+      // be set for interrupts that cannot be delegated as per the
+      // specification, and for reserved interrupts. Bits set for
+      // interrupts designated for platform use are ignored. This
+      // value is ignored when the `mideleg` CSR does not exist.
       "delegatable_bits": {
         "len": "xlen",
         "value": "@CONFIG_MIDELEG_DELEGATABLE_BITS_VALUE@"

--- a/model/core/interrupt_regs.sail
+++ b/model/core/interrupt_regs.sail
@@ -68,6 +68,9 @@ private function legalize_mideleg(o : Minterrupts, v : xlenbits) -> Minterrupts 
 }
 
 bitfield Medeleg : bits(64) = {
+  HardwareError     : 19,
+  SoftwareCheck     : 18,
+  DoubleTrap        : 16,
   SAMO_Page_Fault   : 15,
   Load_Page_Fault   : 13,
   Fetch_Page_Fault  : 12,
@@ -84,9 +87,29 @@ bitfield Medeleg : bits(64) = {
   Fetch_Addr_Align  : 0
 }
 
-private function legalize_medeleg(_o : Medeleg, v : bits(64)) -> Medeleg = {
-  // M-EnvCalls delegation is not supported
-  [Mk_Medeleg(v & plat_medeleg_delegatable_bits) with MEnvCall = 0b0]
+function legalize_medeleg(_o : Medeleg, v : bits(64)) -> Medeleg = {
+  let v = Mk_Medeleg(v & plat_medeleg_delegatable_bits);
+  // M-EnvCalls and DoubleTrap cannot be delegated, and reserved and
+  // custom fields should be read-only zero.
+  [Mk_Medeleg(zeros()) with
+    HardwareError      = v[HardwareError],
+    SoftwareCheck      = v[SoftwareCheck],
+    DoubleTrap         = 0b0,
+    SAMO_Page_Fault    = v[SAMO_Page_Fault],
+    Load_Page_Fault    = v[Load_Page_Fault],
+    Fetch_Page_Fault   = v[Fetch_Page_Fault],
+    MEnvCall           = 0b0,
+    SEnvCall           = v[SEnvCall],
+    UEnvCall           = v[UEnvCall],
+    SAMO_Access_Fault  = v[SAMO_Access_Fault],
+    SAMO_Addr_Align    = v[SAMO_Addr_Align],
+    Load_Access_Fault  = v[Load_Access_Fault],
+    Load_Addr_Align    = v[Load_Addr_Align],
+    Breakpoint         = v[Breakpoint],
+    Illegal_Instr      = v[Illegal_Instr],
+    Fetch_Access_Fault = v[Fetch_Access_Fault],
+    Fetch_Addr_Align   = v[Fetch_Addr_Align],
+  ]
 }
 
 // Note that mip's MEIP and SEIP had special handling. MEIP is always

--- a/model/core/interrupt_regs.sail
+++ b/model/core/interrupt_regs.sail
@@ -62,13 +62,11 @@ private function legalize_mideleg(_o : Minterrupts, v : xlenbits) -> Minterrupts
   // in `mip` and `mie` (see `sys/sys_control.sail:getPendingSet()`,
   // they will not be used (see
   // `sys/sys_control.sail:findPendingInterrupt()`).
+  //
+  // Note also that M-mode interrupts (MTI, MSI, MEI) can be delegated;
+  // see https://github.com/riscv/riscv-isa-manual/issues/3162
   [v with
     LCOFI = if currentlyEnabled(Ext_Sscofpmf) then v[LCOFI] else 0b0,
-    // M-mode interrupts can be delegated;
-    // see https://github.com/riscv/riscv-isa-manual/issues/3162
-    MEI   = v[MEI],
-    MTI   = v[MTI],
-    MSI   = v[MSI],
     SEI   = if currentlyEnabled(Ext_S) then v[SEI] else 0b0,
     STI   = if currentlyEnabled(Ext_S) then v[STI] else 0b0,
     SSI   = if currentlyEnabled(Ext_S) then v[SSI] else 0b0,
@@ -76,9 +74,9 @@ private function legalize_mideleg(_o : Minterrupts, v : xlenbits) -> Minterrupts
 }
 
 bitfield Medeleg : bits(64) = {
-  HardwareError     : 19,
-  SoftwareCheck     : 18,
-  DoubleTrap        : 16,
+  Hardware_Error    : 19,
+  Software_Check    : 18,
+  Double_Trap       : 16,
   SAMO_Page_Fault   : 15,
   Load_Page_Fault   : 13,
   Fetch_Page_Fault  : 12,
@@ -102,7 +100,7 @@ private function legalize_medeleg(_o : Medeleg, v : bits(64)) -> Medeleg = {
   // `sys/sys_control.sail:exception_delegatee()`).
   [Mk_Medeleg(v & plat_medeleg_delegatable_bits) with
     // M-EnvCalls and DoubleTrap cannot be delegated.
-    DoubleTrap         = 0b0,
+    Double_Trap        = 0b0,
     MEnvCall           = 0b0,
   ]
 }

--- a/model/core/interrupt_regs.sail
+++ b/model/core/interrupt_regs.sail
@@ -55,12 +55,13 @@ private function legalize_mie(o : Minterrupts, v : xlenbits) -> Minterrupts = {
 
 private function legalize_mideleg(o : Minterrupts, v : xlenbits) -> Minterrupts = {
   let v = Mk_Minterrupts(v & plat_mideleg_delegatable_bits);
-  // M-mode interrupt delegation bits "should" be hardwired to 0.
   [o with
     LCOFI = if currentlyEnabled(Ext_Sscofpmf) then v[LCOFI] else 0b0,
-    MEI   = 0b0,
-    MTI   = 0b0,
-    MSI   = 0b0,
+    // M-mode interrupts can be delegated;
+    // see https://github.com/riscv/riscv-isa-manual/issues/3162
+    MEI   = v[MEI],
+    MTI   = v[MTI],
+    MSI   = v[MSI],
     SEI   = if currentlyEnabled(Ext_S) then v[SEI] else 0b0,
     STI   = if currentlyEnabled(Ext_S) then v[STI] else 0b0,
     SSI   = if currentlyEnabled(Ext_S) then v[SSI] else 0b0,
@@ -88,27 +89,10 @@ bitfield Medeleg : bits(64) = {
 }
 
 function legalize_medeleg(_o : Medeleg, v : bits(64)) -> Medeleg = {
-  let v = Mk_Medeleg(v & plat_medeleg_delegatable_bits);
-  // M-EnvCalls and DoubleTrap cannot be delegated, and reserved and
-  // custom fields should be read-only zero.
-  [Mk_Medeleg(zeros()) with
-    HardwareError      = v[HardwareError],
-    SoftwareCheck      = v[SoftwareCheck],
+  [Mk_Medeleg(v & plat_medeleg_delegatable_bits) with
+    // M-EnvCalls and DoubleTrap cannot be delegated.
     DoubleTrap         = 0b0,
-    SAMO_Page_Fault    = v[SAMO_Page_Fault],
-    Load_Page_Fault    = v[Load_Page_Fault],
-    Fetch_Page_Fault   = v[Fetch_Page_Fault],
     MEnvCall           = 0b0,
-    SEnvCall           = v[SEnvCall],
-    UEnvCall           = v[UEnvCall],
-    SAMO_Access_Fault  = v[SAMO_Access_Fault],
-    SAMO_Addr_Align    = v[SAMO_Addr_Align],
-    Load_Access_Fault  = v[Load_Access_Fault],
-    Load_Addr_Align    = v[Load_Addr_Align],
-    Breakpoint         = v[Breakpoint],
-    Illegal_Instr      = v[Illegal_Instr],
-    Fetch_Access_Fault = v[Fetch_Access_Fault],
-    Fetch_Addr_Align   = v[Fetch_Addr_Align],
   ]
 }
 

--- a/model/core/interrupt_regs.sail
+++ b/model/core/interrupt_regs.sail
@@ -53,9 +53,16 @@ private function legalize_mie(o : Minterrupts, v : xlenbits) -> Minterrupts = {
   ]
 }
 
-private function legalize_mideleg(o : Minterrupts, v : xlenbits) -> Minterrupts = {
+private function legalize_mideleg(_o : Minterrupts, v : xlenbits) -> Minterrupts = {
   let v = Mk_Minterrupts(v & plat_mideleg_delegatable_bits);
-  [o with
+  // Using `v` allows bits to be set for interrupts designated for
+  // platform use. This is useful for bit-matching test frameworks
+  // like ACT, but these bits do not affect the model as those
+  // interrupts are not known. (Even if the corresponding bits are set
+  // in `mip` and `mie` (see `sys/sys_control.sail:getPendingSet()`,
+  // they will not be used (see
+  // `sys/sys_control.sail:findPendingInterrupt()`).
+  [v with
     LCOFI = if currentlyEnabled(Ext_Sscofpmf) then v[LCOFI] else 0b0,
     // M-mode interrupts can be delegated;
     // see https://github.com/riscv/riscv-isa-manual/issues/3162
@@ -89,6 +96,10 @@ bitfield Medeleg : bits(64) = {
 }
 
 private function legalize_medeleg(_o : Medeleg, v : bits(64)) -> Medeleg = {
+  // Using `v` allows bits for custom exceptions to be set. This is
+  // useful for bit-matching test frameworks like ACT, but these bits
+  // do not affect the model as those exceptions are not known (see
+  // `sys/sys_control.sail:exception_delegatee()`).
   [Mk_Medeleg(v & plat_medeleg_delegatable_bits) with
     // M-EnvCalls and DoubleTrap cannot be delegated.
     DoubleTrap         = 0b0,

--- a/model/core/interrupt_regs.sail
+++ b/model/core/interrupt_regs.sail
@@ -88,7 +88,7 @@ bitfield Medeleg : bits(64) = {
   Fetch_Addr_Align  : 0
 }
 
-function legalize_medeleg(_o : Medeleg, v : bits(64)) -> Medeleg = {
+private function legalize_medeleg(_o : Medeleg, v : bits(64)) -> Medeleg = {
   [Mk_Medeleg(v & plat_medeleg_delegatable_bits) with
     // M-EnvCalls and DoubleTrap cannot be delegated.
     DoubleTrap         = 0b0,

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -561,7 +561,7 @@ private function check_extension_param_constraints() -> bool = {
       print_endline("Bit 11 (Environment call from M-mode) in `base.medeleg.delegatable_bits` is set; this environment call cannot be delegated.");
     };
     let reserved_exception_mask : bits(64) = zero_extend(0x0_FFFF_00F2_4400);
-    if valid & (medelegation.bits & reserved_exception_mask) != zeros() then {
+    if (medelegation.bits & reserved_exception_mask) != zeros() then {
       valid = false;
       print_endline("Bits for reserved exceptions are set in `base.medeleg.delegatable_bits`.");
     };
@@ -569,7 +569,7 @@ private function check_extension_param_constraints() -> bool = {
     let midelegation = Mk_Minterrupts(config base.mideleg.delegatable_bits);
     // Ignore bits set for interrupts designated for platform use.
     let reserved_interrupt_mask : xlenbits = zero_extend(0xD555);
-    if valid & (midelegation.bits & reserved_interrupt_mask) != zeros() then {
+    if (midelegation.bits & reserved_interrupt_mask) != zeros() then {
       valid = false;
       print_endline("Bits for reserved interrupts are set in `base.mideleg.delegatable_bits`.");
     }

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -552,7 +552,7 @@ private function check_extension_param_constraints() -> bool = {
   };
   if (config extensions.S.supported : bool) then {
     let medelegation = Mk_Medeleg(config base.medeleg.delegatable_bits);
-    if medelegation[DoubleTrap] != 0b0 then {
+    if medelegation[Double_Trap] != 0b0 then {
       valid = false;
       print_endline("Bit 16 (Double Trap) in `base.medeleg.delegatable_bits` is set; Double Trap cannot be delegated.");
     };

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -550,6 +550,33 @@ private function check_extension_param_constraints() -> bool = {
       print_endline("The Zicclsm extension is enabled, but misaligned vector loads/stores raise access faults before address translation (as per `memory.misaligned.exceptions.vector`); Zicclsm requires no exceptions or only misaligned exceptions for such accesses.");
     };
   };
+  if (config extensions.S.supported : bool) then {
+    let medelegation = Mk_Medeleg(config base.medeleg.delegatable_bits);
+    if medelegation[DoubleTrap] != 0b0 then {
+      valid = false;
+      print_endline("Bit 16 (Double Trap) in `base.medeleg.delegatable_bits` is set; Double Trap cannot be delegated.");
+    };
+    if medelegation[MEnvCall] != 0b0 then {
+      valid = false;
+      print_endline("Bit 11 (Environment call from M-mode) in `base.medeleg.delegatable_bits` is set; this environment call cannot be delegated.");
+    };
+    if valid & (medelegation.bits != (legalize_medeleg(Mk_Medeleg(zeros()), config base.medeleg.delegatable_bits)).bits) then {
+      valid = false;
+      print_endline("Bits for reserved or custom exceptions are set in `base.medeleg.delegatable_bits`.");
+    };
+
+    let midelegation = Mk_Minterrupts(config base.mideleg.delegatable_bits);
+    if midelegation[MEI] != 0b0 | midelegation[MTI] != 0b0 | midelegation[MSI] != 0b0 then {
+      valid = false;
+      print_endline("One or more bits for machine-mode interrupts (i.e. bits 3, 7, 11) are set in `base.mideleg.delegatable_bits`; machine-mode interrupts cannot be delegated.");
+    };
+    // Ignore bits set for interrupts designated for platform use.
+    let reserved_interrupt_mask : xlenbits = zero_extend(0xD555);
+    if valid & (midelegation.bits & reserved_interrupt_mask) != zeros() then {
+      valid = false;
+      print_endline("Bits for reserved interrupts are set in `base.mideleg.delegatable_bits`.");
+    }
+  };
   valid
 }
 

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -560,16 +560,13 @@ private function check_extension_param_constraints() -> bool = {
       valid = false;
       print_endline("Bit 11 (Environment call from M-mode) in `base.medeleg.delegatable_bits` is set; this environment call cannot be delegated.");
     };
-    if valid & (medelegation.bits != (legalize_medeleg(Mk_Medeleg(zeros()), config base.medeleg.delegatable_bits)).bits) then {
+    let reserved_exception_mask : bits(64) = zero_extend(0x0_FFFF_00F2_4400);
+    if valid & (medelegation.bits & reserved_exception_mask) != zeros() then {
       valid = false;
-      print_endline("Bits for reserved or custom exceptions are set in `base.medeleg.delegatable_bits`.");
+      print_endline("Bits for reserved exceptions are set in `base.medeleg.delegatable_bits`.");
     };
 
     let midelegation = Mk_Minterrupts(config base.mideleg.delegatable_bits);
-    if midelegation[MEI] != 0b0 | midelegation[MTI] != 0b0 | midelegation[MSI] != 0b0 then {
-      valid = false;
-      print_endline("One or more bits for machine-mode interrupts (i.e. bits 3, 7, 11) are set in `base.mideleg.delegatable_bits`; machine-mode interrupts cannot be delegated.");
-    };
     // Ignore bits set for interrupts designated for platform use.
     let reserved_interrupt_mask : xlenbits = zero_extend(0xD555);
     if valid & (midelegation.bits & reserved_interrupt_mask) != zeros() then {

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -70,6 +70,8 @@ function check_CSR_result(csr : csreg, p : Privilege, access_type : CSRAccessTyp
 // it occurred, returns the privilege at which it should be handled.
 function exception_delegatee(e : ExceptionType, p : Privilege) -> Privilege = {
   let idx = unsigned(exceptionType_bits(e));
+  // Note that `medeleg` can have bits set for custom exceptions (see
+  // `core/interrupt_regs.sail:legalize_medeleg()`).
   let super = bit_to_bool(medeleg.bits[idx]);
   // TODO: check VS/VU-mode if hypervisor extension enabled
   let deleg = if currentlyEnabled(Ext_S) & super then Supervisor else Machine;
@@ -109,6 +111,10 @@ function getPendingSet(priv : Privilege) -> option((xlenbits, Privilege)) = {
   // Read mip with the external platform interrupts ORed in.
   let mip_bits = read_mip(IncludePlatformInterrupts).bits;
 
+  // Note that `mideleg` can have bits set for interrupts designated
+  // for platform use (see
+  // `core/interrupt_regs.sail:legalize_mideleg()`), but those
+  // interrupts are not known in `findPendingInterrupt()` above.
   let pending_m = mip_bits & mie.bits & ~(mideleg.bits);
   let pending_s = mip_bits & mie.bits & mideleg.bits;
 


### PR DESCRIPTION
Ensure that bits for reserved exceptions in `medeleg` are read-only zero, and that the double-trap exception cannot be delegated.  Bits for custom exceptions are allowed to be set but ignored.

Validate the delegated bits against reserved bits. For `mideleg`, bits for interrupts designated for platform use are allowed to be set but ignored.

`legalize_mideleg` now allows {`MEI`, `MTI`, `MSI`} to be set in `mideleg` to account for this clarification:
https://github.com/riscv/riscv-isa-manual/issues/3162

This fixes #1803.