### PR TITLE
gdbserver: some minor fixes and cleanup

### DIFF
--- a/c_emulator/gdb/protocol_handler.h
+++ b/c_emulator/gdb/protocol_handler.h
@@ -4,6 +4,7 @@
 #include "requests.h"
 #include "riscv_callbacks_if.h"
 #include "riscv_model_impl.h"
+#include "target_regs.h"
 #include "triggers.h"
 #include <asio.hpp>
 #include <deque>
@@ -30,6 +31,7 @@ public:
       m_run_info{info},
       m_triggers{info} {
 
+    m_reg_map = ::get_register_map();
     m_insns_per_tick = get_config_uint64({"platform", "instructions_per_tick"});
   }
 
@@ -80,6 +82,11 @@ public:
     return m_model;
   }
 
+  // Access to the register map
+  const register_map &get_register_map() const {
+    return m_reg_map;
+  }
+
   // Execution helpers
   void do_step();
   void start_continue();
@@ -115,12 +122,15 @@ private:
   std::deque<response_handler_ptr> m_pending_responses;
   bool m_in_noack_mode = false;
 
+  // configuration
+  register_map m_reg_map;
+
   // execution state
   ModelImpl &m_model;
   gdb_run_info &m_run_info;
   int64_t m_step_no = 0;
   int64_t m_insn_cnt = 0;
-  int64_t m_insns_per_tick = 0;
+  uint64_t m_insns_per_tick = 0;
   int64_t m_interrupt_count = 0;
   bool m_has_trapped = false;
   bool m_triggered = false;

--- a/c_emulator/gdb/responses.cpp
+++ b/c_emulator/gdb/responses.cpp
@@ -124,20 +124,17 @@ void question::dispatch(protocol_handler &proto_handler, gdb_run_info &) {
 }
 
 void read_general_registers::dispatch(protocol_handler &proto_handler, gdb_run_info &) {
-  ModelImpl &model = proto_handler.get_model();
-  auto regs = get_general_regs(model);
+  auto regs = get_general_regs(proto_handler);
   proto_handler.send_response(regs);
 }
 
 void read_register::dispatch(protocol_handler &proto_handler, gdb_run_info &) {
-  ModelImpl &model = proto_handler.get_model();
-  auto reg = get_register(model, m_regidx);
+  auto reg = get_register(proto_handler, m_regidx);
   proto_handler.send_response(reg);
 }
 
 void write_register::dispatch(protocol_handler &proto_handler, gdb_run_info &) {
-  ModelImpl &model = proto_handler.get_model();
-  auto reg = set_register(model, m_regidx, m_regval);
+  auto reg = set_register(proto_handler, m_regidx, m_regval);
   proto_handler.send_response(reg);
 }
 

--- a/c_emulator/gdb/target_regs.cpp
+++ b/c_emulator/gdb/target_regs.cpp
@@ -63,7 +63,7 @@ std::string get_target_xml(const ModelImpl &model) {
 
   bool have_double = get_config_bool({"extensions", "D", "supported"});
   bool have_single = get_config_bool({"extensions", "F", "supported"});
-  if (have_double || have_single) {
+  if (have_single) {
     // The `org.gnu.gdb.riscv.fpu` feature is optional. If present, it
     // should contain registers `f0` through `f31`, `fflags`, `frm`,
     // and `fcsr`. As with the cpu feature, either the architectural
@@ -136,9 +136,8 @@ std::string get_general_regs(protocol_handler &proto_handler) {
   }
   append_reg(buf, model.pc(), int_width_bytes);
 
-  bool have_double = get_config_bool({"extensions", "D", "supported"});
   bool have_single = get_config_bool({"extensions", "F", "supported"});
-  if (have_double || have_single) {
+  if (have_single) {
     int64_t float_width_bytes = model.flen() / 8;
     for (int64_t i = 0; i < 32; ++i) {
       const uint64_t val = model.freg(i);
@@ -158,7 +157,6 @@ std::string get_register(protocol_handler &proto_handler, uint64_t regidx) {
   buf << std::hex << std::setfill('0');
   int64_t int_width_bytes = model.xlen() / 8;
 
-  bool have_double = get_config_bool({"extensions", "D", "supported"});
   bool have_single = get_config_bool({"extensions", "F", "supported"});
 
   if (0 <= idx && idx < map.pc_offset) {
@@ -166,7 +164,7 @@ std::string get_register(protocol_handler &proto_handler, uint64_t regidx) {
     append_reg(buf, val, int_width_bytes);
   } else if (idx == map.pc_offset) {
     append_reg(buf, model.pc(), int_width_bytes);
-  } else if ((have_single || have_double) && map.fpr_offset <= idx && idx <= map.fcsr_offset) {
+  } else if (have_single && map.fpr_offset <= idx && idx <= map.fcsr_offset) {
     if (idx == map.fcsr_offset) {
       append_reg(buf, model.fcsr(), 4);
     } else {
@@ -186,14 +184,13 @@ std::string set_register(protocol_handler &proto_handler, uint64_t regidx, uint6
   const register_map map = proto_handler.get_register_map();
   ModelImpl &model = proto_handler.get_model();
 
-  bool have_double = get_config_bool({"extensions", "D", "supported"});
   bool have_single = get_config_bool({"extensions", "F", "supported"});
 
   if (0 <= reg && reg < map.pc_offset) {
     model.set_xreg(reg, val);
   } else if (reg == map.pc_offset) {
     model.set_pc(val);
-  } else if ((have_single || have_double) && map.fpr_offset <= reg && reg <= map.fcsr_offset) {
+  } else if (have_single && map.fpr_offset <= reg && reg <= map.fcsr_offset) {
     if (reg == map.fcsr_offset) {
       model.set_fcsr(val);
     } else {

--- a/c_emulator/gdb/target_regs.cpp
+++ b/c_emulator/gdb/target_regs.cpp
@@ -1,6 +1,8 @@
 #include "target_regs.h"
 #include "config_utils.h"
+#include "protocol_handler.h"
 #include "riscv_model_impl.h"
+
 #include <sstream>
 
 register_map get_register_map() {
@@ -117,8 +119,9 @@ void append_reg(std::ostringstream &buf, uint64_t val, int64_t width) {
 
 } // namespace
 
-std::string get_general_regs(ModelImpl &model) {
-  const register_map map = get_register_map();
+std::string get_general_regs(protocol_handler &proto_handler) {
+  const register_map map = proto_handler.get_register_map();
+  ModelImpl &model = proto_handler.get_model();
   std::ostringstream buf;
   buf << std::hex << std::setfill('0');
   int64_t int_width_bytes = model.xlen() / 8;
@@ -142,9 +145,10 @@ std::string get_general_regs(ModelImpl &model) {
   return buf.str();
 }
 
-std::string get_register(ModelImpl &model, uint64_t regidx) {
+std::string get_register(protocol_handler &proto_handler, uint64_t regidx) {
   int64_t idx = static_cast<int64_t>(regidx);
-  const register_map map = get_register_map();
+  const register_map map = proto_handler.get_register_map();
+  ModelImpl &model = proto_handler.get_model();
 
   std::ostringstream buf;
   buf << std::hex << std::setfill('0');
@@ -173,9 +177,10 @@ std::string get_register(ModelImpl &model, uint64_t regidx) {
   return buf.str();
 }
 
-std::string set_register(ModelImpl &model, uint64_t regidx, uint64_t val) {
+std::string set_register(protocol_handler &proto_handler, uint64_t regidx, uint64_t val) {
   int64_t reg = static_cast<int64_t>(regidx);
-  const register_map map = get_register_map();
+  const register_map map = proto_handler.get_register_map();
+  ModelImpl &model = proto_handler.get_model();
 
   bool have_double = get_config_bool({"extensions", "D", "supported"});
   bool have_single = get_config_bool({"extensions", "F", "supported"});

--- a/c_emulator/gdb/target_regs.cpp
+++ b/c_emulator/gdb/target_regs.cpp
@@ -45,7 +45,8 @@ std::string get_target_xml(const ModelImpl &model) {
   int regnum = 0;
   for (int i = 0; i < 32; ++i) {
     std::string typ = (i == 1) ? "code_ptr" : ((i == 2 || i == 3 || i == 4 || i == 8) ? "data_ptr" : "int");
-    xml << "  <reg name=\"x" << i << "\" bitsize=\"" << model.xlen() << "\" type=\"" << typ << "\"";
+    xml << "  <reg name=\"x" << i << "\" bitsize=\"" << model.xlen() << "\" type=\"" << typ
+        << "\" save-restore=\"yes\" group=\"general\"";
     if (i == 0) {
       xml << R"( regnum="0" )";
     }
@@ -53,7 +54,8 @@ std::string get_target_xml(const ModelImpl &model) {
     ++regnum;
   }
   assert(regnum == map.pc_offset);
-  xml << "  <reg name=\"pc\" bitsize=\"" << model.xlen() << "\" type=\"code_ptr\"/>" << std::endl;
+  xml << "  <reg name=\"pc\" bitsize=\"" << model.xlen()
+      << "\" type=\"code_ptr\" save-restore=\"yes\" group=\"general\"/>" << std::endl;
   xml << "</feature>" << std::endl;
 
   ++regnum;
@@ -81,14 +83,16 @@ std::string get_target_xml(const ModelImpl &model) {
       fpu_type = "ieee_single";
     }
     for (int i = 0; i < 32; ++i) {
-      xml << "  <reg name=\"f" << i << "\" bitsize=\"" << model.flen() << "\" type=\"" << fpu_type << "\"";
+      xml << "  <reg name=\"f" << i << "\" bitsize=\"" << model.flen() << "\" type=\"" << fpu_type
+          << "\" save-restore=\"yes\" group=\"float\"";
       if (i == 0) {
-        xml << " regnum = \"" << regnum << "\"";
+        xml << " regnum=\"" << regnum << "\"";
       }
       xml << "/>" << std::endl;
       ++regnum;
     }
-    xml << "  <reg name=\"fcsr\" bitsize=\"32\" type=\"int\" regnum=\"" << regnum << "\"/>" << std::endl;
+    xml << "  <reg name=\"fcsr\" bitsize=\"32\" type=\"int\" save-restore=\"no\" group=\"float\" regnum=\"" << regnum
+        << "\"/>" << std::endl;
     xml << "</feature>" << std::endl;
   }
 

--- a/c_emulator/gdb/target_regs.h
+++ b/c_emulator/gdb/target_regs.h
@@ -4,6 +4,7 @@
 #include <string>
 
 class ModelImpl;
+class protocol_handler;
 
 // The indices of the registers in the register map.
 struct register_map {
@@ -25,8 +26,8 @@ std::string get_target_xml(const ModelImpl &model);
 // TODO: make these take `const ModelImpl &`.
 
 // Generates the response for `g` (read general registers).
-std::string get_general_regs(ModelImpl &model);
+std::string get_general_regs(protocol_handler &proto_handler);
 // Generates the response for `p` (read register).
-std::string get_register(ModelImpl &model, uint64_t regidx);
+std::string get_register(protocol_handler &proto_handler, uint64_t regidx);
 // Generates the response for `P` (write register).
-std::string set_register(ModelImpl &model, uint64_t regidx, uint64_t val);
+std::string set_register(protocol_handler &proto_handler, uint64_t regidx, uint64_t val);


### PR DESCRIPTION
This adds the `group` register attribute to allow gdb commands like `info registers float` to work.  The `save-restore` attribute is also added for explicitness, since it is not true for CSRs.

This also removes an unnecessary check for the 'D' extension when checking for 'F' is sufficient, and caches the register map in the `protocol_handler` instead of re-computing it everytime it is needed.  The latter will be useful when CSRs and vector registers are added to the map.

This also fixes a `clang-tidy` warning for `m_insns_per_tick`.

