### PR TITLE
Refresh timer pending bits when `menvcfg` is written.

### DIFF
--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -469,9 +469,14 @@ function clause read_CSR(0x30A) = menvcfg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x31A if xlen == 32) = menvcfg.bits[63 .. 32]
 function clause read_CSR(0x10A) = read_senvcfg().bits[xlen - 1 .. 0]
 
-function clause write_CSR((0x30A, value) if xlen == 32) = { menvcfg = legalize_menvcfg(menvcfg, menvcfg.bits[63 .. 32] @ value); Ok(menvcfg.bits[31 .. 0]) }
-function clause write_CSR((0x30A, value) if xlen == 64) = { menvcfg = legalize_menvcfg(menvcfg, value); Ok(menvcfg.bits) }
-function clause write_CSR((0x31A, value) if xlen == 32) = { menvcfg = legalize_menvcfg(menvcfg, value @ menvcfg.bits[31 .. 0]); Ok(menvcfg.bits[63 .. 32]) }
+// Defined in sys/platform.sail, which comes after this file in the compile order.
+val clint_dispatch : bool -> unit
+
+// menvcfg[STCE] decides whether mip[STI] is derived from stimecmp, so writing
+// it changes the timer interrupt condition just like a stimecmp write does.
+function clause write_CSR((0x30A, value) if xlen == 32) = { menvcfg = legalize_menvcfg(menvcfg, menvcfg.bits[63 .. 32] @ value); clint_dispatch(false); Ok(menvcfg.bits[31 .. 0]) }
+function clause write_CSR((0x30A, value) if xlen == 64) = { menvcfg = legalize_menvcfg(menvcfg, value); clint_dispatch(false); Ok(menvcfg.bits) }
+function clause write_CSR((0x31A, value) if xlen == 32) = { menvcfg = legalize_menvcfg(menvcfg, value @ menvcfg.bits[31 .. 0]); clint_dispatch(false); Ok(menvcfg.bits[63 .. 32]) }
 function clause write_CSR(0x10A, value) = { senvcfg = legalize_senvcfg(senvcfg, zero_extend(value)); Ok(read_senvcfg().bits[xlen - 1 .. 0]) }
 
 // Return whether or not FIOM is currently active, based on the current


### PR DESCRIPTION
Follow up to #1853. mip[STI] is derived from stimecmp, gated by menvcfg[STCE], so setting STCE changes the timer condition the same way a stimecmp write does. Refresh it there too rather than leaving it stale until the next tick (which is legal, just inconsistent).