### PR TITLE
cmake: allow replacing a formal backend's config per arch

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -233,6 +233,17 @@ foreach (xlen IN ITEMS 32 64)
     # for backwards compatibility.
     set(arch "rv${xlen}d")
 
+    # Allow a project that consumes the formal output to generate this architecture from
+    # its own configuration instead of the default one, keeping every target and output
+    # name unchanged. Set to an absolute path.
+    string(TOUPPER ${arch} arch_uc)
+    set(SAIL_FORMAL_CONFIG_${arch_uc} "" CACHE FILEPATH
+        "Configuration JSON the ${arch} formal backends are generated from instead of the default.")
+    if (SAIL_FORMAL_CONFIG_${arch_uc})
+        set(config_file "${SAIL_FORMAL_CONFIG_${arch_uc}}")
+        message(STATUS "Formal backends: ${arch} uses ${config_file}")
+    endif()
+
     ############# SMT #############
 
     # Generate smtlib2 code from the Sail code.


### PR DESCRIPTION
Rewritten (2026-08-19) down to the one thing that was actually missing, after #1879.

A project that consumes the formal output may need a given architecture generated from its own
configuration rather than the generated default, while keeping the target and output names it
already depends on. `SAIL_FORMAL_CONFIG_<ARCH>` replaces `config_file` for that architecture only:

```
cmake -B build -DSAIL_FORMAL_CONFIG_RV64D=/abs/path/to/config.json
cmake --build build --target generated_lean_rv64d
```

The `foreach (xlen …)` loop already funnels every formal backend through a single `config_file`, so
this covers SMT, rmem, Rocq, Lean and Lem uniformly. It adds no targets, renames nothing, and is
inert unless set — configuring without it produces byte-identical build rules.

Verified locally: without the flag the generated rules are unchanged; with it, the `generated_lean_rv64d`
rule becomes `sail … --config /abs/path/to/config.json --lean … -o Lean_RV64D`.

This is orthogonal to #1879's refactor and applies unchanged on top of it — the override sits in the
default loop, not in the custom family. Happy to fold it into #1879 instead if that is preferred.

The `${config_file}` `DEPENDS` additions that used to be in this PR are now #1885.
