### PR TITLE
Refresh timer pending bits when `stimecmp` is written.

### DIFF
--- a/model/extensions/Sstc/sstc.sail
+++ b/model/extensions/Sstc/sstc.sail
@@ -26,5 +26,8 @@ function clause is_CSR_accessible(0x15D, priv, _) = is_stimecmp_accessible(priv)
 function clause read_CSR(0x14D) = stimecmp[xlen - 1 .. 0]
 function clause read_CSR(0x15D if xlen == 32) = stimecmp[63 .. 32]
 
-function clause write_CSR(0x14D, value) = { stimecmp[(xlen - 1) .. 0] = value; Ok(stimecmp[xlen - 1 .. 0]) }
-function clause write_CSR((0x15D, value) if xlen == 32) = { stimecmp[63 .. 32] = value; Ok(stimecmp[63 .. 32]) }
+// Writing stimecmp changes the timer interrupt condition, so refresh the
+// pending bits right away the same way an mtimecmp write does. Without this
+// mip[STI] stays stale until the next clock tick.
+function clause write_CSR(0x14D, value) = { stimecmp[(xlen - 1) .. 0] = value; clint_dispatch(false); Ok(stimecmp[xlen - 1 .. 0]) }
+function clause write_CSR((0x15D, value) if xlen == 32) = { stimecmp[63 .. 32] = value; clint_dispatch(false); Ok(stimecmp[63 .. 32]) }

--- a/model/sys/platform.sail
+++ b/model/sys/platform.sail
@@ -138,7 +138,7 @@ function clint_load(access, paddr, width) = {
   }
 }
 
-private function clint_dispatch(mip_was_written : bool) -> unit = {
+function clint_dispatch(mip_was_written : bool) -> unit = {
   let old_mip = mip.bits;
   mip[MTI] = bool_to_bit(mtimecmp <=_u mtime);
   if currentlyEnabled(Ext_Sstc) & menvcfg[STCE] == 0b1 then {


### PR DESCRIPTION
Only `mtimecmp` writes and clock ticks recomputed `mip[STI]`, so writing the `stimecmp` CSR left the pending bit stale until the next tick (which is legal). Call `clint_dispatch` from the `stimecmp` write clause so it refreshes right away like an `mtimecmp` write does.