### PR TITLE
Add privileged ISA version checks for CSRs since version 1.12.

### DIFF
--- a/model/core/interrupt_regs.sail
+++ b/model/core/interrupt_regs.sail
@@ -137,7 +137,7 @@ mapping clause csr_name_map = 0x303  <-> "mideleg"
 function clause is_CSR_accessible(0x304, _, _) = true // mie
 function clause is_CSR_accessible(0x344, _, _) = true // mip
 function clause is_CSR_accessible(0x302, _, _) = currentlyEnabled(Ext_S) // medeleg
-function clause is_CSR_accessible(0x312, _, _) = currentlyEnabled(Ext_S) & xlen == 32 // medelegh
+function clause is_CSR_accessible(0x312, _, _) = delegh_csrs_are_defined & currentlyEnabled(Ext_S) & xlen == 32 // medelegh
 function clause is_CSR_accessible(0x303, _, _) = currentlyEnabled(Ext_S) // mideleg
 
 enum XipReadType = {

--- a/model/core/isa_version.sail
+++ b/model/core/isa_version.sail
@@ -26,6 +26,12 @@ enum Privileged_ISA_Version = {
   Privileged_ISA_1_13,
 }
 
+mapping privileged_isa_version_name : Privileged_ISA_Version <-> string = {
+  Privileged_ISA_1_11 <-> "1.11",
+  Privileged_ISA_1_12 <-> "1.12",
+  Privileged_ISA_1_13 <-> "1.13",
+}
+
 // For convenience, version comparison operators. This relies on the order of values in the enum.
 function privileged_isa_version_lt(x : Privileged_ISA_Version, y : Privileged_ISA_Version) -> bool =
   num_of_Privileged_ISA_Version(x) < num_of_Privileged_ISA_Version(y)
@@ -50,6 +56,15 @@ let priv_isa_version : Privileged_ISA_Version = config base.privileged_isa_versi
 // TODO: This is not used yet; this is an example that will be implemented in a future commit.
 let pte_reserved_bits_must_be_zero = priv_isa_version >= Privileged_ISA_1_12
 
-// This version defined the `{m,s,h}envcfg` CSRs. These CSRs are not
+
+// CSRs added in version 1.12. These CSRs are not
 // available in earlier versions.
 let xenvcfg_csrs_are_defined = priv_isa_version >= Privileged_ISA_1_12
+let mconfigptr_is_defined = priv_isa_version >= Privileged_ISA_1_12
+let mseccfg_csrs_are_defined = priv_isa_version >= Privileged_ISA_1_12
+let mstatush_is_defined = priv_isa_version >= Privileged_ISA_1_12
+// PMP register count is checked in validate_config() by check_version_constraints().
+
+// CSRs added in version 1.13. These CSRs are not
+// available in earlier versions.
+let delegh_csrs_are_defined = priv_isa_version >= Privileged_ISA_1_13

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -271,7 +271,7 @@ mapping clause csr_name_map = 0x300  <-> "mstatus"
 mapping clause csr_name_map = 0x310  <-> "mstatush"
 
 function clause is_CSR_accessible(0x300, _, _) = true // mstatus
-function clause is_CSR_accessible(0x310, _, _) = xlen == 32 // mstatush
+function clause is_CSR_accessible(0x310, _, _) = mstatush_is_defined & xlen == 32 // mstatush
 
 function clause read_CSR(0x300) = mstatus.bits[xlen - 1 .. 0]
 function clause read_CSR(0x310 if xlen == 32) = mstatus.bits[63 .. 32]
@@ -334,9 +334,9 @@ register mseccfg : Seccfg = legalize_mseccfg(Mk_Seccfg(zeros()), zeros())
 mapping clause csr_name_map = 0x747  <-> "mseccfg"
 mapping clause csr_name_map = 0x757  <-> "mseccfgh"
 
-// "mseccfg exists if Zkr is implemented, or if it is required by other processor features."
-function clause is_CSR_accessible(0x747, _, _) = currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp) | currentlyEnabled(Ext_Smmpm) // mseccfg
-function clause is_CSR_accessible(0x757, _, _) = (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp)) & xlen == 32 // mseccfgh
+// For Sm1p12 and later, "mseccfg exists if Zkr is implemented, or if it is required by other processor features."
+function clause is_CSR_accessible(0x747, _, _) = mseccfg_csrs_are_defined & currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp) | currentlyEnabled(Ext_Smmpm) // mseccfg
+function clause is_CSR_accessible(0x757, _, _) = mseccfg_csrs_are_defined & (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp)) & xlen == 32 // mseccfgh
 
 function clause read_CSR(0x747) = mseccfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x757 if xlen == 32) = mseccfg.bits[63 .. 32]
@@ -683,7 +683,7 @@ function clause is_CSR_accessible(0xf11, _, _) = true // mvendorid
 function clause is_CSR_accessible(0xf12, _, _) = true // marchdid
 function clause is_CSR_accessible(0xf13, _, _) = true // mimpid
 function clause is_CSR_accessible(0xf14, _, _) = true // mhartid
-function clause is_CSR_accessible(0xf15, _, _) = true // mconfigptr
+function clause is_CSR_accessible(0xf15, _, _) = mconfigptr_is_defined // mconfigptr
 
 function clause read_CSR(0xF11) = zero_extend(mvendorid)
 function clause read_CSR(0xF12) = marchid

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -335,7 +335,7 @@ mapping clause csr_name_map = 0x747  <-> "mseccfg"
 mapping clause csr_name_map = 0x757  <-> "mseccfgh"
 
 // For Sm1p12 and later, "mseccfg exists if Zkr is implemented, or if it is required by other processor features."
-function clause is_CSR_accessible(0x747, _, _) = mseccfg_csrs_are_defined & currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp) | currentlyEnabled(Ext_Smmpm) // mseccfg
+function clause is_CSR_accessible(0x747, _, _) = mseccfg_csrs_are_defined & (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp) | currentlyEnabled(Ext_Smmpm)) // mseccfg
 function clause is_CSR_accessible(0x757, _, _) = mseccfg_csrs_are_defined & (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp)) & xlen == 32 // mseccfgh
 
 function clause read_CSR(0x747) = mseccfg.bits[xlen - 1 .. 0]

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -638,6 +638,19 @@ private function check_mstatus_fields() -> bool = {
   valid
 }
 
+function check_version_constraints() -> bool = {
+  var valid : bool = true;
+
+  // The internal variables are used here rather than the `config` constructs due to their non-trivial types.
+  if (sys_pmp_count > 16 & priv_isa_version < Privileged_ISA_1_12) then {
+    valid = false;
+    print_endline("More than 16 PMP registers are specified, but the privileged ISA version is set to " ^
+                  privileged_isa_version_name(priv_isa_version) ^ " which only allows 16 PMP registers.");
+  };
+
+  valid
+}
+
 function config_is_valid() -> bool = {
     check_privs()
   & check_tvecs()
@@ -650,5 +663,6 @@ function config_is_valid() -> bool = {
   & check_pmp()
   & check_misc_extension_dependencies()
   & check_extension_param_constraints()
+  & check_version_constraints()
   & check_stateen_config()
 }


### PR DESCRIPTION
Checks for version 1.11 and earlier can be added as needed.

Version checks for other features can be similarly added as needed.

Fixes #1818.