### PR TITLE
Fix an assertion for non-zero `mideleg` that tripped when `misa.S` was changed.

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -11,6 +11,7 @@
     when mstatus[FS/SD] is set by floating point instructions.
 
 - Important issues addressed and bugs fixed:
+  - https://github.com/riscv/sail-riscv/issues/1807 : fix assertion on non-zero `mideleg` triggered by clearing `misa.S`
   - https://github.com/riscv/sail-riscv/issues/1794 : `vtype.vill` was not set when SEW was configured to exceed ELEN
   - https://github.com/riscv/sail-riscv/issues/1753 : Access to `xenvcfg` CSRs need to be gated by the specification version
   - https://github.com/riscv/sail-riscv/issues/1750 : Non-segmented indexed loads were trapping on legal overlaps

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -105,8 +105,9 @@ function findPendingInterrupt(ip : xlenbits) -> option(InterruptType) = {
 //
 // TODO: check hip/hie if hypervisor enabled.
 function getPendingSet(priv : Privilege) -> option((xlenbits, Privilege)) = {
-  // mideleg can only be non-zero if we support Supervisor mode.
-  assert(currentlyEnabled(Ext_S) | mideleg.bits == zeros());
+  // If supervisor mode is not currently enabled then ignore mideleg
+  // (it does not exist).
+  let mideleg_bits = if currentlyEnabled(Ext_S) then mideleg.bits else zeros();
 
   // Read mip with the external platform interrupts ORed in.
   let mip_bits = read_mip(IncludePlatformInterrupts).bits;


### PR DESCRIPTION
When `misa.S` is zero, treat it as S mode not being enabled (via `currentlyEnabled()`), in which case `mideleg` does not exist.

Fixes #1807.