### PR TITLE
Report physical address for physical memory exceptions.

### DIFF
--- a/model/extensions/A/zaamo_insts.sail
+++ b/model/extensions/A/zaamo_insts.sail
@@ -98,15 +98,18 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
     Ok(addr, pbmt, _) => (addr, pbmt),
   };
 
-  // FIXME: the AMO could lie outside a MAG PMA region, which will be
-  // determined by the following `mem_write_value`.  This might result
-  // in a `mem_write_ea` without a matching write of a value to
-  // memory.  See https://github.com/riscv/sail-riscv/issues/1761.
-
   let loaded : bits('width * 8) = match mem_write_ea(addr, width, access, pbmt, aq & rl, rl, true) {
-    Err(e) => return memory_exception(vaddr, e),
+    Err(exc_addr, e) => {
+      // AMOs should not get split.
+      assert(exc_addr == addr);
+      return memory_exception(vaddr, e)
+    },
     Ok(_)  => match mem_read(access, pbmt, addr, width, aq, aq & rl, true) {
-      Err(e)     => return memory_exception(vaddr, e),
+      Err(exc_addr, e) => {
+        // AMOs should not get split.
+        assert(exc_addr == addr);
+        return memory_exception(vaddr, e)
+      },
       Ok(loaded) => loaded,
     },
   };
@@ -148,7 +151,11 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
       RETIRE_SUCCESS
     },
     Ok(false) => internal_error(__FILE__, __LINE__, "AMO got false from mem_write_value"),
-    Err(e)    => memory_exception(vaddr, e),
+    Err(exc_addr, e) => {
+      // AMOs should not get split.
+      assert(exc_addr == addr);
+      memory_exception(vaddr, e)
+    }
   }
 }
 

--- a/model/extensions/Zicboz/zicboz_insts.sail
+++ b/model/extensions/Zicboz/zicboz_insts.sail
@@ -52,12 +52,20 @@ function clause execute ZICBOZ(rs1) = {
         Err(e, _) => memory_exception(vaddr - negative_offset, e),
         Ok(paddr, pbmt, _) => {
           match mem_write_ea(paddr, cache_block_size, access, pbmt, false, false, false) {
-            Err(e) => memory_exception(vaddr - negative_offset, e),
+            Err(exc_addr, e) => {
+              // Cache accesses should not get split.
+              assert(exc_addr == paddr);
+              memory_exception(vaddr - negative_offset, e)
+            },
             Ok(_)  => {
               match mem_write_value(paddr, cache_block_size, zeros(), access, pbmt, false, false, false) {
                 Ok(true)  => RETIRE_SUCCESS,
                 Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
-                Err(e)    => memory_exception(vaddr - negative_offset, e),
+                Err(exc_addr, e) => {
+                  // Cache accesses should not get split.
+                  assert(exc_addr == paddr);
+                  memory_exception(vaddr - negative_offset, e)
+                },
               }
             }
           }

--- a/model/extensions/cfi/zicfiss_insts.sail
+++ b/model/extensions/cfi/zicfiss_insts.sail
@@ -199,11 +199,6 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
   // release consistency semantics, using the aq and rl bits, to help
   // implement multiprocessor synchronization."
 
-  // FIXME: the AMO could lie outside a MAG PMA region, which will be
-  // determined by the following `mem_write_value`.  This might result
-  // in a `mem_write_ea` without a matching write of a value to
-  // memory.  See https://github.com/riscv/sail-riscv/issues/1761.
-
   let 'width = width;
   let mem_val : bits('width * 8) = match mem_write_ea(paddr, width, access, pbmt, aq & rl, rl, true) {
     Err(exc_addr, e) => {

--- a/model/extensions/cfi/zicfiss_insts.sail
+++ b/model/extensions/cfi/zicfiss_insts.sail
@@ -206,9 +206,17 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
 
   let 'width = width;
   let mem_val : bits('width * 8) = match mem_write_ea(paddr, width, access, pbmt, aq & rl, rl, true) {
-    Err(e) => return memory_exception(vaddr, e),
-    Ok(_)  => match mem_read(access, pbmt, paddr, width, aq, aq & rl, true) {
-      Err(e) => return memory_exception(vaddr, e),
+    Err(exc_addr, e) => {
+      // AMOs should not get split.
+      assert(exc_addr == paddr);
+      return memory_exception(vaddr, e)
+    },
+    Ok(_) => match mem_read(access, pbmt, paddr, width, aq, aq & rl, true) {
+      Err(exc_addr, e) => {
+        // AMOs should not get split.
+        assert(exc_addr == paddr);
+        return memory_exception(vaddr, e)
+      },
       Ok(v)  => v,
     },
   };
@@ -222,7 +230,11 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
   match mem_write_value(paddr, width, write_val, access, pbmt, aq & rl, rl, true) {
     Ok(true)  => X(rd) = sign_extend(mem_val),
     Ok(false) => internal_error(__FILE__, __LINE__, "AMOSWAP_SS got false from mem_write_value"),
-    Err(e)    => return memory_exception(vaddr, e),
+    Err(exc_addr, e) => {
+      // AMOs should not get split.
+      assert(exc_addr == paddr);
+      return memory_exception(vaddr, e)
+    },
   };
 
   RETIRE_SUCCESS

--- a/model/postlude/fetch.sail
+++ b/model/postlude/fetch.sail
@@ -39,7 +39,11 @@ private function fetch_bytes forall 'n, 'n in {2, 4} . (fetch_start : xlenbits, 
   };
 
   match mem_read(InstructionFetch(), pbmt, paddr, width, false, false, false) {
-    Err(e)    => FetchBytes_Exception(e),
+    Err(exc_addr, e) => {
+      // Instruction fetches are not currently split at the physical memory layer.
+      assert(exc_addr == paddr);
+      FetchBytes_Exception(e)
+    },
     Ok(bytes) => FetchBytes_Success(bytes),
   }
 }

--- a/model/sys/mem.sail
+++ b/model/sys/mem.sail
@@ -261,7 +261,7 @@ private function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (
 
   let access_info : Phys_Mem_Access_Info = match check_pma_with_pmp_priority(access, pbmt, priv, paddr, width, res) {
     Ok(access_info) => access_info,
-    Err(e)          => return Err(e),
+    Err(e)          => return Err(paddr, e),
   };
 
   // Split into `N` (single-copy-atomic) memory operations, each
@@ -286,7 +286,7 @@ private function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (
 
     // As mentioned above, PMP checks are done on each split access.
     match pmpCheck(paddr, split_width, access, priv) {
-      Some(e) => return Err(e),
+      Some(e) => return Err(paddr, e),
       None()  => (),
     };
 
@@ -335,7 +335,7 @@ function mem_read_priv_meta (access, pbmt, priv, paddr, width, aq, rl, res, meta
   };
   match result {
     Ok(value, _) => mem_read_callback(to_str(access), bits_of(paddr), width, value),
-    Err(e) => mem_exception_callback(bits_of(paddr), exceptionType_bits(e)),
+    Err(addr, e) => mem_exception_callback(bits_of(addr), exceptionType_bits(e)),
   };
   result
 }
@@ -373,7 +373,7 @@ function mem_write_ea(paddr, width, access, pbmt, aq, rl, con) = {
 
   let access_info : Phys_Mem_Access_Info = match check_pma_with_pmp_priority(access, pbmt, priv, paddr, width, con) {
     Ok(access_info) => access_info,
-    Err(e)          => return Err(e),
+    Err(e)          => return Err(paddr, e),
   };
 
   let ('N, 'split_width) = split_misaligned(paddr, width, access_info.granule_size_exp, access_info.splittable);
@@ -391,7 +391,7 @@ function mem_write_ea(paddr, width, access, pbmt, aq, rl, con) = {
     let paddr = Physaddr(paddr_bits + (offset * split_width));
 
     match pmpCheck(paddr, split_width, access, priv) {
-      Some(e) => return Err(e),
+      Some(e) => return Err(paddr, e),
       None()  => write_ram_ea(wk, paddr, split_width),
     };
 
@@ -425,7 +425,7 @@ function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
 
   let access_info : Phys_Mem_Access_Info = match check_pma_with_pmp_priority(access, pbmt, priv, paddr, width, con) {
     Ok(access_info) => access_info,
-    Err(e)          => return Err(e),
+    Err(e)          => return Err(paddr, e),
   };
 
   // Split into `N` (single-copy-atomic) memory operations, each
@@ -450,7 +450,7 @@ function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
     // As mentioned above (see `checked_mem_read()`), PMP checks are
     // done on each split access.
     match pmpCheck(paddr, split_width, access, priv) {
-      Some(e) => return Err(e),
+      Some(e) => return Err(paddr, e),
       None()  => (),
     };
 
@@ -491,7 +491,7 @@ function mem_write_value_priv_meta (paddr, width, value, access, pbmt, priv, met
   let result = checked_mem_write(paddr, width, value, access, pbmt, priv, meta, aq, rl, con);
   match result {
     Ok(_) => mem_write_callback(to_str(access), bits_of(paddr), width, value),
-    Err(e) => mem_exception_callback(bits_of(paddr), exceptionType_bits(e)),
+    Err(addr, e) => mem_exception_callback(bits_of(addr), exceptionType_bits(e)),
   };
   result
 }

--- a/model/sys/platform.sail
+++ b/model/sys/platform.sail
@@ -82,7 +82,8 @@ let MTIME_BASE       : physaddrbits = zero_extend(0x0bff8)
 let MTIME_BASE_HI    : physaddrbits = zero_extend(0x0bffc)
 
 private val clint_load : forall 'n, 'n > 0. (MemoryAccessType(mem_payload), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
-function clint_load(access, Physaddr(addr), width) = {
+function clint_load(access, paddr, width) = {
+  let Physaddr(addr) = paddr;
   let addr = addr - plat_clint_base;
   // FIXME: For now, only allow exact aligned access.
   if addr == MSIP_BASE & ('n == 8 | 'n == 4)
@@ -133,7 +134,7 @@ function clint_load(access, Physaddr(addr), width) = {
   else {
     if   get_config_print_clint()
     then print_log("clint[" ^ bits_str(addr) ^ "] -> <not-mapped>");
-    Err(accessFaultFromAccessType(access))
+    Err(paddr, accessFaultFromAccessType(access))
   }
 }
 
@@ -151,7 +152,8 @@ private function clint_dispatch(mip_was_written : bool) -> unit = {
 }
 
 private val clint_store: forall 'n, 'n > 0. (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
-function clint_store(Physaddr(addr), width, data) = {
+function clint_store(paddr, width, data) = {
+  let Physaddr(addr) = paddr;
   let addr = addr - plat_clint_base;
   if addr == MSIP_BASE & ('n == 8 | 'n == 4) then {
     if   get_config_print_clint()
@@ -198,7 +200,7 @@ function clint_store(Physaddr(addr), width, data) = {
   } else {
     if   get_config_print_clint()
     then print_log("clint[" ^ bits_str(addr) ^ "] <- " ^ bits_str(data) ^ " (<unmapped>)");
-    Err(E_SAMO_Access_Fault())
+    Err(paddr, E_SAMO_Access_Fault())
   }
 }
 
@@ -259,7 +261,8 @@ private function reset_htif () -> unit = {
 // dispatched the address.
 
 private val htif_load : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(mem_payload), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
-function htif_load(access, Physaddr(paddr), width) = {
+function htif_load(access, addr, width) = {
+  let Physaddr(paddr) = addr;
   if   get_config_print_htif()
   then print_log("htif[" ^ hex_bits_str(paddr) ^ "] -> " ^ bits_str(htif_tohost));
 
@@ -275,11 +278,12 @@ function htif_load(access, Physaddr(paddr), width) = {
   then    Ok(zero_extend(32, htif_tohost[31..0]))  // FIXME: Redundant zero_extend currently required by Lem backend
   else if width == 4 & paddr == base + 4
   then    Ok(zero_extend(32, htif_tohost[63..32])) // FIXME: Redundant zero_extend currently required by Lem backend
-  else    Err(accessFaultFromAccessType(access))
+  else    Err(addr, accessFaultFromAccessType(access))
 }
 
 private val htif_store : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
-function htif_store(Physaddr(paddr), width, data) = {
+function htif_store(addr, width, data) = {
+  let Physaddr(paddr) = addr;
   if   get_config_print_htif()
   then print_log("htif[" ^ hex_bits_str(paddr) ^ "] <- " ^ bits_str(data));
 
@@ -305,7 +309,7 @@ function htif_store(Physaddr(paddr), width, data) = {
             else htif_payload_writes = 0x1;
             htif_cmd_write = 0b1;
             htif_tohost = vector_update_subrange(htif_tohost, 63, 32, data) }
-  else return Err(E_SAMO_Access_Fault());
+  else return Err(addr, E_SAMO_Access_Fault());
 
   // Execute if there were repeated writes of the same payload without
   // a cmd (e.g. in riscv-tests), or we have a complete htif command.
@@ -359,7 +363,7 @@ function mmio_read forall 'n, 0 < 'n <= max_mem_access . (access : MemoryAccessT
   then sig_load(access, paddr, width)
   else if within_htif_readable(paddr, width)
   then htif_load(access, paddr, width)
-  else Err(accessFaultFromAccessType(access))
+  else Err(paddr, accessFaultFromAccessType(access))
 
 function mmio_write forall 'n, 0 < 'n <= max_mem_access . (paddr : physaddr, width : int('n), data: bits(8 * 'n)) -> MemoryOpResult(bool) =
   if   within_clint(paddr, width)
@@ -368,4 +372,4 @@ function mmio_write forall 'n, 0 < 'n <= max_mem_access . (paddr : physaddr, wid
   then sig_store(paddr, width, data)
   else if within_htif_writable(paddr, width)
   then htif_store(paddr, width, data)
-  else Err(E_SAMO_Access_Fault())
+  else Err(paddr, E_SAMO_Access_Fault())

--- a/model/sys/simple_interrupt_generator.sail
+++ b/model/sys/simple_interrupt_generator.sail
@@ -11,26 +11,28 @@ let SIG_VERSION_OFFSET = 0
 let SIG_PLATFORM_OFFSET = 4
 
 private val sig_load : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(mem_payload), physaddr, int('n)) -> MemoryOpResult(bits(8 * 'n))
-function sig_load(access, Physaddr(paddr), width) = {
+function sig_load(access, addr, width) = {
+  let Physaddr(paddr) = addr;
   // Version of this MMIO device (1.0 currently).
   // This follows semver.
   let VERSION = 0x00010000;
 
   if width != 4 | paddr[1 .. 0] != zeros()
-  then Err(accessFaultFromAccessType(access))
+  then Err(addr, accessFaultFromAccessType(access))
   else {
     if paddr == plat_sig_base + SIG_VERSION_OFFSET
     then Ok(VERSION)
     else if paddr == plat_sig_base + SIG_PLATFORM_OFFSET
     then Ok(zeros())
-    else Err(accessFaultFromAccessType(access))
+    else Err(addr, accessFaultFromAccessType(access))
   }
 }
 
 private val sig_store : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n)) -> MemoryOpResult(bool)
-function sig_store(Physaddr(paddr), width, data) = {
+function sig_store(addr, width, data) = {
+  let Physaddr(paddr) = addr;
   if width != 4 | paddr[1 .. 0] != zeros()
-  then Err(E_SAMO_Access_Fault())
+  then Err(addr, E_SAMO_Access_Fault())
   else {
     if paddr == plat_sig_base + SIG_VERSION_OFFSET
     then Ok(true)
@@ -41,7 +43,7 @@ function sig_store(Physaddr(paddr), width, data) = {
 
       // Reserved bits must currently be written with zeros.
       if [data with MEI = 0b0, SEI = 0b0, MSI = 0b0, SSI = 0b0].bits[30 .. 0] != zeros()
-      then return Err(E_SAMO_Access_Fault());
+      then return Err(addr, E_SAMO_Access_Fault());
 
       if data[MEI] == 0b1 then sig_meip = value;
       if data[SEI] == 0b1 then sig_seip = value;
@@ -52,6 +54,6 @@ function sig_store(Physaddr(paddr), width, data) = {
       csr_write_callback("mip", read_mip(IncludePlatformInterrupts).bits);
 
       Ok(true)
-    } else Err(E_SAMO_Access_Fault())
+    } else Err(addr, E_SAMO_Access_Fault())
   }
 }

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -413,7 +413,7 @@ function reset_sys() -> unit = {
 
 // memory access exceptions, defined here for use by the platform model.
 
-type MemoryOpResult('a : Type) = result('a, ExceptionType)
+type MemoryOpResult('a : Type) = result('a, (physaddr, ExceptionType))
 
 val MemoryOpResult_add_meta : forall ('t : Type). (MemoryOpResult('t), mem_meta) -> MemoryOpResult(('t, mem_meta))
 function MemoryOpResult_add_meta(r, m) = match r {

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -37,6 +37,24 @@ function plat_misaligned_exception(access : MemoryAccessType(mem_payload), res :
   else plat_misaligned_access.load_store
 }
 
+// Memory exceptions from `mem.sail` are reported in terms of
+// `physaddr`, while the utilities here need to report them in terms
+// of the corresponding `virtaddr`.  In particular, since the original
+// `virtaddr` access may be split into smaller `physaddr` accesses,
+// the correct offset from the base `virtaddr` needs to be reported.
+// Since `virtaddr` accesses that straddle page boundaries are already
+// split, the offset computation is quite simple.
+
+private function offset_virtaddr_by(
+  Virtaddr(base_vaddr) : virtaddr,
+  Physaddr(base_paddr) : physaddr,
+  Physaddr(exc_paddr)  : physaddr,
+) -> virtaddr = {
+  // Physical addresses may have a different size.
+  let offset = (exc_paddr - base_paddr)[xlen - 1 .. 0];
+  Virtaddr(base_vaddr + offset)
+}
+
 // External API
 
 // Transforms the effective address based on PMM settings and the current translation mode.
@@ -88,7 +106,10 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
       Err(e,_) => return Err(memory_exception(access_addr, e)),
 
       Ok(paddr, pbmt, _) => match mem_read(access, pbmt, paddr, next_page_bytes, aq, rl, res) {
-        Err(e) => return Err(memory_exception(access_addr, e)),
+        Err(exc_paddr, e) => {
+          let exc_vaddr = offset_virtaddr_by(access_addr, paddr, exc_paddr);
+          return Err(memory_exception(exc_vaddr, e))
+        },
         Ok(v)  => data[8 * width - 1 .. 8 * in_page_bytes] = v,
       },
     }
@@ -101,8 +122,10 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
     Err(e, _) => return Err(memory_exception(vaddr, e)),
 
     Ok(paddr, pbmt, _) => match mem_read(access, pbmt, paddr, access_width, aq, rl, res) {
-      Err(e) => return Err(memory_exception(vaddr, e)),
-
+      Err(exc_paddr, e) => {
+        let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
+        return Err(memory_exception(exc_vaddr, e))
+      },
       Ok(v)  => {
         if res then {
           load_reservation(bits_of(paddr), width);
@@ -123,7 +146,10 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
       Err(e,_) => return Err(memory_exception(access_addr, e)),
 
       Ok(paddr, pbmt, _) => match mem_read(access, pbmt, paddr, next_page_bytes, aq, rl, res) {
-        Err(e) => return Err(memory_exception(access_addr, e)),
+        Err(exc_paddr, e) => {
+          let exc_vaddr = offset_virtaddr_by(access_addr, paddr, exc_paddr);
+          return Err(memory_exception(exc_vaddr, e))
+        },
         Ok(v)  => data[8 * width - 1 .. 8 * in_page_bytes] = v,
       },
     }
@@ -172,12 +198,18 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
       Err(e, _) => return Err(memory_exception(access_addr, e)),
 
       Ok(paddr, pbmt, _) => match mem_write_ea(paddr, next_page_bytes, access, pbmt, aq, rl, res) {
-        Err(e) => return Err(memory_exception(access_addr, e)),
+        Err(exc_paddr, e) => {
+          let exc_vaddr = offset_virtaddr_by(access_addr, paddr, exc_paddr);
+          return Err(memory_exception(exc_vaddr, e))
+        },
 
         Ok(()) => {
           let write_value = data[8 * width - 1 .. 8 * in_page_bytes];
           match mem_write_value(paddr, next_page_bytes, write_value, access, pbmt, aq, rl, res) {
-            Err(e) => return Err(memory_exception(access_addr, e)),
+            Err(exc_paddr, e) => {
+              let exc_vaddr = offset_virtaddr_by(access_addr, paddr, exc_paddr);
+              return Err(memory_exception(exc_vaddr, e))
+            },
             Ok(s)  => write_success = write_success & s,
           }
         },
@@ -205,12 +237,18 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
           Ok(_)  => write_success = false,
         }
       } else match mem_write_ea(paddr, access_width, access, pbmt, aq, rl, res) {
-        Err(e) => return Err(memory_exception(vaddr, e)),
+        Err(exc_paddr, e) => {
+          let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
+          return Err(memory_exception(exc_vaddr, e))
+        },
 
         Ok(()) => {
           let write_value = data[8 * access_width - 1 .. 0];
           match mem_write_value(paddr, access_width, write_value, access, pbmt, aq, rl, res) {
-            Err(e) => return Err(memory_exception(vaddr, e)),
+            Err(exc_paddr, e) => {
+              let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
+              return Err(memory_exception(exc_vaddr, e))
+            },
             Ok(s)  => write_success = write_success & s,
           }
         },
@@ -227,12 +265,18 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
       Err(e, _) => return Err(memory_exception(access_addr, e)),
 
       Ok(paddr, pbmt, _) => match mem_write_ea(paddr, next_page_bytes, access, pbmt, aq, rl, res) {
-        Err(e) => return Err(memory_exception(access_addr, e)),
+        Err(exc_paddr, e) => {
+          let exc_vaddr = offset_virtaddr_by(access_addr, paddr, exc_paddr);
+          return Err(memory_exception(exc_vaddr, e))
+        },
 
         Ok(()) => {
           let write_value = data[8 * width - 1 .. 8 * in_page_bytes];
           match mem_write_value(paddr, next_page_bytes, write_value, access, pbmt, aq, rl, res) {
-            Err(e) => return Err(memory_exception(access_addr, e)),
+            Err(exc_paddr, e) => {
+              let exc_vaddr = offset_virtaddr_by(access_addr, paddr, exc_paddr);
+              return Err(memory_exception(exc_vaddr, e))
+            },
             Ok(s)  => write_success = write_success & s,
           }
         },


### PR DESCRIPTION
Since physical memory accesses can now be split, the precise physical memory address needs to be reported for any exception encountered by a physical memory operation. This adds this physical memory address to the `Err` case of `MemoryOpResult`.

The helpers in `vmem_utils` have been updated to appropriately offset any virtual memory addresses reported in exceptions.

Accesses that do not split (e.g. AMOs and cache operations) assert this for physical addresses in exceptions.

All this addresses the `xtval` regression mentioned in the previous commit of #1734. 

Two obsolete FIXMEs have been removed since they were fixed by #1734.