### PR TITLE
Fix CLINT allocated size

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -451,7 +451,7 @@
       // If supported, this must be in a suitable IO memory region (see `memory.regions`).
       // Otherwise, these values can be left as 0.
       "base": 33554432,
-      "size": 786432
+      "size": 49152
     },
     // Very simple MMIO device to generate interrupts for testing
     // purposes. See docs/SimpleInterruptGenerator.md for details.

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -14,6 +14,9 @@
   - Zilx
 
 - Updates to the [configuration file](../config/config.json.in):
+  - The default `platform.clint.size` is now 0xc000 rather than 0xc0000.
+    The CLINT register map ends at offset 0xbfff, so everything behond it
+    was claimed by the model but never used.
   - Which VS-stage translation modes `vsatp` supports can be specified, see
     `extensions.H.vsatp_modes`. Bare is always supported.
   - Whether the Sstvecd extension is supported can be specified, see

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -15,7 +15,7 @@
 
 - Updates to the [configuration file](../config/config.json.in):
   - The default `platform.clint.size` is now 0xc000 rather than 0xc0000.
-    The CLINT register map ends at offset 0xbfff, so everything behond it
+    The CLINT register map ends at offset 0xbfff, so everything beyond it
     was claimed by the model but never used.
   - Which VS-stage translation modes `vsatp` supports can be specified, see
     `extensions.H.vsatp_modes`. Bare is always supported.

--- a/test/first_party/src/common/link.ld
+++ b/test/first_party/src/common/link.ld
@@ -7,7 +7,7 @@ MEMORY
 {
   /* Match the default configuration in config.json.in, which is roughly based on Spike. */
   /* MMIO peripherals. */
-  if_clint (wa) : org = 0x2000000, len = 768k
+  if_clint (wa) : org = 0x2000000, len = 48k
   if_htif (wa)  : org = 0x20c0000, len = 512k
 
   /* Main RAM. */


### PR DESCRIPTION
Change `platform.clint.size` from 0xC0000 (786432) to 0xC000 (49152). We needed to allocate space for MSIP (4095 * 4 = 16380 Byte), 4 Byte reserved, MTIMECMP (4095 * 8 = 32760 Byte) and MTIME (8 Byte), in total 49152 bytes.