### PR TITLE
Update zvabd encodings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,8 @@ The following unratified extensions are supported and can be enabled using the `
 
 - Zibi extension for conditional branches with immediate operands, v0.6
 - Zilx extension for indexed integer load instructions, v0.1
-- Zvabd extension for vector absolute difference, v0.7
 - Svukte extension for Address-Independent Latency of User-Mode Faults to Supervisor Addresses, v0.8
+- Zvabd extension for vector absolute difference, v0.9
 
 **For a list of unsupported extensions and features, see the [Extension Roadmap](https://github.com/riscv/sail-riscv/wiki/Extension-Roadmap).**
 

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -62,6 +62,7 @@
     rejects a configuration that supports supervisor mode but no `satp` mode.
   - https://github.com/riscv/sail-riscv/issues/1882 : missed overlap checks for widening vector multiply accumulates
   - https://github.com/riscv/sail-riscv/issues/1880 : some cases of Zvknh instructions did not check for valid `vl`
+  - https://github.com/riscv/sail-riscv/issues/1883 : `Zvabd` was bumped from 0.7 to 0.9. The encoding changed incompatibly during ARC review
 
 - Other notes:
   - The test suite has been updated to the latest release (2026-08-20)

--- a/model/extensions/Zvabd/zvabd_insts.sail
+++ b/model/extensions/Zvabd/zvabd_insts.sail
@@ -8,66 +8,24 @@
 
 function clause currentlyEnabled(Ext_Zvabd) = hartSupports(Ext_Zvabd) & currentlyEnabled(Ext_Zve32x)
 
-// Since the targeted use cases are mostly based on 8-bit and 16-bit integer,
-// `vabd/vabdu/vwabda/vwabdau` are designed for only SEW=8 and SEW=16.
-// Additionally, `vabs` is considered to support all the element sizes
-// as it is quite common used and simple to implement.
-private function valid_zvabd_sew(sew : sew_bitsize) -> bool = sew == 8 | sew == 16
+// The widening `vwabda/vwabdau` instructions are defined for only SEW=8 and
+// SEW=16; other element sizes are reserved encodings.
+private function valid_zvwabda_sew(sew : sew_bitsize) -> bool = sew == 8 | sew == 16
 
-union clause instruction = VABS_V : (bits(1), vregidx, vregidx)
-
-$[wavedrom "funct6 _ _ _ OPMVV _ OP-V"]
-mapping clause encdec = VABS_V(vm, vs2, vd)
-  <-> 0b010010 @ vm @ encdec_vreg(vs2) @ 0b10000 @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when currentlyEnabled(Ext_Zvabd)
-    & ((get_sew() <= 32) | (currentlyEnabled(Ext_Zve64x) & get_sew() <= 64))
-
-function clause execute VABS_V(vm, vs2, vd) = {
-  let SEW      = get_sew();
-  let LMUL_pow = get_lmul_pow();
-  let num_elem = get_num_elem(LMUL_pow, SEW);
-
-  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
-     illegal_normal(vd, vm) |
-     not(valid_vm_src_overlap(vm, vs2, SEW))
-  then return Illegal_Instruction();
-
-  let 'n = num_elem;
-  let 'm = SEW;
-
-  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
-  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
-  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
-
-  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
-  var result = initial_result;
-
-  foreach (i from 0 to (num_elem - 1)) {
-    if mask[i] == 0b1 then
-      result[i] = to_bits(SEW, abs_int(signed(vs2_val[i])))
-  };
-
-  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
-  set_vstart(zeros());
-  RETIRE_SUCCESS
-}
-
-mapping clause assembly = VABS_V(vm, vs2, vd)
-  <-> "vabs.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
-
-union clause instruction = ZVABDTYPE : (zvabd_vabd_func6, bits(1), vregidx, vregidx, vregidx)
+// ****************************** OPMVV (vabd.vv / vabdu.vv) ********************************
+union clause instruction = ZVABD_VV : (zvabd_vabd_func6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_zvabd_vabd_func6 : zvabd_vabd_func6 <-> bits(6) = {
-  VV_VABD  <-> 0b010001,
-  VV_VABDU <-> 0b010011
+  VABD  <-> 0b010101,
+  VABDU <-> 0b010110
 }
 
 $[wavedrom "funct6 _ _ _ OPMVV _ OP-V"]
-mapping clause encdec = ZVABDTYPE(funct6, vm, vs2, vs1, vd)
+mapping clause encdec = ZVABD_VV(funct6, vm, vs2, vs1, vd)
   <-> encdec_zvabd_vabd_func6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when currentlyEnabled(Ext_Zvabd) & valid_zvabd_sew(get_sew())
+  when currentlyEnabled(Ext_Zvabd) & (get_sew() <= 32 | (currentlyEnabled(Ext_Zve64x) & get_sew() <= 64))
 
-function clause execute ZVABDTYPE(funct6, vm, vs2, vs1, vd) = {
+function clause execute ZVABD_VV(funct6, vm, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -92,8 +50,8 @@ function clause execute ZVABDTYPE(funct6, vm, vs2, vs1, vd) = {
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == 0b1 then {
       result[i] = match funct6 {
-        VV_VABD  => to_bits(SEW, abs_int(signed(vs2_val[i]) - signed(vs1_val[i]))),
-        VV_VABDU => to_bits(SEW, abs_int(unsigned(vs2_val[i]) - unsigned(vs1_val[i])))
+        VABD  => to_bits(SEW, abs_int(signed(vs2_val[i]) - signed(vs1_val[i]))),
+        VABDU => to_bits(SEW, abs_int(unsigned(vs2_val[i]) - unsigned(vs1_val[i])))
       };
     }
   };
@@ -103,27 +61,86 @@ function clause execute ZVABDTYPE(funct6, vm, vs2, vs1, vd) = {
   RETIRE_SUCCESS
 }
 
-mapping vabd_mnemonic : zvabd_vabd_func6 <-> string = {
-  VV_VABD  <-> "vabd.vv",
-  VV_VABDU <-> "vabdu.vv"
+mapping vabd_vv_mnemonic : zvabd_vabd_func6 <-> string = {
+  VABD  <-> "vabd.vv",
+  VABDU <-> "vabdu.vv"
 }
 
-mapping clause assembly = ZVABDTYPE(funct6, vm, vs2, vs1, vd)
-  <-> vabd_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+mapping clause assembly = ZVABD_VV(funct6, vm, vs2, vs1, vd)
+  <-> vabd_vv_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
 
-union clause instruction = ZVWABDATYPE : (zvabd_vwabda_func6, bits(1), vregidx, vregidx, vregidx)
+// ****************************** OPMVX (vabd.vx / vabdu.vx) ********************************
+union clause instruction = ZVABD_VX : (zvabd_vabd_func6, bits(1), vregidx, regidx, vregidx)
+
+$[wavedrom "funct6 _ _ _ OPMVX _ OP-V"]
+mapping clause encdec = ZVABD_VX(funct6, vm, vs2, rs1, vd)
+  <-> encdec_zvabd_vabd_func6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b110 @ encdec_vreg(vd) @ 0b1010111
+  when currentlyEnabled(Ext_Zvabd) & (get_sew() <= 32 | (currentlyEnabled(Ext_Zve64x) & get_sew() <= 64))
+
+function clause execute ZVABD_VX(funct6, vm, vs2, rs1, vd) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
+     illegal_normal(vd, vm) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
+  then return Illegal_Instruction();
+
+  let 'n = num_elem;
+  let 'm = SEW;
+
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
+  let rs1_val : bits('m)             = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+  let vd_val  : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vd);
+
+  let (initial_result, mask) : (vector('n, bits('m)), bits('n)) = init_masked_result(num_elem, SEW, LMUL_pow, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == 0b1 then {
+      result[i] = match funct6 {
+        VABD  => to_bits(SEW, abs_int(signed(vs2_val[i]) - signed(rs1_val))),
+        VABDU => to_bits(SEW, abs_int(unsigned(vs2_val[i]) - unsigned(rs1_val)))
+      };
+    }
+  };
+
+  write_vreg(num_elem, SEW, LMUL_pow, vd, result);
+  set_vstart(zeros());
+  RETIRE_SUCCESS
+}
+
+mapping vabd_vx_mnemonic : zvabd_vabd_func6 <-> string = {
+  VABD  <-> "vabd.vx",
+  VABDU <-> "vabdu.vx"
+}
+
+// `vabs.v vd, vs2` is a pseudoinstruction for `vabd.vx vd, vs2, x0`
+// (abs(vs2 - x0) == abs(vs2)). Only the disassembly (forwards) direction is
+// provided; the assembly direction still uses `vabd.vx vd, vs2, x0`.
+mapping clause assembly =
+  forwards ZVABD_VX(VABD, vm, vs2, rs1, vd) => "vabs.v" ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ maybe_vmask(vm)
+    when rs1 == zreg
+
+mapping clause assembly = ZVABD_VX(funct6, vm, vs2, rs1, vd)
+  <-> vabd_vx_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)
+
+// ************************** OPIVV (vwabda.vv / vwabdau.vv Widening) ***************************
+union clause instruction = ZVWABDA_VV : (zvabd_vwabda_func6, bits(1), vregidx, vregidx, vregidx)
 
 mapping encdec_zvabd_vwabda_func6 : zvabd_vwabda_func6 <-> bits(6) = {
-  VV_VWABDA  <-> 0b010101,
-  VV_VWABDAU <-> 0b010110
+  VWABDA  <-> 0b111101,
+  VWABDAU <-> 0b111110
 }
 
-$[wavedrom "funct6 _ _ _ OPMVV _ OP-V"]
-mapping clause encdec = ZVWABDATYPE(funct6, vm, vs2, vs1, vd)
-  <-> encdec_zvabd_vwabda_func6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b010 @ encdec_vreg(vd) @ 0b1010111
-  when currentlyEnabled(Ext_Zvabd) & valid_zvabd_sew(get_sew())
+$[wavedrom "funct6 _ _ _ OPIVV _ OP-V"]
+mapping clause encdec = ZVWABDA_VV(funct6, vm, vs2, vs1, vd)
+  <-> encdec_zvabd_vwabda_func6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_vreg(vs1) @ 0b000 @ encdec_vreg(vd) @ 0b1010111
+  when currentlyEnabled(Ext_Zvabd) & valid_zvwabda_sew(get_sew())
 
-function clause execute ZVWABDATYPE(funct6, vm, vs2, vs1, vd) = {
+function clause execute ZVWABDA_VV(funct6, vm, vs2, vs1, vd) = {
   let SEW      = get_sew();
   let LMUL_pow = get_lmul_pow();
   let num_elem = get_num_elem(LMUL_pow, SEW);
@@ -134,6 +151,9 @@ function clause execute ZVWABDATYPE(funct6, vm, vs2, vs1, vd) = {
      illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
      not(valid_reg_overlap(vs1, vd, LMUL_pow, LMUL_pow_widen)) |
      not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     // vd is also a source register
+     not(valid_src_overlap(vs1, SEW, LMUL_pow, vd, SEW_widen, LMUL_pow_widen)) |
+     not(valid_src_overlap(vs2, SEW, LMUL_pow, vd, SEW_widen, LMUL_pow_widen)) |
      not(valid_vm_src_overlap(vm, vs1, SEW)) |
      not(valid_vm_src_overlap(vm, vs2, SEW))
   then return Illegal_Instruction();
@@ -156,15 +176,15 @@ function clause execute ZVWABDATYPE(funct6, vm, vs2, vs1, vd) = {
   foreach (i from 0 to (num_elem - 1)) {
     if mask[i] == 0b1 then {
       result[i] = match funct6 {
-        VV_VWABDA  => {
+        VWABDA  => {
           let diff = signed(vs2_val[i]) - signed(vs1_val[i]);
-          to_bits_unsafe(SEW_widen, signed(vd_val[i]) + abs_int(diff))
+          to_bits_truncate(SEW_widen, signed(vd_val[i]) + abs_int(diff))
         },
-        VV_VWABDAU => {
+        VWABDAU => {
           let abs_diff = if unsigned(vs2_val[i]) >= unsigned(vs1_val[i])
                          then unsigned(vs2_val[i] - vs1_val[i])
                          else unsigned(vs1_val[i] - vs2_val[i]);
-          to_bits_unsafe(SEW_widen, unsigned(vd_val[i]) + abs_diff)
+          to_bits_truncate(SEW_widen, unsigned(vd_val[i]) + abs_diff)
         }
       };
     }
@@ -175,10 +195,78 @@ function clause execute ZVWABDATYPE(funct6, vm, vs2, vs1, vd) = {
   RETIRE_SUCCESS
 }
 
-mapping vwabda_mnemonic : zvabd_vwabda_func6 <-> string = {
-  VV_VWABDA  <-> "vwabda.vv",
-  VV_VWABDAU <-> "vwabdau.vv"
+mapping vwabda_vv_mnemonic : zvabd_vwabda_func6 <-> string = {
+  VWABDA  <-> "vwabda.vv",
+  VWABDAU <-> "vwabdau.vv"
 }
 
-mapping clause assembly = ZVWABDATYPE(funct6, vm, vs2, vs1, vd)
-  <-> vwabda_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+mapping clause assembly = ZVWABDA_VV(funct6, vm, vs2, vs1, vd)
+  <-> vwabda_vv_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ vreg_name(vs1) ^ maybe_vmask(vm)
+
+// ************************** OPIVX (vwabda.vx / vwabdau.vx Widening) ***************************
+union clause instruction = ZVWABDA_VX : (zvabd_vwabda_func6, bits(1), vregidx, regidx, vregidx)
+
+$[wavedrom "funct6 _ _ _ OPIVX _ OP-V"]
+mapping clause encdec = ZVWABDA_VX(funct6, vm, vs2, rs1, vd)
+  <-> encdec_zvabd_vwabda_func6(funct6) @ vm @ encdec_vreg(vs2) @ encdec_reg(rs1) @ 0b100 @ encdec_vreg(vd) @ 0b1010111
+  when currentlyEnabled(Ext_Zvabd) & valid_zvwabda_sew(get_sew())
+
+function clause execute ZVWABDA_VX(funct6, vm, vs2, rs1, vd) = {
+  let SEW      = get_sew();
+  let LMUL_pow = get_lmul_pow();
+  let num_elem = get_num_elem(LMUL_pow, SEW);
+  let SEW_widen      = SEW * 2;
+  let LMUL_pow_widen = LMUL_pow + 1;
+
+  if illegal_vstart(VSTART_ARITH, num_elem, LMUL_pow) |
+     illegal_variable_width(vd, vm, SEW_widen, LMUL_pow_widen) |
+     not(valid_reg_overlap(vs2, vd, LMUL_pow, LMUL_pow_widen)) |
+     // vd is also a source register
+     not(valid_src_overlap(vs2, SEW, LMUL_pow, vd, SEW_widen, LMUL_pow_widen)) |
+     not(valid_vm_src_overlap(vm, vs2, SEW))
+  then return Illegal_Instruction();
+
+  assert(SEW_widen == 16 | SEW_widen == 32);
+  assert(LMUL_pow_widen <= 3);
+
+  let 'n = num_elem;
+  let 'm = SEW;
+  let 'o = SEW_widen;
+
+  let vm_val  : bits('n)             = read_vmask(num_elem, vm, zvreg);
+  let vd_val  : vector('n, bits('o)) = read_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd);
+  let rs1_val : bits('m)             = get_scalar(rs1, SEW);
+  let vs2_val : vector('n, bits('m)) = read_vreg(num_elem, SEW, LMUL_pow, vs2);
+
+  let (initial_result, mask) : (vector('n, bits('o)), bits('n)) = init_masked_result(num_elem, SEW_widen, LMUL_pow_widen, vd_val, vm_val);
+  var result = initial_result;
+
+  foreach (i from 0 to (num_elem - 1)) {
+    if mask[i] == 0b1 then {
+      result[i] = match funct6 {
+        VWABDA  => {
+          let diff = signed(vs2_val[i]) - signed(rs1_val);
+          to_bits_truncate(SEW_widen, signed(vd_val[i]) + abs_int(diff))
+        },
+        VWABDAU => {
+          let abs_diff = if unsigned(vs2_val[i]) >= unsigned(rs1_val)
+                         then unsigned(vs2_val[i] - rs1_val)
+                         else unsigned(rs1_val - vs2_val[i]);
+          to_bits_truncate(SEW_widen, unsigned(vd_val[i]) + abs_diff)
+        }
+      };
+    }
+  };
+
+  write_vreg(num_elem, SEW_widen, LMUL_pow_widen, vd, result);
+  set_vstart(zeros());
+  RETIRE_SUCCESS
+}
+
+mapping vwabda_vx_mnemonic : zvabd_vwabda_func6 <-> string = {
+  VWABDA  <-> "vwabda.vx",
+  VWABDAU <-> "vwabdau.vx"
+}
+
+mapping clause assembly = ZVWABDA_VX(funct6, vm, vs2, rs1, vd)
+  <-> vwabda_vx_mnemonic(funct6) ^ spc() ^ vreg_name(vd) ^ sep() ^ vreg_name(vs2) ^ sep() ^ reg_name(rs1) ^ maybe_vmask(vm)

--- a/model/extensions/Zvabd/zvabd_types.sail
+++ b/model/extensions/Zvabd/zvabd_types.sail
@@ -6,5 +6,5 @@
 // SPDX-License-Identifier: BSD-2-Clause
 // =======================================================================================
 
-enum zvabd_vabd_func6 = {VV_VABD, VV_VABDU}
-enum zvabd_vwabda_func6 = {VV_VWABDA, VV_VWABDAU}
+enum zvabd_vabd_func6 = {VABD, VABDU}
+enum zvabd_vwabda_func6 = {VWABDA, VWABDAU}


### PR DESCRIPTION
See https://github.com/riscv/riscv-isa-manual/pull/3279

During freeze review process, the encodings have changed incompatibly and the version has been bumped from 0.7 to 0.9.

new encodings from ARC:
- vabd.vv funct3=OPMVV, funct6=0x15, support all SEWs
- vabd.vx funct3=OPMVX, funct6=0x15, support all SEWs
- vabdu.vv funct3=OPMVV, funct6=0x16, support all SEWs
- vabdu.vx funct3=OPMVX, funct6=0x16, support all SEWs
- vwabda.vv funct3=OPIVV, funct6=0x3D, support SEW of 8 and 16
- vwabda.vx funct3=OPIVX, funct6=0x3D, support SEW of 8 and 16
- vwabdau.vv funct3=OPIVV, funct6=0x3E, support SEW of 8 and 16
- vwabdau.vx funct3=OPIVX, funct6=0x3E, support SEW of 8 and 16

Closes #1883