### PR TITLE
Make satp.ASID width and hgatp.VMID width configurable via `memory.asid_bits` and `memory.vmidlen`

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -36,9 +36,11 @@ foreach(CONFIG__BASE__XLEN IN ITEMS 32 64)
             if(CONFIG_XLEN_IS_32 STREQUAL true)
                 set(CONFIG__PHYSADDR__BITS 34)
                 set(CONFIG__ASID__LEN 9)
+                set(CONFIG__VMID__LEN 7)
             elseif(CONFIG_XLEN_IS_64 STREQUAL true)
                 set(CONFIG__PHYSADDR__BITS 56)
                 set(CONFIG__ASID__LEN 16)
+                set(CONFIG__VMID__LEN 14)
             endif()
 
             # GEILEN is at most XLEN-1.

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -35,8 +35,10 @@ foreach(CONFIG__BASE__XLEN IN ITEMS 32 64)
 
             if(CONFIG_XLEN_IS_32 STREQUAL true)
                 set(CONFIG__PHYSADDR__BITS 34)
+                set(CONFIG__ASID__LEN 9)
             elseif(CONFIG_XLEN_IS_64 STREQUAL true)
                 set(CONFIG__PHYSADDR__BITS 56)
+                set(CONFIG__ASID__LEN 16)
             endif()
 
             # GEILEN is at most XLEN-1.

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -221,6 +221,12 @@
     // bitvectors in the model and since it is unlikely real implementations
     // will have lower values.
     "physaddr_bits": @CONFIG__PHYSADDR__BITS@,
+    // This specifies the number of implemented ASID bits (ASIDLEN) in
+    // the `satp` register.  If ASIDLEN > 0, ASID[ASIDLEN-1:0] is writable and bits above that are
+    // read-only zero. The maximal value (ASIDMAX) is 9 for Sv32 or 16 for
+    // Sv39, Sv48, and Sv57. A value of 0 means no ASID bits are
+    // implemented (all ASID bits read as zero).
+    "asidlen": @CONFIG__ASID__LEN@,
     "pmp": {
       "grain": 0,
       // This specifies the number of PMP entries present.

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -227,6 +227,13 @@
     // Sv39, Sv48, and Sv57. A value of 0 means no ASID bits are
     // implemented (all ASID bits read as zero).
     "asidlen": @CONFIG__ASID__LEN@,
+    // This specifies the number of implemented VMID bits (VMIDLEN) in
+    // the `hgatp` register.  If VMIDLEN > 0, VMID[VMIDLEN-1:0] is
+    // writable and bits above that are read-only zero. The maximal
+    // value (VMIDMAX) is 7 for Sv32x4 and 14 for Sv39x4, Sv48x4, and
+    // Sv57x4. A value of 0 means no VMID bits are implemented (all
+    // VMID bits read as zero).
+    "vmidlen": @CONFIG__VMID__LEN@,
     "pmp": {
       "grain": 0,
       // This specifies the number of PMP entries present.

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -55,6 +55,10 @@
   - Writes of reserved values to `xenvcfg.CBIE` and `xtvec.MODE` can
     now also be ignored; see `reserved_behavior.pmpcfg_write_only` and
     `reserved_behavior.xenvcfg_cbie`.
+  - The number of implemented ASID bits (`satp.ASID` / `vsatp.ASID`)
+    can be specified, see `memory.asidlen`. The default is ASIDMAX
+    (9 for RV32, 16 for RV64). Values from 0 through ASIDMAX are
+    allowed; bits above ASIDLEN are read-only zero.
 
 - Xvisor boot is now tested in CI. The `os-boot` Makefile has been
   generalized to build both the Linux and Xvisor images.

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -59,6 +59,10 @@
     can be specified, see `memory.asidlen`. The default is ASIDMAX
     (9 for RV32, 16 for RV64). Values from 0 through ASIDMAX are
     allowed; bits above ASIDLEN are read-only zero.
+  - The number of implemented VMID bits (`hgatp.VMID`) can be
+    specified, see `memory.vmidlen`. The default is VMIDMAX (7 for
+    RV32, 14 for RV64). Values from 0 through VMIDMAX are allowed;
+    bits above VMIDLEN are read-only zero.
 
 - Xvisor boot is now tested in CI. The `os-boot` Makefile has been
   generalized to build both the Linux and Xvisor images.

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -1088,8 +1088,6 @@ bitfield Satp32 : bits(32) = {
   PPN  : 21 .. 0
 }
 
-// TODO: This currently assumes all ASID bits are implemented
-// and does not legalize the asid field if asidlen is not the maximum.
 function legalize_satp(
   arch : Architecture,
   is_vsatp : bool,
@@ -1102,6 +1100,10 @@ function legalize_satp(
   // masked to physaddr_bits, which only bounds real physical memory.
   if xlen == 32 then {
     let s = Mk_Satp32(written_value);
+    // ASID bits above the number of implemented ASID bits are read only zero.
+    let s = [s with
+      Asid = if asidlen == 0 then zeros() else zero_extend(s[Asid][asidlen - 1 .. 0]),
+    ];
     // vsatp's PPN addresses guest-physical memory, bounded only by
     // the field's own width, not the host's physaddr_bits.
     let s = if is_vsatp then s else [s with
@@ -1119,6 +1121,10 @@ function legalize_satp(
     }
   } else if xlen == 64 then {
     let s = Mk_Satp64(written_value);
+    // ASID bits above the number of implemented ASID bits are read only zero.
+    let s = [s with
+      Asid = if asidlen == 0 then zeros() else zero_extend(s[Asid][asidlen - 1 .. 0]),
+    ];
     // vsatp's PPN addresses guest-physical memory, bounded only by
     // the field's own width, not the host's physaddr_bits.
     let s = if is_vsatp then s else [s with

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -1019,7 +1019,6 @@ bitfield Hgatp32 : bits(32) = {
   PPN  : 21 .. 0
 }
 
-// TODO: Add VMIDLEN config option and mask VMID field to implemented width
 function legalize_hgatp(
   arch : Architecture,
   prev_value : xlenbits,
@@ -1037,6 +1036,8 @@ function legalize_hgatp(
     // are read only zero, since the G-stage root page table lives
     // in real physical memory.
     let h = [h with
+      // VMID bits above the number of implemented VMID bits are read only zero.
+      VMID = if vmidlen == 0 then zeros() else zero_extend(h[VMID][vmidlen - 1 .. 0]),
       PPN = zero_extend(h[PPN][physaddr_bits - pagesize_bits - 1 .. 0]),
     ];
     match hgatpMode_of_bits(arch, 0b000 @ h[Mode]) {
@@ -1055,6 +1056,8 @@ function legalize_hgatp(
     // implemented physical address bits are read only zero, since
     // the G-stage root page table lives in real physical memory.
     let h = [h with
+      // VMID bits above the number of implemented VMID bits are read only zero.
+      VMID = if vmidlen == 0 then zeros() else zero_extend(h[VMID][vmidlen - 1 .. 0]),
       PPN = zero_extend(h[PPN][min(physaddr_bits - pagesize_bits, 44) - 1 .. 0]),
     ];
     match hgatpMode_of_bits(arch, h[Mode]) {

--- a/model/core/xlen.sail
+++ b/model/core/xlen.sail
@@ -23,8 +23,9 @@ type gpalen : Int = if xlen == 32 then 34 else 64
 // This is the maximum (ASIDMAX); designs can implement shorter ASIDLENs.
 // The number of implemented ASID bits is configurable via `memory.asidlen`.
 type asidmax    : Int = if xlen == 32 then 9 else 16
-// TODO: Allow configuring shorter VMIDLENs.
-type vmidlen    : Int = if xlen == 32 then 7 else 14
+// This is the maximum (VMIDMAX); designs can implement shorter VMIDLENs.
+// The number of implemented VMID bits is configurable via `memory.vmidlen`.
+type vmidmax    : Int = if xlen == 32 then 7 else 14
 // GEILEN, the number of guest external interrupts. Bits GEILEN:1 of hgeip and
 // hgeie are implemented, all other bit positions are read-only zero. The
 // maximum is 31 for RV32 and 63 for RV64.
@@ -38,6 +39,14 @@ constraint 0 <= geilen & geilen <= xlen - 1
 type asidlen : Int = config memory.asidlen
 constraint 0 <= asidlen & asidlen <= asidmax
 
+// The number of implemented VMID bits (VMIDLEN), which may be less than
+// `vmidmax` (VMIDMAX), including zero. VMID bits above this value are
+// read-only zero in the `VMID` field of `hgatp`. See the RISC-V privileged
+// specification: "The least-significant bits of VMID are implemented first:
+// that is, if VMIDLEN > 0, VMID[VMIDLEN-1:0] is writable."
+type vmidlen : Int = config memory.vmidlen
+constraint 0 <= vmidlen & vmidlen <= vmidmax
+
 // Variable versions of the above types. Variables and types
 // are disjoint in Sail so they are allowed to have the same name.
 // This saves typing `sizeof()` everywhere.
@@ -46,6 +55,7 @@ let xlen_bytes = sizeof(xlen_bytes)
 let xlen = sizeof(xlen)
 let gpalen = sizeof(gpalen)
 let asidmax = sizeof(asidmax)
+let vmidmax = sizeof(vmidmax)
 let asidlen = sizeof(asidlen)
 let vmidlen = sizeof(vmidlen)
 let geilen = sizeof(geilen)
@@ -53,4 +63,4 @@ let geilen = sizeof(geilen)
 type xlenbits = bits(xlen)
 type gpabits  = bits(gpalen)
 type asidbits = bits(asidmax)
-type vmidbits = bits(vmidlen)
+type vmidbits = bits(vmidmax)

--- a/model/core/xlen.sail
+++ b/model/core/xlen.sail
@@ -20,9 +20,9 @@ type physaddrbits_len : Int = if xlen == 32 then 34 else 64
 // Maximum guest physical address width. The usable width comes from the
 // hgatp mode, e.g. 41 bits for Sv39x4.
 type gpalen : Int = if xlen == 32 then 34 else 64
-// This is the maximum; designs can implement shorter ASIDLENs.
-// TODO: Allow configuring shorter ASIDLENs.
-type asidlen    : Int = if xlen == 32 then 9 else 16
+// This is the maximum (ASIDMAX); designs can implement shorter ASIDLENs.
+// The number of implemented ASID bits is configurable via `memory.asidlen`.
+type asidmax    : Int = if xlen == 32 then 9 else 16
 // TODO: Allow configuring shorter VMIDLENs.
 type vmidlen    : Int = if xlen == 32 then 7 else 14
 // GEILEN, the number of guest external interrupts. Bits GEILEN:1 of hgeip and
@@ -31,6 +31,13 @@ type vmidlen    : Int = if xlen == 32 then 7 else 14
 type geilen : Int = config extensions.H.geilen
 constraint 0 <= geilen & geilen <= xlen - 1
 
+// The number of implemented ASID bits (ASIDLEN), which may be less than
+// `asidmax` (ASIDMAX), including zero. ASID bits above this value are
+// read-only zero in the `Asid` field of `satp`. See the RISC-V privileged
+// specification: "The number of ASID bits is UNSPECIFIED and may be zero."
+type asidlen : Int = config memory.asidlen
+constraint 0 <= asidlen & asidlen <= asidmax
+
 // Variable versions of the above types. Variables and types
 // are disjoint in Sail so they are allowed to have the same name.
 // This saves typing `sizeof()` everywhere.
@@ -38,11 +45,12 @@ let log2_xlen = sizeof(log2_xlen)
 let xlen_bytes = sizeof(xlen_bytes)
 let xlen = sizeof(xlen)
 let gpalen = sizeof(gpalen)
+let asidmax = sizeof(asidmax)
 let asidlen = sizeof(asidlen)
 let vmidlen = sizeof(vmidlen)
 let geilen = sizeof(geilen)
 
 type xlenbits = bits(xlen)
 type gpabits  = bits(gpalen)
-type asidbits = bits(asidlen)
+type asidbits = bits(asidmax)
 type vmidbits = bits(vmidlen)

--- a/model/extensions/H/hext_insts.sail
+++ b/model/extensions/H/hext_insts.sail
@@ -193,7 +193,7 @@ function clause execute HFENCE_GVMA(rs1, rs2) = {
   // following the htval/tval2 convention for G-stage traps. Pass it unshifted.
   // flush_TLB_Entry recovers the full GPA in a wide type, which can exceed XLEN on RV32.
   let addr = if rs1 != zreg then Some(X(rs1)) else None();
-  let vmid = if rs2 != zreg then Some(X(rs2)[vmidlen - 1 .. 0]) else None();
+  let vmid : option(vmidbits) = if rs2 != zreg then Some(if vmidlen == 0 then zeros() else zero_extend(X(rs2)[vmidlen - 1 .. 0])) else None();
   let asid : option(asidbits) = None();
 
   flush_TLB(asid, vmid, addr, G_Stage);

--- a/model/extensions/H/hext_insts.sail
+++ b/model/extensions/H/hext_insts.sail
@@ -165,7 +165,7 @@ function clause execute HFENCE_VVMA(rs1, rs2) = {
   then return Illegal_Instruction();
 
   let addr = if rs1 != zreg then Some(X(rs1)) else None();
-  let asid = if rs2 != zreg then Some(X(rs2)[asidlen - 1 .. 0]) else None();
+  let asid : option(asidbits) = if rs2 != zreg then Some(if asidlen == 0 then zeros() else zero_extend(X(rs2)[asidlen - 1 .. 0])) else None();
   let vmid = Some(get_vmid(VS_Stage));
 
   flush_TLB(asid, vmid, addr, VS_Stage);

--- a/model/extensions/I/base_insts.sail
+++ b/model/extensions/I/base_insts.sail
@@ -718,9 +718,9 @@ mapping clause encdec = SFENCE_VMA(rs1, rs2)
 function clause execute SFENCE_VMA(rs1, rs2) = {
   let addr = if rs1 != zreg then Some(X(rs1)) else None();
   // Note, the Sail model does not currently support Sv32 & SXLEN=32 on RV64.
-  // In that case this asidlen would be incorrect because the maximum asidlen
-  // is 9 but we always set it to 16 for RV64.
-  let asid = if rs2 != zreg then Some(X(rs2)[asidlen - 1 .. 0]) else None();
+  // In that case this `asidlen` may be incorrect because ASIDMAX for Sv32 is 9,
+  // but `asidlen` would have been validated against the ASIDMAX for RV64.
+  let asid : option(asidbits) = if rs2 != zreg then Some(if asidlen == 0 then zeros() else zero_extend(X(rs2)[asidlen - 1 .. 0])) else None();
   let vmid = if cur_privilege == VirtualSupervisor then Some(get_vmid(VS_Stage)) else None();
   match cur_privilege {
     User              => Illegal_Instruction(),

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -210,6 +210,12 @@ private function check_mmu_config() -> bool = {
   if (config extensions.Svvptc.supported : bool)
   then valid = valid & require_virtual_memory("Svvptc");
 
+  let asidlen_nat : nat = asidlen;
+  if (config extensions.S.supported : bool) & asidlen_nat > asidmax then {
+    valid = false;
+    print_endline("`memory.asidlen` is " ^ dec_str(asidlen) ^ " but cannot be greater than " ^ dec_str(asidmax) ^ " on " ^ (if xlen == 32 then "RV32." else "RV64."));
+  };
+
   valid
 }
 

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -216,6 +216,12 @@ private function check_mmu_config() -> bool = {
     print_endline("`memory.asidlen` is " ^ dec_str(asidlen) ^ " but cannot be greater than " ^ dec_str(asidmax) ^ " on " ^ (if xlen == 32 then "RV32." else "RV64."));
   };
 
+  let vmidlen_nat : nat = vmidlen;
+  if (config extensions.H.supported : bool) & vmidlen_nat > vmidmax then {
+    valid = false;
+    print_endline("`memory.vmidlen` is " ^ dec_str(vmidlen) ^ " but cannot be greater than " ^ dec_str(vmidmax) ^ " on " ^  (if xlen == 32 then "RV32." else "RV64."));
+  };
+
   valid
 }
 

--- a/test/first_party/CMakeLists.txt
+++ b/test/first_party/CMakeLists.txt
@@ -138,6 +138,8 @@ add_first_party_override_test("test_satp_physaddr_bits.S" "satp_physaddr_bits.js
 add_first_party_experimental_test("test_zilx.S")
 add_first_party_override_test("test_satp_asidlen.S" "satp_asidlen.json")
 add_first_party_override_test("test_satp_asidlen_partial.S" "satp_asidlen_partial.json")
+add_first_party_override_test("test_hgatp_vmidlen.S" "hgatp_vmidlen.json")
+add_first_party_override_test("test_hgatp_vmidlen_partial.S" "hgatp_vmidlen_partial.json")
 
 list(LENGTH tests tests_len)
 math(EXPR test_last "${tests_len} - 1")

--- a/test/first_party/CMakeLists.txt
+++ b/test/first_party/CMakeLists.txt
@@ -136,6 +136,8 @@ add_first_party_test("test_tlb_stale_pte_access_fault.S")
 add_first_party_override_test("test_sew_elen_bound.S" "elen_32.json")
 add_first_party_override_test("test_satp_physaddr_bits.S" "satp_physaddr_bits.json")
 add_first_party_experimental_test("test_zilx.S")
+add_first_party_override_test("test_satp_asidlen.S" "satp_asidlen.json")
+add_first_party_override_test("test_satp_asidlen_partial.S" "satp_asidlen_partial.json")
 
 list(LENGTH tests tests_len)
 math(EXPR test_last "${tests_len} - 1")

--- a/test/first_party/src/hgatp_vmidlen.json
+++ b/test/first_party/src/hgatp_vmidlen.json
@@ -1,0 +1,5 @@
+{
+  "memory": {
+    "vmidlen": 0
+  }
+}

--- a/test/first_party/src/hgatp_vmidlen_partial.json
+++ b/test/first_party/src/hgatp_vmidlen_partial.json
@@ -1,0 +1,5 @@
+{
+  "memory": {
+    "vmidlen": 5
+  }
+}

--- a/test/first_party/src/satp_asidlen.json
+++ b/test/first_party/src/satp_asidlen.json
@@ -1,0 +1,5 @@
+{
+  "memory": {
+    "asidlen": 0
+  }
+}

--- a/test/first_party/src/satp_asidlen_partial.json
+++ b/test/first_party/src/satp_asidlen_partial.json
@@ -1,0 +1,5 @@
+{
+  "memory": {
+    "asidlen": 7
+  }
+}

--- a/test/first_party/src/test_hgatp_vmidlen.S
+++ b/test/first_party/src/test_hgatp_vmidlen.S
@@ -1,0 +1,64 @@
+#include "common/encoding.h"
+
+// A test for the `memory.vmidlen` configuration parameter (VMIDLEN).
+//
+// The test is configured with an override of 0 implemented VMID bits.
+// In that case the entire `VMID` field of `hgatp` must read as zero,
+// even after writing all ones to it.
+//
+// See RISC-V Privileged ISA: "The number of implemented VMID bits,
+// termed VMIDLEN, may be determined by writing one to every bit
+// position in the VMID field" and "if VMIDLEN > 0, VMID[VMIDLEN-1:0]
+// is writable" — i.e. with VMIDLEN=0 no VMID bits are writable.
+
+.global main
+main:
+  # Save the return address.
+  mv s1, ra
+
+write_hgatp:
+#if __riscv_xlen == 32
+  # Sv32x4: set MODE=Sv32x4 and write all ones to the VMID field.
+  li t0, HGATP32_MODE * HGATP_MODE_SV32X4
+  li t1, HGATP32_VMID
+  or t0, t0, t1
+#else
+  # Sv39x4: set MODE=Sv39x4 and write all ones to the VMID field.
+  li t0, (HGATP64_MODE & ~(HGATP64_MODE << 1)) * HGATP_MODE_SV39X4
+  li t1, HGATP64_VMID
+  or t0, t0, t1
+#endif
+  csrw hgatp, t0
+
+read_vmid:
+  csrr t0, hgatp
+#if __riscv_xlen == 32
+  li t1, HGATP32_VMID
+#else
+  li t1, HGATP64_VMID
+#endif
+  and t0, t0, t1
+  # With vmidlen=0, the entire VMID field must read as zero.
+  li t1, 0
+  bne t0, t1, fail
+
+read_mode:
+  # The MODE field must still be preserved.
+  csrr t0, hgatp
+#if __riscv_xlen == 32
+  li t1, HGATP32_MODE * HGATP_MODE_SV32X4
+#else
+  li t1, (HGATP64_MODE & ~(HGATP64_MODE << 1)) * HGATP_MODE_SV39X4
+#endif
+  and t0, t0, t1
+  bne t0, t1, fail
+
+pass:
+  li a0, 0
+  mv ra, s1
+  ret
+
+fail:
+  li a0, 1
+  mv ra, s1
+  ret

--- a/test/first_party/src/test_hgatp_vmidlen_partial.S
+++ b/test/first_party/src/test_hgatp_vmidlen_partial.S
@@ -1,0 +1,57 @@
+#include "common/encoding.h"
+
+// A test for the `memory.vmidlen` configuration parameter (VMIDLEN) with a
+// non-zero, non-maximal value (here 5). This exercises the general case:
+// VMID[VMIDLEN-1:0] is writable, and bits above VMIDLEN are read-only zero.
+//
+// See RISC-V Privileged ISA: "The least-significant bits of VMID are
+// implemented first: that is, if VMIDLEN > 0, VMID[VMIDLEN-1:0] is writable."
+
+#define VMIDLEN 5
+
+.global main
+main:
+  # Save the return address.
+  mv s1, ra
+
+write_hgatp:
+#if __riscv_xlen == 32
+  # Sv32x4: set MODE=Sv32x4 and write all ones to the VMID field.
+  li t0, HGATP32_MODE * HGATP_MODE_SV32X4
+  li t1, HGATP32_VMID
+  or t0, t0, t1
+#else
+  # Sv39x4: set MODE=Sv39x4 and write all ones to the VMID field.
+  li t0, (HGATP64_MODE & ~(HGATP64_MODE << 1)) * HGATP_MODE_SV39X4
+  li t1, HGATP64_VMID
+  or t0, t0, t1
+#endif
+  csrw hgatp, t0
+
+read_vmid:
+  csrr t0, hgatp
+  # Extract the VMID field into the low bits of t2.
+#if __riscv_xlen == 32
+  # VMID occupies bits 28:22 (7 bits); shift down and mask to 7 bits.
+  srli t2, t0, 22
+  li t1, 0x7F
+#else
+  # VMID occupies bits 57:44 (14 bits); shift down and mask to 14 bits.
+  srli t2, t0, 44
+  li t1, 0x3FFF
+#endif
+  and t2, t2, t1
+
+  # Only the low VMIDLEN bits may be set; the rest must read as zero.
+  li t1, ((1 << VMIDLEN) - 1)
+  bne t2, t1, fail
+
+pass:
+  li a0, 0
+  mv ra, s1
+  ret
+
+fail:
+  li a0, 1
+  mv ra, s1
+  ret

--- a/test/first_party/src/test_satp_asidlen.S
+++ b/test/first_party/src/test_satp_asidlen.S
@@ -1,0 +1,64 @@
+#include "common/encoding.h"
+
+// A test for the `memory.asidlen` configuration parameter (ASIDLEN).
+//
+// The test is configured with an override of 0 implemented ASID bits,
+// which models implementations such as the StarFive JH7110 / SiFive U74
+// (VisionFive 2) that implement ASIDLEN=0. In that case the entire `Asid`
+// field of `satp` must read as zero, even after writing all ones to it.
+//
+// See RISC-V Privileged ISA: "The number of ASID bits is UNSPECIFIED and
+// may be zero." and "if ASIDLEN > 0, ASID[ASIDLEN-1:0] is writable" — i.e.
+// with ASIDLEN=0 no ASID bits are writable.
+
+.global main
+main:
+  # Save the return address.
+  mv s1, ra
+
+write_satp:
+#if __riscv_xlen == 32
+  # Sv32: set MODE=Sv32 and write all ones to the ASID field.
+  li t0, SATP32_MODE * SATP_MODE_SV32
+  li t1, SATP32_ASID
+  or t0, t0, t1
+#else
+  # Sv39: set MODE=Sv39 and write all ones to the ASID field.
+  li t0, (SATP_MODE & ~(SATP_MODE << 1)) * SATP_MODE_SV39
+  li t1, SATP64_ASID
+  or t0, t0, t1
+#endif
+  csrw satp, t0
+
+read_asid:
+  csrr t0, satp
+#if __riscv_xlen == 32
+  li t1, SATP32_ASID
+#else
+  li t1, SATP64_ASID
+#endif
+  and t0, t0, t1
+  # With asidlen=0, the entire ASID field must read as zero.
+  li t1, 0
+  bne t0, t1, fail
+
+read_mode:
+  # The MODE field must still be preserved.
+  csrr t0, satp
+#if __riscv_xlen == 32
+  li t1, SATP32_MODE * SATP_MODE_SV32
+#else
+  li t1, (SATP_MODE & ~(SATP_MODE << 1)) * SATP_MODE_SV39
+#endif
+  and t0, t0, t1
+  bne t0, t1, fail
+
+pass:
+  li a0, 0
+  mv ra, s1
+  ret
+
+fail:
+  li a0, 1
+  mv ra, s1
+  ret

--- a/test/first_party/src/test_satp_asidlen_partial.S
+++ b/test/first_party/src/test_satp_asidlen_partial.S
@@ -1,0 +1,57 @@
+#include "common/encoding.h"
+
+// A test for the `memory.asidlen` configuration parameter (ASIDLEN) with a
+// non-zero, non-maximal value (here 7). This exercises the general case:
+// ASID[ASIDLEN-1:0] is writable, and bits above ASIDLEN are read-only zero.
+//
+// See RISC-V Privileged ISA: "The least-significant bits of ASID are
+// implemented first: that is, if ASIDLEN > 0, ASID[ASIDLEN-1:0] is writable."
+
+#define ASIDLEN 7
+
+.global main
+main:
+  # Save the return address.
+  mv s1, ra
+
+write_satp:
+#if __riscv_xlen == 32
+  # Sv32: set MODE=Sv32 and write all ones to the ASID field.
+  li t0, SATP32_MODE * SATP_MODE_SV32
+  li t1, SATP32_ASID
+  or t0, t0, t1
+#else
+  # Sv39: set MODE=Sv39 and write all ones to the ASID field.
+  li t0, (SATP_MODE & ~(SATP_MODE << 1)) * SATP_MODE_SV39
+  li t1, SATP64_ASID
+  or t0, t0, t1
+#endif
+  csrw satp, t0
+
+read_asid:
+  csrr t0, satp
+  # Extract the ASID field into the low bits of t2.
+#if __riscv_xlen == 32
+  # ASID occupies bits 30:22 (9 bits); shift down and mask to 9 bits.
+  srli t2, t0, 22
+  li t1, 0x1FF
+#else
+  # ASID occupies bits 59:44 (16 bits); shift down and mask to 16 bits.
+  srli t2, t0, 44
+  li t1, 0xFFFF
+#endif
+  and t2, t2, t1
+
+  # Only the low ASIDLEN bits may be set; the rest must read as zero.
+  li t1, ((1 << ASIDLEN) - 1)
+  bne t2, t1, fail
+
+pass:
+  li a0, 0
+  mv ra, s1
+  ret
+
+fail:
+  li a0, 1
+  mv ra, s1
+  ret


### PR DESCRIPTION
Fixes #1846
Fixes #1859