### PR TITLE
Fix FCLASS assembly to use x-register names under Zfinx

### DIFF
--- a/model/extensions/FD/dext_insts.sail
+++ b/model/extensions/FD/dext_insts.sail
@@ -871,7 +871,7 @@ mapping f_un_x_type_mnemonic_D : f_un_x_op_D <-> string = {
 mapping clause assembly = F_UN_X_TYPE_D(rs1, rd, op)
                       <-> f_un_x_type_mnemonic_D(op)
                           ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ freg_or_reg_name(rs1)
 
 mapping f_un_f_type_mnemonic_D : f_un_f_op_D <-> string = {
     FMV_D_X  <-> "fmv.d.x"

--- a/model/extensions/FD/fext_insts.sail
+++ b/model/extensions/FD/fext_insts.sail
@@ -919,7 +919,7 @@ mapping f_un_type_mnemonic_x_S : f_un_op_x_S <-> string = {
 mapping clause assembly = F_UN_TYPE_X_S(rs1, rd, op)
                       <-> f_un_type_mnemonic_x_S(op)
                           ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ freg_or_reg_name(rs1)
 
 mapping f_un_type_mnemonic_f_S : f_un_op_f_S <-> string = {
     FMV_W_X  <-> "fmv.w.x"

--- a/model/extensions/FD/zfh_insts.sail
+++ b/model/extensions/FD/zfh_insts.sail
@@ -848,4 +848,4 @@ mapping f_un_x_type_mnemonic_H : f_un_x_op_H <-> string = {
 mapping clause assembly = F_UN_X_TYPE_H(rs1, rd, op)
                       <-> f_un_x_type_mnemonic_H(op)
                           ^ spc() ^ reg_name(rd)
-                          ^ sep() ^ freg_name(rs1)
+                          ^ sep() ^ freg_or_reg_name(rs1)


### PR DESCRIPTION
FMV.X.* share these mappings but are unaffected. On Zfinx harts they don't decode and raise an illegal instruction exception, and on F harts freg_or_reg_name prints the same as freg_name.