### PR TITLE
Add Sscpuutil extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ An experimental emulator in the Lean language is available, see its
 
 The following unratified extensions are supported and can be enabled using the `--enable-experimental-extensions` flag:
 
+- Sscpuutil extension for CPU utilization counters, fast-track draft
 - Zibi extension for conditional branches with immediate operands, v0.6
 - Zvabd extension for vector absolute difference, v0.7
 

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -777,6 +777,9 @@
     "Sscounterenw": {
       "supported": true
     },
+    "Sscpuutil": {
+      "supported": true
+    },
     "Sstc": {
       "supported": true
     },

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -466,6 +466,10 @@ function clause hartSupports(Ext_Sscofpmf) = config extensions.Sscofpmf.supporte
 enum clause extension = Ext_Sscounterenw
 mapping clause extensionName = Ext_Sscounterenw <-> "sscounterenw"
 function clause hartSupports(Ext_Sscounterenw) = config extensions.Sscounterenw.supported
+// CPU Utilization counters
+enum clause extension = Ext_Sscpuutil
+mapping clause extensionName = Ext_Sscpuutil <-> "sscpuutil"
+function clause hartSupports(Ext_Sscpuutil) = sys_enable_experimental_extensions() & config extensions.Sscpuutil.supported
 // Supervisor-Level pointer masking for next lower privilege mode
 enum clause extension = Ext_Ssnpm
 mapping clause extensionName = Ext_Ssnpm <-> "ssnpm"
@@ -815,6 +819,7 @@ let extensions_ordered_for_isa_string = [
   Ext_Ssccptr,
   Ext_Sscofpmf,
   Ext_Sscounterenw,
+  Ext_Sscpuutil,
   Ext_Ssnpm,
   Ext_Sspm,
   Ext_Ssqosid,

--- a/model/extensions/Sscpuutil/sscpuutil.sail
+++ b/model/extensions/Sscpuutil/sscpuutil.sail
@@ -1,0 +1,39 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// Sscpuutil - CPU Utilization counters
+function clause currentlyEnabled(Ext_Sscpuutil) = hartSupports(Ext_Sscpuutil) & currentlyEnabled(Ext_Zicntr)
+
+register macttime : bits(64)
+
+// FIXME: Waiting for CSR address allocation
+mapping clause csr_name_map = 0xC23 <-> "acttime"
+mapping clause csr_name_map = 0xCA3 <-> "acttimeh"
+mapping clause csr_name_map = 0xF00 <-> "macttime"
+mapping clause csr_name_map = 0xF80 <-> "macttimeh"
+
+private function acttime_accessible(priv : Privilege) -> bool =
+  currentlyEnabled(Ext_Sscpuutil) & (
+    match priv {
+      Machine           => true,
+      Supervisor        => true,
+      User              => counter_enabled(0, priv),
+      VirtualSupervisor => true,
+      VirtualUser       => counter_enabled(0, priv),
+    }
+  )
+
+function clause is_CSR_accessible(0xC23, priv, _) = acttime_accessible(priv)
+function clause is_CSR_accessible(0xCA3, priv, _) = xlen == 32 & acttime_accessible(priv)
+function clause is_CSR_accessible(0xF00, _, _) = currentlyEnabled(Ext_Sscpuutil)
+function clause is_CSR_accessible(0xF80, _, _) = xlen == 32 & currentlyEnabled(Ext_Sscpuutil)
+
+function clause read_CSR(0xC23) = macttime[xlen - 1 .. 0]
+function clause read_CSR(0xCA3 if xlen == 32) = macttime[63 .. 32]
+function clause read_CSR(0xF00) = macttime[xlen - 1 .. 0]
+function clause read_CSR(0xF80 if xlen == 32) = macttime[63 .. 32]

--- a/model/extensions/Stateen/stateen_access_checks.sail
+++ b/model/extensions/Stateen/stateen_access_checks.sail
@@ -52,6 +52,11 @@ function stateen_allows_CSR_access(csr : csreg, priv : Privilege, _access_type :
     // srmcfg
     (0x181, priv) => check_stateen_bit(priv, STATEEN_SRMCFG, 0),
 
+    // acttime
+    (0xC23, priv) => check_stateen_bit(priv, STATEEN_ACTTIME, 0),
+    // acttimeh
+    (0xCA3, priv) => check_stateen_bit(priv, STATEEN_ACTTIME, 0),
+
     // fflags
     (0x001, priv) => if hartSupports(Ext_Zfinx) then check_stateen_bit(priv, STATEEN_FCSR, 0) else true,
     // frm

--- a/model/extensions/Stateen/stateen_regs.sail
+++ b/model/extensions/Stateen/stateen_regs.sail
@@ -16,12 +16,15 @@ function is_sstateen_accessible() -> bool = currentlyEnabled(Ext_S) & (currently
 termination_measure is_hstateen_accessible() = 5 // > Ext_H
 termination_measure is_sstateen_accessible() = 2 // > Ext_S
 
-enum stateen_bit = {STATEEN_FCSR, STATEEN_SRMCFG, STATEEN_ENVCFG, STATEEN_SE}
+// FIXME: Waiting for CSR address allocation
+enum stateen_bit = {STATEEN_FCSR, STATEEN_ACTTIME, STATEEN_SRMCFG, STATEEN_ENVCFG, STATEEN_SE}
 
 mapping stateen_bit_index : stateen_bit <-> range(0, 63) = {
   STATEEN_SE     <-> 63,
   STATEEN_ENVCFG <-> 62,
   STATEEN_SRMCFG <-> 55,
+  // Temporary model assignment while the Sscpuutil stateen bit is TBD in ARC.
+  STATEEN_ACTTIME <-> 53,
   STATEEN_FCSR   <-> 1,
 }
 
@@ -36,6 +39,7 @@ bitfield Mstateen0 : bits(64) = {
   P1P13   : 56,
   SRMCFG  : 55,
   CTR     : 54,
+  ACTTIME : 53,
 
   JVT     : 2,
   FCSR    : 1,
@@ -67,6 +71,7 @@ function legalize_mstateen0(m : Mstateen0, v : bits(64)) -> Mstateen0 = {
     SE0    = if config extensions.Stateen.SE0_readonly_zero then 0b0 else v[SE0],
     ENVCFG = if currentlyEnabled(Ext_S) then v[ENVCFG] else 0b0,
     SRMCFG = if currentlyEnabled(Ext_Ssqosid) then v[SRMCFG] else 0b0,
+    ACTTIME = if currentlyEnabled(Ext_Sscpuutil) then v[ACTTIME] else 0b0,
     FCSR   = if hartSupports(Ext_Zfinx) & (misa[F] == 0b0) then v[FCSR] else 0b0,
     C      = if config extensions.Stateen.C_readonly_zero then 0b0 else v[C],
   ];
@@ -85,6 +90,7 @@ bitfield Hstateen0 : bits(64) = {
   IMSIC   : 58,
   CONTEXT : 57,
   CTR     : 54,
+  ACTTIME : 53,
 
   JVT     : 2,
   FCSR    : 1,
@@ -119,6 +125,7 @@ function legalize_hstateen0(h : Hstateen0, v : bits(64)) -> Hstateen0 = {
   [h with
     SE0    = if config extensions.Stateen.SE0_readonly_zero then 0b0 else v[SE0],
     ENVCFG = if currentlyEnabled(Ext_S) then v[ENVCFG] else 0b0,
+    ACTTIME = if currentlyEnabled(Ext_Sscpuutil) then v[ACTTIME] else 0b0,
     FCSR   = if hartSupports(Ext_Zfinx) & (misa[F] == 0b0) then v[FCSR] else 0b0,
     C      = if config extensions.Stateen.C_readonly_zero then 0b0 else v[C],
   ];
@@ -184,9 +191,13 @@ function check_stateen_bit(priv : Privilege, bit_idx : stateen_bit, stateen_reg 
   let mask : bits(64) = match priv {
     Machine           => ones(),
     Supervisor        => get_mstateen(stateen_reg),
-    User              => get_mstateen(stateen_reg) & get_sstateen(stateen_reg),
+    User              => if bit_idx == STATEEN_ACTTIME
+                         then get_mstateen(stateen_reg)
+                         else get_mstateen(stateen_reg) & get_sstateen(stateen_reg),
     VirtualSupervisor => get_mstateen(stateen_reg) & get_hstateen(stateen_reg),
-    VirtualUser       => get_mstateen(stateen_reg) & get_hstateen(stateen_reg) & get_sstateen(stateen_reg),
+    VirtualUser       => if bit_idx == STATEEN_ACTTIME
+                         then get_mstateen(stateen_reg) & get_hstateen(stateen_reg)
+                         else get_mstateen(stateen_reg) & get_hstateen(stateen_reg) & get_sstateen(stateen_reg),
   };
   mask[stateen_bit_index(bit_idx)] == bitone
 }

--- a/model/postlude/step.sail
+++ b/model/postlude/step.sail
@@ -281,6 +281,11 @@ function try_step(step_no : nat, exit_wait : bool) -> bool = {
   }
 }
 
+// Wrapper for tick_clock_with_wfi_idle which is also used by the C side.
+function tick_clock() -> unit = {
+  tick_clock_with_wfi_idle(hart_is_waiting_for_wfi(hart_state))
+}
+
 function loop () : unit -> nat = {
   var i : nat = 0;
   var step_no : nat = 0;

--- a/model/postlude/step_common.sail
+++ b/model/postlude/step_common.sail
@@ -41,6 +41,12 @@ function hart_is_waiting(s : HartState) -> bool =
     HART_WAITING(_) => true,
   }
 
+function hart_is_waiting_for_wfi(s : HartState) -> bool =
+  match s {
+    HART_WAITING(WAIT_WFI, _) => true,
+    _                         => false,
+  }
+
 // The result of a fetch, which includes any possible error
 // from an extension that interposes on the fetch operation.
 

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -61,7 +61,7 @@ pmp {
 }
 
 sys {
-  requires prelude, core, exceptions, pmp, V_core, Smcntrpmf, Zicfilp_regs, A_types, Stateen, Zicbop_types, PM_utils
+  requires prelude, core, exceptions, pmp, V_core, Smcntrpmf, Sscpuutil, Zicfilp_regs, A_types, Stateen, Zicbop_types, PM_utils
 
   files
     sys/sys_reservation.sail,
@@ -474,6 +474,11 @@ extensions {
     files extensions/Ssqosid/ssqosid.sail
   }
 
+  Sscpuutil {
+    requires core
+    files extensions/Sscpuutil/sscpuutil.sail
+  }
+
   CFI {
     requires core
 
@@ -567,7 +572,7 @@ mops {
 postlude {
   after extensions, mops, core
 
-  requires prelude, core, sys, exceptions, Smcntrpmf, pmp, Zicfilp_regs, Zicfilp_insts
+  requires prelude, core, sys, exceptions, Smcntrpmf, Sscpuutil, pmp, Zicfilp_regs, Zicfilp_insts
 
   files
     postlude/insts_end.sail,

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -475,7 +475,7 @@ extensions {
   }
 
   Sscpuutil {
-    requires core
+    requires core, Zicntr
     files extensions/Sscpuutil/sscpuutil.sail
   }
 

--- a/model/sys/platform.sail
+++ b/model/sys/platform.sail
@@ -212,9 +212,17 @@ function should_inc_mcycle(priv : Privilege) -> bool =
 function should_inc_minstret(priv : Privilege) -> bool =
   mcountinhibit[IR] == 0b0 & counter_priv_filter_bit(minstretcfg, priv) == 0b0
 
-function tick_clock() -> unit = {
-  if   should_inc_mcycle(cur_privilege)
+function tick_clock_with_wfi_idle(wfi_idle : bool) -> unit = {
+  // Cycle pauses when the hart enters an idle state (i.e., the hart has
+  // executed WFI and the associated clock domain is gated)
+  let pause_active_counters = currentlyEnabled(Ext_Sscpuutil) & wfi_idle;
+
+  if   not(pause_active_counters) & should_inc_mcycle(cur_privilege)
   then mcycle = mcycle + 1;
+
+  // macttime is not affected by mcountinhibit (unlike cycle).
+  if   not(pause_active_counters) & currentlyEnabled(Ext_Sscpuutil)
+  then macttime = macttime + 1;
 
   mtime  = mtime  + 1;
   clint_dispatch(false)

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -365,6 +365,9 @@ function reset_sys() -> unit = {
   // "The misa register is reset to enable the maximal set of supported extensions"
   reset_misa();
 
+  // "Initializes to 0 on reset."
+  macttime = zeros();
+
   // "For implementations with the "A" standard extension, there is no valid load reservation."
   cancel_reservation();
 

--- a/test/first_party/CMakeLists.txt
+++ b/test/first_party/CMakeLists.txt
@@ -100,18 +100,23 @@ set(common_deps
 )
 
 set(tests)
-macro(add_first_party_test_with_config name march xlen override_json_file)
-    list(APPEND tests "${name}" "${march}" "${xlen}" "${override_json_file}")
+macro(add_first_party_test_with_config name march xlen override_json_file experimental)
+    list(APPEND tests "${name}" "${march}" "${xlen}" "${override_json_file}" "${experimental}")
 endmacro()
 macro(add_first_party_test name)
     set(isa_extension gcv_zfbfmin)
-    add_first_party_test_with_config("${name}" "rv32${isa_extension}" 32 "no_override.json")
-    add_first_party_test_with_config("${name}" "rv64${isa_extension}" 64 "no_override.json")
+    add_first_party_test_with_config("${name}" "rv32${isa_extension}" 32 "no_override.json" FALSE)
+    add_first_party_test_with_config("${name}" "rv64${isa_extension}" 64 "no_override.json" FALSE)
 endmacro()
 macro(add_first_party_override_test name override)
     set(isa_extension gcv_zfbfmin)
-    add_first_party_test_with_config("${name}" "rv32${isa_extension}" 32 "${override}")
-    add_first_party_test_with_config("${name}" "rv64${isa_extension}" 64 "${override}")
+    add_first_party_test_with_config("${name}" "rv32${isa_extension}" 32 "${override}" FALSE)
+    add_first_party_test_with_config("${name}" "rv64${isa_extension}" 64 "${override}" FALSE)
+endmacro()
+macro(add_first_party_experimental_test name)
+    set(isa_extension gcv_zfbfmin)
+    add_first_party_test_with_config("${name}" "rv32${isa_extension}" 32 "no_override.json" TRUE)
+    add_first_party_test_with_config("${name}" "rv64${isa_extension}" 64 "no_override.json" TRUE)
 endmacro()
 
 add_first_party_test("test_bf16_nan_boxing.S")
@@ -128,14 +133,17 @@ add_first_party_test("test_tlb_stale_pte_access_fault.S")
 add_first_party_override_test("test_sew_elen_bound.S" "elen_32.json")
 add_first_party_override_test("test_satp_physaddr_bits.S" "satp_physaddr_bits.json")
 
+add_first_party_experimental_test("test_sscpuutil.S")
+
 list(LENGTH tests tests_len)
 math(EXPR test_last "${tests_len} - 1")
-foreach(idx RANGE 0 ${test_last} 4)
-    list(SUBLIST tests ${idx} 4 entry)
+foreach(idx RANGE 0 ${test_last} 5)
+    list(SUBLIST tests ${idx} 5 entry)
     list(GET entry 0 test_source)
     list(GET entry 1 march)
     list(GET entry 2 xlen)
     list(GET entry 3 override_config)
+    list(GET entry 4 experimental)
 
     set(arch "rv${xlen}d")
     if (xlen EQUAL 32)
@@ -195,8 +203,13 @@ foreach(idx RANGE 0 ${test_last} 4)
 
     add_custom_target(build_${arch}_${test_source} ALL DEPENDS ${elf} ${config} ${override_config})
 
+    set(extra_args)
+    if (experimental)
+        set(extra_args --enable-experimental-extensions)
+    endif()
+
     add_test(
         NAME "first_party_${arch}_${test_source}"
-        COMMAND $<TARGET_FILE:sail_riscv_sim> --config ${config} --config-override ${override_config} ${elf}
+        COMMAND $<TARGET_FILE:sail_riscv_sim> --config ${config} --config-override ${override_config} ${extra_args} ${elf}
     )
 endforeach()

--- a/test/first_party/src/test_sscpuutil.S
+++ b/test/first_party/src/test_sscpuutil.S
@@ -1,0 +1,277 @@
+#include "common/encoding.h"
+
+#define CSR_ACTTIME 0xC23
+#define CSR_ACTTIMEH 0xCA3
+#define CSR_MACTTIME 0xF00
+#define CSR_MACTTIMEH 0xF80
+
+#if __riscv_xlen == 64
+#define CSR_MSTATEEN0_ACTTIME CSR_MSTATEEN0
+#define STATEEN_ACTTIME (1ULL << 53)
+#else
+#define CSR_MSTATEEN0_ACTTIME CSR_MSTATEEN0H
+#define STATEEN_ACTTIME (1U << 21)
+#endif
+
+.section .text
+
+.global main
+main:
+  la t0, fail
+  csrw mtvec, t0
+  csrw medeleg, zero
+
+#if __riscv_xlen == 32
+1:
+  csrr t0, CSR_MACTTIMEH
+  csrr t1, CSR_ACTTIMEH
+  bne t0, t1, fail
+#endif
+
+2:
+  # macttime advances while the hart is active.
+  csrr t0, CSR_MACTTIME
+  addi t6, t6, 1
+  csrr t1, CSR_MACTTIME
+  bgeu t0, t1, fail
+
+3:
+  # macttime is M-mode only.
+  la t0, test_3_trap_handler
+  csrw mtvec, t0
+  la a0, test_3_s_body
+  j enter_s_mode
+
+.balign 4
+test_3_s_body:
+  csrr t0, CSR_MACTTIME
+  ecall
+
+.balign 4
+test_3_trap_handler:
+  csrr t0, mcause
+  li t1, CAUSE_ILLEGAL_INSTRUCTION
+  bne t0, t1, fail
+  la a0, 4f
+  j return_to_m_mode
+
+4:
+  # mcountinhibit.CY stops mcycle but not macttime.
+  li t2, 1
+  csrw mcountinhibit, t2
+  csrr t0, CSR_MCYCLE
+  csrr t1, CSR_MACTTIME
+  addi t6, t6, 1
+  csrr t2, CSR_MCYCLE
+  csrr t3, CSR_MACTTIME
+  bne t0, t2, fail
+  bgeu t1, t3, fail
+  csrw mcountinhibit, zero
+
+5:
+  # mstateen0.ACTTIME gates S-mode shadow access.
+  li t0, STATEEN_ACTTIME
+  csrc CSR_MSTATEEN0_ACTTIME, t0
+  li t0, 1
+  csrs mcounteren, t0
+  csrs scounteren, t0
+  la t0, test_5_trap_handler
+  csrw mtvec, t0
+  la a0, test_5_s_body
+  j enter_s_mode
+
+.balign 4
+test_5_s_body:
+  csrr t0, CSR_ACTTIME
+  ecall
+
+.balign 4
+test_5_trap_handler:
+  csrr t0, mcause
+  li t1, CAUSE_ILLEGAL_INSTRUCTION
+  bne t0, t1, fail
+  la a0, 6f
+  j return_to_m_mode
+
+6:
+  # mstateen0.ACTTIME gates U-mode shadow access.
+  li t0, STATEEN_ACTTIME
+  csrc CSR_MSTATEEN0_ACTTIME, t0
+  li t0, 1
+  csrs mcounteren, t0
+  csrs scounteren, t0
+  la t0, test_6_trap_handler
+  csrw mtvec, t0
+  la a0, test_6_u_body
+  j enter_u_mode
+
+.balign 4
+test_6_u_body:
+  csrr t0, CSR_ACTTIME
+  ecall
+
+.balign 4
+test_6_trap_handler:
+  csrr t0, mcause
+  li t1, CAUSE_ILLEGAL_INSTRUCTION
+  bne t0, t1, fail
+  la a0, 7f
+  j return_to_m_mode
+
+7:
+  # With stateen enabled, U-mode also needs mcounteren.CY.
+  li t0, STATEEN_ACTTIME
+  csrs CSR_MSTATEEN0_ACTTIME, t0
+  li t0, 1
+  csrc mcounteren, t0
+  csrs scounteren, t0
+  la t0, test_7_trap_handler
+  csrw mtvec, t0
+  la a0, test_7_u_body
+  j enter_u_mode
+
+.balign 4
+test_7_u_body:
+  csrr t0, CSR_ACTTIME
+  ecall
+
+.balign 4
+test_7_trap_handler:
+  csrr t0, mcause
+  li t1, CAUSE_ILLEGAL_INSTRUCTION
+  bne t0, t1, fail
+  la a0, 8f
+  j return_to_m_mode
+
+8:
+  # With mcounteren enabled, U-mode still needs scounteren.CY.
+  li t0, 1
+  csrs CSR_MSTATEEN0_ACTTIME, t0
+  csrs mcounteren, t0
+  csrc scounteren, t0
+  la t0, test_8_trap_handler
+  csrw mtvec, t0
+  la a0, test_8_u_body
+  j enter_u_mode
+
+.balign 4
+test_8_u_body:
+  csrr t0, CSR_ACTTIME
+  ecall
+
+.balign 4
+test_8_trap_handler:
+  csrr t0, mcause
+  li t1, CAUSE_ILLEGAL_INSTRUCTION
+  bne t0, t1, fail
+  la a0, 9f
+  j return_to_m_mode
+
+9:
+  # S-mode succeeds with all gates enabled.
+  li t0, STATEEN_ACTTIME
+  csrs CSR_MSTATEEN0_ACTTIME, t0
+  li t0, 1
+  csrs mcounteren, t0
+  csrs scounteren, t0
+  la t0, test_9_trap_handler
+  csrw mtvec, t0
+  la a0, test_9_s_body
+  j enter_s_mode
+
+.balign 4
+test_9_s_body:
+  csrr s1, CSR_ACTTIME
+  csrr s2, CSR_ACTTIME
+  ecall
+
+.balign 4
+test_9_trap_handler:
+  csrr t0, mcause
+  li t1, CAUSE_SUPERVISOR_ECALL
+  bne t0, t1, fail
+  bltu s2, s1, fail
+  la a0, 10f
+  j return_to_m_mode
+
+10:
+  # U-mode succeeds with all gates enabled.
+  li t0, STATEEN_ACTTIME
+  csrs CSR_MSTATEEN0_ACTTIME, t0
+  li t0, 1
+  csrs mcounteren, t0
+  csrs scounteren, t0
+  la t0, test_10_trap_handler
+  csrw mtvec, t0
+  la a0, test_10_u_body
+  j enter_u_mode
+
+.balign 4
+test_10_u_body:
+  csrr s1, CSR_ACTTIME
+  csrr s2, CSR_ACTTIME
+  ecall
+
+.balign 4
+test_10_trap_handler:
+  csrr t0, mcause
+  li t1, CAUSE_USER_ECALL
+  bne t0, t1, fail
+  bltu s2, s1, fail
+  la a0, 11f
+  j return_to_m_mode
+
+11:
+  # WFI stops macttime and mcycle.
+  csrr t0, CSR_TIME
+  csrr t1, CSR_MCYCLE
+  csrr t2, CSR_MACTTIME
+  wfi
+  csrr t3, CSR_TIME
+  csrr t4, CSR_MCYCLE
+  csrr t5, CSR_MACTTIME
+  addi t1, t1, 3
+  bltu t1, t4, fail
+  sub t0, t3, t0
+  sub t2, t5, t2
+  sub t0, t0, t2
+  # max_time_to_wait=10
+  # time = macttime + 10
+  li t2, 10
+  bne t0, t2, fail
+
+pass:
+  li a0, 0
+  ret
+
+fail:
+  li a0, 1
+  ret
+
+enter_s_mode:
+  csrr t0, mstatus
+  li t1, ~MSTATUS_MPP
+  and t0, t0, t1
+  li t1, (MSTATUS_MPP & (MSTATUS_MPP >> 1))
+  or t0, t0, t1
+  csrw mstatus, t0
+  csrw mepc, a0
+  mret
+
+enter_u_mode:
+  csrr t0, mstatus
+  li t1, ~MSTATUS_MPP
+  and t0, t0, t1
+  csrw mstatus, t0
+  csrw mepc, a0
+  mret
+
+return_to_m_mode:
+  csrw mepc, a0
+  csrr t0, mstatus
+  li t1, ~MSTATUS_MPP
+  and t0, t0, t1
+  li t1, MSTATUS_MPP
+  or t0, t0, t1
+  csrw mstatus, t0
+  mret


### PR DESCRIPTION
This extension is currently waiting for
- Assignment of the stateen bit position for macttime access control.
- CSR address allocation for macttime, macttimeh, acttime, acttimeh.

See

Proposal：
https://lists.riscv.org/g/tech-arch-review/message/457

Ratification plan：
https://riscv.atlassian.net/wiki/spaces/PSXX/pages/2012938246/CPU+Utilization+Counter+Extension+Sscpuutil+Ratification+Plan

Jira：
https://riscv.atlassian.net/browse/RVS-4802

github repo：
https://github.com/riscv/riscv-sscpuutil

