### PR TITLE
Correct cache key reference in Rocq CI

### DIFF
--- a/.github/workflows/rocq.yml
+++ b/.github/workflows/rocq.yml
@@ -37,7 +37,7 @@ jobs:
           sail-version: ${{ env.SAIL_VERSION }}
 
       - name: Restore cached opam
-        id: cache-opam-restore
+        id: cache-rocq-opam-restore
         uses: actions/cache/restore@v6
         with:
           path: ~/.opam


### PR DESCRIPTION
Fix a typo that we didn't notice because we only store caches on the master branch, so it didn't show up until after merging the PR.