### PR TITLE
Fix the condition for `currentlyEnabled(Ext_Svpbmt)`.

### DIFF
--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -419,7 +419,7 @@ private function legalize_menvcfg(o : MEnvcfg, v : bits(64)) -> MEnvcfg = {
     STCE = if currentlyEnabled(Ext_Sstc) then v[STCE] else 0b0,
     PMM = if currentlyEnabled(Ext_Smnpm) & is_supported_pmm(PM_SMNPM, pmm_mode(v[PMM])) then v[PMM] else o[PMM],
     ADUE = if currentlyEnabled(Ext_Svadu) then v[ADUE] else 0b0,
-    PBMTE = if currentlyEnabled(Ext_Svpbmt) then v[PBMTE] else 0b0,
+    PBMTE = if hartSupports(Ext_Svpbmt) & currentlyEnabled(Ext_Sv39) then v[PBMTE] else 0b0,
     // Other extensions are not implemented yet so all other fields are read only zero.
   ]
 }

--- a/model/sys/vmem_pte.sail
+++ b/model/sys/vmem_pte.sail
@@ -74,7 +74,7 @@ private function pte_is_non_leaf(pte_flags : PTE_Flags) -> bool =
 // NAPOT Translation Contiguity
 function clause currentlyEnabled(Ext_Svnapot) = hartSupports(Ext_Svnapot) & currentlyEnabled(Ext_Sv39)
 // Page-Based Memory Types
-function clause currentlyEnabled(Ext_Svpbmt) =  hartSupports(Ext_Svpbmt) & currentlyEnabled(Ext_Sv39)
+function clause currentlyEnabled(Ext_Svpbmt) = menvcfg[PBMTE] == 0b1
 // Svrsw60t59b: PTE Reserved for software bits 60-59
 function clause currentlyEnabled(Ext_Svrsw60t59b) = hartSupports(Ext_Svrsw60t59b) & currentlyEnabled(Ext_Sv39)
 // Obviating Memory-management Instructions after Marking PTEs valid


### PR DESCRIPTION
Svpbmt is dynamically enabled by `menvcfg[PBMTE]`; this bit was not examined when checking whether Svpbmt was currently enabled when checking PTE bits for validity.