### PR TITLE
Fix zicfiss shadow stack page permissions

### DIFF
--- a/model/sys/vmem_pte.sail
+++ b/model/sys/vmem_pte.sail
@@ -200,6 +200,11 @@ private function check_PTE_permission(
 
     };
     if not(shadow_stack_ok) then return PTE_Check_Failure((), PTE_No_Access());
+    // On a shadow stack page the rules above fully decide the access. The R, W
+    // and X bits do not apply because the encoding is R=0 W=1 X=0, so grant the
+    // access here rather than falling through to the normal permission check,
+    // which would reject any load or atomic because the page is not readable.
+    return PTE_Check_Success(());
   } else if is_shadow_stack_access(access) then {
     // "Should a shadow stack instruction access a page that is not designated
     // as a shadow stack page and is not marked as read-only (pte.xwr=001), a

--- a/model/sys/vmem_pte.sail
+++ b/model/sys/vmem_pte.sail
@@ -143,9 +143,10 @@ private function check_PTE_permission(
   let pte_W = bit_to_bool(pte_flags[W]);
   let pte_X = bit_to_bool(pte_flags[X]);
 
-  // Since we assume a valid PTE: Writable pages must be readable. Write-only
-  // pages are reserved.
-  assert(pte_W ==> pte_R);
+  // We assume a valid PTE, so a writable page is either also readable or it is
+  // the write only shadow stack encoding (R=0, W=1, X=0). Any other write only
+  // page is reserved and would already have been rejected as invalid.
+  assert(pte_W ==> (pte_R | not(pte_X)));
 
   // Step 6 of VATP (see vmem.sail).
   let priv_ok : bool = match priv {


### PR DESCRIPTION
Two bugs in `check_PTE_permission` that fire the moment a shadow stack page (R=0 W=1 X=0) is accessed.

First is a crash. The assert that a writable page is also readable trips on a shadow stack page, even though `pte_is_invalid` already accepts that encoding as valid. I relaxed the assert to allow it while still catching reserved R=0 W=1 X=1.

Second is a wrong fault. After the shadow stack rules approve an access the code fell through to the normal check, which needs R, so loads, SSPOPCHK, and SSAMOSWAP got rejected with a store/AMO page fault while only SSPUSH worked.