### PR TITLE
Fix usage of `get_16_random_bits` for the `seed` CSR.

### DIFF
--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -206,7 +206,7 @@ unit ModelImpl::tlb_flush_end_callback(TLB tlb) {
 mach_bits ModelImpl::plat_get_16_random_bits(unit) {
   // This function can be changed to support deterministic sequences of
   // pseudo-random bytes. This is useful for testing.
-  return m_gen64();
+  return m_gen64() & 0xFFFF;
 }
 
 // Note: Store-Conditionals are allowed to spuriously fail. If you want

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -1,5 +1,8 @@
 # Release notes for the next version
 
+- Important issues addressed and bugs fixed:
+  - https://github.com/riscv/sail-riscv/issues/1829 : seed CSR OPST field contained random values
+
 # Release notes for version 0.13
 
 The main highlights of this release are the addition of the misaligned


### PR DESCRIPTION
The Sail declaration is:
```
val get_16_random_bits = impure {
    interpreter: "Platform.get_16_random_bits",
    cpp: "plat_get_16_random_bits",
    lem: "plat_get_16_random_bits"
} : unit -> bits(16)
```

while the C++ implementation is:

```
mach_bits ModelImpl::plat_get_16_random_bits(unit) {
  return m_gen64();
}
```

This resulted in the generated C++ or-ing more than 16 bits in `read_seed_csr`:
```
  zseed = plat_get_16_random_bits(UNIT);
  z2zE19672 = (zcustom_bits << 16) | zseed;        // this has 64 random bits
  z2zE19673 = (zreserved_bits << 24) | z2zE19672;
  z2zE19674 = (UINT64_C(0b10) << 30) | z2zE19673;  // which corrupt the 0b10 (ES16) bits.

```

This fixes `plat_get_16_random_bits` to return 16 random bits as required.

Fixes #1829.