### PR TITLE
Add the Shvsatpa extension and vsatp mode config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ An experimental emulator in the Lean language is available, see its
 - Shcounterenw extension for writable `hcounteren` enables for any supported counter, v1.0
 - Shgatpa extension for `hgatp` mode support matching `satp`, v1.0
 - Shtvala extension for Trap Value Reporting, v1.0
+- Shvsatpa extension for `vsatp` supporting all `satp` translation modes, v1.0
 - Shvstvala extension for Trap Value Reporting, v1.0
 - Shvstvecd extension for Direct Trap Vectoring, v1.0
 - Physical Memory Protection (PMP)

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ An experimental emulator in the Lean language is available, see its
 - Shcounterenw extension for writable `hcounteren` enables for any supported counter, v1.0
 - Shgatpa extension for `hgatp` mode support matching `satp`, v1.0
 - Shtvala extension for Trap Value Reporting, v1.0
-- Shvsatpa extension for `vsatp` supporting all `satp` translation modes, v1.0
+- Shvsatpa extension for Translation Mode Support, v1.0
 - Shvstvala extension for Trap Value Reporting, v1.0
 - Shvstvecd extension for Direct Trap Vectoring, v1.0
 - Physical Memory Protection (PMP)

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -580,6 +580,14 @@
         "Sv39x4": @CONFIG_XLEN_IS_64@,
         "Sv48x4": @CONFIG_XLEN_IS_64@,
         "Sv57x4": @CONFIG_XLEN_IS_64@
+      },
+      // Which VS-stage translation modes `vsatp` supports. Bare is always
+      // supported.
+      "vsatp_modes": {
+        "Sv32": @CONFIG_XLEN_IS_32@,
+        "Sv39": @CONFIG_XLEN_IS_64@,
+        "Sv48": @CONFIG_XLEN_IS_64@,
+        "Sv57": @CONFIG_XLEN_IS_64@
       }
     },
     "Zibi": {
@@ -823,6 +831,11 @@
       "supported": true
     },
     "Sscounterenw": {
+      "supported": true
+    },
+    // Enabling Shvsatpa requires that every mode supported in `satp` is also
+    // supported in `vsatp` (under `extensions.H.vsatp_modes`).
+    "Shvsatpa": {
       "supported": true
     },
     // Enabling Shvstvala requires that the exceptions specified in the

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -5,10 +5,13 @@
   - Shcounterenw
   - Shgatpa
   - Shtvala
+  - Shvsatpa
   - Shvstvala
   - Shvstvecd
 
 - Updates to the [configuration file](../config/config.json.in):
+  - Which VS-stage translation modes `vsatp` supports can be specified, see
+    `extensions.H.vsatp_modes`. Bare is always supported.
   - Whether the Sstvecd extension is supported can be specified, see
     `extensions.Sstvecd.supported`. It was previously implied by
     supervisor mode, so the model claimed `sstvecd` even when `stvec`

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -85,6 +85,11 @@ enum clause extension = Ext_Shtvala
 mapping clause extensionName = Ext_Shtvala <-> "shtvala"
 function clause hartSupports(Ext_Shtvala) = config extensions.Shtvala.supported
 function clause currentlyEnabled(Ext_Shtvala) = hartSupports(Ext_Shtvala) & currentlyEnabled(Ext_H)
+// Every translation mode supported in satp is also supported in vsatp.
+enum clause extension = Ext_Shvsatpa
+mapping clause extensionName = Ext_Shvsatpa <-> "shvsatpa"
+function clause hartSupports(Ext_Shvsatpa) = config extensions.Shvsatpa.supported
+function clause currentlyEnabled(Ext_Shvsatpa) = hartSupports(Ext_Shvsatpa) & currentlyEnabled(Ext_H)
 // `vstval` provides all the values `stval` does
 enum clause extension = Ext_Shvstvala
 mapping clause extensionName = Ext_Shvstvala <-> "shvstvala"
@@ -695,6 +700,7 @@ function currentlyEnabled_measure(ext : extension) -> int =
     Ext_Shcounterenw => 5, // > H
     Ext_Shgatpa => 5, // > H
     Ext_Shtvala => 5, // > H
+    Ext_Shvsatpa => 5, // > H
     Ext_Shvstvala => 5, // > H
     Ext_Shvstvecd => 5, // > H
     Ext_V => 5, // > Zve64d
@@ -869,6 +875,7 @@ let extensions_ordered_for_isa_string = [
   Ext_Shcounterenw,
   Ext_Shgatpa,
   Ext_Shtvala,
+  Ext_Shvsatpa,
   Ext_Shvstvala,
   Ext_Shvstvecd,
 

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -1116,6 +1116,8 @@ function legalize_satp(
     let s = if is_vsatp then s else [s with
       PPN = zero_extend(s[PPN][min(physaddr_bits - pagesize_bits, 44) - 1 .. 0]),
     ];
+    // NOTE: Sv32 is not listed because VSXLEN=XLEN here, hstatus.VSXL is
+    // read-only. It could be added if changing VSXL is supported.
     let sv39_supported = currentlyEnabled(Ext_Sv39) & (not(is_vsatp) | sys_vsatp_sv39_supported);
     let sv48_supported = currentlyEnabled(Ext_Sv48) & (not(is_vsatp) | sys_vsatp_sv48_supported);
     let sv57_supported = currentlyEnabled(Ext_Sv57) & (not(is_vsatp) | sys_vsatp_sv57_supported);

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -96,6 +96,14 @@ let sys_hgatp_sv39x4_supported : bool = config extensions.H.hgatp_modes.Sv39x4
 let sys_hgatp_sv48x4_supported : bool = config extensions.H.hgatp_modes.Sv48x4
 let sys_hgatp_sv57x4_supported : bool = config extensions.H.hgatp_modes.Sv57x4
 
+// Which VS-stage translation modes vsatp supports. Bare is always supported.
+// Shvsatpa requires vsatp to support every mode supported in satp, which
+// validate_config() checks.
+let sys_vsatp_sv32_supported : bool = config extensions.H.vsatp_modes.Sv32
+let sys_vsatp_sv39_supported : bool = config extensions.H.vsatp_modes.Sv39
+let sys_vsatp_sv48_supported : bool = config extensions.H.vsatp_modes.Sv48
+let sys_vsatp_sv57_supported : bool = config extensions.H.vsatp_modes.Sv57
+
 // Whether a guest-page fault writes the faulting guest physical address to
 // htval/mtval2, or writes zero instead. Shtvala requires the address to be
 // written, which validate_config() checks.
@@ -1091,11 +1099,13 @@ function legalize_satp(
     let s = if is_vsatp then s else [s with
       PPN = zero_extend(s[PPN][physaddr_bits - pagesize_bits - 1 .. 0]),
     ];
+    let sv32_supported = currentlyEnabled(Ext_Sv32) & (not(is_vsatp) | sys_vsatp_sv32_supported);
     match satpMode_of_bits(arch, 0b000 @ s[Mode]) {
       None()  => prev_value,
       Some(Sv_mode) => match Sv_mode {
-        Bare if currentlyEnabled(Ext_Svbare) => s.bits,
-        Sv32 if currentlyEnabled(Ext_Sv32) => s.bits,
+        // vsatp.MODE resets to 0, so Bare is always supported there.
+        Bare if is_vsatp | currentlyEnabled(Ext_Svbare) => s.bits,
+        Sv32 if sv32_supported => s.bits,
         _ => prev_value,
       }
     }
@@ -1106,13 +1116,17 @@ function legalize_satp(
     let s = if is_vsatp then s else [s with
       PPN = zero_extend(s[PPN][min(physaddr_bits - pagesize_bits, 44) - 1 .. 0]),
     ];
+    let sv39_supported = currentlyEnabled(Ext_Sv39) & (not(is_vsatp) | sys_vsatp_sv39_supported);
+    let sv48_supported = currentlyEnabled(Ext_Sv48) & (not(is_vsatp) | sys_vsatp_sv48_supported);
+    let sv57_supported = currentlyEnabled(Ext_Sv57) & (not(is_vsatp) | sys_vsatp_sv57_supported);
     match satpMode_of_bits(arch, s[Mode]) {
       None()  => prev_value,
       Some(Sv_mode) =>  match Sv_mode {
-        Bare if currentlyEnabled(Ext_Svbare) => s.bits,
-        Sv39 if currentlyEnabled(Ext_Sv39) => s.bits,
-        Sv48 if currentlyEnabled(Ext_Sv48) => s.bits,
-        Sv57 if currentlyEnabled(Ext_Sv57) => s.bits,
+        // vsatp.MODE resets to 0, so Bare is always supported there.
+        Bare if is_vsatp | currentlyEnabled(Ext_Svbare) => s.bits,
+        Sv39 if sv39_supported => s.bits,
+        Sv48 if sv48_supported => s.bits,
+        Sv57 if sv57_supported => s.bits,
         _ => prev_value,
       }
     }

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -1099,7 +1099,7 @@ function legalize_satp(
     let s = if is_vsatp then s else [s with
       PPN = zero_extend(s[PPN][physaddr_bits - pagesize_bits - 1 .. 0]),
     ];
-    let sv32_supported = currentlyEnabled(Ext_Sv32) & (not(is_vsatp) | sys_vsatp_sv32_supported);
+    let sv32_supported = if is_vsatp then sys_vsatp_sv32_supported else currentlyEnabled(Ext_Sv32);
     match satpMode_of_bits(arch, 0b000 @ s[Mode]) {
       None()  => prev_value,
       Some(Sv_mode) => match Sv_mode {
@@ -1118,9 +1118,9 @@ function legalize_satp(
     ];
     // NOTE: Sv32 is not listed because VSXLEN=XLEN here, hstatus.VSXL is
     // read-only. It could be added if changing VSXL is supported.
-    let sv39_supported = currentlyEnabled(Ext_Sv39) & (not(is_vsatp) | sys_vsatp_sv39_supported);
-    let sv48_supported = currentlyEnabled(Ext_Sv48) & (not(is_vsatp) | sys_vsatp_sv48_supported);
-    let sv57_supported = currentlyEnabled(Ext_Sv57) & (not(is_vsatp) | sys_vsatp_sv57_supported);
+    let sv39_supported = if is_vsatp then sys_vsatp_sv39_supported else currentlyEnabled(Ext_Sv39);
+    let sv48_supported = if is_vsatp then sys_vsatp_sv48_supported else currentlyEnabled(Ext_Sv48);
+    let sv57_supported = if is_vsatp then sys_vsatp_sv57_supported else currentlyEnabled(Ext_Sv57);
     match satpMode_of_bits(arch, s[Mode]) {
       None()  => prev_value,
       Some(Sv_mode) =>  match Sv_mode {

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -126,7 +126,7 @@ private function check_mmu_config() -> bool = {
       if sys_vsatp_sv32_supported
       then {
         valid = false;
-        print_endline("Sv32 is enabled for `vsatp`: Sv32 is not supported on RV64.");
+        print_endline("Sv32 is enabled for `vsatp`: Sv32 is not currently supported on RV64.");
       };
     };
   } else {

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -121,6 +121,8 @@ private function check_mmu_config() -> bool = {
         valid = false;
         print_endline("Sv48 is enabled for `vsatp` but Sv39 is disabled: supporting Sv48 requires supporting Sv39.");
       };
+      // NOTE: Sv32 for `vsatp` needs VSXLEN=32, which needs a writable
+      // `hstatus.VSXL`. Revisit this if RV32 guests on RV64 are supported.
       if sys_vsatp_sv32_supported
       then {
         valid = false;

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -60,6 +60,14 @@ private function check_shgatpa_mode(sv_name : string, satp_supported : bool, hga
   true
 }
 
+private function check_shvsatpa_mode(sv_name : string, satp_supported : bool, vsatp_supported : bool) -> bool = {
+  if satp_supported & not(vsatp_supported) then {
+    print_endline("The Shvsatpa extension is enabled and " ^ sv_name ^ " is supported in `satp`, but " ^ sv_name ^ " is disabled in `vsatp` (under `extensions.H.vsatp_modes`).");
+    return false;
+  };
+  true
+}
+
 private function require_virtual_memory(ext_name : string) -> bool = {
   if xlen == 32 then return require_Sv32(ext_name);
 
@@ -99,6 +107,26 @@ private function check_mmu_config() -> bool = {
       valid = false;
       print_endline("Sv32 is enabled: Sv32 is not supported on RV64.");
     };
+    // The spec states this ordering for the modes an implementation supports,
+    // but does not say explicitly whether it also applies to `vsatp`. Mirror
+    // the `satp` rule, so a guest cannot be left without the smaller modes.
+    if (config extensions.H.supported : bool) then {
+      if sys_vsatp_sv57_supported & not(sys_vsatp_sv48_supported)
+      then {
+        valid = false;
+        print_endline("Sv57 is enabled for `vsatp` but Sv48 is disabled: supporting Sv57 requires supporting Sv48.");
+      };
+      if sys_vsatp_sv48_supported & not(sys_vsatp_sv39_supported)
+      then {
+        valid = false;
+        print_endline("Sv48 is enabled for `vsatp` but Sv39 is disabled: supporting Sv48 requires supporting Sv39.");
+      };
+      if sys_vsatp_sv32_supported
+      then {
+        valid = false;
+        print_endline("Sv32 is enabled for `vsatp`: Sv32 is not supported on RV64.");
+      };
+    };
   } else {
     assert(xlen == 32);
     if not(config extensions.S.supported : bool) & (config extensions.Sv32.supported : bool)
@@ -115,6 +143,12 @@ private function check_mmu_config() -> bool = {
     then {
       valid = false;
       print_endline("One or more of Sv39/Sv48/Sv57 is enabled: these are not supported on RV32.");
+    };
+    if (config extensions.H.supported : bool) &
+       (sys_vsatp_sv39_supported | sys_vsatp_sv48_supported | sys_vsatp_sv57_supported)
+    then {
+      valid = false;
+      print_endline("One or more of Sv39/Sv48/Sv57 is enabled for `vsatp`: these are not supported on RV32.");
     };
   };
 
@@ -677,6 +711,18 @@ private function check_misc_extension_dependencies() -> bool = {
       valid = false;
       print_endline("The Shvstvecd extension is enabled but `vstvec` does not support the `direct` mode (see `base.vstvec.direct.supported`).");
     };
+  };
+  // "If the Shvsatpa extension is implemented, all translation modes supported
+  //  in `satp` must be supported in `vsatp`."
+  if (config extensions.Shvsatpa.supported : bool) then {
+    if not(config extensions.H.supported : bool) then {
+      valid = false;
+      print_endline("The Shvsatpa extension is enabled but the H extension is disabled: supporting Shvsatpa requires H.");
+    };
+    valid = valid & check_shvsatpa_mode("Sv32", (config extensions.Sv32.supported : bool), sys_vsatp_sv32_supported);
+    valid = valid & check_shvsatpa_mode("Sv39", (config extensions.Sv39.supported : bool), sys_vsatp_sv39_supported);
+    valid = valid & check_shvsatpa_mode("Sv48", (config extensions.Sv48.supported : bool), sys_vsatp_sv48_supported);
+    valid = valid & check_shvsatpa_mode("Sv57", (config extensions.Sv57.supported : bool), sys_vsatp_sv57_supported);
   };
   valid
 }


### PR DESCRIPTION
Adds Shvsatpa along with `extensions.H.vsatp_modes`, mirroring the `hgatp` mode options from #1893.

We have `satp` (Svnn), `vsatp` (Svnn), and `hgatp` (SvXnn).

The translation modes for satp enforce a dependency. For example, supporting Sv57 without supporting Sv48 is not possible. I can't find anywhere in the spec that explicitly says whether this dependency also applies to `vsatp`, but I'm pretty sure the same rules apply there.

`hgatp` however, is a bit strange in this regard, because it is allowed to support Sv57x4 without supporting Sv48x4, etc.

On top of that, both `vsatp` and `hgatp` need to support Bare, since that is their reset value and they are WARL.

So `vsatp` gets the same ordering checks as `satp`, and Bare stays unconditional for `vsatp`. Keeping Bare unconditional also fixes a regression from #1894. `legalize_satp` is shared between `satp` and `vsatp`, so gating Bare on Svbare applied to `vsatp` too, which according to the spec is incorrect since `vsatp.MODE` (and `hgatp.MODE`) resets to 0.