### PR TITLE
Expose AK_ifetch / AK_ttw at the concurrency interface

### DIFF
--- a/model/core/phys_mem_interface.sail
+++ b/model/core/phys_mem_interface.sail
@@ -30,6 +30,7 @@ enum write_kind = {
 enum read_kind = {
   Read_plain,
   Read_ifetch,
+  Read_ttw,
   // Note: Read_RISCV_acquire and Read_RISCV_strong_acquire are currently
   // unused but removing them may break Isla, and they might be used in future
   // by Zalasr.
@@ -128,6 +129,7 @@ function read_ram(rk, Physaddr(addr), width, read_meta) = {
     access_kind = match rk {
       Read_plain => AK_explicit(struct { variety = AV_plain, strength = AS_normal }),
       Read_ifetch => AK_ifetch(),
+      Read_ttw => AK_ttw(),
       Read_RISCV_acquire => internal_error(__FILE__, __LINE__, "Read_RISCV_acquire is unused"),
       Read_RISCV_strong_acquire => internal_error(__FILE__, __LINE__, "Read_RISCV_strong_acquire is unused"),
       Read_RISCV_reserved => AK_explicit(struct { variety = AV_exclusive, strength = AS_normal }),

--- a/model/sys/mem.sail
+++ b/model/sys/mem.sail
@@ -284,7 +284,11 @@ private function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (
   var i : range(0, 'N - 1) = first;
   var finished : bool = false;
 
-  let rk = read_kind_of_flags(aq, rl, res);
+  let rk : read_kind = match (access, res) {
+    (InstructionFetch(), false)   => Read_ifetch,
+    (Load(PageTableEntry), false) => Read_ttw,
+    (_, _)                        => read_kind_of_flags(aq, rl, res),
+  };
 
   repeat {
     let offset = i;


### PR DESCRIPTION
The concurrency interface defines AK_ifetch and AK_ttw, but the current Sail model does not carry the information about the reason for a memory load through to the MemRead event.  This change propagates the memory read type all the way through to the MemRead event.  This makes it possible to implement memory models where instruction or page-table reads are treated differently (e.g., RISC-V's non-coherent icache).

This patch is the result of a verification project on top of the Sail model using Claude Code, and the patch itself was also co-developed together with Claude Code.