### PR TITLE
Refactor `memory_exception` to take additional information about an access.

### DIFF
--- a/model/extensions/A/zaamo_insts.sail
+++ b/model/extensions/A/zaamo_insts.sail
@@ -73,12 +73,12 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
   assert(width <= xlen_bytes * 2);
 
   let access = Atomic(op, aq, rl, Data, Data);
-  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
-  let pmlen = get_pmlen(access, eff_priv);
+  let access_info = default_access_info(access);
+  let eff_priv = access_info.eff_privilege;
 
   // Get the address, X(rs1) (no offset).
   // Some extensions perform additional checks on address validity.
-  let vaddr : virtaddr = match get_transformed_data_addr(rs1, zeros(), access, eff_priv, pmlen, width) {
+  let vaddr : virtaddr = match get_transformed_data_addr(rs1, zeros(), access, access_info, width) {
     Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
     Ext_DataAddr_OK(vaddr) => vaddr,
   };
@@ -87,8 +87,8 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
     // Check if the model is configured to raise an exception based on
     // the misaligned virtual address.
     match plat_misaligned_exception(access, false) {
-      Some(AccessFault)        => return memory_exception(E_SAMO_Access_Fault(), bits_of(vaddr), access),
-      Some(AlignmentException) => return memory_exception(E_SAMO_Addr_Align(), bits_of(vaddr), access),
+      Some(AccessFault)        => return memory_exception(E_SAMO_Access_Fault(), bits_of(vaddr), access_info),
+      Some(AlignmentException) => return memory_exception(E_SAMO_Addr_Align(), bits_of(vaddr), access_info),
       // No exception yet, but we may still get one based on the
       // physical address after address translation and checking PMAs.
       None()                   => (),
@@ -104,13 +104,13 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
     Err(exc_addr, e) => {
       // AMOs should not get split.
       assert(exc_addr == addr);
-      return memory_exception(e, bits_of(vaddr), access)
+      return memory_exception(e, bits_of(vaddr), access_info)
     },
     Ok(_)  => match mem_read(access, pbmt, eff_priv, addr, width, aq, aq & rl, true) {
       Err(exc_addr, e) => {
         // AMOs should not get split.
         assert(exc_addr == addr);
-        return memory_exception(e, bits_of(vaddr), access)
+        return memory_exception(e, bits_of(vaddr), access_info)
       },
       Ok(loaded) => loaded,
     },
@@ -156,7 +156,7 @@ function clause execute AMO(op, aq, rl, rs2, rs1, width, rd) = {
     Err(exc_addr, e) => {
       // AMOs should not get split.
       assert(exc_addr == addr);
-      memory_exception(e, bits_of(vaddr), access)
+      memory_exception(e, bits_of(vaddr), access_info)
     }
   }
 }

--- a/model/extensions/H/hext_insts.sail
+++ b/model/extensions/H/hext_insts.sail
@@ -53,12 +53,18 @@ function clause execute HLVTYPE(width, op, is_unsigned, rs1, rd) = {
     HLVX => LoadExecute(Data),
   };
   assert(width <= xlen_bytes);
+
   let eff_priv : Privilege = privLevel_bits(zero_extend(hstatus[SPVP]), 0b1);
-  let pmlen = get_hlsv_pmlen(access, eff_priv);
+  let access_info : AccessInfo = struct {
+    eff_privilege = eff_priv,
+    pmlen = get_hlsv_pmlen(access, eff_priv),
+    as_guest = true,
+  };
+
   match ext_data_get_addr(rs1, zeros(), access, width) {
     Ext_DataAddr_Error(e)  => { Ext_DataAddr_Check_Failure(e) },
     Ext_DataAddr_OK(vaddr) => {
-      let vaddr = transform_effective_address(vaddr, eff_priv, pmlen);
+      let vaddr = transform_effective_address(vaddr, access_info);
       // TODO: HLV and HSV emulate ordinary VS-mode accesses, so a misaligned
       // one that crosses a page boundary should be split and translated per
       // page, the way vmem_read_addr and vmem_write_addr do. That needs
@@ -66,8 +72,8 @@ function clause execute HLVTYPE(width, op, is_unsigned, rs1, rd) = {
       // model/sys/mem.sail.
       if not(is_aligned_addr(vaddr, width)) then {
         match plat_misaligned_exception(access, false) {
-          Some(AccessFault)        => return hlsv_memory_exception(E_Load_Access_Fault(), bits_of(vaddr)),
-          Some(AlignmentException) => return hlsv_memory_exception(E_Load_Addr_Align(), bits_of(vaddr)),
+          Some(AccessFault)        => return memory_exception(E_Load_Access_Fault(), bits_of(vaddr), access_info),
+          Some(AlignmentException) => return memory_exception(E_Load_Addr_Align(), bits_of(vaddr), access_info),
           None()                   => (),
         };
       };
@@ -81,7 +87,7 @@ function clause execute HLVTYPE(width, op, is_unsigned, rs1, rd) = {
           Ok(result) => { X(rd) = extend_value(is_unsigned, result); RETIRE_SUCCESS },
           Err(exc_addr, e) => {
             assert(exc_addr == paddr);
-            return hlsv_memory_exception(e, bits_of(vaddr))
+            return memory_exception(e, bits_of(vaddr), access_info)
           }
         },
       };
@@ -107,14 +113,19 @@ function clause execute(HSV(width, rs1, rs2)) = {
   then return Illegal_Instruction();
 
   assert(width <= xlen_bytes);
+
   let eff_priv : Privilege = privLevel_bits(zero_extend(hstatus[SPVP]), 0b1);
   let access = Store(Data);
-  let pmlen = get_hlsv_pmlen(access, eff_priv);
+  let access_info : AccessInfo = struct {
+    eff_privilege = eff_priv,
+    pmlen = get_hlsv_pmlen(access, eff_priv),
+    as_guest = true,
+  };
 
   match ext_data_get_addr(rs1, zeros(), access, width) {
     Ext_DataAddr_Error(e)  => Ext_DataAddr_Check_Failure(e),
     Ext_DataAddr_OK(vaddr) => {
-      let vaddr = transform_effective_address(vaddr, eff_priv, pmlen);
+      let vaddr = transform_effective_address(vaddr, access_info);
       // TODO: HLV and HSV emulate ordinary VS-mode accesses, so a misaligned
       // one that crosses a page boundary should be split and translated per
       // page, the way vmem_read_addr and vmem_write_addr do. That needs
@@ -122,8 +133,8 @@ function clause execute(HSV(width, rs1, rs2)) = {
       // model/sys/mem.sail.
       if not(is_aligned_addr(vaddr, width)) then {
         match plat_misaligned_exception(access, false) {
-          Some(AccessFault)        => return hlsv_memory_exception(E_SAMO_Access_Fault(), bits_of(vaddr)),
-          Some(AlignmentException) => return hlsv_memory_exception(E_SAMO_Addr_Align(), bits_of(vaddr)),
+          Some(AccessFault)        => return memory_exception(E_SAMO_Access_Fault(), bits_of(vaddr), access_info),
+          Some(AlignmentException) => return memory_exception(E_SAMO_Addr_Align(), bits_of(vaddr), access_info),
           None()                   => (),
         };
       };
@@ -133,7 +144,7 @@ function clause execute(HSV(width, rs1, rs2)) = {
           match mem_write_ea(paddr, width, eff_priv, access, pbmt, false, false, false) {
             Err(exc_paddr, e) => {
               let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
-              return hlsv_memory_exception(e, bits_of(exc_vaddr))
+              return memory_exception(e, bits_of(exc_vaddr), access_info)
             },
             Ok(_) => {
               match mem_write_value(paddr, width, X(rs2)[8 * width - 1 .. 0], eff_priv, access, pbmt, false, false, false) {
@@ -141,7 +152,7 @@ function clause execute(HSV(width, rs1, rs2)) = {
                 Ok(false) => internal_error(__FILE__, __LINE__, "HSV got false from mem_write_value"),
                 Err(exc_paddr, e) => {
                   let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
-                  return hlsv_memory_exception(e, bits_of(exc_vaddr))
+                  return memory_exception(e, bits_of(exc_vaddr), access_info)
                 }
               }
             }

--- a/model/extensions/H/hext_insts.sail
+++ b/model/extensions/H/hext_insts.sail
@@ -11,15 +11,6 @@ mapping maybe_hlvx : hlvop <-> string = {
   HLVX <-> "x",
 }
 
-// The spec says that "GVA is redundant with field SPV ... except when the
-// explicit memory access of an HLV, HLVX, or HSV instruction causes a fault.
-// In that case, SPV=0 but GVA=1."
-private function hlsv_exception_context(e : ExceptionType, va : xlenbits) -> ExceptionContext =
-  make_exception_context(e, va, true, None())
-
-private function hlsv_memory_exception(e : ExceptionType, va : xlenbits) -> ExecutionResult =
-  trap(hlsv_exception_context(e, va))
-
 union clause instruction = HLVTYPE : (word_width, hlvop, bool, regidx, regidx)
 
 mapping clause encdec = HLVTYPE(width, HLV, is_unsigned, rs1, rd)

--- a/model/extensions/Zicbom/zicbom_insts.sail
+++ b/model/extensions/Zicbom/zicbom_insts.sail
@@ -72,9 +72,10 @@ private function cbop_priv_check(p: Privilege) -> checked_cbop = {
 private function process_clean_inval(rs1 : regidx, cbop : cbop_zicbom) -> ExecutionResult = {
   let rs1_val = X(rs1);
   let cache_block_size = 2 ^ plat_cache_block_size_exp;
+
   let access : MemoryAccessType(mem_payload) = CacheAccess(CB_manage(cbop));
-  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
-  let pmlen = get_pmlen(access, eff_priv);
+  let access_info = default_access_info(access);
+  let eff_priv = access_info.eff_privilege;
 
   // Offset from rs1 to the beginning of the cache block. This is 0 if rs1
   // is aligned to the cache block, or negative if rs1 is misaligned.
@@ -83,7 +84,7 @@ private function process_clean_inval(rs1 : regidx, cbop : cbop_zicbom) -> Execut
   // TODO: This is incorrect since CHERI only requires at least one byte
   // to be in bounds here, whereas `get_transformed_data_addr()` checks that all bytes
   // are in bounds. We will need to add a new function, parameter or access type.
-  match get_transformed_data_addr(rs1, negative_offset, access, eff_priv, pmlen, cache_block_size) {
+  match get_transformed_data_addr(rs1, negative_offset, access, access_info, cache_block_size) {
     Ext_DataAddr_Error(e) => Ext_DataAddr_Check_Failure(e),
     Ext_DataAddr_OK(vaddr) => {
       // vaddr is the aligned address, but errors report the address that
@@ -96,7 +97,7 @@ private function process_clean_inval(rs1 : regidx, cbop : cbop_zicbom) -> Execut
         Ok(paddr, pbmt, _) => {
           // Check PMA and PMP access controls.
           match phys_access_check(access, pbmt, eff_priv, paddr, cache_block_size, false) {
-            Err(e)  => memory_exception(e, bits_of(vaddr_for_error), access),
+            Err(e)  => memory_exception(e, bits_of(vaddr_for_error), access_info),
             // If there is no error, the model has no caches so there's no
             // more action required.
             Ok(_)   => RETIRE_SUCCESS

--- a/model/extensions/Zicbop/zicbop_insts.sail
+++ b/model/extensions/Zicbop/zicbop_insts.sail
@@ -39,14 +39,15 @@ function clause execute ZICBOP(cbop, rs1, offset) = {
   let addr = rs1_val + sign_extend(offset);
   let cache_block_addr = addr & ~(zero_extend(ones(plat_cache_block_size_exp)));
   let offset = cache_block_addr - rs1_val;
+
   let access : MemoryAccessType(mem_payload) = CacheAccess(CB_prefetch(cbop));
-  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
-  let pmlen = get_pmlen(access, eff_priv);
+  let access_info = default_access_info(access);
+  let eff_priv = access_info.eff_privilege;
 
   // TODO: This is incorrect since CHERI only requires at least one byte
   // to be in bounds here, whereas `get_transformed_data_addr()` checks that all bytes
   // are in bounds. We will need to add a new function, parameter or access type.
-  match get_transformed_data_addr(rs1, offset, access, eff_priv, pmlen, cache_block_size) {
+  match get_transformed_data_addr(rs1, offset, access, access_info, cache_block_size) {
     Ext_DataAddr_Error(_) => (), // No access to cache; no-op.
 
     Ext_DataAddr_OK(vaddr) => match translateAddr(vaddr, access, eff_priv) {

--- a/model/extensions/Zicboz/zicboz_insts.sail
+++ b/model/extensions/Zicboz/zicboz_insts.sail
@@ -31,14 +31,14 @@ function clause execute ZICBOZ(rs1) = {
   let rs1_val = X(rs1);
   let cache_block_size = 2 ^ plat_cache_block_size_exp;
   let access : MemoryAccessType(mem_payload) = CacheAccess(CB_zero());
-  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
-  let pmlen = get_pmlen(access, eff_priv);
+  let access_info = default_access_info(access);
+  let eff_priv = access_info.eff_privilege;
 
   // Offset from rs1 to the beginning of the cache block. This is 0 if rs1
   // is aligned to the cache block, or negative if rs1 is misaligned.
   let negative_offset = (rs1_val & ~(zero_extend(ones(plat_cache_block_size_exp)))) - rs1_val;
 
-  match get_transformed_data_addr(rs1, negative_offset, access, eff_priv, pmlen, cache_block_size) {
+  match get_transformed_data_addr(rs1, negative_offset, access, access_info, cache_block_size) {
     Ext_DataAddr_Error(e) => Ext_DataAddr_Check_Failure(e),
     Ext_DataAddr_OK(vaddr) => {
       // "An implementation may update the bytes in any order and with any granularity
@@ -56,7 +56,7 @@ function clause execute ZICBOZ(rs1) = {
             Err(exc_addr, e) => {
               // Cache accesses should not get split.
               assert(exc_addr == paddr);
-              memory_exception(e, bits_of(vaddr - negative_offset), access)
+              memory_exception(e, bits_of(vaddr - negative_offset), access_info)
             },
             Ok(_)  => {
               match mem_write_value(paddr, cache_block_size, zeros(), eff_priv, access, pbmt, false, false, false) {
@@ -65,7 +65,7 @@ function clause execute ZICBOZ(rs1) = {
                 Err(exc_addr, e) => {
                   // Cache accesses should not get split.
                   assert(exc_addr == paddr);
-                  memory_exception(e, bits_of(vaddr - negative_offset), access)
+                  memory_exception(e, bits_of(vaddr - negative_offset), access_info)
                 },
               }
             }

--- a/model/extensions/cfi/zicfiss_insts.sail
+++ b/model/extensions/cfi/zicfiss_insts.sail
@@ -27,10 +27,10 @@ function clause execute SSPUSH(rs2) = {
 
   let vaddr_bits = ssp - xlen_bytes;
   let access = Store(ShadowStack);
-  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
-  let pmlen = get_pmlen(access, eff_priv);
+  let access_info = default_access_info(access);
+  let eff_priv = access_info.eff_privilege;
 
-  let vaddr = transform_effective_address(Virtaddr(vaddr_bits), eff_priv, pmlen);
+  let vaddr = transform_effective_address(Virtaddr(vaddr_bits), access_info);
   // "If the virtual address in ssp is not XLEN aligned, then the
   // SSPUSH/C.SSPUSH/SSPOPCHK/C.SSPOPCHK instructions cause a
   // store/AMO access-fault exception."
@@ -42,9 +42,9 @@ function clause execute SSPUSH(rs2) = {
   // TODO: get the dynamic xlen here.
   let width = xlen_bytes;
   if not(is_aligned_addr(vaddr, width))
-  then return memory_exception(E_SAMO_Access_Fault(), bits_of(vaddr), access);
+  then return memory_exception(E_SAMO_Access_Fault(), bits_of(vaddr), access_info);
 
-  match vmem_write_addr(vaddr, width, X(rs2), access, eff_priv, false, false, false) {
+  match vmem_write_addr(vaddr, width, X(rs2), access, access_info, false, false, false) {
     Ok(_)  => { ssp = vaddr_bits;
                 csr_write_callback("ssp", ssp);
                 RETIRE_SUCCESS },
@@ -85,17 +85,18 @@ function clause execute SSPOPCHK(rs1) = {
   if not(zicfiss_xSSE(cur_privilege)) then return RETIRE_SUCCESS;
 
   let access = Load(ShadowStack);
-  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
-  let pmlen = get_pmlen(access, eff_priv);
-  let ssp_addr = transform_effective_address(Virtaddr(ssp), eff_priv, pmlen);
+  let access_info = default_access_info(access);
+  let eff_priv = access_info.eff_privilege;
+
+  let ssp_addr = transform_effective_address(Virtaddr(ssp), access_info);
 
   // See above on checking alignment.
   // TODO: get the dynamic xlen here.
   let width = xlen_bytes;
   if not(is_aligned_addr(ssp_addr, width))
-  then return memory_exception(E_SAMO_Access_Fault(), bits_of(ssp_addr), access);
+  then return memory_exception(E_SAMO_Access_Fault(), bits_of(ssp_addr), access_info);
 
-  match vmem_read_addr(ssp_addr, width, access, eff_priv, false, false, false) {
+  match vmem_read_addr(ssp_addr, width, access, access_info, false, false, false) {
     Ok(data) => {
       if X(rs1) != data then {
         trap(make_shadow_stack_exception())
@@ -177,10 +178,10 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
   };
 
   let access = Atomic(AMOSWAP, aq, rl, ShadowStack, ShadowStack);
-  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
-  let pmlen = get_pmlen(access, eff_priv);
+  let access_info = default_access_info(access);
+  let eff_priv = access_info.eff_privilege;
 
-  let vaddr : virtaddr = match get_transformed_data_addr(rs1, zeros(), access, eff_priv, pmlen, width) {
+  let vaddr : virtaddr = match get_transformed_data_addr(rs1, zeros(), access, access_info, width) {
     Ext_DataAddr_Error(e)  => return Ext_DataAddr_Check_Failure(e),
     Ext_DataAddr_OK(vaddr) => vaddr,
   };
@@ -191,8 +192,8 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
     // Check if the model is configured to raise an exception based on
     // the misaligned virtual address.
     match plat_misaligned_exception(access, false) {
-      Some(AccessFault)        => return memory_exception(E_SAMO_Access_Fault(), bits_of(vaddr), access),
-      Some(AlignmentException) => return memory_exception(E_SAMO_Addr_Align(), bits_of(vaddr), access),
+      Some(AccessFault)        => return memory_exception(E_SAMO_Access_Fault(), bits_of(vaddr), access_info),
+      Some(AlignmentException) => return memory_exception(E_SAMO_Addr_Align(), bits_of(vaddr), access_info),
       // No exception yet, but we may still get one based on the
       // physical address after address translation and checking PMAs.
       None()                   => (),
@@ -214,13 +215,13 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
     Err(exc_addr, e) => {
       // AMOs should not get split.
       assert(exc_addr == paddr);
-      return memory_exception(e, bits_of(vaddr), access)
+      return memory_exception(e, bits_of(vaddr), access_info)
     },
     Ok(_) => match mem_read(access, pbmt, eff_priv, paddr, width, aq, aq & rl, true) {
       Err(exc_addr, e) => {
         // AMOs should not get split.
         assert(exc_addr == paddr);
-        return memory_exception(e, bits_of(vaddr), access)
+        return memory_exception(e, bits_of(vaddr), access_info)
       },
       Ok(v)  => v,
     },
@@ -238,7 +239,7 @@ function clause execute SSAMOSWAP(aq, rl, rs2, rs1, width, rd) = {
     Err(exc_addr, e) => {
       // AMOs should not get split.
       assert(exc_addr == paddr);
-      return memory_exception(e, bits_of(vaddr), access)
+      return memory_exception(e, bits_of(vaddr), access_info)
     },
   };
 

--- a/model/extensions/cfi/zicfiss_insts.sail
+++ b/model/extensions/cfi/zicfiss_insts.sail
@@ -28,7 +28,6 @@ function clause execute SSPUSH(rs2) = {
   let vaddr_bits = ssp - xlen_bytes;
   let access = Store(ShadowStack);
   let access_info = default_access_info(access);
-  let eff_priv = access_info.eff_privilege;
 
   let vaddr = transform_effective_address(Virtaddr(vaddr_bits), access_info);
   // "If the virtual address in ssp is not XLEN aligned, then the
@@ -86,7 +85,6 @@ function clause execute SSPOPCHK(rs1) = {
 
   let access = Load(ShadowStack);
   let access_info = default_access_info(access);
-  let eff_priv = access_info.eff_privilege;
 
   let ssp_addr = transform_effective_address(Virtaddr(ssp), access_info);
 

--- a/model/riscv.sail_project
+++ b/model/riscv.sail_project
@@ -111,7 +111,7 @@ extensions {
       files extensions/A/aext_types.sail
     }
     Zaamo {
-      requires core, sys, exceptions, A_types, PM_utils
+      requires core, sys, exceptions, A_types
       files extensions/A/zaamo_insts.sail
     }
     Zalrsc {
@@ -388,7 +388,7 @@ extensions {
       files extensions/cfi/zicfiss_regs.sail
     }
     Zicfiss_insts {
-      requires sys, exceptions, CFI_types, Zicfiss_regs, A_types, PM_utils
+      requires sys, exceptions, CFI_types, Zicfiss_regs, A_types
       files extensions/cfi/zicfiss_insts.sail
     }
   }
@@ -416,7 +416,7 @@ extensions {
       files extensions/Zicbom/zicbom_types.sail
     }
     Zicbom_insts {
-      requires core, sys, exceptions, Zicbom_types, PM_utils
+      requires core, sys, exceptions, Zicbom_types
       files extensions/Zicbom/zicbom_insts.sail
     }
   }
@@ -429,7 +429,7 @@ extensions {
     Zicbop_insts {
       // PREFETCH.{I,R,W} instructions override ORI hints (rd=0)
       before I_insts
-      requires core, sys, exceptions, Zicbop_types, PM_utils
+      requires core, sys, exceptions, Zicbop_types
       files extensions/Zicbop/zicbop_insts.sail
     }
   }
@@ -447,7 +447,7 @@ extensions {
   }
 
   Zicboz {
-    requires core, sys, exceptions, PM_utils
+    requires core, sys, exceptions
     files extensions/Zicboz/zicboz_insts.sail
   }
 

--- a/model/sys/vmem_utils.sail
+++ b/model/sys/vmem_utils.sail
@@ -59,60 +59,87 @@ function offset_virtaddr_by(
   Virtaddr(masked)
 }
 
+// The context for an access.
+
+struct AccessInfo = {
+  eff_privilege  : Privilege,
+  pmlen          : pm_len,
+  as_guest       : bool,
+}
+
+function default_access_info(access : MemoryAccessType(mem_payload)) -> AccessInfo = {
+  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
+
+  struct {
+    eff_privilege = eff_priv,
+    pmlen = get_pmlen(access, eff_priv),
+    as_guest = false,
+  }
+}
+
 // External API
 
 // Apply pointer masking to an effective address given a precomputed PMLEN.
 // Whether the address is virtual (sign-extend) or physical (zero-extend) follows
 // the first-stage satp register feeding the address: vsatp for VS/VU, otherwise
 // satp. A guest-physical address (vsatp.MODE == Bare) is treated as physical.
-function transform_effective_address(vaddr : virtaddr, eff_privilege : Privilege, pmlen : pm_len) -> virtaddr = {
+function transform_effective_address(vaddr : virtaddr, access_info : AccessInfo) -> virtaddr = {
+  let eff_privilege = access_info.eff_privilege;
+  let pmlen = access_info.pmlen;
+
   let mode = if eff_privilege == VirtualSupervisor | eff_privilege == VirtualUser
              then vsatp_mode()
              else satp_mode(eff_privilege);
   if mode == Bare then pm_transform_PA(vaddr, pmlen) else pm_transform_VA(vaddr, pmlen)
 }
 
-// Whether a data access is effectively to a guest VA (VS/VU mode, or M-mode MPRV+MPV).
-function access_is_gva(access : MemoryAccessType(mem_payload)) -> bool =
-  privLevel_is_virtual(effectivePrivilege(access, mstatus, cur_privilege))
+// Whether a data access is effectively to a guest VA (VS/VU mode, or M-mode MPRV+MPV, or HS/U-mode doing HLV/HSV).
+private function access_is_gva(access_info : AccessInfo) -> bool =
+  privLevel_is_virtual(access_info.eff_privilege) | access_info.as_guest
 
-function mem_exception_context(e : ExceptionType, excinfo : xlenbits, access : MemoryAccessType(mem_payload)) -> ExceptionContext =
-  make_exception_context(e, excinfo, access_is_gva(access), None())
+private function mem_exception_context(e : ExceptionType, excinfo : xlenbits, access_info : AccessInfo) -> ExceptionContext =
+  make_exception_context(e, excinfo, access_is_gva(access_info), None())
 
-function memory_exception(e : ExceptionType, excinfo : xlenbits, access : MemoryAccessType(mem_payload)) -> ExecutionResult =
-  trap(mem_exception_context(e, excinfo, access))
+function memory_exception(e : ExceptionType, excinfo : xlenbits, access_info : AccessInfo) -> ExecutionResult =
+  trap(mem_exception_context(e, excinfo, access_info))
 
 // Helper for translated read access.
 private function translate_and_read_value forall 'width, 0 < 'width <= max_mem_access.
-  (vaddr : virtaddr, width : int('width), eff_priv : Privilege, access : MemoryAccessType(mem_payload), aq : bool, rl : bool, res : bool)
-  -> result((physaddr, bits(8 * 'width)), ExecutionResult) =
+  (vaddr : virtaddr, width : int('width), access : MemoryAccessType(mem_payload), access_info : AccessInfo, aq : bool, rl : bool, res : bool)
+  -> result((physaddr, bits(8 * 'width)), ExecutionResult) = {
+
+  let eff_priv = access_info.eff_privilege;
+
   match translateAddr(vaddr, access, eff_priv) {
     Err(e, _) => Err(trap(e)),
 
     Ok(paddr, pbmt, _) => match mem_read(access, pbmt, eff_priv, paddr, width, aq, rl, res) {
       Err(exc_paddr, e) => {
         let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
-        Err(memory_exception(e, bits_of(exc_vaddr), access))
+        Err(memory_exception(e, bits_of(exc_vaddr), access_info))
       },
 
       Ok(v) => Ok(paddr, v),
     }
   }
+}
 
 val vmem_read_addr : forall 'width, is_mem_width('width).
-  (virtaddr, int('width), MemoryAccessType(mem_payload), Privilege, bool, bool, bool)
+  (virtaddr, int('width), MemoryAccessType(mem_payload), AccessInfo, bool, bool, bool)
   -> result(bits(8 * 'width), ExecutionResult)
 
-function vmem_read_addr(vaddr, width, access, eff_priv, aq, rl, res) = {
+function vmem_read_addr(vaddr, width, access, access_info, aq, rl, res) = {
   // Other AMOs currently don't go through `vmem_utils` functions.
   assert(res == is_load_reserved(access));
+
+  let eff_priv = access_info.eff_privilege;
 
   // "LR faults like a normal load, even though it's in the AMO major opcode space."
   // - Andrew Waterman, isa-dev, 10 Jul 2018.
   if not(is_aligned_addr(vaddr, width)) then {
     match plat_misaligned_exception(access, res) {
-      Some(AccessFault)        => return Err(memory_exception(E_Load_Access_Fault(), bits_of(vaddr), access)),
-      Some(AlignmentException) => return Err(memory_exception(E_Load_Addr_Align(), bits_of(vaddr), access)),
+      Some(AccessFault)        => return Err(memory_exception(E_Load_Access_Fault(), bits_of(vaddr), access_info)),
+      Some(AlignmentException) => return Err(memory_exception(E_Load_Addr_Align(), bits_of(vaddr), access_info)),
       // Even if the CPU does support misaligned accesses, it might be
       // that the PMA doesn't support misaligned accesses so you can
       // still get a fault later, but this will be after address
@@ -138,7 +165,7 @@ function vmem_read_addr(vaddr, width, access, eff_priv, aq, rl, res) = {
   if sys_misaligned_order_decreasing & do_split_access then {
     // Do next page access first.
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
-    match translate_and_read_value(access_addr, next_page_bytes, eff_priv, access, aq, rl, res) {
+    match translate_and_read_value(access_addr, next_page_bytes, access, access_info, aq, rl, res) {
       Err(e)   => return Err(e),
       Ok(_, v) => data[8 * width - 1 .. 8 * in_page_bytes] = v,
     }
@@ -147,7 +174,7 @@ function vmem_read_addr(vaddr, width, access, eff_priv, aq, rl, res) = {
   // If the access was split, only the in-page bytes should be
   // accessed, otherwise all bytes should be accessed.
   let access_width = if do_split_access then in_page_bytes else width;
-  match translate_and_read_value(vaddr, access_width, eff_priv, access, aq, rl, res) {
+  match translate_and_read_value(vaddr, access_width, access, access_info, aq, rl, res) {
     Err(e)       => return Err(e),
     Ok(paddr, v) => {
       if res then {
@@ -162,7 +189,7 @@ function vmem_read_addr(vaddr, width, access, eff_priv, aq, rl, res) = {
   if not(sys_misaligned_order_decreasing) & do_split_access then {
     // Do next page access next.
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
-    match translate_and_read_value(access_addr, next_page_bytes, eff_priv, access, aq, rl, res) {
+    match translate_and_read_value(access_addr, next_page_bytes, access, access_info, aq, rl, res) {
       Err(e)   => return Err(e),
       Ok(_, v) => data[8 * width - 1 .. 8 * in_page_bytes] = v,
     }
@@ -173,8 +200,10 @@ function vmem_read_addr(vaddr, width, access, eff_priv, aq, rl, res) = {
 
 // Helper for translated write access.
 private function translate_and_write_value forall 'width, 0 < 'width <= max_mem_access.
-  (vaddr : virtaddr, width : int('width), value : bits(8 * 'width), eff_priv : Privilege, access : MemoryAccessType(mem_payload), aq : bool, rl : bool, res : bool)
-  -> result(bool, ExecutionResult) =
+  (vaddr : virtaddr, width : int('width), value : bits(8 * 'width), access : MemoryAccessType(mem_payload), access_info : AccessInfo, aq : bool, rl : bool, res : bool)
+  -> result(bool, ExecutionResult) = {
+
+  let eff_priv = access_info.eff_privilege;
 
   match translateAddr(vaddr, access, eff_priv) {
     Err(e, _) => Err(trap(e)),
@@ -182,33 +211,36 @@ private function translate_and_write_value forall 'width, 0 < 'width <= max_mem_
     Ok(paddr, pbmt, _) => match mem_write_ea(paddr, width, eff_priv, access, pbmt, aq, rl, res) {
       Err(exc_paddr, e) => {
         let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
-        Err(memory_exception(e, bits_of(exc_vaddr), access))
+        Err(memory_exception(e, bits_of(exc_vaddr), access_info))
       },
 
       Ok(()) => match mem_write_value(paddr, width, value, eff_priv, access, pbmt, aq, rl, res) {
         Err(exc_paddr, e) => {
           let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
-          Err(memory_exception(e, bits_of(exc_vaddr), access))
+          Err(memory_exception(e, bits_of(exc_vaddr), access_info))
         },
 
         Ok(s) => Ok(s),
       },
     },
   }
+}
 
 val vmem_write_addr : forall 'width, is_mem_width('width).
-  (virtaddr, int('width), bits(8 * 'width), MemoryAccessType(mem_payload), Privilege, bool, bool, bool)
+  (virtaddr, int('width), bits(8 * 'width), MemoryAccessType(mem_payload), AccessInfo, bool, bool, bool)
   -> result(bool, ExecutionResult)
 
-function vmem_write_addr(vaddr, width, data, access, eff_priv, aq, rl, res) = {
+function vmem_write_addr(vaddr, width, data, access, access_info, aq, rl, res) = {
   // Other AMOs currently don't go through `vmem_utils` functions.
   assert(res == is_store_conditional(access));
+
+  let eff_priv = access_info.eff_privilege;
 
   // See comments in vmem_read_addr for an explanation of this check.
   if not(is_aligned_addr(vaddr, width)) then {
     match plat_misaligned_exception(access, res) {
-      Some(AccessFault)        => return Err(memory_exception(E_SAMO_Access_Fault(), bits_of(vaddr), access)),
-      Some(AlignmentException) => return Err(memory_exception(E_SAMO_Addr_Align(), bits_of(vaddr), access)),
+      Some(AccessFault)        => return Err(memory_exception(E_SAMO_Access_Fault(), bits_of(vaddr), access_info)),
+      Some(AlignmentException) => return Err(memory_exception(E_SAMO_Addr_Align(), bits_of(vaddr), access_info)),
       None()                   => (),
     };
   };
@@ -235,7 +267,7 @@ function vmem_write_addr(vaddr, width, data, access, eff_priv, aq, rl, res) = {
   if sys_misaligned_order_decreasing & do_split_access then {
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
     let write_value = data[8 * width - 1 .. 8 * in_page_bytes];
-    match translate_and_write_value(access_addr, next_page_bytes, write_value, eff_priv, access, aq, rl, res) {
+    match translate_and_write_value(access_addr, next_page_bytes, write_value, access, access_info, aq, rl, res) {
       Err(e) => return Err(e),
       Ok(s)  => write_success = write_success & s,
     }
@@ -254,13 +286,13 @@ function vmem_write_addr(vaddr, width, data, access, eff_priv, aq, rl, res) = {
         // PMP region without write permissions raises a store
         // access-fault exception."
         match phys_access_check(access, pbmt, eff_priv, paddr, access_width, true) {
-          Err(e) => return Err(memory_exception(e, bits_of(vaddr), access)),
+          Err(e) => return Err(memory_exception(e, bits_of(vaddr), access_info)),
           Ok(_)  => write_success = false,
         }
       } else match mem_write_ea(paddr, access_width, eff_priv, access, pbmt, aq, rl, res) {
         Err(exc_paddr, e) => {
           let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
-          return Err(memory_exception(e, bits_of(exc_vaddr), access))
+          return Err(memory_exception(e, bits_of(exc_vaddr), access_info))
         },
 
         Ok(()) => {
@@ -268,7 +300,7 @@ function vmem_write_addr(vaddr, width, data, access, eff_priv, aq, rl, res) = {
           match mem_write_value(paddr, access_width, write_value, eff_priv, access, pbmt, aq, rl, res) {
             Err(exc_paddr, e) => {
               let exc_vaddr = offset_virtaddr_by(vaddr, paddr, exc_paddr);
-              return Err(memory_exception(e, bits_of(exc_vaddr), access))
+              return Err(memory_exception(e, bits_of(exc_vaddr), access_info))
             },
             Ok(s)  => write_success = write_success & s,
           }
@@ -280,7 +312,7 @@ function vmem_write_addr(vaddr, width, data, access, eff_priv, aq, rl, res) = {
   if not(sys_misaligned_order_decreasing) & do_split_access then {
     let access_addr = Virtaddr(vaddr_bits + in_page_bytes);
     let write_value = data[8 * width - 1 .. 8 * in_page_bytes];
-    match translate_and_write_value(access_addr, next_page_bytes, write_value, eff_priv, access, aq, rl, res) {
+    match translate_and_write_value(access_addr, next_page_bytes, write_value, access, access_info, aq, rl, res) {
       Err(e) => return Err(e),
       Ok(s)  => write_success = write_success & s,
     }
@@ -290,49 +322,59 @@ function vmem_write_addr(vaddr, width, data, access, eff_priv, aq, rl, res) = {
 }
 
 // Compute effective address with extension checks and apply pointer masking.
-function get_transformed_data_addr(base : regidx, offset : xlenbits, access : MemoryAccessType(mem_payload), eff_priv : Privilege, pmlen: pm_len, width : mem_access_width)
+function get_transformed_data_addr(base : regidx, offset : xlenbits, access : MemoryAccessType(mem_payload), access_info : AccessInfo, width : mem_access_width)
          -> Ext_DataAddr_Check(ext_data_addr_error) = {
+  let eff_priv = access_info.eff_privilege;
   match ext_data_get_addr(base, offset, access, width) {
     Ext_DataAddr_Error(e) => Ext_DataAddr_Error(e),
     Ext_DataAddr_OK(vaddr) => {
-      let vaddr = transform_effective_address(vaddr, eff_priv, pmlen);
+      let vaddr = transform_effective_address(vaddr, access_info);
       Ext_DataAddr_OK(vaddr)
     }
   }
+}
+
+val vmem_read_explicit : forall 'width, is_mem_width('width).
+  (regidx, xlenbits, int('width), MemoryAccessType(mem_payload), AccessInfo, bool, bool, bool)
+  -> result(bits(8 * 'width), ExecutionResult)
+
+function vmem_read_explicit(rs, offset, width, access, access_info, aq, rl, res) = {
+  // Get the address, X(rs1) + offset.
+  // Extensions might perform additional checks on address validity.
+  let vaddr : virtaddr = match get_transformed_data_addr(rs, offset, access, access_info, width) {
+    Ext_DataAddr_OK(vaddr) => vaddr,
+    Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
+  };
+
+  vmem_read_addr(vaddr, width, access, access_info, aq, rl, res)
 }
 
 val vmem_read : forall 'width, is_mem_width('width).
   (regidx, xlenbits, int('width), MemoryAccessType(mem_payload), bool, bool, bool)
   -> result(bits(8 * 'width), ExecutionResult)
 
-function vmem_read(rs, offset, width, access, aq, rl, res) = {
-  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
-  let pmlen = get_pmlen(access, eff_priv);
+function vmem_read(rs, offset, width, access, aq, rl, res) =
+  vmem_read_explicit(rs, offset, width, access, default_access_info(access), aq, rl, res)
 
-  // Get the address, X(rs1) + offset.
+
+val vmem_write_explicit : forall 'width, is_mem_width('width).
+  (regidx, xlenbits, int('width), bits(8 * 'width), MemoryAccessType(mem_payload), AccessInfo, bool, bool, bool)
+  -> result(bool, ExecutionResult)
+
+function vmem_write_explicit(rs_addr, offset, width, data, access, access_info, aq, rl, res) = {
+  // Get the address, X(rs_addr) + offset.
   // Extensions might perform additional checks on address validity.
-  let vaddr : virtaddr = match get_transformed_data_addr(rs, offset, access, eff_priv, pmlen, width) {
+  let vaddr : virtaddr = match get_transformed_data_addr(rs_addr, offset, access, access_info, width) {
     Ext_DataAddr_OK(vaddr) => vaddr,
     Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
   };
 
-  vmem_read_addr(vaddr, width, access, eff_priv, aq, rl, res)
+  vmem_write_addr(vaddr, width, data, access, access_info, aq, rl, res)
 }
 
 val vmem_write : forall 'width, is_mem_width('width).
   (regidx, xlenbits, int('width), bits(8 * 'width), MemoryAccessType(mem_payload), bool, bool, bool)
   -> result(bool, ExecutionResult)
 
-function vmem_write(rs_addr, offset, width, data, access, aq, rl, res) = {
-  let eff_priv = effectivePrivilege(access, mstatus, cur_privilege);
-  let pmlen = get_pmlen(access, eff_priv);
-
-  // Get the address, X(rs_addr) + offset.
-  // Extensions might perform additional checks on address validity.
-  let vaddr : virtaddr = match get_transformed_data_addr(rs_addr, offset, access, eff_priv, pmlen, width) {
-    Ext_DataAddr_OK(vaddr) => vaddr,
-    Ext_DataAddr_Error(e)  => return Err(Ext_DataAddr_Check_Failure(e)),
-  };
-
-  vmem_write_addr(vaddr, width, data, access, eff_priv, aq, rl, res)
-}
+function vmem_write(rs_addr, offset, width, data, access, aq, rl, res) =
+  vmem_write_explicit(rs_addr, offset, width, data, access, default_access_info(access), aq, rl, res)


### PR DESCRIPTION
This allows differentiating exceptions for HLV/HSV from other cases.

The guest-access flag is bundled with effective privilege and pointer-masking length into an `AccessInfo` structure that is used to access the `vmem_utils` functions.

The HLV/HSV instructions are not yet changed to use the `vmem_utils` API, but this should be the last refactor needed before they can use it to fix #1913.