### PR TITLE
Wake from WFI on platform external interrupts

### DIFF
--- a/doc/SimpleInterruptGenerator.md
+++ b/doc/SimpleInterruptGenerator.md
@@ -36,7 +36,7 @@ _Reserved_ bits must be written with 0 otherwise an access fault is raised. In f
 
 Bit 31 controls whether the relevant interrupts are set or cleared.
 
-MEI and MSI control the platform interrupt inputs to the hart, which directly control the corresponding bits in `mip` (there is no way for software running on the hart to set these bits directly). SEI and SSI are slightly more subtle because software on the hart can also write to these bits.
+MEI and MSI control the platform interrupt inputs to the hart (there is no way for software running on the hart to set these bits directly). MSI updates `mip[MSI]` directly. MEI is a separate input that is ORed into `mip[MEI]` on read, like SEI below. SEI and SSI are slightly more subtle because software on the hart can also write to these bits.
 
 SEI controls the supervisor external platform interrupt input, which is distinct from the software-writable `mip[SEI]` bit. These two values are ORed together when reading `mip` (or `sip`) for CSR reads and to dispatch interrupts, but NOT when reading `mip`/`sip` for the CSR read-modify-write process.
 

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -147,7 +147,7 @@ function getPendingSet(priv : Privilege) -> option((xlenbits, Privilege)) = {
 // (i.e., implementations should avoid resuming the hart if the
 // interrupt is pending but not individually enabled)."
 function shouldWakeForInterrupt() -> bool = {
-  (mip.bits & mie.bits) != zeros()
+  (read_mip(IncludePlatformInterrupts).bits & mie.bits) != zeros()
 }
 
 // Examine the current interrupt state and return an interrupt to be *

--- a/test/first_party/CMakeLists.txt
+++ b/test/first_party/CMakeLists.txt
@@ -122,6 +122,7 @@ add_first_party_test("test_misaligned_vector_register_groups.S")
 add_first_party_test("test_pmp_access.c")
 add_first_party_test("test_phys_perms_on_failing_sc.S")
 add_first_party_test("test_wfi_wait.S")
+add_first_party_test("test_wfi_external_simple_interrupt_generator.S")
 add_first_party_test("test_vrgatherei16_reg_group.S")
 add_first_party_test("test_tlb_stale_pte_access_fault.S")
 

--- a/test/first_party/src/test_wfi_external_simple_interrupt_generator.S
+++ b/test/first_party/src/test_wfi_external_simple_interrupt_generator.S
@@ -1,56 +1,55 @@
 #include "common/encoding.h"
 
-// WFI must wake for a locally enabled machine external interrupt.
-// This test is for the simple test generator and assumes that the base of the simple
-// platform's memory-mapped interrupt controller is at 0x0C000000.
-
 #define SIG_VERSION_OFFSET 0
 #define SIG_PLATFORM_OFFSET 4
 
 #define SIG_REQUIRED_MAJOR_VERSION 1
 #define SIG_MINIMUM_MINOR_VERSION 0
-
 #define SIG_BASE 0x0C000000
-// Bit 31 is the value to drive, the remaining bits select which lines it
-// applies to.
+
+# Bit 31 is the value to drive, the remaining bits select which lines it
+# applies to.
 #define SIG_VALUE_HIGH (1 << 31)
 
 .global main
 main:
+  # WFI must wake for a locally enabled machine external interrupt.
+  # This test is for the simple test generator and assumes that the base of the simple
+  # platform's memory-mapped interrupt controller is at 0x0C000000 by default (see config/config.json.in).
+
   mv t6, ra
 
-  // Keep interrupts from actually being taken.
-  // WFI must wake regardless of mstatus.MIE.
+  # Keep interrupts from actually being taken.
+  # WFI must wake regardless of mstatus.MIE.
   li t0, MSTATUS_MIE
   csrc mstatus, t0
 
-  // Only the machine external interrupt is locally enabled, so nothing else
-  // can wake the WFI below.
+  # Only the machine external interrupt is locally enabled, so nothing else
+  # can wake the WFI below.
   li t0, MIP_MEIP
   csrw mie, t0
 
   li t3, SIG_BASE
 
-  // Check the device version before using it.
+  # Check the device version of the simple interrupt generator before using it.
   lw t0, SIG_VERSION_OFFSET(t3)
   srli t1, t0, 16
 
   li t2, SIG_REQUIRED_MAJOR_VERSION
   bne t1, t2, fail
 
-  // Mask rather than shift: on RV64 `lw` sign-extends into a 64-bit register.
   li t2, 0xFFFF
   and t0, t0, t2
   li t2, SIG_MINIMUM_MINOR_VERSION
   bltu t0, t2, fail
 
-  // Drive MEIP high.
+  # Drive MEIP high.
   li t1, SIG_VALUE_HIGH | MIP_MEIP
   sw t1, SIG_PLATFORM_OFFSET(t3)
 
-  // Reading mip includes the platform interrupts, so MEIP must be visible
-  // here. If it isn't, the SIG write did not take effect and the rest of the
-  // test would be measuring nothing.
+  # Reading mip includes the platform interrupts, so MEIP must be visible
+  # here. If it isn't, the SIG write did not take effect and the rest of the
+  # test would be measuring nothing.
   csrr t0, mip
   li t1, MIP_MEIP
   and t0, t0, t1
@@ -60,10 +59,11 @@ main:
   wfi
   csrr t1, time
 
-  // A WFI that never woke on its own runs out the full max_time_to_wait (10).
+  # 2 if it woke, ~11 if it ran out max_time_to_wait.
+  # Assumes instructions_per_tick is 2 and max_time_to_wait is 10 as per default.
   sub t1, t1, t0
-  li t2, 5
-  bge t1, t2, fail
+  li t2, 2
+  bne t1, t2, fail
 
   j pass
 

--- a/test/first_party/src/test_wfi_external_simple_interrupt_generator.S
+++ b/test/first_party/src/test_wfi_external_simple_interrupt_generator.S
@@ -1,0 +1,77 @@
+#include "common/encoding.h"
+
+// WFI must wake for a locally enabled machine external interrupt.
+// This test is for the simple test generator and assumes that the base of the simple
+// platform's memory-mapped interrupt controller is at 0x0C000000.
+
+#define SIG_VERSION_OFFSET 0
+#define SIG_PLATFORM_OFFSET 4
+
+#define SIG_REQUIRED_MAJOR_VERSION 1
+#define SIG_MINIMUM_MINOR_VERSION 0
+
+#define SIG_BASE 0x0C000000
+// Bit 31 is the value to drive, the remaining bits select which lines it
+// applies to.
+#define SIG_VALUE_HIGH (1 << 31)
+
+.global main
+main:
+  mv t6, ra
+
+  // Keep interrupts from actually being taken.
+  // WFI must wake regardless of mstatus.MIE.
+  li t0, MSTATUS_MIE
+  csrc mstatus, t0
+
+  // Only the machine external interrupt is locally enabled, so nothing else
+  // can wake the WFI below.
+  li t0, MIP_MEIP
+  csrw mie, t0
+
+  li t3, SIG_BASE
+
+  // Check the device version before using it.
+  lw t0, SIG_VERSION_OFFSET(t3)
+  srli t1, t0, 16
+
+  li t2, SIG_REQUIRED_MAJOR_VERSION
+  bne t1, t2, fail
+
+  // Mask rather than shift: on RV64 `lw` sign-extends into a 64-bit register.
+  li t2, 0xFFFF
+  and t0, t0, t2
+  li t2, SIG_MINIMUM_MINOR_VERSION
+  bltu t0, t2, fail
+
+  // Drive MEIP high.
+  li t1, SIG_VALUE_HIGH | MIP_MEIP
+  sw t1, SIG_PLATFORM_OFFSET(t3)
+
+  // Reading mip includes the platform interrupts, so MEIP must be visible
+  // here. If it isn't, the SIG write did not take effect and the rest of the
+  // test would be measuring nothing.
+  csrr t0, mip
+  li t1, MIP_MEIP
+  and t0, t0, t1
+  beqz t0, fail
+
+  csrr t0, time
+  wfi
+  csrr t1, time
+
+  // A WFI that never woke on its own runs out the full max_time_to_wait (10).
+  sub t1, t1, t0
+  li t2, 5
+  bge t1, t2, fail
+
+  j pass
+
+pass:
+  li a0, 0
+  mv ra, t6
+  ret
+fail:
+  li a0, 1
+  mv ra, t6
+  ret


### PR DESCRIPTION
MEIP/SEIP are not held in `mip`, so reading the bare register hid them from `shouldWakeForInterrupt()` and a hart stalled in WFI or WRS ignored them until the simulator forced the wait to end.

Add a first-party test (`test_wfi_external_simple_interrupt_generator.S`) and slightly modify `SimpleInterruptGenerator.md`.