### PR TITLE
Use Bare translation when S-mode is unsupported

### DIFF
--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -338,7 +338,8 @@ private function xatp_to_ppn(stage : TranslationStage) -> bits(if xlen == 32 the
 
 // Return the active address translation mode for S-Stage translation.
 private function satp_mode(priv : Privilege) -> SATPMode = {
-  if priv == Machine then Bare
+  // Without S-mode enabled, satp is inactive and translation is Bare at every privilege.
+  if priv == Machine | not(currentlyEnabled(Ext_S)) then Bare
   else {
     let arch = architecture(Supervisor);
     let mbits : satp_mode = match arch {


### PR DESCRIPTION
The model cannot run code below M-mode on a hart without S-mode. For non-M-mode
accesses, `translationMode` uses `mstatus.SXL`, which is zero when S-mode is
unsupported, causing an internal error.

Reproduction on current master:

Save this configuration override as `/tmp/no-s.json`:
```
    {
      "extensions": {
        "S": {"supported": false},
        "Sv39": {"supported": false},
        "Sv48": {"supported": false},
        "Sv57": {"supported": false},
        "Svrsw60t59b": {"supported": false},
        "Ssccptr": {"supported": false},
        "Svade": {"supported": false},
        "Svadu": {"supported": false},
        "Svpbmt": {"supported": false},
        "Svnapot": {"supported": false},
        "Svvptc": {"supported": false},
        "Sstvala": {"supported": false}
      }
    }
```
Then
```
$ sail_riscv_sim --config-override /tmp/no-s.json rv64ui-p-simple  
Internal error: core/types.sail:62: architecture(0b00) is invalid
```
A hart without S-mode has no satp and no page tables, so every implemented
privilege uses Bare translation. The fix adds the S-less case to the existing
M-mode check, after which the command above succeeds.
