### PR TITLE
Add `platform.msi_supported` config for cores without MSI.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -421,6 +421,10 @@
       "base": 33554432,
       "size": 786432
     },
+    // Whether machine software interrupts are implemented (mip.MSIP / mie.MSIE).
+    // When false, those bits are read-only zero for CSR access and interrupt
+    // dispatch, and the Simple Interrupt Generator cannot set MSIP.
+    "msi_supported": true,
     // Very simple MMIO device to generate interrupts for testing
     // purposes. See docs/SimpleInterruptGenerator.md for details.
     "simple_interrupt_generator": {

--- a/model/core/interrupt_regs.sail
+++ b/model/core/interrupt_regs.sail
@@ -26,6 +26,9 @@ bitfield Minterrupts : xlenbits = {
   SSI  : 1,  // Supervisor software interrupt
 }
 
+private function apply_msi_policy(m : Minterrupts) -> Minterrupts =
+  if plat_msi_supported then m else [m with MSI = 0b0]
+
 private function legalize_mip(o : Minterrupts, v : xlenbits) -> Minterrupts = {
   // The only writable bits are the S-mode bits.
   let v = Mk_Minterrupts(v);
@@ -46,7 +49,7 @@ private function legalize_mie(o : Minterrupts, v : xlenbits) -> Minterrupts = {
     LCOFI = if currentlyEnabled(Ext_Sscofpmf) then v[LCOFI] else 0b0,
     MEI = v[MEI],
     MTI = v[MTI],
-    MSI = v[MSI],
+    MSI = if plat_msi_supported then v[MSI] else 0b0,
     SEI = if currentlyEnabled(Ext_S) then v[SEI] else 0b0,
     STI = if currentlyEnabled(Ext_S) then v[STI] else 0b0,
     SSI = if currentlyEnabled(Ext_S) then v[SSI] else 0b0,
@@ -146,16 +149,18 @@ enum XipReadType = {
 }
 
 function read_mip(read_type : XipReadType) -> Minterrupts =
-  match read_type {
-    IncludePlatformInterrupts => Mk_Minterrupts(mip.bits | external_interrupts_pending().bits),
-    ExcludePlatformInterrupts => mip,
-  }
+  apply_msi_policy(
+    match read_type {
+      IncludePlatformInterrupts => Mk_Minterrupts(mip.bits | external_interrupts_pending().bits),
+      ExcludePlatformInterrupts => mip,
+    }
+  )
 
 function write_mip(value : xlenbits) -> unit = {
   mip = legalize_mip(mip, value);
 }
 
-function clause read_CSR(0x304) = mie.bits
+function clause read_CSR(0x304) = apply_msi_policy(mie).bits
 function clause read_CSR(0x344) = read_mip(ExcludePlatformInterrupts).bits
 function clause read_CSR(0x302) = medeleg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x312 if xlen == 32) = medeleg.bits[63 .. 32]
@@ -244,7 +249,7 @@ private function lift_sie(o : Minterrupts, d : Minterrupts, s : Sinterrupts) -> 
     SEI   = if d[SEI] == 0b1 then s[SEI] else o[SEI],
     MTI   = if d[MTI] == 0b1 then s[MTI] else o[MTI],
     STI   = if d[STI] == 0b1 then s[STI] else o[STI],
-    MSI   = if d[MSI] == 0b1 then s[MSI] else o[MSI],
+    MSI   = if plat_msi_supported & d[MSI] == 0b1 then s[MSI] else o[MSI],
     SSI   = if d[SSI] == 0b1 then s[SSI] else o[SSI],
     LCOFI = if d[LCOFI] == 0b1 then s[LCOFI] else o[LCOFI],
   ]

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -104,6 +104,10 @@ let plat_have_clint : bool = config platform.clint.supported
 let plat_clint_base : physaddrbits = to_bits_checked(config platform.clint.base : int)
 let plat_clint_size : physaddrbits = to_bits_checked(config platform.clint.size : int)
 
+// When false, mip.MSIP and mie.MSIE are read-only zero for CSR access and
+// interrupt dispatch, and the Simple Interrupt Generator cannot set MSIP.
+let plat_msi_supported : bool = config platform.msi_supported
+
 // Simple Interrupt Generator. See docs/SimpleInterruptGenerator.md for details.
 let plat_have_sig : bool = config platform.simple_interrupt_generator.supported
 let plat_sig_base : physaddrbits = to_bits_checked(config platform.simple_interrupt_generator.base : int)

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -426,6 +426,13 @@ private function check_mem_layout() -> bool =
     pmas_ok & clint_ok & sig_ok
   }
 
+private function check_msi_config() -> bool =
+  if plat_msi_supported then true
+  else if Mk_Minterrupts(plat_mideleg_delegatable_bits)[MSI] == 0b1 then {
+    print_endline("platform.msi_supported is false but base.mideleg.delegatable_bits includes MSI (bit 3).");
+    false
+  } else true
+
 private function check_pmp() -> bool = {
   var valid : bool = true;
   if (config memory.pmp.na4_supported : bool) & sys_pmp_grain != 0
@@ -691,6 +698,7 @@ function config_is_valid() -> bool = {
   & check_physaddr_bits()
   & check_mmu_config()
   & check_mem_layout()
+  & check_msi_config()
   & check_mmio_devices()
   & check_vlen_elen()
   & check_vext_config()

--- a/model/sys/simple_interrupt_generator.sail
+++ b/model/sys/simple_interrupt_generator.sail
@@ -47,7 +47,7 @@ function sig_store(addr, width, data) = {
 
       if data[MEI] == 0b1 then sig_meip = value;
       if data[SEI] == 0b1 then sig_seip = value;
-      if data[MSI] == 0b1 then mip[MSI] = value;
+      if data[MSI] == 0b1 & plat_msi_supported then mip[MSI] = value;
       // SSI is read-only zero if the hart does not support supervisor mode.
       if data[SSI] == 0b1 & currentlyEnabled(Ext_S) then mip[SSI] = value;
 


### PR DESCRIPTION
MSI may not be supported on some implementations. Default true preserves current behaviour. When false, mip.MSIP and mie.MSIE are read-only zero for CSR access and interrupt dispatch, sie/sip MSI is not writable via delegation, and the Simple Interrupt Generator cannot set MSIP.

Validated against ACT Interrupt suites for cores that do not implement MSI (Sail goldens aligned with Whisper/RTL mideleg WARL of 0x2222).

Generative AI (Cursor) was used to draft this change and commit message.