### PR TITLE
Do not mask translated physical addresses to the implemented width.

### DIFF
--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -458,13 +458,12 @@ function translateAddr(
         // On RV64 paddr can be 34 or 56 bits, so we zero extend to 64.
         // On RV32 paddr can only be 34 bits. Sail knows this due to
         // the assertion above.
-        let paddr : physaddrbits = zero_extend(paddr);
-
-        // Trim the physical address based on the number of
-        // implemented physical address bits.
-        let paddr : physaddrbits = zero_extend(paddr[physaddr_bits - 1 .. 0]);
-
-        Ok(Physaddr(paddr), pbmt, ext_ptw)
+        // High PPN bits above the implemented physical address width are
+        // deliberately not masked: "The algorithm does not admit the
+        // possibility of ignoring high-order PPN bits for implementations
+        // with narrower physical addresses." Such addresses instead fault
+        // at the PMA/PMP checks.
+        Ok(Physaddr(zero_extend(paddr)), pbmt, ext_ptw)
       },
       Err(f, ext_ptw)  => Err(translationException(access, f), ext_ptw)
     }


### PR DESCRIPTION
The privileged spec explicitly disallows this, see the following quote: "The algorithm does not admit the possibility of ignoring high-order PPN bits for implementations with narrower physical addresses." A leaf PTE with PPN bits above the implemented width must produce the full physical address, which then faults at the PMA/PMP checks since no memory region can exist there (enforced by check_pma_regions). Masking instead silently aliased such accesses into implemented memory, and was also inconsistent with Bare mode and non-leaf PTE pointers, which are not masked.

That's a quick follow-up to #1412