### PR TITLE
Allow configuration of supported platform interrupts.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -463,6 +463,19 @@
       // the reservation set.
       "invalidate_on_same_hart_store": false
     },
+    "interrupts": {
+      "machine": {
+        "software" : {
+          "supported" : true
+        },
+        "external" : {
+          "supported" : true
+        },
+        "timer" : {
+          "supported" : true
+        }
+      }
+    },
     "clint": {
       // Whether the platform contains a CLINT.
       "supported": true,
@@ -582,7 +595,19 @@
       "supported": true
     },
     "S": {
-      "supported": true
+      "supported": true,
+      "interrupts": {
+        "software" : {
+          "supported" : true
+        },
+        "external" : {
+          "supported" : true
+        },
+        // This should be set to true if the Sstc extension is supported.
+        "timer" : {
+          "supported" : true
+        }
+      }
     },
     "U": {
       "supported": true

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -44,6 +44,10 @@
     `xtval` CSRs; these are the guest-page-fault exceptions, and the
     virtual-instruction and hardware-error exceptions. See
     `base.xtval_nonzero`.
+  - Whether machine-mode and supervisor-mode interrupts are supported
+    by a platform can be individually configured, see
+    `platform.interrupts` for machine-mode and
+    `extensions.S.interrupts` for supervisor-mode interrupts respectively.
   - The default value of `base.medeleg.delegatable_bits` now also
     includes the exception codes introduced by H, i.e. VS-mode
     environment calls, virtual instructions, and the guest-page faults.

--- a/model/core/interrupt_regs.sail
+++ b/model/core/interrupt_regs.sail
@@ -55,10 +55,22 @@ function clause write_CSR(0x607, value) = { hgeie = legalize_hgeie(value); Ok(hg
 
 register hvip : Minterrupts
 
+private function supported_interrupts_mask(i : Minterrupts) -> Minterrupts =
+  Mk_Minterrupts(
+    [Mk_Minterrupts(ones()) with
+      MEI = bool_to_bit(plat_has_mei),
+      MSI = bool_to_bit(plat_has_msi),
+      MTI = bool_to_bit(plat_has_mti),
+      SEI = bool_to_bit(plat_has_sei),
+      SSI = bool_to_bit(plat_has_ssi),
+      STI = bool_to_bit(plat_has_sti),
+    ].bits & i.bits
+  )
+
 private function legalize_mip(o : Minterrupts, v : xlenbits) -> Minterrupts = {
   // The only writable bits are the S-mode bits.
   let v = Mk_Minterrupts(v);
-  [o with
+  supported_interrupts_mask([o with
     LCOFI = if currentlyEnabled(Ext_Sscofpmf) then v[LCOFI] else 0b0,
     SEI = if currentlyEnabled(Ext_S) then v[SEI] else 0b0,
     SSI = if currentlyEnabled(Ext_S) then v[SSI] else 0b0,
@@ -85,12 +97,12 @@ private function legalize_mip(o : Minterrupts, v : xlenbits) -> Minterrupts = {
       else hvip[VSTI] // software-only, use hvip
     ) else 0b0,
     VSSI = if currentlyEnabled(Ext_H) then v[VSSI] else 0b0,
-  ]
+  ])
 }
 
 private function legalize_mie(o : Minterrupts, v : xlenbits) -> Minterrupts = {
   let v = Mk_Minterrupts(v);
-  [o with
+  supported_interrupts_mask([o with
     LCOFI = if currentlyEnabled(Ext_Sscofpmf) then v[LCOFI] else 0b0,
     MEI  = v[MEI],
     MTI  = v[MTI],
@@ -102,7 +114,7 @@ private function legalize_mie(o : Minterrupts, v : xlenbits) -> Minterrupts = {
     VSEI = if currentlyEnabled(Ext_H) then v[VSEI] else 0b0,
     VSTI = if currentlyEnabled(Ext_H) then v[VSTI] else 0b0,
     VSSI = if currentlyEnabled(Ext_H) then v[VSSI] else 0b0,
-  ]
+  ])
 }
 
 private function legalize_mideleg(_o : Minterrupts, v : xlenbits) -> Minterrupts = {
@@ -215,8 +227,9 @@ function read_mip(read_type : XipReadType) -> Minterrupts =
   match read_type {
     IncludePlatformInterrupts => {
       let platform_interrupts =
-        [external_interrupts_pending(hgeie)
-           with SSI = if currentlyEnabled(Ext_S) then supervisor_software_interrupt_pending() else 0b0];
+        supported_interrupts_mask([external_interrupts_pending(hgeie) with
+          SSI = if currentlyEnabled(Ext_S) then supervisor_software_interrupt_pending() else 0b0,
+        ]);
       Mk_Minterrupts(mip.bits | platform_interrupts.bits)
     },
     ExcludePlatformInterrupts => mip,

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -118,6 +118,14 @@ let plat_wfi_available_to_usermode : bool = config platform.wfi_available_to_use
 // used within the model but instead configures the external C++ harness.
 let max_wait_time : nat = config platform.max_time_to_wait
 
+// Supported interrupts
+let plat_has_msi : bool = config platform.interrupts.machine.software.supported
+let plat_has_mti : bool = config platform.interrupts.machine.timer.supported
+let plat_has_mei : bool = config platform.interrupts.machine.external.supported
+let plat_has_ssi : bool = config extensions.S.interrupts.software.supported
+let plat_has_sti : bool = config extensions.S.interrupts.timer.supported
+let plat_has_sei : bool = config extensions.S.interrupts.external.supported
+
 // which exceptions write information into `xtval`
 let illegal_instruction_writes_xtval : bool = config base.xtval_nonzero.illegal_instruction
 let virtual_instruction_writes_xtval : bool = config base.xtval_nonzero.virtual_instruction

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -820,6 +820,14 @@ private function check_extension_param_constraints() -> bool = {
     if (midelegation.bits & reserved_interrupt_mask) != zeros() then {
       valid = false;
       print_endline("Bits for reserved interrupts are set in `base.mideleg.delegatable_bits`.");
+    };
+
+    // Sstc implies supervisor timer interrupts should be supported.
+    if (config extensions.Sstc.supported : bool) then {
+      if not(config extensions.S.interrupts.timer.supported : bool) then {
+        valid = false;
+        print_endline("Supervisor timer interrupts are disabled in `extensions.S.interrupts.timer` but the Sstc extension is enabled: Sstc requires supervisor-mode timer interrupts to be supported.");
+      }
     }
   };
   if (config extensions.H.supported : bool) then {


### PR DESCRIPTION
Some interrupts may not be implemented on a platform. For e.g, systems with IMSICs may not have machine-mode software interrupts.  This allows supported machine-mode and supervisor-mode interrupts to be specified in the configuration.  Similar configuration for hypervisor-mode interrupts can be done later along similar lines.

No AI was used to write this code, though this is based on the description of an AI-assisted PR.