### PR TITLE
Add the XUANTIE-RV/damo-rv-priv-ats hypervisor tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
             -DFIRST_PARTY_TESTS=${{ matrix.first_party_tests }} \
             -DENABLE_RISCV_TESTS=TRUE \
             -DENABLE_RISCV_ARCH_TESTS=TRUE \
+            -DENABLE_DAMO_TESTS=TRUE \
             -DENABLE_RISCV_VECTOR_TESTS_V64_E64=TRUE \
             -DENABLE_RISCV_VECTOR_TESTS_V128_E32=TRUE \
             -DENABLE_LTO=TRUE \

--- a/.github/workflows/run-full-tests.yml
+++ b/.github/workflows/run-full-tests.yml
@@ -23,6 +23,7 @@ jobs:
           [
             RISCV_TESTS,
             RISCV_ARCH_TESTS,
+            DAMO_TESTS,
             RISCV_VECTOR_TESTS_V64_E32,
             RISCV_VECTOR_TESTS_V64_E64,
             RISCV_VECTOR_TESTS_V128_E32,

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -20,6 +20,11 @@
   - https://github.com/riscv/sail-riscv/issues/1882 : missed overlap checks for widening vector multiply accumulates
   - https://github.com/riscv/sail-riscv/issues/1880 : some cases of Zvknh instructions did not check for valid `vl`
 
+- Other notes:
+  - The test suite has been updated to the latest release (2026-08-20)
+    from sail-riscv-tests. This adds the `XUANTIE-RV/damo-rv-priv-ats` hypervisor
+    tests, enabled with `-DENABLE_DAMO_TESTS=TRUE`.
+
 # Release notes for version 0.13.1
 
 This is primarily a bug-fix release with fixes for the issues listed

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake options for test downloads
 set(TEST_DOWNLOAD_URL "https://github.com/riscv-software-src/sail-riscv-tests/releases/download" CACHE STRING "Base URL to download precompiled riscv-tests and riscv-vector-tests from")
-set(TEST_DOWNLOAD_VERSION "2026-06-10" CACHE STRING "Version of precompiled tests to download")
+set(TEST_DOWNLOAD_VERSION "2026-08-20" CACHE STRING "Version of precompiled tests to download")
 
 # Function to download and extract test files
 function(download_riscv_tests DOWNLOAD_PATH TARBALL_NAME DOWNLOAD_URL)
@@ -126,6 +126,38 @@ if(ENABLE_RISCV_TESTS)
     endforeach()
 endif()
 
+# Download and add damo-rv-priv-ats hypervisor tests.
+option(ENABLE_DAMO_TESTS "Enable damo-rv-priv-ats tests" OFF)
+
+if(ENABLE_DAMO_TESTS)
+    set(TARBALL_NAME "damo-tests")
+    set(DOWNLOAD_PATH "${CMAKE_CURRENT_BINARY_DIR}/${TEST_DOWNLOAD_VERSION}")
+    set(DOWNLOAD_URL "${TEST_DOWNLOAD_URL}/${TEST_DOWNLOAD_VERSION}/${TARBALL_NAME}.tar.gz")
+
+    download_riscv_tests(
+        "${DOWNLOAD_PATH}"
+        "${TARBALL_NAME}"
+        "${DOWNLOAD_URL}"
+    )
+
+    # Currently, damo-rv-priv-ats only supports RV64.
+    # Each ELF lives one directory deep, e.g. Sv39x4/sv39x4_test.elf.
+    file(GLOB elf_list CONFIGURE_DEPENDS LIST_DIRECTORIES false
+        "${DOWNLOAD_PATH}/${TARBALL_NAME}/*/*.elf"
+    )
+    foreach(elf IN LISTS elf_list)
+        file(RELATIVE_PATH elf_name "${CMAKE_CURRENT_BINARY_DIR}" ${elf})
+        add_test(
+            NAME "${elf_name}"
+            COMMAND
+                $<TARGET_FILE:sail_riscv_sim>
+                # ELEN=XLEN. These tests don't use vector so it doesn't matter.
+                --config "${CMAKE_BINARY_DIR}/config/rv64d_v256_e64.json"
+                ${elf}
+        )
+    endforeach()
+endif()
+
 # Download and add RISC-V arch tests.
 option(ENABLE_RISCV_ARCH_TESTS "Enable riscv-arch-tests" OFF)
 
@@ -136,29 +168,10 @@ function(filter_arch_tests test_elfs elfs_to_use_varname)
     # test-specific configurations in CI.
     list(FILTER test_elfs EXCLUDE REGEX ".*/InterruptsS-00\\.elf$")
     list(FILTER test_elfs EXCLUDE REGEX ".*/InterruptsSm-00\\.elf$")
+    list(FILTER test_elfs EXCLUDE REGEX ".*/InterruptsSSm-00\\.elf$")
+    list(FILTER test_elfs EXCLUDE REGEX ".*/InterruptsU-00\\.elf$")
     list(FILTER test_elfs EXCLUDE REGEX ".*/S-00\\.elf$")
-    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictS-01\\.elf$")
     list(FILTER test_elfs EXCLUDE REGEX ".*/UV-00\\.elf$")
-
-    # These tests fail because
-    # https://github.com/riscv/sail-riscv/pull/1690 strengthened illegal
-    # instruction checks for vector instructions (like vbrev8).
-    # Instructions that executed with the 0.11 release now raise illegal
-    # instruction exceptions with the current version.
-    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-14\\.elf$")
-
-    # These tests similarly fail because
-    # https://github.com/riscv/sail-riscv/pull/1698 strengthens checks
-    # for vector source register overlaps (like vwadd.vv).
-    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-13\\.elf$")
-
-    # These RV64 tests fail because
-    # https://github.com/riscv/sail-riscv/pull/1712 fixed an incorrect
-    # decoding of add.uw, and now correctly treats that encoding as
-    # reserved and traps with an illegal instruction exception.
-    list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictS-06\\.elf$")
-    list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictSm-06\\.elf$")
-    list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv64-max/.*/SsstrictU-02\\.elf$")
 
     # These tests fail because
     # https://github.com/riscv/sail-riscv/pull/1734 does not raise
@@ -170,16 +183,26 @@ function(filter_arch_tests test_elfs elfs_to_use_varname)
     list(FILTER test_elfs EXCLUDE REGEX ".*/ExceptionsZaamo-00\\.elf$")
     list(FILTER test_elfs EXCLUDE REGEX ".*/Zama16b-00\\.elf$")
 
-    # With H enabled, VS CSRs (vsstatus, etc.) and the extra mideleg bits are
-    # legal from M/HS-mode, so accesses these tests expect to trap no longer do.
-    # The reference signatures assume a non-H config (all pass with H disabled).
-    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-00\\.elf$")
-    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-01\\.elf$")
-    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-02\\.elf$")
-    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-04\\.elf$")
-    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm-07\\.elf$")
-    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictU-03\\.elf$")
-    list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv32-max/.*/SsstrictS-06\\.elf$")
+    # ACT split the numbered Ssstrict tests into _CSR/_IllegalInstr/_VectorInstr.
+    # These expect vsstatus and hfence.vvma to raise an illegal instruction,
+    # but both are legal once H is enabled. The signatures assume a non-H config.
+    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictS_CSR-0[01]\\.elf$")
+    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm_CSR-0[012]\\.elf$")
+    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictS_IllegalInstr-03\\.elf$")
+    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm_IllegalInstr-03\\.elf$")
+
+    # These tests fail because
+    # https://github.com/riscv/sail-riscv/pull/1690 strengthened illegal
+    # instruction checks for vector instructions, and
+    # https://github.com/riscv/sail-riscv/pull/1698 for source register
+    # overlaps. The signatures expect the reserved encodings to execute.
+    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictS_VectorInstr-0[01]\\.elf$")
+    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm_VectorInstr-0[01]\\.elf$")
+    list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictU_VectorInstr-0[01]\\.elf$")
+
+    # This checks bit 24 of mstateen0h (P1P13), which became writable
+    # when hedelegh was gated on it. The signature assumes a non-H config.
+    list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv32-max/.*/Smstateen-00\\.elf$")
 
     set(${elfs_to_use_varname} "${test_elfs}" PARENT_SCOPE)
 endfunction()
@@ -195,10 +218,23 @@ if(ENABLE_RISCV_ARCH_TESTS)
         "${DOWNLOAD_URL}"
     )
 
+    # ACT builds the arch-test signatures with VLEN=1024. Our generated
+    # configs only go up to VLEN=512, so override the default config.
+    # The default configs already match ACT on ELEN=64 and the Full vector
+    # support level for both XLENs.
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/arch_test_override.json"
+         "{\"extensions\": {\"V\": {\"vlen_exp\": 10}}}\n")
+
     foreach(xlen IN ITEMS 32 64)
         file(GLOB_RECURSE elf_list CONFIGURE_DEPENDS LIST_DIRECTORIES false
            "${DOWNLOAD_PATH}/${TARBALL_NAME}/sail-rv${xlen}-max/*.elf"
         )
+
+        if(xlen EQUAL 32)
+            set(xlen_flag --rv32)
+        else()
+            set(xlen_flag)
+        endif()
 
         # Filter out tests that fail for a good reason.
         filter_arch_tests("${elf_list}" elfs_to_use)
@@ -210,8 +246,8 @@ if(ENABLE_RISCV_ARCH_TESTS)
                 NAME "${elf_name}"
                 COMMAND
                     $<TARGET_FILE:sail_riscv_sim>
-                    # Use ELEN=XLEN. These tests don't yet use vector so it doesn't matter.
-                    --config "${CMAKE_BINARY_DIR}/config/rv${xlen}d_v256_e${xlen}.json"
+                    ${xlen_flag}
+                    --config-override "${CMAKE_CURRENT_BINARY_DIR}/arch_test_override.json"
                     ${elf}
             )
         endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -184,7 +184,7 @@ function(filter_arch_tests test_elfs elfs_to_use_varname)
     list(FILTER test_elfs EXCLUDE REGEX ".*/Zama16b-00\\.elf$")
 
     # ACT split the numbered Ssstrict tests into _CSR/_IllegalInstr/_VectorInstr.
-    # These expect vsstatus and hfence.vvma to raise an illegal instruction,
+    # These expect accesses to vsstatus and hfence.vvma to raise an illegal instruction,
     # but both are legal once H is enabled. The signatures assume a non-H config.
     list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictS_CSR-0[01]\\.elf$")
     list(FILTER test_elfs EXCLUDE REGEX ".*/SsstrictSm_CSR-0[012]\\.elf$")

--- a/test/README.md
+++ b/test/README.md
@@ -8,6 +8,8 @@ The simulator supports multiple test suites that are downloaded on-demand during
 
 - **RISC-V Architectural Certification Tests** from the [`riscv-arch-test`](https://github.com/riscv/riscv-arch-test) repository: Tests designed to certify that a design faithfully implements the RISC-V specification (can be enabled with `-DENABLE_RISCV_ARCH_TESTS=TRUE`).
 
+- **Hypervisor Tests** from the [`damo-rv-priv-ats`](https://github.com/XUANTIE-RV/damo-rv-priv-ats) repository: RV64 tests for the H extension and the privileged extensions that interact with it (can be enabled with `-DENABLE_DAMO_TESTS=TRUE`).
+
 ## Local Test Directory
 
 - `first_party` - tests specifically designed for this Sail model. These tests are not designed to test all the features of RISC-V. Rather they are for testing new code that we add, and bug fixes.


### PR DESCRIPTION
Update to the latest test suite release (2026-08-20), which includes the new XUANTIE-RV/damo-rv-priv-ats test suite.

Sail RISC-V Tests - 2026-08-20

Built with:
riscv-software-src/sail-riscv-tests: dcb4a38
riscv-tests: 1eb47d946c55f55cab8653c224c2993acc0276bd
riscv-vector-tests: f76bff121dce91b6b23e1d37be77a5e44af914c3
riscv-arch-test: db2b9fd7aa71a6e669417f711379988541f1464c
damo-rv-priv-ats: 3d7b83b79799f57f812da13b2a21b055e79b6c27
Spike: 20feb9c2bf2a7deab964d8190b0cbd4b4131bec3
Toolchain release: 2026.07.15
Sail RISC-V release: 0.13.1

```
$ ./compare-releases.py -p releases/2026-06-10 -c releases/2026-08-20
riscv-tests has 667 test files, with 0 added to and 0 removed from the previous release.`
riscv-arch-tests has 3815 test files, with 1813 added to and 78 removed from the previous release.
damo-tests with 43 test files was added.
riscv-vector-tests-v64x32 has 1941 test files, with 0 added to and 0 removed from the previous release.
riscv-vector-tests-v64x64 has 3025 test files, with 0 added to and 0 removed from the previous release.
riscv-vector-tests-v128x32 has 1944 test files, with 0 added to and 0 removed from the previous release.
riscv-vector-tests-v128x64 has 3042 test files, with 0 added to and 0 removed from the previous release.
riscv-vector-tests-v256x32 has 1945 test files, with 0 added to and 0 removed from the previous release.
riscv-vector-tests-v256x64 has 3043 test files, with 0 added to and 0 removed from the previous release.
riscv-vector-tests-v512x32 is not present in both releases.
riscv-vector-tests-v512x64 has 3043 test files, with 0 added to and 0 removed from the previous release.
```