### PR TITLE
Legalize the Exception Code field of the `{ms}cause` CSRs.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -156,6 +156,7 @@
       "fetch_page_fault": true,
       "fetch_guest_page_fault": true,
       "software_check": true,
+      "hardware_error": true,
       "reserved_exceptions": false
     },
     "reserved_behavior": {

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -39,12 +39,11 @@
     requires this option to be enabled.
   - Whether each bit of `hcounteren` is writable or read-only zero can
     be specified, see `base.hcounteren_writable_bits`.
-  - Whether the guest-page-fault exceptions write a non-zero `xtval`
-    can be specified, see `base.xtval_nonzero.load_guest_page_fault`,
-    `base.xtval_nonzero.samo_guest_page_fault` and
-    `base.xtval_nonzero.fetch_guest_page_fault`.
-  - Whether virtual-instruction exceptions write a non-zero `xtval`
-    can be specified, see `base.xtval_nonzero.virtual_instruction`.
+  - Additional exceptions are now supported by `base.xtval_nonzero`,
+    which specifies which exceptions write non-zero values to the
+    `xtval` CSRs; these are the guest-page-fault exceptions, and the
+    virtual-instruction and hardware-error exceptions. See
+    `base.xtval_nonzero`.
   - The default value of `base.medeleg.delegatable_bits` now also
     includes the exception codes introduced by H, i.e. VS-mode
     environment calls, virtual instructions, and the guest-page faults.

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -135,7 +135,8 @@ let misaligned_fetch_writes_xtval : bool = config base.xtval_nonzero.fetch_addre
 let fetch_access_fault_writes_xtval : bool = config base.xtval_nonzero.fetch_access_fault
 let fetch_page_fault_writes_xtval : bool = config base.xtval_nonzero.fetch_page_fault
 let fetch_guest_page_fault_writes_xtval : bool = config base.xtval_nonzero.fetch_guest_page_fault
-let software_check_fault_writes_xtval : bool = config base.xtval_nonzero.software_check
+let software_check_exception_writes_xtval : bool = config base.xtval_nonzero.software_check
+let hardware_error_exception_writes_xtval : bool = config base.xtval_nonzero.hardware_error
 let reserved_exceptions_write_xtval : bool = config base.xtval_nonzero.reserved_exceptions
 
 // Define the policy for handling reserved behaviors.

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -655,11 +655,51 @@ bitfield Mcause : xlenbits = {
   IsInterrupt : xlen - 1,
   Cause       : xlen - 2 .. 0
 }
+
+// The Exception Code is a WLRL field of the `{ms}cause` CSRs.  The
+// read-legal is implemented by preserving the previous value.
+function legalize_cause(o : Mcause, v : xlenbits) -> Mcause = {
+  let v = Mk_Mcause(v);
+  let code = v[Cause];
+  if v[IsInterrupt] == 0b1 then {
+    // No platform interrupts are currently supported.
+    let is_platform_interrupt = (code & sign_extend(0xF0)) != zeros();
+    if is_platform_interrupt then return o;
+    // The code should now be in the domain of the `interruptType_bits` mapping.
+    let intr = interruptType_bits(code[5 .. 0]);
+    if is_reserved_interrupt(intr) then return o;
+    // The LCOFI interrupt 13 depends on Sscofpmf.
+    if intr == I_COF & not(hartSupports(Ext_Sscofpmf))
+    then return o;
+    if is_hypervisor_interrupt(intr) & not(hartSupports(Ext_H))
+    then return o;
+  } else {
+    // Reserved and custom exceptions with set bits above index 5 are not supported.
+    if (code & sign_extend(0xC0)) != zeros() then return o;
+    let code = code[5 .. 0];
+    if not(exceptionType_bits_backwards_matches(code))
+    then return o;
+    let exc = exceptionType_bits(code);
+    // This doesn't allow custom exceptions to be written.  Currently,
+    // a custom exception is only used for an old version of CHERI, but
+    // the current version should now have exception codes in the standard space.
+    if is_reserved_or_custom_exception(exc) then return o;
+    if exc == E_Software_Check() & not(hartSupports(Ext_Zicfilp) | hartSupports(Ext_Zicfiss))
+    then return o;
+    // The hardware-error exception code was introduced in version 1.13.
+    if exc == E_Hardware_Error() & (priv_isa_version < Privileged_ISA_1_13)
+    then return o;
+    if is_hypervisor_exception(exc) & not(hartSupports(Ext_H))
+    then return o;
+  };
+  v
+}
+
 register mcause : Mcause
 mapping clause csr_name_map = 0x342  <-> "mcause"
 function clause is_CSR_accessible(0x342, _, _) = true // mcause
 function clause read_CSR(0x342) = mcause.bits
-function clause write_CSR(0x342, value) = { mcause.bits = value; Ok(mcause.bits) }
+function clause write_CSR(0x342, value) = { mcause = legalize_cause(mcause, value); Ok(mcause.bits) }
 
 // Interpreting the trap-vector address
 function tvec_addr(m : Mtvec, c : Mcause) -> option(xlenbits) = {
@@ -977,7 +1017,7 @@ function clause read_CSR(0x242) = vscause.bits
 function clause read_CSR(0x243) = vstval
 
 function clause write_CSR(0x240, value) = { vsscratch = value; Ok(vsscratch) }
-function clause write_CSR(0x242, value) = { vscause.bits = value; Ok(vscause.bits) }
+function clause write_CSR(0x242, value) = { vscause = legalize_cause(vscause, value); Ok(vscause.bits) }
 function clause write_CSR(0x243, value) = { vstval = value; Ok(vstval) }
 
 // other non-VM related supervisor state
@@ -1000,7 +1040,7 @@ function clause read_CSR(0x142) = if inVirtualPrivilege() then vscause.bits else
 function clause read_CSR(0x143) = if inVirtualPrivilege() then vstval else stval
 
 function clause write_CSR(0x140, value) = if inVirtualPrivilege() then { vsscratch = value; Ok(vsscratch) } else { sscratch = value; Ok(sscratch) }
-function clause write_CSR(0x142, value) = if inVirtualPrivilege() then { vscause.bits = value; Ok(vscause.bits) } else { scause.bits = value; Ok(scause.bits) }
+function clause write_CSR(0x142, value) = if inVirtualPrivilege() then { vscause = legalize_cause(vscause, value); Ok(vscause.bits) } else { scause = legalize_cause(scause, value); Ok(scause.bits) }
 function clause write_CSR(0x143, value) = if inVirtualPrivilege() then { vstval = value; Ok(vstval) } else { stval = value; Ok(stval) }
 
 //

--- a/model/core/types.sail
+++ b/model/core/types.sail
@@ -180,6 +180,8 @@ enum InterruptType = {
   I_M_External,
   I_SG_External,
   I_COF,
+  I_Reserved_14,
+  I_Reserved_15,
 }
 
 mapping interruptType_bits : InterruptType <-> exc_code = {
@@ -197,10 +199,12 @@ mapping interruptType_bits : InterruptType <-> exc_code = {
   I_M_External   <-> 0b001011, // 11
   I_SG_External  <-> 0b001100, // 12
   I_COF          <-> 0b001101, // 13
+  I_Reserved_14  <-> 0b001110, // 14
+  I_Reserved_15  <-> 0b001111, // 15
 }
 
 function interruptType_to_str(i : InterruptType) -> string =
-  match (i) {
+  match i {
     I_Reserved_0  => "reserved-interrupt-0",
     I_S_Software  => "supervisor-software-interrupt",
     I_VS_Software => "virtual-supervisor-software-interrupt",
@@ -215,9 +219,30 @@ function interruptType_to_str(i : InterruptType) -> string =
     I_M_External  => "machine-external-interrupt",
     I_SG_External => "supervisor guest-external-interrupt",
     I_COF         => "counter-overflow interrupt",
+    I_Reserved_14 => "reserved-interrupt-14",
+    I_Reserved_15 => "reserved-interrupt-15",
   }
 
 overload to_str = {interruptType_to_str}
+
+function is_reserved_interrupt(i : InterruptType) -> bool =
+  match i {
+    I_Reserved_0  => true,
+    I_Reserved_4  => true,
+    I_Reserved_8  => true,
+    I_Reserved_14 => true,
+    I_Reserved_15 => true,
+    _             => false,
+  }
+
+function is_hypervisor_interrupt(i : InterruptType) -> bool =
+  match i {
+    I_VS_Software => true,
+    I_VS_Timer    => true,
+    I_VS_External => true,
+    I_SG_External => true,
+    _             => false,
+  }
 
 // architectural exception definitions
 
@@ -243,7 +268,7 @@ union ExceptionType = {
   E_Reserved_16        : unit,
   E_Reserved_17        : unit,
   E_Software_Check     : unit,
-  E_Reserved_19        : unit,
+  E_Hardware_Error     : unit,
   E_Fetch_GPage_Fault  : unit,
   E_Load_GPage_Fault   : unit,
   E_Virtual_Instr      : unit,
@@ -272,7 +297,7 @@ mapping exceptionType_bits : ExceptionType <-> exc_code = {
   E_Reserved_16()        <-> 0b010000, // 16
   E_Reserved_17()        <-> 0b010001, // 17
   E_Software_Check()     <-> 0b010010, // 18
-  E_Reserved_19()        <-> 0b010011, // 19
+  E_Hardware_Error()     <-> 0b010011, // 19
   E_Fetch_GPage_Fault()  <-> 0b010100, // 20
   E_Load_GPage_Fault()   <-> 0b010101, // 21
   E_Virtual_Instr()      <-> 0b010110, // 22
@@ -287,7 +312,7 @@ mapping exceptionType_bits : ExceptionType <-> exc_code = {
 }
 
 function exceptionType_to_str(e : ExceptionType) -> string =
-  match (e) {
+  match e {
     E_Fetch_Addr_Align()   => "misaligned-fetch",
     E_Fetch_Access_Fault() => "fetch-access-fault",
     E_Illegal_Instr()      => "illegal-instruction",
@@ -305,8 +330,8 @@ function exceptionType_to_str(e : ExceptionType) -> string =
     E_SAMO_Page_Fault()    => "store/amo-page-fault",
     E_Reserved_16()        => "reserved-2",
     E_Reserved_17()        => "reserved-3",
-    E_Software_Check()     => "software-check-fault",
-    E_Reserved_19()        => "reserved-19",
+    E_Software_Check()     => "software-check-exception",
+    E_Hardware_Error()     => "hardware-error-exception",
     E_Fetch_GPage_Fault()  => "fetch-guest-page-fault",
     E_Load_GPage_Fault()   => "load-guest-page-fault",
     E_Virtual_Instr()      => "virtual-instruction",
@@ -321,6 +346,25 @@ function exceptionType_to_str(e : ExceptionType) -> string =
   }
 
 overload to_str = {exceptionType_to_str}
+
+function is_reserved_or_custom_exception(e : ExceptionType) -> bool =
+  match e {
+    E_Reserved_14() => true,
+    E_Reserved_16() => true,
+    E_Reserved_17() => true,
+    E_Extension(_)  => true,  // this is a custom extension
+    _               => false,
+  }
+
+function is_hypervisor_exception(e : ExceptionType) -> bool =
+  match e {
+    E_VS_EnvCall()        => true,
+    E_Fetch_GPage_Fault() => true,
+    E_Load_GPage_Fault()  => true,
+    E_Virtual_Instr()     => true,
+    E_SAMO_GPage_Fault()  => true,
+    _                     => false,
+  }
 
 // SW check exception codes
 enum SWCheckCodes = {LANDING_PAD_FAULT}

--- a/model/sys/sys_control.sail
+++ b/model/sys/sys_control.sail
@@ -245,7 +245,8 @@ function xtval_exception_value(e : ExceptionType, excinfo : xlenbits) -> option(
     E_Fetch_Access_Fault() => fetch_access_fault_writes_xtval,
     E_Fetch_Page_Fault() => fetch_page_fault_writes_xtval,
     E_Fetch_GPage_Fault() => fetch_guest_page_fault_writes_xtval,
-    E_Software_Check() => software_check_fault_writes_xtval,
+    E_Software_Check() => software_check_exception_writes_xtval,
+    E_Hardware_Error() => hardware_error_exception_writes_xtval,
     E_U_EnvCall()  => false,
     E_S_EnvCall()  => false,
     E_VS_EnvCall() => false,
@@ -255,7 +256,6 @@ function xtval_exception_value(e : ExceptionType, excinfo : xlenbits) -> option(
     E_Reserved_14() => reserved_exceptions_write_xtval,
     E_Reserved_16() => reserved_exceptions_write_xtval,
     E_Reserved_17() => reserved_exceptions_write_xtval,
-    E_Reserved_19() => reserved_exceptions_write_xtval,
   } then Some(excinfo) else None()
 }
 


### PR DESCRIPTION
This validates the code against the supported extensions. Reserved and custom codes, and those reserved for platform use,  are not written by CSR writes; instead, the previous value is preserved.

The hardware error exception (code 19) is added along with associated configuration, since it is not a reserved exception.

Fixes #1862.