### PR TITLE
Add support for the Zabhlrsc extension (byte/halfword LR/SC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ The following unratified extensions are supported and can be enabled using the `
 
 - Zibi extension for conditional branches with immediate operands, v0.6
 - Zvabd extension for vector absolute difference, v0.7
+- Zabhlrsc extension for byte and halfword load reserved/store conditional instructions
 
 **For a list of unsupported extensions and features, see the [Extension Roadmap](https://github.com/riscv/sail-riscv/wiki/Extension-Roadmap).**
 

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -600,6 +600,9 @@
     "Zabha": {
       "supported": true
     },
+    "Zabhlrsc": {
+      "supported": true
+    },
     "Zacas": {
       "supported": true
     },

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -144,6 +144,10 @@ function clause hartSupports(Ext_Zaamo) = config extensions.Zaamo.supported
 enum clause extension = Ext_Zabha
 mapping clause extensionName = Ext_Zabha <-> "zabha"
 function clause hartSupports(Ext_Zabha) = config extensions.Zabha.supported
+// Byte and Halfword Load Reserved/Store Conditional
+enum clause extension = Ext_Zabhlrsc
+mapping clause extensionName = Ext_Zabhlrsc <-> "zabhlrsc"
+function clause hartSupports(Ext_Zabhlrsc) = sys_enable_experimental_extensions() & config extensions.Zabhlrsc.supported
 // Atomic Compare-and-Swap (CAS) Instructions
 enum clause extension = Ext_Zacas
 mapping clause extensionName = Ext_Zacas <-> "zacas"
@@ -720,6 +724,7 @@ let extensions_ordered_for_isa_string = [
   Ext_Za64rs,
   Ext_Zaamo,
   Ext_Zabha,
+  Ext_Zabhlrsc,
   Ext_Zacas,
   Ext_Zalrsc,
   Ext_Zawrs,

--- a/model/extensions/A/zalrsc_insts.sail
+++ b/model/extensions/A/zalrsc_insts.sail
@@ -9,15 +9,18 @@
 function clause currentlyEnabled(Ext_Zalrsc) = hartSupports(Ext_Zalrsc) | currentlyEnabled(Ext_A)
 function clause currentlyEnabled(Ext_Za64rs) = hartSupports(Ext_Za64rs) & currentlyEnabled(Ext_Zalrsc)
 function clause currentlyEnabled(Ext_Za128rs) = hartSupports(Ext_Za128rs) & currentlyEnabled(Ext_Zalrsc)
+function clause currentlyEnabled(Ext_Zabhlrsc) = hartSupports(Ext_Zabhlrsc) & currentlyEnabled(Ext_Zalrsc)
 
 function clause currentlyEnabled(Ext_Ziccrse) = hartSupports(Ext_Ziccrse)
 
-// Zalrsc defines LR/SC for word and double
+// Zalrsc defines LR/SC for word and double.
+// Zabhlrsc defines LR/SC for byte and halfword.
 function lrsc_width_valid(width : word_width) -> bool = {
   match width {
     4 => true,
     8 => xlen >= 64,
-    _ => false,
+    1 => currentlyEnabled(Ext_Zabhlrsc),
+    2 => currentlyEnabled(Ext_Zabhlrsc),
   }
 }
 

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -449,6 +449,10 @@ private function check_misc_extension_dependencies() -> bool = {
     valid = false;
     print_endline("The Zabha extension is enabled but Zaamo and A are disabled: supporting Zabha requires Zaamo or A.");
   };
+  if (config extensions.Zabhlrsc.supported : bool) & not((config extensions.Zalrsc.supported : bool) | (config extensions.A.supported : bool)) then {
+    valid = false;
+    print_endline("The Zabhlrsc extension is enabled but Zalrsc and A are disabled: supporting Zabhlrsc requires Zalrsc or A.");
+  };
   if (config extensions.Zacas.supported : bool) & not((config extensions.Zaamo.supported : bool) | (config extensions.A.supported : bool)) then {
     valid = false;
     print_endline("The Zacas extension is enabled but Zaamo and A are disabled: supporting Zacas requires Zaamo or A.");


### PR DESCRIPTION
Widens lrsc_width_valid to accept byte/halfword widths when Zabhlrsc is enabled. Gated behind --enable-experimental-extensions since it is not yet ratified.

Specification: https://github.com/riscv/riscv-isa-manual/pull/3234