### PR TITLE
Make sstvecd configurable

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -842,6 +842,11 @@
     "Sstvala": {
       "supported": true
     },
+    // Enabling Sstvecd requires that `stvec` supports the `direct` mode,
+    // see `base.stvec.direct.supported`.
+    "Sstvecd": {
+      "supported": true
+    },
     "Svade": {
       "supported": true
     },

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -8,6 +8,10 @@
   - Shvstvecd
 
 - Updates to the [configuration file](../config/config.json.in):
+  - Whether the Sstvecd extension is supported can be specified, see
+    `extensions.Sstvecd.supported`. It was previously implied by
+    supervisor mode, so the model claimed `sstvecd` even when `stvec`
+    did not support the `direct` mode.
   - Which trap vector modes `vstvec` supports can be specified, see
     `base.vstvec.direct` and `base.vstvec.vectored`, mirroring the
     existing `base.stvec` options.

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -511,6 +511,7 @@ function clause currentlyEnabled(Ext_Sstvala) = hartSupports(Ext_Sstvala) & curr
 enum clause extension = Ext_Sstvecd
 mapping clause extensionName = Ext_Sstvecd <-> "sstvecd"
 function clause hartSupports(Ext_Sstvecd) = hartSupports(Ext_S)
+function clause currentlyEnabled(Ext_Sstvecd) = hartSupports(Ext_Sstvecd) & currentlyEnabled(Ext_S)
 // sstatus.UXL must be capable of holding the value 2 (i.e., UXLEN=64 must be supported)
 enum clause extension = Ext_Ssu64xl
 mapping clause extensionName = Ext_Ssu64xl <-> "ssu64xl"

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -510,7 +510,7 @@ function clause currentlyEnabled(Ext_Sstvala) = hartSupports(Ext_Sstvala) & curr
 // capable of holding any valid four-byte-aligned address.
 enum clause extension = Ext_Sstvecd
 mapping clause extensionName = Ext_Sstvecd <-> "sstvecd"
-function clause hartSupports(Ext_Sstvecd) = hartSupports(Ext_S)
+function clause hartSupports(Ext_Sstvecd) = config extensions.Sstvecd.supported
 function clause currentlyEnabled(Ext_Sstvecd) = hartSupports(Ext_Sstvecd) & currentlyEnabled(Ext_S)
 // sstatus.UXL must be capable of holding the value 2 (i.e., UXLEN=64 must be supported)
 enum clause extension = Ext_Ssu64xl
@@ -609,7 +609,6 @@ function clause currentlyEnabled(Ext_Supm) = hartSupports(Ext_Supm) & currentlyE
 function hartSupports_measure(ext : extension) -> int =
   match ext {
     Ext_D => 1, // > F
-    Ext_Sstvecd => 1, // > S
     Ext_Ssu64xl => 1, // > S
     Ext_Zvkn => 1, // > Zvkned
     Ext_Zvks => 1, // > Zvksed

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -654,8 +654,6 @@ function tvec_addr(m : Mtvec, c : Mcause) -> option(xlenbits) = {
   }
 }
 
-function clause currentlyEnabled(Ext_Sstvecd) = hartSupports(Ext_Sstvecd) & currentlyEnabled(Ext_S)
-
 // Exception PC
 
 register mepc : xlenbits

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -584,6 +584,16 @@ private function check_misc_extension_dependencies() -> bool = {
     valid = valid & check_required_xtval_option("Shvstvala", "hardware breakpoint exceptions", hardware_breakpoint_writes_xtval);
     valid = valid & check_required_xtval_option("Shvstvala", "illegal instruction exceptions", illegal_instruction_writes_xtval);
   };
+  if (config extensions.Sstvecd.supported : bool) then {
+    if not(config extensions.S.supported : bool) then {
+      valid = false;
+      print_endline("The Sstvecd extension is enabled but supervisor mode (S) is disabled: supporting Sstvecd requires S.");
+    };
+    if not(config base.stvec.direct.supported : bool) then {
+      valid = false;
+      print_endline("The Sstvecd extension is enabled but `stvec` does not support the `direct` mode (see `base.stvec.direct.supported`).");
+    };
+  };
   if (config extensions.Ssqosid.supported : bool) & not(config extensions.Zicsr.supported : bool) then {
     valid = false;
     print_endline("The Ssqosid extension is enabled but Zicsr is disabled: supporting Ssqosid requires Zicsr.");


### PR DESCRIPTION
`hartSupports(Ext_Sstvecd)` was just `hartSupports(Ext_S)`, so the model claimed `sstvecd` even with `base.stvec.direct.supported` off. It now has its own `extensions.Sstvecd.supported` option, checked in `validate_config`.