### PR TITLE
Implement a basic event framework.

### DIFF
--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -2,10 +2,12 @@
 #include <algorithm>
 #include <cassert>
 #include <random>
+#include <set>
 #include <unistd.h>
 
 #include "config_utils.h"
 #include "riscv_callbacks_if.h"
+#include "sail.h"
 #include "symbol_table.h"
 
 void ModelImpl::register_callback(std::shared_ptr<callbacks_if> cb) {
@@ -240,6 +242,107 @@ bool ModelImpl::valid_reservation(unit) {
   return m_reservation_valid;
 }
 
+bool ModelImpl::validate_event_selectors(unit) {
+  std::set<EventSelector> selectors;
+  std::map<Event, EventSelector> event_map;
+  std::ostringstream msg;
+
+  // Since this is called from Sail by `validate_config.sail`, use the
+  // same print function when logging errors, i.e. `print_endline()`.
+  int idx = 0;
+  for (const auto *ent = zplatform_event_selectors; ent != nullptr; ent = ent->tl) {
+    auto event = ent->hd.zevent;
+    auto sel = ent->hd.zselector;
+
+    std::ostringstream event_buf;
+    event_buf << "event #" << idx << " (i.e. " << name_of_event(event) << ")";
+
+    if (sel == 0) {
+      msg << "The selector for " << event_buf.str()
+          << " in platform.event_selectors is 0; selector 0 is reserved for 'no event'." << std::endl;
+      print_endline(msg.str().c_str());
+      return false;
+    }
+    if (selectors.find(sel) != selectors.end()) {
+      msg << "The selector " << sel << " for " << event_buf.str()
+          << " in platform.event_selectors is repeated; event selectors need to be unique." << std::endl;
+      print_endline(msg.str().c_str());
+      return false;
+    }
+    if (event_map.find(event) != event_map.end()) {
+      msg << "The " << event_buf.str() << " in platform.event_selectors repeats an event; events need to be unique."
+          << std::endl;
+      print_endline(msg.str().c_str());
+      return false;
+    }
+
+    selectors.insert(sel);
+    event_map[event] = sel;
+    ++idx;
+  }
+
+  m_event_to_selector = event_map;
+  return true;
+}
+
+// TODO: This code implements an exact match on selectors.
+// Implementations could use a bitmask match (e.g. a bit per event).
+// This could be extended to support such common cases.
+unit ModelImpl::event_csr_write_callback(HpmIdx index, EventSelector old_selector, EventSelector new_selector) {
+  // Unregister index for its previous selector.  `old_selector` could be
+  // zero, but if so it should not be found.
+  auto sel_ent = m_selector_to_hpmidxs.find(old_selector);
+  if (sel_ent != m_selector_to_hpmidxs.end()) {
+    sel_ent->second.erase(index);
+  }
+
+  if (new_selector == 0) {
+    // No event.
+    return UNIT;
+  }
+
+  auto ev_ent = std::find_if(m_event_to_selector.begin(), m_event_to_selector.end(), [&new_selector](const auto &elem) {
+    return elem.second == new_selector;
+  });
+  if (ev_ent == m_event_to_selector.end()) {
+    // TODO: this could be used as a legalizer by
+    // `zihpm.sail:legalize_hpmevent()`: `new_selector` is legal only if it
+    // is registered in the config.
+    return UNIT;
+  }
+
+  // Register index for the new selector.
+  auto &idxs = m_selector_to_hpmidxs[new_selector];
+  idxs.insert(index);
+  return UNIT;
+}
+
+unit ModelImpl::event_callback(Event ev, Privilege priv) {
+  triggered_events.push_back(std::make_pair(ev, priv));
+  return UNIT;
+}
+
+unit ModelImpl::dispatch_events(unit) {
+  for (const auto &[ev, priv] : triggered_events) {
+    auto event_ent = m_event_to_selector.find(ev);
+    if (event_ent == m_event_to_selector.end()) {
+      // No selector specified for this event.
+      continue;
+    }
+    auto selector_ent = m_selector_to_hpmidxs.find(event_ent->second);
+    if (selector_ent == m_selector_to_hpmidxs.end()) {
+      // This selector was not written to any `mhpmevent`.
+      continue;
+    }
+    for (const auto &idx : selector_ent->second) {
+      zincrement_hpmcounter(idx, priv);
+    }
+  }
+
+  triggered_events.clear();
+  return UNIT;
+}
+
 unit ModelImpl::plat_term_write(mach_bits s) {
   char c = static_cast<char>(s);
   if (write(m_term_fd, &c, sizeof(c)) < 0) {
@@ -447,6 +550,15 @@ std::string ModelImpl::generate_isa_string() {
   std::string isa(c_isa);
   KILL(sail_string)(&c_isa);
   return isa;
+}
+
+std::string ModelImpl::name_of_event(Event ev) {
+  sail_string str = nullptr;
+  CREATE(sail_string)(&str);
+  zname_of_event(&str, ev);
+  std::string name(str);
+  KILL(sail_string)(&str);
+  return name;
 }
 
 std::optional<std::string> ModelImpl::string_of_current_exception() {

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <optional>
 #include <random>
+#include <set>
 #include <vector>
 
 #include "sail.h"
@@ -25,6 +26,9 @@ public:
   using MemoryAccessType = hart::zMemoryAccessTypezIEmem_payloadz5zK;
   using PTW_Error = hart::zPTW_Error;
   using TLB = hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9;
+  using Event = hart::zEvent;
+  using EventSelector = uint64_t;
+  using HpmIdx = int64_t;
 
   // callbacks
 
@@ -150,10 +154,18 @@ private:
   // Provides entropy for the scalar cryptography extension.
   mach_bits plat_get_16_random_bits(unit) override;
 
+  // Reservation handling
   unit load_reservation(sbits, uint64_t) override;
   bool match_reservation(sbits) override;
   unit cancel_reservation(unit) override;
   bool valid_reservation(unit) override;
+
+  // Events
+  std::string name_of_event(Event ev);
+  bool validate_event_selectors(unit) override;
+  unit event_callback(Event ev, Privilege priv) override;
+  unit event_csr_write_callback(HpmIdx index, EventSelector old_selector, EventSelector new_selector) override;
+  unit dispatch_events(unit) override;
 
   unit plat_term_write(mach_bits) override;
 
@@ -204,6 +216,15 @@ private:
   uint64_t m_reservation_set_addr_mask = 0;
   bool m_reservation_require_exact_addr = false;
   bool m_reservation_invalidate_on_same_hart_store = false;
+
+  // Map from events to their selector values.
+  std::map<Event, EventSelector> m_event_to_selector;
+  // Map from selectors to the indices of `mhpmevent` containing
+  // those selectors.  Multiple `mhpmevent` CSRs could be written with the
+  // same selector.
+  std::map<EventSelector, std::set<HpmIdx>> m_selector_to_hpmidxs;
+  // Events that triggered during the current instruction.
+  std::vector<std::pair<Event, Privilege>> triggered_events;
 
   bool m_enable_experimental_extensions = false;
 

--- a/c_emulator/riscv_platform_if.cpp
+++ b/c_emulator/riscv_platform_if.cpp
@@ -154,6 +154,22 @@ bool PlatformInterface::valid_reservation(unit) {
   return false;
 }
 
+bool PlatformInterface::validate_event_selectors(unit) {
+  return true;
+}
+
+unit PlatformInterface::event_callback(hart::zEvent, hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9) {
+  return UNIT;
+}
+
+unit PlatformInterface::event_csr_write_callback(int64_t, uint64_t, uint64_t) {
+  return UNIT;
+}
+
+unit PlatformInterface::dispatch_events(unit) {
+  return UNIT;
+}
+
 unit PlatformInterface::plat_term_write(mach_bits) {
   return UNIT;
 }

--- a/c_emulator/riscv_platform_if.h
+++ b/c_emulator/riscv_platform_if.h
@@ -12,6 +12,7 @@ struct zMemoryAccessTypezIEmem_payloadz5zK;
 struct ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9;
 struct zPTW_Error;
 struct zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9;
+enum zEvent : int;
 
 } // namespace hart
 
@@ -66,6 +67,12 @@ public:
   virtual unit tlb_flush_begin_callback(unit);
   virtual unit tlb_flush_callback(uint64_t index);
   virtual unit tlb_flush_end_callback(hart::zz5vecz8z5unionz0zzoptionzzIRTLB_EntryzzKz9 tlb);
+
+  // Events
+  virtual bool validate_event_selectors(unit);
+  virtual unit event_callback(hart::zEvent ev, hart::ztuple_z8z5enumz0zzPrivilegezCz0z5unitz9 privilege);
+  virtual unit event_csr_write_callback(int64_t index, uint64_t old_selector, uint64_t new_selector);
+  virtual unit dispatch_events(unit);
 
   // Provides entropy for the scalar cryptography extension.
   virtual mach_bits plat_get_16_random_bits(unit);

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -450,7 +450,38 @@
     // Note: it is also legal for these instructions to spuriously
     // retire successfully at any point, but there is currently no
     // configuration option for this behaviour.
-    "max_time_to_wait": 10
+    "max_time_to_wait": 10,
+
+    // The model can generate the following events that can be tracked
+    // using the HPM counters:
+    // - EV_MISALIGNED_LOAD
+    // - EV_MISALIGNED_STORE
+    // - EV_TLB_MISS
+    //
+    // An event can be mapped to a selector value, that when written
+    // to the lowest 56 bits of an `mhpmeventNN` CSR, will increment
+    // the corresponding `mhpmcounterNN` CSR as per the specification
+    // (e.g. the `Sscofpmf` extension).
+    //
+    // The `event_selectors` list can contain any subset of these
+    // supported events.  Events cannot be repeated in the list,
+    // and the selector values should be unique.
+    "event_selectors": [
+      {
+        "event": "EV_MISALIGNED_LOAD",
+        "selector": {
+          "len": 56,
+          "value": "0x1"
+        }
+      },
+      {
+        "event": "EV_MISALIGNED_STORE",
+        "selector": {
+          "len": 56,
+          "value": "0x2"
+        }
+      }
+    ]
   },
   "extensions": {
     "M": {

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -109,11 +109,13 @@ add_custom_command(
         --c-preserve tick_clock
         --c-preserve enable_htif
         --c-preserve set_pc_reset_address
+        --c-preserve increment_hpmcounter
         --c-preserve generate_dts
         --c-preserve config_is_valid
         --c-preserve dtb_within_configured_pma_memory
         --c-preserve generate_canonical_isa_string
         --c-preserve string_of_exception
+        --c-preserve name_of_event
         # Preserve RVFI functions.
         --c-preserve rvfi_set_instr_packet
         --c-preserve rvfi_get_cmd

--- a/model/core/events.sail
+++ b/model/core/events.sail
@@ -1,0 +1,45 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// Types for events supported by the model.
+
+enum Event = {
+  EV_TLB_MISS,
+  EV_MISALIGNED_LOAD,
+  EV_MISALIGNED_STORE,
+}
+
+mapping event_name : Event <-> string = {
+  EV_TLB_MISS         <-> "TLB miss",
+  EV_MISALIGNED_LOAD  <-> "misaligned load",
+  EV_MISALIGNED_STORE <-> "misaligned store",
+}
+
+// For C++.
+function name_of_event(e : Event) -> string = event_name(e)
+
+val event_callback = impure {cpp: "event_callback", c: "event_callback"} : (Event, (Privilege, unit)) -> unit
+
+function generate_event(ev : Event) -> unit =
+  event_callback(ev, (cur_privilege, ()))
+
+function generate_trap_event(trap : TrapCause) -> unit = {
+  match trap {
+    Exception(E_Load_Addr_Align()) => generate_event(EV_MISALIGNED_LOAD),
+    Exception(E_SAMO_Addr_Align()) => generate_event(EV_MISALIGNED_STORE),
+    _ => (),
+  }
+}
+
+// This is defined here and not in `platform_config.sail` since it needs `types.sail`.
+struct event_selector = {
+  event    : Event,
+  selector : bits(56),  // The value that should be in the event field of an `hpmeventx` CSR to select this event.
+}
+
+let platform_event_selectors : list(event_selector) = config platform.event_selectors

--- a/model/core/interrupt_regs.sail
+++ b/model/core/interrupt_regs.sail
@@ -128,6 +128,8 @@ register mip     : Minterrupts // Pending
 register medeleg : Medeleg     // Exception delegation to S-mode
 register mideleg : Minterrupts // Interrupt delegation to S-mode
 
+let mip_csreg : csreg = 0x344
+
 mapping clause csr_name_map = 0x304  <-> "mie"
 mapping clause csr_name_map = 0x344  <-> "mip"
 mapping clause csr_name_map = 0x302  <-> "medeleg"

--- a/model/extensions/Zihpm/zihpm.sail
+++ b/model/extensions/Zihpm/zihpm.sail
@@ -171,7 +171,7 @@ bitfield HpmEvent : bits(64) = {
   VSINH : 59,
   VUINH : 58,
 
-  event : 31 .. 0,
+  event : 55 .. 0,
 }
 
 // HPM events selector. These control what the HPM counters measure. The lowest
@@ -193,6 +193,7 @@ function hpmidx_from_bits(b : bits(5)) -> hpmidx = {
 }
 
 function legalize_hpmevent(v : HpmEvent) -> HpmEvent = {
+  // TODO: we could use event_csr_write_callback as a legalizer for the event field.
   [ Mk_HpmEvent(zeros()) with
     OF = if currentlyEnabled(Ext_Sscofpmf) then v[OF] else 0b0,
     MINH  = if currentlyEnabled(Ext_Sscofpmf) then v[MINH] else 0b0,
@@ -208,20 +209,60 @@ function read_mhpmcounter(index : hpmidx) -> xlenbits = mhpmcounter[index][(xlen
 function read_mhpmcounterh(index : hpmidx) -> bits(32) = mhpmcounter[index][63 .. 32]
 function read_mhpmevent(index : hpmidx) -> xlenbits = mhpmevent[index].bits[(xlen - 1) .. 0]
 
-// Write the HPM CSRs. These return the new value of the CSR, for use in writeCSR.
+// Track any HPM event selector CSR and counter CSR written by the
+// current instruction. If the event for that counter fires during
+// that write, the counter should not be incremented, since according
+// to the spec:
+//
+//  "Any CSR write takes effect after the writing instruction has
+//   otherwise completed."
+//
+// As the model dispatches events after instruction execution, it
+// should not overwrite any CSR writes (similar to the handling of
+// minstret).
+//
+// For simplicity, the model also does not update a counter if its
+// event selector CSR was written, since the write could have changed
+// the Sscofpmf flags or the selector code.
+
+register written_event_index : option(hpmidx) = None()
+
+// Called at the end of the step, after any events have been
+// dispatched.
+function clear_written_event_index() -> unit =
+  written_event_index = None()
+
+// Write the HPM CSRs.
 function write_mhpmcounter(index : hpmidx, value : xlenbits) -> unit =
-  if sys_writable_hpm_counters[index] == 0b1 then mhpmcounter[index][(xlen - 1) .. 0] = value
+  if sys_writable_hpm_counters[index] == 0b1 then {
+    mhpmcounter[index][(xlen - 1) .. 0] = value;
+    written_event_index = Some(index)
+  }
 
 function write_mhpmcounterh(index : hpmidx, value : bits(32)) -> unit =
-  if sys_writable_hpm_counters[index] == 0b1 then mhpmcounter[index][63 .. 32] = value
+  if sys_writable_hpm_counters[index] == 0b1 then {
+    mhpmcounter[index][63 .. 32] = value;
+    written_event_index = Some(index)
+  }
+
+val event_csr_write_callback = pure {cpp: "event_csr_write_callback"} : (hpmidx, bits(64), bits(64)) -> unit
 
 function write_mhpmevent(index : hpmidx, value : xlenbits) -> unit =
-  if sys_writable_hpm_counters[index] == 0b1 then
-  mhpmevent[index] = legalize_hpmevent(Mk_HpmEvent(match xlen {
-    32 => mhpmevent[index].bits[63 .. 32] @ value,
-    64 => value,
-    _ => internal_error(__FILE__, __LINE__, "Unsupported xlen"),
-  }))
+  if sys_writable_hpm_counters[index] == 0b1 then {
+    let old_value = mhpmevent[index];
+    let value = legalize_hpmevent(Mk_HpmEvent(match xlen {
+      32 => mhpmevent[index].bits[63 .. 32] @ value,
+      64 => value,
+      _  => internal_error(__FILE__, __LINE__, "Unsupported xlen"),
+    }));
+    mhpmevent[index] = value;
+
+    written_event_index = Some(index);
+
+    // C++ callback to update the [selector -> counter register(s)] map.
+    // TODO: in the absence of Sscofpmf, the whole CSR is the event code, not just bits 55..0.
+    event_csr_write_callback(index, zero_extend(old_value[event]), zero_extend(value[event]))
+  }
 
 // Hardware Performance Monitoring event selection
 function clause is_CSR_accessible((0b0011001 /* 0x320 */ @ index : bits(5), _, _) if unsigned(index) >= 3) = currentlyEnabled(Ext_Zihpm) // mhpmevent3..31
@@ -256,3 +297,54 @@ function clause is_CSR_accessible((0b1100100 /* 0xC80 */ @ index : bits(5), priv
 
 function clause read_CSR(0b1100000 /* 0xC00 */ @ index : bits(5) if unsigned(index) >= 3) = read_mhpmcounter(hpmidx_from_bits(index))
 function clause read_CSR(0b1100100 /* 0xC80 */ @ index : bits(5) if xlen == 32 & unsigned(index) >= 3) = read_mhpmcounterh(hpmidx_from_bits(index))
+
+// Dispatch an event.  The privilege at which the event occurred is
+// tracked in case the privilege changed after the event occurred.
+function increment_hpmcounter(index : hpmidx, (event_priv,_) : (Privilege, unit)) -> unit = {
+  // Ensure that an event does not increment a counter that was
+  // written by the current instruction.  This also does not increment
+  // the counter if its hpmevent CSR was written (see above).
+  match written_event_index {
+    Some(idx) => { if idx == index then return () },
+    None()    => (),
+  };
+
+  // Filter the privilege mode according to Sscofpmf.
+  if currentlyEnabled(Ext_Sscofpmf) then {
+    let event_cfg = mhpmevent[index];
+    let is_inhibited_bit : bits(1) = match event_priv {
+      Machine           => event_cfg[MINH],
+      Supervisor        => event_cfg[SINH],
+      User              => event_cfg[UINH],
+      VirtualSupervisor => event_cfg[VSINH],
+      VirtualUser       => event_cfg[VUINH],
+    };
+    if is_inhibited_bit == 0b1 then return ()
+  };
+
+  let index_bits  : bits(5) = to_bits(index);
+  let counter_csr : csreg   = 0b1011000 /* 0xB00 */ @ index_bits;
+  let event_csr   : csreg   = 0b0011001 /* 0x320 */ @ index_bits;
+
+  // Increment and check overflow.
+  let count : xlenbits = mhpmcounter[index][(xlen - 1) .. 0];
+  let overflowed : bool = count == ones();
+  let new_count = if overflowed then zeros() else count + 1;
+  mhpmcounter[index][(xlen - 1) .. 0] = new_count;
+  csr_write_callback(counter_csr, new_count);
+
+  // Set OF and LCOFI if needed.
+  if currentlyEnabled(Ext_Sscofpmf) & overflowed then {
+    let event_cfg = mhpmevent[index];
+    let previously_overflowed = event_cfg[OF] == 0b1;
+    if not(previously_overflowed) then {
+      let new_event_cfg = [event_cfg with OF = 0b1];
+      mhpmevent[index] = new_event_cfg;
+      mip = [mip with LCOFI = 0b1];
+
+      let event_csr_name = csr_name_map(event_csr);
+      long_csr_write_callback(event_csr_name, event_csr_name ^ "h", new_event_cfg.bits);
+      csr_write_callback(mip_csreg, mip.bits);
+    }
+  }
+}

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -166,6 +166,9 @@ private function wait_is_nop(wr : WaitReason) -> bool =
     WAIT_WRS_NTO => config extensions.Zawrs.nto.is_nop,
   }
 
+// The event dispatch function.
+val dispatch_events = impure {cpp : "dispatch_events"} : unit -> unit
+
 // The `try_step` function is the main internal driver of the Sail
 // model. It performs the fetch-decode-execute for an instruction. It
 // is also the primary interface to the non-Sail execution harness.
@@ -263,6 +266,9 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
       // update wasn't suppressed by writing to it explicitly or
       // mcountinhibit[IR] or minstretcfg.
       if retired & minstret_increment then minstret = minstret + 1;
+
+      dispatch_events();
+      clear_written_event_index();
 
       // Record the next PC for RVFI.
       // TODO: Remove this and implement it in C.

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -684,6 +684,16 @@ private function check_version_constraints() -> bool = {
   valid
 }
 
+// Checks for selector-value validity are done in C++ for efficiency
+// since Sail does not have a `set` type.
+private val validate_event_selectors = pure {cpp:"validate_event_selectors"} : unit -> bool
+// FIXME: Uncomment this default for other backends once this bug is fixed:
+// https://github.com/rems-project/sail/issues/1713
+// function validate_event_selectors () = true
+
+private function check_platform_constraints() -> bool =
+  validate_event_selectors()
+
 function config_is_valid() -> bool = {
     check_privs()
   & check_tvecs()
@@ -698,5 +708,6 @@ function config_is_valid() -> bool = {
   & check_misc_extension_dependencies()
   & check_extension_param_constraints()
   & check_version_constraints()
+  & check_platform_constraints()
   & check_stateen_config()
 }

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -36,6 +36,7 @@ core {
     core/regs.sail,
     core/pc_access.sail,
     core/sys_regs.sail,
+    core/events.sail,
     core/ext_regs.sail,
     core/interrupt_regs.sail,
     core/addr_checks_common.sail,
@@ -567,7 +568,7 @@ mops {
 postlude {
   after extensions, mops, core
 
-  requires prelude, core, sys, exceptions, Smcntrpmf, pmp, Zicfilp_regs, Zicfilp_insts
+  requires prelude, core, sys, exceptions, Smcntrpmf, pmp, Zicfilp_regs, Zicfilp_insts, Zihpm
 
   files
     postlude/insts_end.sail,

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -205,6 +205,8 @@ function trap_handler(del_priv : Privilege, c : TrapCause, pc : xlenbits, info :
 
   if hartSupports(Ext_Zicfilp) then zicfilp_preserve_elp_on_trap(del_priv);
 
+  generate_trap_event(c);
+
   match (del_priv) {
     Machine => {
       mcause[IsInterrupt] = bool_to_bit(is_interrupt);

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -379,10 +379,14 @@ private function translate forall 'v, is_sv_mode('v) . (
   // On first reading, assume lookup_TLB returns None(), since TLBs
   // are not part of RISC-V archticture spec (see TLB NOTE above)
   match lookup_TLB(sv_width, asid, vpn) {
-    Some(index, ent) => translate_TLB_hit(sv_width, asid, vpn, access, priv,
-                                          mxr, do_sum, ext_ptw, index, ent),
-    None()           => translate_TLB_miss(sv_width, asid, base_ppn, vpn, access, priv,
-                                           mxr, do_sum, ext_ptw),
+    Some(index, ent) =>
+      translate_TLB_hit(sv_width, asid, vpn, access, priv,
+                        mxr, do_sum, ext_ptw, index, ent),
+    None()           => {
+      generate_event(EV_TLB_MISS);
+      translate_TLB_miss(sv_width, asid, base_ppn, vpn, access, priv,
+                         mxr, do_sum, ext_ptw)
+    },
   }
 }
 

--- a/test/first_party/CMakeLists.txt
+++ b/test/first_party/CMakeLists.txt
@@ -126,6 +126,7 @@ add_first_party_test("test_vrgatherei16_reg_group.S")
 add_first_party_test("test_tlb_stale_pte_access_fault.S")
 
 add_first_party_override_test("test_sew_elen_bound.S" "elen_32.json")
+add_first_party_override_test("test_event_counter.S" "misaligned_event.json")
 
 list(LENGTH tests tests_len)
 math(EXPR test_last "${tests_len} - 1")

--- a/test/first_party/src/misaligned_event.json
+++ b/test/first_party/src/misaligned_event.json
@@ -1,0 +1,11 @@
+{
+  "memory": {
+    "misaligned": {
+      "exceptions": {
+        "load_store": {
+          "Some": "AlignmentException"
+        }
+      }
+    }
+  }
+}

--- a/test/first_party/src/test_event_counter.S
+++ b/test/first_party/src/test_event_counter.S
@@ -1,0 +1,69 @@
+.global main
+main:
+
+  # This is a simple test to ensure event generation increments event
+  # counters.  It uses events triggered by misaligned load and store
+  # accesses using the default selector codes of 0x1 and 0x2.
+
+setup:
+  # Save the return address
+  mv s1, ra
+  # Save the current mtvec before changing it
+  csrr s2, mtvec
+  # Setup trivial handler
+  la t0, ignore_trap
+  csrw mtvec, t0
+  csrw mcause, x0
+  # Enable event counters
+  csrw mcountinhibit, zero
+  # In case we want to test other privilege levels.
+  li t0, 0xFFFFFFFF
+  csrw mcounteren, t0
+  # Register interest in the events
+  li t0, 0x1
+  csrw mhpmevent3, t0
+  li t0, 0x2
+  csrw mhpmevent31, t0
+  # Zero counters
+  csrw mhpmcounter3, zero
+  csrw mhpmcounter31, zero
+
+trigger_events:
+  la t1, test_data
+  lw t2, 0x2(t1)
+  sw t2, 0x2(t1)
+
+check_events:
+  # Restore trap handler
+  csrw mtvec, s2
+  # There should be 1 instance of each registered event
+  li t3, 1
+  csrr t4, mhpmcounter3
+  bne t3, t4, fail
+  csrr t4, mhpmcounter31
+  bne t3, t4, fail
+  j pass
+
+.p2align 3
+ignore_trap:
+  # Advance PC and return.
+  csrr t5, mepc
+  addi t5, t5, 4
+  csrw mepc, t5
+  mret
+
+pass:
+  li a0, 0
+  mv ra, s1
+  ret
+
+fail:
+  li a0, 1
+  mv ra, s1
+  ret
+
+.data
+.p2align 4
+test_data:
+  .word 0x12345678
+  .word 0x87654321


### PR DESCRIPTION
This defines a few basic events (TLB misses and misaligned load/store exceptions) around which to build the framework.  The implementation-specific selector codes for the events can be specified in the config file. After a selector value is written to an event selector CSR, the generation of its event results in an increment of the corresponding event counter CSR (subject to Sscofpmf).

To improve efficiency, the event to CSR mapping is implemented in the C++ harness, as Sail doesn't have efficient sets and maps.  Event config validation is also done in the harness.

This framework could be extended in several ways:

- The registered selector codes could be used for WARL legalization of the `hpmevent` CSRs.

- Event selector codes are restricted to 56 bits, as made available by Sscofpmf.  When Sscofpmf is not supported, the use of all 64-bits should be supported.

- The events are counted based on exact matching of selector codes.  It would be good to support bit-mask-based event selection.

Fixes #1733.