### PR TITLE
Add platform msi_supported, mti_supported, and mei_supported config.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -453,6 +453,18 @@
       "base": 33554432,
       "size": 49152
     },
+    // Whether machine software interrupts are implemented (mip.MSIP / mie.MSIE).
+    // When false, those bits are read-only zero for CSR access and interrupt
+    // dispatch, and the Simple Interrupt Generator cannot set MSIP.
+    "msi_supported": true,
+    // Whether machine timer interrupts are implemented (mip.MTIP / mie.MTIE).
+    // When false, those bits are read-only zero for CSR access and interrupt
+    // dispatch.
+    "mti_supported": true,
+    // Whether machine external interrupts are implemented (mip.MEIP / mie.MEIE).
+    // When false, those bits are read-only zero for CSR access and interrupt
+    // dispatch.
+    "mei_supported": true,
     // Very simple MMIO device to generate interrupts for testing
     // purposes. See docs/SimpleInterruptGenerator.md for details.
     "simple_interrupt_generator": {

--- a/model/core/interrupt_regs.sail
+++ b/model/core/interrupt_regs.sail
@@ -54,6 +54,13 @@ bitfield Minterrupts : xlenbits = {
 
 register hvip : Minterrupts
 
+private function apply_mxi_policy(m : Minterrupts) -> Minterrupts =
+  [m with
+    MSI = if plat_msi_supported then m[MSI] else 0b0,
+    MTI = if plat_mti_supported then m[MTI] else 0b0,
+    MEI = if plat_mei_supported then m[MEI] else 0b0,
+  ]
+
 private function legalize_mip(o : Minterrupts, v : xlenbits) -> Minterrupts = {
   // The only writable bits are the S-mode bits.
   let v = Mk_Minterrupts(v);
@@ -89,9 +96,9 @@ private function legalize_mie(o : Minterrupts, v : xlenbits) -> Minterrupts = {
   let v = Mk_Minterrupts(v);
   [o with
     LCOFI = if currentlyEnabled(Ext_Sscofpmf) then v[LCOFI] else 0b0,
-    MEI  = v[MEI],
-    MTI  = v[MTI],
-    MSI  = v[MSI],
+    MEI  = if plat_mei_supported then v[MEI] else 0b0,
+    MTI  = if plat_mti_supported then v[MTI] else 0b0,
+    MSI  = if plat_msi_supported then v[MSI] else 0b0,
     SEI  = if currentlyEnabled(Ext_S) then v[SEI] else 0b0,
     STI  = if currentlyEnabled(Ext_S) then v[STI] else 0b0,
     SSI  = if currentlyEnabled(Ext_S) then v[SSI] else 0b0,
@@ -214,16 +221,18 @@ enum XipReadType = {
 }
 
 function read_mip(read_type : XipReadType) -> Minterrupts =
-  match read_type {
-    IncludePlatformInterrupts => Mk_Minterrupts(mip.bits | external_interrupts_pending().bits),
-    ExcludePlatformInterrupts => mip,
-  }
+  apply_mxi_policy(
+    match read_type {
+      IncludePlatformInterrupts => Mk_Minterrupts(mip.bits | external_interrupts_pending().bits),
+      ExcludePlatformInterrupts => mip,
+    }
+  )
 
 function write_mip(value : xlenbits) -> unit = {
   mip = legalize_mip(mip, value);
 }
 
-function clause read_CSR(0x304) = mie.bits
+function clause read_CSR(0x304) = apply_mxi_policy(mie).bits
 function clause read_CSR(0x344) = read_mip(ExcludePlatformInterrupts).bits
 function clause read_CSR(0x302) = medeleg.bits[xlen - 1 .. 0]
 function clause read_CSR(0x312 if xlen == 32) = medeleg.bits[63 .. 32]

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -104,6 +104,18 @@ let plat_have_clint : bool = config platform.clint.supported
 let plat_clint_base : physaddrbits = to_bits_checked(config platform.clint.base : int)
 let plat_clint_size : physaddrbits = to_bits_checked(config platform.clint.size : int)
 
+// When false, mip.MSIP and mie.MSIE are read-only zero for CSR access and
+// interrupt dispatch, and the Simple Interrupt Generator cannot set MSIP.
+let plat_msi_supported : bool = config platform.msi_supported
+
+// When false, mip.MTIP and mie.MTIE are read-only zero for CSR access and
+// interrupt dispatch.
+let plat_mti_supported : bool = config platform.mti_supported
+
+// When false, mip.MEIP and mie.MEIE are read-only zero for CSR access and
+// interrupt dispatch.
+let plat_mei_supported : bool = config platform.mei_supported
+
 // Simple Interrupt Generator. See docs/SimpleInterruptGenerator.md for details.
 let plat_have_sig : bool = config platform.simple_interrupt_generator.supported
 let plat_sig_base : physaddrbits = to_bits_checked(config platform.simple_interrupt_generator.base : int)

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -505,6 +505,24 @@ private function check_mem_layout() -> bool =
     pmas_ok & clint_ok & sig_ok
   }
 
+private function check_m_interrupts() -> bool = {
+  var valid : bool = true;
+  let mideleg_bits = Mk_Minterrupts(plat_mideleg_delegatable_bits);
+  if not(plat_msi_supported) & mideleg_bits[MSI] == 0b1 then {
+    print_endline("platform.msi_supported is false but base.mideleg.delegatable_bits includes MSI (bit 3).");
+    valid = false
+  };
+  if not(plat_mti_supported) & mideleg_bits[MTI] == 0b1 then {
+    print_endline("platform.mti_supported is false but base.mideleg.delegatable_bits includes MTI (bit 7).");
+    valid = false
+  };
+  if not(plat_mei_supported) & mideleg_bits[MEI] == 0b1 then {
+    print_endline("platform.mei_supported is false but base.mideleg.delegatable_bits includes MEI (bit 11).");
+    valid = false
+  };
+  valid
+}
+
 private function check_pmp() -> bool = {
   var valid : bool = true;
   if (config memory.pmp.na4_supported : bool) & sys_pmp_grain != 0
@@ -918,6 +936,7 @@ function config_is_valid() -> bool = {
   & check_physaddr_bits()
   & check_mmu_config()
   & check_mem_layout()
+  & check_m_interrupts()
   & check_mmio_devices()
   & check_vlen_elen()
   & check_vext_config()

--- a/model/sys/simple_interrupt_generator.sail
+++ b/model/sys/simple_interrupt_generator.sail
@@ -47,7 +47,7 @@ function sig_store(addr, width, data) = {
 
       if data[MEI] == 0b1 then sig_meip = value;
       if data[SEI] == 0b1 then sig_seip = value;
-      if data[MSI] == 0b1 then mip[MSI] = value;
+      if data[MSI] == 0b1 & plat_msi_supported then mip[MSI] = value;
       // SSI is read-only zero if the hart does not support supervisor mode.
       if data[SSI] == 0b1 & currentlyEnabled(Ext_S) then mip[SSI] = value;
 


### PR DESCRIPTION
Machine software, timer, and external interrupts may not be supported on some implementations. Default true preserves current behaviour. When false, the corresponding mip/mie bits are read-only zero for CSR access and interrupt dispatch, sie/sip cannot write them via delegation, and the Simple Interrupt Generator cannot set MSIP.

Validated against ACT4 Interrupt suites for cores that do not implement these interrupts.

Generative AI (Cursor) was used to draft this change and commit message.