### PR TITLE
Add a `--trace-pmp` option to aid debugging access faults due to PMP.

### DIFF
--- a/c_emulator/cli_options.cpp
+++ b/c_emulator/cli_options.cpp
@@ -111,6 +111,7 @@ CLIOptions parse_cli(int argc, char **argv) {
   app.add_flag("--trace-interrupt", opts.config_print_interrupt, "Enable trace output for interrupts");
   app.add_flag("--trace-htif", opts.config_print_htif, "Enable trace output for HTIF operations");
   app.add_flag("--trace-pma", opts.config_print_pma, "Enable trace output for PMA checks");
+  app.add_flag("--trace-pmp", opts.config_print_pmp, "Enable trace output for PMP checks");
   app.add_flag_callback(
     "--trace-platform",
     [&opts] {
@@ -119,9 +120,10 @@ CLIOptions parse_cli(int argc, char **argv) {
       opts.config_print_interrupt = true;
       opts.config_print_htif = true;
       opts.config_print_pma = true;
+      opts.config_print_pmp = true;
     },
     "Enable trace output for platform-level events (MMIO, interrupts, "
-    "exceptions, CLINT, HTIF, PMA)"
+    "exceptions, CLINT, HTIF, PMA, PMP)"
   );
   app.add_flag("--trace-step", opts.config_print_step, "Add a blank line between steps in the trace output");
   app.add_flag("--trace-gdbserver", opts.config_print_gdbserver, "Enable trace output for gdbserver");
@@ -141,6 +143,7 @@ CLIOptions parse_cli(int argc, char **argv) {
       opts.config_print_interrupt = true;
       opts.config_print_htif = true;
       opts.config_print_pma = true;
+      opts.config_print_pmp = true;
       opts.config_print_step = true;
     },
     "Enable all trace output except TLB, PTW and gdbserver traces"

--- a/c_emulator/cli_options.h
+++ b/c_emulator/cli_options.h
@@ -50,6 +50,7 @@ struct CLIOptions {
   bool config_print_interrupt = false;
   bool config_print_htif = false;
   bool config_print_pma = false;
+  bool config_print_pmp = false;
   bool config_print_rvfi = false;
   bool config_print_step = false;
   bool config_print_ptw = false;

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -303,6 +303,10 @@ bool ModelImpl::get_config_print_pma(unit) {
   return m_config_print_pma;
 }
 
+bool ModelImpl::get_config_print_pmp(unit) {
+  return m_config_print_pmp;
+}
+
 bool ModelImpl::get_config_rvfi(unit) {
   return m_config_rvfi;
 }
@@ -333,6 +337,10 @@ void ModelImpl::set_config_print_htif(bool on) {
 
 void ModelImpl::set_config_print_pma(bool on) {
   m_config_print_pma = on;
+}
+
+void ModelImpl::set_config_print_pmp(bool on) {
+  m_config_print_pmp = on;
 }
 
 void ModelImpl::set_config_rvfi(bool on) {

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -47,6 +47,7 @@ public:
   void set_config_print_interrupt(bool on);
   void set_config_print_htif(bool on);
   void set_config_print_pma(bool on);
+  void set_config_print_pmp(bool on);
   void set_config_print_step(bool on);
 
   void set_config_rvfi(bool on);
@@ -170,6 +171,7 @@ private:
   bool get_config_print_interrupt(unit) override;
   bool get_config_print_htif(unit) override;
   bool get_config_print_pma(unit) override;
+  bool get_config_print_pmp(unit) override;
   bool get_config_rvfi(unit) override;
   bool get_config_use_abi_names(unit) override;
 
@@ -179,6 +181,7 @@ private:
   bool m_config_print_interrupt = false;
   bool m_config_print_htif = false;
   bool m_config_print_pma = false;
+  bool m_config_print_pmp = false;
   bool m_config_rvfi = false;
   bool m_config_use_abi_names = false;
 

--- a/c_emulator/riscv_platform_if.cpp
+++ b/c_emulator/riscv_platform_if.cpp
@@ -207,6 +207,10 @@ bool PlatformInterface::get_config_print_pma(unit) {
   return false;
 }
 
+bool PlatformInterface::get_config_print_pmp(unit) {
+  return false;
+}
+
 bool PlatformInterface::get_config_rvfi(unit) {
   return false;
 }

--- a/c_emulator/riscv_platform_if.h
+++ b/c_emulator/riscv_platform_if.h
@@ -91,6 +91,7 @@ public:
   virtual bool get_config_print_interrupt(unit);
   virtual bool get_config_print_htif(unit);
   virtual bool get_config_print_pma(unit);
+  virtual bool get_config_print_pmp(unit);
   virtual bool get_config_rvfi(unit);
   virtual bool get_config_use_abi_names(unit);
 };

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -512,6 +512,7 @@ InitResult preinit_model(
   model.set_config_print_interrupt(opts.config_print_interrupt);
   model.set_config_print_htif(opts.config_print_htif);
   model.set_config_print_pma(opts.config_print_pma);
+  model.set_config_print_pmp(opts.config_print_pmp);
   model.set_config_rvfi(run_info.rvfi.has_value());
   model.set_config_use_abi_names(opts.config_use_abi_names);
 

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -1,5 +1,9 @@
 # Release notes for the next version
 
+- The command line interface has been updated:
+  - A new `--trace-pmp` option has been added to enable trace output
+    for PMP checks.
+
 - Important issues addressed and bugs fixed:
   - https://github.com/riscv/sail-riscv/issues/1829 : seed CSR OPST field contained random values
 

--- a/model/pmp/pmp_control.sail
+++ b/model/pmp/pmp_control.sail
@@ -136,15 +136,27 @@ function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
 
     match pmpMatchAddr(addr, width, cfg, pmpReadAddrReg(i), prev_pmpaddr) {
       PMP_NoMatch      => (),
-      PMP_PartialMatch => return Some(accessFaultFromAccessType(access)),
-      PMP_Match        => return (
+      PMP_PartialMatch => {
+        if get_config_print_pmp()
+        then print_log("PMP check failed with a partial match at entry #" ^ dec_str(i) ^ ".");
+        return Some(accessFaultFromAccessType(access))
+      },
+      PMP_Match        =>
         if pmpCheckRWX(cfg, access) | (priv == Machine & not(pmpLocked(cfg)))
-        then None()
-        else Some(accessFaultFromAccessType(access))
-      ),
+        then return None()
+        else {
+          if get_config_print_pmp()
+          then print_log("PMP check failed at matching entry #" ^ dec_str(i) ^ ".");
+          return Some(accessFaultFromAccessType(access))
+        },
     };
   };
-  if priv == Machine then None() else Some(accessFaultFromAccessType(access))
+  if priv == Machine then None()
+  else {
+    if get_config_print_pmp()
+    then print_log("PMP check failed with no matching entry.");
+    Some(accessFaultFromAccessType(access))
+  }
 }
 
 function reset_pmp() -> unit = {

--- a/model/prelude/prelude.sail
+++ b/model/prelude/prelude.sail
@@ -71,6 +71,7 @@ val get_config_print_exception = pure {cpp:"get_config_print_exception"} : unit 
 val get_config_print_interrupt = pure {cpp:"get_config_print_interrupt"} : unit -> bool
 val get_config_print_htif = pure {cpp:"get_config_print_htif"} : unit -> bool
 val get_config_print_pma = pure {cpp:"get_config_print_pma"} : unit -> bool
+val get_config_print_pmp = pure {cpp:"get_config_print_pmp"} : unit -> bool
 val get_config_rvfi = pure {cpp:"get_config_rvfi"} : unit -> bool
 val get_config_use_abi_names = pure {cpp:"get_config_use_abi_names"} : unit -> bool
 // defaults for other backends
@@ -80,6 +81,7 @@ function get_config_print_exception () = false
 function get_config_print_interrupt () = false
 function get_config_print_htif () = false
 function get_config_print_pma () = false
+function get_config_print_pmp () = false
 function get_config_rvfi () = false
 function get_config_use_abi_names () = false
 


### PR DESCRIPTION
This complements the existing `--trace-pma` option.