### PR TITLE
coq: bind the reservation and terminal platform externs

### DIFF
--- a/handwritten_support/riscv_extras.v
+++ b/handwritten_support/riscv_extras.v
@@ -32,3 +32,10 @@ Definition sys_enable_experimental_extensions (_:unit) : bool := false.
 Definition mults_vec {n} (l : mword n) (r : mword n) : mword (2 * n) := mults_vec l r.
 Definition mult_vec {n} (l : mword n) (r : mword n) : mword (2 * n) := mult_vec l r.
 Definition print_string (_ _:string) : unit := tt.
+
+Axiom load_reservation : forall {Mon : Type -> Type} `{base.MRet Mon} {n}, mword n -> Z -> Mon unit.
+Axiom cancel_reservation : forall {Mon : Type -> Type} `{base.MRet Mon}, unit -> Mon unit.
+Axiom match_reservation : forall {n}, mword n -> bool.
+Axiom valid_reservation : unit -> bool.
+Axiom plat_term_write : forall {Mon : Type -> Type} `{base.MRet Mon}, mword 8 -> Mon unit.
+Axiom plat_term_read : forall {Mon : Type -> Type} `{base.MRet Mon}, unit -> Mon (mword 8).

--- a/model/sys/platform.sail
+++ b/model/sys/platform.sail
@@ -242,8 +242,8 @@ function tick_clock() -> unit = {
 
 // Basic terminal character I/O.
 
-val plat_term_write = impure {cpp: "plat_term_write", lem: "plat_term_write"} : bits(8) -> unit
-val plat_term_read  = impure {cpp: "plat_term_read", lem: "plat_term_read"}  : unit -> bits(8)
+val plat_term_write = impure {cpp: "plat_term_write", lem: "plat_term_write", coq: "plat_term_write"} : bits(8) -> unit
+val plat_term_read  = impure {cpp: "plat_term_read", lem: "plat_term_read", coq: "plat_term_read"}  : unit -> bits(8)
 
 // Spike's HTIF device interface, which multiplexes the above MMIO devices.
 

--- a/model/sys/sys_reservation.sail
+++ b/model/sys/sys_reservation.sail
@@ -17,7 +17,7 @@
 // transition.  Ideally, the platform should get more visibility into
 // where cancellation can be performed.
 
-val load_reservation = impure {interpreter: "Platform.load_reservation", cpp: "load_reservation", c: "load_reservation", lem: "load_reservation"} : forall 'n, 0 < 'n < max_mem_access . (/* addr */ physaddrbits, /* width */ int('n)) -> unit
-val match_reservation = pure {interpreter: "Platform.match_reservation", cpp: "match_reservation", c: "match_reservation", lem: "match_reservation"} : physaddrbits -> bool
-val cancel_reservation = impure {interpreter: "Platform.cancel_reservation", cpp: "cancel_reservation", c: "cancel_reservation", lem: "cancel_reservation"} : unit -> unit
-val valid_reservation = pure {interpreter: "Platform.valid_reservation", cpp: "valid_reservation", c: "valid_reservation", lem: "valid_reservation"} : unit -> bool
+val load_reservation = impure {interpreter: "Platform.load_reservation", cpp: "load_reservation", c: "load_reservation", lem: "load_reservation", coq: "load_reservation"} : forall 'n, 0 < 'n < max_mem_access . (/* addr */ physaddrbits, /* width */ int('n)) -> unit
+val match_reservation = pure {interpreter: "Platform.match_reservation", cpp: "match_reservation", c: "match_reservation", lem: "match_reservation", coq: "match_reservation"} : physaddrbits -> bool
+val cancel_reservation = impure {interpreter: "Platform.cancel_reservation", cpp: "cancel_reservation", c: "cancel_reservation", lem: "cancel_reservation", coq: "cancel_reservation"} : unit -> unit
+val valid_reservation = pure {interpreter: "Platform.valid_reservation", cpp: "valid_reservation", c: "valid_reservation", lem: "valid_reservation", coq: "valid_reservation"} : unit -> bool


### PR DESCRIPTION
The Rocq backend emits a bare Axiom for every val it sees declared but not defined.  This means that a Rocq development built on the generated model inherits dangling axioms.  Binding them allows the Rocq development to be linked with actual definitions provided in Rocq.