### PR TITLE
Add config options for vstvec and the Shvstvecd extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ An experimental emulator in the Lean language is available, see its
 - Smmpm, Smnpm, Ssnpm, Sspm and Supm extensions for pointer masking, v1.0
 - H extension for Hypervisor Support, v1.0
 - Shgatpa extension for `hgatp` mode support matching `satp`, v1.0
-- Shvstvecd extension for Direct mode support in `vstvec.MODE`, v1.0
+- Shvstvecd extension for Direct Trap Vectoring, v1.0
 - Physical Memory Protection (PMP)
 - Static memory regions with some static PMAs (Physical Memory Attributes)
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ An experimental emulator in the Lean language is available, see its
 - Smmpm, Smnpm, Ssnpm, Sspm and Supm extensions for pointer masking, v1.0
 - H extension for Hypervisor Support, v1.0
 - Shgatpa extension for `hgatp` mode support matching `satp`, v1.0
+- Shvstvecd extension for Direct mode support in `vstvec.MODE`, v1.0
 - Physical Memory Protection (PMP)
 - Static memory regions with some static PMAs (Physical Memory Attributes)
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ An experimental emulator in the Lean language is available, see its
 - Ssqosid extension for Quality-of-Service (QoS) Identifiers, v1.0
 - Sstc extension for Supervisor-mode Timer Interrupts, v1.0
 - Sstvala extension for `stval` provides all needed values, v1.0
-- Sstvecd extension for Direct mode support in `stvec.MODE`, v1.0
+- Sstvecd extension for Direct Trap Vectoring, v1.0
 - Ssu64xl extension to ensure `sstatus.UXL` is capable of supporting UXLEN=64, v1.0
 - Sv32, Sv39, Sv48 and Sv57 page-based virtual-memory systems
 - Svadu extension for Hardware Updating of A/D Bits, Version 1.0

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -92,6 +92,18 @@
         "base_alignment": 2
       }
     },
+    "vstvec": {
+      // The spec requires `base_alignment` for `vstvec.direct` to be 2
+      // (i.e. 4-byte alignment), hence there is no configuration
+      // parameter for it.
+      "direct": {
+        "supported": true
+      },
+      "vectored": {
+        "supported": true,
+        "base_alignment": 2
+      }
+    },
     "medeleg": {
       // A bit set to 1 in this value specifies that the corresponding
       // bit of `medeleg` can be set to 1. It represents the subset of

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -92,6 +92,8 @@
         "base_alignment": 2
       }
     },
+    // Similar to `stvec` above. If the `H` extension is not supported,
+    // these values need to be present and legal but are ignored.
     "vstvec": {
       // The spec requires `base_alignment` for `vstvec.direct` to be 2
       // (i.e. 4-byte alignment), hence there is no configuration
@@ -812,6 +814,9 @@
       "supported": true
     },
     "Sscounterenw": {
+      "supported": true
+    },
+    "Shvstvecd": {
       "supported": true
     },
     "Sstc": {

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -3,6 +3,7 @@
 - The following extensions have been added:
   - H
   - Shgatpa
+  - Shvstvecd
 
 - Updates to the [configuration file](../config/config.json.in):
   - Which trap vector modes `vstvec` supports can be specified, see

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -5,6 +5,9 @@
   - Shgatpa
 
 - Updates to the [configuration file](../config/config.json.in):
+  - Which trap vector modes `vstvec` supports can be specified, see
+    `base.vstvec.direct` and `base.vstvec.vectored`, mirroring the
+    existing `base.stvec` options.
   - Which G-stage translation modes `hgatp` supports can be specified,
     see `extensions.H.hgatp_modes`. Bare is always supported. With
     Shgatpa enabled, each mode supported in `satp` must have its

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -75,6 +75,12 @@ enum clause extension = Ext_Shgatpa
 mapping clause extensionName = Ext_Shgatpa <-> "shgatpa"
 function clause hartSupports(Ext_Shgatpa) = config extensions.Shgatpa.supported
 function clause currentlyEnabled(Ext_Shgatpa) = hartSupports(Ext_Shgatpa) & currentlyEnabled(Ext_H)
+// vstvec.MODE supports Direct, and in that mode vstvec.BASE must be
+// capable of holding any valid four-byte-aligned address.
+enum clause extension = Ext_Shvstvecd
+mapping clause extensionName = Ext_Shvstvecd <-> "shvstvecd"
+function clause hartSupports(Ext_Shvstvecd) = config extensions.Shvstvecd.supported
+function clause currentlyEnabled(Ext_Shvstvecd) = hartSupports(Ext_Shvstvecd) & currentlyEnabled(Ext_H)
 
 enum clause extension = Ext_Zibi
 mapping clause extensionName = Ext_Zibi <-> "zibi"
@@ -672,6 +678,7 @@ function currentlyEnabled_measure(ext : extension) -> int =
     Ext_Zvfh => 4, // > Zfhmin
 
     Ext_Shgatpa => 5, // > H
+    Ext_Shvstvecd => 5, // > H
     Ext_V => 5, // > Zve64d
     Ext_Zvfhmin => 5, // > Zvfh
 
@@ -842,6 +849,7 @@ let extensions_ordered_for_isa_string = [
 
   // Hypervisor extensions, ordered alphabetically.
   Ext_Shgatpa,
+  Ext_Shvstvecd,
 
   // Machine mode extensions, ordered alphabetically.
   Ext_Smcntrpmf,

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -15,11 +15,15 @@ let plat_mtvec_vectored_mode_supported : bool = config base.mtvec.vectored.suppo
 let plat_stvec_direct_mode_supported : bool = config base.stvec.direct.supported
 let plat_stvec_vectored_mode_supported : bool = config base.stvec.vectored.supported
 
+let plat_vstvec_direct_mode_supported : bool = config base.vstvec.direct.supported
+let plat_vstvec_vectored_mode_supported : bool = config base.vstvec.vectored.supported
+
 // Trap vector alignment.
 type tvec_alignment = range(2, 24)
 let plat_mtvec_direct_base_alignment_exp   : tvec_alignment = config base.mtvec.direct.base_alignment
 let plat_mtvec_vectored_base_alignment_exp : tvec_alignment = config base.mtvec.vectored.base_alignment
 let plat_stvec_vectored_base_alignment_exp : tvec_alignment = config base.stvec.vectored.base_alignment
+let plat_vstvec_vectored_base_alignment_exp : tvec_alignment = config base.vstvec.vectored.base_alignment
 
 // Delegatable bits of `medeleg` and `mideleg`.
 let plat_medeleg_delegatable_bits : bits(64) = config base.medeleg.delegatable_bits

--- a/model/exceptions/sys_exceptions.sail
+++ b/model/exceptions/sys_exceptions.sail
@@ -90,7 +90,12 @@ function set_stvec(value : xlenbits) -> xlenbits = {
 }
 
 function set_vstvec(value : xlenbits) -> xlenbits = {
-  vstvec = legalize_tvec(vstvec, value, true, 2, true, 2);
+  vstvec = legalize_tvec(vstvec,
+                         value,
+                         plat_vstvec_direct_mode_supported,
+                         2,
+                         plat_vstvec_vectored_mode_supported,
+                         plat_vstvec_vectored_base_alignment_exp);
   vstvec.bits
 }
 
@@ -107,8 +112,11 @@ function reset_tvecs() -> unit = {
   } else if plat_stvec_vectored_mode_supported then {
     stvec[Mode] = trapVectorMode(TV_Vector)
   };
-  // TODO: Define config options for vstvec
-  vstvec[Mode] = trapVectorMode(TV_Direct)
+  if plat_vstvec_direct_mode_supported then {
+    vstvec[Mode] = trapVectorMode(TV_Direct)
+  } else if plat_vstvec_vectored_mode_supported then {
+    vstvec[Mode] = trapVectorMode(TV_Vector)
+  }
 }
 
 mapping clause csr_name_map = 0x205  <-> "vstvec"

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -583,7 +583,6 @@ private function check_misc_extension_dependencies() -> bool = {
     };
     valid = valid & require_virtual_memory("H");
   };
-
   if xlen == 32 then {
     if sys_hgatp_sv39x4_supported | sys_hgatp_sv48x4_supported | sys_hgatp_sv57x4_supported then {
       valid = false;
@@ -595,7 +594,6 @@ private function check_misc_extension_dependencies() -> bool = {
       print_endline("Sv32x4 is enabled: Sv32x4 is not supported on RV64.");
     };
   };
-
   // "For each supported virtual memory scheme SvNN supported in `satp`, the
   //  corresponding hgatp SvNNx4 mode must be supported."
   if (config extensions.Shgatpa.supported : bool) then {
@@ -607,6 +605,16 @@ private function check_misc_extension_dependencies() -> bool = {
     valid = valid & check_shgatpa_mode("Sv39", (config extensions.Sv39.supported : bool), sys_hgatp_sv39x4_supported);
     valid = valid & check_shgatpa_mode("Sv48", (config extensions.Sv48.supported : bool), sys_hgatp_sv48x4_supported);
     valid = valid & check_shgatpa_mode("Sv57", (config extensions.Sv57.supported : bool), sys_hgatp_sv57x4_supported);
+  };
+  if (config extensions.Shvstvecd.supported : bool) then {
+    if not(config extensions.H.supported : bool) then {
+      valid = false;
+      print_endline("The Shvstvecd extension is enabled but the H extension is disabled: supporting Shvstvecd requires H.");
+    };
+    if not(config base.vstvec.direct.supported : bool) then {
+      valid = false;
+      print_endline("The Shvstvecd extension is enabled but `vstvec` does not support the `direct` mode (see `base.vstvec.direct.supported`).");
+    };
   };
   valid
 }

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -28,6 +28,11 @@ private function check_tvecs() -> bool = {
     print_endline("`stvec` specifies neither `direct` or `vectored` is supported; one of the modes must be supported.");
   };
 
+  if (config extensions.H.supported : bool) & not(config base.vstvec.direct.supported : bool) & not(config base.vstvec.vectored.supported : bool) then {
+    valid = false;
+    print_endline("`vstvec` specifies neither `direct` or `vectored` is supported; one of the modes must be supported.");
+  };
+
   valid
 }
 


### PR DESCRIPTION
This adds config option for `vstvec`: it now has `base.vstvec.direct` and `base.vstvec.vectored`, mirroring `base.stvec`. On top of that this adds Shvstvecd, which requires `vstvec.MODE` to hold `Direct`.