### PR TITLE
Require privileged ISA version 1.12+ for Svnapot and Svpbmt

### DIFF
--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -658,6 +658,21 @@ function check_version_constraints() -> bool = {
                   privileged_isa_version_name(priv_isa_version) ^ " which only allows 16 PMP registers.");
   };
 
+  // These extensions were ratified alongside priv 1.12, which is also when
+  // reserved PTE bits/encodings were required to fault. Allowing them on 1.11
+  // would make the reserved-encoding checks ambiguous.
+  if hartSupports(Ext_Svnapot) & priv_isa_version < Privileged_ISA_1_12 then {
+    valid = false;
+    print_endline("Svnapot is enabled, but it requires privileged ISA version 1.12 or later (version is set to " ^
+                  privileged_isa_version_name(priv_isa_version) ^ ").");
+  };
+
+  if hartSupports(Ext_Svpbmt) & priv_isa_version < Privileged_ISA_1_12 then {
+    valid = false;
+    print_endline("Svpbmt is enabled, but it requires privileged ISA version 1.12 or later (version is set to " ^
+                  privileged_isa_version_name(priv_isa_version) ^ ").");
+  };
+
   valid
 }
 


### PR DESCRIPTION
Both extensions were ratified alongside priv 1.12, which also introduced the requirement that reserved PTE bits and encodings fault. Rejecting these extensions on 1.11 configs avoids ambiguity in the version gating of the reserved-encoding checks from #677.