### PR TITLE
Add `memory.misaligned.misaligned_has_priority` config.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -230,14 +230,21 @@
       "na4_supported": true,
       "napot_supported": true
     },
-    // These settings control global support for misaligned access so they are
-    // checked before address translation. `misaligned_fault` in
-    // `regions` is checked after address translation.
+    // These settings control global support for misaligned access.
+    // `misaligned_has_priority` chooses whether a configured VA-misaligned
+    // exception is taken before address translation, or whether
+    // translation is attempted first. PMA `misaligned_exceptions` in
+    // `regions` are always checked after address translation.
     "misaligned": {
       // `exceptions` specifies the treatment of misaligned accesses
-      // before address translation.  If a fault is specified for an access,
-      // it will have a higher priority than memory-protection faults arising from
-      // that access if it were allowed to proceed.
+      // at the virtual-address level.  If a fault is specified for an
+      // access, `misaligned_has_priority` below controls whether that
+      // fault is taken before address translation (`true`, the default)
+      // or only after translation succeeds (`false`).  When true, the
+      // VA-misaligned exception has higher priority than page/guest-page
+      // faults and PMA faults.  When false, a page/guest-page fault from
+      // translation is reported instead; the configured VA-misaligned
+      // exception is taken only if translation succeeds.
       "exceptions": {
         // A misaligned scalar or vector load/store, or an AMO, can either proceed
         // without a fault (use `{"None" : null}`), or raise an access fault
@@ -263,6 +270,12 @@
         // or a misaligned exception (use `"AlignmentException"`).
         "lrsc": "AccessFault"
       },
+      // When a misaligned access would also page-fault (or guest-page-fault):
+      //   true  - take the configured VA-misaligned exception without
+      //           translating (default; historical Sail behaviour)
+      //   false - translate first; report a page/guest-page fault if
+      //           translation fails, otherwise the VA-misaligned exception
+      "misaligned_has_priority": true,
       // If multiple memory operations are needed (e.g. when an access
       // straddles a page boundary), this controls whether they are
       // done in increasing or decreasing address order. This is

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -15,6 +15,13 @@
     see `extensions.H.hgatp_modes`. Bare is always supported. With
     Shgatpa enabled, each mode supported in `satp` must have its
     matching SvNNx4 mode enabled.
+  - The relative priority of a configured VA-misaligned exception and a
+    page/guest-page fault can be specified; see
+    `memory.misaligned.misaligned_has_priority`. The default `true`
+    preserves historical Sail behaviour (the VA-misaligned exception is
+    taken without translating). `false` translates first and reports a
+    page/guest-page fault if translation fails. Matches Whisper's
+    `misaligned_has_priority`.
   - Whether each bit of `hcounteren` is writable or read-only zero can
     be specified, see `base.hcounteren_writable_bits`.
   - Whether the guest-page-fault exceptions write a non-zero `xtval`

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -93,6 +93,12 @@ struct GlobalMisalignedExceptions = {
 // The handling of misaligned accesses before address translation.
 let plat_misaligned_access : GlobalMisalignedExceptions = config memory.misaligned.exceptions
 
+// When true (default), a configured VA-misaligned exception is taken
+// without translating. When false, translation is attempted first and a
+// page/guest-page fault is reported if it fails. Matches Whisper's
+// `misaligned_has_priority`.
+let plat_misaligned_has_priority : bool = config memory.misaligned.misaligned_has_priority
+
 // Legal values for FS and VS.  This is an enumeration to avoid lists.
 enum ExtContextPolicy = {
   ExtContext_Off,        // The extension is always off.

--- a/model/extensions/A/zaamo_insts.sail
+++ b/model/extensions/A/zaamo_insts.sail
@@ -82,20 +82,20 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
   };
 
   if not(is_aligned_addr(vaddr, width)) then {
-    // Check if the model is configured to raise an exception based on
-    // the misaligned virtual address.
-    match plat_misaligned_exception(access, false) {
-      Some(AccessFault)        => return memory_exception(E_SAMO_Access_Fault(), bits_of(vaddr), access),
-      Some(AlignmentException) => return memory_exception(E_SAMO_Addr_Align(), bits_of(vaddr), access),
-      // No exception yet, but we may still get one based on the
-      // physical address after address translation and checking PMAs.
-      None()                   => (),
+    match check_va_misaligned(vaddr, width, access, false, true, false) {
+      Some(e) => return memory_exception(e, bits_of(vaddr), access),
+      None()  => (),
     };
   };
 
   let (addr, pbmt) : (physaddr, page_based_mem_type) = match translateAddr(vaddr, access) {
     Err(e, _) => return trap(e),
     Ok(addr, pbmt, _) => (addr, pbmt),
+  };
+
+  match check_va_misaligned(vaddr, width, access, false, true, true) {
+    Some(e) => return memory_exception(e, bits_of(vaddr), access),
+    None()  => (),
   };
 
   let loaded : bits('width * 8) = match mem_write_ea(addr, width, access, pbmt, aq & rl, rl, true) {

--- a/model/extensions/H/hext_insts.sail
+++ b/model/extensions/H/hext_insts.sail
@@ -64,10 +64,9 @@ function clause execute HLVTYPE(width, op, is_unsigned, rs1, rd) = {
       // privilege aware versions of those helpers, see the refactor TODO in
       // model/sys/mem.sail.
       if not(is_aligned_addr(vaddr, width)) then {
-        match plat_misaligned_exception(access, false) {
-          Some(AccessFault)        => return hlsv_memory_exception(E_Load_Access_Fault(), bits_of(vaddr)),
-          Some(AlignmentException) => return hlsv_memory_exception(E_Load_Addr_Align(), bits_of(vaddr)),
-          None()                   => (),
+        match check_va_misaligned(vaddr, width, access, false, false, false) {
+          Some(e) => return hlsv_memory_exception(e, bits_of(vaddr)),
+          None()  => (),
         };
       };
       match translateAddr_eff_priv(vaddr, access, eff_priv) {
@@ -76,11 +75,17 @@ function clause execute HLVTYPE(width, op, is_unsigned, rs1, rd) = {
         // matching the spec's "[HLVX] still raise the same exceptions as other load
         // instructions, rather than raising fetch exceptions instead."
         Err(e, _) => trap(e),
-        Ok(paddr, pbmt,_) => match mem_read_priv(access, pbmt, eff_priv, paddr, width, false, false, false) {
-          Ok(result) => { X(rd) = extend_value(is_unsigned, result); RETIRE_SUCCESS },
-          Err(exc_addr, e) => {
-            assert(exc_addr == paddr);
-            return hlsv_memory_exception(e, bits_of(vaddr))
+        Ok(paddr, pbmt,_) => {
+          match check_va_misaligned(vaddr, width, access, false, false, true) {
+            Some(e) => return hlsv_memory_exception(e, bits_of(vaddr)),
+            None()  => (),
+          };
+          match mem_read_priv(access, pbmt, eff_priv, paddr, width, false, false, false) {
+            Ok(result) => { X(rd) = extend_value(is_unsigned, result); RETIRE_SUCCESS },
+            Err(exc_addr, e) => {
+              assert(exc_addr == paddr);
+              return hlsv_memory_exception(e, bits_of(vaddr))
+            }
           }
         },
       };
@@ -117,15 +122,18 @@ function clause execute(HSV(width, rs1, rs2)) = {
       // privilege aware versions of those helpers, see the refactor TODO in
       // model/sys/mem.sail.
       if not(is_aligned_addr(vaddr, width)) then {
-        match plat_misaligned_exception(Store(Data), false) {
-          Some(AccessFault)        => return hlsv_memory_exception(E_SAMO_Access_Fault(), bits_of(vaddr)),
-          Some(AlignmentException) => return hlsv_memory_exception(E_SAMO_Addr_Align(), bits_of(vaddr)),
-          None()                   => (),
+        match check_va_misaligned(vaddr, width, Store(Data), false, true, false) {
+          Some(e) => return hlsv_memory_exception(e, bits_of(vaddr)),
+          None()  => (),
         };
       };
       match translateAddr_eff_priv(vaddr, Store(Data), eff_priv) {
         Err(e, _) => trap(e),
         Ok(paddr, pbmt, _) => {
+          match check_va_misaligned(vaddr, width, Store(Data), false, true, true) {
+            Some(e) => return hlsv_memory_exception(e, bits_of(vaddr)),
+            None()  => (),
+          };
           match mem_write_ea_priv(paddr, width, eff_priv, Store(Data), pbmt, false, false, false) {
             Err(exc_paddr, e) => {
               let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);

--- a/model/extensions/cfi/zicfiss_insts.sail
+++ b/model/extensions/cfi/zicfiss_insts.sail
@@ -179,21 +179,19 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
 
   // "The same exception options [as AMOs in the A extension] apply if
   // the address is not naturally aligned."
-  if not(is_aligned_addr(vaddr, width)) then {
-    // Check if the model is configured to raise an exception based on
-    // the misaligned virtual address.
-    match plat_misaligned_exception(access, false) {
-      Some(AccessFault)        => return memory_exception(E_SAMO_Access_Fault(), bits_of(vaddr), access),
-      Some(AlignmentException) => return memory_exception(E_SAMO_Addr_Align(), bits_of(vaddr), access),
-      // No exception yet, but we may still get one based on the
-      // physical address after address translation and checking PMAs.
-      None()                   => (),
-    };
+  match check_va_misaligned(vaddr, width, access, false, true, false) {
+    Some(e) => return memory_exception(e, bits_of(vaddr), access),
+    None()  => (),
   };
 
   let (paddr, pbmt) : (physaddr, page_based_mem_type) = match translateAddr(vaddr, access) {
     Ok(addr, pbmt, _) => (addr, pbmt),
     Err(e, _)   => return trap(e),
+  };
+
+  match check_va_misaligned(vaddr, width, access, false, true, true) {
+    Some(e) => return memory_exception(e, bits_of(vaddr), access),
+    None()  => (),
   };
 
   // The `aq` and `rl` flags follow the AMO model in Zaamo: "Just as

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -37,6 +37,26 @@ function plat_misaligned_exception(access : MemoryAccessType(mem_payload), res :
   else plat_misaligned_access.load_store
 }
 
+function va_misaligned_exception_type(access : MemoryAccessType(mem_payload), res : bool, is_store : bool) -> option(ExceptionType) = {
+  match plat_misaligned_exception(access, res) {
+    Some(AccessFault)        => Some(if is_store then E_SAMO_Access_Fault() else E_Load_Access_Fault()),
+    Some(AlignmentException) => Some(if is_store then E_SAMO_Addr_Align() else E_Load_Addr_Align()),
+    None()                   => None(),
+  }
+}
+
+// Report the configured VA-misaligned exception according to
+// `memory.misaligned.misaligned_has_priority`.
+// `after_translation` is false for the pre-translation check and true
+// once translation has succeeded. At most one of the two calls returns Some.
+function check_va_misaligned(vaddr : virtaddr, width : nat1, access : MemoryAccessType(mem_payload), res : bool, is_store : bool, after_translation : bool) -> option(ExceptionType) = {
+  if is_aligned_addr(vaddr, width) then None()
+  else {
+    if after_translation == plat_misaligned_has_priority then None()
+    else va_misaligned_exception_type(access, res, is_store)
+  }
+}
+
 // Memory exceptions from `mem.sail` are reported in terms of
 // `physaddr`, while the utilities here need to report them in terms
 // of the corresponding `virtaddr`.  In particular, since the original
@@ -91,19 +111,26 @@ function memory_exception(e : ExceptionType, excinfo : xlenbits, access : Memory
   trap(mem_exception_context(e, excinfo, access))
 
 // Helper for translated read access.
+// `orig_vaddr` / `deferred_misal` are the original (possibly misaligned)
+// access address and the VA-misaligned exception deferred until after
+// translation when `misaligned_has_priority` is false.
 private function translate_and_read_value forall 'width, 0 < 'width <= max_mem_access.
-  (vaddr : virtaddr, width : int('width), access : MemoryAccessType(mem_payload), aq : bool, rl : bool, res : bool)
+  (vaddr : virtaddr, width : int('width), access : MemoryAccessType(mem_payload), aq : bool, rl : bool, res : bool,
+   orig_vaddr : virtaddr, deferred_misal : option(ExceptionType))
   -> result((physaddr, bits(8 * 'width)), ExecutionResult) =
   match translateAddr(vaddr, access) {
     Err(e, _) => Err(trap(e)),
 
-    Ok(paddr, pbmt, _) => match mem_read(access, pbmt, paddr, width, aq, rl, res) {
-      Err(exc_paddr, e) => {
-        let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
-        Err(memory_exception(e, bits_of(exc_vaddr), access))
-      },
+    Ok(paddr, pbmt, _) => match deferred_misal {
+      Some(e) => Err(memory_exception(e, bits_of(orig_vaddr), access)),
+      None()  => match mem_read(access, pbmt, paddr, width, aq, rl, res) {
+        Err(exc_paddr, e) => {
+          let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
+          Err(memory_exception(e, bits_of(exc_vaddr), access))
+        },
 
-      Ok(v) => Ok(paddr, v),
+        Ok(v) => Ok(paddr, v),
+      },
     }
   }
 
@@ -114,17 +141,13 @@ val vmem_read_addr : forall 'width, is_mem_width('width).
 function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
   // "LR faults like a normal load, even though it's in the AMO major opcode space."
   // - Andrew Waterman, isa-dev, 10 Jul 2018.
-  if not(is_aligned_addr(vaddr, width)) then {
-    match plat_misaligned_exception(access, res) {
-      Some(AccessFault)        => return Err(memory_exception(E_Load_Access_Fault(), bits_of(vaddr), access)),
-      Some(AlignmentException) => return Err(memory_exception(E_Load_Addr_Align(), bits_of(vaddr), access)),
-      // Even if the CPU does support misaligned accesses, it might be
-      // that the PMA doesn't support misaligned accesses so you can
-      // still get a fault later, but this will be after address
-      // translation below.
-      None()                   => (),
-    };
+  match check_va_misaligned(vaddr, width, access, res, false, false) {
+    Some(e) => return Err(memory_exception(e, bits_of(vaddr), access)),
+    None()  => (),
   };
+  // If `misaligned_has_priority` is false, take the VA-misaligned
+  // exception only after translation succeeds (see translate_and_read_value).
+  let deferred_misal = check_va_misaligned(vaddr, width, access, res, false, true);
 
   let vaddr_bits = bits_of(vaddr);
 
@@ -147,7 +170,7 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
 
     // Do next page access first.
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
-    match translate_and_read_value(access_addr, next_page_bytes, access, aq, rl, res) {
+    match translate_and_read_value(access_addr, next_page_bytes, access, aq, rl, res, vaddr, deferred_misal) {
       Err(e)   => return Err(e),
       Ok(_, v) => data[8 * width - 1 .. 8 * in_page_bytes] = v,
     }
@@ -156,7 +179,7 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
   // If the access was split, only the in-page bytes should be
   // accessed, otherwise all bytes should be accessed.
   let access_width = if do_split_access then in_page_bytes else width;
-  match translate_and_read_value(vaddr, access_width, access, aq, rl, res) {
+  match translate_and_read_value(vaddr, access_width, access, aq, rl, res, vaddr, deferred_misal) {
     Err(e)       => return Err(e),
     Ok(paddr, v) => {
       if res then {
@@ -174,7 +197,7 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
 
     // Do next page access next.
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
-    match translate_and_read_value(access_addr, next_page_bytes, access, aq, rl, res) {
+    match translate_and_read_value(access_addr, next_page_bytes, access, aq, rl, res, vaddr, deferred_misal) {
       Err(e)   => return Err(e),
       Ok(_, v) => data[8 * width - 1 .. 8 * in_page_bytes] = v,
     }
@@ -185,26 +208,30 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
 
 // Helper for translated write access.
 private function translate_and_write_value forall 'width, 0 < 'width <= max_mem_access.
-  (vaddr : virtaddr, width : int('width), value : bits(8 * 'width), access : MemoryAccessType(mem_payload), aq : bool, rl : bool, res : bool)
+  (vaddr : virtaddr, width : int('width), value : bits(8 * 'width), access : MemoryAccessType(mem_payload), aq : bool, rl : bool, res : bool,
+   orig_vaddr : virtaddr, deferred_misal : option(ExceptionType))
   -> result(bool, ExecutionResult) =
   match translateAddr(vaddr, access) {
     Err(e, _) => Err(trap(e)),
 
-    Ok(paddr, pbmt, _) => match mem_write_ea(paddr, width, access, pbmt, aq, rl, res) {
-      Err(exc_paddr, e) => {
-        let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
-        Err(memory_exception(e, bits_of(exc_vaddr), access))
-      },
-
-      Ok(()) => match mem_write_value(paddr, width, value, access, pbmt, aq, rl, res) {
+    Ok(paddr, pbmt, _) => match deferred_misal {
+      Some(e) => Err(memory_exception(e, bits_of(orig_vaddr), access)),
+      None()  => match mem_write_ea(paddr, width, access, pbmt, aq, rl, res) {
         Err(exc_paddr, e) => {
           let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
           Err(memory_exception(e, bits_of(exc_vaddr), access))
         },
 
-        Ok(s) => Ok(s),
+        Ok(()) => match mem_write_value(paddr, width, value, access, pbmt, aq, rl, res) {
+          Err(exc_paddr, e) => {
+            let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
+            Err(memory_exception(e, bits_of(exc_vaddr), access))
+          },
+
+          Ok(s) => Ok(s),
+        },
       },
-    },
+    }
   }
 
 val vmem_write_addr : forall 'width, is_mem_width('width).
@@ -212,14 +239,11 @@ val vmem_write_addr : forall 'width, is_mem_width('width).
   -> result(bool, ExecutionResult)
 
 function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
-  // See comments in vmem_read_addr for an explanation of this check.
-  if not(is_aligned_addr(vaddr, width)) then {
-    match plat_misaligned_exception(access, res) {
-      Some(AccessFault)        => return Err(memory_exception(E_SAMO_Access_Fault(), bits_of(vaddr), access)),
-      Some(AlignmentException) => return Err(memory_exception(E_SAMO_Addr_Align(), bits_of(vaddr), access)),
-      None()                   => (),
-    };
+  match check_va_misaligned(vaddr, width, access, res, true, false) {
+    Some(e) => return Err(memory_exception(e, bits_of(vaddr), access)),
+    None()  => (),
   };
+  let deferred_misal = check_va_misaligned(vaddr, width, access, res, true, true);
 
   // See vmem_read_addr above for additional comments.
 
@@ -247,7 +271,7 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
 
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
     let write_value = data[8 * width - 1 .. 8 * in_page_bytes];
-    match translate_and_write_value(access_addr, next_page_bytes, write_value, access, aq, rl, res) {
+    match translate_and_write_value(access_addr, next_page_bytes, write_value, access, aq, rl, res, vaddr, deferred_misal) {
       Err(e) => return Err(e),
       Ok(s)  => write_success = write_success & s,
     }
@@ -258,6 +282,10 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
     Err(e, _) => return Err(trap(e)),
 
     Ok(paddr, pbmt, _) => {
+      match deferred_misal {
+        Some(e) => return Err(memory_exception(e, bits_of(vaddr), access)),
+        None()  => (),
+      };
       // If res is true, the store should be aligned.
       assert(res == is_store_conditional(access));
       if res & not(match_reservation(bits_of(paddr))) then {
@@ -298,7 +326,7 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
 
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
     let write_value = data[8 * width - 1 .. 8 * in_page_bytes];
-    match translate_and_write_value(access_addr, next_page_bytes, write_value, access, aq, rl, res) {
+    match translate_and_write_value(access_addr, next_page_bytes, write_value, access, aq, rl, res, vaddr, deferred_misal) {
       Err(e) => return Err(e),
       Ok(s)  => write_success = write_success & s,
     }


### PR DESCRIPTION
The new option is `memory.misaligned.misaligned_has_priority`. The default `true` preserves existing Sail behaviour: a configured VA-misaligned exception (access-fault or address-misaligned) is taken without performing address translation. Setting it to `false` translates first and reports a page/guest-page fault if translation fails.

This exists because the privileged ISA leaves that ordering implementation-defined. Beneath Table "Synchronous exception priority in decreasing priority order":

  The relative priority of load/store/AMO address-misaligned and
  page-fault exceptions is implementation-defined to flexibly cater to
  two design points. Implementations that never support misaligned
  accesses can unconditionally raise the misaligned-address exception
  without performing address translation or protection checks.
  Implementations that support misaligned accesses only to some physical
  addresses must translate and check the address before determining
  whether the misaligned access may proceed, in which case raising the
  page-fault exception or access is more appropriate.

Generative AI (Cursor) was used to draft this change and commit message.