### PR TITLE
Add bounds checks when loading ELF files.

### DIFF
--- a/c_emulator/riscv_model_impl.cpp
+++ b/c_emulator/riscv_model_impl.cpp
@@ -423,6 +423,14 @@ bool ModelImpl::dtb_within_configured_pma_memory(uint64_t addr, uint64_t size) {
   return zdtb_within_configured_pma_memory(addr, size);
 }
 
+std::vector<MemoryRegion> ModelImpl::memory_regions() const {
+  std::vector<MemoryRegion> regions;
+  for (const auto *region = zpma_regions; region != nullptr; region = region->tl) {
+    regions.push_back({region->hd.zbase, region->hd.zsizze});
+  }
+  return regions;
+}
+
 std::vector<MemoryRegion> ModelImpl::main_memory_regions() const {
   std::vector<MemoryRegion> regions;
   for (const auto *region = zpma_regions; region != nullptr; region = region->tl) {

--- a/c_emulator/riscv_model_impl.h
+++ b/c_emulator/riscv_model_impl.h
@@ -75,6 +75,7 @@ public:
 
   bool config_is_valid();
   bool dtb_within_configured_pma_memory(uint64_t addr, uint64_t size);
+  std::vector<MemoryRegion> memory_regions() const;
   std::vector<MemoryRegion> main_memory_regions() const;
   std::string generate_dts();
   std::string generate_isa_string();

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -129,7 +129,8 @@ void deep_merge_json(jsoncons::json &base, const jsoncons::json &json_override, 
   base = json_override;
 }
 
-void write_dtb_to_rom(ModelImpl &model, const std::vector<uint8_t> &dtb) {
+void write_dtb_to_rom(ModelImpl &model, const std::string &filename, elf_info &elf_info) {
+  std::vector<uint8_t> dtb = read_file(filename);
   uint64_t addr = get_config_uint64({"memory", "dtb_address"});
   uint64_t size = static_cast<uint64_t>(dtb.size());
 
@@ -144,9 +145,10 @@ void write_dtb_to_rom(ModelImpl &model, const std::vector<uint8_t> &dtb) {
   if (!model.dtb_within_configured_pma_memory(addr, size)) {
     fprintf(
       stderr,
-      "DTB does not fit in any configured PMA memory region: "
+      "DTB in '%s' does not fit in any configured PMA memory region: "
       "addr=0x%0" PRIx64 ", size=0x%0" PRIx64 " (end=0x%0" PRIx64 ")\n"
       "Hint: adjust memory.dtb_address or memory.regions in the config.\n",
+      filename.c_str(),
       addr,
       size,
       end
@@ -154,9 +156,24 @@ void write_dtb_to_rom(ModelImpl &model, const std::vector<uint8_t> &dtb) {
     exit(EXIT_FAILURE);
   }
 
+  // Check for conflicts with already loaded regions.
+  const auto &loaded_region_ptr =
+    std::find_if(elf_info.loaded_regions.begin(), elf_info.loaded_regions.end(), [addr, size](const auto &ent) {
+      return addr + size > ent.offset && ent.offset + ent.length > addr;
+    });
+  if (loaded_region_ptr != elf_info.loaded_regions.end()) {
+    std::ostringstream msg;
+    msg << "DTB in " << filename << " of size 0x" << std::hex << size << " @0x" << addr
+        << " conflicts with already loaded segment from file " << loaded_region_ptr->filename << " of size 0x"
+        << loaded_region_ptr->length << " @0x" << loaded_region_ptr->offset << std::endl;
+    throw std::runtime_error(msg.str());
+  }
+
   for (uint8_t d : dtb) {
     write_mem(addr++, d);
   }
+
+  elf_info.loaded_regions.emplace_back(filename, addr, size);
 }
 
 void write_signature(const std::string &file, unsigned signature_granularity, const elf_info &elf_info) {
@@ -696,7 +713,7 @@ InitResult init_model(
 
   if (!opts.dtb_file.empty()) {
     fprintf(stderr, "using %s as DTB file.\n", opts.dtb_file.c_str());
-    write_dtb_to_rom(model, read_file(opts.dtb_file));
+    write_dtb_to_rom(model, opts.dtb_file, elf_info);
   }
 
   entry = run_info.rvfi.has_value() ? rvfi_handler::get_entry()

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -265,13 +265,45 @@ uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file
     break;
   }
 
+  auto memory_regions = model.memory_regions();
+
   // Load into memory.
-  elf.load([](uint64_t address, const uint8_t *data, uint64_t length) {
+  elf.load([&filename, &elf_info, &memory_regions](uint64_t address, const uint8_t *data, uint64_t length) {
+    // Ensure these ELFs are loaded into defined memory regions. Each
+    // ELF segment is required to fit into a single memory
+    // region. This is a conservative check: the memory regions could
+    // technically be contiguous and compatible for the ELF segment,
+    // but this is unlikely.
+    const auto &memory_region_ptr =
+      std::find_if(memory_regions.begin(), memory_regions.end(), [address, length](const auto &ent) {
+        return address >= ent.base && address + length <= ent.base + ent.size;
+      });
+    if (memory_region_ptr == memory_regions.end()) {
+      std::ostringstream msg;
+      msg << "Cannot load segment from " << filename << " of size 0x" << std::hex << length << " @0x" << address
+          << " since it does not lie within any defined main memory region." << std::endl;
+      throw std::runtime_error(msg.str());
+    }
+
+    // Check for conflicts with already loaded regions.
+    const auto &loaded_region_ptr =
+      std::find_if(elf_info.loaded_regions.begin(), elf_info.loaded_regions.end(), [address, length](const auto &ent) {
+        return address + length > ent.offset && ent.offset + ent.length > address;
+      });
+    if (loaded_region_ptr != elf_info.loaded_regions.end()) {
+      std::ostringstream msg;
+      msg << "Load of segment from " << filename << " of size 0x" << std::hex << length << " @0x" << address
+          << " conflicts with already loaded segment from file " << loaded_region_ptr->filename << " of size 0x"
+          << loaded_region_ptr->length << " @0x" << loaded_region_ptr->offset << std::endl;
+      throw std::runtime_error(msg.str());
+    }
+
     // TODO: We could definitely improve on rts.c's memory implementation
     // (which is O(N^2)) and writing one byte at a time here.
     for (uint64_t i = 0; i < length; ++i) {
       write_mem(address + i, data[i]);
     }
+    elf_info.loaded_regions.emplace_back(filename, address, length);
   });
 
   // Load the entire symbol table.

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -169,11 +169,12 @@ void write_dtb_to_rom(ModelImpl &model, const std::string &filename, elf_info &e
     throw std::runtime_error(msg.str());
   }
 
+  auto dtb_addr = addr;
   for (uint8_t d : dtb) {
     write_mem(addr++, d);
   }
 
-  elf_info.loaded_regions.emplace_back(filename, addr, size);
+  elf_info.loaded_regions.emplace_back(filename, dtb_addr, size);
 }
 
 void write_signature(const std::string &file, unsigned signature_granularity, const elf_info &elf_info) {

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -293,7 +293,11 @@ uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file
     // but this is unlikely.
     const auto &memory_region_ptr =
       std::find_if(memory_regions.begin(), memory_regions.end(), [address, length](const auto &ent) {
-        return address >= ent.base && address + length <= ent.base + ent.size;
+        // Handle corner case where a memory region ends at 2^64 for
+        // RV64. `validate_config.sail:check_pma_regions()` ensures
+        // that the end of the memory region cannot exceed this bound.
+        // (There is no such overflow issue for RV32.)
+        return address >= ent.base && (address + length <= ent.base + ent.size || ent.base + ent.size == 0);
       });
     if (memory_region_ptr == memory_regions.end()) {
       std::ostringstream msg;

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -281,7 +281,7 @@ uint64_t load_sail(ModelImpl &model, const std::string &filename, bool main_file
     if (memory_region_ptr == memory_regions.end()) {
       std::ostringstream msg;
       msg << "Cannot load segment from " << filename << " of size 0x" << std::hex << length << " @0x" << address
-          << " since it does not lie within any defined main memory region." << std::endl;
+          << " since it does not lie within any defined memory region." << std::endl;
       throw std::runtime_error(msg.str());
     }
 

--- a/c_emulator/riscv_sim.h
+++ b/c_emulator/riscv_sim.h
@@ -15,12 +15,26 @@ class traploop_detector;
 class stop_at_pc_callbacks;
 class ModelImpl;
 
+// Track the main memory regions initialized by loaded files.
+struct loaded_region {
+  loaded_region(const std::string &filename, uint64_t offset, uint64_t length) :
+      filename(filename),
+      offset(offset),
+      length(length) {
+  }
+  std::string filename;
+  uint64_t offset = 0;
+  uint64_t length = 0;
+};
+
 struct elf_info {
   // The address of the HTIF tohost port, if it is enabled.
   std::optional<uint64_t> htif_tohost_address = {};
   uint64_t mem_sig_start = 0;
   uint64_t mem_sig_end = 0;
   std::map<uint64_t, std::string> symbols = {};
+  // Main memory regions written during initialization.
+  std::vector<loaded_region> loaded_regions;
 };
 
 struct run_info {


### PR DESCRIPTION
This adds two checks:

- each ELF segment is required to fit into a defined memory region

- ELF segments are required to not overlap

The second check is more important when multiple ELF files are loaded.