### PR TITLE
Allow ignoring of writes of reserved values to `xtvec.MODE` and `xenvcfg.CBIE`.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -159,11 +159,12 @@
       "reserved_exceptions": false
     },
     "reserved_behavior": {
-      // The configuration option determines how to handle the reserved behavior `amocas_odd_registers`.
+      // This option determines how to handle AMOCAS.{D,Q} instructions that specify
+      // a reserved register pair.
       // "AMOCAS_Fatal"  – raise a Sail exception, stopping execution.
       // "AMOCAS_Illegal" – treat it as an illegal instruction.
       "amocas_odd_register": "AMOCAS_Illegal",
-      // The configuration option determines how to handle execution of a floating-point
+      // This option determines how to handle execution of a floating-point
       // instruction with DYN (dynamic) rounding mode when `fcsr.FRM` contains a
       // reserved value (0b101, 0b110, 0b111).
       // This does not affect the execution of floating-point instructions that have a
@@ -171,19 +172,22 @@
       // "Fcsr_RM_Fatal"  – raise a Sail exception, stopping execution.
       // "Fcsr_RM_Illegal" – treat it as an illegal instruction.
       "fcsr_rm": "Fcsr_RM_Illegal",
-      // The configuration option determines how to handle the reserved behavior `pmpcfg_with_R0W1`.
+      // This option determines how to handle writes to a `pmpcfg` register of a reserved
+      // combination with `R=0` and `W=1`.
       // "PMP_Fatal"  – raise a Sail exception, stopping execution.
       // "PMP_ClearPermissions" – convert a PMP entry with R=0, W=1 to R=0, W=0, X=0.
+      // "PMP_Ignore" - preserve the previous value.
       "pmpcfg_write_only": "PMP_ClearPermissions",
-      // The configuration option determines how to handle the reserved behavior `xenvcfg.CBIE` with 0b10.
+      // This option determines how to handle writes of the reserved value of 0b10 to `xenvcfg.CBIE`.
       // "Xenvcfg_Fatal"  – raise a Sail exception, stopping execution.
-      // "Xenvcfg_ClearPermissions" – convert CBIE with 0b10 to 0b00.
+      // "Xenvcfg_ClearPermissions" – write 0b00 to CBIE instead.
+      // "Xenvcfg_Ignore" - preserve the previous value of the field.
       "xenvcfg_cbie": "Xenvcfg_ClearPermissions",
-      // The configuration option determines how to handle the reserved behavior `xtvec[Mode] >= 2`.
+      // This option determines how to handle writes of reserved values (>=2) to the `xtvec.Mode`.
       // "Xtvec_Fatal"  – raise a Sail exception, stopping execution.
       // "Xtvec_Ignore" – use old Mode of xtvec.
       "xtvec_mode": "Xtvec_Ignore",
-      // The configuration option determines how to handle the reserved behavior: Odd-numbered registers for RV32Zdinx.
+      // This option determines how to handle the reserved behavior: Odd-numbered registers for RV32Zdinx.
       // "Zdinx_Fatal"  – raise a Sail exception, stopping execution.
       // "Zdinx_Illegal" – treat it as an illegal instruction.
       "rv32zdinx_odd_register": "Zdinx_Illegal"
@@ -476,7 +480,7 @@
     // wait. It is not possible to wait indefinitely.
     //
     // If WFI or WRS.STO (Short TimeOut) exceed this limit in
-    // non-machine privilege with mstatus[TW] set, an illegal
+    // non-machine privilege with mstatus.TW set, an illegal
     // instruction is raised. Otherwise they retire successfully.
     //
     // Note: it is also legal for these instructions to spuriously
@@ -493,7 +497,7 @@
     },
     "F": {
       "supported": true,
-      // When to set mstatus[FS] and mstatus[SD] to 1, as a result of fflags
+      // When to set mstatus.FS and mstatus.SD to 1, as a result of fflags
       // being set. There are three options:
       //
       // - Fflags_Dirty_Precise: Only set FS/SD when absolutely required, because

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -52,6 +52,9 @@
     modified; they now have a configuration that is similar to, but
     independent of, AMOs. See `memory.misaligned.exceptions.lrsc`
     and the `misaligned_exceptions.lrsc` PMA attribute.
+  - Writes of reserved values to `xenvcfg.CBIE` and `xtvec.MODE` can
+    now also be ignored; see `reserved_behavior.pmpcfg_write_only` and
+    `reserved_behavior.xenvcfg_cbie`.
 
 - Xvisor boot is now tested in CI. The `os-boot` Makefile has been
   generalized to build both the Linux and Xvisor images.

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -153,11 +153,13 @@ enum FcsrRmReservedBehavior = {
 enum PmpWriteOnlyReservedBehavior = {
   PMP_Fatal,
   PMP_ClearPermissions,
+  PMP_Ignore,
 }
 
 enum XenvcfgCbieReservedBehavior = {
   Xenvcfg_Fatal,
   Xenvcfg_ClearPermissions,
+  Xenvcfg_Ignore,
 }
 
 enum XtvecModeReservedBehavior = {

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -470,12 +470,13 @@ bitfield HEnvcfg : bits(64) = {
   FIOM  : 0,
 }
 
-private function legalize_xenvcfg_cbie(cbie : bits(2)) -> bits(2) = {
-  if cbie != 0b10 then {
-    cbie
+private function legalize_xenvcfg_cbie(old_cbie : bits(2), new_cbie : bits(2)) -> bits(2) = {
+  if new_cbie != 0b10 then {
+    new_cbie
   } else match xenvcfg_cbie_reserved_behavior {
       Xenvcfg_Fatal => reserved_behavior("xenvcfg.CBIE = 0b10"),
       Xenvcfg_ClearPermissions => 0b00,
+      Xenvcfg_Ignore => old_cbie,
     }
 }
 
@@ -487,7 +488,7 @@ private function legalize_menvcfg(o : MEnvcfg, v : bits(64)) -> MEnvcfg = {
     SSE  = if hartSupports(Ext_Zicfiss) then v[SSE] else 0b0,
     CBZE = if currentlyEnabled(Ext_Zicboz) then v[CBZE] else 0b0,
     CBCFE = if currentlyEnabled(Ext_Zicbom) then v[CBCFE] else 0b0,
-    CBIE = if currentlyEnabled(Ext_Zicbom) then legalize_xenvcfg_cbie(v[CBIE]) else 0b00,
+    CBIE = if currentlyEnabled(Ext_Zicbom) then legalize_xenvcfg_cbie(o[CBIE], v[CBIE]) else 0b00,
     STCE = if currentlyEnabled(Ext_Sstc) then v[STCE] else 0b0,
     PMM = if currentlyEnabled(Ext_Smnpm) & is_supported_pmm(PM_SMNPM, pmm_mode(v[PMM])) then v[PMM] else o[PMM],
     ADUE = if currentlyEnabled(Ext_Svadu) then v[ADUE] else 0b0,
@@ -510,7 +511,7 @@ private function legalize_senvcfg(o : SEnvcfg, v : bits(64)) -> SEnvcfg = {
     SSE = if hartSupports(Ext_Zicfiss) then v[SSE] else 0b0,
     CBZE = if currentlyEnabled(Ext_Zicboz) then v[CBZE] else 0b0,
     CBCFE = if currentlyEnabled(Ext_Zicbom) then v[CBCFE] else 0b0,
-    CBIE = if currentlyEnabled(Ext_Zicbom) then legalize_xenvcfg_cbie(v[CBIE]) else 0b00,
+    CBIE = if currentlyEnabled(Ext_Zicbom) then legalize_xenvcfg_cbie(o[CBIE], v[CBIE]) else 0b00,
     PMM = if currentlyEnabled(Ext_Ssnpm) & is_supported_pmm(PM_SSNPM, pmm_mode(v[PMM])) then v[PMM] else o[PMM],
     UKTE = if currentlyEnabled(Ext_Svukte) then v[UKTE] else 0b0,
     // Other extensions are not implemented yet so all other fields are read only zero.
@@ -530,7 +531,7 @@ private function legalize_henvcfg(h : HEnvcfg, v : bits(64)) -> HEnvcfg = {
     PMM  = if currentlyEnabled(Ext_Ssnpm) & is_supported_pmm(PM_SSNPM, pmm_mode(v[PMM])) then v[PMM] else h[PMM],
     CBZE  = if currentlyEnabled(Ext_Zicboz) then v[CBZE]  else 0b0,
     CBCFE = if currentlyEnabled(Ext_Zicbom) then v[CBCFE] else 0b0,
-    CBIE  = if currentlyEnabled(Ext_Zicbom) then legalize_xenvcfg_cbie(v[CBIE]) else 0b00,
+    CBIE  = if currentlyEnabled(Ext_Zicbom) then legalize_xenvcfg_cbie(h[CBIE], v[CBIE]) else 0b00,
     SSE   = if currentlyEnabled(Ext_Zicfiss) & menvcfg[SSE] == 0b1 then v[SSE] else 0b0,
     LPE   = if hartSupports(Ext_Zicfilp) then v[LPE]  else 0b0,
     FIOM  = if sys_enable_writable_fiom  then v[FIOM] else 0b0,

--- a/model/pmp/pmp_regs.sail
+++ b/model/pmp/pmp_regs.sail
@@ -100,18 +100,19 @@ private function pmpWriteCfg(cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent =
   if pmpLocked(cfg) then cfg
   else {
     // Bits 5 and 6 are zero.
-    let cfg = Mk_Pmpcfg_ent(v & 0x9f);
+    let new_cfg = Mk_Pmpcfg_ent(v & 0x9f);
 
     // "The R, W, and X fields form a collective WARL field for which the combinations with R=0 and W=1 are reserved."
     // if R=0 and W=1, we allow two options currently:
     // 1. exit the simulation with a fatal error
     // 2. R, W and X are all set to 0.
-    let cfg = if cfg[W] == 0b1 & cfg[R] == 0b0 then (
+    let cfg = if new_cfg[W] == 0b1 & new_cfg[R] == 0b0 then (
       match pmp_write_only_reserved_behavior {
         PMP_Fatal => reserved_behavior("pmpcfg with R=0,W=1"),
-        PMP_ClearPermissions => [cfg with X = 0b0, W = 0b0, R = 0b0],
+        PMP_ClearPermissions => [new_cfg with X = 0b0, W = 0b0, R = 0b0],
+        PMP_Ignore => cfg,
       }
-    ) else cfg;
+    ) else new_cfg;
 
     // We support disabling all modes globally, which is allowed since this
     // is a WARL field.


### PR DESCRIPTION
This adds additional `Ignore` option values for the corresponding config parameters.

Make some of the documentation comments in the config file a bit clearer.

Fixes #1912.