### PR TITLE
Add Smcfiss machine mode shadow stack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ An experimental emulator in the Lean language is available, see its
 - Machine, Supervisor, and User modes
 - Smcntrpmf extension for cycle and instret privilege mode filtering, v1.0
 - Smstateen/Ssstateen extensions for fine-grained privileged state access control, v1.0
+- Smepmp extension for pmp enhancements for memory access and execution prevention on Machine mode, v1.0
 - Ssccptr extension for Main memory supports hardware page table reads, v1.0
 - Sscounterenw extension for writable enables for any supported counter, v1.0
 - Sscofpmf extension for Count Overflow and Mode-Based Filtering, v1.0

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -786,6 +786,9 @@
     "Smpmpind": {
       "supported": true
     },
+    "Smcfiss": {
+      "supported": true
+    },
     "Smepmp": {
       "supported": true
     },

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -780,6 +780,12 @@
     "Smepmp": {
       "supported": true
     },
+    "Smcsrind": {
+      "supported": true
+    },
+    "Sscsrind": {
+      "supported": true
+    },
     "Sstc": {
       "supported": true
     },

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -777,6 +777,9 @@
     "Sscounterenw": {
       "supported": true
     },
+    "Smepmp": {
+      "supported": true
+    },
     "Sstc": {
       "supported": true
     },

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -777,13 +777,16 @@
     "Sscounterenw": {
       "supported": true
     },
-    "Smepmp": {
-      "supported": true
-    },
     "Smcsrind": {
       "supported": true
     },
     "Sscsrind": {
+      "supported": true
+    },
+    "Smpmpind": {
+      "supported": true
+    },
+    "Smepmp": {
       "supported": true
     },
     "Sstc": {

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -558,6 +558,14 @@ function clause currentlyEnabled(Ext_Smnpm) = hartSupports(Ext_Smnpm)
 enum clause extension = Ext_Smepmp
 mapping clause extensionName = Ext_Smepmp <-> "smepmp"
 function clause hartSupports(Ext_Smepmp) = config extensions.Smepmp.supported
+// Supervisor-mode view of the Indirect CSR Access
+enum clause extension = Ext_Sscsrind
+mapping clause extensionName = Ext_Sscsrind <-> "sscsrind"
+function clause hartSupports(Ext_Sscsrind) = config extensions.Sscsrind.supported
+// Machine-mode view of the Indirect CSR Access
+enum clause extension = Ext_Smcsrind
+mapping clause extensionName = Ext_Smcsrind <-> "smcsrind"
+function clause hartSupports(Ext_Smcsrind) = config extensions.Smcsrind.supported
 // Machine-mode view of the state-enable extension
 enum clause extension = Ext_Smstateen
 mapping clause extensionName = Ext_Smstateen <-> "smstateen"
@@ -650,6 +658,7 @@ function currentlyEnabled_measure(ext : extension) -> int =
     Ext_Zicfiss => 2, // > Zaamo
 
     Ext_Ssccptr => 3, // > Sv39
+    Ext_Sscsrind => 3, // > Smcsrind
     Ext_Supm => 3, // > U
     Ext_Svnapot => 3, // > Sv39
     Ext_Svpbmt => 3, // > Sv39
@@ -819,6 +828,7 @@ let extensions_ordered_for_isa_string = [
   Ext_Ssccptr,
   Ext_Sscofpmf,
   Ext_Sscounterenw,
+  Ext_Sscsrind,
   Ext_Ssnpm,
   Ext_Sspm,
   Ext_Ssqosid,
@@ -840,6 +850,7 @@ let extensions_ordered_for_isa_string = [
 
   // Machine mode extensions, ordered alphabetically.
   Ext_Smcntrpmf,
+  Ext_Smcsrind,
   Ext_Smepmp,
   Ext_Smmpm,
   Ext_Smnpm,

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -554,6 +554,10 @@ enum clause extension = Ext_Smnpm
 mapping clause extensionName = Ext_Smnpm <-> "smnpm"
 function clause hartSupports(Ext_Smnpm) = config extensions.Smnpm.supported : bool & (xlen == 64)
 function clause currentlyEnabled(Ext_Smnpm) = hartSupports(Ext_Smnpm)
+// Pmp enhancements for memory access and execution prevention on Machine mode
+enum clause extension = Ext_Smepmp
+mapping clause extensionName = Ext_Smepmp <-> "smepmp"
+function clause hartSupports(Ext_Smepmp) = config extensions.Smepmp.supported
 // Machine-mode view of the state-enable extension
 enum clause extension = Ext_Smstateen
 mapping clause extensionName = Ext_Smstateen <-> "smstateen"
@@ -836,6 +840,7 @@ let extensions_ordered_for_isa_string = [
 
   // Machine mode extensions, ordered alphabetically.
   Ext_Smcntrpmf,
+  Ext_Smepmp,
   Ext_Smmpm,
   Ext_Smnpm,
   Ext_Smstateen,

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -566,6 +566,10 @@ function clause hartSupports(Ext_Smcsrind) = config extensions.Smcsrind.supporte
 enum clause extension = Ext_Smpmpind
 mapping clause extensionName = Ext_Smpmpind <-> "smpmpind"
 function clause hartSupports(Ext_Smpmpind) = sys_enable_experimental_extensions() & config extensions.Smpmpind.supported
+// Machine-mode Shadow Stack
+enum clause extension = Ext_Smcfiss
+mapping clause extensionName = Ext_Smcfiss <-> "smcfiss"
+function clause hartSupports(Ext_Smcfiss) = sys_enable_experimental_extensions() & config extensions.Smcfiss.supported
 // Pmp enhancements for memory access and execution prevention on Machine mode
 enum clause extension = Ext_Smepmp
 mapping clause extensionName = Ext_Smepmp <-> "smepmp"
@@ -678,6 +682,7 @@ function currentlyEnabled_measure(ext : extension) -> int =
     Ext_Zvknhb => 3, // > Zve64x
 
     Ext_H => 4, // > virtual_mem_supported
+    Ext_Smcfiss => 4, // > Smpmpind, Zicfiss
     Ext_Zve64d => 4, // > Zve64f
     Ext_Zvfbfwma => 4, // > Zvfbfmin
     Ext_Zvfh => 4, // > Zfhmin
@@ -854,6 +859,7 @@ let extensions_ordered_for_isa_string = [
   // Hypervisor extensions, ordered alphabetically.
 
   // Machine mode extensions, ordered alphabetically.
+  Ext_Smcfiss,
   Ext_Smcntrpmf,
   Ext_Smcsrind,
   Ext_Smepmp,

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -462,6 +462,10 @@ function clause hartSupports(Ext_Ssccptr) = config extensions.Ssccptr.supported
 enum clause extension = Ext_Sscofpmf
 mapping clause extensionName = Ext_Sscofpmf <-> "sscofpmf"
 function clause hartSupports(Ext_Sscofpmf) = config extensions.Sscofpmf.supported
+// Indirect CSR Access (S-mode view)
+enum clause extension = Ext_Sscsrind
+mapping clause extensionName = Ext_Sscsrind <-> "sscsrind"
+function clause hartSupports(Ext_Sscsrind) = config extensions.Sscsrind.supported
 // Support writeable enables for any supported counter
 enum clause extension = Ext_Sscounterenw
 mapping clause extensionName = Ext_Sscounterenw <-> "sscounterenw"
@@ -554,18 +558,18 @@ enum clause extension = Ext_Smnpm
 mapping clause extensionName = Ext_Smnpm <-> "smnpm"
 function clause hartSupports(Ext_Smnpm) = config extensions.Smnpm.supported : bool & (xlen == 64)
 function clause currentlyEnabled(Ext_Smnpm) = hartSupports(Ext_Smnpm)
+// Indirect CSR Access (M-mode view)
+enum clause extension = Ext_Smcsrind
+mapping clause extensionName = Ext_Smcsrind <-> "smcsrind"
+function clause hartSupports(Ext_Smcsrind) = config extensions.Smcsrind.supported
+// Indirect PMP CSR Access
+enum clause extension = Ext_Smpmpind
+mapping clause extensionName = Ext_Smpmpind <-> "smpmpind"
+function clause hartSupports(Ext_Smpmpind) = sys_enable_experimental_extensions() & config extensions.Smpmpind.supported
 // Pmp enhancements for memory access and execution prevention on Machine mode
 enum clause extension = Ext_Smepmp
 mapping clause extensionName = Ext_Smepmp <-> "smepmp"
 function clause hartSupports(Ext_Smepmp) = config extensions.Smepmp.supported
-// Supervisor-mode view of the Indirect CSR Access
-enum clause extension = Ext_Sscsrind
-mapping clause extensionName = Ext_Sscsrind <-> "sscsrind"
-function clause hartSupports(Ext_Sscsrind) = config extensions.Sscsrind.supported
-// Machine-mode view of the Indirect CSR Access
-enum clause extension = Ext_Smcsrind
-mapping clause extensionName = Ext_Smcsrind <-> "smcsrind"
-function clause hartSupports(Ext_Smcsrind) = config extensions.Smcsrind.supported
 // Machine-mode view of the state-enable extension
 enum clause extension = Ext_Smstateen
 mapping clause extensionName = Ext_Smstateen <-> "smstateen"
@@ -657,6 +661,7 @@ function currentlyEnabled_measure(ext : extension) -> int =
     Ext_Zcmop => 2, // > Zca
     Ext_Zicfiss => 2, // > Zaamo
 
+    Ext_Smpmpind => 3, // > Smcsrind
     Ext_Ssccptr => 3, // > Sv39
     Ext_Sscsrind => 3, // > Smcsrind
     Ext_Supm => 3, // > U
@@ -854,5 +859,6 @@ let extensions_ordered_for_isa_string = [
   Ext_Smepmp,
   Ext_Smmpm,
   Ext_Smnpm,
+  Ext_Smpmpind,
   Ext_Smstateen,
 ]

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -330,10 +330,10 @@ private function legalize_mseccfg(o : Seccfg, v : bits(64)) -> Seccfg = {
   let rlb_read_only_zero =
       not(currentlyEnabled(Ext_Smepmp))
     | (o[RLB] == 0b0 & anyPmpLocked());
-  let mml_unable_to_set =
+  let mml_read_only =
       not(currentlyEnabled(Ext_Smepmp))
     | (o[MML] == 0b1);
-  let mmwp_unable_to_set =
+  let mmwp_read_only =
       not(currentlyEnabled(Ext_Smepmp))
     | (o[MMWP] == 0b1);
 
@@ -344,8 +344,8 @@ private function legalize_mseccfg(o : Seccfg, v : bits(64)) -> Seccfg = {
     SSEED = if sseed_read_only_zero then 0b0 else v[SSEED],
     USEED = if useed_read_only_zero then 0b0 else v[USEED],
     RLB   = if rlb_read_only_zero then 0b0 else v[RLB],
-    MMWP  = if mmwp_unable_to_set then o[MMWP] else v[MMWP],
-    MML   = if mml_unable_to_set then o[MML] else v[MML],
+    MMWP  = if mmwp_read_only then o[MMWP] else v[MMWP],
+    MML   = if mml_read_only then o[MML] else v[MML],
   ]
 }
 

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -316,7 +316,7 @@ bitfield Seccfg : bits(64) = {
   MML    : 0,
 }
 
-val checkPmpNcfgL : range(0, 63) -> bits(1)
+val anyPmpLocked : unit -> bool
 
 private function legalize_mseccfg(o : Seccfg, v : bits(64)) -> Seccfg = {
   let sseed_read_only_zero =
@@ -327,15 +327,10 @@ private function legalize_mseccfg(o : Seccfg, v : bits(64)) -> Seccfg = {
       (config extensions.Zkr.useed_read_only_zero : bool)
     | not(currentlyEnabled(Ext_U))
     | not(currentlyEnabled(Ext_Zkr));
-  let rlb_read_only_zero =
-      not(currentlyEnabled(Ext_Smepmp))
-    | (o[RLB] == 0b0 & anyPmpLocked());
-  let mml_read_only =
-      not(currentlyEnabled(Ext_Smepmp))
-    | (o[MML] == 0b1);
-  let mmwp_read_only =
-      not(currentlyEnabled(Ext_Smepmp))
-    | (o[MMWP] == 0b1);
+
+  let rlb_read_only = o[RLB] == 0b0 & anyPmpLocked();
+  let mml_read_only = o[MML] == 0b1;
+  let mmwp_read_only = o[MMWP] == 0b1;
 
   let v = Mk_Seccfg(v);
   [o with
@@ -343,9 +338,9 @@ private function legalize_mseccfg(o : Seccfg, v : bits(64)) -> Seccfg = {
     MLPE  = if hartSupports(Ext_Zicfilp) then v[MLPE] else 0b0,
     SSEED = if sseed_read_only_zero then 0b0 else v[SSEED],
     USEED = if useed_read_only_zero then 0b0 else v[USEED],
-    RLB   = if rlb_read_only_zero then 0b0 else v[RLB],
-    MMWP  = if mmwp_read_only then o[MMWP] else v[MMWP],
-    MML   = if mml_read_only then o[MML] else v[MML],
+    RLB   = if not(currentlyEnabled(Ext_Smepmp)) then 0b0 else if rlb_read_only  then o[RLB]  else v[RLB],
+    MMWP  = if not(currentlyEnabled(Ext_Smepmp)) then 0b0 else if mmwp_read_only then o[MMWP] else v[MMWP],
+    MML   = if not(currentlyEnabled(Ext_Smepmp)) then 0b0 else if mml_read_only  then o[MML]  else v[MML],
   ]
 }
 

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -344,7 +344,11 @@ private function legalize_mseccfg(o : Seccfg, v : bits(64)) -> Seccfg = {
   ]
 }
 
-register mseccfg : Seccfg = legalize_mseccfg(Mk_Seccfg(zeros()), zeros())
+// TODO: Ideally this would use legalize_mseccfg however it can't due to a Sail
+// compiler bug. In this case that's fine since the result is actually all zeros anyway.
+// See https://github.com/rems-project/sail/issues/1653
+register mseccfg : Seccfg = Mk_Seccfg(zeros())
+// register mseccfg : Seccfg = legalize_mseccfg(Mk_Seccfg(zeros()), zeros())
 
 mapping clause csr_name_map = 0x747  <-> "mseccfg"
 mapping clause csr_name_map = 0x757  <-> "mseccfgh"

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -313,7 +313,7 @@ bitfield Seccfg : bits(64) = {
   // Machine Mode Whitelist Policy
   MMWP   : 1,
   // Machine Mode Lockdown
-  MML    : 0
+  MML    : 0,
 }
 
 val checkPmpNcfgL : range(0, 63) -> bits(1)
@@ -329,7 +329,7 @@ private function legalize_mseccfg(o : Seccfg, v : bits(64)) -> Seccfg = {
     | not(currentlyEnabled(Ext_Zkr));
   let rlb_read_only_zero =
       not(currentlyEnabled(Ext_Smepmp))
-    | (o[RLB] == 0b0 & checkPmpNcfgL(63) == 0b1);
+    | (o[RLB] == 0b0 & anyPmpLocked());
   let mml_unable_to_set =
       not(currentlyEnabled(Ext_Smepmp))
     | (o[MML] == 0b1);

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -302,6 +302,8 @@ function in32BitMode() -> bool = {
 bitfield Seccfg : bits(64) = {
   // Pointer Masking Extension
   PMM    : 33 .. 32,
+  // Machine Shadow Stack Enable (Smcfiss)
+  MSSE   : 11,
   // Enable Zicfilp in M-mode
   MLPE   : 10,
   // Enable access to SEED in S-mode
@@ -332,9 +334,15 @@ private function legalize_mseccfg(o : Seccfg, v : bits(64)) -> Seccfg = {
   let mml_read_only = o[MML] == 0b1;
   let mmwp_read_only = o[MMWP] == 0b1;
 
+  // With Smepmp, locked PMP entries make MSSE read-only while RLB is clear.
+  let msse_read_only =
+      not(hartSupports(Ext_Smcfiss))
+    | (currentlyEnabled(Ext_Smepmp) & o[RLB] == 0b0 & anyPmpLocked());
+
   let v = Mk_Seccfg(v);
   [o with
     PMM   = if currentlyEnabled(Ext_Smmpm) & is_supported_pmm(PM_SMMPM, pmm_mode(v[PMM])) then v[PMM] else o[PMM],
+    MSSE  = if msse_read_only then o[MSSE] else v[MSSE],
     MLPE  = if hartSupports(Ext_Zicfilp) then v[MLPE] else 0b0,
     SSEED = if sseed_read_only_zero then 0b0 else v[SSEED],
     USEED = if useed_read_only_zero then 0b0 else v[USEED],
@@ -354,8 +362,8 @@ mapping clause csr_name_map = 0x747  <-> "mseccfg"
 mapping clause csr_name_map = 0x757  <-> "mseccfgh"
 
 // For Sm1p12 and later, "mseccfg exists if Zkr is implemented, or if it is required by other processor features."
-function clause is_CSR_accessible(0x747, _, _) = mseccfg_csrs_are_defined & (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp) | currentlyEnabled(Ext_Smmpm) | currentlyEnabled(Ext_Smepmp)) // mseccfg
-function clause is_CSR_accessible(0x757, _, _) = mseccfg_csrs_are_defined & (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp) | currentlyEnabled(Ext_Smepmp)) & xlen == 32 // mseccfgh
+function clause is_CSR_accessible(0x747, _, _) = mseccfg_csrs_are_defined & (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp) | currentlyEnabled(Ext_Smmpm) | currentlyEnabled(Ext_Smepmp) | hartSupports(Ext_Smcfiss)) // mseccfg
+function clause is_CSR_accessible(0x757, _, _) = mseccfg_csrs_are_defined & (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp) | currentlyEnabled(Ext_Smepmp) | hartSupports(Ext_Smcfiss)) & xlen == 32 // mseccfgh
 
 function clause read_CSR(0x747) = mseccfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x757 if xlen == 32) = mseccfg.bits[63 .. 32]

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -308,7 +308,15 @@ bitfield Seccfg : bits(64) = {
   SSEED  : 9,
   // Enable access to SEED in U-mode
   USEED  : 8,
+  // Rule Locking Bypass
+  RLB    : 2,
+  // Machine Mode Whitelist Policy
+  MMWP   : 1,
+  // Machine Mode Lockdown
+  MML    : 0
 }
+
+val checkPmpNcfgL : range(0, 63) -> bits(1)
 
 private function legalize_mseccfg(o : Seccfg, v : bits(64)) -> Seccfg = {
   let sseed_read_only_zero =
@@ -319,6 +327,15 @@ private function legalize_mseccfg(o : Seccfg, v : bits(64)) -> Seccfg = {
       (config extensions.Zkr.useed_read_only_zero : bool)
     | not(currentlyEnabled(Ext_U))
     | not(currentlyEnabled(Ext_Zkr));
+  let rlb_read_only_zero =
+      not(currentlyEnabled(Ext_Smepmp))
+    | (o[RLB] == 0b0 & checkPmpNcfgL(63) == 0b1);
+  let mml_unable_to_set =
+      not(currentlyEnabled(Ext_Smepmp))
+    | (o[MML] == 0b1);
+  let mmwp_unable_to_set =
+      not(currentlyEnabled(Ext_Smepmp))
+    | (o[MMWP] == 0b1);
 
   let v = Mk_Seccfg(v);
   [o with
@@ -326,6 +343,9 @@ private function legalize_mseccfg(o : Seccfg, v : bits(64)) -> Seccfg = {
     MLPE  = if hartSupports(Ext_Zicfilp) then v[MLPE] else 0b0,
     SSEED = if sseed_read_only_zero then 0b0 else v[SSEED],
     USEED = if useed_read_only_zero then 0b0 else v[USEED],
+    RLB   = if rlb_read_only_zero then 0b0 else v[RLB],
+    MMWP  = if mmwp_unable_to_set then o[MMWP] else v[MMWP],
+    MML   = if mml_unable_to_set then o[MML] else v[MML],
   ]
 }
 
@@ -335,8 +355,8 @@ mapping clause csr_name_map = 0x747  <-> "mseccfg"
 mapping clause csr_name_map = 0x757  <-> "mseccfgh"
 
 // For Sm1p12 and later, "mseccfg exists if Zkr is implemented, or if it is required by other processor features."
-function clause is_CSR_accessible(0x747, _, _) = mseccfg_csrs_are_defined & (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp) | currentlyEnabled(Ext_Smmpm)) // mseccfg
-function clause is_CSR_accessible(0x757, _, _) = mseccfg_csrs_are_defined & (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp)) & xlen == 32 // mseccfgh
+function clause is_CSR_accessible(0x747, _, _) = mseccfg_csrs_are_defined & (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp) | currentlyEnabled(Ext_Smmpm) | currentlyEnabled(Ext_Smepmp)) // mseccfg
+function clause is_CSR_accessible(0x757, _, _) = mseccfg_csrs_are_defined & (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp) | currentlyEnabled(Ext_Smepmp)) & xlen == 32 // mseccfgh
 
 function clause read_CSR(0x747) = mseccfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x757 if xlen == 32) = mseccfg.bits[63 .. 32]

--- a/model/extensions/Smcfiss/smcfiss.sail
+++ b/model/extensions/Smcfiss/smcfiss.sail
@@ -1,0 +1,33 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// Smcfiss: Machine-mode shadow stack.
+
+function clause currentlyEnabled(Ext_Smcfiss) =
+  hartSupports(Ext_Smcfiss)
+  & currentlyEnabled(Ext_Zicfiss)
+  & currentlyEnabled(Ext_Smpmpind)
+
+// M-mode SS region: E=1, XWR=010, mseccfg.MSSE=1.
+function pmp_is_m_ss_region(cfg : Pmpcfg_ent, e_bit : bits(1)) -> bool =
+  currentlyEnabled(Ext_Smcfiss)
+  & e_bit == 0b1
+  & mseccfg[MSSE] == 0b1
+  & cfg[X] == 0b0 & cfg[W] == 0b1 & cfg[R] == 0b0
+
+// M-mode shadow-stack accesses and explicit loads are allowed. All others fault.
+function pmp_check_m_ss_access(access : MemoryAccessType(mem_payload), priv : Privilege) -> bool =
+  match (priv, access) {
+    (Machine, Load(ShadowStack))        => true,
+    (Machine, Store(ShadowStack))       => true,
+    (Machine, Atomic(_, _, _, ShadowStack, ShadowStack)) => true,
+    (Machine, Load(Data))               => true,
+    (Machine, Load(Vector))             => true,
+    (Machine, LoadReserved(_, _, Data)) => true,
+    _                                   => false,
+  }

--- a/model/extensions/Smcsrind/csrind_regs.sail
+++ b/model/extensions/Smcsrind/csrind_regs.sail
@@ -1,0 +1,100 @@
+/*=======================================================================================*/
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except where otherwise noted is subject the BSD                          */
+/*  two-clause license in the LICENSE file.                                              */
+/*                                                                                       */
+/*  SPDX-License-Identifier: BSD-2-Clause                                                */
+/*=======================================================================================*/
+
+function clause currentlyEnabled(Ext_Smcsrind) = hartSupports(Ext_Smcsrind) & currentlyEnabled(Ext_Zicsr)
+function clause currentlyEnabled(Ext_Sscsrind) = (hartSupports(Ext_Sscsrind) | currentlyEnabled(Ext_Smcsrind)) & currentlyEnabled(Ext_Zicsr) & currentlyEnabled(Ext_S)
+
+bitfield Iselect : xlenbits = {
+    csr : 11 .. 0
+}
+
+register miselect : Iselect
+register siselect : Iselect
+
+enum IregType = { Mireg, Sireg }
+
+function legalize_iselect(v : xlenbits) -> Iselect = Mk_Iselect(zero_extend(v[11 .. 0]))
+
+function is_ireg_accessible(i: Iselect, ireg : IregType) -> bool =
+    match ireg {
+        Mireg => match i[csr] {
+            _ => false
+        },
+        Sireg => match i[csr] {
+            _ => false
+        },
+    }
+
+function get_ireg(ireg : IregType, i : range(0, 6)) -> xlenbits = zeros()
+function set_ireg(ireg : IregType, i : range(0, 6), value : xlenbits) -> xlenbits = zeros()
+
+/* Machine indirect register select and alias CSRs */
+mapping clause csr_name_map = 0x350  <-> "miselect"
+mapping clause csr_name_map = 0x351  <-> "mireg"
+mapping clause csr_name_map = 0x352  <-> "mireg2"
+mapping clause csr_name_map = 0x353  <-> "mireg3"
+mapping clause csr_name_map = 0x355  <-> "mireg4"
+mapping clause csr_name_map = 0x356  <-> "mireg5"
+mapping clause csr_name_map = 0x357  <-> "mireg6"
+
+/* supervisor indirect register select and alias CSRs */
+mapping clause csr_name_map = 0x150  <-> "siselect"
+mapping clause csr_name_map = 0x151  <-> "sireg"
+mapping clause csr_name_map = 0x152  <-> "sireg2"
+mapping clause csr_name_map = 0x153  <-> "sireg3"
+mapping clause csr_name_map = 0x155  <-> "sireg4"
+mapping clause csr_name_map = 0x156  <-> "sireg5"
+mapping clause csr_name_map = 0x157  <-> "sireg6"
+
+function clause is_CSR_accessible(0x350, _, _) = currentlyEnabled(Ext_Smcsrind)
+function clause is_CSR_accessible(0x351, _, _) = currentlyEnabled(Ext_Smcsrind) & is_ireg_accessible(miselect, Mireg)
+function clause is_CSR_accessible(0x352, _, _) = currentlyEnabled(Ext_Smcsrind) & is_ireg_accessible(miselect, Mireg)
+function clause is_CSR_accessible(0x353, _, _) = currentlyEnabled(Ext_Smcsrind) & is_ireg_accessible(miselect, Mireg)
+function clause is_CSR_accessible(0x355, _, _) = currentlyEnabled(Ext_Smcsrind) & is_ireg_accessible(miselect, Mireg)
+function clause is_CSR_accessible(0x356, _, _) = currentlyEnabled(Ext_Smcsrind) & is_ireg_accessible(miselect, Mireg)
+function clause is_CSR_accessible(0x357, _, _) = currentlyEnabled(Ext_Smcsrind) & is_ireg_accessible(miselect, Mireg)
+
+function clause is_CSR_accessible(0x150, _, _) = currentlyEnabled(Ext_Sscsrind)
+function clause is_CSR_accessible(0x151, _, _) = currentlyEnabled(Ext_Sscsrind) & is_ireg_accessible(siselect, Sireg)
+function clause is_CSR_accessible(0x152, _, _) = currentlyEnabled(Ext_Sscsrind) & is_ireg_accessible(siselect, Sireg)
+function clause is_CSR_accessible(0x153, _, _) = currentlyEnabled(Ext_Sscsrind) & is_ireg_accessible(siselect, Sireg)
+function clause is_CSR_accessible(0x155, _, _) = currentlyEnabled(Ext_Sscsrind) & is_ireg_accessible(siselect, Sireg)
+function clause is_CSR_accessible(0x156, _, _) = currentlyEnabled(Ext_Sscsrind) & is_ireg_accessible(siselect, Sireg)
+function clause is_CSR_accessible(0x157, _, _) = currentlyEnabled(Ext_Sscsrind) & is_ireg_accessible(siselect, Sireg)
+
+function clause read_CSR(0x350) = miselect.bits
+function clause read_CSR(0x351) = get_ireg(Mireg, 1)
+function clause read_CSR(0x352) = get_ireg(Mireg, 2)
+function clause read_CSR(0x353) = get_ireg(Mireg, 3)
+function clause read_CSR(0x355) = get_ireg(Mireg, 4)
+function clause read_CSR(0x356) = get_ireg(Mireg, 5)
+function clause read_CSR(0x357) = get_ireg(Mireg, 6)
+
+function clause read_CSR(0x150) = siselect.bits
+function clause read_CSR(0x151) = get_ireg(Sireg, 1)
+function clause read_CSR(0x152) = get_ireg(Sireg, 2)
+function clause read_CSR(0x153) = get_ireg(Sireg, 3)
+function clause read_CSR(0x155) = get_ireg(Sireg, 4)
+function clause read_CSR(0x156) = get_ireg(Sireg, 5)
+function clause read_CSR(0x157) = get_ireg(Sireg, 6)
+
+function clause write_CSR(0x350, value) = { miselect = legalize_iselect(value); Ok(miselect.bits) }
+function clause write_CSR(0x351, value) = Ok(set_ireg(Mireg, 1, value))
+function clause write_CSR(0x352, value) = Ok(set_ireg(Mireg, 2, value))
+function clause write_CSR(0x353, value) = Ok(set_ireg(Mireg, 3, value))
+function clause write_CSR(0x355, value) = Ok(set_ireg(Mireg, 4, value))
+function clause write_CSR(0x356, value) = Ok(set_ireg(Mireg, 5, value))
+function clause write_CSR(0x357, value) = Ok(set_ireg(Mireg, 6, value))
+
+function clause write_CSR(0x150, value) = { siselect = legalize_iselect(value); Ok(siselect.bits) }
+function clause write_CSR(0x151, value) = Ok(set_ireg(Sireg, 1, value))
+function clause write_CSR(0x152, value) = Ok(set_ireg(Sireg, 2, value))
+function clause write_CSR(0x153, value) = Ok(set_ireg(Sireg, 3, value))
+function clause write_CSR(0x155, value) = Ok(set_ireg(Sireg, 4, value))
+function clause write_CSR(0x156, value) = Ok(set_ireg(Sireg, 5, value))
+function clause write_CSR(0x157, value) = Ok(set_ireg(Sireg, 6, value))

--- a/model/extensions/Smcsrind/csrind_regs.sail
+++ b/model/extensions/Smcsrind/csrind_regs.sail
@@ -20,18 +20,23 @@ enum IregType = { Mireg, Sireg }
 
 function legalize_iselect(v : xlenbits) -> Iselect = Mk_Iselect(zero_extend(v[11 .. 0]))
 
+/* Hooks implemented by the consumer extensions (Smpmpind). */
+val smpmpind_ireg_accessible : (Iselect, IregType) -> bool
+val smpmpind_ireg_read       : (IregType, range(0, 6)) -> xlenbits
+val smpmpind_ireg_write      : (IregType, range(0, 6), xlenbits) -> xlenbits
 function is_ireg_accessible(i: Iselect, ireg : IregType) -> bool =
     match ireg {
-        Mireg => match i[csr] {
-            _ => false
-        },
+        Mireg => if currentlyEnabled(Ext_Smpmpind) then smpmpind_ireg_accessible(i, Mireg)
+                 else match i[csr] {
+                     _ => false
+                 },
         Sireg => match i[csr] {
             _ => false
         },
     }
 
-function get_ireg(ireg : IregType, i : range(0, 6)) -> xlenbits = zeros()
-function set_ireg(ireg : IregType, i : range(0, 6), value : xlenbits) -> xlenbits = zeros()
+function get_ireg(ireg : IregType, i : range(0, 6)) -> xlenbits = if currentlyEnabled(Ext_Smpmpind) then smpmpind_ireg_read(ireg, i) else zeros()
+function set_ireg(ireg : IregType, i : range(0, 6), value : xlenbits) -> xlenbits = if currentlyEnabled(Ext_Smpmpind) then smpmpind_ireg_write(ireg, i, value) else zeros()
 
 /* Machine indirect register select and alias CSRs */
 mapping clause csr_name_map = 0x350  <-> "miselect"

--- a/model/extensions/Smpmpind/smpmpind.sail
+++ b/model/extensions/Smpmpind/smpmpind.sail
@@ -1,0 +1,83 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// Smpmpind: indirect PMP CSR access.
+//
+// miselect 0x300..0x33F selects PMP entries 0..63. mireg accesses pmpaddr,
+// while mireg2 accesses pmpcfg and the E bit.
+
+function clause currentlyEnabled(Ext_Smpmpind) =
+  hartSupports(Ext_Smpmpind) & currentlyEnabled(Ext_Smcsrind)
+
+let SMPMPIND_SEL_BASE : nat = 768   // 0x300
+let SMPMPIND_SEL_LAST : nat = 831   // 0x33F
+
+private function smpmpind_sel_in_range(sel : Iselect) -> bool = {
+  let v = unsigned(sel[csr]);
+  (v >= SMPMPIND_SEL_BASE) & (v <= SMPMPIND_SEL_LAST)
+}
+
+private function smpmpind_read_entry(idx : range(0, 63), ireg_index : range(0, 6)) -> xlenbits =
+  match ireg_index {
+    1 => pmpReadAddrReg(idx),
+    2 => {
+      // pmpcfg byte in the low bits, E bit at MXLEN-1.
+      let cfg_low : xlenbits = zero_extend(pmpcfg_n[idx].bits);
+      [cfg_low with (xlen - 1) .. (xlen - 1) = pmp_E[idx]]
+    },
+    // mireg3..6 reserved WPRI: read zero, writes ignored.
+    _ => zeros(),
+  }
+
+private function smpmpind_write_entry(idx : range(0, 63), ireg_index : range(0, 6), value : xlenbits) -> xlenbits =
+  if idx >= sys_pmp_usable_count then zeros()
+  else match ireg_index {
+    1 => { pmpWriteAddrReg(idx, value); pmpReadAddrReg(idx) },
+    2 => {
+      let new_byte : bits(8) = value[7 .. 0];
+      let new_E    : bits(1) = value[(xlen - 1) .. (xlen - 1)];
+
+      let old_cfg = pmpcfg_n[idx];
+      let was_locked = pmpLocked(old_cfg);
+
+      if not(was_locked) then {
+        pmpcfg_n[idx] = pmpWriteCfg(old_cfg, new_byte, new_E);
+        pmp_E[idx] = new_E;
+      };
+
+      let cfg_low : xlenbits = zero_extend(pmpcfg_n[idx].bits);
+      [cfg_low with (xlen - 1) .. (xlen - 1) = pmp_E[idx]]
+    },
+    _ => zeros(),
+  }
+
+function smpmpind_ireg_accessible(sel : Iselect, ireg : IregType) -> bool =
+  ireg == Mireg & smpmpind_sel_in_range(sel)
+  & (unsigned(sel[csr]) - SMPMPIND_SEL_BASE) < sys_pmp_count
+
+function smpmpind_ireg_read(ireg : IregType, i : range(0, 6)) -> xlenbits = {
+  if ireg == Mireg & smpmpind_sel_in_range(miselect) then {
+    let raw_idx = unsigned(miselect[csr]) - SMPMPIND_SEL_BASE;
+    if (raw_idx >= 0) & (raw_idx <= 63) & (raw_idx < sys_pmp_count)
+    then {
+      let idx : range(0, 63) = raw_idx;
+      smpmpind_read_entry(idx, i)
+    } else zeros()
+  } else zeros()
+}
+
+function smpmpind_ireg_write(ireg : IregType, i : range(0, 6), value : xlenbits) -> xlenbits = {
+  if ireg == Mireg & smpmpind_sel_in_range(miselect) then {
+    let raw_idx = unsigned(miselect[csr]) - SMPMPIND_SEL_BASE;
+    if (raw_idx >= 0) & (raw_idx <= 63) & (raw_idx < sys_pmp_count)
+    then {
+      let idx : range(0, 63) = raw_idx;
+      smpmpind_write_entry(idx, i, value)
+    } else zeros()
+  } else zeros()
+}

--- a/model/extensions/cfi/zicfiss_insts.sail
+++ b/model/extensions/cfi/zicfiss_insts.sail
@@ -152,7 +152,7 @@ mapping clause encdec = SSAMOSWAP(aq, rl, rs2, rs1, width, rd)
 // This instruction is not predicated by `xSSE`.
 function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
   match cur_privilege {
-    Machine           => if not(currentlyEnabled(Ext_S))
+    Machine           => if not(currentlyEnabled(Ext_S) | currentlyEnabled(Ext_Smcfiss))
                          then return Illegal_Instruction(),
     Supervisor        => if menvcfg[SSE] == 0b0
                          then return Illegal_Instruction(),

--- a/model/extensions/cfi/zicfiss_regs.sail
+++ b/model/extensions/cfi/zicfiss_regs.sail
@@ -19,15 +19,14 @@ function clause currentlyEnabled(Ext_Zicfiss) =
 // `xSSE` in the specification.
 
 function zicfiss_xSSE(priv : Privilege) -> bool =
-  currentlyEnabled(Ext_S) & (match priv {
-    Machine           => // "Use of Zicfiss in M-mode is not supported."
-                         false,
-    Supervisor        => bool_bit(menvcfg[SSE]),
+  match priv {
+    Machine           => currentlyEnabled(Ext_Smcfiss) & bool_bit(mseccfg[MSSE]),
     // TODO: needs currentlyEnabled(Ext_H) & read_henvcfg()[SSE]
     VirtualSupervisor => internal_error(__FILE__, __LINE__, "Hypervisor extension not supported"),
-    User              => bool_bit(read_senvcfg()[SSE]),
-    VirtualUser       => bool_bit(read_senvcfg()[SSE]),
-  })
+    Supervisor        => currentlyEnabled(Ext_S) & bool_bit(menvcfg[SSE]),
+    User              => currentlyEnabled(Ext_S) & bool_bit(read_senvcfg()[SSE]),
+    VirtualUser       => currentlyEnabled(Ext_S) & bool_bit(read_senvcfg()[SSE]),
+  }
 
 // See "Shadow Stack Pointer (ssp) CSR access control".
 private function is_ssp_accessible(priv : Privilege) -> bool =

--- a/model/pmp/pmp_control.sail
+++ b/model/pmp/pmp_control.sail
@@ -203,8 +203,9 @@ function reset_pmp() -> unit = {
   };
 }
 
-function checkPmpNcfgL(n : range(0, 63)) -> bits(1) = {
-  if n == 0
-  then pmpcfg_n[0][L]
-  else checkPmpNcfgL(n - 1) | (pmpcfg_n[n][L])
+function anyPmpLocked() -> bool = {
+  foreach (i from 0 to sys_pmp_count - 1) {
+    if pmpcfg_n[i][L] == 0b1 then return true;
+  };
+  false
 }

--- a/model/pmp/pmp_control.sail
+++ b/model/pmp/pmp_control.sail
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // =======================================================================================
 
+function clause currentlyEnabled(Ext_Smepmp) = hartSupports(Ext_Smepmp)
 
 // permission checks
 
@@ -48,6 +49,34 @@ private function pmpCheckRWX(ent : Pmpcfg_ent, access : MemoryAccessType(mem_pay
     },
   }
 
+// This needs to be called with the effective current privilege.
+val pmpCheckPerms: (Pmpcfg_ent, AccessType(ext_access_type), Privilege) -> bool
+function pmpCheckPerms(ent, acc, priv) = {
+  if mseccfg[MML] == 0b1
+  then {
+    match (ent[L], ent[R], ent[W], ent[X]) {
+      (0b1, 0b0, 0b1, _) =>
+        match acc {
+          InstructionFetch(_) => true,
+          Read(_)    => priv == Machine & ent[X] == 0b1,
+          _          => false
+        },
+      (0b0, 0b0, 0b1, _) =>
+        match acc {
+          Read(_)  => true,
+          Write(_) => priv == Machine | ent[X] == 0b1,
+          _        => false
+        },
+      (0b1, 0b1, 0b1, 0b1) =>
+        match acc {
+          Read(_) => true,
+          _       => false
+        },
+      (L, _, _, _) => ((priv == Machine) == (L == 0b1)) & pmpCheckRWX(ent, acc)
+    }
+  }
+  else (priv == Machine & not(pmpLocked(ent))) | pmpCheckRWX(ent, acc)
+}
 
 // matching logic
 
@@ -142,7 +171,9 @@ function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
         return Some(accessFaultFromAccessType(access))
       },
       PMP_Match        =>
-        if pmpCheckRWX(cfg, access) | (priv == Machine & not(pmpLocked(cfg)))
+        if (currentlyEnabled(Ext_Smepmp) & pmpCheckPerms(cfg, acc, priv)) |
+            pmpCheckRWX(cfg, acc) |
+           (priv == Machine & not(pmpLocked(cfg)))
         then return None()
         else {
           if get_config_print_pmp()
@@ -151,18 +182,29 @@ function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
         },
     };
   };
-  if priv == Machine then None()
+  // Make Read, Write and execute denied by default, if mseccfg[MMWP] == 0b1 for M mode.
+  // Make execute denied, if mseccfg[MML] == 0b1 for M mode.
+  if priv == Machine & mseccfg[MMWP] == 0b0 & (mseccfg[MML] == 0b0 | acc != InstructionFetch())
+  then None()
   else {
     if get_config_print_pmp()
     then print_log("PMP check failed with no matching entry.");
-    Some(accessFaultFromAccessType(access))
+    Some(accessToFault(acc))
   }
 }
 
 function reset_pmp() -> unit = {
+  mseccfg = [mseccfg with MML = 0b0, MMWP = 0b0, RLB = 0b0];
+
   foreach (i from 0 to 63) {
     // On reset the PMP register's A and L bits are set to 0 unless the platform
     // mandates a different value.
     pmpcfg_n[i] = [pmpcfg_n[i] with A = pmpAddrMatchType_encdec(OFF), L = 0b0];
   };
+}
+
+function checkPmpNcfgL(n : range(0, 63)) -> bits(1) = {
+  if n == 0
+  then pmpcfg_n[0][L]
+  else checkPmpNcfgL(n - 1) | (pmpcfg_n[n][L])
 }

--- a/model/pmp/pmp_control.sail
+++ b/model/pmp/pmp_control.sail
@@ -50,32 +50,35 @@ private function pmpCheckRWX(ent : Pmpcfg_ent, access : MemoryAccessType(mem_pay
   }
 
 // This needs to be called with the effective current privilege.
-val pmpCheckPerms: (Pmpcfg_ent, AccessType(ext_access_type), Privilege) -> bool
-function pmpCheckPerms(ent, acc, priv) = {
+function pmpCheckPerms(
+  ent : Pmpcfg_ent,
+  access : MemoryAccessType(mem_payload),
+  priv : Privilege,
+) -> bool = {
   if mseccfg[MML] == 0b1
   then {
     match (ent[L], ent[R], ent[W], ent[X]) {
       (0b1, 0b0, 0b1, _) =>
-        match acc {
+        match access {
           InstructionFetch(_) => true,
-          Read(_)    => priv == Machine & ent[X] == 0b1,
-          _          => false
+          Load(_)    => priv == Machine & ent[X] == 0b1,
+          _          => false,
         },
       (0b0, 0b0, 0b1, _) =>
-        match acc {
-          Read(_)  => true,
-          Write(_) => priv == Machine | ent[X] == 0b1,
-          _        => false
+        match access {
+          Load(_)  => true,
+          Store(_) => priv == Machine | ent[X] == 0b1,
+          _        => false,
         },
       (0b1, 0b1, 0b1, 0b1) =>
-        match acc {
-          Read(_) => true,
-          _       => false
+        match access {
+          Load(_) => true,
+          _       => false,
         },
-      (L, _, _, _) => ((priv == Machine) == (L == 0b1)) & pmpCheckRWX(ent, acc)
+      (L, _, _, _) => ((priv == Machine) == (L == 0b1)) & pmpCheckRWX(ent, access),
     }
   }
-  else (priv == Machine & not(pmpLocked(ent))) | pmpCheckRWX(ent, acc)
+  else (priv == Machine & not(pmpLocked(ent))) | pmpCheckRWX(ent, access)
 }
 
 // matching logic
@@ -171,8 +174,8 @@ function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
         return Some(accessFaultFromAccessType(access))
       },
       PMP_Match        =>
-        if (currentlyEnabled(Ext_Smepmp) & pmpCheckPerms(cfg, acc, priv)) |
-            pmpCheckRWX(cfg, acc) |
+        if (currentlyEnabled(Ext_Smepmp) & pmpCheckPerms(cfg, access, priv)) |
+            pmpCheckRWX(cfg, access) |
            (priv == Machine & not(pmpLocked(cfg)))
         then return None()
         else {
@@ -184,12 +187,12 @@ function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
   };
   // Make Read, Write and execute denied by default, if mseccfg[MMWP] == 0b1 for M mode.
   // Make execute denied, if mseccfg[MML] == 0b1 for M mode.
-  if priv == Machine & mseccfg[MMWP] == 0b0 & (mseccfg[MML] == 0b0 | acc != InstructionFetch())
+  if priv == Machine & mseccfg[MMWP] == 0b0 & (mseccfg[MML] == 0b0 | access != InstructionFetch())
   then None()
   else {
     if get_config_print_pmp()
     then print_log("PMP check failed with no matching entry.");
-    Some(accessToFault(acc))
+    Some(accessFaultFromAccessType(access))
   }
 }
 

--- a/model/pmp/pmp_control.sail
+++ b/model/pmp/pmp_control.sail
@@ -174,7 +174,9 @@ function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
         return Some(accessFaultFromAccessType(access))
       },
       PMP_Match        =>
-        if (currentlyEnabled(Ext_Smepmp) & pmpCheckPerms(cfg, access, priv)) |
+        if currentlyEnabled(Ext_Smpmpind) & pmp_E[i] == 0b1
+        then return Some(accessFaultFromAccessType(access))
+        else if (currentlyEnabled(Ext_Smepmp) & pmpCheckPerms(cfg, access, priv)) |
             pmpCheckRWX(cfg, access) |
            (priv == Machine & not(pmpLocked(cfg)))
         then return None()
@@ -203,6 +205,7 @@ function reset_pmp() -> unit = {
     // On reset the PMP register's A and L bits are set to 0 unless the platform
     // mandates a different value.
     pmpcfg_n[i] = [pmpcfg_n[i] with A = pmpAddrMatchType_encdec(OFF), L = 0b0];
+    pmp_E[i] = 0b0;
   };
 }
 

--- a/model/pmp/pmp_control.sail
+++ b/model/pmp/pmp_control.sail
@@ -8,6 +8,9 @@
 
 function clause currentlyEnabled(Ext_Smepmp) = hartSupports(Ext_Smepmp)
 
+val pmp_is_m_ss_region    : (Pmpcfg_ent, bits(1)) -> bool
+val pmp_check_m_ss_access : (MemoryAccessType(mem_payload), Privilege) -> bool
+
 // permission checks
 
 private function pmpCheckRWX(ent : Pmpcfg_ent, access : MemoryAccessType(mem_payload)) -> bool =
@@ -150,7 +153,10 @@ function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
   priv : Privilege,
 ) -> option(ExceptionType) = {
 
-  if sys_pmp_count == 0 then return None();
+  let ss_pmp_required = is_shadow_stack_access(access) & priv == Machine;
+
+  if sys_pmp_count == 0 then
+    return (if ss_pmp_required then Some(accessFaultFromAccessType(access)) else None());
 
   let width : xlenbits = to_bits(width);
 
@@ -175,6 +181,14 @@ function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
       },
       PMP_Match        =>
         if currentlyEnabled(Ext_Smpmpind) & pmp_E[i] == 0b1
+        then {
+          let ss_access_allowed =
+            if pmp_is_m_ss_region(cfg, pmp_E[i])
+            then pmp_check_m_ss_access(access, priv)
+            else false;
+          return (if ss_access_allowed then None() else Some(accessFaultFromAccessType(access)))
+        }
+        else if ss_pmp_required
         then return Some(accessFaultFromAccessType(access))
         else if (currentlyEnabled(Ext_Smepmp) & pmpCheckPerms(cfg, access, priv)) |
             pmpCheckRWX(cfg, access) |
@@ -190,6 +204,7 @@ function pmpCheck forall 'n, 0 < 'n <= max_mem_access . (
   // Make Read, Write and execute denied by default, if mseccfg[MMWP] == 0b1 for M mode.
   // Make execute denied, if mseccfg[MML] == 0b1 for M mode.
   if priv == Machine & mseccfg[MMWP] == 0b0 & (mseccfg[MML] == 0b0 | access != InstructionFetch())
+     & not(ss_pmp_required)
   then None()
   else {
     if get_config_print_pmp()

--- a/model/pmp/pmp_regs.sail
+++ b/model/pmp/pmp_regs.sail
@@ -91,27 +91,36 @@ private function pmpReadAddrReg(n : range(0, 63)) -> xlenbits = {
 
 // Helpers to handle locked entries
 private function pmpLocked(cfg: Pmpcfg_ent) -> bool =
-   cfg[L] == 0b1
+  (cfg[L] == 0b1) & (not(currentlyEnabled(Ext_Smepmp)) | mseccfg[RLB] == 0b0)
 
 private function pmpTORLocked(cfg: Pmpcfg_ent) -> bool =
-   (cfg[L] == 0b1) & (pmpAddrMatchType_encdec(cfg[A]) == TOR)
+  (cfg[L] == 0b1) & (pmpAddrMatchType_encdec(cfg[A]) == TOR)
 
-private function pmpWriteCfg(cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent =
+private function pmpWriteCfg(cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent = {
+  // If locked then configuration is unchanged.
   if pmpLocked(cfg) then cfg
+  // To prevent adding a rule with execution privileges if MML is enabled unless RLB is set.
   else {
-    // Bits 5 and 6 are zero.
-    let cfg = Mk_Pmpcfg_ent(v & 0x9f);
-
+    // Constructing legal Pmpcfg_ent by making bit 5 and 6 zero.
+    let legal_v : Pmpcfg_ent = Mk_Pmpcfg_ent([v with 6 .. 5 = zeros()]);
     // "The R, W, and X fields form a collective WARL field for which the combinations with R=0 and W=1 are reserved."
-    // if R=0 and W=1, we allow two options currently:
-    // 1. exit the simulation with a fatal error
-    // 2. R, W and X are all set to 0.
-    let cfg = if cfg[W] == 0b1 & cfg[R] == 0b0 then (
-      match pmp_write_only_reserved_behavior {
-        PMP_Fatal => reserved_behavior("pmpcfg with R=0,W=1"),
-        PMP_ClearPermissions => [cfg with X = 0b0, W = 0b0, R = 0b0],
+    // In this implementation if R=0 and W=1 then R, W and X are all set to 0.
+    // This is the least risky option from a security perspective.
+    let legal_v : Pmpcfg_ent = match (mseccfg[MML], legal_v[R], legal_v[W]) {
+      (0b0, 0b0, 0b1) => [legal_v with W = 0b0],
+      (_, _, _)       => legal_v
+    };
+
+    let legal_v : Pmpcfg_ent = if (mseccfg[MML] == 0b1 & mseccfg[RLB] == 0b0 & legal_v[L] == 0b1)
+    then {
+      match (legal_v[R], legal_v[W], legal_v[X]) {
+        (0b0, 0b0, 0b1) => cfg,
+        (0b0, 0b1, 0b0) => cfg,
+        (0b0, 0b1, 0b1) => cfg,
+        (0b1, 0b0, 0b1) => cfg,
+        (_, _, _)       => legal_v
       }
-    ) else cfg;
+    } else legal_v;
 
     // We support disabling all modes globally, which is allowed since this
     // is a WARL field.
@@ -131,6 +140,7 @@ private function pmpWriteCfg(cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent =
 
     cfg
   }
+}
 
 private function pmpWriteCfgReg(n : range(0, 15), v : xlenbits) -> unit = {
   if xlen == 32

--- a/model/pmp/pmp_regs.sail
+++ b/model/pmp/pmp_regs.sail
@@ -96,31 +96,35 @@ private function pmpLocked(cfg: Pmpcfg_ent) -> bool =
 private function pmpTORLocked(cfg: Pmpcfg_ent) -> bool =
   (cfg[L] == 0b1) & (pmpAddrMatchType_encdec(cfg[A]) == TOR)
 
-private function pmpWriteCfg(cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent = {
+private function pmpIgnoreWrite(cfg : Pmpcfg_ent) -> bool =
   // If locked then configuration is unchanged.
-  if pmpLocked(cfg) then cfg
-  // To prevent adding a rule with execution privileges if MML is enabled unless RLB is set.
-  else {
-    // Constructing legal Pmpcfg_ent by making bit 5 and 6 zero.
-    let legal_v : Pmpcfg_ent = Mk_Pmpcfg_ent([v with 6 .. 5 = zeros()]);
-    // "The R, W, and X fields form a collective WARL field for which the combinations with R=0 and W=1 are reserved."
-    // In this implementation if R=0 and W=1 then R, W and X are all set to 0.
-    // This is the least risky option from a security perspective.
-    let legal_v : Pmpcfg_ent = match (mseccfg[MML], legal_v[R], legal_v[W]) {
-      (0b0, 0b0, 0b1) => [legal_v with W = 0b0],
-      (_, _, _)       => legal_v
-    };
+  pmpLocked(cfg) |
+  // If mseccfg[MML] is set:
+  //
+  // "Adding a rule with executable privileges that either is M-mode-only or a
+  // locked Shared-Region [i.e. L is set] is not possible and such pmpcfg
+  // writes are ignored, leaving pmpcfg unchanged. This restriction can be
+  // temporarily lifted by setting mseccfg.RLB e.g. during the boot process."
+  currentlyEnabled(Ext_Smepmp) & (mseccfg[MML] == 0b1 & mseccfg[RLB] == 0b0 & cfg[L] == 0b1 & cfg[X] == 0b1)
 
-    let legal_v : Pmpcfg_ent = if (mseccfg[MML] == 0b1 & mseccfg[RLB] == 0b0 & legal_v[L] == 0b1)
-    then {
-      match (legal_v[R], legal_v[W], legal_v[X]) {
-        (0b0, 0b0, 0b1) => cfg,
-        (0b0, 0b1, 0b0) => cfg,
-        (0b0, 0b1, 0b1) => cfg,
-        (0b1, 0b0, 0b1) => cfg,
-        (_, _, _)       => legal_v
+private function pmpWriteCfg(cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent =
+  if pmpIgnoreWrite(cfg) then cfg
+  else {
+    // Bits 5 and 6 are zero.
+    let cfg = Mk_Pmpcfg_ent([v with 6 .. 5 = zeros()]);
+
+    // "The R, W, and X fields form a collective WARL field for which the combinations with R=0 and W=1 are reserved."
+    // if R=0 and W=1, we allow two options currently:
+    // 1. exit the simulation with a fatal error
+    // 2. R, W and X are all set to 0.
+    //
+    // This combination is NOT reserved with Smepmp if mseccfg[MML] is set.
+    let cfg = if cfg[W] == 0b1 & cfg[R] == 0b0 & not(currentlyEnabled(Ext_Smepmp) & mseccfg[MML] == 0b1) then (
+      match pmp_write_only_reserved_behavior {
+        PMP_Fatal => reserved_behavior("pmpcfg with R=0,W=1"),
+        PMP_ClearPermissions => [cfg with X = 0b0, W = 0b0, R = 0b0],
       }
-    } else legal_v;
+    ) else cfg;
 
     // We support disabling all modes globally, which is allowed since this
     // is a WARL field.
@@ -140,7 +144,6 @@ private function pmpWriteCfg(cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent = {
 
     cfg
   }
-}
 
 private function pmpWriteCfgReg(n : range(0, 15), v : xlenbits) -> unit = {
   if xlen == 32

--- a/model/pmp/pmp_regs.sail
+++ b/model/pmp/pmp_regs.sail
@@ -41,8 +41,8 @@ bitfield Pmpcfg_ent : bits(8) = {
   R : 0         // read
 }
 
-register pmpcfg_n : vector(64, Pmpcfg_ent)
-register pmpaddr_n : vector(64, xlenbits)
+register pmpcfg_n : vector(64, Pmpcfg_ent) = vector_init(Mk_Pmpcfg_ent(zeros()))
+register pmpaddr_n : vector(64, xlenbits) = vector_init(zeros())
 
 // Packing and unpacking pmpcfg regs for xlen-width accesses
 

--- a/model/pmp/pmp_regs.sail
+++ b/model/pmp/pmp_regs.sail
@@ -67,7 +67,7 @@ private function pmpReadCfgReg(n : range(0, 15)) -> xlenbits = {
   }
 }
 
-private function pmpReadAddrReg(n : range(0, 63)) -> xlenbits = {
+function pmpReadAddrReg(n : range(0, 63)) -> xlenbits = {
   let G = sys_pmp_grain;
   let match_type = pmpcfg_n[n][A];
   let addr = pmpaddr_n[n];
@@ -90,7 +90,7 @@ private function pmpReadAddrReg(n : range(0, 63)) -> xlenbits = {
 }
 
 // Helpers to handle locked entries
-private function pmpLocked(cfg: Pmpcfg_ent) -> bool =
+function pmpLocked(cfg: Pmpcfg_ent) -> bool =
   (cfg[L] == 0b1) & (not(currentlyEnabled(Ext_Smepmp)) | mseccfg[RLB] == 0b0)
 
 private function pmpTORLocked(cfg: Pmpcfg_ent) -> bool =
@@ -107,7 +107,7 @@ private function pmpIgnoreWrite(cfg : Pmpcfg_ent) -> bool =
   // temporarily lifted by setting mseccfg.RLB e.g. during the boot process."
   currentlyEnabled(Ext_Smepmp) & (mseccfg[MML] == 0b1 & mseccfg[RLB] == 0b0 & cfg[L] == 0b1 & cfg[X] == 0b1)
 
-private function pmpWriteCfg(cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent =
+function pmpWriteCfg(cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent =
   if pmpIgnoreWrite(cfg) then cfg
   else {
     // Bits 5 and 6 are zero.
@@ -173,7 +173,7 @@ private function pmpWriteAddr(locked: bool, tor_locked: bool, reg: xlenbits, v: 
   else zero_extend(v[min(physaddr_bits - 3, 53) .. 0]);
 }
 
-private function pmpWriteAddrReg(n : range(0, 63), v : xlenbits) -> unit = {
+function pmpWriteAddrReg(n : range(0, 63), v : xlenbits) -> unit = {
   if n < sys_pmp_usable_count then
     pmpaddr_n[n] = pmpWriteAddr(
       pmpLocked(pmpcfg_n[n]),

--- a/model/pmp/pmp_regs.sail
+++ b/model/pmp/pmp_regs.sail
@@ -44,6 +44,9 @@ bitfield Pmpcfg_ent : bits(8) = {
 register pmpcfg_n : vector(64, Pmpcfg_ent) = vector_init(Mk_Pmpcfg_ent(zeros()))
 register pmpaddr_n : vector(64, xlenbits) = vector_init(zeros())
 
+// Smpmpind E bit per PMP entry: bit MXLEN-1 of the indirect pmpcfg view.
+register pmp_E : vector(64, bits(1)) = vector_init(0b0)
+
 // Packing and unpacking pmpcfg regs for xlen-width accesses
 
 private function pmpReadCfgReg(n : range(0, 15)) -> xlenbits = {
@@ -107,7 +110,7 @@ private function pmpIgnoreWrite(cfg : Pmpcfg_ent) -> bool =
   // temporarily lifted by setting mseccfg.RLB e.g. during the boot process."
   currentlyEnabled(Ext_Smepmp) & (mseccfg[MML] == 0b1 & mseccfg[RLB] == 0b0 & cfg[L] == 0b1 & cfg[X] == 0b1)
 
-function pmpWriteCfg(cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent =
+function pmpWriteCfg(cfg: Pmpcfg_ent, v: bits(8), e_bit: bits(1)) -> Pmpcfg_ent =
   if pmpIgnoreWrite(cfg) then cfg
   else {
     // Bits 5 and 6 are zero.
@@ -119,7 +122,10 @@ function pmpWriteCfg(cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent =
     // 2. R, W and X are all set to 0.
     //
     // This combination is NOT reserved with Smepmp if mseccfg[MML] is set.
-    let cfg = if cfg[W] == 0b1 & cfg[R] == 0b0 & not(currentlyEnabled(Ext_Smepmp) & mseccfg[MML] == 0b1) then (
+    // Smpmpind permits it when E=1. MSSE and SSE are checked on access.
+    let mml_active   = currentlyEnabled(Ext_Smepmp) & mseccfg[MML] == 0b1;
+    let e_bit_active = currentlyEnabled(Ext_Smpmpind) & e_bit == 0b1;
+    let cfg = if cfg[W] == 0b1 & cfg[R] == 0b0 & not(mml_active | e_bit_active) then (
       match pmp_write_only_reserved_behavior {
         PMP_Fatal => reserved_behavior("pmpcfg with R=0,W=1"),
         PMP_ClearPermissions => [cfg with X = 0b0, W = 0b0, R = 0b0],
@@ -151,7 +157,7 @@ private function pmpWriteCfgReg(n : range(0, 15), v : xlenbits) -> unit = {
     foreach (i from 0 to 3) {
       let idx = n*4 + i;
       if idx < sys_pmp_usable_count then
-        pmpcfg_n[idx]  = pmpWriteCfg(pmpcfg_n[idx],  v[8*i+7 .. 8*i]);
+        pmpcfg_n[idx]  = pmpWriteCfg(pmpcfg_n[idx],  v[8*i+7 .. 8*i], pmp_E[idx]);
     }
   }
   else {
@@ -159,7 +165,7 @@ private function pmpWriteCfgReg(n : range(0, 15), v : xlenbits) -> unit = {
     foreach (i from 0 to 7) {
       let idx = n*4 + i;
       if idx < sys_pmp_usable_count then
-        pmpcfg_n[idx]  = pmpWriteCfg(pmpcfg_n[idx],  v[8*i+7 .. 8*i]);
+        pmpcfg_n[idx]  = pmpWriteCfg(pmpcfg_n[idx],  v[8*i+7 .. 8*i], pmp_E[idx]);
     }
   }
 }

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -351,6 +351,11 @@ extensions {
     files extensions/Smcntrpmf/smcntrpmf.sail
   }
 
+  Smcsrind {
+    requires core
+    files extensions/Smcsrind/csrind_regs.sail
+  }
+
   Sscofpmf {
     requires core, Zihpm
     files extensions/Sscofpmf/sscofpmf.sail

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -356,6 +356,11 @@ extensions {
     files extensions/Smcsrind/csrind_regs.sail
   }
 
+  Smpmpind {
+    requires core, pmp, Smcsrind
+    files extensions/Smpmpind/smpmpind.sail
+  }
+
   Sscofpmf {
     requires core, Zihpm
     files extensions/Sscofpmf/sscofpmf.sail

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -361,6 +361,11 @@ extensions {
     files extensions/Smpmpind/smpmpind.sail
   }
 
+  Smcfiss {
+    requires core, pmp, Zicfiss, Smpmpind
+    files extensions/Smcfiss/smcfiss.sail
+  }
+
   Sscofpmf {
     requires core, Zihpm
     files extensions/Sscofpmf/sscofpmf.sail

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -411,14 +411,14 @@ function translateAddr(
 
   let mode = translationMode(effPriv);
 
-  // "If satp.MODE (or vsatp.MODE when V=1) is set to Bare and the
-  // effective privilege mode is less than M, shadow stack
-  // instructions raise a store/AMO access-fault exception."
-  // "Use of Zicfiss in M-mode is not supported."
-  if is_shadow_stack_access(access) then {
-    if (mode == Bare & effPriv != Machine) | effPriv == Machine
-    then return Err(E_SAMO_Access_Fault(), init_ext_ptw);
+  // A shadow-stack access faults unless this privilege has a shadow-stack
+  // protection mechanism in effect.
+  let ss_permitted : bool = match effPriv {
+    Machine => currentlyEnabled(Ext_Smcfiss) & mseccfg[MSSE] == 0b1,
+    _       => mode != Bare,
   };
+  if is_shadow_stack_access(access) & not(ss_permitted)
+  then return Err(E_SAMO_Access_Fault(), init_ext_ptw);
 
   if mode == Bare then return Ok(Physaddr(zero_extend(bits_of(vAddr))), PBMT_PMA, init_ext_ptw);
 


### PR DESCRIPTION
Adds experimental support for Smcfiss, which gives M-mode a shadow stack protected by PMP.

Smcfiss uses PMP regions with E set and XWR=010 as M-mode shadow stack regions. They are active when mseccfg.MSSE is set.

Specification: https://github.com/ved-rivos/riscv-isa-manual/blob/smpmpss/src/smcfiss.adoc

Dependencies:

- #1864 for Smpmpind and the pmpcfg E field

The diff against master is cumulative. Only the final commit adds Smcfiss.

Smcfiss requires --enable-experimental-extensions.
