### PR TITLE
Add the Shcounterenw extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ An experimental emulator in the Lean language is available, see its
 - Svvptc extension for Obviating Memory-management Instructions after Marking PTEs valid, v1.0
 - Smmpm, Smnpm, Ssnpm, Sspm and Supm extensions for pointer masking, v1.0
 - H extension for Hypervisor Support, v1.0
+- Shcounterenw extension for writable `hcounteren` enables for any supported counter, v1.0
 - Shgatpa extension for `hgatp` mode support matching `satp`, v1.0
 - Physical Memory Protection (PMP)
 - Static memory regions with some static PMAs (Physical Memory Attributes)

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -53,7 +53,9 @@
     // and `cycle`, `time` and `instret` registers from VS/VU-mode,
     // are read-only zero. A set bit specifies that the corresponding
     // bit of `hcounteren` is writable, otherwise the bit is read-only
-    // zero. Same layout as `mcounteren`.
+    // zero. Same layout as `mcounteren`. If Shcounterenw is supported the
+    // top 29 bits must be a superset of the top 29 bits of
+    // `writable_hpm_counters`.
     "hcounteren_writable_bits": {
       "len": 32,
       "value": "0xFFFF_FFFF"
@@ -797,6 +799,9 @@
       "supported": true
     },
     "Sscofpmf": {
+      "supported": true
+    },
+    "Shcounterenw": {
       "supported": true
     },
     "Sscounterenw": {

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -2,6 +2,7 @@
 
 - The following extensions have been added:
   - H
+  - Shcounterenw
   - Shgatpa
 
 - Updates to the [configuration file](../config/config.json.in):

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -69,6 +69,11 @@ function clause hartSupports(Ext_U) = config extensions.U.supported
 enum clause extension = Ext_H
 mapping clause extensionName = Ext_H <-> "h"
 function clause hartSupports(Ext_H) = config extensions.H.supported
+// Any hpmcounter that is not read-only zero has a writable hcounteren bit
+enum clause extension = Ext_Shcounterenw
+mapping clause extensionName = Ext_Shcounterenw <-> "shcounterenw"
+function clause hartSupports(Ext_Shcounterenw) = config extensions.Shcounterenw.supported
+function clause currentlyEnabled(Ext_Shcounterenw) = hartSupports(Ext_Shcounterenw) & currentlyEnabled(Ext_H)
 // For each SvNN supported in satp, the matching hgatp SvNNx4 mode is
 // supported, as is hgatp Bare.
 enum clause extension = Ext_Shgatpa
@@ -671,6 +676,7 @@ function currentlyEnabled_measure(ext : extension) -> int =
     Ext_Zvfbfwma => 4, // > Zvfbfmin
     Ext_Zvfh => 4, // > Zfhmin
 
+    Ext_Shcounterenw => 5, // > H
     Ext_Shgatpa => 5, // > H
     Ext_V => 5, // > Zve64d
     Ext_Zvfhmin => 5, // > Zvfh
@@ -841,6 +847,7 @@ let extensions_ordered_for_isa_string = [
   Ext_Svvptc,
 
   // Hypervisor extensions, ordered alphabetically.
+  Ext_Shcounterenw,
   Ext_Shgatpa,
 
   // Machine mode extensions, ordered alphabetically.

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -559,9 +559,15 @@ private function check_misc_extension_dependencies() -> bool = {
     valid = false;
     print_endline("The Ssqosid extension is enabled but Zicsr is disabled: supporting Ssqosid requires Zicsr.");
   };
-  if (config extensions.Sscounterenw.supported : bool) & ((sys_writable_hpm_counters[31 .. 3] & sys_scounteren_writable_bits[31 .. 3]) != sys_writable_hpm_counters[31 .. 3]) then {
-    valid = false;
-    print_endline("The Sscounterenw extension is enabled but `scounteren` is not writable (via `base.scounteren_writable_bits`) for some supported HPM counters (specified in `base.writable_hpm_counters`).");
+  if (config extensions.Sscounterenw.supported : bool) then {
+    if not(config extensions.S.supported : bool) then {
+      valid = false;
+      print_endline("The Sscounterenw extension is enabled but supervisor mode (S) is disabled: supporting Sscounterenw requires S.");
+    };
+    if (sys_writable_hpm_counters[31 .. 3] & sys_scounteren_writable_bits[31 .. 3]) != sys_writable_hpm_counters[31 .. 3] then {
+      valid = false;
+      print_endline("The Sscounterenw extension is enabled but `scounteren` is not writable (via `base.scounteren_writable_bits`) for some supported HPM counters (specified in `base.writable_hpm_counters`).");
+    };
   };
   if (config extensions.Shcounterenw.supported : bool) then {
     if not(config extensions.H.supported : bool) then {

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -563,6 +563,16 @@ private function check_misc_extension_dependencies() -> bool = {
     valid = false;
     print_endline("The Sscounterenw extension is enabled but `scounteren` is not writable (via `base.scounteren_writable_bits`) for some supported HPM counters (specified in `base.writable_hpm_counters`).");
   };
+  if (config extensions.Shcounterenw.supported : bool) then {
+    if not(config extensions.H.supported : bool) then {
+      valid = false;
+      print_endline("The Shcounterenw extension is enabled but the H extension is disabled: supporting Shcounterenw requires H.");
+    };
+    if (sys_writable_hpm_counters[31 .. 3] & sys_hcounteren_writable_bits[31 .. 3]) != sys_writable_hpm_counters[31 .. 3] then {
+      valid = false;
+      print_endline("The Shcounterenw extension is enabled but `hcounteren` is not writable (via `base.hcounteren_writable_bits`) for some supported HPM counters (specified in `base.writable_hpm_counters`).");
+    };
+  };
   if (xlen == 32 & ((config extensions.Ssnpm.supported : bool) | (config extensions.Smmpm.supported : bool) | (config extensions.Smnpm.supported : bool))) then {
     valid = false;
     print_endline("The Ssnpm, Smmpm and Smnpm extensions are not supported on RV32.");


### PR DESCRIPTION
hcounteren must be writable for every supported hpmcounter, mirroring the existing Sscounterenw check for scounteren.