### PR TITLE
Make extensions.Svbare.supported actually take effect

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -17,6 +17,9 @@
     environment calls, virtual instructions, and the guest-page faults.
 
 - Important issues addressed and bugs fixed:
+  - `extensions.Svbare.supported` had no effect, `satp` accepted the Bare
+    mode whether or not Svbare was configured. `validate_config()` now also
+    rejects a configuration that supports supervisor mode but no `satp` mode.
   - https://github.com/riscv/sail-riscv/issues/1882 : missed overlap checks for widening vector multiply accumulates
   - https://github.com/riscv/sail-riscv/issues/1880 : some cases of Zvknh instructions did not check for valid `vl`
 

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -140,7 +140,7 @@ function clause currentlyEnabled(Ext_H) =
 // This will need adjusting for dynamic XLEN.
 function clause currentlyEnabled(Ext_Ssu64xl) = hartSupports(Ext_Ssu64xl) & currentlyEnabled(Ext_S)
 
-function clause currentlyEnabled(Ext_Svbare) = currentlyEnabled(Ext_S)
+function clause currentlyEnabled(Ext_Svbare) = hartSupports(Ext_Svbare) & currentlyEnabled(Ext_S)
 function clause currentlyEnabled(Ext_Sv32) = hartSupports(Ext_Sv32) &  currentlyEnabled(Ext_S)
 function clause currentlyEnabled(Ext_Sv39) = hartSupports(Ext_Sv39) &  currentlyEnabled(Ext_S)
 function clause currentlyEnabled(Ext_Sv48) = hartSupports(Ext_Sv48) &  currentlyEnabled(Ext_S)

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -63,6 +63,14 @@ private function check_mmu_config() -> bool = {
       valid = false;
       print_endline("Supervisor mode (S) disabled but one of (Sv57, Sv48, Sv39) is enabled: cannot support address translation without supervisor mode.");
     };
+    // satp.MODE is WARL, so at least one mode has to be supported or no write
+    // to satp can ever take effect.
+    if (config extensions.S.supported : bool) &
+      not((config extensions.Svbare.supported : bool) | (config extensions.Sv39.supported : bool) | (config extensions.Sv48.supported : bool) | (config extensions.Sv57.supported : bool))
+    then {
+      valid = false;
+      print_endline("Supervisor mode (S) is enabled but no `satp` mode is supported for RV64: enable Svbare or one of (Sv39, Sv48, Sv57).");
+    };
     if (config extensions.Sv57.supported : bool) & not(config extensions.Sv48.supported : bool)
     then {
       valid = false;
@@ -85,22 +93,16 @@ private function check_mmu_config() -> bool = {
       valid = false;
       print_endline("Supervisor mode (S) is disabled but Sv32 is enabled: cannot support address translation without supervisor mode.");
     };
+    if (config extensions.S.supported : bool) & not((config extensions.Svbare.supported : bool) | (config extensions.Sv32.supported : bool))
+    then {
+      valid = false;
+      print_endline("Supervisor mode (S) is enabled but no `satp` mode is supported for RV32: enable Svbare or Sv32.");
+    };
     if (config extensions.Sv39.supported : bool) | (config extensions.Sv48.supported : bool) |  (config extensions.Sv57.supported : bool)
     then {
       valid = false;
       print_endline("One or more of Sv39/Sv48/Sv57 is enabled: these are not supported on RV32.");
     };
-  };
-
-  // satp.MODE is WARL, so at least one mode has to be supported or no write
-  // to satp can ever take effect.
-  if (config extensions.S.supported : bool) &
-     not((config extensions.Svbare.supported : bool) | (config extensions.Sv32.supported : bool) |
-         (config extensions.Sv39.supported : bool) | (config extensions.Sv48.supported : bool) |
-         (config extensions.Sv57.supported : bool))
-  then {
-    valid = false;
-    print_endline("Supervisor mode (S) is enabled but no `satp` mode is supported: enable Svbare or one of Sv32/Sv39/Sv48/Sv57.");
   };
 
   if (config extensions.Svrsw60t59b.supported : bool) then {

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -92,6 +92,17 @@ private function check_mmu_config() -> bool = {
     };
   };
 
+  // satp.MODE is WARL, so at least one mode has to be supported or no write
+  // to satp can ever take effect.
+  if (config extensions.S.supported : bool) &
+     not((config extensions.Svbare.supported : bool) | (config extensions.Sv32.supported : bool) |
+         (config extensions.Sv39.supported : bool) | (config extensions.Sv48.supported : bool) |
+         (config extensions.Sv57.supported : bool))
+  then {
+    valid = false;
+    print_endline("Supervisor mode (S) is enabled but no `satp` mode is supported: enable Svbare or one of Sv32/Sv39/Sv48/Sv57.");
+  };
+
   if (config extensions.Svrsw60t59b.supported : bool) then {
     if xlen == 32 then {
       valid = false;


### PR DESCRIPTION
currentlyEnabled(Ext_Svbare) ignored hartSupports, so satp always accepted Bare. Also reject a config with supervisor mode but no satp mode.