### PR TITLE
Add a GEILEN config option

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -39,6 +39,9 @@ foreach(CONFIG__BASE__XLEN IN ITEMS 32 64)
                 set(CONFIG__PHYSADDR__BITS 56)
             endif()
 
+            # GEILEN is at most XLEN-1.
+            math(EXPR CONFIG__H__GEILEN "${CONFIG__BASE__XLEN} - 1")
+
             configure_file(config.json.in ${CMAKE_CURRENT_BINARY_DIR}/${config_filename})
 
             install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${config_filename}

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -571,6 +571,12 @@
     },
     "H": {
       "supported": true,
+      // GEILEN, the number of guest external interrupts. Bits GEILEN:1 of
+      // `hgeip` and `hgeie` are implemented, all other bit positions are
+      // read-only zero. Zero means no guest external interrupts, in which case
+      // `hstatus.VGEIN` is read-only zero and the `mideleg` SGEI bit is
+      // read-only zero instead of read-only one. The maximum is XLEN-1.
+      "geilen": @CONFIG__H__GEILEN@,
       // Whether a guest-page fault writes the faulting guest physical address
       // to `htval`/`mtval2`. If false, `htval`/`mtval2` is written as zero.
       // Enabling Shtvala requires this option to be enabled.

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -571,11 +571,7 @@
     },
     "H": {
       "supported": true,
-      // GEILEN, the number of guest external interrupts. Bits GEILEN:1 of
-      // `hgeip` and `hgeie` are implemented, all other bit positions are
-      // read-only zero. Zero means no guest external interrupts, in which case
-      // `hstatus.VGEIN` is read-only zero and the `mideleg` SGEI bit is
-      // read-only zero instead of read-only one. The maximum is XLEN-1.
+      // GEILEN, the number of guest external interrupts. The maximum is XLEN-1.
       "geilen": @CONFIG__H__GEILEN@,
       // Whether a guest-page fault writes the faulting guest physical address
       // to `htval`/`mtval2`. If false, `htval`/`mtval2` is written as zero.

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -15,9 +15,7 @@
 
 - Updates to the [configuration file](../config/config.json.in):
   - The number of guest external interrupts (GEILEN) can be specified, see
-    `extensions.H.geilen`. It bounds the implemented bits of `hgeip` and
-    `hgeie` and the legal values of `hstatus.VGEIN`, and when it is zero the
-    `mideleg` SGEI bit is read-only zero. The default is XLEN-1.
+    `extensions.H.geilen`. The default is XLEN-1.
   - The default `platform.clint.size` is now 0xc000 rather than 0xc0000.
     The CLINT register map ends at offset 0xbfff, so everything beyond it
     was claimed by the model but never used.

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -14,6 +14,10 @@
   - Zilx
 
 - Updates to the [configuration file](../config/config.json.in):
+  - The number of guest external interrupts (GEILEN) can be specified, see
+    `extensions.H.geilen`. It bounds the implemented bits of `hgeip` and
+    `hgeie` and the legal values of `hstatus.VGEIN`, and when it is zero the
+    `mideleg` SGEI bit is read-only zero. The default is XLEN-1.
   - The default `platform.clint.size` is now 0xc000 rather than 0xc0000.
     The CLINT register map ends at offset 0xbfff, so everything beyond it
     was claimed by the model but never used.

--- a/model/core/interrupt_regs.sail
+++ b/model/core/interrupt_regs.sail
@@ -13,17 +13,17 @@
 
 // Guest External Interrupt Registers
 
-// GEILEN is XLEN-1, so hgeie bits 1..XLEN-1 are writable.
-// TODO: Legalize against a GEILEN config once one exists.
-private function legalize_hgeie(v : xlenbits) -> xlenbits = {
-  [v with 0 = bitzero]
-}
+// Bits GEILEN:1 of hgeip and hgeie are implemented, all other bit positions
+// are read-only zero.
+let hgei_mask : xlenbits = zero_extend(ones(geilen) @ 0b0)
 
-register hgeie : xlenbits
+private function legalize_hgeie(v : xlenbits) -> xlenbits = v & hgei_mask
+
+register hgeie : xlenbits = zeros()
 
 // hgeip stays zero because no interrupt controller in the model asserts
 // guest external interrupts, which also makes mip.SGEIP permanently zero.
-register hgeip : xlenbits
+register hgeip : xlenbits = zeros()
 
 mapping clause csr_name_map = 0x607 <-> "hgeie"
 mapping clause csr_name_map = 0xE12 <-> "hgeip"
@@ -32,7 +32,7 @@ function clause is_CSR_accessible(0x607, _, _) = currentlyEnabled(Ext_H) // hgei
 function clause is_CSR_accessible(0xE12, _, _) = currentlyEnabled(Ext_H) // hgeip
 
 function clause read_CSR(0x607) = hgeie
-function clause read_CSR(0xE12) = hgeip
+function clause read_CSR(0xE12) = hgeip & hgei_mask
 
 function clause write_CSR(0x607, value) = { hgeie = legalize_hgeie(value); Ok(hgeie) }
 
@@ -70,8 +70,8 @@ private function legalize_mip(o : Minterrupts, v : xlenbits) -> Minterrupts = {
     // * bit VSEIP of hvip;
     // * the bit of hgeip selected by hstatus.VGEIN; and
     // * any other platform-specific external interrupt signal directed to VS-Level"
-    // The hgeip term is always zero (see GEILEN above) and there are no
-    // platform-specific VS-level signals, so only hvip is left.
+    // The hgeip term is always zero because nothing drives hgeip yet,
+    // and there are no platform-specific VS-level signals, so only hvip is left.
     VSEI = if currentlyEnabled(Ext_H) then hvip[VSEI] else 0b0,
     // " VSTIP is read-only in hip, and is the logical-OR of
     // * hvip.VSTIP; and
@@ -123,8 +123,9 @@ private function legalize_mideleg(_o : Minterrupts, v : xlenbits) -> Minterrupts
     VSEI = if currentlyEnabled(Ext_H) then 0b1 else 0b0,
     VSTI = if currentlyEnabled(Ext_H) then 0b1 else 0b0,
     VSSI = if currentlyEnabled(Ext_H) then 0b1 else 0b0,
-    // SGEI is always delegated when GEILEN > 0, assumed whenever H is present
-    SGEI = if currentlyEnabled(Ext_H) then 0b1 else 0b0,
+    // "if any guest external interrupts are implemented (GEILEN is nonzero),
+    //  bit 12 of mideleg ... is also read-only one."
+    SGEI = if currentlyEnabled(Ext_H) & geilen > 0 then 0b1 else 0b0,
   ]
 }
 

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -331,9 +331,10 @@ private function legalize_hstatus(h : Hstatus, v : bits(64)) -> Hstatus = {
     VTSR  = v[VTSR],
     VTW   = v[VTW],
     VTVM  = v[VTVM],
-    // VGEIN is WLRL and GEILEN is XLEN-1, so every value is accepted.
-    // TODO: Legalize against a GEILEN config once one exists.
-    VGEIN = v[VGEIN],
+    // "VGEIN is a WLRL field that must be able to hold values between zero and
+    //  the maximum guest external interrupt number (known as GEILEN), inclusive."
+    //  Being WLRL, an out-of-range value keeps the previous one.
+    VGEIN = if unsigned(v[VGEIN]) <= geilen then v[VGEIN] else h[VGEIN],
     HU    = v[HU],
     SPVP  = v[SPVP],
     SPV   = v[SPV],

--- a/model/core/xlen.sail
+++ b/model/core/xlen.sail
@@ -25,6 +25,11 @@ type gpalen : Int = if xlen == 32 then 34 else 64
 type asidlen    : Int = if xlen == 32 then 9 else 16
 // TODO: Allow configuring shorter VMIDLENs.
 type vmidlen    : Int = if xlen == 32 then 7 else 14
+// GEILEN, the number of guest external interrupts. Bits GEILEN:1 of hgeip and
+// hgeie are implemented, all other bit positions are read-only zero. The
+// maximum is 31 for RV32 and 63 for RV64.
+type geilen : Int = config extensions.H.geilen
+constraint 0 <= geilen & geilen <= xlen - 1
 
 // Variable versions of the above types. Variables and types
 // are disjoint in Sail so they are allowed to have the same name.
@@ -35,6 +40,7 @@ let xlen = sizeof(xlen)
 let gpalen = sizeof(gpalen)
 let asidlen = sizeof(asidlen)
 let vmidlen = sizeof(vmidlen)
+let geilen = sizeof(geilen)
 
 type xlenbits = bits(xlen)
 type gpabits  = bits(gpalen)

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -882,6 +882,14 @@ private function check_physaddr_bits() -> bool = {
   } else { true }
 }
 
+private function check_geilen() -> bool = {
+  let geilen_nat : nat = geilen;
+  if geilen_nat > xlen - 1 then {
+    print_endline("`extensions.H.geilen` is " ^ dec_str(geilen) ^ " but cannot be greater than " ^ dec_str(xlen - 1) ^ " for RV" ^ dec_str(xlen) ^ ".");
+    false
+  } else { true }
+}
+
 private function check_version_constraints() -> bool = {
   var valid : bool = true;
 
@@ -900,6 +908,7 @@ function config_is_valid() -> bool = {
   & check_tvecs()
   & check_mstatus_fields()
   & check_physaddr_bits()
+  & check_geilen()
   & check_mmu_config()
   & check_mem_layout()
   & check_mmio_devices()

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -801,6 +801,13 @@ private function check_extension_param_constraints() -> bool = {
       print_endline("Bits for reserved interrupts are set in `base.mideleg.delegatable_bits`.");
     }
   };
+  if (config extensions.H.supported : bool) then {
+    let geilen_nat : nat = geilen;
+    if geilen_nat > xlen - 1 then {
+      valid = false;
+      print_endline("`extensions.H.geilen` is " ^ dec_str(geilen) ^ " but cannot be greater than " ^ dec_str(xlen - 1) ^ " for RV" ^ dec_str(xlen) ^ ".");
+    };
+  };
   valid
 }
 
@@ -882,14 +889,6 @@ private function check_physaddr_bits() -> bool = {
   } else { true }
 }
 
-private function check_geilen() -> bool = {
-  let geilen_nat : nat = geilen;
-  if geilen_nat > xlen - 1 then {
-    print_endline("`extensions.H.geilen` is " ^ dec_str(geilen) ^ " but cannot be greater than " ^ dec_str(xlen - 1) ^ " for RV" ^ dec_str(xlen) ^ ".");
-    false
-  } else { true }
-}
-
 private function check_version_constraints() -> bool = {
   var valid : bool = true;
 
@@ -908,7 +907,6 @@ function config_is_valid() -> bool = {
   & check_tvecs()
   & check_mstatus_fields()
   & check_physaddr_bits()
-  & check_geilen()
   & check_mmu_config()
   & check_mem_layout()
   & check_mmio_devices()


### PR DESCRIPTION
`extensions.H.geilen` sets the number of guest external interrupts. It bounds the implemented bits of `hgeip` and `hgeie`, the legal values of `hstatus.VGEIN`, and whether the `mideleg` SGEI bit is read-only one.