### PR TITLE
Switch to an opam cache instead of container for Rocq CI

### DIFF
--- a/.github/workflows/rocq.yml
+++ b/.github/workflows/rocq.yml
@@ -4,16 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    env:
-      OPAMROOT: /home/rocq/.opam
-      # See root comment below
-      OPAMROOTISOK: true
-    container:
-      image: rocq/rocq-prover:9.0.1
-      # github requires root to access some resources from outside the container
-      # (e.g. https://github.com/actions/checkout/issues/47)
-      options: --user root
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v7
@@ -21,10 +12,10 @@ jobs:
           # Git history is needed for `git describe` in the build to work.
           fetch-depth: 0
 
-      # The container doesn't appear to have full package information, unlike
-      # the Ubuntu setup used in other workflows
-      - name: Update Debian package information
-        run: apt update
+      - name: System dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -o Acquire::Retries=3 install -y opam
 
       - name: Extract version numbers
         run: |
@@ -39,15 +30,24 @@ jobs:
         with:
           sail-version: ${{ env.SAIL_VERSION }}
 
+      - name: Restore cached opam
+        id: cache-opam-restore
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.opam
+          key: ${{ runner.os }}-${{ runner.arch }}-rocq-opam-sail-${{ env.SAIL_VERSION }}
+
       - name: Install Rocq-specific opam packages
+        if: steps.cache-rocq-opam-restore.outputs.cache-hit != 'true'
         run: |
+          opam init --yes --no-setup --shell=sh --compiler=5.2.1
           eval `opam env --safe`
-          opam update
-          # We're still using Rocq's old name for compatibility with versions < 9
-          opam install -y coq=9.0.1 coq-sail-stdpp=$SAIL_VERSION
-          # We're using the Sail binary release, so fake sail opam packages and avoid dune dependency hell
+          opam repo add --yes rocq-released https://rocq-prover.org/opam/released
+          opam update -y
+          opam install -y rocq-core=9.1.1 rocq-stdlib=9.0.0 rocq-stdpp-bitvector=1.13.0 rocq-sail-stdpp=$SAIL_VERSION
+          # We're using the Sail binary release, so fake sail opam packages
           # This will also install fake dependencies, so it has to be the last install before the build
-          opam install --fake --yes --ignore-constraints-on=dune \
+          opam install --fake --yes \
             sail.$SAIL_VERSION \
             sail_c_backend.$SAIL_VERSION \
             sail_coq_backend.$SAIL_VERSION \
@@ -59,6 +59,17 @@ jobs:
             sail_sv_backend.$SAIL_VERSION \
             sail_ocaml_backend.$SAIL_VERSION \
             sail_output.$SAIL_VERSION
+          # Reduce size for caching
+          opam clean -y
+
+      - name: Cache Rocq opam packages
+        id: cache-rocq-opam-save
+        # Only on the master branch to reduce storage use
+        if: steps.cache-rocq-opam-restore.outputs.cache-hit != 'true' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.opam
+          key: ${{ steps.cache-rocq-opam-restore.outputs.cache-primary-key }}
 
       - name: Build Rocq model
         run: |
@@ -74,7 +85,7 @@ jobs:
       - name: Locate Rocq sources
         run: |
           eval `opam env --safe`
-          echo "artifactPath=$(coqc -where)/user-contrib/Riscv/*.v" >> $GITHUB_ENV
+          echo "artifactPath=$(rocq c -where)/user-contrib/Riscv/*.v" >> $GITHUB_ENV
           echo "artifactName=rocq-sail-riscv-$(opam var coq-sail-riscv:version)-ci" >> $GITHUB_ENV
 
       - name: Upload Rocq sources

--- a/.github/workflows/rocq.yml
+++ b/.github/workflows/rocq.yml
@@ -2,6 +2,12 @@ name: Rocq
 
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  ocaml_version: 5.2.1
+  rocq_core_version: 9.1.1
+  rocq_stdlib_version: 9.0.0
+  rocq_stdpp_version: 1.13.0
+
 jobs:
   build:
     runs-on: ubuntu-24.04
@@ -35,16 +41,16 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ~/.opam
-          key: ${{ runner.os }}-${{ runner.arch }}-rocq-opam-sail-${{ env.SAIL_VERSION }}
+          key: rocq-opam-${{ runner.os }}-${{ runner.arch }}-ocaml-${{ env.ocaml_version }}-sail-${{ env.SAIL_VERSION }}-rocq-${{ env.rocq_core_version}}-stdlib-${{ env.rocq_stdlib_version }}-stdpp-${{ env.rocq_stdpp_version }}
 
       - name: Install Rocq-specific opam packages
         if: steps.cache-rocq-opam-restore.outputs.cache-hit != 'true'
         run: |
-          opam init --yes --no-setup --shell=sh --compiler=5.2.1
+          opam init --yes --no-setup --shell=sh --compiler=${{ env.ocaml_version }}
           eval `opam env --safe`
           opam repo add --yes rocq-released https://rocq-prover.org/opam/released
           opam update -y
-          opam install -y rocq-core=9.1.1 rocq-stdlib=9.0.0 rocq-stdpp-bitvector=1.13.0 rocq-sail-stdpp=$SAIL_VERSION
+          opam install -y rocq-core=${{ env.rocq_core_version }} rocq-stdlib=${{ env.rocq_stdlib_version }} rocq-stdpp-bitvector=${{ env.rocq_stdpp_version }} rocq-sail-stdpp=$SAIL_VERSION
           # We're using the Sail binary release, so fake sail opam packages
           # This will also install fake dependencies, so it has to be the last install before the build
           opam install --fake --yes \

--- a/.github/workflows/rocq.yml
+++ b/.github/workflows/rocq.yml
@@ -77,16 +77,16 @@ jobs:
           # The cmake fragment that computes the version uses git, which needs to be
           # reassured about github action's use of root.
           git config --global --add safe.directory /__w/sail-riscv/sail-riscv
-          cmake -P coq-sail-riscv.cmake
+          cmake -P rocq-sail-riscv.cmake
           # Ignore dune constraints because they come from the fake sail packages
           # Assume depexts because we've already installed cmake, but opam doesn't realise
-          opam install --yes --ignore-constraints-on=dune --assume-depexts ./coq-sail-riscv.opam
+          opam install --yes --ignore-constraints-on=dune --assume-depexts ./rocq-sail-riscv.opam
 
       - name: Locate Rocq sources
         run: |
           eval `opam env --safe`
           echo "artifactPath=$(rocq c -where)/user-contrib/Riscv/*.v" >> $GITHUB_ENV
-          echo "artifactName=rocq-sail-riscv-$(opam var coq-sail-riscv:version)-ci" >> $GITHUB_ENV
+          echo "artifactName=rocq-sail-riscv-$(opam var rocq-sail-riscv:version)-ci" >> $GITHUB_ENV
 
       - name: Upload Rocq sources
         uses: actions/upload-artifact@v7

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ z3_problems
 # z3 cache
 sail_smt_cache
 # Rocq packaging
-coq-sail-riscv.opam
+rocq-sail-riscv.opam

--- a/dependencies/asio/CMakeLists.txt
+++ b/dependencies/asio/CMakeLists.txt
@@ -6,19 +6,24 @@ FetchContent_Declare(
   URL_HASH SHA3_256=5979be31450b6e8d09ab7e766f62f4f7e1be85f090f2a9a773e12203922e5ce9
 )
 
-FetchContent_MakeAvailable(asio)
+# Allow downloads to be turned off (in particular, for targets that don't need it).
+option(DOWNLOAD_ASIO "Download asio" ON)
 
-add_library(asio INTERFACE
-    "${asio_SOURCE_DIR}/include/asio.hpp"
-)
-target_include_directories(asio INTERFACE
-    "${asio_SOURCE_DIR}/include"
-)
-target_compile_definitions(asio INTERFACE
-    -DASIO_NO_DEPRECATED
-)
+if (DOWNLOAD_ASIO)
+  FetchContent_MakeAvailable(asio)
 
-# On Rocky Linux 8.9, the build fails unless linked with -pthread.
-set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-find_package(Threads)
-target_link_libraries(asio INTERFACE Threads::Threads)
+  add_library(asio INTERFACE
+      "${asio_SOURCE_DIR}/include/asio.hpp"
+  )
+  target_include_directories(asio INTERFACE
+      "${asio_SOURCE_DIR}/include"
+  )
+  target_compile_definitions(asio INTERFACE
+      -DASIO_NO_DEPRECATED
+  )
+
+  # On Rocky Linux 8.9, the build fails unless linked with -pthread.
+  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+  find_package(Threads)
+  target_link_libraries(asio INTERFACE Threads::Threads)
+endif()

--- a/handwritten_support/CMakeLists.txt
+++ b/handwritten_support/CMakeLists.txt
@@ -6,7 +6,7 @@ add_custom_command(
     COMMENT "Building Rocq riscv_extras file"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND
-        coqc
+        rocq c
         -R "${CMAKE_BINARY_DIR}/rocq" Riscv
         -o "${CMAKE_BINARY_DIR}/rocq/riscv_extras.vo"
         "riscv_extras.v"

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -380,10 +380,10 @@ foreach (xlen IN ITEMS 32 64)
         COMMAND
             ${SAIL_BIN}
             ${sail_common}
-            --dcoq-undef-axioms
-            --coq
-            --coq-lib riscv_extras
-            --coq-output-dir "${CMAKE_BINARY_DIR}/rocq"
+            --drocq-undef-axioms
+            --rocq
+            --rocq-lib riscv_extras
+            --rocq-output-dir "${CMAKE_BINARY_DIR}/rocq"
             # The prefix of the output files.
             -o "${arch}"
             --config ${config_file}
@@ -398,11 +398,11 @@ foreach (xlen IN ITEMS 32 64)
         COMMENT "Building Rocq definitions from Sail model (${arch})"
         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/rocq"
         COMMAND
-            coqc
+            rocq c
             -R . Riscv
             "${arch}_types.v"
         COMMAND
-            coqc
+            rocq c
             -R . Riscv
             "${arch}.v"
     )

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -315,7 +315,7 @@ function loop () : unit -> nat = {
 
 // Termination measures for loops are not supported by the Lean backend, so they
 // should be guarded by this condition:
-$iftarget coq
+$iftarget rocq
 
 // The top-level loop isn't terminating, but we put a limit so that it can still
 // be included in the Coq output

--- a/model/prelude/prelude.sail
+++ b/model/prelude/prelude.sail
@@ -40,11 +40,11 @@ val sub_vec_int = pure {c: "sub_bits_int", cpp: "sub_bits_int", lean: "BitVec.su
 
 overload operator - = {sub_vec, sub_vec_int}
 
-val quot_positive_round_zero = pure {interpreter: "quot_round_zero", lem: "hardware_quot", lean: "Int.tdiv", c: "tdiv_int", cpp: "tdiv_int", coq: "Z.quot"} : forall 'n 'm, 'n >= 0 & 'm > 0. (int('n), int('m)) -> int(div('n, 'm))
-val quot_round_zero = pure {interpreter: "quot_round_zero", lem: "hardware_quot", c: "tdiv_int", cpp: "tdiv_int", coq: "Z.quot", lean: "Int.tdiv"} : forall 'm, 'm != 0 . (int, int('m)) -> int
+val quot_positive_round_zero = pure {interpreter: "quot_round_zero", lem: "hardware_quot", lean: "Int.tdiv", c: "tdiv_int", cpp: "tdiv_int", rocq: "Z.quot"} : forall 'n 'm, 'n >= 0 & 'm > 0. (int('n), int('m)) -> int(div('n, 'm))
+val quot_round_zero = pure {interpreter: "quot_round_zero", lem: "hardware_quot", c: "tdiv_int", cpp: "tdiv_int", rocq: "Z.quot", lean: "Int.tdiv"} : forall 'm, 'm != 0 . (int, int('m)) -> int
 
-val rem_positive_round_zero = pure {interpreter: "rem_round_zero", lem: "hardware_mod", c: "tmod_int", cpp: "tmod_int", coq: "Z.rem", lean: "Int.tmod"} : forall 'n 'm, 'n >= 0 & 'm > 0. (int('n), int('m)) -> int(mod('n, 'm))
-val rem_round_zero = pure {interpreter: "rem_round_zero", lem: "hardware_mod", c: "tmod_int", cpp: "tmod_int", coq: "Z.rem", lean: "Int.tmod"} : forall 'm, 'm != 0 . (int, int('m)) -> int
+val rem_positive_round_zero = pure {interpreter: "rem_round_zero", lem: "hardware_mod", c: "tmod_int", cpp: "tmod_int", rocq: "Z.rem", lean: "Int.tmod"} : forall 'n 'm, 'n >= 0 & 'm > 0. (int('n), int('m)) -> int(mod('n, 'm))
+val rem_round_zero = pure {interpreter: "rem_round_zero", lem: "hardware_mod", c: "tmod_int", cpp: "tmod_int", rocq: "Z.rem", lean: "Int.tmod"} : forall 'm, 'm != 0 . (int, int('m)) -> int
 
 // For working with division / modulus we require the divisor to be >= 1.
 // This type describes that.

--- a/rocq-sail-riscv.cmake
+++ b/rocq-sail-riscv.cmake
@@ -1,7 +1,7 @@
 # This small script fills in the version numbers in the opam package file.
 # It can be invoked using
 #
-#   cmake -P coq-sail-riscv.cmake
+#   cmake -P rocq-sail-riscv.cmake
 
 include(cmake/project_version.cmake)
 include(cmake/sail_required_version.cmake)
@@ -13,4 +13,4 @@ if(EXISTS "cmake/sail_required_version_rocq.txt")
 else()
   set(sail_required_version_rocq ${SAIL_REQUIRED_VER})
 endif()
-configure_file("coq-sail-riscv.opam.in" "coq-sail-riscv.opam" @ONLY)
+configure_file("rocq-sail-riscv.opam.in" "rocq-sail-riscv.opam" @ONLY)

--- a/rocq-sail-riscv.opam.in
+++ b/rocq-sail-riscv.opam.in
@@ -9,7 +9,7 @@ license: "BSD-2-Clause"
 dev-repo: "git+https://github.com/riscv/sail-riscv.git"
 build: [
   # Turn off all downloads for sandboxing; they're not required for the Rocq build anyway
-  ["cmake" "-S" "." "-B" "build" "-DCMAKE_BUILD_TYPE=RelWithDebInfo" "-DDOWNLOAD_GMP=FALSE" "-DDOWNLOAD_JSONCONS=FALSE" "-DDOWNLOAD_CLI11=FALSE"]
+  ["cmake" "-S" "." "-B" "build" "-DCMAKE_BUILD_TYPE=RelWithDebInfo" "-DDOWNLOAD_GMP=FALSE" "-DDOWNLOAD_JSONCONS=FALSE" "-DDOWNLOAD_CLI11=FALSE" "-DDOWNLOAD_ASIO=FALSE"]
   ["cmake" "--build" "build" "--target" "build_rocq_rv64d" "build_rocq_rv32d"]
 ]
 install: [

--- a/rocq-sail-riscv.opam.in
+++ b/rocq-sail-riscv.opam.in
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "coq-sail-riscv"
+name: "rocq-sail-riscv"
 version: "@sail_riscv_release_version@"
 maintainer: "Sail Devs <cl-sail-dev@lists.cam.ac.uk>"
 authors: "Sail RISC-V contributors"
@@ -13,8 +13,8 @@ build: [
   ["cmake" "--build" "build" "--target" "build_rocq_rv64d" "build_rocq_rv32d"]
 ]
 install: [
-  ["sh" "-c" "install -d `coqc -where`/user-contrib/Riscv"]
-  ["sh" "-c" "install build/rocq/* `coqc -where`/user-contrib/Riscv"]
+  ["sh" "-c" "install -d `rocq c -where`/user-contrib/Riscv"]
+  ["sh" "-c" "install build/rocq/* `rocq c -where`/user-contrib/Riscv"]
 ]
 depends: [
   "sail" {>= "@sail_required_version_rocq@"}
@@ -28,7 +28,7 @@ depends: [
   "sail_sv_backend" {>= "@sail_required_version_rocq@"}
   "sail_ocaml_backend" {>= "@sail_required_version_rocq@"}
   "sail_output" {>= "@sail_required_version_rocq@"}
-  "coq-sail-stdpp" {>= "@sail_required_version_rocq@"}
+  "rocq-sail-stdpp" {>= "@sail_required_version_rocq@"}
   "conf-cmake"
 ]
 synopsis:


### PR DESCRIPTION
Also starts using the new-style rocq- package names for dependencies.