### PR TITLE
Fix RVV memory assertions and NaN reductions (#1800)

### DIFF
--- a/model/extensions/V/vext_fp_red_insts.sail
+++ b/model/extensions/V/vext_fp_red_insts.sail
@@ -11,6 +11,8 @@
 // Chapter 14: Vector Reduction Instructions
 // ******************************************************************************
 
+let canonicalize_nan_on_empty_sum_reduction : bool = config extensions.V.reductions.canonicalize_nan_on_empty_unordered_sum
+
 // ********************* OPFVV (Single-Width Floating-Point Reduction) ***********************
 union clause instruction = RFVVTYPE : (rfvvfunct6, bits(1), vregidx, vregidx, vregidx)
 
@@ -66,6 +68,10 @@ function clause execute RFVVTYPE(funct6, vm, vs2, vs1, vd) = {
         FVV_VFREDMIN    => fp_min(sum, vs2_val[i]),
       }
     }
+  };
+
+  if canonicalize_nan_on_empty_sum_reduction & funct6 == FVV_VFREDUSUM & unsigned(mask) == 0 & f_is_NaN(sum) then {
+    sum = canonical_NaN('m)
   };
 
   write_single_element(SEW, 0, vd, sum);
@@ -142,6 +148,10 @@ function clause execute RFWVVTYPE(_funct6, vm, vs2, vs1, vd) = {
     }
   };
 
+  if canonicalize_nan_on_empty_sum_reduction & unsigned(mask) == 0 & f_is_NaN(sum) then {
+    sum = canonical_NaN('o)
+  };
+
   write_single_element(SEW_widen, 0, vd, sum);
   // other elements in vd are treated as tail elements, currently remain unchanged
   // TODO: configuration support for agnostic behavior
@@ -156,3 +166,4 @@ mapping rfwvvtype_mnemonic : rfwvvfunct6 <-> string = {
 
 mapping clause assembly = RFWVVTYPE(funct6, vm, vs2, vs1, vd)
   <-> rfwvvtype_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+  

--- a/model/extensions/V/vext_mem_insts.sail
+++ b/model/extensions/V/vext_mem_insts.sail
@@ -58,7 +58,7 @@ function clause execute VLSEGTYPE(nf, vm, rs1, width, vd) = {
   let LMUL_pow = get_lmul_pow();
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
 
-  assert(-3 <= EMUL_pow & EMUL_pow <= 3);
+  if EMUL_pow < -3 | EMUL_pow > 3 then return Illegal_Instruction();
 
   let num_elem = get_num_elem(EMUL_pow, EEW); // # of element of each register group
   assert(num_elem > 0);
@@ -115,7 +115,7 @@ function clause execute VLSEGFFTYPE(nf, vm, rs1, width, vd) = {
   let LMUL_pow = get_lmul_pow();
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
 
-  assert(-3 <= EMUL_pow & EMUL_pow <= 3);
+  if EMUL_pow < -3 | EMUL_pow > 3 then return Illegal_Instruction();
 
   let num_elem = get_num_elem(EMUL_pow, EEW);
   assert(num_elem > 0);
@@ -189,7 +189,7 @@ function clause execute VSSEGTYPE(nf, vm, rs1, width, vs3) = {
   let LMUL_pow = get_lmul_pow();
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
 
-  assert(-3 <= EMUL_pow & EMUL_pow <= 3);
+  if EMUL_pow < -3 | EMUL_pow > 3 then return Illegal_Instruction();
 
   let num_elem = get_num_elem(EMUL_pow, EEW);
   assert(num_elem > 0);
@@ -246,7 +246,7 @@ function clause execute VLSSEGTYPE(nf, vm, rs2, rs1, width, vd) = {
   let LMUL_pow = get_lmul_pow();
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
 
-  assert(-3 <= EMUL_pow & EMUL_pow <= 3);
+  if EMUL_pow < -3 | EMUL_pow > 3 then return Illegal_Instruction();
 
   let num_elem = get_num_elem(EMUL_pow, EEW);
   assert(num_elem > 0);
@@ -304,7 +304,7 @@ function clause execute VSSSEGTYPE(nf, vm, rs2, rs1, width, vs3) = {
   let LMUL_pow = get_lmul_pow();
   let EMUL_pow = EEW_pow - SEW_pow + LMUL_pow;
 
-  assert(-3 <= EMUL_pow & EMUL_pow <= 3);
+  if EMUL_pow < -3 | EMUL_pow > 3 then return Illegal_Instruction();
 
   let num_elem = get_num_elem(EMUL_pow, EEW);
   assert(num_elem > 0);


### PR DESCRIPTION
Resolves #1800.

This PR addresses two categories of RVVTS deviations against Spike:

**1. Vector Memory Assertions (`SAIL_RISCV_ASSERT_VALID_REJECT`)**
Out-of-bounds `EMUL_pow` values were triggering a hard assertion crash before reaching legality checks in `model/extensions/V/vext_mem_insts.sail`. 
* **Fix:** Replaced `assert(-3 <= EMUL_pow & EMUL_pow <= 3);` with `if EMUL_pow < -3 | EMUL_pow > 3 then return Illegal_Instruction();` across all 5 segment load/store functions (`VLSEGTYPE`, `VLSEGFFTYPE`, `VSSEGTYPE`, `VLSSEGTYPE`, `VSSSEGTYPE`). This ensures invalid EEW/SEW/LMUL combinations trap gracefully.

**2. Unordered Floating-Point Sum Reductions (`VREG_ONLY`)**
When all elements are masked off in `vfredusum.vs` and `vfwredusum.vs`, Spike canonicalizes the initial NaN scalar, whereas Sail passes it through unmodified. 
* **Fix:** Added a new configuration flag `extensions.V.reductions.canonicalize_nan_on_empty_unordered_sum` (defaulting to `false`) in `config/config.json.in`.
* Implemented the conditional canonicalization in `model/extensions/V/vext_fp_red_insts.sail` for both single-width and widening unordered reductions when the flag is enabled.