### PR TITLE
Allow configuring the `mcountinhibit` CSR.

### DIFF
--- a/config/config.json.in
+++ b/config/config.json.in
@@ -60,6 +60,17 @@
       "len": 32,
       "value": "0xFFFF_FFFF"
     },
+    "mcountinhibit" : {
+      // Whether the `mcountinhibit` CSR is implemented.
+      "supported": true,
+      // This bits in this value control whether the corresponding
+      // bits of the CSR are writable.  Note that bit 1 cannot be  written to
+      // as it is read-only zero.
+      "writable_bits": {
+        "len": 32,
+        "value": "0xFFFF_FFFD"
+      }
+    },
     // `mtvec.{direct,vectored}.supported` indicates whether the
     // corresponding mode is supported for `mtvec`.  At least one mode
     // should be supported.  If both modes are supported, the mode on

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -1,5 +1,9 @@
 # Release notes for the next version
 
+- Updates to the [configuration file](../config/config.json.in):
+  - Whether the `mcountinhibit` CSR is supported, and if so, which
+    bits are writable, can now be specified; see `base.mcountinhibit`.
+
 # Release notes for version 0.14
 
 The highlight of this release is the addition of the `H` hypervisor

--- a/model/core/platform_config.sail
+++ b/model/core/platform_config.sail
@@ -8,6 +8,10 @@
 
 // Platform-specific configuration parameters.
 
+// Configuration for `mcountinhibit`.
+let plat_have_mcountinhibit : bool = config base.mcountinhibit.supported
+let plat_mcountinhibit_writable_bits : bits(32) = config base.mcountinhibit.writable_bits
+
 // Trap vector mode.
 let plat_mtvec_direct_mode_supported : bool = config base.mtvec.direct.supported
 let plat_mtvec_vectored_mode_supported : bool = config base.mtvec.vectored.supported

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -811,14 +811,13 @@ bitfield Counterin : bits(32) = {
 }
 
 private function legalize_mcountinhibit(_c : Counterin, v : xlenbits) -> Counterin = {
-  // Note the 0 in 0b101 is because the mtimer counter can't be paused.
-  let supported_counters = sys_writable_hpm_counters[31 .. 3] @ 0b101;
-  Mk_Counterin(v[31 .. 0] & supported_counters)
+  Mk_Counterin(v[31 .. 0] & plat_mcountinhibit_writable_bits)
 }
 
-register mcountinhibit : Counterin
+// "If mcountinhibit is not implemented, the model should behave as if the register was zero."
+register mcountinhibit : Counterin = Mk_Counterin(zeros())
 mapping clause csr_name_map = 0x320  <-> "mcountinhibit"
-function clause is_CSR_accessible(0x320, _, _) = true // mcountinhibit
+function clause is_CSR_accessible(0x320, _, _) = plat_have_mcountinhibit // mcountinhibit
 function clause read_CSR(0x320) = zero_extend(mcountinhibit.bits)
 function clause write_CSR(0x320, value) = { mcountinhibit = legalize_mcountinhibit(mcountinhibit, value); Ok(zero_extend(mcountinhibit.bits)) }
 

--- a/model/postlude/validate_config.sail
+++ b/model/postlude/validate_config.sail
@@ -683,6 +683,14 @@ private function check_misc_extension_dependencies() -> bool = {
       print_endline("The Shcounterenw extension is enabled but `hcounteren` is not writable (via `base.hcounteren_writable_bits`) for some supported HPM counters (specified in `base.writable_hpm_counters`).");
     };
   };
+  // When Smcdeleg/Ssccfg are supported, `mcountinhibit` will be required.
+  if (config base.mcountinhibit.supported : bool) then {
+    let inhibitable_counters : bits(32) = config base.mcountinhibit.writable_bits;
+    if inhibitable_counters[1] == 0b1 then {
+      valid = false;
+      print_endline("Bit 1 of `base.mcountinhibit.writable_bits` is set; `mcountinhibit[1]` is read-only zero.");
+    }
+  };
   if (xlen == 32 & ((config extensions.Ssnpm.supported : bool) | (config extensions.Smmpm.supported : bool) | (config extensions.Smnpm.supported : bool))) then {
     valid = false;
     print_endline("The Ssnpm, Smmpm and Smnpm extensions are not supported on RV32.");


### PR DESCRIPTION
The configuration allows specifying whether the CSR is implemented, and if so, which bits are writable.  The latter configuration decouples it from `base.writable_hpm_counters` which was used to control the writable bits.

Decoupling the two now loosens the constraints, making it possible to configure the inhibition of an unimplemented counter.

Fixes #1933.