### PR TITLE
Refactor `init_model` to use the `InitResult` return type.

### DIFF
--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -502,7 +502,7 @@ void init_logs(const CLIOptions &opts, run_info &run_info) {
 // Processes options that don't need an initialized model and gets the
 // json configuration string; returns whether to continue with model
 // initialization.
-InitResult preinit_args(CLIOptions &opts, std::string &config_json_string) {
+InitResult preinit_args(const CLIOptions &opts, std::string &config_json_string) {
   if (opts.do_print_version) {
     std::cout << version_info::release_version() << std::endl;
     return InitResult::ExitSuccess;
@@ -571,7 +571,7 @@ InitResult preinit_args(CLIOptions &opts, std::string &config_json_string) {
 // options requiring a configured model and returns whether to continue with
 // model simulation.
 InitResult preinit_model(
-  CLIOptions &opts,
+  const CLIOptions &opts,
   ModelImpl &model,
   const std::string &config_json_string,
   run_info &run_info
@@ -646,12 +646,18 @@ InitResult preinit_model(
   return InitResult::Continue;
 }
 
-uint64_t init_model(CLIOptions &opts, ModelImpl &model, elf_info &elf_info, run_info &run_info) {
+InitResult init_model(
+  const CLIOptions &opts,
+  ModelImpl &model,
+  elf_info &elf_info,
+  run_info &run_info,
+  uint64_t &entry
+) {
   run_info.init_start = steady_clock::now();
 
   if (run_info.rvfi.has_value()) {
     if (!run_info.rvfi->setup_socket(opts.config_print_rvfi)) {
-      return 1;
+      return InitResult::ExitFailure;
     }
     model.register_callback(std::make_shared<rvfi_callbacks>());
   }
@@ -661,8 +667,8 @@ uint64_t init_model(CLIOptions &opts, ModelImpl &model, elf_info &elf_info, run_
     write_dtb_to_rom(model, read_file(opts.dtb_file));
   }
 
-  uint64_t entry = run_info.rvfi.has_value() ? rvfi_handler::get_entry()
-                                             : load_sail(model, opts.elfs[0], /*main_file=*/true, elf_info);
+  entry = run_info.rvfi.has_value() ? rvfi_handler::get_entry()
+                                    : load_sail(model, opts.elfs[0], /*main_file=*/true, elf_info);
 
   fprintf(stdout, "Entry point: 0x%" PRIx64 "\n", entry);
 
@@ -678,5 +684,5 @@ uint64_t init_model(CLIOptions &opts, ModelImpl &model, elf_info &elf_info, run_
 
   run_info.init_end = steady_clock::now();
 
-  return entry;
+  return InitResult::Continue;
 }

--- a/c_emulator/riscv_sim.h
+++ b/c_emulator/riscv_sim.h
@@ -46,15 +46,26 @@ enum class InitResult {
 // Processes options that don't need an initialized model and gets the
 // json configuration string; returns whether to continue with model
 // initialization.
-InitResult preinit_args(CLIOptions &opts, std::string &config_json_string);
+InitResult preinit_args(const CLIOptions &opts, std::string &config_json_string);
 
 // Configures the model, validates the configuration, processes
 // options requiring a configured model and returns whether to continue with
 // model simulation.
-InitResult preinit_model(CLIOptions &opts, ModelImpl &model, const std::string &config_json_string, run_info &run_info);
+InitResult preinit_model(
+  const CLIOptions &opts,
+  ModelImpl &model,
+  const std::string &config_json_string,
+  run_info &run_info
+);
 
-// Returns the entry address.
-uint64_t init_model(CLIOptions &opts, ModelImpl &model, elf_info &elf_info, run_info &run_info);
+// Initializes the start address in `entry`.
+InitResult init_model(
+  const CLIOptions &opts,
+  ModelImpl &model,
+  elf_info &elf_info,
+  run_info &run_info,
+  uint64_t &entry
+);
 
 uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file, elf_info &elf_info);
 

--- a/c_emulator/rvfi_dii.cpp
+++ b/c_emulator/rvfi_dii.cpp
@@ -25,7 +25,7 @@ uint64_t rvfi_handler::get_entry() {
   return 0x80000000;
 }
 
-// returns zero on success
+// returns true on success
 bool rvfi_handler::setup_socket(bool config_print) {
   int listen_sock = socket(AF_INET, SOCK_STREAM, 0);
   if (listen_sock == -1) {

--- a/c_emulator/sail_riscv_sim.cpp
+++ b/c_emulator/sail_riscv_sim.cpp
@@ -60,7 +60,15 @@ int inner_main(int argc, char **argv) {
   }
 
   elf_info elf_info;
-  uint64_t entry = init_model(opts, model, elf_info, run_info);
+  uint64_t entry = 0;
+  switch (init_model(opts, model, elf_info, run_info, entry)) {
+  case InitResult::ExitSuccess:
+    return EXIT_SUCCESS;
+  case InitResult::ExitFailure:
+    return EXIT_FAILURE;
+  case InitResult::Continue:
+    break;
+  }
 
   auto log_cbs = std::make_shared<log_callbacks>(
     opts.config_print_gpr,


### PR DESCRIPTION
This avoids using a fake entry point when RVFI fails to initialize its socket, resulting in the error getting ignored by the RVFI path.

While here, make the `InitResult` returning functions take a `const` options argument.