### PR TITLE
Add `initramfs` support to boot Linux to a shell. 

### DIFF
--- a/c_emulator/cli_options.cpp
+++ b/c_emulator/cli_options.cpp
@@ -37,6 +37,10 @@ CLIOptions parse_cli(int argc, char **argv) {
   );
 
   app.add_option("--device-tree-blob", opts.dtb_file, "Device tree blob file")
+    ->excludes("--print-device-tree")
+    ->check(CLI::ExistingFile)
+    ->option_text("<file>");
+  app.add_option("--initramfs", opts.initramfs_file, "File containing the initramfs (for Linux boot)")
     ->check(CLI::ExistingFile)
     ->option_text("<file>");
   app.add_option("--terminal-log", opts.term_log, "Terminal log output file")->option_text("<file>");

--- a/c_emulator/cli_options.h
+++ b/c_emulator/cli_options.h
@@ -26,6 +26,7 @@ struct CLIOptions {
   std::string term_log = {};
   std::string trace_log_path = {};
   std::string dtb_file;
+  std::string initramfs_file;
   unsigned rvfi_dii_port = 0;
   unsigned gdb_server_port = 0;
   std::vector<std::string> elfs;

--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -315,6 +315,20 @@ bool ModelImpl::get_config_use_abi_names(unit) {
   return m_config_use_abi_names;
 }
 
+mach_bits ModelImpl::get_initramfs_base(unit) {
+  if (m_initramfs_region.has_value()) {
+    return m_initramfs_region.value().base;
+  }
+  return 0;
+}
+
+mach_bits ModelImpl::get_initramfs_size(unit) {
+  if (m_initramfs_region.has_value()) {
+    return m_initramfs_region.value().size;
+  }
+  return 0;
+}
+
 void ModelImpl::set_config_print_instr(bool on) {
   m_config_print_instr = on;
 }
@@ -353,6 +367,10 @@ void ModelImpl::set_config_use_abi_names(bool on) {
 
 void ModelImpl::set_config_print_step(bool on) {
   m_config_print_step = on;
+}
+
+void ModelImpl::set_initramfs_location(uint64_t ramfs_start, uint64_t ramfs_size) {
+  m_initramfs_region = {ramfs_start, ramfs_size};
 }
 
 void ModelImpl::set_elf_symbols(std::map<uint64_t, std::string> symbols) {

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -54,6 +54,7 @@ public:
   void set_config_rvfi(bool on);
   void set_config_use_abi_names(bool on);
 
+  void set_initramfs_location(uint64_t ramfs_start, uint64_t ramfs_size);
   void set_elf_symbols(std::map<uint64_t, std::string> symbols);
   void set_term_fd(int fd);
   void set_trace_log(FILE *log);
@@ -181,6 +182,9 @@ private:
   bool get_config_rvfi(unit) override;
   bool get_config_use_abi_names(unit) override;
 
+  mach_bits get_initramfs_base(unit) override;
+  mach_bits get_initramfs_size(unit) override;
+
   bool m_config_print_instr = false;
   bool m_config_print_clint = false;
   bool m_config_print_exception = false;
@@ -197,8 +201,9 @@ private:
 
   // Initialization.
   uint64_t m_elf_entry = 0;
-  std::string m_config_file = {};
-  std::optional<uint64_t> m_htif_tohost_address = {};
+  std::string m_config_file;
+  std::optional<uint64_t> m_htif_tohost_address;
+  std::optional<MemoryRegion> m_initramfs_region;
 
   std::map<uint64_t, std::string> m_symbols;
   int m_term_fd = 1;

--- a/c_emulator/riscv_platform_if.cpp
+++ b/c_emulator/riscv_platform_if.cpp
@@ -218,3 +218,11 @@ bool PlatformInterface::get_config_rvfi(unit) {
 bool PlatformInterface::get_config_use_abi_names(unit) {
   return false;
 }
+
+mach_bits PlatformInterface::get_initramfs_base(unit) {
+  return 0;
+}
+
+mach_bits PlatformInterface::get_initramfs_size(unit) {
+  return 0;
+}

--- a/c_emulator/riscv_platform_if.h
+++ b/c_emulator/riscv_platform_if.h
@@ -94,4 +94,7 @@ public:
   virtual bool get_config_print_pmp(unit);
   virtual bool get_config_rvfi(unit);
   virtual bool get_config_use_abi_names(unit);
+
+  virtual mach_bits get_initramfs_base(unit);
+  virtual mach_bits get_initramfs_size(unit);
 };

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -177,6 +177,75 @@ void write_dtb_to_rom(ModelImpl &model, const std::string &filename, elf_info &e
   elf_info.loaded_regions.emplace_back(filename, dtb_addr, size);
 }
 
+// Returns the starting address in the region.
+uint64_t locate_initramfs_in_region(const MemoryRegion &reg, uint64_t ramfs_size) {
+  assert(reg.size >= ramfs_size);
+  // Compute a placement at the top of the range, leaving a page of
+  // space after. It seems most loaders (e.g. u-boot) using the
+  // initramfs keep some space after.  Spike keeps one 4K page
+  // after, so do the same.
+  uint64_t ramfs_end = reg.base + reg.size - 0x1000U;
+  return ramfs_end - ramfs_size;
+}
+
+bool load_initramfs(
+  ModelImpl &model,
+  const elf_info &elf_info,
+  std::string initramfs_file,
+  const std::vector<uint8_t> initramfs,
+  bool log_locations
+) {
+  uint64_t ramfs_size = static_cast<uint64_t>(initramfs.size());
+
+  // This just finds the first main memory region where it can fit,
+  // locates it at the top of the range, and checks for conflicts with
+  // other loaded files.
+  auto regions = model.main_memory_regions();
+  const auto &reg_ptr = std::find_if(regions.begin(), regions.end(), [ramfs_size, &elf_info](const auto &reg) {
+    // The region should accommodate the initramfs with padding.
+    if (reg.size < ramfs_size + 0x1000U) {
+      return false;
+    }
+
+    auto ramfs_start = locate_initramfs_in_region(reg, ramfs_size);
+
+    // Check for conflicts with already loaded files.
+    const auto &conflict_reg = std::find_if(
+      elf_info.loaded_regions.begin(),
+      elf_info.loaded_regions.end(),
+      [ramfs_start, ramfs_size](const auto &ent) {
+        return ramfs_start + ramfs_size > ent.offset && ent.offset + ent.length > ramfs_start;
+      }
+    );
+
+    // This region is okay if there is no conflict.
+    return conflict_reg == elf_info.loaded_regions.end();
+  });
+
+  if (reg_ptr == regions.end()) {
+    fprintf(stderr, "Could not find a suitable location in memory for initramfs from %s.\n", initramfs_file.c_str());
+    return false;
+  }
+
+  auto ramfs_start = locate_initramfs_in_region(*reg_ptr, ramfs_size);
+  auto addr = ramfs_start;
+  for (uint8_t d : initramfs) {
+    write_mem(addr++, d);
+  }
+
+  model.set_initramfs_location(ramfs_start, ramfs_size);
+  if (log_locations) {
+    fprintf(
+      stdout,
+      "Placed initramfs of size 0x%0" PRIx64 " at 0x%0" PRIx64 " (extending to 0x%0" PRIx64 ")\n",
+      ramfs_size,
+      ramfs_start,
+      ramfs_start + ramfs_size
+    );
+  }
+  return true;
+}
+
 void write_signature(const std::string &file, unsigned signature_granularity, const elf_info &elf_info) {
   if (elf_info.mem_sig_start >= elf_info.mem_sig_end) {
     fprintf(
@@ -265,7 +334,13 @@ std::string describe_config(const CLIOptions &opts) {
 
 } // namespace
 
-uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file, elf_info &elf_info) {
+uint64_t load_sail(
+  const CLIOptions &opts,
+  ModelImpl &model,
+  const std::string &filename,
+  bool main_file,
+  elf_info &elf_info
+) {
   ELF elf = ELF::open(filename);
 
   switch (elf.architecture()) {
@@ -339,24 +414,33 @@ uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file
 
   if (main_file) {
     // Only scan for test-signature/htif symbols in the main ELF file.
+    // This code might be called when generating device-tree, so do not log in that case.
 
     const auto &tohost = symbols.find("tohost");
     if (tohost == symbols.end()) {
-      fprintf(stderr, "Unable to locate tohost symbol; disabling HTIF.\n");
+      if (!opts.do_print_dts) {
+        fprintf(stderr, "Unable to locate tohost symbol; disabling HTIF.\n");
+      }
       elf_info.htif_tohost_address = std::nullopt;
     } else {
       elf_info.htif_tohost_address = tohost->second;
-      fprintf(stdout, "HTIF located at 0x%0" PRIx64 "\n", *elf_info.htif_tohost_address);
+      if (!opts.do_print_dts) {
+        fprintf(stdout, "HTIF located at 0x%0" PRIx64 "\n", *elf_info.htif_tohost_address);
+      }
     }
     // Locate test-signature locations if any.
     const auto &begin_sig = symbols.find("begin_signature");
     if (begin_sig != symbols.end()) {
-      fprintf(stdout, "begin_signature: 0x%0" PRIx64 "\n", begin_sig->second);
+      if (!opts.do_print_dts) {
+        fprintf(stdout, "begin_signature: 0x%0" PRIx64 "\n", begin_sig->second);
+      }
       elf_info.mem_sig_start = begin_sig->second;
     }
     const auto &end_sig = symbols.find("end_signature");
     if (end_sig != symbols.end()) {
-      fprintf(stdout, "end_signature: 0x%0" PRIx64 "\n", end_sig->second);
+      if (!opts.do_print_dts) {
+        fprintf(stdout, "end_signature: 0x%0" PRIx64 "\n", end_sig->second);
+      }
       elf_info.mem_sig_end = end_sig->second;
     }
   }
@@ -673,8 +757,9 @@ InitResult preinit_model(
   }
 
   // Print a device tree or an ISA string only after the configuration
-  // is validated above.
-  if (opts.do_print_dts) {
+  // is validated above.  If there is an initramfs present, do it later
+  // once it has a memory location.
+  if (opts.do_print_dts && opts.initramfs_file.empty()) {
     fprintf(stdout, "%s", model.generate_dts().c_str());
     return InitResult::ExitSuccess;
   }
@@ -687,7 +772,8 @@ InitResult preinit_model(
     return InitResult::ExitSuccess;
   }
 
-  // If we get here, we need to have ELF files to run (except in RVFI mode).
+  // If we get here, we need to have ELF files to run (except in RVFI mode),
+  // or to place in memory for generating a device-tree with an initramfs.
   if (opts.elfs.empty() && !run_info.rvfi.has_value()) {
     fprintf(stderr, "No elf file provided.\n");
     return InitResult::ExitFailure;
@@ -722,15 +808,33 @@ InitResult init_model(
   }
 
   entry = run_info.rvfi.has_value() ? rvfi_handler::get_entry()
-                                    : load_sail(model, opts.elfs[0], /*main_file=*/true, elf_info);
+                                    : load_sail(opts, model, opts.elfs[0], /*main_file=*/true, elf_info);
 
-  fprintf(stdout, "Entry point: 0x%" PRIx64 "\n", entry);
+  // Do not log if we are generating a device tree.
+  if (!opts.do_print_dts) {
+    fprintf(stdout, "Entry point: 0x%" PRIx64 "\n", entry);
+  }
 
   // Load any additional ELF files into memory. If RVFI was NOT used skip
   // the first one because it was loaded above.
   for (auto it = opts.elfs.cbegin() + (run_info.rvfi.has_value() ? 0 : 1); it != opts.elfs.cend(); it++) {
-    fprintf(stdout, "Loading additional ELF file %s.\n", it->c_str());
-    (void)load_sail(model, *it, /*main_file=*/false, elf_info);
+    if (!opts.do_print_dts) {
+      fprintf(stdout, "Loading additional ELF file %s.\n", it->c_str());
+    }
+    (void)load_sail(opts, model, *it, /*main_file=*/false, elf_info);
+  }
+
+  // Load the initramfs if specified after all the ELFs are loaded.
+  if (!opts.initramfs_file.empty()) {
+    if (!load_initramfs(model, elf_info, opts.initramfs_file, read_file(opts.initramfs_file), !opts.do_print_dts)) {
+      return InitResult::ExitFailure;
+    }
+
+    // We can now print out a device-tree with the initramfs if requested.
+    if (opts.do_print_dts) {
+      fprintf(stdout, "%s", model.generate_dts().c_str());
+      return InitResult::ExitSuccess;
+    }
   }
 
   model.set_elf_symbols(std::move(elf_info.symbols));

--- a/c_emulator/riscv_sim.h
+++ b/c_emulator/riscv_sim.h
@@ -81,7 +81,13 @@ InitResult init_model(
   uint64_t &entry
 );
 
-uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file, elf_info &elf_info);
+uint64_t load_sail(
+  const CLIOptions &opts,
+  ModelImpl &model,
+  const std::string &filename,
+  bool main_file,
+  elf_info &elf_info
+);
 
 void run_sail(
   ModelImpl &model,

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -1,5 +1,9 @@
 # Release notes for the next version
 
+- Support for booting Linux with an `initramfs` has been added, see
+  `os-boot/README.md`. This allows a boot upto a terminal shell
+  prompt.
+
 # Release notes for version 0.14
 
 The highlight of this release is the addition of the `H` hypervisor

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -1,5 +1,9 @@
 # Release notes for the next version
 
+- Support for booting Linux with an `initramfs` has been added, see
+  `os-boot/README.md`. This allows a boot upto a terminal shell
+  prompt.
+
 - Important issues addressed and bugs fixed:
   - https://github.com/riscv/sail-riscv/issues/1943 : `mstatus.SPELP` should be read-only zero when Supervisor mode is not implemented
   - https://github.com/riscv/sail-riscv/issues/1938 : `scause`/`vscause` rejected Exception Codes in 0-31 that the spec requires them to hold, such as hypervisor codes when `H` is not implemented

--- a/model/postlude/device_tree.sail
+++ b/model/postlude/device_tree.sail
@@ -153,6 +153,33 @@ function generate_soc_clint() -> option(string) = {
   } else None()
 }
 
+val get_initramfs_base = pure {
+    cpp: "get_initramfs_base"
+} : unit -> bits(64)
+
+val get_initramfs_size = pure {
+    cpp: "get_initramfs_size"
+} : unit -> bits(64)
+
+private function have_initrd() -> bool =
+  get_initramfs_size() != zeros()
+
+private function generate_chosen_initrd() -> option((string, string)) = {
+  let size = get_initramfs_size();
+  if size == zeros() then return None();
+
+  let base = get_initramfs_base();
+  let end_ = base + size;
+
+  let base_hi = unsigned(base >> 32);
+  let base_lo = unsigned(base[31 .. 0]);
+
+  let end_hi  = unsigned(end_ >> 32);
+  let end_lo  = unsigned(end_[31 .. 0]);
+  Some("linux,initrd-start = <" ^ hex_str(base_hi) ^ " " ^ hex_str(base_lo) ^ ">",
+       "linux,initrd-end   = <" ^ hex_str(end_hi) ^ " " ^ hex_str(end_lo) ^ ">")
+}
+
 function generate_dts() -> string = {
   let clock_freq : nat = config platform.clock_frequency;
 
@@ -168,7 +195,13 @@ function generate_dts() -> string = {
 ^ "  compatible = \"ucbbar,spike-bare-dev\";\n"
 ^ "  model = \"ucbbar,spike-bare\";\n"
 ^ "  chosen {\n"
-^ "    bootargs = \"console=hvc0 earlycon=sbi\";\n"
+^ "    bootargs = \"" ^ (if have_initrd() then "root=/dev/ram " else "") ^ "console=hvc0 earlycon=sbi\";\n"
+^ (match generate_chosen_initrd() {
+     None()     => "",
+     Some(s, e) =>
+  "    " ^ s ^ ";\n"
+^ "    " ^ e ^ ";\n"
+   })
 ^ "  };\n"
 ^ "  cpus {\n"
 ^ "    #address-cells = <1>;\n"

--- a/os-boot/Makefile
+++ b/os-boot/Makefile
@@ -6,14 +6,27 @@ RISCV_COMPILER_PREFIX := riscv64-buildroot-linux-gnu-
 payload_linux  := build/linux/arch/riscv/boot/Image
 payload_xvisor := build/xvisor/build/vmm.bin
 
+# Built binaries.
+linux_elf  := build/fw_payload_linux.elf
+xvisor_elf := build/fw_payload_xvisor.elf
+
+# Initramfs filesystem image.
+ramfs := build/rootfs.cpio
+
 .PHONY: all linux xvisor
-all: linux xvisor
+all: linux xvisor ramfs
 
-linux: build/fw_payload_linux.elf
-xvisor: build/fw_payload_xvisor.elf
+linux: $(linux_elf)
+xvisor: $(xvisor_elf)
+ramfs: $(ramfs)
 
-# Generic rule to download tools.
+# Generic rules to download tools.
+
 downloads/%.tar.xz: %.url
+	mkdir -p downloads
+	curl --location '$(shell cat $<)' --output $@
+
+downloads/%.tar.bz2: %.url
 	mkdir -p downloads
 	curl --location '$(shell cat $<)' --output $@
 
@@ -33,6 +46,10 @@ build/xvisor/Makefile: downloads/xvisor.tar.xz
 build/opensbi/Makefile: downloads/opensbi.tar.xz
 	mkdir -p build/opensbi
 	tar --touch --directory build/opensbi --strip-components=1 --extract --file downloads/opensbi.tar.xz
+
+build/busybox/Makefile: downloads/busybox.tar.bz2
+	mkdir -p build/busybox
+	tar --touch --directory build/busybox --strip-components=1 --extract --file downloads/busybox.tar.bz2
 
 CROSS_COMPILE := $(shell pwd)/build/gcc/bin/$(RISCV_COMPILER_PREFIX)
 
@@ -62,14 +79,46 @@ build/fw_payload_%.elf: build/opensbi/Makefile
 	  PLATFORM=generic CROSS_COMPILE=$(CROSS_COMPILE)
 	cp build/opensbi_$*/platform/generic/firmware/fw_payload.elf $@
 
+# Build Busybox as a static binary.
+#
+# Traffic control (networking/tc.c) doesn't compile on some kernels.
+# Ensure the Busybox uses the cross compiler.
+build/busybox/.config: build/busybox/Makefile build/gcc/bin/$(RISCV_COMPILER_PREFIX)gcc
+	CROSS_COMPILE=$(CROSS_COMPILE) $(MAKE) -C build/busybox defconfig
+	sed 's/^.*CONFIG_STATIC is not set.*/CONFIG_STATIC=y/' -i build/busybox/.config
+	sed 's/^CONFIG_TC=y/CONFIG_TC=n/' -i build/busybox/.config
+
+# Prepare busybox install
+build/busybox/_install/bin/busybox: build/busybox/.config
+	CROSS_COMPILE=$(CROSS_COMPILE) $(MAKE) -C build/busybox
+	CROSS_COMPILE=$(CROSS_COMPILE) $(MAKE) -C build/busybox install
+
+# Prepare rootfs cpio.
+$(ramfs): init-busybox build/busybox/_install/bin/busybox
+	cp init-busybox build/busybox/_install/init
+	cd build/busybox/_install && find . | cpio --create --format=newc --file ../rootfs.cpio
+	cp build/busybox/rootfs.cpio $(ramfs)
+
 # Path to Sail emulator.
 SAIL_SIM ?= ../build/c_emulator/sail_riscv_sim
+
+# Device tree without initramfs.
 
 build/sail.dts: $(SAIL_SIM)
 	mkdir -p build
 	$(SAIL_SIM) --print-device-tree >$@
 
 build/sail.dtb: build/sail.dts
+	mkdir -p build
+	dtc $< -o $@
+
+# Device tree with initramfs.
+
+build/sail_ramfs.dts: $(SAIL_SIM) $(linux_elf) $(ramfs)
+	mkdir -p build
+	$(SAIL_SIM) --initramfs $(ramfs) $(linux_elf) --print-device-tree >$@
+
+build/sail_ramfs.dtb: build/sail_ramfs.dts
 	mkdir -p build
 	dtc $< -o $@
 
@@ -96,6 +145,11 @@ limit_xvisor := 21000000
 # Run with the Sail emulator from this repo.
 %_sail: build/fw_payload_%.elf build/sail.dtb $(SAIL_SIM)
 	$(SAIL_SIM) --show-times --inst-limit $(limit_$*) --device-tree-blob build/sail.dtb $<
+
+# Boot with initramfs
+
+linux_ramfs_sail: build/sail_ramfs.dtb $(linux_elf) $(ramfs) $(SAIL_SIM)
+	$(SAIL_SIM) --initramfs $(ramfs) --device-tree-blob build/sail_ramfs.dtb $(linux_elf)
 
 # Run the profiler. This requires gperftools and pprof:
 #

--- a/os-boot/Makefile
+++ b/os-boot/Makefile
@@ -13,7 +13,7 @@ xvisor_elf := build/fw_payload_xvisor.elf
 # Initramfs filesystem image.
 ramfs := build/rootfs.cpio
 
-.PHONY: all linux xvisor
+.PHONY: all linux xvisor ramfs
 all: linux xvisor ramfs
 
 linux: $(linux_elf)
@@ -22,11 +22,7 @@ ramfs: $(ramfs)
 
 # Generic rules to download tools.
 
-downloads/%.tar.xz: %.url
-	mkdir -p downloads
-	curl --location '$(shell cat $<)' --output $@
-
-downloads/%.tar.bz2: %.url
+downloads/%.tar.bz2 downloads/%.tar.xz: %.url
 	mkdir -p downloads
 	curl --location '$(shell cat $<)' --output $@
 

--- a/os-boot/README.md
+++ b/os-boot/README.md
@@ -4,7 +4,7 @@ The Sail model implements a very simple platform based on the one implemented by
 
 32-bit OS boots require a workaround for the 64-bit HTIF interface, which is currently not supported.
 
-## Build your own ELF
+## Build and boot a basic Linux image
 
 Two images can be built, Linux and the Xvisor hypervisor. Both are OpenSBI with
 the payload embedded in it.
@@ -17,7 +17,7 @@ This generates `os-boot/build/fw_payload_linux.elf` and
 `os-boot/build/fw_payload_xvisor.elf`. Build just one with `make linux` or
 `make xvisor`.
 
-### Boot ELF
+This image can be booted on the model as follows:
 
 ```bash
 make linux_sail
@@ -45,3 +45,41 @@ the extensions in the device tree to what Spike actually supports makes it work.
 The QEMU failure has not been diagnosed.
 
 TODO: get both targets working.
+
+## Booting a more complete Linux image
+
+To boot Linux to a prompt, Linux typically uses a `initramfs`, which needs to be placed in memory, with its location specified in the device tree. Such an image takes much longer to boot, and while it boots to a user space shell, input to the shell is not currently supported.
+
+The build command above also builds the `initramfs` image using Busybox.
+
+```bash
+make -j4
+```
+
+This version can be booted on the model using:
+
+```bash
+make linux_ramfs_sail
+```
+
+## Booting custom Linux images
+
+When booting custom versions of Linux and `initramfs` images, the following
+steps need to be followed after those images are built:
+
+1. Generate a device tree blob for the configuration that includes the
+   memory location of the `initramfs` (e.g. `rootfs.cpio`) for the
+   boot image (e.g. `fw_payload.elf` when bundled with OpenSBI). This
+   uses the device tree compiler (`dtc`) available in the
+   `device-tree-compiler` package on Debian-based systems and the
+   `dtc` package on Fedora-based ones.
+
+```bash
+$ sail_riscv_sim --print-device-tree --initramfs rootfs.cpio fw_payload.elf | dtc > sail_boot.dtb
+```
+
+2. Boot the image:
+
+```bash
+$ sail_riscv_sim --initramfs rootfs.cpio --device-tree-blob sail_boot.dtb fw_payload.elf
+```

--- a/os-boot/README.md
+++ b/os-boot/README.md
@@ -83,3 +83,6 @@ $ sail_riscv_sim --print-device-tree --initramfs rootfs.cpio fw_payload.elf | dt
 ```bash
 $ sail_riscv_sim --initramfs rootfs.cpio --device-tree-blob sail_boot.dtb fw_payload.elf
 ```
+
+Booting with device tree blobs and `initramfs` images that do not
+follow this two-step process is not supported.

--- a/os-boot/busybox.url
+++ b/os-boot/busybox.url
@@ -1,0 +1,1 @@
+https://www.busybox.net/downloads/busybox-1.38.0.tar.bz2

--- a/os-boot/init-busybox
+++ b/os-boot/init-busybox
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin
+
+mount -t devtmpfs none /dev
+
+exec /sbin/init "$@"


### PR DESCRIPTION
This support involves:

- Adding an `--initramfs` option to specify a file containing the `initramfs`.

- The specified `initramfs` has to be loaded into an appropriate place in memory after the kernel has been loaded.

  The `initramfs` is simply placed at the top-end of the first memory region with the space to fit it without conflicts with existing loaded files.

- This location has to be communicated in the device-tree.

  If an `initramfs` is specified, the `--print-device-tree` option is handled after the binaries and `initramfs` are placed into memory.  Some initial logging is suppressed in this case to avoid interfering with the print.  Another option could be to print the device tree to a file, but the logging would still be confusing.

New targets are added to `os-boot/Makefile` to download Busybox and prepare a ramfs image, and to boot Linux with it.  The boot now proceeds to the point where input is needed to activate the terminal shell.