### PR TITLE
Use an explicit (effective) privilege in some memory utility functions.

### DIFF
--- a/model/core/vmem_types.sail
+++ b/model/core/vmem_types.sail
@@ -133,6 +133,14 @@ function is_vector_access(access : MemoryAccessType(mem_payload)) -> bool =
     _             => false,
   }
 
+function is_implicit_access(access : MemoryAccessType(mem_payload)) -> bool =
+  match access {
+    InstructionFetch()    => true,
+    Load(PageTableEntry)  => true,
+    Store(PageTableEntry) => true,
+    _                     => false,
+  }
+
 // Memory attributes for Page-based Memory Types
 
 enum page_based_mem_type = { PBMT_PMA, PBMT_NC, PBMT_IO }

--- a/model/extensions/A/zaamo_insts.sail
+++ b/model/extensions/A/zaamo_insts.sail
@@ -93,18 +93,20 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
     };
   };
 
-  let (addr, pbmt) : (physaddr, page_based_mem_type) = match translateAddr(vaddr, access) {
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+
+  let (addr, pbmt) : (physaddr, page_based_mem_type) = match translateAddr(vaddr, access, eff_priv) {
     Err(e, _) => return trap(e),
     Ok(addr, pbmt, _) => (addr, pbmt),
   };
 
-  let loaded : bits('width * 8) = match mem_write_ea(addr, width, access, pbmt, aq & rl, rl, true) {
+  let loaded : bits('width * 8) = match mem_write_ea(addr, width, eff_priv, access, pbmt, aq & rl, rl, true) {
     Err(exc_addr, e) => {
       // AMOs should not get split.
       assert(exc_addr == addr);
       return memory_exception(e, bits_of(vaddr), access)
     },
-    Ok(_)  => match mem_read(access, pbmt, addr, width, aq, aq & rl, true) {
+    Ok(_)  => match mem_read(access, pbmt, eff_priv, addr, width, aq, aq & rl, true) {
       Err(exc_addr, e) => {
         // AMOs should not get split.
         assert(exc_addr == addr);
@@ -143,7 +145,7 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
     then X(rd) = sign_extend(loaded)
     else X_pair(rd) = sign_extend(loaded);
     RETIRE_SUCCESS
-  } else match mem_write_value(addr, width, sign_extend(result), access, pbmt, aq & rl, rl, true) {
+  } else match mem_write_value(addr, width, sign_extend(result), eff_priv, access, pbmt, aq & rl, rl, true) {
     Ok(true)  => {
       if width <= xlen_bytes
       then X(rd) = sign_extend(loaded)

--- a/model/extensions/H/hext_insts.sail
+++ b/model/extensions/H/hext_insts.sail
@@ -70,13 +70,13 @@ function clause execute HLVTYPE(width, op, is_unsigned, rs1, rd) = {
           None()                   => (),
         };
       };
-      match translateAddr_eff_priv(vaddr, access, eff_priv) {
+      match translateAddr(vaddr, access, eff_priv) {
         // No fetch->load exception conversion is needed: LoadExecute already raises load
         // (not fetch) exceptions on translation failure (see model/sys/vmem_ptw.sail),
         // matching the spec's "[HLVX] still raise the same exceptions as other load
         // instructions, rather than raising fetch exceptions instead."
         Err(e, _) => trap(e),
-        Ok(paddr, pbmt,_) => match mem_read_priv(access, pbmt, eff_priv, paddr, width, false, false, false) {
+        Ok(paddr, pbmt,_) => match mem_read(access, pbmt, eff_priv, paddr, width, false, false, false) {
           Ok(result) => { X(rd) = extend_value(is_unsigned, result); RETIRE_SUCCESS },
           Err(exc_addr, e) => {
             assert(exc_addr == paddr);
@@ -107,32 +107,33 @@ function clause execute(HSV(width, rs1, rs2)) = {
 
   assert(width <= xlen_bytes);
   let eff_priv : Privilege = privLevel_bits(zero_extend(hstatus[SPVP]), 0b1);
-  match ext_data_get_addr(rs1, zeros(), Store(Data), width) {
+  let access = Store(Data);
+  match ext_data_get_addr(rs1, zeros(), access, width) {
     Ext_DataAddr_Error(e)  => Ext_DataAddr_Check_Failure(e),
     Ext_DataAddr_OK(vaddr) => {
-      let vaddr = transform_hlsv_address(vaddr, Store(Data), eff_priv);
+      let vaddr = transform_hlsv_address(vaddr, access, eff_priv);
       // TODO: HLV and HSV emulate ordinary VS-mode accesses, so a misaligned
       // one that crosses a page boundary should be split and translated per
       // page, the way vmem_read_addr and vmem_write_addr do. That needs
       // privilege aware versions of those helpers, see the refactor TODO in
       // model/sys/mem.sail.
       if not(is_aligned_addr(vaddr, width)) then {
-        match plat_misaligned_exception(Store(Data), false) {
+        match plat_misaligned_exception(access, false) {
           Some(AccessFault)        => return hlsv_memory_exception(E_SAMO_Access_Fault(), bits_of(vaddr)),
           Some(AlignmentException) => return hlsv_memory_exception(E_SAMO_Addr_Align(), bits_of(vaddr)),
           None()                   => (),
         };
       };
-      match translateAddr_eff_priv(vaddr, Store(Data), eff_priv) {
+      match translateAddr(vaddr, access, eff_priv) {
         Err(e, _) => trap(e),
         Ok(paddr, pbmt, _) => {
-          match mem_write_ea_priv(paddr, width, eff_priv, Store(Data), pbmt, false, false, false) {
+          match mem_write_ea(paddr, width, eff_priv, access, pbmt, false, false, false) {
             Err(exc_paddr, e) => {
               let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
               return hlsv_memory_exception(e, bits_of(exc_vaddr))
             },
             Ok(_) => {
-              match mem_write_value_priv(paddr, width, X(rs2)[8 * width - 1 .. 0], eff_priv, Store(Data), pbmt, false, false, false) {
+              match mem_write_value(paddr, width, X(rs2)[8 * width - 1 .. 0], eff_priv, access, pbmt, false, false, false) {
                 Ok(true)  => RETIRE_SUCCESS,
                 Ok(false) => internal_error(__FILE__, __LINE__, "HSV got false from mem_write_value"),
                 Err(exc_paddr, e) => {

--- a/model/extensions/Zicbom/zicbom_insts.sail
+++ b/model/extensions/Zicbom/zicbom_insts.sail
@@ -84,17 +84,17 @@ private function process_clean_inval(rs1 : regidx, cbop : cbop_zicbom) -> Execut
   match get_transformed_data_addr(rs1, negative_offset, access, cache_block_size) {
     Ext_DataAddr_Error(e) => Ext_DataAddr_Check_Failure(e),
     Ext_DataAddr_OK(vaddr) => {
+      let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
       // vaddr is the aligned address, but errors report the address that
       // was encoded in the instruction. We subtract the negative offset
       // (add the positive offset) to get it. Normally this will be
       // equal to rs1, but pointer masking can change that.
       let vaddr_for_error = vaddr - negative_offset;
       // TODO/NOTE: This is weird, we should not translateAddr a different address than specified and report it
-      match translateAddr(vaddr, access) {
+      match translateAddr(vaddr, access, eff_priv) {
         Ok(paddr, pbmt, _) => {
           // Check PMA and PMP access controls.
-          let ep = effectivePrivilege(access, mstatus, cur_privilege);
-          match phys_access_check(access, pbmt, ep, paddr, cache_block_size, false) {
+          match phys_access_check(access, pbmt, eff_priv, paddr, cache_block_size, false) {
             Err(e)  => memory_exception(e, bits_of(vaddr_for_error), access),
             // If there is no error, the model has no caches so there's no
             // more action required.

--- a/model/extensions/Zicbop/zicbop_insts.sail
+++ b/model/extensions/Zicbop/zicbop_insts.sail
@@ -40,6 +40,7 @@ function clause execute ZICBOP(cbop, rs1, offset) = {
   let cache_block_addr = addr & ~(zero_extend(ones(plat_cache_block_size_exp)));
   let offset = cache_block_addr - rs1_val;
   let access : MemoryAccessType(mem_payload) = CacheAccess(CB_prefetch(cbop));
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
 
   // TODO: This is incorrect since CHERI only requires at least one byte
   // to be in bounds here, whereas `get_transformed_data_addr()` checks that all bytes
@@ -47,7 +48,7 @@ function clause execute ZICBOP(cbop, rs1, offset) = {
   match get_transformed_data_addr(rs1, offset, access, cache_block_size) {
     Ext_DataAddr_Error(_) => (), // No access to cache; no-op.
 
-    Ext_DataAddr_OK(vaddr) => match translateAddr(vaddr, access) {
+    Ext_DataAddr_OK(vaddr) => match translateAddr(vaddr, access, eff_priv) {
       Ok(paddr, pbmt, _) => {
           // Check PMA and PMP access controls.
           let ep = effectivePrivilege(access, mstatus, cur_privilege);

--- a/model/extensions/Zicbop/zicbop_insts.sail
+++ b/model/extensions/Zicbop/zicbop_insts.sail
@@ -51,8 +51,7 @@ function clause execute ZICBOP(cbop, rs1, offset) = {
     Ext_DataAddr_OK(vaddr) => match translateAddr(vaddr, access, eff_priv) {
       Ok(paddr, pbmt, _) => {
           // Check PMA and PMP access controls.
-          let ep = effectivePrivilege(access, mstatus, cur_privilege);
-          match phys_access_check(access, pbmt, ep, paddr, cache_block_size, false) {
+          match phys_access_check(access, pbmt, eff_priv, paddr, cache_block_size, false) {
             Err(_e)  => (), // No access to cache; no-op.
             Ok(_)    => (), // The model has no caches so there's no action required.
           }

--- a/model/extensions/Zicboz/zicboz_insts.sail
+++ b/model/extensions/Zicboz/zicboz_insts.sail
@@ -43,21 +43,22 @@ function clause execute ZICBOZ(rs1) = {
       //  and atomicity, including individual bytes."
       //
       // This implementation does a single atomic write.
-      match translateAddr(vaddr, access) {
+      let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+      match translateAddr(vaddr, access, eff_priv) {
         // vaddr is the aligned address, but errors report the address that
         // was encoded in the instruction. We subtract the negative offset
         // (add the positive offset) to get it. Normally this will be
         // equal to rs1, but pointer masking can change that.
         Err(e, _) => trap({ e with excinfo = bits_of(vaddr - negative_offset) }),
         Ok(paddr, pbmt, _) => {
-          match mem_write_ea(paddr, cache_block_size, access, pbmt, false, false, false) {
+          match mem_write_ea(paddr, cache_block_size, eff_priv, access, pbmt, false, false, false) {
             Err(exc_addr, e) => {
               // Cache accesses should not get split.
               assert(exc_addr == paddr);
               memory_exception(e, bits_of(vaddr - negative_offset), access)
             },
             Ok(_)  => {
-              match mem_write_value(paddr, cache_block_size, zeros(), access, pbmt, false, false, false) {
+              match mem_write_value(paddr, cache_block_size, zeros(), eff_priv, access, pbmt, false, false, false) {
                 Ok(true)  => RETIRE_SUCCESS,
                 Ok(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
                 Err(exc_addr, e) => {

--- a/model/extensions/cfi/zicfiss_insts.sail
+++ b/model/extensions/cfi/zicfiss_insts.sail
@@ -191,7 +191,9 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
     };
   };
 
-  let (paddr, pbmt) : (physaddr, page_based_mem_type) = match translateAddr(vaddr, access) {
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+
+  let (paddr, pbmt) : (physaddr, page_based_mem_type) = match translateAddr(vaddr, access, eff_priv) {
     Ok(addr, pbmt, _) => (addr, pbmt),
     Err(e, _)   => return trap(e),
   };
@@ -202,13 +204,13 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
   // implement multiprocessor synchronization."
 
   let 'width = width;
-  let mem_val : bits('width * 8) = match mem_write_ea(paddr, width, access, pbmt, aq & rl, rl, true) {
+  let mem_val : bits('width * 8) = match mem_write_ea(paddr, width, eff_priv, access, pbmt, aq & rl, rl, true) {
     Err(exc_addr, e) => {
       // AMOs should not get split.
       assert(exc_addr == paddr);
       return memory_exception(e, bits_of(vaddr), access)
     },
-    Ok(_) => match mem_read(access, pbmt, paddr, width, aq, aq & rl, true) {
+    Ok(_) => match mem_read(access, pbmt, eff_priv, paddr, width, aq, aq & rl, true) {
       Err(exc_addr, e) => {
         // AMOs should not get split.
         assert(exc_addr == paddr);
@@ -224,7 +226,7 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
   // Sequence the read of `rs2` after the call to `mem_write_ea` with the effective address.
   // See https://github.com/riscv/sail-riscv/issues/1761.
   let write_val : bits('width * 8) = X(rs2)['width * 8 - 1 .. 0];
-  match mem_write_value(paddr, width, write_val, access, pbmt, aq & rl, rl, true) {
+  match mem_write_value(paddr, width, write_val, eff_priv, access, pbmt, aq & rl, rl, true) {
     Ok(true)  => X(rd) = sign_extend(mem_val),
     Ok(false) => internal_error(__FILE__, __LINE__, "AMOSWAP_SS got false from mem_write_value"),
     Err(exc_addr, e) => {

--- a/model/postlude/fetch.sail
+++ b/model/postlude/fetch.sail
@@ -33,12 +33,15 @@ private function fetch_bytes forall 'n, 'n in {2, 4} . (fetch_start : xlenbits, 
     None()  => (),
   };
 
-  let (paddr, pbmt) : (physaddr, page_based_mem_type) = match translateAddr(Virtaddr(granule_start), InstructionFetch()) {
+  let access : MemoryAccessType(mem_payload) = InstructionFetch();
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+
+  let (paddr, pbmt) : (physaddr, page_based_mem_type) = match translateAddr(Virtaddr(granule_start), access, eff_priv) {
     Err(e, _)    => return FetchBytes_Exception(e),
     Ok(paddr, pbmt, _) => (paddr, pbmt),
   };
 
-  match mem_read(InstructionFetch(), pbmt, paddr, width, false, false, false) {
+  match mem_read(access, pbmt, eff_priv, paddr, width, false, false, false) {
     Err(exc_addr, e) => {
       // Instruction fetches are not currently split at the physical memory layer.
       assert(exc_addr == paddr);

--- a/model/postlude/fetch_rvfi.sail
+++ b/model/postlude/fetch_rvfi.sail
@@ -22,7 +22,10 @@ private function rvfi_fetch() -> FetchResult = {
   if   (PC[0] != 0b0 | (PC[1] != 0b0 & not(currentlyEnabled(Ext_Zca))))
   then return F_Error(exception_context(E_Fetch_Addr_Align(), PC));
 
-  match translateAddr(Virtaddr(PC), InstructionFetch()) {
+  let access : MemoryAccessType(mem_payload) = InstructionFetch();
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+
+  match translateAddr(Virtaddr(PC), access, eff_priv) {
     Err(e, _)   => return F_Error(e),
     Ok(_, _, _) => (),
   };
@@ -39,7 +42,7 @@ private function rvfi_fetch() -> FetchResult = {
     None()  => (),
   };
 
-  match translateAddr(Virtaddr(PC_hi), InstructionFetch()) {
+  match translateAddr(Virtaddr(PC_hi), access, eff_priv) {
     Err(e, _)   => F_Error({ e with excinfo = PC }),
     Ok(_, _, _) => F_Base(i)
   }

--- a/model/sys/mem.sail
+++ b/model/sys/mem.sail
@@ -22,13 +22,11 @@
 //
 // and some special cases which partially apply these functions:
 //
-//   mem_read_priv - strips metadata from reads
-//   mem_read_meta - uses effectivePrivilege
-//   mem_read      - both of the above partial applications
+//   mem_read_meta - returns read value and metadata
+//   mem_read      - strips metadata from reads
 //
-//   mem_write_value_meta - uses effectivePrivilege
-//   mem_write_value_priv - uses a default value for metadata
-//   mem_write_value      - both of the above partial applications
+//   mem_write_value_meta - requires an explicit metadata value
+//   mem_write_value      - uses a default metadata
 //
 // The internal implementation first performs a PMP check (if PMP is
 // enabled) and a PMA check, and then dispatches to MMIO regions or physical
@@ -327,16 +325,8 @@ termination_measure checked_mem_read repeat N
 
 // Atomic accesses can be done to MMIO regions, e.g. in kernel access to device registers.
 
-// TODO: mem_read, mem_read_meta, mem_write_ea, mem_write_value and
-// mem_write_value_meta derive the privilege internally via
-// effectivePrivilege(). translateAddr and access_is_gva recompute it again
-// for the same access. Refactor so callers compute the privilege once and
-// pass it down explicitly, i.e. use only the explicit-privilege variants
-// (mem_read_priv, mem_write_ea_priv, mem_write_value_priv, ...) and delete
-// the implicit wrappers.
-val mem_read      : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(mem_payload), page_based_mem_type, physaddr, int('n), bool, bool, bool)       -> MemoryOpResult(bits(8 * 'n))
-val mem_read_priv : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(mem_payload), page_based_mem_type, Privilege, physaddr, int('n), bool, bool, bool)       -> MemoryOpResult(bits(8 * 'n))
-val mem_read_meta : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(mem_payload), page_based_mem_type, physaddr, int('n), bool, bool, bool, bool) -> MemoryOpResult((bits(8 * 'n), mem_meta))
+val mem_read      : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(mem_payload), page_based_mem_type, Privilege, physaddr, int('n), bool, bool, bool)       -> MemoryOpResult(bits(8 * 'n))
+val mem_read_meta : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(mem_payload), page_based_mem_type, Privilege, physaddr, int('n), bool, bool, bool, bool) -> MemoryOpResult((bits(8 * 'n), mem_meta))
 val mem_read_priv_meta : forall 'n, 0 < 'n <= max_mem_access . (MemoryAccessType(mem_payload), page_based_mem_type, Privilege, physaddr, int('n), bool, bool, bool, bool) -> MemoryOpResult((bits(8 * 'n), mem_meta))
 
 // The most generic memory read operation
@@ -353,21 +343,16 @@ function mem_read_priv_meta (access, pbmt, priv, paddr, width, aq, rl, res, meta
   result
 }
 
-function mem_read_meta (access, pbmt, paddr, width, aq, rl, res, meta) =
-  mem_read_priv_meta(access, pbmt, effectivePrivilege(access, mstatus, cur_privilege), paddr, width, aq, rl, res, meta)
+function mem_read_meta (access, pbmt, eff_priv, paddr, width, aq, rl, res, meta) =
+  mem_read_priv_meta(access, pbmt, eff_priv, paddr, width, aq, rl, res, meta)
 
-// Specialized mem_read_meta that drops the metadata
-function mem_read_priv (access, pbmt, priv, paddr, width, aq, rl, res) =
-  MemoryOpResult_drop_meta(mem_read_priv_meta(access, pbmt, priv, paddr, width, aq, rl, res, false))
+// Specialized mem_read_meta that drops the metadata; this is called with the effective privilege.
+function mem_read(access, pbmt, eff_priv, paddr, width, aq, rl, res) =
+  MemoryOpResult_drop_meta(mem_read_priv_meta(access, pbmt, eff_priv, paddr, width, aq, rl, res, false))
 
-// Specialized mem_read_priv that operates at the default effective privilege
-function mem_read (access, pbmt, paddr, width, aq, rel, res) =
-  mem_read_priv(access, pbmt, effectivePrivilege(access, mstatus, cur_privilege), paddr, width, aq, rel, res)
-
-// Explicit-privilege variant, called before `mem_write_value_priv`. Used by
-// HLV/HSV whose effective privilege comes from hstatus.SPVP rather than MPRV.
-val mem_write_ea_priv : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), Privilege, MemoryAccessType(mem_payload), page_based_mem_type, bool, bool, bool) -> MemoryOpResult(unit)
-function mem_write_ea_priv(paddr, width, priv, access, pbmt, aq, rl, con) = {
+// This function is always called before `mem_write_value`.
+val mem_write_ea : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), Privilege, MemoryAccessType(mem_payload), page_based_mem_type, bool, bool, bool) -> MemoryOpResult(unit)
+function mem_write_ea(paddr, width, priv, access, pbmt, aq, rl, con) = {
   // This function should only succeed when `mem_write_value` would
   // succeed, and fail when `mem_write_value` would fail. This means
   // it should at least perform the same PMP/PMA checks, and includes
@@ -418,13 +403,7 @@ function mem_write_ea_priv(paddr, width, priv, access, pbmt, aq, rl, con) = {
 }
 
 // This lets the Rocq extraction know why the repeat loop above terminates
-termination_measure mem_write_ea_priv repeat N
-
-// This function is always called before `mem_write_value`.
-// It hence operates at effective privilege.
-val mem_write_ea : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), MemoryAccessType(mem_payload), page_based_mem_type, bool, bool, bool) -> MemoryOpResult(unit)
-function mem_write_ea(paddr, width, access, pbmt, aq, rl, con) =
-  mem_write_ea_priv(paddr, width, effectivePrivilege(access, mstatus, cur_privilege), access, pbmt, aq, rl, con)
+termination_measure mem_write_ea repeat N
 
 // dispatches to MMIO regions or physical memory regions depending on physical memory map
 function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (
@@ -514,19 +493,11 @@ function mem_write_value_priv_meta (paddr, width, value, access, pbmt, priv, met
 }
 
 // Memory write with explicit Privilege and MemoryAccessType, and implicit metadata
-val mem_write_value_priv : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), Privilege, MemoryAccessType(mem_payload), page_based_mem_type, bool, bool, bool) -> MemoryOpResult(bool)
-function mem_write_value_priv (paddr, width, value, priv, access, pbmt, aq, rl, con) =
+val mem_write_value : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), Privilege, MemoryAccessType(mem_payload), page_based_mem_type, bool, bool, bool) -> MemoryOpResult(bool)
+function mem_write_value(paddr, width, value, priv, access, pbmt, aq, rl, con) =
   mem_write_value_priv_meta(paddr, width, value, access, pbmt, priv, default_meta, aq, rl, con)
 
 // Memory write with explicit metadata and MemoryAccessType, and implicit Privilege
-val mem_write_value_meta : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), MemoryAccessType(mem_payload), page_based_mem_type, mem_meta, bool, bool, bool) -> MemoryOpResult(bool)
-function mem_write_value_meta (paddr, width, value, access, pbmt, meta, aq, rl, con) = {
-  let ep = effectivePrivilege(access, mstatus, cur_privilege);
-  mem_write_value_priv_meta(paddr, width, value, access, pbmt, ep, meta, aq, rl, con)
-}
-
-// Memory write with explicit MemoryAccessType, default metadata and implicit Privilege
-val mem_write_value : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), MemoryAccessType(mem_payload), page_based_mem_type, bool, bool, bool) -> MemoryOpResult(bool)
-function mem_write_value (paddr, width, value, access, pbmt, aq, rl, con) = {
-  mem_write_value_meta(paddr, width, value, access, pbmt, default_meta, aq, rl, con)
-}
+val mem_write_value_meta : forall 'n, 0 < 'n <= max_mem_access . (physaddr, int('n), bits(8 * 'n), Privilege, MemoryAccessType(mem_payload), page_based_mem_type, mem_meta, bool, bool, bool) -> MemoryOpResult(bool)
+function mem_write_value_meta (paddr, width, value, eff_priv, access, pbmt, meta, aq, rl, con) =
+  mem_write_value_priv_meta(paddr, width, value, access, pbmt, eff_priv, meta, aq, rl, con)

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -9,7 +9,7 @@
 // Machine-mode and supervisor-mode functionality.
 
 function effectivePrivilege(access : MemoryAccessType(mem_payload), m : Mstatus, priv : Privilege) -> Privilege =
-  if   access != InstructionFetch() & m[MPRV] == 0b1
+  if   not(is_implicit_access(access)) & m[MPRV] == 0b1
   // MPV is ignored when MPP=3, as there is no virtual machine mode
   then privLevel_bits(m[MPP], if m[MPP] == 0b11 then 0b0 else m[MPV])
   else priv

--- a/model/sys/vmem.sail
+++ b/model/sys/vmem.sail
@@ -58,7 +58,7 @@ private function write_pte forall 'n, 'n in {4, 8} . (
   pte_size : int('n),
   pte      : bits('n * 8),
 ) -> MemoryOpResult(bool) =
-  mem_write_value_priv(paddr, pte_size, pte, Supervisor, Store(PageTableEntry), PBMT_PMA, false, false, false)
+  mem_write_value(paddr, pte_size, pte, Supervisor, Store(PageTableEntry), PBMT_PMA, false, false, false)
 
 // Sscptr: Main memory supports page table read
 function clause currentlyEnabled(Ext_Ssccptr) = hartSupports(Ext_Ssccptr) & (currentlyEnabled(Ext_Sv32) | currentlyEnabled(Ext_Sv39))
@@ -68,7 +68,7 @@ private function read_pte forall 'n, 'n in {4, 8} . (
   paddr    : physaddr,
   pte_size : int('n),
 ) -> MemoryOpResult(bits(8 * 'n)) =
-  mem_read_priv(Load(PageTableEntry), PBMT_PMA, Supervisor, paddr, pte_size, false, false, false)
+  mem_read(Load(PageTableEntry), PBMT_PMA, Supervisor, paddr, pte_size, false, false, false)
 
 // Perform PTE address translation as part of VS-stage translation for implicit PTE accesses
 private function translate_PTE_addr(
@@ -697,14 +697,13 @@ private function build_exception_context(
   }
 }
 
-// NOTE: We must pass the effective privilege level, since hypervisor
-// instructions may execute with a different effective privilege.
-function translateAddr_eff_priv(
+// Top-level addr-translation function
+// PUBLIC: invoked from load-store utils, instr-fetch, atomics and CBOs, etc.
+function translateAddr(
   gva    : virtaddr,
   access : MemoryAccessType(mem_payload),
   p      : Privilege
 ) -> TR_Result(physaddr, ExceptionContext) = {
-
 
   // True if the effective privilege is virtual (VS/VU), as opposed to
   // the hart's current privilege. Used by hlv/hsv which execute in
@@ -752,19 +751,6 @@ function translateAddr_eff_priv(
     // S/VS-stage failure
     Err(ptw_error, ext_ptw) => Err(build_exception_context(gva, zeros(), access, ptw_error, if is_virtual_access then VS_Stage else S_Stage), ext_ptw)
   }
-}
-
-// Top-level addr-translation function
-// PUBLIC: invoked from instr-fetch, atomics and CBOs
-// [postlude/fetch.sail, A/zaamo_insts.sail, Zicbo{zm}/zicbo{zm}_insts.sail].
-function translateAddr(
-  vAddr : virtaddr,
-  access : MemoryAccessType(mem_payload),
-) -> TR_Result(physaddr, ExceptionContext) = {
-  // Effective privilege takes into account mstatus.PRV, mstatus.MPP
-  // See sys_control.sail for effectivePrivilege() and sys_regs.sail for cur_privilege.
-  let effPriv = effectivePrivilege(access, mstatus, cur_privilege);
-  translateAddr_eff_priv(vAddr, access, effPriv)
 }
 
 // ****************************************************************

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -92,12 +92,12 @@ function memory_exception(e : ExceptionType, excinfo : xlenbits, access : Memory
 
 // Helper for translated read access.
 private function translate_and_read_value forall 'width, 0 < 'width <= max_mem_access.
-  (vaddr : virtaddr, width : int('width), access : MemoryAccessType(mem_payload), aq : bool, rl : bool, res : bool)
+  (vaddr : virtaddr, width : int('width), eff_priv : Privilege, access : MemoryAccessType(mem_payload), aq : bool, rl : bool, res : bool)
   -> result((physaddr, bits(8 * 'width)), ExecutionResult) =
-  match translateAddr(vaddr, access) {
+  match translateAddr(vaddr, access, eff_priv) {
     Err(e, _) => Err(trap(e)),
 
-    Ok(paddr, pbmt, _) => match mem_read(access, pbmt, paddr, width, aq, rl, res) {
+    Ok(paddr, pbmt, _) => match mem_read(access, pbmt, eff_priv, paddr, width, aq, rl, res) {
       Err(exc_paddr, e) => {
         let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
         Err(memory_exception(e, bits_of(exc_vaddr), access))
@@ -138,16 +138,16 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
   // We should only split the access before address translation if (a)
   // virtual memory is in effect, and (b) it crosses a page boundary.
   // If we do split, perform the split access in the configured order.
-  let effPriv = effectivePrivilege(access, mstatus, cur_privilege);
-  let vmem_active : bool = if privLevel_is_virtual(cur_privilege)
-  then vsatp_mode() != Bare | hgatp_mode() != HBare
-  else satp_mode(cur_privilege) != Bare;
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+  let vmem_active : bool = if privLevel_is_virtual(eff_priv)
+                           then vsatp_mode() != Bare | hgatp_mode() != HBare
+                           else satp_mode(eff_priv) != Bare;
   let do_split_access = vmem_active & next_page_bytes > 0 & not(res);
 
   if sys_misaligned_order_decreasing & do_split_access then {
     // Do next page access first.
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
-    match translate_and_read_value(access_addr, next_page_bytes, access, aq, rl, res) {
+    match translate_and_read_value(access_addr, next_page_bytes, eff_priv, access, aq, rl, res) {
       Err(e)   => return Err(e),
       Ok(_, v) => data[8 * width - 1 .. 8 * in_page_bytes] = v,
     }
@@ -156,7 +156,7 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
   // If the access was split, only the in-page bytes should be
   // accessed, otherwise all bytes should be accessed.
   let access_width = if do_split_access then in_page_bytes else width;
-  match translate_and_read_value(vaddr, access_width, access, aq, rl, res) {
+  match translate_and_read_value(vaddr, access_width, eff_priv, access, aq, rl, res) {
     Err(e)       => return Err(e),
     Ok(paddr, v) => {
       if res then {
@@ -171,7 +171,7 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
   if not(sys_misaligned_order_decreasing) & do_split_access then {
     // Do next page access next.
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
-    match translate_and_read_value(access_addr, next_page_bytes, access, aq, rl, res) {
+    match translate_and_read_value(access_addr, next_page_bytes, eff_priv, access, aq, rl, res) {
       Err(e)   => return Err(e),
       Ok(_, v) => data[8 * width - 1 .. 8 * in_page_bytes] = v,
     }
@@ -182,18 +182,19 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
 
 // Helper for translated write access.
 private function translate_and_write_value forall 'width, 0 < 'width <= max_mem_access.
-  (vaddr : virtaddr, width : int('width), value : bits(8 * 'width), access : MemoryAccessType(mem_payload), aq : bool, rl : bool, res : bool)
+  (vaddr : virtaddr, width : int('width), value : bits(8 * 'width), eff_priv : Privilege, access : MemoryAccessType(mem_payload), aq : bool, rl : bool, res : bool)
   -> result(bool, ExecutionResult) =
-  match translateAddr(vaddr, access) {
+
+  match translateAddr(vaddr, access, eff_priv) {
     Err(e, _) => Err(trap(e)),
 
-    Ok(paddr, pbmt, _) => match mem_write_ea(paddr, width, access, pbmt, aq, rl, res) {
+    Ok(paddr, pbmt, _) => match mem_write_ea(paddr, width, eff_priv, access, pbmt, aq, rl, res) {
       Err(exc_paddr, e) => {
         let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
         Err(memory_exception(e, bits_of(exc_vaddr), access))
       },
 
-      Ok(()) => match mem_write_value(paddr, width, value, access, pbmt, aq, rl, res) {
+      Ok(()) => match mem_write_value(paddr, width, value, eff_priv, access, pbmt, aq, rl, res) {
         Err(exc_paddr, e) => {
           let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
           Err(memory_exception(e, bits_of(exc_vaddr), access))
@@ -235,23 +236,24 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
 
   let (in_page_bytes, next_page_bytes) = split_on_page_boundary(vaddr_bits, width);
 
-  let effPriv = effectivePrivilege(access, mstatus, cur_privilege);
-  let vmem_active : bool = if privLevel_is_virtual(cur_privilege)
-  then vsatp_mode() != Bare | hgatp_mode() != HBare
-  else satp_mode(cur_privilege) != Bare;
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+
+  let vmem_active : bool = if privLevel_is_virtual(eff_priv)
+                           then vsatp_mode() != Bare | hgatp_mode() != HBare
+                           else satp_mode(eff_priv) != Bare;
   let do_split_access = vmem_active & next_page_bytes > 0 & not(res);
 
   if sys_misaligned_order_decreasing & do_split_access then {
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
     let write_value = data[8 * width - 1 .. 8 * in_page_bytes];
-    match translate_and_write_value(access_addr, next_page_bytes, write_value, access, aq, rl, res) {
+    match translate_and_write_value(access_addr, next_page_bytes, write_value, eff_priv, access, aq, rl, res) {
       Err(e) => return Err(e),
       Ok(s)  => write_success = write_success & s,
     }
   };
 
   let access_width = if do_split_access then in_page_bytes else width;
-  match translateAddr(vaddr, access) {
+  match translateAddr(vaddr, access, eff_priv) {
     Err(e, _) => return Err(trap(e)),
 
     Ok(paddr, pbmt, _) => {
@@ -262,12 +264,11 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
         // instruction which accesses a physical address within a
         // PMP region without write permissions raises a store
         // access-fault exception."
-        let effPriv = effectivePrivilege(access, mstatus, cur_privilege);
-        match phys_access_check(access, pbmt, effPriv, paddr, access_width, true) {
+        match phys_access_check(access, pbmt, eff_priv, paddr, access_width, true) {
           Err(e) => return Err(memory_exception(e, bits_of(vaddr), access)),
           Ok(_)  => write_success = false,
         }
-      } else match mem_write_ea(paddr, access_width, access, pbmt, aq, rl, res) {
+      } else match mem_write_ea(paddr, access_width, eff_priv, access, pbmt, aq, rl, res) {
         Err(exc_paddr, e) => {
           let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
           return Err(memory_exception(e, bits_of(exc_vaddr), access))
@@ -275,7 +276,7 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
 
         Ok(()) => {
           let write_value = data[8 * access_width - 1 .. 0];
-          match mem_write_value(paddr, access_width, write_value, access, pbmt, aq, rl, res) {
+          match mem_write_value(paddr, access_width, write_value, eff_priv, access, pbmt, aq, rl, res) {
             Err(exc_paddr, e) => {
               let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
               return Err(memory_exception(e, bits_of(exc_vaddr), access))
@@ -290,7 +291,7 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
   if not(sys_misaligned_order_decreasing) & do_split_access then {
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
     let write_value = data[8 * width - 1 .. 8 * in_page_bytes];
-    match translate_and_write_value(access_addr, next_page_bytes, write_value, access, aq, rl, res) {
+    match translate_and_write_value(access_addr, next_page_bytes, write_value, eff_priv, access, aq, rl, res) {
       Err(e) => return Err(e),
       Ok(s)  => write_success = write_success & s,
     }


### PR DESCRIPTION
This reduces the impedance mismatch between the handling of instructions such as the hypervisor load/store instructions that operate at a different privilege than the current privilege, and the functions in `vmem_utils`.

The `mem.sail` wrappers that used an implicit privilege have been removed or now require an explicit (effective) privilege.

A subsequent refactor will align the exception contexts, and require an explicit privilege to be passed to the functions in `vmem_utils`.