### PR TITLE
Add the Zama16b extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ For booting operating system images, see the information under the
 - Zaamo extension for atomic memory operations, v1.0
 - Za64rs extension for reservation sets that are contiguous, naturally aligned, and a maximum of 64 bytes, v1.0
 - Za128rs extension for reservation sets that are contiguous, naturally aligned, and at most 128 bytes in size, v1.0
+- Zama16b extension for 16-byte Misaligned Atomicity, v1.0
 - Zawrs extension for Wait-on-Reservation-Set instructions, v1.01
 - Zabha extension for byte and halfword atomic memory operations, v1.0
 - Zacas extension atomic Compare-and-Swap (CAS) instructions, v1.0.0

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -262,8 +262,9 @@
     // the `misaligned` PMA attribute for a region, see the comments for
     // `memory.misaligned.exceptions` above.
     // The optional misaligned atomicity granule (MAG) can be specified as a
-    // power of 2, upto a maximum of a page size (i.e. 12).  A value of 0
-    // indicates that the MAG attribute is not present.
+    // power of 2, upto a maximum of a page size (i.e. 12). For
+    // Zama16b, for e.g., the specified value should be 4. A value of
+    // 0 indicates that the MAG attribute is not present.
     "regions": [
       // ROM
       {
@@ -605,6 +606,14 @@
     },
     "Zalrsc": {
       "supported": false
+    },
+    // This extension just asserts that each memory region has a MAG
+    // PMA of 16 bytes.  If you enable this you also need to ensure
+    // `misaligned_atomicity_granule_size_exp` for each coherent and
+    // cacheable main memory region is 4, otherwise you will get a
+    // config validation error.
+    "Zama16b": {
+      "supported": true
     },
     "Zawrs": {
       "supported": true,

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -1,5 +1,8 @@
 # Release notes for the next version
 
+- The following extensions have been added:
+  - Zama16b
+
 - Updates to the [configuration file](../config/config.json.in):
   - The version of the privileged ISA specification for the model can
     be specified; see `base.privileged_isa_version`. Note that not

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -152,6 +152,11 @@ function clause hartSupports(Ext_Zacas) = config extensions.Zacas.supported
 enum clause extension = Ext_Zalrsc
 mapping clause extensionName = Ext_Zalrsc <-> "zalrsc"
 function clause hartSupports(Ext_Zalrsc) = config extensions.Zalrsc.supported
+// Extension for 16-byte Misaligned Atomicity
+enum clause extension = Ext_Zama16b
+mapping clause extensionName = Ext_Zama16b <-> "zama16b"
+function clause hartSupports(Ext_Zama16b) = config extensions.Zama16b.supported
+function clause currentlyEnabled(Ext_Zama16b) = hartSupports(Ext_Zama16b)
 // Wait-On-Reservation-Set
 enum clause extension = Ext_Zawrs
 mapping clause extensionName = Ext_Zawrs <-> "zawrs"
@@ -722,6 +727,7 @@ let extensions_ordered_for_isa_string = [
   Ext_Zabha,
   Ext_Zacas,
   Ext_Zalrsc,
+  Ext_Zama16b,
   Ext_Zawrs,
 
   // Zf, Zd, and Zq

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -292,6 +292,7 @@ private function check_pma_region(region : PMA_Region) -> bool = {
 }
 
 private struct pma_check_opts = {
+  zama16b  : bool,
   ziccamoa : bool,
   ziccamoc : bool,
   ziccif   : bool,
@@ -320,6 +321,14 @@ private function check_pma_regions(regions : list(PMA_Region), prev_base : bits(
 
       let attributes = region.attributes;
       if attributes.mem_type == MainMemory & attributes.cacheable & attributes.coherent then {
+        if check_opts.zama16b & attributes.misaligned_atomicity_granule_size_exp != 4 then {
+          let mag = attributes.misaligned_atomicity_granule_size_exp;
+          print_endline("Main memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^
+                        (if mag == 0 then "no specified misaligned atomicity granule PMA"
+                         else "a misaligned atomicity granule size of 2^" ^ dec_str(mag)) ^
+                        ", but Zama16b is enabled which requires granule size of 2^4 bytes.");
+          return false;
+        };
         if check_opts.ziccamoa & attributes.atomic_support < AMOArithmetic then {
           print_endline("Main memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^ atomic_support_str(attributes.atomic_support) ^ " atomicity support, but Ziccamoa is enabled which requires AMOArithmetic support.");
           return false;
@@ -388,6 +397,7 @@ private function check_mem_layout() -> bool =
     false
   } else {
     let check_opts : pma_check_opts = struct {
+      zama16b  = config extensions.Zama16b.supported,
       ziccamoa = config extensions.Ziccamoa.supported,
       ziccamoc = config extensions.Ziccamoc.supported,
       ziccif   = config extensions.Ziccif.supported,

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -321,8 +321,8 @@ private function check_pma_regions(regions : list(PMA_Region), prev_base : bits(
 
       let attributes = region.attributes;
       if attributes.mem_type == MainMemory & attributes.cacheable & attributes.coherent then {
-        if check_opts.zama16b & attributes.misaligned_atomicity_granule_size_exp != 4 then {
-          let mag = attributes.misaligned_atomicity_granule_size_exp;
+        let mag = attributes.misaligned_atomicity_granule_size_exp;
+        if check_opts.zama16b & mag != 4 then {
           print_endline("Main memory region starting at " ^ bits_str(region.base) ^ " is coherent and cacheable with " ^
                         (if mag == 0 then "no specified misaligned atomicity granule PMA"
                          else "a misaligned atomicity granule size of 2^" ^ dec_str(mag)) ^


### PR DESCRIPTION
This simply checks the value of the MAG PMA for coherent and cacheable main memory regions.