### PR TITLE
[RFC] Add Zimt memory tagging extension (v0.2 draft spec, experimental)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ The following unratified extensions are supported and can be enabled using the `
 
 - Zibi extension for conditional branches with immediate operands, v0.6
 - Zilx extension for indexed integer load instructions, v0.1
+- Zimt extension for memory tagging with the Svatag/Smvatag tag table extensions, v0.2 draft
+  (partial; CSR addresses and several spec constants are placeholders pending TG allocation)
 - Zvabd extension for vector absolute difference, v0.7
 
 **For a list of unsupported extensions and features, see the [Extension Roadmap](https://github.com/riscv/sail-riscv/wiki/Extension-Roadmap).**

--- a/config/config.json.in
+++ b/config/config.json.in
@@ -658,6 +658,11 @@
     "Zimop": {
       "supported": true
     },
+    "Zimt": {
+      "supported": @CONFIG_XLEN_IS_64@,
+      "supported_pointer_tag_width_4": true,
+      "supported_pointer_tag_width_7": true
+    },
     "Zmmul": {
       "supported": false
     },
@@ -909,6 +914,12 @@
     },
     "Smcntrpmf": {
       "supported": true
+    },
+    "Svatag": {
+      "supported": @CONFIG_XLEN_IS_64@
+    },
+    "Smvatag": {
+      "supported": @CONFIG_XLEN_IS_64@
     },
     "Svbare": {
       "supported": true,

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -12,8 +12,15 @@
 
 - The following unratified extensions have been added:
   - Zilx
+  - Zimt (with Svatag/Smvatag), partial: instructions, CSRs and
+    no-paging implicit tag checks; CSR addresses are placeholders
+    pending allocation by the memory tagging TG
 
 - Updates to the [configuration file](../config/config.json.in):
+  - The supported Zimt pointer tag widths can be specified, see
+    `extensions.Zimt.supported_pointer_tag_width_4` and
+    `extensions.Zimt.supported_pointer_tag_width_7` (width 4 is
+    mandatory when Zimt is supported).
   - Which VS-stage translation modes `vsatp` supports can be specified, see
     `extensions.H.vsatp_modes`. Bare is always supported.
   - Whether the Sstvecd extension is supported can be specified, see

--- a/model/core/extensions.sail
+++ b/model/core/extensions.sail
@@ -170,6 +170,10 @@ function clause hartSupports(Ext_Zilx) = sys_enable_experimental_extensions() & 
 enum clause extension = Ext_Zimop
 mapping clause extensionName = Ext_Zimop <-> "zimop"
 function clause hartSupports(Ext_Zimop) = config extensions.Zimop.supported
+// Memory Tagging (v0.2, DRAFT)
+enum clause extension = Ext_Zimt
+mapping clause extensionName = Ext_Zimt <-> "zimt"
+function clause hartSupports(Ext_Zimt) = sys_enable_experimental_extensions() & config extensions.Zimt.supported : bool & (xlen == 64)
 
 // Multiplication and Division: Multiplication only
 enum clause extension = Ext_Zmmul
@@ -573,6 +577,10 @@ function clause hartSupports(Ext_Svade) = config extensions.Svade.supported
 enum clause extension = Ext_Svadu
 mapping clause extensionName = Ext_Svadu <-> "svadu"
 function clause hartSupports(Ext_Svadu) = config extensions.Svadu.supported
+// Virtually indexed tag table for memory tagging (v0.2, DRAFT)
+enum clause extension = Ext_Svatag
+mapping clause extensionName = Ext_Svatag <-> "svatag"
+function clause hartSupports(Ext_Svatag) = sys_enable_experimental_extensions() & config extensions.Svatag.supported : bool & (xlen == 64)
 // Fine-Grained Address-Translation Cache Invalidation
 enum clause extension = Ext_Svinval
 mapping clause extensionName = Ext_Svinval <-> "svinval"
@@ -612,6 +620,10 @@ function clause currentlyEnabled(Ext_Smnpm) = hartSupports(Ext_Smnpm)
 enum clause extension = Ext_Smstateen
 mapping clause extensionName = Ext_Smstateen <-> "smstateen"
 function clause hartSupports(Ext_Smstateen) = config extensions.Stateen.Smstateen.supported
+// Machine-mode virtually indexed tag table for memory tagging (v0.2, DRAFT)
+enum clause extension = Ext_Smvatag
+mapping clause extensionName = Ext_Smvatag <-> "smvatag"
+function clause hartSupports(Ext_Smvatag) = sys_enable_experimental_extensions() & config extensions.Smvatag.supported : bool & (xlen == 64)
 
 // QoS identifiers
 enum clause extension = Ext_Ssqosid
@@ -713,7 +725,11 @@ function currentlyEnabled_measure(ext : extension) -> int =
     Ext_Zvkb => 3, // > Zvbb
     Ext_Zvknhb => 3, // > Zve64x
 
+    Ext_Zimt => 3, // > Ssnpm, Smnpm, Smmpm
+
     Ext_H => 4, // > virtual_mem_supported
+    Ext_Svatag => 4, // > Zimt
+    Ext_Smvatag => 4, // > Zimt
     Ext_Zve64d => 4, // > Zve64f
     Ext_Zvfbfwma => 4, // > Zvfbfmin
     Ext_Zvfh => 4, // > Zfhmin
@@ -779,6 +795,7 @@ let extensions_ordered_for_isa_string = [
   Ext_Zihpm,
   Ext_Zilx,
   Ext_Zimop,
+  Ext_Zimt,
 
   // Zm
   Ext_Zmmul,
@@ -889,6 +906,7 @@ let extensions_ordered_for_isa_string = [
   Ext_Supm,
   Ext_Svade,
   Ext_Svadu,
+  Ext_Svatag,
   Ext_Svinval,
   Ext_Svnapot,
   Ext_Svpbmt,

--- a/model/core/mem_type_utils.sail
+++ b/model/core/mem_type_utils.sail
@@ -29,6 +29,11 @@ function accessFaultFromAccessType(access : MemoryAccessType(mem_payload)) -> Ex
 
     Atomic(_, _, _, ShadowStack, ShadowStack) => E_SAMO_Access_Fault(),
 
+    // Memory tagging (Zimt) tag table accesses fault like regular
+    // loads and stores.
+    Load(Tag)                           => E_Load_Access_Fault(),
+    Store(Tag)                          => E_SAMO_Access_Fault(),
+
     LoadExecute(p)                      => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadExecute."),
     LoadReserved(_, _, p)               => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
     StoreConditional(_, _, p)           => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),
@@ -71,6 +76,11 @@ function alignmentFaultFromAccessType(access : MemoryAccessType(mem_payload)) ->
     Store(ShadowStack)                  => E_SAMO_Addr_Align(),
 
     Atomic(_, _, _, ShadowStack, ShadowStack) => E_SAMO_Addr_Align(),
+
+    // Memory tagging (Zimt) tag table accesses fault like regular
+    // loads and stores.
+    Load(Tag)                           => E_Load_Addr_Align(),
+    Store(Tag)                          => E_SAMO_Addr_Align(),
 
     LoadExecute(p)                      => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadExecute."),
     LoadReserved(_, _, p)               => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -308,6 +308,9 @@ function clause write_CSR((0x300, value) if xlen == 32) = { mstatus = legalize_m
 function clause write_CSR((0x310, value) if xlen == 32) = { mstatus = legalize_mstatus(mstatus, value @ mstatus.bits[31 .. 0]); Ok(mstatus.bits[63 .. 32]) }
 
 bitfield Hstatus : bits(64) = {
+  // MT_MODE for HLV*/HSV* executed from HU with effective privilege VU
+  // (Zimt, v0.2 DRAFT)
+  VUMT_MODE : 51 .. 50,
   HUPMM : 49 .. 48,
   VSXL  : 33 .. 32,
   VTSR  : 22,
@@ -324,6 +327,7 @@ bitfield Hstatus : bits(64) = {
 private function legalize_hstatus(h : Hstatus, v : bits(64)) -> Hstatus = {
   let v = Mk_Hstatus(v);
   [h with
+    VUMT_MODE = if hartSupports(Ext_Zimt) & is_supported_mt_mode(mt_mode(v[VUMT_MODE])) then v[VUMT_MODE] else h[VUMT_MODE],
     // HUPMM controls pointer masking for HLV.*/HSV in U-mode (effective VU)
     HUPMM = if currentlyEnabled(Ext_Ssnpm) & is_supported_pmm(PM_SSNPM, pmm_mode(v[HUPMM])) then v[HUPMM] else h[HUPMM],
     // We don't currently support changing VSXL
@@ -353,6 +357,8 @@ function clause read_CSR(0x600) = hstatus.bits[xlen - 1 .. 0]
 function clause write_CSR(0x600, value) = { hstatus = legalize_hstatus(hstatus, zero_extend(value)); Ok(hstatus.bits[xlen - 1 .. 0]) }
 
 bitfield Seccfg : bits(64) = {
+  // Memory Tagging Extension (Zimt, v0.2 DRAFT)
+  MT_MODE : 35 .. 34,
   // Pointer Masking Extension
   PMM    : 33 .. 32,
   // Enable Zicfilp in M-mode
@@ -375,6 +381,7 @@ private function legalize_mseccfg(o : Seccfg, v : bits(64)) -> Seccfg = {
 
   let v = Mk_Seccfg(v);
   [o with
+    MT_MODE = if hartSupports(Ext_Zimt) & is_supported_mt_mode(mt_mode(v[MT_MODE])) then v[MT_MODE] else o[MT_MODE],
     PMM   = if currentlyEnabled(Ext_Smmpm) & is_supported_pmm(PM_SMMPM, pmm_mode(v[PMM])) then v[PMM] else o[PMM],
     MLPE  = if hartSupports(Ext_Zicfilp) then v[MLPE] else 0b0,
     SSEED = if sseed_read_only_zero then 0b0 else v[SSEED],
@@ -388,7 +395,7 @@ mapping clause csr_name_map = 0x747  <-> "mseccfg"
 mapping clause csr_name_map = 0x757  <-> "mseccfgh"
 
 // For Sm1p12 and later, "mseccfg exists if Zkr is implemented, or if it is required by other processor features."
-function clause is_CSR_accessible(0x747, _, _) = mseccfg_csrs_are_defined & (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp) | currentlyEnabled(Ext_Smmpm)) // mseccfg
+function clause is_CSR_accessible(0x747, _, _) = mseccfg_csrs_are_defined & (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp) | currentlyEnabled(Ext_Smmpm) | hartSupports(Ext_Zimt)) // mseccfg
 function clause is_CSR_accessible(0x757, _, _) = mseccfg_csrs_are_defined & (currentlyEnabled(Ext_Zkr) | hartSupports(Ext_Zicfilp)) & xlen == 32 // mseccfgh
 
 function clause read_CSR(0x747) = mseccfg.bits[xlen - 1 .. 0]
@@ -416,6 +423,8 @@ bitfield MEnvcfg : bits(64) = {
   PBMTE  : 62,
   // Svadu
   ADUE   : 61,
+  // Memory Tagging Extension (Zimt, v0.2 DRAFT)
+  MT_MODE : 35 .. 34,
   // Pointer Masking Extension
   PMM    : 33 .. 32,
   // Cache Block Zero instruction Enable
@@ -435,6 +444,8 @@ bitfield MEnvcfg : bits(64) = {
 // NOTE: senvcfg's actual width is SXLEN, but this cannot currently be expressed in Sail,
 // as PMM occupies bits above 31 and conditional enable/disable of bits is not supported.
 bitfield SEnvcfg : bits(64) = {
+  // Memory Tagging Extension (Zimt, v0.2 DRAFT)
+  MT_MODE : 35 .. 34,
   // Pointer Masking Extension
   PMM    : 33 .. 32,
   // Cache Block Zero instruction Enable
@@ -456,6 +467,8 @@ bitfield HEnvcfg : bits(64) = {
   PBMTE : 62,
   ADUE  : 61,
   DTE   : 59,
+  // Memory Tagging Extension (Zimt, v0.2 DRAFT)
+  MT_MODE : 35 .. 34,
   PMM   : 33 .. 32,
   CBZE  : 7,
   CBCFE : 6,
@@ -484,6 +497,7 @@ private function legalize_menvcfg(o : MEnvcfg, v : bits(64)) -> MEnvcfg = {
     CBCFE = if currentlyEnabled(Ext_Zicbom) then v[CBCFE] else 0b0,
     CBIE = if currentlyEnabled(Ext_Zicbom) then legalize_xenvcfg_cbie(v[CBIE]) else 0b00,
     STCE = if currentlyEnabled(Ext_Sstc) then v[STCE] else 0b0,
+    MT_MODE = if hartSupports(Ext_Zimt) & is_supported_mt_mode(mt_mode(v[MT_MODE])) then v[MT_MODE] else o[MT_MODE],
     PMM = if currentlyEnabled(Ext_Smnpm) & is_supported_pmm(PM_SMNPM, pmm_mode(v[PMM])) then v[PMM] else o[PMM],
     ADUE = if currentlyEnabled(Ext_Svadu) then v[ADUE] else 0b0,
     PBMTE = if currentlyEnabled(Ext_Svpbmt) then v[PBMTE] else 0b0,
@@ -506,6 +520,7 @@ private function legalize_senvcfg(o : SEnvcfg, v : bits(64)) -> SEnvcfg = {
     CBZE = if currentlyEnabled(Ext_Zicboz) then v[CBZE] else 0b0,
     CBCFE = if currentlyEnabled(Ext_Zicbom) then v[CBCFE] else 0b0,
     CBIE = if currentlyEnabled(Ext_Zicbom) then legalize_xenvcfg_cbie(v[CBIE]) else 0b00,
+    MT_MODE = if hartSupports(Ext_Zimt) & is_supported_mt_mode(mt_mode(v[MT_MODE])) then v[MT_MODE] else o[MT_MODE],
     PMM = if currentlyEnabled(Ext_Ssnpm) & is_supported_pmm(PM_SSNPM, pmm_mode(v[PMM])) then v[PMM] else o[PMM],
     // Other extensions are not implemented yet so all other fields are read only zero.
   ]
@@ -521,6 +536,7 @@ private function legalize_henvcfg(h : HEnvcfg, v : bits(64)) -> HEnvcfg = {
     PBMTE = if currentlyEnabled(Ext_Svpbmt) & menvcfg[PBMTE] == 0b1 then v[PBMTE] else 0b0,
     ADUE  = if currentlyEnabled(Ext_Svadu) & menvcfg[ADUE] == 0b1 then v[ADUE] else 0b0,
     // DTE  = if currentlyEnabled(Ext_Ssdbltrp) then v[DTE] else 0b0,
+    MT_MODE = if hartSupports(Ext_Zimt) & is_supported_mt_mode(mt_mode(v[MT_MODE])) then v[MT_MODE] else h[MT_MODE],
     PMM  = if currentlyEnabled(Ext_Ssnpm) & is_supported_pmm(PM_SSNPM, pmm_mode(v[PMM])) then v[PMM] else h[PMM],
     CBZE  = if currentlyEnabled(Ext_Zicboz) then v[CBZE]  else 0b0,
     CBCFE = if currentlyEnabled(Ext_Zicbom) then v[CBCFE] else 0b0,

--- a/model/core/vmem_types.sail
+++ b/model/core/vmem_types.sail
@@ -57,13 +57,15 @@ type vpn_bits('v), is_sv_or_svx4_mode('v) = bits('v - pagesize_bits)
 // handled by adding ShadowStack{Load,Store,Atomic} variants to
 // MemoryAccessType and removing the ShadowStack variant here.
 
-enum mem_payload = { Data, Vector, PageTableEntry, ShadowStack }
+enum mem_payload = { Data, Vector, PageTableEntry, ShadowStack, Tag }
 
 mapping mem_payload_name : mem_payload <-> string = {
   Data           <-> "Data",
   Vector         <-> "Vector",
   PageTableEntry <-> "PageTableEntry",
   ShadowStack    <-> "ShadowStack",
+  // Memory tagging (Zimt, v0.2 DRAFT) tag table access
+  Tag            <-> "Tag",
 }
 
 mapping mem_payload_str : mem_payload <-> string = {
@@ -71,6 +73,7 @@ mapping mem_payload_str : mem_payload <-> string = {
   Vector          <-> "",
   PageTableEntry  <-> "",
   ShadowStack     <-> ".ss",
+  Tag             <-> ".tag",
 }
 
 function accessType_to_str(access : MemoryAccessType(mem_payload)) -> string =
@@ -98,11 +101,13 @@ function is_shadow_stack_access(access : MemoryAccessType(mem_payload)) -> bool 
     Load(Data)                          => false,
     Load(Vector)                        => false,
     Load(PageTableEntry)                => false,
+    Load(Tag)                           => false,
     LoadExecute(Data)                   => false,
     LoadReserved(_, _, Data)            => false,
     Store(Data)                         => false,
     Store(Vector)                       => false,
     Store(PageTableEntry)               => false,
+    Store(Tag)                          => false,
     StoreConditional(_, _, Data)        => false,
     Atomic(_, _, _, Data, Data)         => false,
     CacheAccess(_)                      => false,

--- a/model/extensions/Zimt/zimt_insts.sail
+++ b/model/extensions/Zimt/zimt_insts.sail
@@ -1,0 +1,167 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// Instructions of the Zimt memory tagging extension (v0.2, DRAFT):
+// gentag, addtag, settag, checktag.
+//
+// All four are taken from the Zimop MOP.RR encoding space (SYSTEM
+// opcode, funct3 0b100): gentag/addtag/checktag from MOP.RR.1
+// (funct7 0b1000011) and settag from MOP.RR.0 (funct7 0b1000001).
+// Within MOP.RR.1, gentag has rs1 = x0 and tag_imm4 = 0, addtag has
+// tag_imm4 != 0, and checktag has rd = x0.
+//
+// The decode clauses are guarded on currentlyEnabled(Ext_Zimt); when
+// Zimt is not enabled the encodings fall through to the ZIMOP_MOP_RR
+// clause (the `mops` module is loaded after `extensions` for exactly
+// this reason). When Zimt is enabled but memory tagging is disabled
+// in the current execution environment, the execute clauses implement
+// the spec-mandated fallback: zero the destination (identical to
+// Zimop), except addtag which copies rs1 to rd so that rd always
+// holds a valid pointer on an MT-implementing hart.
+
+union clause instruction = GENTAG : (regidx)
+union clause instruction = ADDTAG : (bits(4), regidx, regidx)
+union clause instruction = SETTAG : (bits(4), regidx)
+union clause instruction = CHECKTAG : (bits(4), regidx)
+
+mapping clause encdec = GENTAG(rd)
+  <-> 0b1000011 @ 0b0 @ 0b0000 @ 0b00000 @ 0b100 @ encdec_reg(rd) @ 0b1110011
+  when currentlyEnabled(Ext_Zimt) & rd != zreg
+
+mapping clause encdec = ADDTAG(imm, rs1, rd)
+  <-> 0b1000011 @ 0b0 @ imm @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b1110011
+  when currentlyEnabled(Ext_Zimt) & imm != 0b0000 & rd != zreg
+
+mapping clause encdec = CHECKTAG(imm, rs1)
+  <-> 0b1000011 @ 0b0 @ imm @ encdec_reg(rs1) @ 0b100 @ 0b00000 @ 0b1110011
+  when currentlyEnabled(Ext_Zimt) & rs1 != zreg
+
+mapping clause encdec = SETTAG(imm, rs1)
+  <-> 0b1000001 @ 0b0 @ imm @ encdec_reg(rs1) @ 0b100 @ 0b00000 @ 0b1110011
+  when currentlyEnabled(Ext_Zimt) & rs1 != zreg
+
+// gentag state.
+//
+// TG DISCUSSION ITEM: the spec requires gentag to produce
+// pseudorandom, uniformly distributed tags over the permitted values.
+// A deterministic reference model cannot be both reproducible and
+// unpredictable; this implementation keeps a free-running 7-bit
+// counter and returns the first permitted tag value cyclically at or
+// above it, which guarantees every permitted value occurs but NOT
+// uniformity or unpredictability. Tests must not rely on specific
+// generated values, except when the exclusion mask permits exactly
+// one value.
+register zimt_gentag_state : bits(7) = zeros()
+
+// First tag value permitted by `mask`, searching cyclically from
+// `start`. The exclusion-mask WARL rule guarantees at least one
+// permitted value in [15:0], so the search always succeeds.
+function zimt_pick_tag(mask : bits(128), start : range(0, 127), num_tags : {16, 128}) -> range(0, 127) = {
+  var chosen : range(0, 127) = 0;
+  var found : bool = false;
+  foreach (i from 0 to 127) {
+    if (i < num_tags) & not(found) then {
+      let cand = (start + i) % num_tags;
+      if mask[cand] == bitzero then {
+        chosen = cand;
+        found = true;
+      }
+    }
+  };
+  assert(found, "Zimt: exclusion mask permits no tag value");
+  chosen
+}
+
+function clause execute GENTAG(rd) = {
+  let mode = get_mt_mode(cur_privilege);
+  if mode == MT_MODE_Disabled then {
+    // Zimop fallback: zero the destination.
+    X(rd) = zeros();
+    return RETIRE_SUCCESS
+  };
+  let w = enabled_pointer_tag_width(mode);
+  let num_tags : {16, 128} = if w == 4 then 16 else 128;
+  let mask = get_mtag_exclusion_mask(cur_privilege);
+  zimt_gentag_state = zimt_gentag_state + 1;
+  let start = unsigned(zimt_gentag_state) % num_tags;
+  let tag = zimt_pick_tag(mask, start, num_tags);
+  X(rd) = insert_pointer_tag(zeros(), to_bits(7, tag), w);
+  RETIRE_SUCCESS
+}
+
+function clause execute ADDTAG(imm, rs1, rd) = {
+  let mode = get_mt_mode(cur_privilege);
+  if mode == MT_MODE_Disabled then {
+    // Implemented-but-disabled: move rs1 to rd (NOT the Zimop
+    // zeroing), so rd always holds a valid pointer.
+    X(rd) = X(rs1);
+    return RETIRE_SUCCESS
+  };
+  let w = enabled_pointer_tag_width(mode);
+  let tag = extract_pointer_tag(X(rs1), w) + zero_extend(imm);
+  X(rd) = insert_pointer_tag(X(rs1), tag, w);
+  RETIRE_SUCCESS
+}
+
+function clause execute SETTAG(imm, rs1) = {
+  let mode = get_mt_mode(cur_privilege);
+  // Zimop fallback (write x0) is a no-op.
+  if mode == MT_MODE_Disabled then return RETIRE_SUCCESS;
+  let w = enabled_pointer_tag_width(mode);
+  let raw = X(rs1);
+  let mc_tag = mc_tag_of_pointer_tag(extract_pointer_tag(raw, w), mode);
+  let vitt : xlenbits = match get_vitt_base(cur_privilege) {
+    Some(base) => base,
+    // No tag table (Svatag/Smvatag not enabled for this privilege).
+    None() => return memory_exception(E_SAMO_Access_Fault(), raw, Store(Tag)),
+  };
+  // Strip the pointer tag via the pointer-masking transform; the
+  // first chunk is at the 16-byte aligned address.
+  let va = bits_of(transform_effective_address(Virtaddr(raw), Store(Data)));
+  let chunk0 = va >> 4;
+  foreach (i from 0 to unsigned(imm)) {
+    match zimt_store_mc_tag(vitt, chunk0 + to_bits(xlen, i), mc_tag, mode) {
+      Err(e) => return e,
+      Ok(()) => (),
+    }
+  };
+  RETIRE_SUCCESS
+}
+
+function clause execute CHECKTAG(imm, rs1) = {
+  let mode = get_mt_mode(cur_privilege);
+  // Zimop fallback (write x0) is a no-op.
+  if mode == MT_MODE_Disabled then return RETIRE_SUCCESS;
+  let w = enabled_pointer_tag_width(mode);
+  let raw = X(rs1);
+  let expected = mc_tag_of_pointer_tag(extract_pointer_tag(raw, w), mode);
+  let vitt : xlenbits = match get_vitt_base(cur_privilege) {
+    Some(base) => base,
+    None() => return memory_exception(E_Load_Access_Fault(), raw, Load(Tag)),
+  };
+  let va = bits_of(transform_effective_address(Virtaddr(raw), Load(Data)));
+  // checktag checks whole chunks: chunk_count + 1 chunks of 16 bytes
+  // starting at the chunk containing va.
+  let chunk0 = va >> 4;
+  foreach (i from 0 to unsigned(imm)) {
+    match zimt_load_mc_tag(vitt, chunk0 + to_bits(xlen, i), mode) {
+      Err(e) => return e,
+      Ok(mc_tag) => if mc_tag != expected then return trap(make_mem_tag_exception(Load(Tag))),
+    }
+  };
+  RETIRE_SUCCESS
+}
+
+mapping clause assembly = GENTAG(rd)
+  <-> "gentag" ^ spc() ^ reg_name(rd)
+mapping clause assembly = ADDTAG(imm, rs1, rd)
+  <-> "addtag" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ hex_bits_4(imm)
+mapping clause assembly = SETTAG(imm, rs1)
+  <-> "settag" ^ spc() ^ reg_name(rs1) ^ sep() ^ hex_bits_4(imm)
+mapping clause assembly = CHECKTAG(imm, rs1)
+  <-> "checktag" ^ spc() ^ reg_name(rs1) ^ sep() ^ hex_bits_4(imm)

--- a/model/extensions/Zimt/zimt_regs.sail
+++ b/model/extensions/Zimt/zimt_regs.sail
@@ -20,3 +20,33 @@ function clause currentlyEnabled(Ext_Zimt) =
 // S/HS/U/VS/VU modes; Smvatag defines it for M-mode.
 function clause currentlyEnabled(Ext_Svatag) = hartSupports(Ext_Svatag) & currentlyEnabled(Ext_Zimt)
 function clause currentlyEnabled(Ext_Smvatag) = hartSupports(Ext_Smvatag) & currentlyEnabled(Ext_Zimt)
+
+// ---------------------------------------------------------------------
+// MT_MODE lookup ("Enabling memory tagging", MEM_TAG_EN)
+//
+// Return the MemTaggingMode controlling regular explicit accesses and
+// Zimt instructions at the given (effective) privilege:
+//   M    : mseccfg.MT_MODE
+//   HS/S : menvcfg.MT_MODE
+//   U    : senvcfg.MT_MODE
+//   VS   : henvcfg.MT_MODE
+//   VU   : senvcfg.MT_MODE
+// HLV*/HSV* executed from HU with effective privilege VU use
+// hstatus.VUMT_MODE instead; that case is handled by the (future)
+// HLV/HSV tag check plumbing, not here.
+function get_mt_mode(priv : Privilege) -> MemTaggingMode = {
+  if not(currentlyEnabled(Ext_Zimt)) then return MT_MODE_Disabled;
+  match priv {
+    Machine    => mt_mode(mseccfg[MT_MODE]),
+    Supervisor => mt_mode(menvcfg[MT_MODE]),
+    User       => if currentlyEnabled(Ext_S) then mt_mode(read_senvcfg()[MT_MODE]) else mt_mode(menvcfg[MT_MODE]),
+    VirtualSupervisor => mt_mode(read_henvcfg()[MT_MODE]),
+    VirtualUser       => mt_mode(read_senvcfg()[MT_MODE]),
+  }
+}
+
+// Whether memory tagging is active at the given privilege. When
+// inactive, the Zimt instructions implement their Zimop fallback
+// behavior (see zimt_insts.sail).
+function zimt_active(priv : Privilege) -> bool =
+  get_mt_mode(priv) != MT_MODE_Disabled

--- a/model/extensions/Zimt/zimt_regs.sail
+++ b/model/extensions/Zimt/zimt_regs.sail
@@ -50,3 +50,143 @@ function get_mt_mode(priv : Privilege) -> MemTaggingMode = {
 // behavior (see zimt_insts.sail).
 function zimt_active(priv : Privilege) -> bool =
   get_mt_mode(priv) != MT_MODE_Disabled
+
+// ---------------------------------------------------------------------
+// !!! PLACEHOLDER CSR ADDRESSES - TG ALLOCATION NEEDED !!!
+//
+// The v0.2 draft specification explicitly leaves the CSR addresses of
+// the tag-generation exclusion mask CSRs and the VITT base CSRs
+// unallocated ("CSR addresses for these registers are to be
+// allocated"). The addresses below are placeholders taken from the
+// custom read/write ranges (machine 0x7C0+, supervisor 0x5C0+,
+// hypervisor/VS 0x6C0+) and MUST be updated once the memory tagging
+// TG obtains allocations.
+//
+// TODO: Smstateen/Ssstateen gating of the U/VU-controlling CSRs via
+// mstateen0.MT / hstateen0.MT is NOT implemented: the spec carries an
+// explicit warning that the MT bit position in [mh]stateen0 is not
+// fixed yet.
+
+// ---------------------------------------------------------------------
+// Tag-generation exclusion mask CSR pairs.
+//
+// Bit i of the active 128-bit mask (high @ low) set means gentag must
+// not generate pointer_tag value i. With pointer_tag_width = 4 only
+// bits [15:0] are active. Zimt is RV64-only, so these registers are
+// modelled at xlen bits (they are inaccessible on RV32).
+register mmtagexclude0    : xlenbits = zeros()
+register mmtagexclude1    : xlenbits = zeros()
+register menvmtagexclude0 : xlenbits = zeros()
+register menvmtagexclude1 : xlenbits = zeros()
+register senvmtagexclude0 : xlenbits = zeros()
+register senvmtagexclude1 : xlenbits = zeros()
+register henvmtagexclude0 : xlenbits = zeros()
+register henvmtagexclude1 : xlenbits = zeros()
+
+// "At least one bit in [15:0] must remain clear" (WARL): if software
+// attempts to exclude all 16 low tag values, this implementation
+// clears bit 0.
+function legalize_mtagexclude0(v : xlenbits) -> xlenbits =
+  if v[15 .. 0] == ones() then [v with 0 = bitzero] else v
+
+mapping clause csr_name_map = 0x7C0 <-> "mmtagexclude0"
+mapping clause csr_name_map = 0x7C1 <-> "mmtagexclude1"
+mapping clause csr_name_map = 0x7C2 <-> "menvmtagexclude0"
+mapping clause csr_name_map = 0x7C3 <-> "menvmtagexclude1"
+mapping clause csr_name_map = 0x5C0 <-> "senvmtagexclude0"
+mapping clause csr_name_map = 0x5C1 <-> "senvmtagexclude1"
+mapping clause csr_name_map = 0x6C0 <-> "henvmtagexclude0"
+mapping clause csr_name_map = 0x6C1 <-> "henvmtagexclude1"
+
+function clause is_CSR_accessible(0x7C0, _, _) = currentlyEnabled(Ext_Zimt)
+function clause is_CSR_accessible(0x7C1, _, _) = currentlyEnabled(Ext_Zimt)
+function clause is_CSR_accessible(0x7C2, _, _) = currentlyEnabled(Ext_Zimt) & currentlyEnabled(Ext_S)
+function clause is_CSR_accessible(0x7C3, _, _) = currentlyEnabled(Ext_Zimt) & currentlyEnabled(Ext_S)
+function clause is_CSR_accessible(0x5C0, _, _) = currentlyEnabled(Ext_Zimt) & currentlyEnabled(Ext_S)
+function clause is_CSR_accessible(0x5C1, _, _) = currentlyEnabled(Ext_Zimt) & currentlyEnabled(Ext_S)
+function clause is_CSR_accessible(0x6C0, _, _) = currentlyEnabled(Ext_Zimt) & currentlyEnabled(Ext_H)
+function clause is_CSR_accessible(0x6C1, _, _) = currentlyEnabled(Ext_Zimt) & currentlyEnabled(Ext_H)
+
+function clause read_CSR(0x7C0) = mmtagexclude0
+function clause read_CSR(0x7C1) = mmtagexclude1
+function clause read_CSR(0x7C2) = menvmtagexclude0
+function clause read_CSR(0x7C3) = menvmtagexclude1
+function clause read_CSR(0x5C0) = senvmtagexclude0
+function clause read_CSR(0x5C1) = senvmtagexclude1
+function clause read_CSR(0x6C0) = henvmtagexclude0
+function clause read_CSR(0x6C1) = henvmtagexclude1
+
+function clause write_CSR(0x7C0, value) = { mmtagexclude0 = legalize_mtagexclude0(value); Ok(mmtagexclude0) }
+function clause write_CSR(0x7C1, value) = { mmtagexclude1 = value; Ok(mmtagexclude1) }
+function clause write_CSR(0x7C2, value) = { menvmtagexclude0 = legalize_mtagexclude0(value); Ok(menvmtagexclude0) }
+function clause write_CSR(0x7C3, value) = { menvmtagexclude1 = value; Ok(menvmtagexclude1) }
+function clause write_CSR(0x5C0, value) = { senvmtagexclude0 = legalize_mtagexclude0(value); Ok(senvmtagexclude0) }
+function clause write_CSR(0x5C1, value) = { senvmtagexclude1 = value; Ok(senvmtagexclude1) }
+function clause write_CSR(0x6C0, value) = { henvmtagexclude0 = legalize_mtagexclude0(value); Ok(henvmtagexclude0) }
+function clause write_CSR(0x6C1, value) = { henvmtagexclude1 = value; Ok(henvmtagexclude1) }
+
+// The 128-bit tag-generation exclusion mask (high @ low) active at
+// `priv`. Zimt is RV64-only, so xlen is 64 whenever this is
+// reachable; zero_extend keeps the RV32 build type-correct.
+function mtag_exclusion_pair(hi : xlenbits, lo : xlenbits) -> bits(128) = {
+  let hi64 : bits(64) = zero_extend(hi);
+  let lo64 : bits(64) = zero_extend(lo);
+  hi64 @ lo64
+}
+
+function get_mtag_exclusion_mask(priv : Privilege) -> bits(128) =
+  match priv {
+    Machine           => mtag_exclusion_pair(mmtagexclude1, mmtagexclude0),
+    Supervisor        => mtag_exclusion_pair(menvmtagexclude1, menvmtagexclude0),
+    User              => mtag_exclusion_pair(senvmtagexclude1, senvmtagexclude0),
+    VirtualSupervisor => mtag_exclusion_pair(henvmtagexclude1, henvmtagexclude0),
+    VirtualUser       => mtag_exclusion_pair(senvmtagexclude1, senvmtagexclude0),
+  }
+
+// ---------------------------------------------------------------------
+// VITT (virtually indexed tag table) base CSRs, Svatag/Smvatag.
+// "Tag table base address must be 4K aligned" - bits [11:0] are WARL
+// read-only zero.
+register mvitt   : xlenbits = zeros()
+register svitts  : xlenbits = zeros()
+register svittu  : xlenbits = zeros()
+register vsvitts : xlenbits = zeros()
+register vsvittu : xlenbits = zeros()
+
+function legalize_vitt(v : xlenbits) -> xlenbits = [v with 11 .. 0 = zeros()]
+
+mapping clause csr_name_map = 0x7C4 <-> "mvitt"
+mapping clause csr_name_map = 0x5C2 <-> "svitts"
+mapping clause csr_name_map = 0x5C3 <-> "svittu"
+mapping clause csr_name_map = 0x6C2 <-> "vsvitts"
+mapping clause csr_name_map = 0x6C3 <-> "vsvittu"
+
+function clause is_CSR_accessible(0x7C4, _, _) = currentlyEnabled(Ext_Smvatag)
+function clause is_CSR_accessible(0x5C2, _, _) = currentlyEnabled(Ext_Svatag) & currentlyEnabled(Ext_S)
+function clause is_CSR_accessible(0x5C3, _, _) = currentlyEnabled(Ext_Svatag) & currentlyEnabled(Ext_S)
+function clause is_CSR_accessible(0x6C2, _, _) = currentlyEnabled(Ext_Svatag) & currentlyEnabled(Ext_H)
+function clause is_CSR_accessible(0x6C3, _, _) = currentlyEnabled(Ext_Svatag) & currentlyEnabled(Ext_H)
+
+function clause read_CSR(0x7C4) = mvitt
+function clause read_CSR(0x5C2) = svitts
+function clause read_CSR(0x5C3) = svittu
+function clause read_CSR(0x6C2) = vsvitts
+function clause read_CSR(0x6C3) = vsvittu
+
+function clause write_CSR(0x7C4, value) = { mvitt = legalize_vitt(value); Ok(mvitt) }
+function clause write_CSR(0x5C2, value) = { svitts = legalize_vitt(value); Ok(svitts) }
+function clause write_CSR(0x5C3, value) = { svittu = legalize_vitt(value); Ok(svittu) }
+function clause write_CSR(0x6C2, value) = { vsvitts = legalize_vitt(value); Ok(vsvitts) }
+function clause write_CSR(0x6C3, value) = { vsvittu = legalize_vitt(value); Ok(vsvittu) }
+
+// The VITT base used for tag load/store operations on behalf of
+// accesses at the given (effective) privilege. None() if the relevant
+// tag-table extension is not enabled.
+function get_vitt_base(priv : Privilege) -> option(xlenbits) =
+  match priv {
+    Machine    => if currentlyEnabled(Ext_Smvatag) then Some(mvitt) else None(),
+    Supervisor => if currentlyEnabled(Ext_Svatag) then Some(svitts) else None(),
+    User       => if currentlyEnabled(Ext_Svatag) then Some(svittu) else None(),
+    VirtualSupervisor => if currentlyEnabled(Ext_Svatag) then Some(vsvitts) else None(),
+    VirtualUser       => if currentlyEnabled(Ext_Svatag) then Some(vsvittu) else None(),
+  }

--- a/model/extensions/Zimt/zimt_regs.sail
+++ b/model/extensions/Zimt/zimt_regs.sail
@@ -1,0 +1,22 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// Architectural state and enablement for the Zimt memory tagging
+// extension and the Svatag/Smvatag tag storage extensions (v0.2, DRAFT).
+// https://github.com/riscv/riscv-memory-tagging
+
+// "The Zimt extension depends on Zicsr, Zimop and pointer masking
+// extensions and is applicable only for XLEN=64."
+function clause currentlyEnabled(Ext_Zimt) =
+  hartSupports(Ext_Zimt) & currentlyEnabled(Ext_Zicsr) & currentlyEnabled(Ext_Zimop)
+  & (currentlyEnabled(Ext_Ssnpm) | currentlyEnabled(Ext_Smnpm) | currentlyEnabled(Ext_Smmpm))
+
+// Svatag defines the virtually indexed tag table (VITT) for
+// S/HS/U/VS/VU modes; Smvatag defines it for M-mode.
+function clause currentlyEnabled(Ext_Svatag) = hartSupports(Ext_Svatag) & currentlyEnabled(Ext_Zimt)
+function clause currentlyEnabled(Ext_Smvatag) = hartSupports(Ext_Smvatag) & currentlyEnabled(Ext_Zimt)

--- a/model/extensions/Zimt/zimt_types.sail
+++ b/model/extensions/Zimt/zimt_types.sail
@@ -1,0 +1,58 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// Types for the Zimt memory tagging extension (v0.2, DRAFT).
+// https://github.com/riscv/riscv-memory-tagging
+
+// Width in bits of the tag carried in the masked bits of a pointer.
+// 0 means memory tagging is disabled.
+type pointer_tag_width_t = {0, 4, 7}
+
+// Width in bits of the tag associated with a memory chunk in the tag
+// table. 0 means memory tagging is disabled.
+type mc_tag_width_t = {0, 4, 8}
+
+// Encodings of the 2-bit MT_MODE field in mseccfg, menvcfg, senvcfg
+// and henvcfg (and of hstatus.VUMT_MODE).
+enum MemTaggingMode = {
+  MT_MODE_Disabled,
+  MT_MODE_Reserved,
+  MT_MODE_Tag4,     // pointer_tag_width = 4, mc_tag_width = 4
+  MT_MODE_Tag7,     // pointer_tag_width = 7, mc_tag_width = 8
+}
+
+mapping mt_mode : MemTaggingMode <-> bits(2) = {
+  MT_MODE_Disabled <-> 0b00,
+  MT_MODE_Reserved <-> 0b01,
+  MT_MODE_Tag4     <-> 0b10,
+  MT_MODE_Tag7     <-> 0b11,
+}
+
+// Return whether the given MT_MODE value is supported. An
+// implementation of Zimt must support pointer_tag_width = 4;
+// pointer_tag_width = 7 is optional.
+function is_supported_mt_mode(mode : MemTaggingMode) -> bool = match mode {
+  MT_MODE_Disabled => true,
+  MT_MODE_Reserved => false,
+  MT_MODE_Tag4     => config extensions.Zimt.supported_pointer_tag_width_4,
+  MT_MODE_Tag7     => config extensions.Zimt.supported_pointer_tag_width_7,
+}
+
+function pointer_tag_width(mode : MemTaggingMode) -> pointer_tag_width_t = match mode {
+  MT_MODE_Disabled => 0,
+  MT_MODE_Reserved => 0,
+  MT_MODE_Tag4     => 4,
+  MT_MODE_Tag7     => 7,
+}
+
+function mc_tag_width(mode : MemTaggingMode) -> mc_tag_width_t = match mode {
+  MT_MODE_Disabled => 0,
+  MT_MODE_Reserved => 0,
+  MT_MODE_Tag4     => 4,
+  MT_MODE_Tag7     => 8,
+}

--- a/model/extensions/Zimt/zimt_types.sail
+++ b/model/extensions/Zimt/zimt_types.sail
@@ -56,3 +56,12 @@ function mc_tag_width(mode : MemTaggingMode) -> mc_tag_width_t = match mode {
   MT_MODE_Tag4     => 4,
   MT_MODE_Tag7     => 8,
 }
+
+// pointer_tag width of an enabled (non-disabled, non-reserved) mode.
+type zimt_tag_width = {4, 7}
+
+function enabled_pointer_tag_width(mode : MemTaggingMode) -> zimt_tag_width =
+  match mode {
+    MT_MODE_Tag7 => 7,
+    _            => 4,
+  }

--- a/model/extensions/cfi/cfi_types.sail
+++ b/model/extensions/cfi/cfi_types.sail
@@ -12,10 +12,13 @@ enum Software_Check_Code = {
   SWC_NO_INFO,
   SWC_LANDING_PAD_FAULT,
   SWC_SHADOW_STACK_FAULT,
+  SWC_MEM_TAG_FAULT,
 }
 
-mapping software_check_cause : Software_Check_Code <-> bits(2) = {
-  SWC_NO_INFO            <-> 0b00,
-  SWC_LANDING_PAD_FAULT  <-> 0b10,
-  SWC_SHADOW_STACK_FAULT <-> 0b11,
+mapping software_check_cause : Software_Check_Code <-> bits(3) = {
+  SWC_NO_INFO            <-> 0b000,
+  SWC_LANDING_PAD_FAULT  <-> 0b010,
+  SWC_SHADOW_STACK_FAULT <-> 0b011,
+  // Memory tagging (Zimt, v0.2 DRAFT) tag mismatch
+  SWC_MEM_TAG_FAULT      <-> 0b100,
 }

--- a/model/pmp/pmp_control.sail
+++ b/model/pmp/pmp_control.sail
@@ -33,6 +33,11 @@ private function pmpCheckRWX(ent : Pmpcfg_ent, access : MemoryAccessType(mem_pay
 
     Atomic(_, _, _, ShadowStack, ShadowStack) => ent[R] == 0b1 & ent[W] == 0b1,
 
+    // Memory tagging (Zimt) tag table accesses are checked like
+    // regular loads and stores.
+    Load(Tag)                     => ent[R] == 0b1,
+    Store(Tag)                    => ent[W] == 0b1,
+
     LoadExecute(p)                => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadExecute."),
     LoadReserved(_, _, p)         => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for LoadReserved."),
     StoreConditional(_, _, p)     => internal_error(__FILE__, __LINE__, "Invalid payload (" ^ mem_payload_name(p) ^ ") for StoreConditional."),

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -564,6 +564,18 @@ private function check_misc_extension_dependencies() -> bool = {
     valid = false;
     print_endline("The Zicfiss extension is enabled but one or more of Zicsr, Zimop and (Zaamo or A) are disabled: supporting Zicfiss requires Zicsr, Zimop and (Zaamo or A).");
   };
+  if (config extensions.Zimt.supported : bool) & not((config extensions.Zicsr.supported : bool) & (config extensions.Zimop.supported : bool) & ((config extensions.Ssnpm.supported : bool) | (config extensions.Smnpm.supported : bool) | (config extensions.Smmpm.supported : bool))) then {
+    valid = false;
+    print_endline("The Zimt extension is enabled but one or more of Zicsr, Zimop and (Ssnpm or Smnpm or Smmpm) are disabled: supporting Zimt requires Zicsr, Zimop and pointer masking.");
+  };
+  if (config extensions.Zimt.supported : bool) & not((config extensions.Zimt.supported_pointer_tag_width_4 : bool)) then {
+    valid = false;
+    print_endline("The Zimt extension is enabled but supported_pointer_tag_width_4 is false: implementations of Zimt must support pointer_tag_width = 4.");
+  };
+  if ((config extensions.Svatag.supported : bool) | (config extensions.Smvatag.supported : bool)) & not(config extensions.Zimt.supported : bool) then {
+    valid = false;
+    print_endline("The Svatag/Smvatag extensions are enabled but Zimt is disabled: the tag table extensions require Zimt.");
+  };
   if (config extensions.Zfbfmin.supported : bool) & not(config extensions.F.supported : bool) then {
     valid = false;
     print_endline("The Zfbfmin extension is enabled but F is disabled: supporting Zfbfmin requires F.");

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -555,6 +555,16 @@ extensions {
     }
   }
 
+  Zimt {
+    Zimt_types {
+      files extensions/Zimt/zimt_types.sail
+    }
+    Zimt_regs {
+      requires core, Zimt_types, Stateen
+      files extensions/Zimt/zimt_regs.sail
+    }
+  }
+
   rmem {
     requires core, sys
     files

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -61,7 +61,7 @@ pmp {
 }
 
 sys {
-  requires prelude, core, exceptions, pmp, V_core, Smcntrpmf, Zicfilp_regs, A_types, Stateen, Zicbop_types, PM_utils
+  requires prelude, core, exceptions, pmp, V_core, Smcntrpmf, Zicfilp_regs, A_types, Stateen, Zicbop_types, PM_utils, CFI_types, Zimt_types, Zimt_regs
 
   files
     sys/sys_reservation.sail,
@@ -80,6 +80,7 @@ sys {
     sys/vmem.sail,
     sys/insts_begin.sail,
     sys/vmem_utils.sail,
+    sys/zimt_tag_ops.sail,
 }
 
 extensions {
@@ -562,6 +563,10 @@ extensions {
     Zimt_regs {
       requires core, Zimt_types, Stateen
       files extensions/Zimt/zimt_regs.sail
+    }
+    Zimt_insts {
+      requires core, sys, exceptions, CFI_types, Zimt_types, Zimt_regs, PM_utils
+      files extensions/Zimt/zimt_insts.sail
     }
   }
 

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -7,7 +7,7 @@ prelude {
 }
 
 core {
-  requires prelude, A_types, Zicbop_types, Zicbom_types, PM_types
+  requires prelude, A_types, Zicbop_types, Zicbom_types, PM_types, Zimt_types
 
   files
     core/isa_version.sail,

--- a/model/sys/mem.sail
+++ b/model/sys/mem.sail
@@ -120,6 +120,10 @@ private function pmaCheck forall 'n, 0 < 'n <= max_mem_access .
     // to be idempotent."
     Load(ShadowStack)      => {assert(not(res_or_con)); attributes.readable & attributes.read_idempotent},
     Store(ShadowStack)     => {assert(not(res_or_con)); attributes.writable & attributes.write_idempotent},
+
+    // Zimt tag table accesses are checked like regular loads/stores.
+    Load(Tag)              => {assert(not(res_or_con)); attributes.readable},
+    Store(Tag)             => {assert(not(res_or_con)); attributes.writable},
     Atomic(AMOSWAP, _, _, ShadowStack, ShadowStack) => {assert(res_or_con); attributes.readable & attributes.writable & attributes.read_idempotent & attributes.write_idempotent & pma_allows_atomic_op(attributes.atomic_support, AMOSWAP, width)},
 
     // TODO for the CMO extensions: "The PMAs shall be the

--- a/model/sys/pma.sail
+++ b/model/sys/pma.sail
@@ -162,6 +162,9 @@ function pma_misaligned_exception(pma : PMA, access : MemoryAccessType(mem_paylo
     StoreConditional(_, _, p) => internal_error(__FILE__, __LINE__, "PMA: Invalid misaligned store-conditional (" ^ mem_payload_name(p) ^ ")."),
     Load(ShadowStack)         => internal_error(__FILE__, __LINE__, "PMA: Invalid misaligned shadow-stack load."),
     Store(ShadowStack)        => internal_error(__FILE__, __LINE__, "PMA: Invalid misaligned shadow-stack store."),
+    // Zimt tag table accesses are single bytes and cannot be misaligned.
+    Load(Tag)                 => internal_error(__FILE__, __LINE__, "PMA: Invalid misaligned tag load."),
+    Store(Tag)                => internal_error(__FILE__, __LINE__, "PMA: Invalid misaligned tag store."),
     CacheAccess(_)            => internal_error(__FILE__, __LINE__, "PMA: Invalid misaligned cache-access."),
     LoadExecute(p)            => internal_error(__FILE__, __LINE__, "PMA: Invalid misaligned load-execute (" ^ mem_payload_name(p) ^ ")."),
   }
@@ -185,6 +188,9 @@ private function is_mag_applicable_access(access : MemoryAccessType(mem_payload)
     // Not in the base ISA.
     Load(ShadowStack)                   => false,
     Store(ShadowStack)                  => false,
+    // Zimt tag table accesses are single bytes and never misaligned.
+    Load(Tag)                           => false,
+    Store(Tag)                          => false,
     // AMOs
     Atomic(_, _, _, Data, Data)         => true,
     // Treat like an AMO.

--- a/model/sys/vmem_pte.sail
+++ b/model/sys/vmem_pte.sail
@@ -205,6 +205,10 @@ private function check_PTE_permission(
       Store(ShadowStack)                        => true,
       Atomic(_, _, _, ShadowStack, ShadowStack) => true,
 
+      // Zimt tag table accesses behave like regular loads/stores.
+      Load(Tag)                                 => true,
+      Store(Tag)                                => false,
+
       // "Access to a SS page using cache-block operation (CBO.*) instructions
       // is not permitted. Such accesses will raise a store/AMO access-fault
       // exception."

--- a/model/sys/vmem_ptw.sail
+++ b/model/sys/vmem_ptw.sail
@@ -104,6 +104,13 @@ function translationException(access : MemoryAccessType(mem_payload),
     (Store(ShadowStack), PTW_No_Access())        => E_SAMO_Access_Fault(),
     (Store(ShadowStack), _)                      => E_SAMO_Page_Fault(),
 
+    // Zimt tag table accesses fault like regular loads/stores; the
+    // tag virtual address is reported in xtval.
+    (Load(Tag), PTW_No_Access())                 => E_Load_Access_Fault(),
+    (Load(Tag), _)                               => E_Load_Page_Fault(),
+    (Store(Tag), PTW_No_Access())                => E_SAMO_Access_Fault(),
+    (Store(Tag), _)                              => E_SAMO_Page_Fault(),
+
     (InstructionFetch(), PTW_No_Access())        => E_Fetch_Access_Fault(),
     (InstructionFetch(), _)                      => E_Fetch_Page_Fault(),
 

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -311,6 +311,12 @@ function get_transformed_data_addr(base : regidx, offset : xlenbits, acc : Memor
   }
 }
 
+// Zimt implicit tag check hook; defined in zimt_tag_ops.sail, which
+// must follow this file in the module since it uses vmem_read_addr.
+val zimt_implicit_check : forall 'width, is_mem_width('width).
+  (regidx, xlenbits, virtaddr, int('width), MemoryAccessType(mem_payload))
+  -> option(ExecutionResult)
+
 val vmem_read : forall 'width, is_mem_width('width).
   (regidx, xlenbits, int('width), MemoryAccessType(mem_payload), bool, bool, bool)
   -> result(bits(8 * 'width), ExecutionResult)
@@ -321,6 +327,14 @@ function vmem_read(rs, offset, width, access, aq, rl, res) = {
   let vaddr : virtaddr = match get_transformed_data_addr(rs, offset, access, width) {
     Ext_DataAddr_OK(vaddr) => vaddr,
     Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
+  };
+
+  // Zimt: perform the implicit tag check, if one applies. The raw
+  // (untransformed) address carries the pointer_tag in its masked
+  // bits.
+  match zimt_implicit_check(rs, X(rs) + offset, vaddr, width, access) {
+    Some(e) => return Err(e),
+    None()  => (),
   };
 
   vmem_read_addr(vaddr, width, access, aq, rl, res)
@@ -336,6 +350,14 @@ function vmem_write(rs_addr, offset, width, data, access, aq, rl, res) = {
   let vaddr : virtaddr = match get_transformed_data_addr(rs_addr, offset, access, width) {
     Ext_DataAddr_OK(vaddr) => vaddr,
     Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
+  };
+
+  // Zimt: perform the implicit tag check, if one applies. The raw
+  // (untransformed) address carries the pointer_tag in its masked
+  // bits.
+  match zimt_implicit_check(rs_addr, X(rs_addr) + offset, vaddr, width, access) {
+    Some(e) => return Err(e),
+    None()  => (),
   };
 
   vmem_write_addr(vaddr, width, data, access, aq, rl, res)

--- a/model/sys/zimt_tag_ops.sail
+++ b/model/sys/zimt_tag_ops.sail
@@ -107,3 +107,51 @@ function zimt_check_chunks forall 'width, is_mem_width('width). (
   };
   None()
 }
+
+// ---------------------------------------------------------------------
+// Implicit tag checks on regular loads/stores (no-translation
+// environments only).
+//
+// When memory tagging is active at the effective privilege of a
+// regular Data load/store and address translation is not in effect
+// (Bare mode), every data page is a tagged-data page ("If paging is
+// not enabled then all data pages are treated as tagged-data pages")
+// and there are no tagcheck-exempt code pages, so the access is
+// checked unless it is performed via the stack pointer (x2).
+//
+// TODO (blocked on spec): with paging enabled, checks are controlled
+// by the PTE.MTAG bit, whose position the v0.2 draft has not fixed;
+// accesses under paging are currently unchecked. mstatus.MTAG_I /
+// hstatus.MTAG_I, HLV*/HSV* (hstatus.VUMT_MODE) and vector/LR/SC/AMO
+// accesses are likewise not checked yet.
+// The val declaration (with the type) is in vmem_utils.sail, where
+// vmem_read/vmem_write invoke this hook.
+function zimt_implicit_check(base, raw_addr, vaddr, width, access) = {
+  if not(currentlyEnabled(Ext_Zimt)) then return None();
+  // Only regular data loads/stores are checked (vector/LR/SC/AMO: TODO).
+  let checked_kind : bool = match access {
+    Load(Data)  => true,
+    Store(Data) => true,
+    _           => false,
+  };
+  if not(checked_kind) then return None();
+  // "Memory accesses performed using the stack pointer (x2) as the
+  // base register do not generate checked accesses."
+  if base == sp then return None();
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+  let mode = get_mt_mode(eff_priv);
+  if mode == MT_MODE_Disabled then return None();
+  // Paging enabled: PTE.MTAG-based checks are TODO (see above).
+  let vmem_active : bool = if privLevel_is_virtual(eff_priv)
+    then vsatp_mode() != Bare | hgatp_mode() != HBare
+    else satp_mode(eff_priv) != Bare;
+  if vmem_active then return None();
+  let vitt : xlenbits = match get_vitt_base(eff_priv) {
+    Some(b) => b,
+    // No tag table available for this privilege: no checked accesses.
+    None()  => return None(),
+  };
+  let w = enabled_pointer_tag_width(mode);
+  let expected = mc_tag_of_pointer_tag(extract_pointer_tag(raw_addr, w), mode);
+  zimt_check_chunks(vitt, bits_of(vaddr), width, expected, mode, access)
+}

--- a/model/sys/zimt_tag_ops.sail
+++ b/model/sys/zimt_tag_ops.sail
@@ -1,0 +1,109 @@
+// =======================================================================================
+// This Sail RISC-V architecture model, comprising all files and
+// directories except where otherwise noted is subject the BSD
+// two-clause license in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// Tag load/store operations for the Zimt memory tagging extension and
+// the Svatag/Smvatag virtually-indexed tag table (v0.2, DRAFT).
+//
+// A memory chunk is 16 bytes; the tag of the chunk containing virtual
+// address va lives at
+//   mc_tag_va = VITT_BASE + (((va >> 4) * mc_tag_width) >> 3)
+// i.e. two 4-bit tags packed per byte, or one 8-bit tag per byte.
+// Tag loads/stores flow through vmem_read_addr/vmem_write_addr with
+// the Tag payload, so page faults and access faults on the tag table
+// are reported against the tag virtual address as required.
+
+// Software-check exception for a tag mismatch, xtval = 4.
+function make_mem_tag_exception(access : MemoryAccessType(mem_payload)) -> ExceptionContext =
+  make_exception_context(E_Software_Check(), zero_extend(software_check_cause(SWC_MEM_TAG_FAULT)),
+                         access_is_gva(access), None())
+
+// Extract pointer_tag from the masked bits [xlen-1 .. xlen-w] of a pointer.
+function extract_pointer_tag(ptr : xlenbits, w : zimt_tag_width) -> bits(7) = {
+  let 'w = w;
+  zero_extend(ptr[xlen - 1 .. xlen - w])
+}
+
+// Insert pointer_tag into bits [xlen-1 .. xlen-w] of a pointer.
+function insert_pointer_tag(ptr : xlenbits, tag : bits(7), w : zimt_tag_width) -> xlenbits = {
+  let 'w = w;
+  [ptr with (xlen - 1) .. (xlen - w) = tag[w - 1 .. 0]]
+}
+
+// The mc_tag stored for / compared against pointer_tag `tag`:
+// mc_tag_width is 4 for 4-bit pointer tags and 8 for 7-bit ones.
+function mc_tag_of_pointer_tag(tag : bits(7), mode : MemTaggingMode) -> bits(8) =
+  match mode {
+    MT_MODE_Tag4 => zero_extend(tag[3 .. 0]),
+    _            => zero_extend(tag),
+  }
+
+// Virtual address of the tag-table byte holding the mc_tag of the
+// chunk with index `chunk` (= va >> 4), and whether it occupies the
+// upper nibble of that byte (mc_tag_width = 4 only).
+function zimt_tag_byte_addr(vitt : xlenbits, chunk : xlenbits, mode : MemTaggingMode) -> (xlenbits, bool) =
+  match mode {
+    MT_MODE_Tag4 => (vitt + (chunk >> 1), chunk[0] == bitone),
+    _            => (vitt + chunk, false),
+  }
+
+// Perform a "load tag" operation for one memory chunk.
+function zimt_load_mc_tag(vitt : xlenbits, chunk : xlenbits, mode : MemTaggingMode)
+  -> result(bits(8), ExecutionResult) = {
+  let (tag_va, upper_nibble) = zimt_tag_byte_addr(vitt, chunk, mode);
+  match vmem_read_addr(Virtaddr(tag_va), 1, Load(Tag), false, false, false) {
+    Err(e) => Err(e),
+    Ok(byte) => Ok(match mode {
+      MT_MODE_Tag4 => if upper_nibble then zero_extend(byte[7 .. 4]) else zero_extend(byte[3 .. 0]),
+      _            => byte,
+    }),
+  }
+}
+
+// Perform a "store tag" operation for one memory chunk. For
+// mc_tag_width = 4 this is a read-modify-write of the shared byte;
+// the spec provides no atomicity guarantee for settag.
+function zimt_store_mc_tag(vitt : xlenbits, chunk : xlenbits, mc_tag : bits(8), mode : MemTaggingMode)
+  -> result(unit, ExecutionResult) = {
+  let (tag_va, upper_nibble) = zimt_tag_byte_addr(vitt, chunk, mode);
+  let value : bits(8) = match mode {
+    MT_MODE_Tag4 => {
+      match vmem_read_addr(Virtaddr(tag_va), 1, Load(Tag), false, false, false) {
+        Err(e) => return Err(e),
+        Ok(byte) => if upper_nibble then [byte with 7 .. 4 = mc_tag[3 .. 0]]
+                    else [byte with 3 .. 0 = mc_tag[3 .. 0]],
+      }
+    },
+    _ => mc_tag,
+  };
+  match vmem_write_addr(Virtaddr(tag_va), 1, value, Store(Tag), false, false, false) {
+    Err(e) => Err(e),
+    Ok(_)  => Ok(()),
+  }
+}
+
+// Check the tags of all chunks overlapped by [va, va + width) against
+// `expected`; returns None() on success, or the resulting trap.
+function zimt_check_chunks forall 'width, is_mem_width('width). (
+  vitt : xlenbits,
+  va : xlenbits,
+  width : int('width),
+  expected : bits(8),
+  mode : MemTaggingMode,
+  access : MemoryAccessType(mem_payload),
+) -> option(ExecutionResult) = {
+  let first_chunk = va >> 4;
+  let last_chunk = (va + to_bits(xlen, width - 1)) >> 4;
+  let nchunks = unsigned(last_chunk - first_chunk);
+  foreach (i from 0 to nchunks) {
+    match zimt_load_mc_tag(vitt, first_chunk + to_bits(xlen, i), mode) {
+      Err(e) => return Some(e),
+      Ok(mc_tag) => if mc_tag != expected then return Some(trap(make_mem_tag_exception(access))),
+    }
+  };
+  None()
+}

--- a/test/first_party/CMakeLists.txt
+++ b/test/first_party/CMakeLists.txt
@@ -136,6 +136,7 @@ add_first_party_test("test_tlb_stale_pte_access_fault.S")
 add_first_party_override_test("test_sew_elen_bound.S" "elen_32.json")
 add_first_party_override_test("test_satp_physaddr_bits.S" "satp_physaddr_bits.json")
 add_first_party_experimental_test("test_zilx.S")
+add_first_party_experimental_test("test_zimt.S")
 
 list(LENGTH tests tests_len)
 math(EXPR test_last "${tests_len} - 1")

--- a/test/first_party/src/test_zimt.S
+++ b/test/first_party/src/test_zimt.S
@@ -1,0 +1,209 @@
+// Self-checking test for the Zimt memory tagging extension (v0.2, DRAFT).
+// Runs in M-mode with mseccfg.MT_MODE enabled and the Smvatag tag table.
+//
+// NOTE: the CSR addresses of mvitt and mmtagexclude0 are PLACEHOLDERS;
+// the draft specification has not allocated CSR addresses yet (see
+// model/extensions/Zimt/zimt_regs.sail).
+
+#define CSR_MSECCFG      0x747
+#define CSR_MMTAGEXCL0   0x7C0
+#define CSR_MVITT        0x7C4
+
+// mseccfg.MT_MODE: bits 35:34; mseccfg.PMM: bits 33:32.
+#define MT_MODE_SHIFT    34
+#define MT_MODE_TAG4     2
+#define PMM_SHIFT        32
+#define PMM_PMLEN_7      2
+
+// Zimt instructions are encoded directly (Zimop MOP.RR space, SYSTEM
+// opcode, funct3 100) since toolchains do not support Zimt yet.
+// Register arguments are architectural register numbers.
+.macro gentag rd
+  .4byte ((0x43 << 25) | (0x4 << 12) | (\rd << 7) | 0x73)
+.endm
+.macro addtag rd, rs1, imm4
+  .4byte ((0x43 << 25) | (\imm4 << 20) | (\rs1 << 15) | (0x4 << 12) | (\rd << 7) | 0x73)
+.endm
+.macro checktag rs1, imm4
+  .4byte ((0x43 << 25) | (\imm4 << 20) | (\rs1 << 15) | (0x4 << 12) | 0x73)
+.endm
+.macro settag rs1, imm4
+  .4byte ((0x41 << 25) | (\imm4 << 20) | (\rs1 << 15) | (0x4 << 12) | 0x73)
+.endm
+
+#define CAUSE_SOFTWARE_CHECK 18
+#define SWCHECK_TVAL_MEM_TAG 4
+
+.global main
+main:
+#if __riscv_xlen == 64
+    mv s11, ra
+
+    // ------------------------------------------------------------------
+    // 1. Enable pointer masking (PMLEN=7) and memory tagging (4-bit
+    //    tags) in M-mode. If MT_MODE reads back 0, Zimt is not present
+    //    (e.g. experimental extensions disabled): pass trivially.
+    li t0, (MT_MODE_TAG4 << MT_MODE_SHIFT) | (PMM_PMLEN_7 << PMM_SHIFT)
+    csrs CSR_MSECCFG, t0
+    csrr t1, CSR_MSECCFG
+    srli t1, t1, MT_MODE_SHIFT
+    andi t1, t1, 3
+    li t2, MT_MODE_TAG4
+    bne t1, t2, pass
+
+    // The reserved MT_MODE value 0b01 must not stick (WARL keep-old).
+    li t0, (3 << MT_MODE_SHIFT)
+    csrc CSR_MSECCFG, t0
+    li t0, (1 << MT_MODE_SHIFT)
+    csrs CSR_MSECCFG, t0
+    csrr t1, CSR_MSECCFG
+    srli t1, t1, MT_MODE_SHIFT
+    andi t1, t1, 3
+    li t2, 1
+    beq t1, t2, fail
+    li t0, (MT_MODE_TAG4 << MT_MODE_SHIFT)
+    csrs CSR_MSECCFG, t0
+
+    // ------------------------------------------------------------------
+    // 2. Point the M-mode tag table (VITT) so that the tag byte of
+    //    data_buf lands inside tag_region:
+    //      mc_tag_va = mvitt + (va >> 5)        (4-bit tags)
+    //    mvitt = (tag_anchor - (data_buf >> 5)) & ~0xFFF, which puts
+    //    the tag byte within (tag_anchor - 4096, tag_anchor].
+    la t0, tag_region
+    li t1, 4096
+    add t0, t0, t1         // tag_anchor = tag_region + 4096
+    la t2, data_buf
+    srli t2, t2, 5
+    sub t0, t0, t2
+    csrw CSR_MVITT, t0
+    // mvitt is 4K-aligned WARL: low 12 bits must read back zero.
+    csrr t1, CSR_MVITT
+    slli t1, t1, 52
+    bnez t1, fail
+
+    // ------------------------------------------------------------------
+    // 3. gentag with an exclusion mask permitting only tag value 5
+    //    must deterministically generate pointer_tag = 5 (in bits
+    //    63:60), with the rest of rd cleared.
+    li t0, 0xFFDF          // exclude all 4-bit tags except 5
+    csrw CSR_MMTAGEXCL0, t0
+    gentag 5               // t0 <- generated tagged (null) pointer
+    li t1, 5
+    slli t1, t1, 60
+    bne t0, t1, fail
+
+    // The exclusion mask is WARL: at least one bit of [15:0] must
+    // remain clear.
+    li t0, 0xFFFF
+    csrw CSR_MMTAGEXCL0, t0
+    csrr t1, CSR_MMTAGEXCL0
+    li t2, 0xFFFF
+    beq t1, t2, fail
+    csrw CSR_MMTAGEXCL0, zero
+
+    // ------------------------------------------------------------------
+    // 4. addtag: in-place tag arithmetic in bits 63:60.
+    li t0, 5
+    slli t0, t0, 60
+    la t2, data_buf
+    or t0, t0, t2          // t0 = data_buf tagged with 5
+    addtag 6, 5, 2         // t1 <- t0 with pointer_tag += 2
+    li t3, 7
+    slli t3, t3, 60
+    or t3, t3, t2
+    bne t1, t3, fail
+
+    // ------------------------------------------------------------------
+    // 5. settag/checktag round trip: tag chunk 0 of data_buf with 5;
+    //    a matching checktag must not trap.
+    settag 5, 0            // t0 still = data_buf tagged with 5
+    checktag 5, 0
+
+    // ------------------------------------------------------------------
+    // 6. checktag with a mismatching pointer_tag must raise a
+    //    software-check exception (cause 18) with xtval = 4.
+    la t3, expect_swcheck
+    csrr s10, mtvec
+    csrw mtvec, t3
+    li s9, 0               // trap-seen flag
+    addtag 6, 5, 1         // t1 = data_buf tagged with 6
+    mv t0, t1
+    checktag 5, 0          // mismatch: must trap
+    beqz s9, fail
+    li s9, 0
+
+    // ------------------------------------------------------------------
+    // 7. Implicit checks (paging disabled => every data page is a
+    //    tagged-data page):
+    //    a. load through a matching tagged pointer succeeds,
+    li t0, 5
+    slli t0, t0, 60
+    la t2, data_buf
+    or t0, t0, t2
+    ld t4, 0(t0)
+    //    b. load through a mismatching pointer traps with tval = 4,
+    addtag 6, 5, 3         // t1 = data_buf tagged with 8
+    ld t4, 0(t1)
+    beqz s9, fail
+    li s9, 0
+    //    c. store through a mismatching pointer traps as well,
+    sd t4, 0(t1)
+    beqz s9, fail
+    li s9, 0
+    //    d. an access via the stack pointer (x2) is never checked.
+    mv s8, sp
+    mv sp, t1              // sp = mismatching tagged pointer
+    ld t4, 0(sp)
+    mv sp, s8
+    bnez s9, fail
+
+    csrw mtvec, s10
+
+    // ------------------------------------------------------------------
+    // 8. Disable memory tagging: gentag must fall back to Zimop
+    //    behavior and zero its destination.
+    li t0, (3 << MT_MODE_SHIFT)
+    csrc CSR_MSECCFG, t0
+    li t0, 42
+    gentag 5
+    bnez t0, fail
+
+pass:
+    mv ra, s11
+    li a0, 0
+    ret
+fail:
+    mv ra, s11
+    li a0, 1
+    ret
+
+// Trap handler: expect a software-check exception with tval = 4, set
+// the flag in s9 and resume at mepc + 4.
+.p2align 6
+expect_swcheck:
+    csrr t4, mcause
+    li t5, CAUSE_SOFTWARE_CHECK
+    bne t4, t5, fail
+    csrr t4, mtval
+    li t5, SWCHECK_TVAL_MEM_TAG
+    bne t4, t5, fail
+    li s9, 1
+    csrr t4, mepc
+    addi t4, t4, 4
+    csrw mepc, t4
+    mret
+#else
+    // Zimt is RV64-only; pass trivially on RV32.
+    li a0, 0
+    ret
+#endif
+
+#if __riscv_xlen == 64
+.section .data
+.p2align 12
+tag_region:
+    .fill 8192, 1, 0
+data_buf:
+    .fill 64, 1, 0
+#endif


### PR DESCRIPTION
This draft PR adds experimental support for the RISC-V Memory Tagging extension (**Zimt**, with the **Svatag**/**Smvatag** tag-table extensions), tracking the [v0.2 draft specification](https://github.com/riscv/riscv-memory-tagging) from the memory tagging TG. It is intended to socialize the model changes with the TG and the sail-riscv maintainers while the specification is in Development — several architectural constants are not yet allocated by the spec (see the table below), so this PR is expected to stay in draft until they are.

Everything is gated behind `--enable-experimental-extensions` plus `extensions.Zimt.supported`, in line with the handling of other unratified extensions (Zibi, Zilx, Zvabd).

## What is implemented

- `Zimt`/`Svatag`/`Smvatag` extension declarations; Zimt requires Zicsr, Zimop and one of the pointer-masking extensions, RV64 only.
- `MT_MODE` (bits 35:34, WARL) in `mseccfg`, `menvcfg`, `senvcfg`, `henvcfg`, and `hstatus.VUMT_MODE` (bits 51:50), with keep-old-value legalization mirroring the PMM fields (this also implements the spec's width-discovery mechanism). Supported tag widths are configurable (`extensions.Zimt.supported_pointer_tag_width_{4,7}`).
- Tag-generation exclusion mask CSRs (`mmtagexclude0/1`, `menvmtagexclude0/1`, `senvmtagexclude0/1`, `henvmtagexclude0/1`) with the ≥1-permitted-tag WARL rule, and the VITT base CSRs (`mvitt`, `svitts`, `svittu`, `vsvitts`, `vsvittu`, 4K-aligned WARL).
- The four instructions overlaid on Zimop `MOP.RR` codepoints: `gentag`, `addtag` (including its three-level implemented/disabled/enabled semantics), `settag` (packed-nibble RMW, no atomicity guarantee), `checktag`. Decode falls through to Zimop when Zimt is not enabled; execute implements the Zimop-equivalent fallback when tagging is disabled at the current privilege.
- A `Tag` memory-access payload so tag-table loads/stores flow through the normal translation/PMP/PMA path and report faults against the tag virtual address in `xtval`.
- Software-check exception code 4 (memory tag mismatch); `software_check_cause` widened to 3 bits.
- Implicit tag checks on regular data loads/stores in no-paging (Bare) environments, where the spec makes every data page a tagged-data page, including the stack-pointer (x2) exemption.
- First-party self-checking test (`test_zimt.S`) covering WARL behaviors, deterministic `gentag` via a single-value exclusion mask, `addtag` arithmetic, a `settag`/`checktag` round trip, mismatch traps (cause 18, `xtval` 4) for both `checktag` and implicit checks, the sp exemption, and the Zimop fallback.

## Deliberately NOT implemented yet (marked TODO in the code)

- `PTE.MTAG`-based checks under paging (tagged-data / tagcheck-exempt pages, TLB attribute caching) — blocked on the spec fixing the PTE bit position.
- `mstatus.MTAG_I` / `hstatus.MTAG_I` deposit and the MPRV/HLV*/HSV* (`hstatus.VUMT_MODE`) rules.
- Vector/LR/SC/AMO implicit checks.
- VITT-range self-protection access faults.
- RVWMO aspects of `settag` ordering (the model implements simple sequential semantics).

## ⚠️ Placeholder architectural constants — TG allocation needed

The v0.2 draft leaves several constants unallocated. This PR uses clearly marked placeholders that MUST be revised before it can leave draft:

| Constant | Placeholder used | Spec status |
|---|---|---|
| `mmtagexclude0/1` CSR addresses | 0x7C0/0x7C1 (custom M R/W range) | unallocated ("to be allocated") |
| `menvmtagexclude0/1` | 0x7C2/0x7C3 | unallocated |
| `senvmtagexclude0/1` | 0x5C0/0x5C1 (custom S R/W range) | unallocated |
| `henvmtagexclude0/1` | 0x6C0/0x6C1 (custom H R/W range) | unallocated |
| `mvitt` | 0x7C4 | unallocated |
| `svitts` / `svittu` | 0x5C2 / 0x5C3 | unallocated |
| `vsvitts` / `vsvittu` | 0x6C2 / 0x6C3 | unallocated |
| `mstateen0.MT` bit | not implemented | spec carries an explicit warning that the position is TBD |
| `PTE.MTAG` bit | not implemented | position not fixed in v0.2 |

One semantic question for the TG is also flagged inline in `zimt_insts.sail`: `gentag` requires pseudorandom, uniformly distributed tags; a deterministic golden model needs an implementation-defined strategy. This PR scans from a free-running counter for the first tag permitted by the exclusion mask — every permitted value occurs, but neither uniformly nor unpredictably. Tests only rely on `gentag`'s value when the mask permits exactly one tag.

## Testing

- Full first-party `ctest` suite (RV32 + RV64), including the new `test_zimt.S` (trivially passing on RV32, where Zimt cannot be enabled).
- The commit series builds at every step; the Tag payload additions extend every affected `mem_payload` match (PMP/PMA/PTW/exception mapping) so no incomplete-pattern warnings remain.

## Disclosure

Per CONTRIBUTING.md: this PR was developed with generative AI assistance (Claude Code), with human review. Each commit message carries the same disclosure.
