### PR TITLE
Restore `pmlen_of_mode` to be a function instead of a mapping.

### DIFF
--- a/model/extensions/pointer_masking/pm_utils.sail
+++ b/model/extensions/pointer_masking/pm_utils.sail
@@ -43,13 +43,14 @@ private function is_pmm_applicable(access : MemoryAccessType(mem_payload), eff_p
   not(mxr_in_effect) & xlen == 64
 }
 
-// Mapping a pointer-masking mode to its PMLEN. Note there is also PMM_Reserved
-// and it's an error to call this with PMM_Reserved.
-mapping pmlen_of_mode : PointerMaskingMode <-> pm_len = {
-  PMM_Disabled <-> 0,
-  PMM_PMLEN_7  <-> 7,
-  PMM_PMLEN_16 <-> 16,
-}
+// Map a pointer-masking mode to its PMLEN.
+function pmlen_of_mode(pmm : PointerMaskingMode) -> pm_len =
+  match pmm {
+    PMM_Disabled => 0,
+    PMM_PMLEN_7  => 7,
+    PMM_PMLEN_16 => 16,
+    PMM_Reserved => { internal_error(__FILE__, __LINE__, "Invalid (reserved) pointer masking mode."); 0 },
+  }
 
 // Get the effective PMLEN for a regular explicit access.
 function get_pmlen(access : MemoryAccessType(mem_payload), eff_privilege : Privilege) -> pm_len =


### PR DESCRIPTION
The mapping was potentially misleading since it was not a complete map.