### PR TITLE
Refactor the `vmem_utils` public API to require the effective privilege and pointer masking width. 

### DIFF
--- a/model/extensions/A/zaamo_insts.sail
+++ b/model/extensions/A/zaamo_insts.sail
@@ -73,10 +73,12 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
   assert(width <= xlen_bytes * 2);
 
   let access = Atomic(op, aq, rl, Data, Data);
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+  let pmlen = get_pmlen(access, eff_priv);
 
   // Get the address, X(rs1) (no offset).
   // Some extensions perform additional checks on address validity.
-  let vaddr : virtaddr = match get_transformed_data_addr(rs1, zeros(), access, width) {
+  let vaddr : virtaddr = match get_transformed_data_addr(rs1, zeros(), access, eff_priv, pmlen, width) {
     Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
     Ext_DataAddr_OK(vaddr) => vaddr,
   };
@@ -92,8 +94,6 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
       None()                   => (),
     };
   };
-
-  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
 
   let (addr, pbmt) : (physaddr, page_based_mem_type) = match translateAddr(vaddr, access, eff_priv) {
     Err(e, _) => return trap(e),

--- a/model/extensions/H/hext_insts.sail
+++ b/model/extensions/H/hext_insts.sail
@@ -54,10 +54,11 @@ function clause execute HLVTYPE(width, op, is_unsigned, rs1, rd) = {
   };
   assert(width <= xlen_bytes);
   let eff_priv : Privilege = privLevel_bits(zero_extend(hstatus[SPVP]), 0b1);
+  let pmlen = get_hlsv_pmlen(access, eff_priv);
   match ext_data_get_addr(rs1, zeros(), access, width) {
     Ext_DataAddr_Error(e)  => { Ext_DataAddr_Check_Failure(e) },
     Ext_DataAddr_OK(vaddr) => {
-      let vaddr = transform_hlsv_address(vaddr, access, eff_priv);
+      let vaddr = transform_effective_address(vaddr, eff_priv, pmlen);
       // TODO: HLV and HSV emulate ordinary VS-mode accesses, so a misaligned
       // one that crosses a page boundary should be split and translated per
       // page, the way vmem_read_addr and vmem_write_addr do. That needs
@@ -108,10 +109,12 @@ function clause execute(HSV(width, rs1, rs2)) = {
   assert(width <= xlen_bytes);
   let eff_priv : Privilege = privLevel_bits(zero_extend(hstatus[SPVP]), 0b1);
   let access = Store(Data);
+  let pmlen = get_hlsv_pmlen(access, eff_priv);
+
   match ext_data_get_addr(rs1, zeros(), access, width) {
     Ext_DataAddr_Error(e)  => Ext_DataAddr_Check_Failure(e),
     Ext_DataAddr_OK(vaddr) => {
-      let vaddr = transform_hlsv_address(vaddr, access, eff_priv);
+      let vaddr = transform_effective_address(vaddr, eff_priv, pmlen);
       // TODO: HLV and HSV emulate ordinary VS-mode accesses, so a misaligned
       // one that crosses a page boundary should be split and translated per
       // page, the way vmem_read_addr and vmem_write_addr do. That needs

--- a/model/extensions/H/hext_insts.sail
+++ b/model/extensions/H/hext_insts.sail
@@ -30,11 +30,11 @@ mapping clause encdec = HLVTYPE(width, HLVX, true, rs1, rd)
   <-> 0b0110 @ width_enc(width) @ 0b000011 @ encdec_reg(rs1) @ 0b100 @ encdec_reg(rd) @ 0b1110011
   when currentlyEnabled(Ext_H) & (width == 2 | width == 4)
 
-// HLV.*/HSV perform an explicit access with effective privilege VS (hstatus.SPVP=1)
-// or VU (SPVP=0), so their effective address is subject to pointer masking via
-// transform_hlsv_address. HLVX.* are exempt (HLVX emulates an implicit fetch,
-// and the PMM fields only cover HLV.*/HSV.*): is_pmm_applicable excludes their
-// LoadExecute access type.
+// HLV.*/HSV perform an explicit access with effective privilege VS
+// (`hstatus.SPVP=1`) or VU (`SPVP=0`).  HLVX.* are exempt (HLVX
+// emulates an implicit fetch, and the PMM fields only cover
+// HLV.*/HSV.*): `is_pmm_applicable` excludes their `LoadExecute`
+// access type.
 function clause execute HLVTYPE(width, op, is_unsigned, rs1, rd) = {
   if inVirtualPrivilege()
   then return Virtual_Instruction()

--- a/model/extensions/Zicbom/zicbom_insts.sail
+++ b/model/extensions/Zicbom/zicbom_insts.sail
@@ -73,6 +73,8 @@ private function process_clean_inval(rs1 : regidx, cbop : cbop_zicbom) -> Execut
   let rs1_val = X(rs1);
   let cache_block_size = 2 ^ plat_cache_block_size_exp;
   let access : MemoryAccessType(mem_payload) = CacheAccess(CB_manage(cbop));
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+  let pmlen = get_pmlen(access, eff_priv);
 
   // Offset from rs1 to the beginning of the cache block. This is 0 if rs1
   // is aligned to the cache block, or negative if rs1 is misaligned.
@@ -81,10 +83,9 @@ private function process_clean_inval(rs1 : regidx, cbop : cbop_zicbom) -> Execut
   // TODO: This is incorrect since CHERI only requires at least one byte
   // to be in bounds here, whereas `get_transformed_data_addr()` checks that all bytes
   // are in bounds. We will need to add a new function, parameter or access type.
-  match get_transformed_data_addr(rs1, negative_offset, access, cache_block_size) {
+  match get_transformed_data_addr(rs1, negative_offset, access, eff_priv, pmlen, cache_block_size) {
     Ext_DataAddr_Error(e) => Ext_DataAddr_Check_Failure(e),
     Ext_DataAddr_OK(vaddr) => {
-      let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
       // vaddr is the aligned address, but errors report the address that
       // was encoded in the instruction. We subtract the negative offset
       // (add the positive offset) to get it. Normally this will be

--- a/model/extensions/Zicbop/zicbop_insts.sail
+++ b/model/extensions/Zicbop/zicbop_insts.sail
@@ -41,11 +41,12 @@ function clause execute ZICBOP(cbop, rs1, offset) = {
   let offset = cache_block_addr - rs1_val;
   let access : MemoryAccessType(mem_payload) = CacheAccess(CB_prefetch(cbop));
   let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+  let pmlen = get_pmlen(access, eff_priv);
 
   // TODO: This is incorrect since CHERI only requires at least one byte
   // to be in bounds here, whereas `get_transformed_data_addr()` checks that all bytes
   // are in bounds. We will need to add a new function, parameter or access type.
-  match get_transformed_data_addr(rs1, offset, access, cache_block_size) {
+  match get_transformed_data_addr(rs1, offset, access, eff_priv, pmlen, cache_block_size) {
     Ext_DataAddr_Error(_) => (), // No access to cache; no-op.
 
     Ext_DataAddr_OK(vaddr) => match translateAddr(vaddr, access, eff_priv) {

--- a/model/extensions/Zicboz/zicboz_insts.sail
+++ b/model/extensions/Zicboz/zicboz_insts.sail
@@ -31,19 +31,20 @@ function clause execute ZICBOZ(rs1) = {
   let rs1_val = X(rs1);
   let cache_block_size = 2 ^ plat_cache_block_size_exp;
   let access : MemoryAccessType(mem_payload) = CacheAccess(CB_zero());
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+  let pmlen = get_pmlen(access, eff_priv);
 
   // Offset from rs1 to the beginning of the cache block. This is 0 if rs1
   // is aligned to the cache block, or negative if rs1 is misaligned.
   let negative_offset = (rs1_val & ~(zero_extend(ones(plat_cache_block_size_exp)))) - rs1_val;
 
-  match get_transformed_data_addr(rs1, negative_offset, access, cache_block_size) {
+  match get_transformed_data_addr(rs1, negative_offset, access, eff_priv, pmlen, cache_block_size) {
     Ext_DataAddr_Error(e) => Ext_DataAddr_Check_Failure(e),
     Ext_DataAddr_OK(vaddr) => {
       // "An implementation may update the bytes in any order and with any granularity
       //  and atomicity, including individual bytes."
       //
       // This implementation does a single atomic write.
-      let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
       match translateAddr(vaddr, access, eff_priv) {
         // vaddr is the aligned address, but errors report the address that
         // was encoded in the instruction. We subtract the negative offset

--- a/model/extensions/cfi/zicfiss_insts.sail
+++ b/model/extensions/cfi/zicfiss_insts.sail
@@ -27,7 +27,10 @@ function clause execute SSPUSH(rs2) = {
 
   let vaddr_bits = ssp - xlen_bytes;
   let access = Store(ShadowStack);
-  let vaddr = transform_effective_address(Virtaddr(vaddr_bits), access);
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+  let pmlen = get_pmlen(access, eff_priv);
+
+  let vaddr = transform_effective_address(Virtaddr(vaddr_bits), eff_priv, pmlen);
   // "If the virtual address in ssp is not XLEN aligned, then the
   // SSPUSH/C.SSPUSH/SSPOPCHK/C.SSPOPCHK instructions cause a
   // store/AMO access-fault exception."
@@ -41,7 +44,7 @@ function clause execute SSPUSH(rs2) = {
   if not(is_aligned_addr(vaddr, width))
   then return memory_exception(E_SAMO_Access_Fault(), bits_of(vaddr), access);
 
-  match vmem_write_addr(vaddr, width, X(rs2), access, false, false, false) {
+  match vmem_write_addr(vaddr, width, X(rs2), access, eff_priv, false, false, false) {
     Ok(_)  => { ssp = vaddr_bits;
                 csr_write_callback("ssp", ssp);
                 RETIRE_SUCCESS },
@@ -82,14 +85,17 @@ function clause execute SSPOPCHK(rs1) = {
   if not(zicfiss_xSSE(cur_privilege)) then return RETIRE_SUCCESS;
 
   let access = Load(ShadowStack);
-  let ssp_addr = transform_effective_address(Virtaddr(ssp), access);
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+  let pmlen = get_pmlen(access, eff_priv);
+  let ssp_addr = transform_effective_address(Virtaddr(ssp), eff_priv, pmlen);
+
   // See above on checking alignment.
   // TODO: get the dynamic xlen here.
   let width = xlen_bytes;
   if not(is_aligned_addr(ssp_addr, width))
   then return memory_exception(E_SAMO_Access_Fault(), bits_of(ssp_addr), access);
 
-  match vmem_read_addr(ssp_addr, width, access, false, false, false) {
+  match vmem_read_addr(ssp_addr, width, access, eff_priv, false, false, false) {
     Ok(data) => {
       if X(rs1) != data then {
         trap(make_shadow_stack_exception())
@@ -171,8 +177,10 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
   };
 
   let access = Atomic(AMOSWAP, aq, rl, ShadowStack, ShadowStack);
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+  let pmlen = get_pmlen(access, eff_priv);
 
-  let vaddr : virtaddr = match get_transformed_data_addr(rs1, zeros(), access, width) {
+  let vaddr : virtaddr = match get_transformed_data_addr(rs1, zeros(), access, eff_priv, pmlen, width) {
     Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
     Ext_DataAddr_OK(vaddr) => vaddr,
   };
@@ -190,8 +198,6 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
       None()                   => (),
     };
   };
-
-  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
 
   let (paddr, pbmt) : (physaddr, page_based_mem_type) = match translateAddr(vaddr, access, eff_priv) {
     Ok(addr, pbmt, _) => (addr, pbmt),

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -62,7 +62,7 @@ pmp {
 }
 
 sys {
-  requires prelude, core, exceptions, pmp, V_core, Smcntrpmf, Zicfilp_regs, A_types, Stateen, Zicbop_types, PM_utils
+  requires prelude, core, exceptions, pmp, V_core, Smcntrpmf, Zicfilp_regs, A_types, Stateen, Zicbop_types, PM_types, PM_utils
 
   files
     sys/sys_reservation.sail,
@@ -111,7 +111,7 @@ extensions {
       files extensions/A/aext_types.sail
     }
     Zaamo {
-      requires core, sys, exceptions, A_types
+      requires core, sys, exceptions, A_types, PM_utils
       files extensions/A/zaamo_insts.sail
     }
     Zalrsc {
@@ -182,7 +182,7 @@ extensions {
       files extensions/H/hext_types.sail
     }
     H_insts {
-      requires sys, exceptions, I_insts, H_types
+      requires sys, exceptions, I_insts, H_types, PM_utils
       files extensions/H/hext_insts.sail
     }
   }
@@ -388,7 +388,7 @@ extensions {
       files extensions/cfi/zicfiss_regs.sail
     }
     Zicfiss_insts {
-      requires sys, exceptions, CFI_types, Zicfiss_regs, A_types
+      requires sys, exceptions, CFI_types, Zicfiss_regs, A_types, PM_utils
       files extensions/cfi/zicfiss_insts.sail
     }
   }
@@ -416,7 +416,7 @@ extensions {
       files extensions/Zicbom/zicbom_types.sail
     }
     Zicbom_insts {
-      requires core, sys, exceptions, Zicbom_types
+      requires core, sys, exceptions, Zicbom_types, PM_utils
       files extensions/Zicbom/zicbom_insts.sail
     }
   }
@@ -429,7 +429,7 @@ extensions {
     Zicbop_insts {
       // PREFETCH.{I,R,W} instructions override ORI hints (rd=0)
       before I_insts
-      requires core, sys, exceptions, Zicbop_types
+      requires core, sys, exceptions, Zicbop_types, PM_utils
       files extensions/Zicbop/zicbop_insts.sail
     }
   }
@@ -447,7 +447,7 @@ extensions {
   }
 
   Zicboz {
-    requires core, sys, exceptions
+    requires core, sys, exceptions, PM_utils
     files extensions/Zicboz/zicboz_insts.sail
   }
 

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -65,24 +65,12 @@ function offset_virtaddr_by(
 // Whether the address is virtual (sign-extend) or physical (zero-extend) follows
 // the first-stage satp register feeding the address: vsatp for VS/VU, otherwise
 // satp. A guest-physical address (vsatp.MODE == Bare) is treated as physical.
-function pm_transform_for_priv(vaddr : virtaddr, eff_privilege : Privilege, pmlen : {0, 7, 16}) -> virtaddr = {
+function transform_effective_address(vaddr : virtaddr, eff_privilege : Privilege, pmlen : pm_len) -> virtaddr = {
   let mode = if eff_privilege == VirtualSupervisor | eff_privilege == VirtualUser
              then vsatp_mode()
              else satp_mode(eff_privilege);
   if mode == Bare then pm_transform_PA(vaddr, pmlen) else pm_transform_VA(vaddr, pmlen)
 }
-
-// Transforms the effective address of a regular explicit access based on PMM
-// settings and the current translation mode.
-function transform_effective_address(vaddr : virtaddr, access : MemoryAccessType(mem_payload)) -> virtaddr = {
-  let eff_privilege = effectivePrivilege(access, mstatus, cur_privilege);
-  pm_transform_for_priv(vaddr, eff_privilege, get_pmlen(access, eff_privilege))
-}
-
-// Transforms the effective address of an HLV/HSV explicit access, whose effective
-// privilege (VS/VU) is taken from hstatus.SPVP rather than effectivePrivilege.
-function transform_hlsv_address(vaddr : virtaddr, access : MemoryAccessType(mem_payload), eff_privilege : Privilege) -> virtaddr =
-  pm_transform_for_priv(vaddr, eff_privilege, get_hlsv_pmlen(access, eff_privilege))
 
 // Whether a data access is effectively to a guest VA (VS/VU mode, or M-mode MPRV+MPV).
 function access_is_gva(access : MemoryAccessType(mem_payload)) -> bool =
@@ -112,10 +100,10 @@ private function translate_and_read_value forall 'width, 0 < 'width <= max_mem_a
   }
 
 val vmem_read_addr : forall 'width, is_mem_width('width).
-  (virtaddr, int('width), MemoryAccessType(mem_payload), bool, bool, bool)
+  (virtaddr, int('width), MemoryAccessType(mem_payload), Privilege, bool, bool, bool)
   -> result(bits(8 * 'width), ExecutionResult)
 
-function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
+function vmem_read_addr(vaddr, width, access, eff_priv, aq, rl, res) = {
   // Other AMOs currently don't go through `vmem_utils` functions.
   assert(res == is_load_reserved(access));
 
@@ -142,7 +130,6 @@ function vmem_read_addr(vaddr, width, access, aq, rl, res) = {
   // We should only split the access before address translation if (a)
   // virtual memory is in effect, and (b) it crosses a page boundary.
   // If we do split, perform the split access in the configured order.
-  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
   let vmem_active : bool = if privLevel_is_virtual(eff_priv)
                            then vsatp_mode() != Bare | hgatp_mode() != HBare
                            else satp_mode(eff_priv) != Bare;
@@ -210,10 +197,10 @@ private function translate_and_write_value forall 'width, 0 < 'width <= max_mem_
   }
 
 val vmem_write_addr : forall 'width, is_mem_width('width).
-  (virtaddr, int('width), bits(8 * 'width), MemoryAccessType(mem_payload), bool, bool, bool)
+  (virtaddr, int('width), bits(8 * 'width), MemoryAccessType(mem_payload), Privilege, bool, bool, bool)
   -> result(bool, ExecutionResult)
 
-function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
+function vmem_write_addr(vaddr, width, data, access, eff_priv, aq, rl, res) = {
   // Other AMOs currently don't go through `vmem_utils` functions.
   assert(res == is_store_conditional(access));
 
@@ -239,8 +226,6 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
   var write_success : bool = true;
 
   let (in_page_bytes, next_page_bytes) = split_on_page_boundary(vaddr_bits, width);
-
-  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
 
   let vmem_active : bool = if privLevel_is_virtual(eff_priv)
                            then vsatp_mode() != Bare | hgatp_mode() != HBare
@@ -305,12 +290,12 @@ function vmem_write_addr(vaddr, width, data, access, aq, rl, res) = {
 }
 
 // Compute effective address with extension checks and apply pointer masking.
-function get_transformed_data_addr(base : regidx, offset : xlenbits, acc : MemoryAccessType(mem_payload), width : mem_access_width)
+function get_transformed_data_addr(base : regidx, offset : xlenbits, access : MemoryAccessType(mem_payload), eff_priv : Privilege, pmlen: pm_len, width : mem_access_width)
          -> Ext_DataAddr_Check(ext_data_addr_error) = {
-  match ext_data_get_addr(base, offset, acc, width) {
+  match ext_data_get_addr(base, offset, access, width) {
     Ext_DataAddr_Error(e) => Ext_DataAddr_Error(e),
     Ext_DataAddr_OK(vaddr) => {
-      let vaddr = transform_effective_address(vaddr, acc);
+      let vaddr = transform_effective_address(vaddr, eff_priv, pmlen);
       Ext_DataAddr_OK(vaddr)
     }
   }
@@ -321,14 +306,17 @@ val vmem_read : forall 'width, is_mem_width('width).
   -> result(bits(8 * 'width), ExecutionResult)
 
 function vmem_read(rs, offset, width, access, aq, rl, res) = {
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+  let pmlen = get_pmlen(access, eff_priv);
+
   // Get the address, X(rs1) + offset.
   // Extensions might perform additional checks on address validity.
-  let vaddr : virtaddr = match get_transformed_data_addr(rs, offset, access, width) {
+  let vaddr : virtaddr = match get_transformed_data_addr(rs, offset, access, eff_priv, pmlen, width) {
     Ext_DataAddr_OK(vaddr) => vaddr,
     Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
   };
 
-  vmem_read_addr(vaddr, width, access, aq, rl, res)
+  vmem_read_addr(vaddr, width, access, eff_priv, aq, rl, res)
 }
 
 val vmem_write : forall 'width, is_mem_width('width).
@@ -336,12 +324,15 @@ val vmem_write : forall 'width, is_mem_width('width).
   -> result(bool, ExecutionResult)
 
 function vmem_write(rs_addr, offset, width, data, access, aq, rl, res) = {
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+  let pmlen = get_pmlen(access, eff_priv);
+
   // Get the address, X(rs_addr) + offset.
   // Extensions might perform additional checks on address validity.
-  let vaddr : virtaddr = match get_transformed_data_addr(rs_addr, offset, access, width) {
+  let vaddr : virtaddr = match get_transformed_data_addr(rs_addr, offset, access, eff_priv, pmlen, width) {
     Ext_DataAddr_OK(vaddr) => vaddr,
     Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
   };
 
-  vmem_write_addr(vaddr, width, data, access, aq, rl, res)
+  vmem_write_addr(vaddr, width, data, access, eff_priv, aq, rl, res)
 }


### PR DESCRIPTION
This further reduces the API mismatch between `vmem_utils` and `hext_insts`, en route  to fixing #1913.