### PR TITLE
Allow misaligned LR/SC to be address-translated.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -253,15 +253,14 @@
         "vector": {
           "None": null
         },
-        // Similarly, a misaligned AMO can be configured with the same
+        // Similarly, a misaligned AMO and LR/SC can be configured with the same
         // option values.
         "amo": {
           "None": null
         },
-        // A misaligned LR/SC currently always faults, and this field can specify
-        // whether it generates an access fault (use `"AccessFault"`)
-        // or a misaligned exception (use `"AlignmentException"`).
-        "lrsc": "AccessFault"
+        "lrsc": {
+          "None": null
+        }
       },
       // If multiple memory operations are needed (e.g. when an access
       // straddles a page boundary), this controls whether they are
@@ -330,7 +329,8 @@
             "vector": {
               "None" : null
             },
-            "amo": "AccessFault"
+            "amo": "AccessFault",
+            "lrsc": "AccessFault"
           },
           "atomic_support": "AMONone",
           "misaligned_atomicity_granule_size_exp": 0,
@@ -368,7 +368,8 @@
             "vector": {
               "None" : null
             },
-            "amo": "AccessFault"
+            "amo": "AccessFault",
+            "lrsc": "AccessFault"
           },
           "atomic_support": "AMONone",
           "misaligned_atomicity_granule_size_exp": 0,
@@ -406,7 +407,8 @@
             "vector": {
               "None" : null
             },
-            "amo": "AccessFault"
+            "amo": "AccessFault",
+            "lrsc": "AccessFault"
           },
           "atomic_support": "AMOCASQ",
           "misaligned_atomicity_granule_size_exp": 4,

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -259,7 +259,7 @@
           "None": null
         },
         "lrsc": {
-          "None": null
+          "Some": "AccessFault"
         }
       },
       // If multiple memory operations are needed (e.g. when an access

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -26,6 +26,10 @@
   - The default value of `base.medeleg.delegatable_bits` now also
     includes the exception codes introduced by H, i.e. VS-mode
     environment calls, virtual instructions, and the guest-page faults.
+  - The configuration for exceptions from misaligned LR/SC has been
+    modified; they now have a configuration that is similar to, but
+    independent of, AMOs. See `memory.misaligned.exceptions.lrsc`
+    and the `misaligned_exceptions.lrsc` PMA attribute.
 
 - Xvisor boot is now tested in CI. The `os-boot` Makefile has been
   generalized to build both the Linux and Xvisor images.
@@ -36,6 +40,7 @@
     rejects a configuration that supports supervisor mode but no `satp` mode.
   - https://github.com/riscv/sail-riscv/issues/1882 : missed overlap checks for widening vector multiply accumulates
   - https://github.com/riscv/sail-riscv/issues/1880 : some cases of Zvknh instructions did not check for valid `vl`
+  - https://github.com/riscv/sail-riscv/issues/1793 : misaligned LR/SC cannot be configured to throw address translation exceptions
 
 - Other notes:
   - The test suite has been updated to the latest release (2026-08-20)

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -40,7 +40,6 @@
     rejects a configuration that supports supervisor mode but no `satp` mode.
   - https://github.com/riscv/sail-riscv/issues/1882 : missed overlap checks for widening vector multiply accumulates
   - https://github.com/riscv/sail-riscv/issues/1880 : some cases of Zvknh instructions did not check for valid `vl`
-  - https://github.com/riscv/sail-riscv/issues/1793 : misaligned LR/SC cannot be configured to throw address translation exceptions
 
 - Other notes:
   - The test suite has been updated to the latest release (2026-08-20)

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -83,11 +83,7 @@ struct GlobalMisalignedExceptions = {
   load_store : option(misaligned_exception),
   vector     : option(misaligned_exception),
   amo        : option(misaligned_exception),
-  // LR/SC must always be aligned. Returning a misaligned exception indicates
-  // that the access can be emulated (the OS/firmware can transparently break
-  // it down into multiple aligned accesses) which isn't the case for LR/SC
-  // in normal implementations.
-  lrsc       : misaligned_exception,
+  lrsc       : option(misaligned_exception),
 }
 
 // The handling of misaligned accesses before address translation.

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -136,6 +136,12 @@ function is_prefetch_access forall ('a : Type) . (access : MemoryAccessType('a))
     _ => false,
   }
 
+function is_load_reserved forall ('a : Type) . (access : MemoryAccessType('a)) -> bool =
+  match access {
+    LoadReserved(_) => true,
+    _ => false,
+  }
+
 function is_store_conditional forall ('a : Type) . (access : MemoryAccessType('a)) -> bool =
   match access {
     StoreConditional(_) => true,

--- a/model/sys/pma.sail
+++ b/model/sys/pma.sail
@@ -85,6 +85,7 @@ struct PMAMisalignedExceptions = {
   load_store : option(misaligned_exception),
   vector     : option(misaligned_exception),
   amo        : misaligned_exception,
+  lrsc       : misaligned_exception,
 }
 
 // Physical Memory Attributes for a region.
@@ -149,6 +150,9 @@ function pma_misaligned_exception(pma : PMA, access : MemoryAccessType(mem_paylo
     Load(Vector)           => exceptions.vector,
     Store(Vector)          => exceptions.vector,
     Atomic(_)              => Some(exceptions.amo),
+
+    LoadReserved(_, _, Data)     => Some(exceptions.lrsc),
+    StoreConditional(_, _, Data) => Some(exceptions.lrsc),
 
     // These access types should not be misaligned at the PMA level.
     InstructionFetch()        => internal_error(__FILE__, __LINE__, "PMA: Invalid misaligned instruction fetch."),

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -139,7 +139,7 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
   let vmem_active : bool = if privLevel_is_virtual(cur_privilege)
   then vsatp_mode() != Bare | hgatp_mode() != HBare
   else satp_mode(cur_privilege) != Bare;
-  let do_split_access = vmem_active & next_page_bytes > 0;
+  let do_split_access = vmem_active & next_page_bytes > 0 & not(res);
 
   if sys_misaligned_order_decreasing & do_split_access then {
     // Do next page access first.
@@ -241,7 +241,7 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
   let vmem_active : bool = if privLevel_is_virtual(cur_privilege)
   then vsatp_mode() != Bare | hgatp_mode() != HBare
   else satp_mode(cur_privilege) != Bare;
-  let do_split_access = vmem_active & next_page_bytes > 0;
+  let do_split_access = vmem_active & next_page_bytes > 0 & not(res);
 
   if sys_misaligned_order_decreasing & do_split_access then {
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -32,7 +32,7 @@
 
 function plat_misaligned_exception(access : MemoryAccessType(mem_payload), res : bool) -> option(misaligned_exception) = {
   if is_amo_access(access) then plat_misaligned_access.amo
-  else if res then Some(plat_misaligned_access.lrsc)
+  else if res then plat_misaligned_access.lrsc
   else if is_vector_access(access) then plat_misaligned_access.vector
   else plat_misaligned_access.load_store
 }
@@ -142,14 +142,15 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
   let do_split_access = vmem_active & next_page_bytes > 0;
 
   if sys_misaligned_order_decreasing & do_split_access then {
-    // Load-reserved cannot be misaligned.
-    assert(not(res));
-
     // Do next page access first.
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
     match translate_and_read_value(access_addr, next_page_bytes, access, aq, rl, res) {
       Err(e)   => return Err(e),
-      Ok(_, v) => data[8 * width - 1 .. 8 * in_page_bytes] = v,
+      Ok(_, v) => {
+        // A misaligned load-reserved should not succeed.
+        assert(not(res));
+        data[8 * width - 1 .. 8 * in_page_bytes] = v
+      },
     }
   };
 
@@ -169,14 +170,15 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
   };
 
   if not(sys_misaligned_order_decreasing) & do_split_access then {
-    // Load-reserved cannot be misaligned.
-    assert(not(res));
-
     // Do next page access next.
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
     match translate_and_read_value(access_addr, next_page_bytes, access, aq, rl, res) {
       Err(e)   => return Err(e),
-      Ok(_, v) => data[8 * width - 1 .. 8 * in_page_bytes] = v,
+      Ok(_, v) => {
+        // A misaligned load-reserved should not succeed.
+        assert(not(res));
+        data[8 * width - 1 .. 8 * in_page_bytes] = v
+      },
     }
   };
 
@@ -242,14 +244,15 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
   let do_split_access = vmem_active & next_page_bytes > 0;
 
   if sys_misaligned_order_decreasing & do_split_access then {
-    // Store-conditionals cannot be misaligned.
-    assert(not(is_store_conditional(access)));
-
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
     let write_value = data[8 * width - 1 .. 8 * in_page_bytes];
     match translate_and_write_value(access_addr, next_page_bytes, write_value, access, aq, rl, res) {
       Err(e) => return Err(e),
-      Ok(s)  => write_success = write_success & s,
+      Ok(s)  => {
+        // A misaligned store-conditional should not succeed.
+        assert(not(is_store_conditional(access)));
+        write_success = write_success & s
+      },
     }
   };
 
@@ -258,7 +261,6 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
     Err(e, _) => return Err(trap(e)),
 
     Ok(paddr, pbmt, _) => {
-      // If res is true, the store should be aligned.
       assert(res == is_store_conditional(access));
       if res & not(match_reservation(bits_of(paddr))) then {
         // Check PMA and PMP access controls before reporting the
@@ -293,14 +295,15 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
   };
 
   if not(sys_misaligned_order_decreasing) & do_split_access then {
-    // Store-conditionals cannot be misaligned.
-    assert(not(is_store_conditional(access)));
-
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
     let write_value = data[8 * width - 1 .. 8 * in_page_bytes];
     match translate_and_write_value(access_addr, next_page_bytes, write_value, access, aq, rl, res) {
       Err(e) => return Err(e),
-      Ok(s)  => write_success = write_success & s,
+      Ok(s)  => {
+        // A misaligned store-conditional should not succeed.
+        assert(not(is_store_conditional(access)));
+        write_success = write_success & s
+      },
     }
   };
 

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -112,6 +112,9 @@ val vmem_read_addr : forall 'width, is_mem_width('width).
   -> result(bits(8 * 'width), ExecutionResult)
 
 function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
+  // Other AMOs currently don't go through `vmem_utils` functions.
+  assert(res == is_load_reserved(access));
+
   // "LR faults like a normal load, even though it's in the AMO major opcode space."
   // - Andrew Waterman, isa-dev, 10 Jul 2018.
   if not(is_aligned_addr(vaddr, width)) then {
@@ -206,6 +209,9 @@ val vmem_write_addr : forall 'width, is_mem_width('width).
   -> result(bool, ExecutionResult)
 
 function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
+  // Other AMOs currently don't go through `vmem_utils` functions.
+  assert(res == is_store_conditional(access));
+
   // See comments in vmem_read_addr for an explanation of this check.
   if not(is_aligned_addr(vaddr, width)) then {
     match plat_misaligned_exception(access, res) {
@@ -240,11 +246,7 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
     let write_value = data[8 * width - 1 .. 8 * in_page_bytes];
     match translate_and_write_value(access_addr, next_page_bytes, write_value, access, aq, rl, res) {
       Err(e) => return Err(e),
-      Ok(s)  => {
-        // A misaligned store-conditional should not succeed.
-        assert(not(is_store_conditional(access)));
-        write_success = write_success & s
-      },
+      Ok(s)  => write_success = write_success & s,
     }
   };
 
@@ -253,7 +255,6 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
     Err(e, _) => return Err(trap(e)),
 
     Ok(paddr, pbmt, _) => {
-      assert(res == is_store_conditional(access));
       if res & not(match_reservation(bits_of(paddr))) then {
         // Check PMA and PMP access controls before reporting the
         // cancelled reservation.
@@ -291,11 +292,7 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
     let write_value = data[8 * width - 1 .. 8 * in_page_bytes];
     match translate_and_write_value(access_addr, next_page_bytes, write_value, access, aq, rl, res) {
       Err(e) => return Err(e),
-      Ok(s)  => {
-        // A misaligned store-conditional should not succeed.
-        assert(not(is_store_conditional(access)));
-        write_success = write_success & s
-      },
+      Ok(s)  => write_success = write_success & s,
     }
   };
 

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -146,11 +146,7 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
     match translate_and_read_value(access_addr, next_page_bytes, access, aq, rl, res) {
       Err(e)   => return Err(e),
-      Ok(_, v) => {
-        // A misaligned load-reserved should not succeed.
-        assert(not(res));
-        data[8 * width - 1 .. 8 * in_page_bytes] = v
-      },
+      Ok(_, v) => data[8 * width - 1 .. 8 * in_page_bytes] = v,
     }
   };
 
@@ -174,11 +170,7 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
     match translate_and_read_value(access_addr, next_page_bytes, access, aq, rl, res) {
       Err(e)   => return Err(e),
-      Ok(_, v) => {
-        // A misaligned load-reserved should not succeed.
-        assert(not(res));
-        data[8 * width - 1 .. 8 * in_page_bytes] = v
-      },
+      Ok(_, v) => data[8 * width - 1 .. 8 * in_page_bytes] = v,
     }
   };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -204,6 +204,11 @@ function(filter_arch_tests test_elfs elfs_to_use_varname)
     # when hedelegh was gated on it. The signature assumes a non-H config.
     list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv32-max/.*/Smstateen-00\\.elf$")
 
+    # Misaligned LR/SC now behave like AMOs, and can throw address translation faults.
+    # These tests assume the earlier, pre-address-translation, misalignment handling for LR/SC.
+    list(FILTER test_elfs EXCLUDE REGEX ".*/ExceptionsSvZalrsc/sv32_exceptions_Zalrsc_.*\\.elf$")
+    list(FILTER test_elfs EXCLUDE REGEX ".*/ExceptionsSvZalrsc/sv39_exceptions_Zalrsc_.*\\.elf$")
+
     set(${elfs_to_use_varname} "${test_elfs}" PARENT_SCOPE)
 endfunction()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -204,11 +204,6 @@ function(filter_arch_tests test_elfs elfs_to_use_varname)
     # when hedelegh was gated on it. The signature assumes a non-H config.
     list(FILTER test_elfs EXCLUDE REGEX ".*/sail-rv32-max/.*/Smstateen-00\\.elf$")
 
-    # Misaligned LR/SC now behave like AMOs, and can throw address translation faults.
-    # These tests assume the earlier, pre-address-translation, misalignment handling for LR/SC.
-    list(FILTER test_elfs EXCLUDE REGEX ".*/ExceptionsSvZalrsc/sv32_exceptions_Zalrsc_.*\\.elf$")
-    list(FILTER test_elfs EXCLUDE REGEX ".*/ExceptionsSvZalrsc/sv39_exceptions_Zalrsc_.*\\.elf$")
-
     set(${elfs_to_use_varname} "${test_elfs}" PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
This modifies the misaligned LR/SC configuration parameters to match those of AMOs.  Their handling is now similar to that of misaligned AMOs, except that the MAG PMA does not apply to LR/SC.

Fixes #1793.