### PR TITLE
Make `mstatus.SPELP` read-only zero when Supervisor mode is not implemented

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -1,6 +1,7 @@
 # Release notes for the next version
 
 - Important issues addressed and bugs fixed:
+  - https://github.com/riscv/sail-riscv/issues/1943 : `mstatus.SPELP` should be read-only zero when Supervisor mode is not implemented
   - https://github.com/riscv/sail-riscv/issues/1938 : `scause`/`vscause` rejected Exception Codes in 0-31 that the spec requires them to hold, such as hypervisor codes when `H` is not implemented
 
 # Release notes for version 0.14

--- a/model/core/sys_regs.sail
+++ b/model/core/sys_regs.sail
@@ -247,7 +247,7 @@ private function legalize_mstatus(o : Mstatus, v : bits(64)) -> Mstatus = {
     // SXL = if xlen == 64 then v[SXL] else o[SXL],
     // UXL = if xlen == 64 then v[UXL] else o[UXL],
     // SDT = v[SDT],
-    SPELP = if hartSupports(Ext_Zicfilp) then v[SPELP] else 0b0,
+    SPELP = if hartSupports(Ext_Zicfilp) & currentlyEnabled(Ext_S) then v[SPELP] else 0b0,
     TSR = if currentlyEnabled(Ext_S) then v[TSR] else 0b0,
     TW = if currentlyEnabled(Ext_U) then v[TW] else 0b0,
     TVM = if currentlyEnabled(Ext_S) then v[TVM] else 0b0,


### PR DESCRIPTION
Fixes #1934.