### PR TITLE
Fix c.lui assembly to use unsigned immediate

### DIFF
--- a/model/extensions/C/zca_insts.sail
+++ b/model/extensions/C/zca_insts.sail
@@ -211,7 +211,7 @@ function clause execute C_LUI(imm, rd) = {
 }
 
 mapping clause assembly = C_LUI(imm, rd)
-  <-> "c.lui" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_signed_6(imm)
+  <-> "c.lui" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(imm)
   when rd != sp & imm != 0b000000
 
 // *****************************************************************


### PR DESCRIPTION
Fixes #1032. c.lui's assembly mapping used hex_bits_signed_6, producing signed hex output (e.g. -0x1d) that GAS/LLVM reject, since c.lui's immediate is expected in unsigned form. Changed to hex_bits_6 to match GAS/LLVM's expected unsigned encoding, consistent with existing unsigned usage elsewhere in the same file (c.srli, c.srai, c.slli).

Written with AI assistance (Claude) per CONTRIBUTING.md disclosure requirement.