### PR TITLE
vmem: mask reconstructed `*tval` to `physaddr_bits`

### DIFF
--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -43,8 +43,8 @@ function plat_misaligned_exception(access : MemoryAccessType(mem_payload), res :
 // `virtaddr` access may be split into smaller `physaddr` accesses,
 // the correct offset from the base `virtaddr` needs to be reported.
 // Since `virtaddr` accesses that straddle page boundaries are already
-// split, the offset computation is quite simple. The result is also 
-// masked to physaddr_bits, since bits above it aren't part of any 
+// split, the offset computation is quite simple. The result is also
+// masked to physaddr_bits, since bits above it aren't part of any
 // physical address this configuration implements.
 
 function offset_virtaddr_by(

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -43,7 +43,9 @@ function plat_misaligned_exception(access : MemoryAccessType(mem_payload), res :
 // `virtaddr` access may be split into smaller `physaddr` accesses,
 // the correct offset from the base `virtaddr` needs to be reported.
 // Since `virtaddr` accesses that straddle page boundaries are already
-// split, the offset computation is quite simple.
+// split, the offset computation is quite simple. The result is also 
+// masked to physaddr_bits, since bits above it aren't part of any 
+// physical address this configuration implements.
 
 function offset_virtaddr_by(
   Virtaddr(base_vaddr) : virtaddr,
@@ -52,7 +54,9 @@ function offset_virtaddr_by(
 ) -> virtaddr = {
   // Physical addresses may have a different size.
   let offset = (exc_paddr - base_paddr)[xlen - 1 .. 0];
-  Virtaddr(base_vaddr + offset)
+  let reconstructed = base_vaddr + offset;
+  let masked = if physaddr_bits < xlen then reconstructed & zero_extend(ones(physaddr_bits)) else reconstructed;
+  Virtaddr(masked)
 }
 
 // External API


### PR DESCRIPTION
`offset_virtaddr_by()` rebuilds the full address reported in `*tval` after a physical-memory access fault. On configs where `physaddr_bits < xlen` this keeps address bits above the implemented physical width, which don't correspond to any real address.  This masks those bits off.

When a load, store, or AMO faults because the address it computed is outside the machine's actual physical memory, Sail reports the *original, full-width* address in `mtval`/`stval` — even on configs where `memory.physaddr_bits` is set narrower than `xlen`. So on a config that says "this chip only has a 40-bit physical address bus," Sail can still report a 64-bit-wide value in `mtval` that has bits set way above bit 39, which isn't a real address on that machine at all. The code responsible is `offset_virtaddr_by()` in `model/sys/vmem_utils.sail` — it reconstructs the pre-fault address to report in `*tval`, but never applies the model's own `physaddr_bits` limit to that value. This isn't specific to any one instruction type: every load/store/AMO in the model funnels through this same function, so the bug affects any DUT that both configures `physaddr_bits < xlen` and can construct a fault-triggering address wide enough to expose it.

This was found via [riscv-arch-test (ACT4)](https://github.com/riscv/riscv-arch-test). Running ACT4's tests on a real 40-bit-physaddr RISC-V board (SpacemiT K1 / Banana Pi BPI-F3) surfaced 128 failing tests (`EEW=64` indexed vector load/store, every load/store/segment-count combination), all with the identical shape: Sail's golden `mtval` was e.g. `0xffffffff042157c0`, while the real chip reported `0x000000ff042157c0` for the exact same fault. The two values are identical except that the hardware's is missing every bit above bit 39, exactly matching the board's configured 40-bit physical width.

Fixes #1918.